### PR TITLE
[settings] change System > Add-ons groupings/labels and add button to access browser

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7714,7 +7714,17 @@ msgctxt "#14260"
 msgid "Debug"
 msgstr ""
 
-#empty strings from id 14261 to 14269
+#: system/settings/settings.xml
+msgctxt "#14261"
+msgid "Add-on Browser"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14262"
+msgid "Update Policy"
+msgstr ""
+
+#empty strings from id 14263 to 14269
 
 #: system/settings/settings.xml
 msgctxt "#14270"
@@ -14551,7 +14561,12 @@ msgctxt "#24147"
 msgid "Failed to scan %s: %s"
 msgstr ""
 
-#empty strings from id 24148 to 24990
+#empty strings from id 24148 to 24989
+
+#: system/settings/settings.xml
+msgctxt "#24990"
+msgid "Browse add-ons..."
+msgstr ""
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp
@@ -14573,7 +14588,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#24994"
-msgid "Running"
+msgid "Running..."
 msgstr ""
 
 #: xbmc/filesystem/AddonsDirectory.cpp
@@ -14583,7 +14598,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#24996"
-msgid "Manage dependencies"
+msgid "Manage dependencies..."
 msgstr ""
 
 #: xbmc/filesystem/AddonsDirectory.cpp
@@ -18737,7 +18752,11 @@ msgctxt "#36603"
 msgid "This category contains the settings for displays."
 msgstr ""
 
-#empty string with id 36604
+#. Description of setting with label #24990 "Browse add-ons..."
+#: system/settings/settings.xml
+msgctxt "#36604"
+msgid "Select to browse all add-ons"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36605"
@@ -18785,12 +18804,12 @@ msgctxt "#36612"
 msgid "Show notification when an add-on have been updated."
 msgstr ""
 
-#. Description of setting with label #24996 "Manage dependencies"
+#. Description of setting with label #24996 "Manage dependencies..."
 msgctxt "#36613"
 msgid "Manage modules and support libraries that have been automatically installed as a dependency to other add-ons. Items listed as \"Orphaned\" are no longer required by any add-ons and are safe to uninstall."
 msgstr ""
 
-#. Description of setting with label #24994 "Running"
+#. Description of setting with label #24994 "Running..."
 #: system/settings/settings.xml
 msgctxt "#36614"
 msgid "Show add-ons that are currently running in the background."

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2601,7 +2601,21 @@
       </group>
     </category>
     <category id="addons" label="24001" help="36610">
-      <group id="1" label="16000">
+      <group id="1" label="14261">
+        <setting id="addon.browser" type="action" label="24990" help="36604">
+          <level>1</level>
+          <control type="button" format="action" />
+        </setting>
+        <setting id="addons.managedependencies" type="action" label="24996" help="36613">
+          <level>1</level>
+          <control type="button" format="action" />
+        </setting>
+        <setting id="addons.showrunning" type="action" label="24994" help="36614">
+          <level>1</level>
+          <control type="button" format="action" />
+        </setting>
+      </group>
+      <group id="2" label="14262">
         <setting id="general.addonupdates" type="integer" label="36605" help="36611">
           <level>0</level>
           <default>0</default>
@@ -2622,14 +2636,8 @@
             <dependency type="enable" setting="general.addonupdates">0</dependency>
           </dependencies>
         </setting>
-        <setting id="addons.managedependencies" type="action" label="24996" help="36613">
-          <level>2</level>
-          <control type="button" format="action" />
-        </setting>
-        <setting id="addons.showrunning" type="action" label="24994" help="36614">
-          <level>2</level>
-          <control type="button" format="action" />
-        </setting>
+      </group>
+      <group id="3" label="14093">
         <setting id="addons.unknownsources" type="boolean" label="36615" help="36616">
           <level>0</level>
           <default>false</default>

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -37,7 +37,12 @@ CAddonSystemSettings& CAddonSystemSettings::GetInstance()
 
 void CAddonSystemSettings::OnSettingAction(const CSetting* setting)
 {
-  if (setting->GetId() == CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES)
+  if (setting->GetId() == CSettings::SETTING_ADDON_BROWSER)
+  {
+    std::vector<std::string> params{"addons://", "return"};
+    g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
+  }
+  else if (setting->GetId() == CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES)
   {
     std::vector<std::string> params{"addons://dependencies/", "return"};
     g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -411,6 +411,7 @@ const std::string CSettings::SETTING_ADDONS_NOTIFICATIONS = "general.addonnotifi
 const std::string CSettings::SETTING_ADDONS_SHOW_RUNNING = "addons.showrunning";
 const std::string CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES = "addons.unknownsources";
 const std::string CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES = "addons.managedependencies";
+const std::string CSettings::SETTING_ADDON_BROWSER = "addon.browser";
 const std::string CSettings::SETTING_GENERAL_ADDONFOREIGNFILTER = "general.addonforeignfilter";
 const std::string CSettings::SETTING_GENERAL_ADDONBROKENFILTER = "general.addonbrokenfilter";
 
@@ -1188,6 +1189,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_ADDONS_SHOW_RUNNING);
   settingSet.insert(CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES);
   settingSet.insert(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES);
+  settingSet.insert(CSettings::SETTING_ADDON_BROWSER);
   m_settingsManager->RegisterCallback(&ADDON::CAddonSystemSettings::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -368,6 +368,7 @@ public:
   static const std::string SETTING_ADDONS_SHOW_RUNNING;
   static const std::string SETTING_ADDONS_MANAGE_DEPENDENCIES;
   static const std::string SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES;
+  static const std::string SETTING_ADDON_BROWSER;
   static const std::string SETTING_GENERAL_ADDONFOREIGNFILTER;
   static const std::string SETTING_GENERAL_ADDONBROKENFILTER;
 


### PR DESCRIPTION
Since we already have buttons for manage dependencies and show running add-ons, this adds a button to access the add-on browser. With this the groupings have been slightly changed and re-labelled.

![image](https://cloud.githubusercontent.com/assets/5781142/17278657/e9567ff2-5759-11e6-924d-b9b510667d55.png)

Where skins such as Confluence currently provide access to the add-on browser via a button in the list of settings Sections, this could be dropped if user can access the browser from System > Add-ons. For example the following "Add-ons" button could be removed if @HitcherUK wished.

![image](https://cloud.githubusercontent.com/assets/5781142/17278743/f2444d72-575b-11e6-8274-3b0d26f21497.png)

Everyone will be relieved to hear this is my last planned settings change that I'll be submitting for consideration to be included in Krypton. Everything from here on in will be cleanup/fixes only where required. 
