### PR TITLE
[cmake/win32] Mirror system/python/* into the build-tree

### DIFF
--- a/project/cmake/installdata/windows/python.txt
+++ b/project/cmake/installdata/windows/python.txt
@@ -1,0 +1,1 @@
+system/python/*


### PR DESCRIPTION
system/python is needed in order to launch from build dir.
