### PR TITLE
Remove all long-press actions from remote.xml

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -27,7 +27,6 @@
   <global>
     <remote>
       <play>PlayPause</play>
-      <play mod="longpress">Info</play>
       <pause>Pause</pause>
       <stop>Stop</stop>
       <forward>FastForward</forward>
@@ -37,14 +36,11 @@
       <up>Up</up>
       <down>Down</down>
       <select>Select</select>
-      <select mod="longpress">ContextMenu</select>
       <enter>FullScreen</enter> 
       <pageplus>PageUp</pageplus>
       <pageminus>PageDown</pageminus>
       <back>Back</back>
-      <back mod="longpress">ActivateWindow(Home)</back>
       <menu>ContextMenu</menu>
-      <menu mod="longpress">Menu</menu>
       <contentsmenu>PreviousMenu</contentsmenu>
       <rootmenu>PreviousMenu</rootmenu>
       <title>ContextMenu</title>
@@ -90,7 +86,6 @@
       <info>ActivateWindow(SystemInfo)</info>
       <clear>ActivateWindow(Weather)</clear>
       <hash>ActivateWindow(Settings)</hash>
-      <back mod="longpress">ActivateWindow(ShutdownMenu)</back>
     </remote>
   </Home>
   <MyTVRecordings>
@@ -135,7 +130,6 @@
       <zero>Highlight</zero>
       <star>Move</star>
       <hash>Rename</hash>
-      <play mod="longpress">Highlight</play>
     </remote>
   </FileManager>
   <MyMusicPlaylist>
@@ -176,18 +170,12 @@
       <right>StepForward</right>
       <up>ChapterOrBigStepForward</up>
       <down>ChapterOrBigStepBack</down>
-      <left mod="longpress">Rewind</left>
-      <right mod="longpress">FastForward</right>
-      <up mod="longpress">AudioNextLanguage</up>
-      <down mod="longpress">NextSubtitle</down>
       <back>Back</back>
-      <back mod="longpress">Stop</back>
       <menu>OSD</menu>
       <contentsmenu>OSD</contentsmenu>
       <rootmenu>OSD</rootmenu>
       <start>OSD</start>
       <select>OSD</select>
-      <select mod="longpress">PlayPause</select>
       <title>CodecInfo</title>
       <info>Info</info>
       <guide>ActivateWindow(PVROSDGuide)</guide>
@@ -229,15 +217,11 @@
       <right>StepForward</right>
       <up>SkipNext</up>
       <down>SkipPrevious</down>
-      <left mod="longpress">Rewind</left>
-      <right mod="longpress">FastForward</right>
       <pageplus>IncreaseRating</pageplus>
       <pageminus>DecreaseRating</pageminus>
       <back>Back</back>
-      <back mod="longpress">Stop</back>
       <title>CodecInfo</title>
       <select>OSD</select>
-      <select mod="longpress">PlayPause</select>
       <menu>OSD</menu>
       <contentsmenu>OSD</contentsmenu>
       <rootmenu>OSD</rootmenu>
@@ -381,7 +365,6 @@
       <enter>Enter</enter>
       <pageminus>CursorLeft</pageminus>
       <pageplus>CursorRight</pageplus>
-      <play mod="longpress">Enter</play>
     </remote>
   </VirtualKeyboard>
   <ContextMenu>


### PR DESCRIPTION
It appears that long-press does not behave well with input devices that use remote.xml (MCE, non-android CEC, etc). This removes those actions for now.
