### PR TITLE
[xbmc/fix] Fix crash on shutdown

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -56,10 +56,8 @@ CGUIDialogPVRChannelsOSD::~CGUIDialogPVRChannelsOSD()
 {
   delete m_vecItems;
 
-  if (IsObserving(g_infoManager))
-    g_infoManager.UnregisterObserver(this);
-  if (IsObserving(g_EpgContainer))
-    g_EpgContainer.UnregisterObserver(this);
+  g_infoManager.UnregisterObserver(this);
+  g_EpgContainer.UnregisterObserver(this);
 }
 
 bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
@@ -183,14 +181,11 @@ CPVRChannelGroupPtr CGUIDialogPVRChannelsOSD::GetPlayingGroup()
 
 void CGUIDialogPVRChannelsOSD::Update()
 {
+  g_infoManager.RegisterObserver(this);
+  g_EpgContainer.RegisterObserver(this);
+
   // lock our display, as this window is rendered from the player thread
   g_graphicsContext.Lock();
-
-  if (!IsObserving(g_infoManager))
-    g_infoManager.RegisterObserver(this);
-  if (!IsObserving(g_EpgContainer))
-    g_EpgContainer.RegisterObserver(this);
-
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
 
   // empty the list ready for population

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -21,6 +21,7 @@
  */
 
 #include "threads/CriticalSection.h"
+#include <atomic>
 #include <vector>
 
 class Observable;
@@ -45,46 +46,15 @@ typedef enum
 
 class Observer
 {
-  friend class Observable;
-
 public:
-  Observer(void) {};
-  virtual ~Observer(void);
-
-  /*!
-   * @brief Remove this observer from all observables.
-   */
-  virtual void StopObserving(void);
-
-  /*!
-   * @brief Check whether this observer is observing an observable.
-   * @param obs The observable to check.
-   * @return True if this observer is observing the given observable, false otherwise.
-   */
-  virtual bool IsObserving(const Observable &obs) const;
-
+  Observer() = default;
+  virtual ~Observer() = default;
   /*!
    * @brief Process a message from an observable.
    * @param obs The observable that sends the message.
    * @param msg The message.
    */
   virtual void Notify(const Observable &obs, const ObservableMessage msg) = 0;
-
-protected:
-  /*!
-   * @brief Callback to register an observable.
-   * @param obs The observable to register.
-   */
-  virtual void RegisterObservable(Observable *obs);
-
-  /*!
-   * @brief Callback to unregister an observable.
-   * @param obs The observable to unregister.
-   */
-  virtual void UnregisterObservable(Observable *obs);
-
-  std::vector<Observable *> m_observables;     /*!< all observables that are watched */
-  CCriticalSection          m_obsCritSection;  /*!< mutex */
 };
 
 class Observable
@@ -92,14 +62,9 @@ class Observable
   friend class ObservableMessageJob;
 
 public:
-  Observable();
-  virtual ~Observable();
+  Observable() = default;
+  virtual ~Observable() = default;
   virtual Observable &operator=(const Observable &observable);
-
-  /*!
-   * @brief Remove this observable from all observers.
-   */
-  virtual void StopObserver(void);
 
   /*!
    * @brief Register an observer.
@@ -140,7 +105,7 @@ protected:
    */
   void SendMessage(const ObservableMessage message);
 
-  bool                    m_bObservableChanged; /*!< true when the observable is marked as changed, false otherwise */
-  std::vector<Observer *> m_observers;          /*!< all observers */
-  CCriticalSection        m_obsCritSection;     /*!< mutex */
+  std::atomic<bool>       m_bObservableChanged{false}; /*!< true when the observable is marked as changed, false otherwise */
+  std::vector<Observer *> m_observers;                 /*!< all observers */
+  CCriticalSection        m_obsCritSection;            /*!< mutex */
 };


### PR DESCRIPTION
On teardown the circular dependencies of Observer and Observable often lead to a crash.
Removed all state from Observer, it shouldn't care about
what it's Observing.
Switched to use atomic for message tracking to simplify and get rid of a lock.

@FernetMenta what do you think? I've noticed both deadlocks and plenty of crashes when closing Kodi related to this so removed most of it that wasn't really used anyway
