### PR TITLE
[macos] change title bar to "Kodi Media Center"

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -686,7 +686,7 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   // set the window title
   NSMutableString *string;
   string = [NSMutableString stringWithUTF8String:CCompileInfo::GetAppName()];
-  [string appendString:@" Entertainment Center" ];
+  [string appendString:@" Media Center" ];
   [ [ [new_context view] window] setTitle:string ];
 
   m_glContext = new_context;


### PR DESCRIPTION
Currently the title bar on macOS says `Kodi Entertainment Center`. 
