### PR TITLE
Drop deinterlace mode in AML renderer

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -81,16 +81,6 @@ bool CRendererAML::Supports(EINTERLACEMETHOD method)
   return false;
 }
 
-bool CRendererAML::Supports(EDEINTERLACEMODE mode)
-{
-  if(mode == VS_DEINTERLACEMODE_OFF
-  || mode == VS_DEINTERLACEMODE_AUTO
-  || mode == VS_DEINTERLACEMODE_FORCE)
-    return true;
-
-  return false;
-}
-
 bool CRendererAML::Supports(ESCALINGMETHOD method)
 {
   return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -41,7 +41,6 @@ public:
 
   // Feature support
   virtual bool Supports(EINTERLACEMETHOD method);
-  virtual bool Supports(EDEINTERLACEMODE mode);
   virtual bool Supports(ESCALINGMETHOD method);
   virtual bool Supports(ERENDERFEATURE feature);
 


### PR DESCRIPTION
This PR drops deinterlace mode in AML renderer to fix amcodec after 25718f4ccebd227eaf63f0f8b53f0552f89f01e5
