### PR TITLE
[cleanup] remove unused leftovers from settings removals

### DIFF
--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -7,7 +7,7 @@
           <visible>false</visible>
         </setting>
       </group>
-      <group id="4">
+      <group id="3">
         <setting id="videoplayer.hqscalers">
           <visible>false</visible>
         </setting>

--- a/system/settings/imx6.xml
+++ b/system/settings/imx6.xml
@@ -2,7 +2,7 @@
 <settings>
   <section id="player">
     <category id="videoplayer">
-      <group id="4">
+      <group id="3">
         <setting id="videoplayer.limitguiupdate" type="integer" label="38013" help="38014">
           <level>2</level>
           <default>10</default>

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -2,7 +2,7 @@
 <settings>
   <section id="player">
     <category id="videoplayer">
-      <group id="4">
+      <group id="3">
         <setting id="videoplayer.rendermethod">
           <visible>false</visible>
         </setting>

--- a/system/settings/rbp2.xml
+++ b/system/settings/rbp2.xml
@@ -2,7 +2,7 @@
 <settings>
   <section id="player">
     <category id="videoplayer">
-      <group id="4">
+      <group id="3">
         <setting id="videoplayer.useomxplayer">
           <default>false</default>
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -78,18 +78,7 @@
           <control type="list" format="string" />
         </setting>
       </group>
-      <group id="3">
-        <requirement>
-          <and>
-            <or>
-              <condition>HAS_GL</condition>
-              <condition>HAS_GLESv2</condition>
-            </or>
-            <condition>HAVE_LIBVDPAU</condition>
-          </and>
-        </requirement>
-      </group>
-      <group id="4" label="14231">
+      <group id="3" label="14231">
         <setting id="videoplayer.rendermethod" type="integer" label="13415" help="36153">
           <level>2</level>
           <default>0</default> <!-- RENDER_METHOD_AUTO -->
@@ -335,7 +324,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="5" label="14232">
+      <group id="4" label="14232">
         <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">
           <level>2</level>
           <default>0</default>
@@ -355,7 +344,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="6" label="14233">
+      <group id="5" label="14233">
         <setting id="videoplayer.teletextenabled" type="boolean" label="23050" help="36174">
           <level>3</level>
           <default>true</default>


### PR DESCRIPTION
This removes leftovers from https://github.com/xbmc/xbmc/pull/6392 by @FernetMenta 

These were copied and pasted into the new layout as when I first started on the settings refactor I wasn't confident to remove this and didn't want to break anything. I now feel I have enough understanding that it would seem to me that these requirements now make no sense, as they are unused with no settings within this `<group>`, since `<requirements>` specified within a `<group>` only apply to that `<group>`.

FernetMenta can you confirm I'm correct and that this is safe to remove.
