### PR TITLE
[settings] restore input devices to system, and move json-rpc app set…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7326,7 +7326,7 @@ msgid "Security"
 msgstr ""
 
 msgctxt "#14094"
-msgid "Input devices"
+msgid "Devices"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -8136,6 +8136,7 @@ msgstr ""
 
 #. Audio DSP process chain indication
 #: xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+#: system/settings/settings.xml
 msgctxt "#15087"
 msgid "Input"
 msgstr ""
@@ -17583,10 +17584,10 @@ msgctxt "#36326"
 msgid "Enable the UPnP control point. This allows you to stream media to any UPnP client and control it's playback."
 msgstr ""
 
-#. Description of settings category with label #20187 "Webserver"
+#. Description of settings category with label #20187 "Control"
 #: system/settings/settings.xml
 msgctxt "#36327"
-msgid "This category contains the settings for how the web server service is handled."
+msgid "This category contains the settings for how the web server service and the application control service is handled."
 msgstr ""
 
 #. Description of setting with label #263 "Allow remote control via HTTP"
@@ -17859,7 +17860,7 @@ msgctxt "#36373"
 msgid "Configure how interface sounds are handled, such as menu navigation and important notifications."
 msgstr ""
 
-#. Description of settings category with label #14219 "Control"
+#. Description of settings category with label #15087 "Input"
 #: system/settings/settings.xml
 msgctxt "#36374"
 msgid "This category contains the settings for how input devices are handled."

--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -22,9 +22,7 @@
         </setting>
       </group>
     </category>
-  </section>
-  <section id="interface">
-    <category id="control">
+    <category id="input">
       <group id="2">
         <setting id="input.appleremotemode" type="integer" label="13600" help="36416">
           <level>1</level>

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -47,16 +47,7 @@
         </setting>
       </group>
     </category>
-  </section>
-  <section id="interface">
-    <category id="skin">
-      <group id="1">
-        <setting id="lookandfeel.skin" type="addon">
-          <default>skin.estouchy</default>
-        </setting>
-      </group>
-    </category>
-    <category id="control">
+    <category id="input">
       <group id="1">
         <setting id="input.peripherals">
           <visible>false</visible>
@@ -71,6 +62,15 @@
         </setting>
         <setting id="input.enablemouse">
           <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
+  <section id="interface">
+    <category id="skin">
+      <group id="1">
+        <setting id="lookandfeel.skin" type="addon">
+          <default>skin.estouchy</default>
         </setting>
       </group>
     </category>

--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -8,9 +8,7 @@
         </setting>
       </group>
     </category>
-  </section>
-  <section id="interface">
-    <category id="control">
+    <category id="input">
       <group id="2">
         <setting id="input.appleremotealwayson">
           <level>1</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1705,48 +1705,9 @@
         </setting>
       </group>
     </category>
-    <category id="upnp" label="20187" help="36322">
-      <requirement>HAS_UPNP</requirement>
-      <group id="1" label="16000">
-        <setting id="services.upnpserver" type="boolean" label="21360" help="36323">
-          <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="services.upnpannounce" type="boolean" parent="services.upnpserver" label="20188" help="36324">
-          <level>2</level>
-          <default>true</default>
-          <dependencies>
-            <dependency type="enable" setting="services.upnpserver">true</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="services.upnplookforexternalsubtitles" type="boolean" parent="services.upnpserver" label="20222" help="36420">
-          <level>2</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="services.upnpserver">true</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="services.upnpcontroller" type="boolean" parent="services.upnpserver" label="21361" help="36326">
-          <level>2</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="services.upnpserver">true</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="services.upnprenderer" type="boolean" label="21881" help="36325">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
-      </group>
-    </category>
-    <category id="webserver" label="33101" help="36327">
+    <category id="control" label="14223" help="36327">
+      <group id="1" label="33101">
       <requirement>HAS_WEB_SERVER</requirement>
-      <group id="1">
         <setting id="services.webserver" type="boolean" label="263" help="36328">
           <level>1</level>
           <default>false</default>
@@ -1801,6 +1762,138 @@
           <control type="button" format="addon">
             <show more="true" details="true">installed</show>
           </control>
+        </setting>
+      </group>
+      <group id="2" label="14275">
+      <requirement>
+        <or>
+          <condition>HAS_EVENT_SERVER</condition>
+          <condition>HAS_JSONRPC</condition>
+        </or>
+      </requirement>
+        <setting id="services.esenabled" type="boolean" label="14276" help="36334">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.esport" type="integer" label="792" help="36335">
+          <requirement>HAS_EVENT_SERVER</requirement>
+          <level>4</level>
+          <default>9777</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="services.esportrange" type="integer" label="793" help="36336">
+          <requirement>HAS_EVENT_SERVER</requirement>
+          <level>4</level>
+          <default>10</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="services.esmaxclients" type="integer" label="797" help="36337">
+          <requirement>HAS_EVENT_SERVER</requirement>
+          <level>4</level>
+          <default>20</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="services.esallinterfaces" type="boolean" label="14277" help="36338">
+          <level>1</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable">
+                <condition setting="services.esenabled" operator="is">true</condition>
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.esinitialdelay" type="integer" label="795" help="36339">
+          <requirement>HAS_EVENT_SERVER</requirement>
+          <level>4</level>
+          <default>750</default>
+          <constraints>
+            <minimum>5</minimum>
+            <step>5</step>
+            <maximum>10000</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>
+        <setting id="services.escontinuousdelay" type="integer" label="796" help="36340">
+          <requirement>HAS_EVENT_SERVER</requirement>
+          <level>4</level>
+          <default>25</default>
+          <constraints>
+            <minimum>5</minimum>
+            <step>5</step>
+            <maximum>10000</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="services.esenabled">true</dependency>
+          </dependencies>
+          <control type="spinner" format="integer" />
+        </setting>
+      </group>
+    </category>
+    <category id="upnp" label="20187" help="36322">
+      <requirement>HAS_UPNP</requirement>
+      <group id="1" label="16000">
+        <setting id="services.upnpserver" type="boolean" label="21360" help="36323">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.upnpannounce" type="boolean" parent="services.upnpserver" label="20188" help="36324">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="services.upnpserver">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.upnplookforexternalsubtitles" type="boolean" parent="services.upnpserver" label="20222" help="36420">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="services.upnpserver">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.upnpcontroller" type="boolean" parent="services.upnpserver" label="21361" help="36326">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="services.upnpserver">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.upnprenderer" type="boolean" label="21881" help="36325">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
       </group>
     </category>
@@ -2485,6 +2578,31 @@
         </setting>
       </group>
     </category>
+    <category id="input" label="15087" help="36374">
+      <group id="1" label="35000">
+        <setting id="input.peripherals" type="action" label="35000" help="36375">
+          <level>2</level>
+          <dependencies>
+            <dependency type="enable" on="property" name="HasPeripherals" />
+          </dependencies>
+          <control type="button" format="action" />
+        </setting>
+      </group>
+      <group id="2" label="14094">
+        <setting id="input.enablemouse" type="boolean" label="21369" help="36377">
+          <level>0</level>
+          <control type="toggle" />
+          <default>true</default>
+        </setting>
+        <setting id="input.controllerconfig" type="action" label="35063" help="35064">
+          <level>0</level>
+          <dependencies>
+            <dependency type="enable" on="property" name="SupportsPeripheralControllers" />
+          </dependencies>
+          <control type="button" format="action" />
+        </setting>
+      </group>
+    </category>
     <category id="network" label="798" help="36379">
       <group id="1" label="16000">
         <setting id="network.usehttpproxy" type="boolean" label="708" help="36380">
@@ -3088,122 +3206,6 @@
             <dependency type="update" setting="locale.country" />
           </dependencies>
           <control type="list" format="string" />
-        </setting>
-      </group>
-    </category>
-    <category id="control" label="14223" help="36374">
-      <group id="1" label="35000">
-        <setting id="input.peripherals" type="action" label="35000" help="36375">
-          <level>2</level>
-          <dependencies>
-            <dependency type="enable" on="property" name="HasPeripherals" />
-          </dependencies>
-          <control type="button" format="action" />
-        </setting>
-      </group>
-      <group id="2" label="14094">
-        <setting id="input.enablemouse" type="boolean" label="21369" help="36377">
-          <level>0</level>
-          <control type="toggle" />
-          <default>true</default>
-        </setting>
-        <setting id="input.controllerconfig" type="action" label="35063" help="35064">
-          <level>0</level>
-          <dependencies>
-            <dependency type="enable" on="property" name="SupportsPeripheralControllers" />
-          </dependencies>
-          <control type="button" format="action" />
-        </setting>
-      </group>
-      <group id="3" label="14275">
-      <requirement>
-        <or>
-          <condition>HAS_EVENT_SERVER</condition>
-          <condition>HAS_JSONRPC</condition>
-        </or>
-      </requirement>
-        <setting id="services.esenabled" type="boolean" label="14276" help="36334">
-          <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="services.esport" type="integer" label="792" help="36335">
-          <requirement>HAS_EVENT_SERVER</requirement>
-          <level>4</level>
-          <default>9777</default>
-          <constraints>
-            <minimum>1</minimum>
-            <step>1</step>
-            <maximum>65535</maximum>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="services.esenabled">true</dependency>
-          </dependencies>
-          <control type="edit" format="integer" />
-        </setting>
-        <setting id="services.esportrange" type="integer" label="793" help="36336">
-          <requirement>HAS_EVENT_SERVER</requirement>
-          <level>4</level>
-          <default>10</default>
-          <constraints>
-            <minimum>1</minimum>
-            <step>1</step>
-            <maximum>100</maximum>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="services.esenabled">true</dependency>
-          </dependencies>
-          <control type="spinner" format="integer" />
-        </setting>
-        <setting id="services.esmaxclients" type="integer" label="797" help="36337">
-          <requirement>HAS_EVENT_SERVER</requirement>
-          <level>4</level>
-          <default>20</default>
-          <constraints>
-            <minimum>1</minimum>
-            <step>1</step>
-            <maximum>100</maximum>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="services.esenabled">true</dependency>
-          </dependencies>
-          <control type="spinner" format="integer" />
-        </setting>
-        <setting id="services.esallinterfaces" type="boolean" label="14277" help="36338">
-          <level>1</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="services.esenabled">true</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="services.esinitialdelay" type="integer" label="795" help="36339">
-          <requirement>HAS_EVENT_SERVER</requirement>
-          <level>4</level>
-          <default>750</default>
-          <constraints>
-            <minimum>5</minimum>
-            <step>5</step>
-            <maximum>10000</maximum>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="services.esenabled">true</dependency>
-          </dependencies>
-          <control type="spinner" format="integer" />
-        </setting>
-        <setting id="services.escontinuousdelay" type="integer" label="796" help="36340">
-          <requirement>HAS_EVENT_SERVER</requirement>
-          <level>4</level>
-          <default>25</default>
-          <constraints>
-            <minimum>5</minimum>
-            <step>5</step>
-            <maximum>10000</maximum>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" setting="services.esenabled">true</dependency>
-          </dependencies>
-          <control type="spinner" format="integer" />
         </setting>
       </group>
     </category>


### PR DESCRIPTION
…tings back to services & combine with webserver settings.

A bit more minor reshuffling to get as many rough edges for the settings refactor ironed out as possible before release. Following feedbck it seems I unintentionally made life slightly more difficult for those users that use the json-rpc remote control apps.

Idea of Control in Interface section was to group settings for both physical and app remotes, but I forgot you still need to enable the webserver to use json-rpc.

This PR places a Input category to System (effectively old Input Devices)

![image](https://cloud.githubusercontent.com/assets/5781142/17278416/d668553c-5754-11e6-8022-dfbf3b512abe.png)

Then moves the json-rpc app settings to a new Control category in Services, and combines these with the webserver settings. Therefore all settings to get the remote apps working are now in the one window. ~~Also since the webserver is required to be enable to use json-rpc app i've introduced a dependency in the settings~~ (removed from pr)

![image](https://cloud.githubusercontent.com/assets/5781142/17278419/edf8ca6a-5754-11e6-913e-8095bd437e3b.png)
