### PR TITLE
[PVR][json-rpc] Fix PVR.AddTimer for timer rules.

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -817,14 +817,30 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
     timerType = CPVRTimerType::CreateFromAttributes(
       PVR_TIMER_TYPE_IS_REPEATING,
       PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES, channel->ClientID());
+
+    if (timerType)
+    {
+      if (timerType->SupportsEpgTitleMatch())
+        newTag->m_strEpgSearchString = newTag->m_strTitle;
+
+      if (timerType->SupportsWeekdays())
+        newTag->m_iWeekdays = PVR_WEEKDAY_ALLDAYS;
+
+      if (timerType->SupportsStartAnyTime())
+        newTag->m_bStartAnyTime = true;
+
+      if (timerType->SupportsEndAnyTime())
+        newTag->m_bEndAnyTime = true;
+    }
   }
-  if (!timerType)
+  else
   {
     // create one-shot epg-based timer
     timerType = CPVRTimerType::CreateFromAttributes(
       PVR_TIMER_TYPE_ATTRIBUTE_NONE,
       PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES, channel->ClientID());
   }
+
   if (!timerType)
   {
     CLog::Log(LOGERROR, "%s - unable to create any epg-based timer type", __FUNCTION__);


### PR DESCRIPTION
This fixes the issue mentioned here: https://github.com/xbmc/xbmc/pull/10074#issuecomment-235228038

Now, if timerrule= true is set for PVR.AddTimer, a EPG-event-based timer rule will be created. channel and epg search string are taken from the epg event, start any time and end any time will be set to true, weekdays will be set to any day.

@joethefox can you test this, please?
