### PR TITLE
[cmake/linux] Require at least PulseAudio 2.0

### DIFF
--- a/project/cmake/modules/FindPulseAudio.cmake
+++ b/project/cmake/modules/FindPulseAudio.cmake
@@ -1,72 +1,49 @@
-# Try to find the PulseAudio library
+#.rst:
+# FindPulseAudio
+# --------------
+# Finds the PulseAudio library
 #
-# Once done this will define:
+# This will define the following variables::
 #
 #  PULSEAUDIO_FOUND - system has the PulseAudio library
-#  PULSEAUDIO_INCLUDE_DIR - the PulseAudio include directory
-#  PULSEAUDIO_LIBRARY - the libraries needed to use PulseAudio
-#  PULSEAUDIO_MAINLOOP_LIBRARY - the libraries needed to use PulsAudio Mailoop
-#
-# Copyright (c) 2008, Matthias Kretz, <kretz@kde.org>
-# Copyright (c) 2009, Marcus Hufgard, <Marcus.Hufgard@hufgard.de>
-#
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#  PULSEAUDIO_INCLUDE_DIRS - the PulseAudio include directory
+#  PULSEAUDIO_LIBRARIES - the libraries needed to use PulseAudio
 
-if(NOT PULSEAUDIO_MINIMUM_VERSION)
-  set(PULSEAUDIO_MINIMUM_VERSION "1.0.0")
+if(NOT PULSEAUDIO_FIND_VERSION)
+  set(PULSEAUDIO_FIND_VERSION 2.0.0)
 endif()
 
-if(PULSEAUDIO_INCLUDE_DIRS AND PULSEAUDIO_LIBRARY AND PULSEAUDIO_MAINLOOP_LIBRARY)
-   # Already in cache, be silent
-   set(PULSEAUDIO_FIND_QUIETLY TRUE)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_PULSEAUDIO libpulse>=${PULSEAUDIO_FIND_VERSION})
+  pkg_check_modules(PC_PULSEAUDIO_MAINLOOP libpulse-mainloop-glib)
 endif()
 
-if(NOT WIN32)
-   include(FindPkgConfig)
-   pkg_check_modules(PC_PULSEAUDIO libpulse>=${PULSEAUDIO_MINIMUM_VERSION})
-   pkg_check_modules(PC_PULSEAUDIO_MAINLOOP libpulse-mainloop-glib)
-endif()
-
-find_path(PULSEAUDIO_INCLUDE_DIRS pulse/pulseaudio.h
-   HINTS
-   ${PC_PULSEAUDIO_INCLUDEDIR}
-   ${PC_PULSEAUDIO_INCLUDE_DIRS}
-   )
+find_path(PULSEAUDIO_INCLUDE_DIR NAMES pulse/pulseaudio.h
+                                 PATHS ${PC_PULSEAUDIO_INCLUDEDIR} ${PC_PULSEAUDIO_INCLUDE_DIRS})
 
 find_library(PULSEAUDIO_LIBRARY NAMES pulse libpulse
-   HINTS
-   ${PC_PULSEAUDIO_LIBDIR}
-   ${PC_PULSEAUDIO_LIBRARY_DIRS}
-   )
+                                PATHS ${PC_PULSEAUDIO_LIBDIR} ${PC_PULSEAUDIO_LIBRARY_DIRS})
 
 find_library(PULSEAUDIO_MAINLOOP_LIBRARY NAMES pulse-mainloop pulse-mainloop-glib libpulse-mainloop-glib
-   HINTS
-   ${PC_PULSEAUDIO_LIBDIR}
-   ${PC_PULSEAUDIO_LIBRARY_DIRS}
-   )
+                                         PATHS ${PC_PULSEAUDIO_LIBDIR} ${PC_PULSEAUDIO_LIBRARY_DIRS})
 
-if(NOT PULSEAUDIO_INCLUDE_DIRS OR NOT PULSEAUDIO_LIBRARY)
-  set(PULSEAUDIO_FOUND FALSE)
-else()
-  set(PULSEAUDIO_FOUND TRUE)
+if(PC_PULSEAUDIO_VERSION)
+  set(PULSEAUDIO_VERSION_STRING ${PC_PULSEAUDIO_VERSION})
+elseif(PULSEAUDIO_INCLUDE_DIR AND EXISTS "${PULSEAUDIO_INCLUDE_DIR}/pulse/version.h")
+  file(STRINGS "${PULSEAUDIO_INCLUDE_DIR}/pulse/version.h" pulseaudio_version_str REGEX "^#define[\t ]+pa_get_headers_version\\(\\)[\t ]+\\(\".*\"\\).*")
+  string(REGEX REPLACE "^#define[\t ]+pa_get_headers_version\\(\\)[\t ]+\\(\"([^\"]+)\"\\).*" "\\1" PULSEAUDIO_VERSION_STRING "${pulseaudio_version_str}")
+  unset(pulseaudio_version_str)
 endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PULSEAUDIO
+                                  REQUIRED_VARS PULSEAUDIO_LIBRARY PULSEAUDIO_MAINLOOP_LIBRARY PULSEAUDIO_INCLUDE_DIR
+                                  VERSION_VAR PULSEAUDIO_VERSION_STRING)
 
 if(PULSEAUDIO_FOUND)
-   if(NOT PULSEAUDIO_FIND_QUIETLY)
-      message(STATUS "Found PulseAudio: ${PULSEAUDIO_LIBRARY}")
-      if(PULSEAUDIO_MAINLOOP_LIBRARY)
-          message(STATUS "Found PulseAudio Mainloop: ${PULSEAUDIO_MAINLOOP_LIBRARY}")
-      else()
-          message(STATUS "Could NOT find PulseAudio Mainloop Library")
-      endif()
-   endif()
-else()
-   message(STATUS "Could NOT find PulseAudio")
+  set(PULSEAUDIO_INCLUDE_DIRS ${PULSEAUDIO_INCLUDE_DIR})
+  set(PULSEAUDIO_LIBRARIES ${PULSEAUDIO_LIBRARY} ${PULSEAUDIO_MAINLOOP_LIBRARY})
+  set(PULSEAUDIO_DEFINITIONS -DHAVE_LIBPULSE=1)
 endif()
 
-set(PULSEAUDIO_LIBRARIES ${PULSEAUDIO_LIBRARY})
-
-list(APPEND PULSEAUDIO_DEFINITIONS -DHAVE_LIBPULSE=1)
-
-mark_as_advanced(PULSEAUDIO_INCLUDE_DIRS PULSEAUDIO_LIBRARIES PULSEAUDIO_LIBRARY PULSEAUDIO_MAINLOOP_LIBRARY)
+mark_as_advanced(PULSEAUDIO_INCLUDE_DIR PULSEAUDIO_LIBRARY PULSEAUDIO_MAINLOOP_LIBRARY)


### PR DESCRIPTION
PA was bumped to at least 2.0 in be64a578961398229ec44879afa252c9648a2f59.

Failed build: http://jenkins.kodi.tv/job/LINUX-64/8476/console
New build triggered: http://jenkins.kodi.tv/job/LINUX-64/8477/console

ping: @fritsch 
