### PR TITLE
[Fix] RPi settings - missing renaming of Library to Media

### DIFF
--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -37,7 +37,7 @@
       </group>
     </category>
   </section>
-  <section id="library">
+  <section id="media">
     <category id="video">
       <group id="1">
         <setting id="myvideos.extractchapterthumbs">


### PR DESCRIPTION
Just noticed this somehow got lost yesterday before https://github.com/xbmc/xbmc/pull/10199 was merged.
