### PR TITLE
Pictures: fix segfault on archive

### DIFF
--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -107,7 +107,10 @@ void CPictureInfoTag::Archive(CArchive& ar)
     ar << m_exifInfo.ThumbnailSizeOffset;
     ar << m_exifInfo.Whitebalance;
     ar << m_exifInfo.Width;
-    ar << m_dateTimeTaken;
+
+    // m_dateTimeTaken is private and we can't pass a ref to a private object
+    CDateTime tmp(m_dateTimeTaken);
+    ar << tmp;
 
     ar << std::string(m_iptcInfo.Author);
     ar << std::string(m_iptcInfo.Byline);


### PR DESCRIPTION
First time picture view was opened triggered a crash on my Mac. The archive method passed a ref to a private object that was not accessible by CArchive function.
