### PR TITLE
inputstream: bump version

### DIFF
--- a/addons/kodi.inputstream/addon.xml
+++ b/addons/kodi.inputstream/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.inputstream" version="1.0.4" provider-name="Team Kodi">
-  <backwards-compatibility abi="1.0.4"/>
+<addon id="kodi.inputstream" version="1.0.5" provider-name="Team Kodi">
+  <backwards-compatibility abi="1.0.5"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
was forgotten with #10177

@tamland what is the story with this versions? It does not seem to be verified when binary addons are loaded and as a result outdated addons make the system crash.
Shouldn't we check the abi version of extension points when addons are loaded?

@mapfau /cc
