### PR TITLE
AE: add atempo filter

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -692,6 +692,8 @@
 		7CE3FB911C9D40EA00366A4C /* ServiceBroker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CE3FB8E1C9D40EA00366A4C /* ServiceBroker.cpp */; };
 		7CE514AA1CD5154A0046BC5C /* GUIDialogKeyboardTouch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CE514A81CD5154A0046BC5C /* GUIDialogKeyboardTouch.cpp */; };
 		7CE514AB1CD5154A0046BC5C /* GUIDialogKeyboardTouch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CE514A81CD5154A0046BC5C /* GUIDialogKeyboardTouch.cpp */; };
+		7CE5D0B41D37EB6900211428 /* ActiveAEFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CE5D0B21D37EB6900211428 /* ActiveAEFilter.cpp */; };
+		7CE5D0B51D37EB6900211428 /* ActiveAEFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CE5D0B21D37EB6900211428 /* ActiveAEFilter.cpp */; };
 		7CEBD8A80F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */; };
 		7CED59391CD340460093F573 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CED59381CD340460093F573 /* VideoToolbox.framework */; };
 		7CED593A1CD340460093F573 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CED59381CD340460093F573 /* VideoToolbox.framework */; };
@@ -3406,6 +3408,8 @@
 		7CE3FB8F1C9D40EA00366A4C /* ServiceBroker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceBroker.h; sourceTree = "<group>"; };
 		7CE514A81CD5154A0046BC5C /* GUIDialogKeyboardTouch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogKeyboardTouch.cpp; sourceTree = "<group>"; };
 		7CE514A91CD5154A0046BC5C /* GUIDialogKeyboardTouch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogKeyboardTouch.h; sourceTree = "<group>"; };
+		7CE5D0B21D37EB6900211428 /* ActiveAEFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ActiveAEFilter.cpp; sourceTree = "<group>"; };
+		7CE5D0B31D37EB6900211428 /* ActiveAEFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActiveAEFilter.h; sourceTree = "<group>"; };
 		7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocolDirectory.cpp; sourceTree = "<group>"; };
 		7CEBD8A70F33A0D800CAF6AD /* SpecialProtocolDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocolDirectory.h; sourceTree = "<group>"; };
 		7CED59381CD340460093F573 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
@@ -9232,6 +9236,8 @@
 				F5CC22D41814FF3B006B5E91 /* ActiveAE.h */,
 				F5CC22D51814FF3B006B5E91 /* ActiveAEBuffer.cpp */,
 				F5CC22D61814FF3B006B5E91 /* ActiveAEBuffer.h */,
+				7CE5D0B21D37EB6900211428 /* ActiveAEFilter.cpp */,
+				7CE5D0B31D37EB6900211428 /* ActiveAEFilter.h */,
 				DF32466019E931A8005E8CFB /* ActiveAEResampleFFMPEG.cpp */,
 				DF32466119E931A8005E8CFB /* ActiveAEResampleFFMPEG.h */,
 				F5CC22D91814FF3B006B5E91 /* ActiveAESink.cpp */,
@@ -10387,6 +10393,7 @@
 				C84828DE156CFCD8005A996F /* GUIWindowPVRBase.cpp in Sources */,
 				C84828DF156CFCD8005A996F /* GUIWindowPVRChannels.cpp in Sources */,
 				C84828E1156CFCD8005A996F /* GUIWindowPVRGuide.cpp in Sources */,
+				7CE5D0B41D37EB6900211428 /* ActiveAEFilter.cpp in Sources */,
 				C84828E2156CFCD8005A996F /* GUIWindowPVRRecordings.cpp in Sources */,
 				C84828E3156CFCD8005A996F /* GUIWindowPVRSearch.cpp in Sources */,
 				C84828E4156CFCD8005A996F /* GUIWindowPVRTimers.cpp in Sources */,
@@ -11397,6 +11404,7 @@
 				E49913F7174E5FB000741B6D /* PVRChannelGroups.cpp in Sources */,
 				E49913F8174E5FB000741B6D /* PVRChannelGroupsContainer.cpp in Sources */,
 				E49913F9174E5FB000741B6D /* GUIDialogPVRChannelManager.cpp in Sources */,
+				7CE5D0B51D37EB6900211428 /* ActiveAEFilter.cpp in Sources */,
 				E49913FA174E5FB000741B6D /* GUIDialogPVRChannelsOSD.cpp in Sources */,
 				E49913FD174E5FB000741B6D /* GUIDialogPVRGroupManager.cpp in Sources */,
 				E49913FE174E5FB000741B6D /* GUIDialogPVRGuideInfo.cpp in Sources */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -261,6 +261,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Encoders\AEEncoderFFmpeg.cpp" />
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAE.cpp" />
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAEBuffer.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAEFilter.cpp" />
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAEResampleFFMPEG.cpp" />
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAESink.cpp" />
     <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAESound.cpp" />
@@ -1022,6 +1023,7 @@ copy "..\Win32BuildSetup\dependencies\python27.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\xbmc\contrib\kissfft\kiss_fft.h" />
     <ClInclude Include="..\..\xbmc\contrib\kissfft\kiss_fftr.h" />
     <ClInclude Include="..\..\xbmc\contrib\kissfft\_kiss_fft_guts.h" />
+    <ClInclude Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAEFilter.h" />
     <ClInclude Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\AudioDSPAddons\ActiveAEDSP.h" />
     <ClInclude Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\AudioDSPAddons\ActiveAEDSPAddon.h" />
     <ClInclude Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\AudioDSPAddons\ActiveAEDSPDatabase.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2845,6 +2845,9 @@
     <ClCompile Include="..\..\xbmc\dialogs\GUIDialogPlayerProcessInfo.cpp">
       <Filter>dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAEFilter.cpp">
+      <Filter>cores\AudioEngine\Engines\ActiveAE</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\media\MediaType.cpp">
@@ -6706,6 +6709,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogPlayerProcessInfo.h">
       <Filter>dialogs</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAEFilter.h">
+      <Filter>cores\AudioEngine\Engines\ActiveAE</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES AEFactory.cpp
             Encoders/AEEncoderFFmpeg.cpp
             Engines/ActiveAE/ActiveAE.cpp
             Engines/ActiveAE/ActiveAEBuffer.cpp
+            Engines/ActiveAE/ActiveAEFilter.cpp
             Engines/ActiveAE/ActiveAESink.cpp
             Engines/ActiveAE/ActiveAEStream.cpp
             Engines/ActiveAE/ActiveAESound.cpp
@@ -33,6 +34,7 @@ set(HEADERS AEFactory.h
             Encoders/AEEncoderFFmpeg.h
             Engines/ActiveAE/ActiveAE.h
             Engines/ActiveAE/ActiveAEBuffer.h
+            Engines/ActiveAE/ActiveAEFilter.h
             Engines/ActiveAE/ActiveAESink.h
             Engines/ActiveAE/ActiveAESound.h
             Engines/ActiveAE/ActiveAEStream.h

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2296,10 +2296,13 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
   double threshold = 100;
   if (stream->m_resampleMode)
   {
-    if (stream->m_pClock && stream->m_pClock->GetClockSpeed() > 1.1)
-      threshold *= 10;
-    else
-      threshold *= 2;
+    threshold *= 2;
+    if (stream->m_pClock)
+    {
+      double clockspeed = stream->m_pClock->GetClockSpeed();
+      if (clockspeed >= 1.05 || clockspeed <= 0.95)
+        threshold *= 5;
+    }
   }
 
   int timeout = (stream->m_syncState != CAESyncInfo::AESyncState::SYNC_INSYNC) ? 100 : (int)stream->m_errorInterval;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1274,7 +1274,9 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       }
       if (initSink && (*it)->m_processingBuffers)
       {
+        (*it)->m_processingBuffers->Flush();
         m_discardBufferPools.push_back((*it)->m_processingBuffers->GetResampleBuffers());
+        m_discardBufferPools.push_back((*it)->m_processingBuffers->GetAtempoBuffers());
         delete (*it)->m_processingBuffers;
         (*it)->m_processingBuffers = nullptr;
       }
@@ -1440,7 +1442,11 @@ void CActiveAE::DiscardStream(CActiveAEStream *stream)
       if ((*it)->m_inputBuffers)
         m_discardBufferPools.push_back((*it)->m_inputBuffers);
       if ((*it)->m_processingBuffers)
+      {
+        (*it)->m_processingBuffers->Flush();
         m_discardBufferPools.push_back((*it)->m_processingBuffers->GetResampleBuffers());
+        m_discardBufferPools.push_back((*it)->m_processingBuffers->GetAtempoBuffers());
+      }
       delete (*it)->m_processingBuffers;
       CLog::Log(LOGDEBUG, "CActiveAE::DiscardStream - audio stream deleted");
       m_stats.RemoveStream((*it)->m_id);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ActiveAEBuffer.h"
+#include "ActiveAEFilter.h"
 #include "cores/AudioEngine/AEFactory.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPProcess.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
@@ -145,7 +146,9 @@ bool CActiveAEBufferPool::Create(unsigned int totaltime)
   return true;
 }
 
-//-----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------
+// Resample
+// ----------------------------------------------------------------------------------
 
 CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(AEAudioFormat inputFormat, AEAudioFormat outputFormat, AEQuality quality)
   : CActiveAEBufferPool(outputFormat)
@@ -180,7 +183,10 @@ CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(AEAudioFormat inputForm
 
 CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
 {
+  Flush();
+
   delete m_resampler;
+  
   if (m_useDSP)
     CServiceBroker::GetADSP().DestroyDSPs(m_streamId);
   if (m_dspBuffer)
@@ -672,4 +678,255 @@ void CActiveAEBufferPoolResample::SetDSPConfig(bool usedsp, bool bypassdsp)
 {
   m_useDSP = usedsp;
   m_bypassDSP = bypassdsp;
+}
+
+// ----------------------------------------------------------------------------------
+// Atempo
+// ----------------------------------------------------------------------------------
+
+CActiveAEBufferPoolAtempo::CActiveAEBufferPoolAtempo(AEAudioFormat format) : CActiveAEBufferPool(format)
+{
+  m_drain = false;
+  m_empty = true;
+  m_tempo = 1.0;
+  m_changeFilter = false;
+  m_procSample = nullptr;
+}
+
+CActiveAEBufferPoolAtempo::~CActiveAEBufferPoolAtempo()
+{
+  Flush();
+}
+
+bool CActiveAEBufferPoolAtempo::Create(unsigned int totaltime)
+{
+  CActiveAEBufferPool::Create(totaltime);
+
+  m_pTempoFilter.reset(new CActiveAEFilter());
+  m_pTempoFilter->Init(CAEUtil::GetAVSampleFormat(m_format.m_dataFormat), m_format.m_sampleRate, CAEUtil::GetAVChannelLayout(m_format.m_channelLayout));
+
+  return true;
+}
+
+void CActiveAEBufferPoolAtempo::ChangeFilter()
+{
+  m_pTempoFilter->SetTempo(m_tempo);
+  m_changeFilter = false;
+}
+
+bool CActiveAEBufferPoolAtempo::ProcessBuffers()
+{
+  bool busy = false;
+  CSampleBuffer *in;
+
+  if (!m_pTempoFilter->IsActive())
+  {
+    if (m_changeFilter)
+    {
+      if (m_changeFilter)
+        ChangeFilter();
+      return true;
+    }
+    while(!m_inputSamples.empty())
+    {
+      in = m_inputSamples.front();
+      m_inputSamples.pop_front();
+      m_outputSamples.push_back(in);
+      busy = true;
+    }
+  }
+  else if (m_procSample || !m_freeSamples.empty())
+  {
+    int free_samples;
+    if (m_procSample)
+      free_samples = m_procSample->pkt->max_nb_samples - m_procSample->pkt->nb_samples;
+    else
+      free_samples = m_format.m_frames;
+
+    bool skipInput = false;
+
+    // avoid that bufferscr grows too large
+    if (!m_pTempoFilter->NeedData())
+      skipInput = true;
+
+    bool hasInput = !m_inputSamples.empty();
+
+    if (hasInput || skipInput || m_drain || m_changeFilter)
+    {
+      if (!m_procSample)
+      {
+        m_procSample = GetFreeBuffer();
+      }
+
+      if (hasInput && !skipInput && !m_changeFilter)
+      {
+        in = m_inputSamples.front();
+        m_inputSamples.pop_front();
+      }
+      else
+        in = nullptr;
+
+      int start = m_procSample->pkt->nb_samples *
+                  m_procSample->pkt->bytes_per_sample *
+                  m_procSample->pkt->config.channels /
+                  m_procSample->pkt->planes;
+
+      for (int i=0; i<m_procSample->pkt->planes; i++)
+      {
+        m_planes[i] = m_procSample->pkt->data[i] + start;
+      }
+
+      int out_samples = m_pTempoFilter->ProcessFilter(m_planes,
+                                                      m_procSample->pkt->max_nb_samples - m_procSample->pkt->nb_samples,
+                                                      in ? in->pkt->data : nullptr,
+                                                      in ? in->pkt->nb_samples : 0,
+                                                      in ? in->pkt->linesize * in->pkt->planes : 0);
+
+      // in case of error, trigger re-create of filter
+      if (out_samples < 0)
+      {
+        out_samples = 0;
+        m_changeFilter = true;
+      }
+
+      m_procSample->pkt->nb_samples += out_samples;
+      busy = true;
+      m_empty = m_pTempoFilter->IsEof();
+
+      if (in)
+      {
+        if (in->timestamp)
+          m_lastSamplePts = in->timestamp;
+        else
+          in->pkt_start_offset = 0;
+
+        // pts of last sample we added to the buffer
+        m_lastSamplePts += (in->pkt->nb_samples-in->pkt_start_offset) * 1000 / m_format.m_sampleRate;
+      }
+
+      // calculate pts for last sample in m_procSample
+      int bufferedSamples = m_pTempoFilter->GetBufferedSamples();
+      m_procSample->pkt_start_offset = m_procSample->pkt->nb_samples;
+      m_procSample->timestamp = m_lastSamplePts - bufferedSamples * 1000 / m_format.m_sampleRate;
+
+      if ((m_drain || m_changeFilter) && m_empty)
+      {
+        if (m_fillPackets && m_procSample->pkt->nb_samples != 0)
+        {
+          // pad with zero
+          start = m_procSample->pkt->nb_samples *
+          m_procSample->pkt->bytes_per_sample *
+          m_procSample->pkt->config.channels /
+          m_procSample->pkt->planes;
+          for (int i=0; i<m_procSample->pkt->planes; i++)
+          {
+            memset(m_procSample->pkt->data[i]+start, 0, m_procSample->pkt->linesize-start);
+          }
+        }
+
+        // check if draining is finished
+        if (m_drain && m_procSample->pkt->nb_samples == 0)
+        {
+          m_procSample->Return();
+          busy = false;
+        }
+        else
+          m_outputSamples.push_back(m_procSample);
+
+        m_procSample = nullptr;
+
+        if (m_changeFilter)
+        {
+          ChangeFilter();
+        }
+      }
+      // some methods like encode require completely filled packets
+      else if (!m_fillPackets || (m_procSample->pkt->nb_samples == m_procSample->pkt->max_nb_samples))
+      {
+        m_outputSamples.push_back(m_procSample);
+        m_procSample = nullptr;
+      }
+
+      if (in)
+        in->Return();
+    }
+  }
+  return busy;
+}
+
+void CActiveAEBufferPoolAtempo::Flush()
+{
+  if (m_procSample)
+  {
+    m_procSample->Return();
+    m_procSample = nullptr;
+  }
+  while (!m_inputSamples.empty())
+  {
+    m_inputSamples.front()->Return();
+    m_inputSamples.pop_front();
+  }
+  while (!m_outputSamples.empty())
+  {
+    m_outputSamples.front()->Return();
+    m_outputSamples.pop_front();
+  }
+  if (m_pTempoFilter)
+    ChangeFilter();
+}
+
+float CActiveAEBufferPoolAtempo::GetDelay()
+{
+  float delay = 0;
+
+  if (m_procSample)
+    delay += (float)m_procSample->pkt->nb_samples / m_procSample->pkt->config.sample_rate;
+
+  for (auto &buf : m_inputSamples)
+  {
+    delay += (float)buf->pkt->nb_samples / buf->pkt->config.sample_rate;
+  }
+
+  for (auto &buf : m_outputSamples)
+  {
+    delay += (float)buf->pkt->nb_samples / buf->pkt->config.sample_rate;
+  }
+
+  if (m_pTempoFilter->IsActive())
+  {
+    int samples = m_pTempoFilter->GetBufferedSamples();
+    delay += (float)samples / m_format.m_sampleRate;
+  }
+
+  return delay;
+}
+
+void CActiveAEBufferPoolAtempo::SetTempo(float tempo)
+{
+  if (tempo > 2.0)
+    tempo = 2.0;
+  else if (tempo < 0.5)
+    tempo = 0.5;
+
+  if (tempo != m_tempo)
+    m_changeFilter = true;
+
+  m_tempo = tempo;
+}
+
+float CActiveAEBufferPoolAtempo::GetTempo()
+{
+  return m_tempo;
+}
+
+void CActiveAEBufferPoolAtempo::FillBuffer()
+{
+  m_fillPackets = true;
+}
+
+void CActiveAEBufferPoolAtempo::SetDrain(bool drain)
+{
+  m_drain = drain;
+  if (!m_drain)
+    m_changeFilter = true;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -23,6 +23,7 @@
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include <deque>
+#include <memory>
 
 extern "C" {
 #include "libavutil/avutil.h"
@@ -148,4 +149,35 @@ protected:
   bool m_bypassDSP;
 };
 
+class CActiveAEFilter;
+
+class CActiveAEBufferPoolAtempo : public CActiveAEBufferPool
+{
+public:
+  CActiveAEBufferPoolAtempo(AEAudioFormat format);
+  virtual ~CActiveAEBufferPoolAtempo();
+  bool Create(unsigned int totaltime) override;
+  bool ProcessBuffers();
+  float GetDelay();
+  void Flush();
+  void SetTempo(float tempo);
+  float GetTempo();
+  void FillBuffer();
+  void SetDrain(bool drain);
+  std::deque<CSampleBuffer*> m_inputSamples;
+  std::deque<CSampleBuffer*> m_outputSamples;
+
+protected:
+  void ChangeFilter();
+  std::unique_ptr<CActiveAEFilter> m_pTempoFilter;
+  uint8_t *m_planes[16];
+  CSampleBuffer *m_procSample;
+  bool m_empty;
+  bool m_drain;
+  bool m_changeFilter;
+  float m_tempo;
+  int64_t m_lastSamplePts;
+  bool m_fillPackets;
+};
+  
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -96,42 +96,56 @@ class CActiveAEBufferPoolResample : public CActiveAEBufferPool
 public:
   CActiveAEBufferPoolResample(AEAudioFormat inputFormat, AEAudioFormat outputFormat, AEQuality quality);
   virtual ~CActiveAEBufferPoolResample();
-  virtual bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true, bool useDSP = false);
+  bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true, bool useDSP = false);
   void SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
-  void ChangeResampler();
-  void ChangeAudioDSP();
   bool ResampleBuffers(int64_t timestamp = 0);
+  void ConfigureResampler(bool normalizelevels, bool dspenabled, bool stereoupmix, AEQuality quality);
   float GetDelay();
   void Flush();
+  void SetDrain(bool drain);
+  void SetRR(double rr);
+  double GetRR();
+  void FillBuffer();
+  bool DoesNormalize();
+  void ForceResampler(bool force);
+  void SetDSPConfig(bool usedsp, bool bypassdsp);
   AEAudioFormat m_inputFormat;
-  AEAudioFormat m_dspFormat;
   std::deque<CSampleBuffer*> m_inputSamples;
   std::deque<CSampleBuffer*> m_outputSamples;
+
+protected:
+  void ChangeResampler();
+
+  uint8_t *m_planes[16];
+  bool m_empty;
+  bool m_drain;
+  int m_Profile;
+  int64_t m_lastSamplePts;
+  bool m_remap;
   CSampleBuffer *m_procSample;
   IAEResample *m_resampler;
-  CSampleBuffer *m_dspSample;
-  CActiveAEBufferPool *m_dspBuffer;
-  CActiveAEDSPProcessPtr m_processor;
-  uint8_t *m_planes[16];
-  bool m_fillPackets;
-  bool m_drain;
-  bool m_empty;
-  bool m_useResampler;
-  bool m_useDSP;
-  bool m_bypassDSP;
-  bool m_changeResampler;
-  bool m_forceResampler;
-  bool m_changeDSP;
   double m_resampleRatio;
-  AEQuality m_resampleQuality;
+  bool m_fillPackets;
   bool m_stereoUpmix;
   bool m_normalize;
-  bool m_remap;
-  int64_t m_lastSamplePts;
+  bool m_useResampler;
+  bool m_changeResampler;
+  bool m_forceResampler;
+  AEQuality m_resampleQuality;
+
+  // ADSP
+  // TODO move away from resample buffers
+  void ChangeAudioDSP();
   unsigned int m_streamId;
   enum AVMatrixEncoding m_MatrixEncoding;
   enum AVAudioServiceType m_AudioServiceType;
-  int m_Profile;
+  CSampleBuffer *m_dspSample;
+  AEAudioFormat m_dspFormat;
+  CActiveAEDSPProcessPtr m_processor;
+  CActiveAEBufferPool *m_dspBuffer;
+  bool m_changeDSP;
+  bool m_useDSP;
+  bool m_bypassDSP;
 };
 
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -1,0 +1,332 @@
+/*
+ *      Copyright (C) 2010-2016 Team Kodi
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ActiveAEFilter.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include <algorithm>
+
+extern "C" {
+#include "libavfilter/avfilter.h"
+#include "libavfilter/buffersink.h"
+#include "libavfilter/buffersrc.h"
+#include "libswresample/swresample.h"
+}
+
+using namespace ActiveAE;
+
+CActiveAEFilter::CActiveAEFilter()
+{
+  m_pFilterGraph = nullptr;
+  m_pFilterCtxIn = nullptr;
+  m_pFilterCtxOut = nullptr;
+  m_pOutFrame = nullptr;
+  m_pConvertCtx = nullptr;
+  m_pConvertFrame = nullptr;
+  m_needConvert = false;
+}
+
+CActiveAEFilter::~CActiveAEFilter()
+{
+  CloseFilter();
+}
+
+void CActiveAEFilter::Init(AVSampleFormat fmt, int sampleRate, uint64_t channelLayout)
+{
+  m_sampleFormat = fmt;
+  m_sampleRate = sampleRate;
+  m_channelLayout = channelLayout;
+  m_tempo = 1.0;
+  m_bufferedSamples = 0;
+}
+
+bool CActiveAEFilter::SetTempo(float tempo)
+{
+  m_tempo = tempo;
+  if (m_tempo == 1.0)
+  {
+    CloseFilter();
+    return true;
+  }
+
+  if (!CreateFilterGraph())
+    return false;
+
+  if (!CreateAtempoFilter())
+  {
+    CloseFilter();
+    return false;
+  }
+
+  m_bufferedSamples = 0;
+  return true;
+}
+
+bool CActiveAEFilter::CreateFilterGraph()
+{
+  CloseFilter();
+
+  m_pFilterGraph = avfilter_graph_alloc();
+  if (!m_pFilterGraph)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateFilterGraph - unable to alloc filter graph");
+    return false;
+  }
+
+  AVFilter* srcFilter = avfilter_get_by_name("abuffer");
+  AVFilter* outFilter = avfilter_get_by_name("abuffersink");
+
+  std::string args = StringUtils::Format("time_base=1/%d:sample_rate=%d:sample_fmt=%s:channel_layout=0x%" PRIx64,
+                                         m_sampleRate,
+                                         m_sampleRate,
+                                         av_get_sample_fmt_name(m_sampleFormat),
+                                         m_channelLayout);
+
+  int ret = avfilter_graph_create_filter(&m_pFilterCtxIn, srcFilter, "in", args.c_str(), NULL, m_pFilterGraph);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateFilterGraph - avfilter_graph_create_filter: src");
+    return false;
+  }
+
+  ret = avfilter_graph_create_filter(&m_pFilterCtxOut, outFilter, "out", NULL, NULL, m_pFilterGraph);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateFilterGraph - avfilter_graph_create_filter: out");
+    return false;
+  }
+
+  m_pOutFrame = av_frame_alloc();
+
+  return true;
+}
+
+bool CActiveAEFilter::CreateAtempoFilter()
+{
+  AVFilter *atempo;
+
+  atempo = avfilter_get_by_name("atempo");
+  m_pFilterCtxAtempo = avfilter_graph_alloc_filter(m_pFilterGraph, atempo, "atempo");
+  std::string args =  StringUtils::Format("tempo=%f", m_tempo);
+  int ret = avfilter_init_str(m_pFilterCtxAtempo, args.c_str());
+
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateAtempoFilter - avfilter_init_str failed");
+    return false;
+  }
+
+  ret = avfilter_link(m_pFilterCtxIn, 0, m_pFilterCtxAtempo, 0);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateAtempoFilter - avfilter_link failed for in filter");
+    return false;
+  }
+
+  ret = avfilter_link(m_pFilterCtxAtempo, 0, m_pFilterCtxOut, 0);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateAtempoFilter - avfilter_link failed for out filter");
+    return false;
+  }
+
+  ret = avfilter_graph_config(m_pFilterGraph, NULL);
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CActiveAEFilter::CreateAtempoFilter - avfilter_graph_config failed");
+    return false;
+  }
+
+  m_needConvert = false;
+  if (m_pFilterCtxAtempo->outputs[0]->format != m_sampleFormat)
+  {
+    m_needConvert = true;
+    m_pConvertCtx = swr_alloc();
+    m_pConvertFrame = av_frame_alloc();
+  }
+
+  m_hasData = false;
+  m_needData = true;
+  m_filterEof = false;
+
+  return true;
+}
+
+void CActiveAEFilter::CloseFilter()
+{
+  if (m_pFilterGraph)
+  {
+    avfilter_graph_free(&m_pFilterGraph);
+
+    m_pFilterCtxIn = nullptr;
+    m_pFilterCtxOut = nullptr;
+  }
+
+  if (m_pOutFrame)
+    av_frame_free(&m_pOutFrame);
+
+  if (m_pConvertFrame)
+    av_frame_free(&m_pConvertFrame);
+
+  if (m_pConvertCtx)
+    swr_free(&m_pConvertCtx);
+
+  m_bufferedSamples = 0;
+}
+
+int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, int src_bufsize)
+{
+  int result;
+
+  if (src_samples)
+  {
+    m_bufferedSamples += src_samples;
+
+    AVFrame *frame = av_frame_alloc();
+    if (!frame)
+      return -1;
+
+    int channels = av_get_channel_layout_nb_channels(m_channelLayout);
+
+    av_frame_set_channel_layout(frame, m_channelLayout);
+    av_frame_set_channels(frame, channels);
+    av_frame_set_sample_rate(frame, m_sampleRate);
+    frame->nb_samples = src_samples;
+    frame->format = m_sampleFormat;
+
+    result = avcodec_fill_audio_frame(frame, channels, m_sampleFormat,
+                             src_buffer[0], src_bufsize, 16);
+    if (result < 0)
+    {
+      CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - avcodec_fill_audio_frame failed");
+      return -1;
+    }
+
+    result = av_buffersrc_write_frame(m_pFilterCtxIn, frame);
+    av_frame_free(&frame);
+    if (result < 0)
+    {
+      CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - av_buffersrc_add_frame failed");
+      return -1;
+    }
+  }
+  else if (!m_filterEof && m_needData)
+  {
+    result = av_buffersrc_write_frame(m_pFilterCtxIn, nullptr);
+    if (result < 0)
+    {
+      CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - av_buffersrc_add_frame");
+      return -1;
+    }
+  }
+
+  if (!m_hasData)
+  {
+    m_needData = false;
+    AVFrame *outFrame = m_needConvert ? m_pConvertFrame : m_pOutFrame;
+
+    result = av_buffersink_get_frame(m_pFilterCtxOut, outFrame);
+
+    if (result  == AVERROR(EAGAIN))
+    {
+      m_needData = true;
+      return 0;
+    }
+    else if (result == AVERROR_EOF)
+    {
+      result = av_buffersink_get_frame(m_pFilterCtxOut, outFrame);
+      m_filterEof = true;
+      if (result < 0)
+        return 0;
+    }
+    else if (result < 0)
+    {
+      CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - av_buffersink_get_frame");
+      return -1;
+    }
+
+    if (m_needConvert)
+    {
+      av_frame_unref(m_pOutFrame);
+      m_pOutFrame->format = m_sampleFormat;
+      av_frame_set_channel_layout(m_pOutFrame, m_channelLayout);
+      av_frame_set_sample_rate(m_pOutFrame, m_sampleRate);
+      result = swr_convert_frame(m_pConvertCtx, m_pOutFrame, m_pConvertFrame);
+      if (result < 0)
+      {
+        CLog::Log(LOGERROR, "CActiveAEFilter::ProcessFilter - swr_convert_frame failed");
+        return -1;
+      }
+    }
+
+    m_hasData = true;
+    m_sampleOffset = 0;
+  }
+
+  if (m_hasData)
+  {
+    int channels = av_get_channel_layout_nb_channels(m_channelLayout);
+    int planes = av_sample_fmt_is_planar(m_sampleFormat) ? channels : 1;
+    int samples = std::min(dst_samples, m_pOutFrame->nb_samples - m_sampleOffset);
+    int bytes = samples * av_get_bytes_per_sample(m_sampleFormat) * channels / planes;
+    int bytesOffset = m_sampleOffset * av_get_bytes_per_sample(m_sampleFormat) * channels / planes;
+    for (int i=0; i<planes; i++)
+    {
+      memcpy(dst_buffer[i], m_pOutFrame->extended_data[i] + bytesOffset, bytes);
+    }
+    m_sampleOffset += samples;
+
+    if (m_sampleOffset >= m_pOutFrame->nb_samples)
+    {
+      av_frame_unref(m_pOutFrame);
+      m_hasData = false;
+    }
+
+    m_bufferedSamples -= samples * m_tempo;
+    if (m_bufferedSamples < 0)
+      m_bufferedSamples = 0;
+    return samples;
+  }
+
+  return 0;
+}
+
+bool CActiveAEFilter::IsEof()
+{
+  return m_filterEof;
+}
+
+bool CActiveAEFilter::NeedData()
+{
+  return m_needData;
+}
+
+bool CActiveAEFilter::IsActive()
+{
+  if (m_pFilterGraph)
+    return true;
+  else
+    return false;
+}
+
+int CActiveAEFilter::GetBufferedSamples()
+{
+  return m_bufferedSamples;
+}

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.h
@@ -1,0 +1,69 @@
+#pragma once
+/*
+ *      Copyright (C) 2010-2016 Team Kodi
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C" {
+#include "libavfilter/avfilter.h"
+#include "libavutil/frame.h"
+}
+
+struct SwrContext;
+
+namespace ActiveAE
+{
+
+class CActiveAEFilter
+{
+public:
+  CActiveAEFilter();
+  virtual ~CActiveAEFilter();
+  void Init(AVSampleFormat fmt, int sampleRate, uint64_t channelLayout);
+  int ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_t **src_buffer, int src_samples, int src_bufsize);
+  bool SetTempo(float tempo);
+  bool NeedData();
+  bool IsEof();
+  bool IsActive();
+  int GetBufferedSamples();
+  
+protected:
+  bool CreateFilterGraph();
+  bool CreateAtempoFilter();
+  void CloseFilter();
+
+  AVSampleFormat m_sampleFormat;
+  int m_sampleRate;
+  uint64_t m_channelLayout;
+  AVFilterGraph* m_pFilterGraph;
+  AVFilterContext* m_pFilterCtxIn;
+  AVFilterContext* m_pFilterCtxOut;
+  AVFilterContext* m_pFilterCtxAtempo;
+  AVFrame* m_pOutFrame;
+  SwrContext* m_pConvertCtx;
+  AVFrame* m_pConvertFrame;
+  bool m_needConvert;
+  float m_tempo;
+  bool m_filterEof;
+  bool m_hasData;
+  bool m_needData;
+  int m_sampleOffset;
+  int m_bufferedSamples;
+};
+
+}

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
@@ -58,6 +58,7 @@ protected:
   int m_src_dither_bits, m_dst_dither_bits;
   SwrContext *m_pContext;
   double m_rematrix[AE_CH_MAX][AE_CH_MAX];
+  double m_resampleRatio;
 };
 
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -70,6 +70,7 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat *format, unsigned int streamid)
   m_lastPts = 0;
   m_lastPtsJump = 0;
   m_errorInterval = 1000;
+  m_clockSpeed = 1.0;
 }
 
 CActiveAEStream::~CActiveAEStream()
@@ -213,7 +214,12 @@ double CActiveAEStream::CalcResampleRatio(double error)
 
   double clockspeed = 1.0;
   if (m_pClock)
+  {
     clockspeed = m_pClock->GetClockSpeed();
+    if (m_clockSpeed != clockspeed)
+      m_resampleIntegral = 0;
+    m_clockSpeed = clockspeed;
+  }
 
   double ret = 1.0 / clockspeed + proportional + m_resampleIntegral;
   //CLog::Log(LOGNOTICE,"----- error: %f, rr: %f, prop: %f, int: %f",

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -89,6 +89,35 @@ protected:
   XbmcThreads::EndTime m_timer;
 };
 
+class CActiveAEStreamBuffers
+{
+public:
+  CActiveAEStreamBuffers(AEAudioFormat inputFormat, AEAudioFormat outputFormat, AEQuality quality);
+  virtual ~CActiveAEStreamBuffers();
+  bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true, bool useDSP = false);
+  void SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
+  bool ProcessBuffers();
+  void ConfigureResampler(bool normalizelevels, bool dspenabled, bool stereoupmix, AEQuality quality);
+  bool HasInputLevel(int level);
+  float GetDelay();
+  void Flush();
+  void SetDrain(bool drain);
+  bool IsDrained();
+  void SetRR(double rr);
+  double GetRR();
+  void FillBuffer();
+  bool DoesNormalize();
+  void ForceResampler(bool force);
+  void SetDSPConfig(bool usedsp, bool bypassdsp);
+  bool HasWork();
+  CActiveAEBufferPool *GetResampleBuffers();
+  AEAudioFormat m_inputFormat;
+  std::deque<CSampleBuffer*> m_outputSamples;
+  std::deque<CSampleBuffer*> m_inputSamples;
+
+protected:
+  CActiveAEBufferPoolResample *m_resampleBuffers;
+};
 
 class CActiveAEStream : public IAEStream
 {
@@ -176,7 +205,7 @@ protected:
 
   // only accessed by engine
   CActiveAEBufferPool *m_inputBuffers;
-  CActiveAEBufferPoolResample *m_resampleBuffers;
+  CActiveAEStreamBuffers *m_processingBuffers;
   std::deque<CSampleBuffer*> m_processingSamples;
   CActiveAEDataProtocol *m_streamPort;
   CEvent m_inMsgEvent;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -111,12 +111,15 @@ public:
   void SetDSPConfig(bool usedsp, bool bypassdsp);
   bool HasWork();
   CActiveAEBufferPool *GetResampleBuffers();
+  CActiveAEBufferPool *GetAtempoBuffers();
+  
   AEAudioFormat m_inputFormat;
   std::deque<CSampleBuffer*> m_outputSamples;
   std::deque<CSampleBuffer*> m_inputSamples;
 
 protected:
   CActiveAEBufferPoolResample *m_resampleBuffers;
+  CActiveAEBufferPoolAtempo *m_atempoBuffers;
 };
 
 class CActiveAEStream : public IAEStream

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -227,6 +227,7 @@ protected:
   int m_profile;
   int m_resampleMode;
   double m_resampleIntegral;
+  double m_clockSpeed;
   enum AVMatrixEncoding m_matrixEncoding;
   enum AVAudioServiceType m_audioServiceType;
   bool m_forceResampler;

--- a/xbmc/cores/AudioEngine/Makefile.in
+++ b/xbmc/cores/AudioEngine/Makefile.in
@@ -34,6 +34,7 @@ SRCS += Engines/ActiveAE/ActiveAESound.cpp
 SRCS += Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
 SRCS += Engines/ActiveAE/ActiveAEResamplePi.cpp
 SRCS += Engines/ActiveAE/ActiveAEBuffer.cpp
+SRCS += Engines/ActiveAE/ActiveAEFilter.cpp
 
 ifeq (@USE_ANDROID@,1)
 SRCS += Sinks/AESinkAUDIOTRACK.cpp

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -297,6 +297,8 @@ double CDVDClock::SystemToPlaying(int64_t system)
 
 double CDVDClock::GetClockSpeed()
 {
+  CSingleLock lock(m_critSection);
+
   double speed = (double)m_systemFrequency / m_systemUsed;
-  return m_videoRefClock->GetSpeed() * speed;
+  return m_videoRefClock->GetSpeed() * speed + m_speedAdjust;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1941,7 +1941,7 @@ void CVideoPlayer::HandlePlaySpeed()
         {
           double adjust = -1.0; // a unique value
           if (m_clock.GetSpeedAdjust() >= 0 && m_VideoPlayerAudio->GetLevel() < 5)
-            adjust = -0.01;
+            adjust = -0.05;
 
           if (m_clock.GetSpeedAdjust() < 0 && m_VideoPlayerAudio->GetLevel() > 10)
             adjust = 0.0;


### PR DESCRIPTION
This adds long desired atempo filter to AE. This filter allows audio going at different speed without changing pitch (chipmunk voices)

This is in particular important for live streams. In order to prevent buffers from running dry VideoPlayer slows down clock speed. Currently that does not work very well. A change of 2% already results in noticeable change of pitch and audio may still stall because the change is not big enough.
