### PR TITLE
fix listprovider updating

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -368,7 +368,7 @@ bool CDirectoryProvider::OnContextMenu(const CGUIListItemPtr& item)
 bool CDirectoryProvider::IsUpdating() const
 {
   CSingleLock lock(m_section);
-  return m_jobID || (m_updateState == DONE);
+  return m_jobID || m_updateState == DONE || m_updateState == INVALIDATED;
 }
 
 void CDirectoryProvider::RegisterListProvider()

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -214,8 +214,11 @@ bool CDirectoryProvider::Update(bool forceRefresh)
     m_jobID = CJobManager::GetInstance().AddJob(new CDirectoryJob(m_currentUrl, m_currentSort, m_currentLimit, m_parentID), this);
   }
 
-  for (std::vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
-    changed |= (*i)->UpdateVisibility(m_parentID);
+  if (!changed)
+  {
+    for (std::vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+      changed |= (*i)->UpdateVisibility(m_parentID);
+  }
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -49,7 +49,7 @@ public:
   typedef enum
   {
     OK,
-    PENDING,
+    INVALIDATED,
     DONE
   } UpdateState;
 
@@ -84,7 +84,6 @@ private:
   std::vector<InfoTagType> m_itemTypes;
   CCriticalSection m_section;
 
-  void FireJob();
   void RegisterListProvider();
   bool UpdateURL();
   bool UpdateLimit();


### PR DESCRIPTION
This fixes updating of dynamic lists that are not visible, but have been invalidated by a background thread. This is due to PENDING to not being included in IsUpdating, which  causes `Update` to never getting called. Also fixes some other issues found (see commits).
