### PR TITLE
VAAPI: Use VAAPI's BOB implementation by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1682,7 +1682,7 @@ if test "x$use_vaapi" != "xno"; then
   else
     initial_val=$use_vaapi
     if test "x$use_vaapi" != "xno"; then
-      PKG_CHECK_MODULES([LIBVA], [libva libva-x11],
+      PKG_CHECK_MODULES([LIBVA], [libva >= 0.38 libva-x11 >= 0.38],
         [INCLUDES="$INCLUDES $LIBVA_CFLAGS"; LIBS="$LIBS $LIBVA_LIBS"; USE_VAAPI=1;
          AC_DEFINE([HAVE_LIBVA], [1], [Define to 1 if you have the 'vaapi' libraries])],
         [use_vaapi="no"; USE_VAAPI=0; AC_MSG_RESULT($vaapi_not_found)])

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1020,7 +1020,7 @@ bool CDecoder::Supports(EINTERLACEMETHOD method)
 
 EINTERLACEMETHOD CDecoder::AutoInterlaceMethod()
 {
-  return VS_INTERLACEMETHOD_RENDER_BOB;
+  return VS_INTERLACEMETHOD_VAAPI_BOB;
 }
 
 bool CDecoder::ConfigVAAPI()
@@ -2000,13 +2000,13 @@ void COutput::InitCycle()
         method == VS_INTERLACEMETHOD_RENDER_BOB)
     {
       if (method == VS_INTERLACEMETHOD_AUTO)
-        method = VS_INTERLACEMETHOD_RENDER_BOB;
+        method = VS_INTERLACEMETHOD_VAAPI_BOB;
     }
     else
     {
       if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-        CLog::Log(LOGDEBUG,"VAAPI - deinterlace method not supported, falling back to BOB");
-      method = VS_INTERLACEMETHOD_RENDER_BOB;
+        CLog::Log(LOGDEBUG,"VAAPI - deinterlace method not supported, falling back to VAAPI's BOB implementation");
+      method = VS_INTERLACEMETHOD_VAAPI_BOB;
     }
 
     if (m_pp && (method != m_currentDiMethod || !m_pp->Compatible(method)))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -45,10 +45,7 @@ extern "C" {
 #include "libavfilter/buffersrc.h"
 }
 
-#if VA_CHECK_VERSION(0,34,0)
 #include <va/va_vpp.h>
-#define HAVE_VPP 1
-#endif
 
 using namespace VAAPI;
 #define NUM_RENDER_PICS 7
@@ -559,7 +556,6 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
       }
       break;
     }
-#if VA_CHECK_VERSION(0,38,0)
     case AV_CODEC_ID_HEVC:
     {
       profile = VAProfileHEVCMain;
@@ -567,7 +563,6 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
         return false;
       break;
     }
-#endif
 #if VA_CHECK_VERSION(0,38,1)
     case AV_CODEC_ID_VP9:
     {
@@ -2568,10 +2563,6 @@ CVppPostproc::~CVppPostproc()
 
 bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
 {
-#if !defined(HAVE_VPP)
-  return false;
-#else
-
   m_config = config;
 
   // create config
@@ -2677,16 +2668,11 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
       }
     }
   }
-#endif
   return true;
 }
 
 bool CVppPostproc::Init(EINTERLACEMETHOD method)
 {
-#if !defined(HAVE_VPP)
-  return false;
-#else
-
   m_vppMethod = method;
 
   VAProcDeinterlacingType vppMethod = VAProcDeinterlacingNone;
@@ -2739,7 +2725,6 @@ bool CVppPostproc::Init(EINTERLACEMETHOD method)
   m_forwardRefs = pplCaps.num_forward_references;
   m_backwardRefs = pplCaps.num_backward_references;
 
-#endif
   return true;
 }
 
@@ -2790,10 +2775,6 @@ bool CVppPostproc::AddPicture(CVaapiDecodedPicture &pic)
 
 bool CVppPostproc::Filter(CVaapiProcessedPicture &outPic)
 {
-#if !defined(HAVE_VPP)
-  return false;
-#else
-
   if (m_step>1)
   {
     Advance();
@@ -2983,7 +2964,6 @@ bool CVppPostproc::Filter(CVaapiProcessedPicture &outPic)
                             DVP_FLAG_REPEAT_TOP_FIELD |
                             DVP_FLAG_INTERLACED);
 
-#endif
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -2048,7 +2048,7 @@ void COutput::InitCycle()
         else if (method == VS_INTERLACEMETHOD_VAAPI_MADI)
           m_config.processInfo->SetVideoDeintMethod("vaapi-madi");
         else if (method == VS_INTERLACEMETHOD_VAAPI_MACI)
-          m_config.processInfo->SetVideoDeintMethod("vaapi-maci");
+          m_config.processInfo->SetVideoDeintMethod("vaapi-mcdi");
       }
       else
       {


### PR DESCRIPTION
In 2016 most of our linux intel users that use VAAPI are running SNB or higher. Those chips support VPP and especially VAAPI-BOB method.

VAAPI-BOB is the lowest hw consuming method. 

This fixes high CPU load with new braswell chips which have a nice GPU but a very slow CPU. The old method copied the decoded surfaces via SSE4 intrinsics back to systemmemory and deinterlaced by rendering bobbing here.

We currently think to drop this SSE4 copy method as VAAPI supports good enough deinterlacers on high end hardware anyways, which makes Yadif on the CPU obsolete.

This render BOB btw. could also be implemented by using the EGL path if needed.
