### PR TITLE
[SpecialProtocol] Fix crash caused by envhome on Windows

### DIFF
--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -253,7 +253,9 @@ void CSpecialProtocol::LogPaths()
   CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetPath("xbmc").c_str());
   CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetPath("xbmcbin").c_str());
   CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetPath("masterprofile").c_str());
+#if defined(TARGET_POSIX)
   CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
+#endif
   CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetPath("home").c_str());
   CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetPath("temp").c_str());
   CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetPath("logpath").c_str());


### PR DESCRIPTION
The path envhome is only set when TARGET_POSIX is defined. On windows this prevents Kodi from starting. Aborts in GetPath due to missing map entry.

Bug was introduced by: https://github.com/xbmc/xbmc/commit/3e2d04ffb4e52118825a1d774e9a03b4d3d8f237
