### PR TITLE
AESinkPULSE: Align m_frames to 32

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -672,6 +672,9 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     process_time = latency / 4;
   }
 
+  // align process time mod 128 which will result in mod 32 m_frames for AE_FMT_FLOAT
+  process_time = ((process_time + 0x7F) >> 7) << 7;
+
   pa_buffer_attr buffer_attr;
   buffer_attr.fragsize = latency;
   buffer_attr.maxlength = (uint32_t) -1;


### PR DESCRIPTION
Still thinking about a proper solution to directly hit the unterlaying ALSA device.
