### PR TITLE
player: make playspeed floating point and add tempo controls

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2216,22 +2216,22 @@ bool CApplication::OnAction(const CAction &action)
     {
       if (action.GetID() == ACTION_PLAYER_FORWARD || action.GetID() == ACTION_PLAYER_REWIND)
       {
-        int iPlaySpeed = m_pPlayer->GetPlaySpeed();
-        if (action.GetID() == ACTION_PLAYER_REWIND && iPlaySpeed == 1) // Enables Rewinding
-          iPlaySpeed *= -2;
-        else if (action.GetID() == ACTION_PLAYER_REWIND && iPlaySpeed > 1) //goes down a notch if you're FFing
-          iPlaySpeed /= 2;
-        else if (action.GetID() == ACTION_PLAYER_FORWARD && iPlaySpeed < 1) //goes up a notch if you're RWing
-          iPlaySpeed /= 2;
+        float playSpeed = m_pPlayer->GetPlaySpeed();
+        if (action.GetID() == ACTION_PLAYER_REWIND && (playSpeed >= 0.8 && playSpeed <= 1.5)) // Enables Rewinding
+          playSpeed *= -2;
+        else if (action.GetID() == ACTION_PLAYER_REWIND && playSpeed > 1.5) //goes down a notch if you're FFing
+          playSpeed /= 2;
+        else if (action.GetID() == ACTION_PLAYER_FORWARD && playSpeed < 0.8) //goes up a notch if you're RWing
+          playSpeed /= 2;
         else
-          iPlaySpeed *= 2;
+          playSpeed *= 2;
 
-        if (action.GetID() == ACTION_PLAYER_FORWARD && iPlaySpeed == -1) //sets iSpeed back to 1 if -1 (didn't plan for a -1)
-          iPlaySpeed = 1;
-        if (iPlaySpeed > 32 || iPlaySpeed < -32)
-          iPlaySpeed = 1;
+        if (action.GetID() == ACTION_PLAYER_FORWARD && playSpeed == -1) //sets iSpeed back to 1 if -1 (didn't plan for a -1)
+          playSpeed = 1;
+        if (playSpeed > 32 || playSpeed < -32)
+          playSpeed = 1;
 
-        m_pPlayer->SetPlaySpeed(iPlaySpeed);
+        m_pPlayer->SetPlaySpeed(playSpeed);
         return true;
       }
       else if ((action.GetAmount() || m_pPlayer->GetPlaySpeed() != 1) && (action.GetID() == ACTION_ANALOG_REWIND || action.GetID() == ACTION_ANALOG_FORWARD))
@@ -3670,7 +3670,7 @@ void CApplication::OnPlayBackSeek(int iTime, int seekOffset)
   CJSONUtils::MillisecondsToTimeObject(iTime, param["player"]["time"]);
   CJSONUtils::MillisecondsToTimeObject(seekOffset, param["player"]["seekoffset"]);
   param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
-  param["player"]["speed"] = m_pPlayer->GetPlaySpeed();
+  param["player"]["speed"] = (int)m_pPlayer->GetPlaySpeed();
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnSeek", m_itemCurrentFile, param);
   g_infoManager.SetDisplayAfterSeek(2500, seekOffset);
 }

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -456,11 +456,11 @@ float CApplicationPlayer::GetCachePercentage() const
     return 0.0;
 }
 
-void CApplicationPlayer::SetSpeed(int iSpeed)
+void CApplicationPlayer::SetSpeed(float speed)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    player->SetSpeed(iSpeed);
+    player->SetSpeed(speed);
 }
 
 void CApplicationPlayer::DoAudioWork()
@@ -717,7 +717,7 @@ void CApplicationPlayer::GetScalingMethods(std::vector<int> &scalingMethods)
     player->OMXGetScalingMethods(scalingMethods);
 }
 
-void CApplicationPlayer::SetPlaySpeed(int iSpeed)
+void CApplicationPlayer::SetPlaySpeed(float speed)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (!player)
@@ -726,24 +726,33 @@ void CApplicationPlayer::SetPlaySpeed(int iSpeed)
   if (!IsPlayingAudio() && !IsPlayingVideo())
     return ;
 
-  SetSpeed(iSpeed);
+  SetSpeed(speed);
   m_speedUpdate.SetExpired();
 }
 
-int CApplicationPlayer::GetPlaySpeed()
+float CApplicationPlayer::GetPlaySpeed()
 {
   if (!m_speedUpdate.IsTimePast())
-    return m_iPlaySpeed;
+    return m_fPlaySpeed;
 
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
   {
-    m_iPlaySpeed = player->GetSpeed();
+    m_fPlaySpeed = player->GetSpeed();
     m_speedUpdate.Set(1000);
-    return m_iPlaySpeed;
+    return m_fPlaySpeed;
   }
   else
     return 0;
+}
+
+bool CApplicationPlayer::SupportsTempo()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return player->SupportsTempo();
+  else
+    return false;
 }
 
 void CApplicationPlayer::FrameMove()

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -66,7 +66,7 @@ class CApplicationPlayer
   XbmcThreads::EndTime m_subtitleStreamUpdate;
   int m_iSubtitleStream;
   XbmcThreads::EndTime m_speedUpdate;
-  int m_iPlaySpeed;
+  float m_fPlaySpeed;
 
 public:
   CApplicationPlayer();
@@ -77,10 +77,10 @@ public:
   void ClosePlayerGapless(std::string &playername);
   void CreatePlayer(const std::string &player, IPlayerCallback& callback);
   std::string GetCurrentPlayer();
-  int  GetPlaySpeed();
+  float  GetPlaySpeed();
   bool HasPlayer() const;
   PlayBackRet OpenFile(const CFileItem& item, const CPlayerOptions& options);
-  void SetPlaySpeed(int iSpeed);
+  void SetPlaySpeed(float speed);
 
   void FrameMove();
   bool HasFrame();
@@ -176,8 +176,9 @@ public:
   void  SetVideoStream(int iStream);
   void  SetVolume(float volume);
   bool  SwitchChannel(const PVR::CPVRChannelPtr &channel);
-  void  SetSpeed(int iSpeed);
-  
+  void  SetSpeed(float speed);
+  bool SupportsTempo();
+
   protected:
     std::shared_ptr<IPlayer> GetInternal() const;
 };

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6963,7 +6963,10 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = g_application.m_pPlayer->IsPlayingVideo();
       break;
     case PLAYER_PLAYING:
-      bReturn = g_application.m_pPlayer->GetPlaySpeed() == 1;
+      {
+        float speed = g_application.m_pPlayer->GetPlaySpeed();
+        bReturn = (speed >= 0.75 && speed <= 1.55);
+      }
       break;
     case PLAYER_PAUSED:
       bReturn = g_application.m_pPlayer->IsPausedPlayback();
@@ -6972,7 +6975,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = g_application.m_pPlayer->GetPlaySpeed() < 0;
       break;
     case PLAYER_FORWARDING:
-      bReturn = g_application.m_pPlayer->GetPlaySpeed() > 1;
+      bReturn = g_application.m_pPlayer->GetPlaySpeed() > 1.5;
       break;
     case PLAYER_REWINDING_2x:
       bReturn = g_application.m_pPlayer->GetPlaySpeed() == -2;
@@ -7777,8 +7780,9 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   else if (info.m_info == PLAYER_TIME_SPEED)
   {
     std::string strTime;
-    if (g_application.m_pPlayer->GetPlaySpeed() != 1)
-      strTime = StringUtils::Format("%s (%ix)", GetCurrentPlayTime((TIME_FORMAT)info.GetData1()).c_str(), g_application.m_pPlayer->GetPlaySpeed());
+    float speed = g_application.m_pPlayer->GetPlaySpeed();
+    if (speed < 0.8 || speed > 1.5)
+      strTime = StringUtils::Format("%s (%ix)", GetCurrentPlayTime((TIME_FORMAT)info.GetData1()).c_str(), (int)speed);
     else
       strTime = GetCurrentPlayTime();
     return strTime;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -506,7 +506,10 @@ const infomap player_labels[] =  {{ "hasmedia",         PLAYER_HAS_MEDIA },     
                                   { "isinternetstream", PLAYER_ISINTERNETSTREAM },
                                   { "pauseenabled",     PLAYER_CAN_PAUSE },
                                   { "seekenabled",      PLAYER_CAN_SEEK },
-                                  { "channelpreviewactive", PLAYER_IS_CHANNEL_PREVIEW_ACTIVE}};
+                                  { "channelpreviewactive", PLAYER_IS_CHANNEL_PREVIEW_ACTIVE},
+                                  { "tempoenabled", PLAYER_SUPPORTS_TEMPO},
+                                  { "istempo", PLAYER_IS_TEMPO},
+                                  { "playspeed", PLAYER_PLAYSPEED}};
 
 /// \page modules__General__List_of_gui_access
 /// @{
@@ -5896,6 +5899,10 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
       }
     }
     break;
+  case PLAYER_PLAYSPEED:
+      if(g_application.m_pPlayer->IsPlaying())
+        strLabel = StringUtils::Format("%.2f", g_application.m_pPlayer->GetPlaySpeed());
+      break;
   case MUSICPLAYER_TITLE:
   case MUSICPLAYER_ALBUM:
   case MUSICPLAYER_ARTIST:
@@ -7015,6 +7022,15 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       break;
     case PLAYER_CAN_SEEK:
       bReturn = g_application.m_pPlayer->CanSeek();
+      break;
+    case PLAYER_SUPPORTS_TEMPO:
+      bReturn = g_application.m_pPlayer->SupportsTempo();
+      break;
+    case PLAYER_IS_TEMPO:
+      {
+        float speed = g_application.m_pPlayer->GetPlaySpeed();
+        bReturn = (speed >= 0.75 && speed <= 1.55 & speed != 1);
+      }
       break;
     case PLAYER_RECORDING:
       bReturn = g_application.m_pPlayer->IsRecording();

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -584,12 +584,12 @@ int64_t CExternalPlayer::GetTotalTime() // in milliseconds
   return (int64_t)m_totalTime * 1000;
 }
 
-void CExternalPlayer::SetSpeed(int iSpeed)
+void CExternalPlayer::SetSpeed(float iSpeed)
 {
-  m_speed = iSpeed;
+  m_speed = static_cast<int>(iSpeed);
 }
 
-int CExternalPlayer::GetSpeed()
+float CExternalPlayer::GetSpeed()
 {
   return m_speed;
 }

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -67,8 +67,8 @@ public:
   virtual void SeekTime(int64_t iTime);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
-  virtual void SetSpeed(int iSpeed) override;
-  virtual int GetSpeed() override;
+  virtual void SetSpeed(float iSpeed) override;
+  virtual float GetSpeed() override;
   virtual void ShowOSD(bool bOnoff);
   virtual void DoAudioWork() {};
   

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -325,8 +325,10 @@ public:
   virtual void SetTotalTime(int64_t time) { }
   virtual int GetSourceBitrate(){ return 0;}
   virtual bool GetStreamDetails(CStreamDetails &details){ return false;}
-  virtual void SetSpeed(int iSpeed) = 0;
-  virtual int GetSpeed() = 0;
+  virtual void SetSpeed(float speed) = 0;
+  virtual float GetSpeed() = 0;
+  virtual bool SupportsTempo() { return false; }
+
   // Skip to next track/item inside the current media (if supported).
   virtual bool SkipNext(){return false;}
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3467,26 +3467,26 @@ int64_t CVideoPlayer::GetTotalTime()
   return GetTotalTimeInMsec();
 }
 
-void CVideoPlayer::SetSpeed(int iSpeed)
+void CVideoPlayer::SetSpeed(float speed)
 {
   // can't rewind in menu as seeking isn't possible
   // forward is fine
-  if (iSpeed < 0 && IsInMenu())
+  if (speed < 0 && IsInMenu())
     return;
 
   if (!CanSeek())
     return;
   
-  m_newPlaySpeed = iSpeed * DVD_PLAYSPEED_NORMAL;
-  SetPlaySpeed(iSpeed * DVD_PLAYSPEED_NORMAL);
+  m_newPlaySpeed = speed * DVD_PLAYSPEED_NORMAL;
+  SetPlaySpeed(speed * DVD_PLAYSPEED_NORMAL);
 }
 
-int CVideoPlayer::GetSpeed()
+float CVideoPlayer::GetSpeed()
 {
   if (m_playSpeed != m_newPlaySpeed)
-    return m_newPlaySpeed / DVD_PLAYSPEED_NORMAL;
+    return (float)m_newPlaySpeed / DVD_PLAYSPEED_NORMAL;
 
-  return m_playSpeed / DVD_PLAYSPEED_NORMAL;
+  return (float)m_playSpeed / DVD_PLAYSPEED_NORMAL;
 }
 
 bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iStream, int source, bool reset /*= true*/)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -640,6 +640,7 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
   m_playSpeed = DVD_PLAYSPEED_NORMAL;
   m_newPlaySpeed = DVD_PLAYSPEED_NORMAL;
   m_streamPlayerSpeed = DVD_PLAYSPEED_NORMAL;
+  m_canTempo = false;
   m_caching = CACHESTATE_DONE;
   m_HasVideo = false;
   m_HasAudio = false;
@@ -746,6 +747,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
 
   m_HasVideo = false;
   m_HasAudio = false;
+  m_canTempo = false;
 
   CLog::Log(LOGNOTICE, "VideoPlayer: finished waiting");
   m_renderManager.UnInit();
@@ -839,6 +841,16 @@ bool CVideoPlayer::OpenInputStream()
   m_dvd.Clear();
   m_errorCount = 0;
   m_ChannelEntryTimeOut.SetInfinite();
+
+  if (CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK) &&
+      !m_pInputStream->IsRealtime())
+  {
+    m_canTempo = true;
+  }
+  else
+  {
+    m_canTempo = false;
+  }
 
   return true;
 }
@@ -3487,6 +3499,11 @@ float CVideoPlayer::GetSpeed()
     return (float)m_newPlaySpeed / DVD_PLAYSPEED_NORMAL;
 
   return (float)m_playSpeed / DVD_PLAYSPEED_NORMAL;
+}
+
+bool CVideoPlayer::SupportsTempo()
+{
+  return m_canTempo;
 }
 
 bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iStream, int source, bool reset /*= true*/)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -299,8 +299,9 @@ public:
   virtual bool SeekTimeRelative(int64_t iTime);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
-  virtual void SetSpeed(int iSpeed) override;
-  virtual int GetSpeed() override;
+  virtual void SetSpeed(float speed) override;
+  virtual float GetSpeed() override;
+  virtual bool SupportsTempo() override { return true; }
   virtual bool OnAction(const CAction &action);
 
   virtual int GetSourceBitrate();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -301,7 +301,7 @@ public:
   virtual int64_t GetTotalTime();
   virtual void SetSpeed(float speed) override;
   virtual float GetSpeed() override;
-  virtual bool SupportsTempo() override { return true; }
+  virtual bool SupportsTempo() override;
   virtual bool OnAction(const CAction &action);
 
   virtual int GetSourceBitrate();
@@ -466,6 +466,7 @@ protected:
     int lastseekpts;
     double  lastabstime;
   } m_SpeedState;
+  std::atomic_bool m_canTempo;
 
   int m_errorCount;
   double m_offset_pts;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -941,13 +941,13 @@ void PAPlayer::SetDynamicRangeCompression(long drc)
 
 }
 
-void PAPlayer::SetSpeed(int iSpeed)
+void PAPlayer::SetSpeed(float speed)
 {
-  m_playbackSpeed  = iSpeed;
+  m_playbackSpeed = static_cast<int>(speed);
   m_signalSpeedChange = true;
 }
 
-int PAPlayer::GetSpeed()
+float PAPlayer::GetSpeed()
 {
   return m_playbackSpeed;
 }

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -61,8 +61,8 @@ public:
   virtual void SetDynamicRangeCompression(long drc);
   virtual void GetAudioInfo( std::string& strAudioInfo) {}
   virtual void GetVideoInfo( std::string& strVideoInfo) {}
-  virtual void SetSpeed(int iSpeed = 0) override;
-  virtual int GetSpeed() override;
+  virtual void SetSpeed(float speed = 0) override;
+  virtual float GetSpeed() override;
   virtual int GetCacheLevel() const;
   virtual int64_t GetTotalTime();
   virtual void SetTotalTime(int64_t time);

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -79,6 +79,9 @@
 #define PLAYER_FILENAME              55
 #define PLAYER_SEEKSTEPSIZE          56
 #define PLAYER_IS_CHANNEL_PREVIEW_ACTIVE  57
+#define PLAYER_SUPPORTS_TEMPO        58
+#define PLAYER_IS_TEMPO              59
+#define PLAYER_PLAYSPEED             60
 
 #define WEATHER_CONDITIONS          100
 #define WEATHER_TEMPERATURE         101

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -41,6 +41,8 @@
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/recordings/PVRRecording.h"
 
+#include <math.h>
+
 #ifdef HAS_DVD_DRIVE
 #include "Autorun.h"
 #endif
@@ -159,6 +161,24 @@ static int PlayerControl(const std::vector<std::string>& params)
         playSpeed = 1;
 
       g_application.m_pPlayer->SetPlaySpeed(playSpeed);
+    }
+  }
+  else if (paramlow =="tempoup" || paramlow == "tempodown")
+  {
+    if (g_application.m_pPlayer->SupportsTempo() &&
+        g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
+    {
+      float playSpeed = g_application.m_pPlayer->GetPlaySpeed();
+      if (playSpeed >= 0.75 && playSpeed <= 1.55)
+      {
+        if (paramlow == "tempodown" && playSpeed > 0.85)
+          playSpeed -= 0.1;
+        else if (paramlow == "tempoup" && playSpeed < 1.45)
+          playSpeed += 0.1;
+
+        playSpeed = floor(playSpeed * 100 + 0.5) / 100;
+        g_application.m_pPlayer->SetPlaySpeed(playSpeed);
+      }
     }
   }
   else if (paramlow == "next")

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -138,23 +138,27 @@ static int PlayerControl(const std::vector<std::string>& params)
   {
     if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
     {
-      int iPlaySpeed = g_application.m_pPlayer->GetPlaySpeed();
-      if (paramlow == "rewind" && iPlaySpeed == 1) // Enables Rewinding
-        iPlaySpeed *= -2;
-      else if (paramlow ==  "rewind" && iPlaySpeed > 1) //goes down a notch if you're FFing
-        iPlaySpeed /= 2;
-      else if (paramlow == "forward" && iPlaySpeed < 1) //goes up a notch if you're RWing
+      float playSpeed = g_application.m_pPlayer->GetPlaySpeed();
+      if (playSpeed >= 0.75 && playSpeed <= 1.55)
+        playSpeed = 1;
+
+      if (paramlow == "rewind" && playSpeed == 1) // Enables Rewinding
+        playSpeed *= -2;
+      else if (paramlow == "rewind" && playSpeed > 1) //goes down a notch if you're FFing
+        playSpeed /= 2;
+      else if (paramlow == "forward" && playSpeed < 1) //goes up a notch if you're RWing
       {
-        iPlaySpeed /= 2;
-        if (iPlaySpeed == -1) iPlaySpeed = 1;
+        playSpeed /= 2;
+        if (playSpeed == -1)
+          playSpeed = 1;
       }
       else
-        iPlaySpeed *= 2;
+        playSpeed *= 2;
 
-      if (iPlaySpeed > 32 || iPlaySpeed < -32)
-        iPlaySpeed = 1;
+      if (playSpeed > 32 || playSpeed < -32)
+        playSpeed = 1;
 
-      g_application.m_pPlayer->SetPlaySpeed(iPlaySpeed);
+      g_application.m_pPlayer->SetPlaySpeed(playSpeed);
     }
   }
   else if (paramlow == "next")

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -283,7 +283,7 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const std::string &method, ITranspor
         else if (!g_application.m_pPlayer->IsPausedPlayback())
           CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
       }
-      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.m_pPlayer->GetPlaySpeed();
+      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : (int)lrint(g_application.m_pPlayer->GetPlaySpeed());
       return OK;
 
     case Picture:
@@ -353,7 +353,7 @@ JSONRPC_STATUS CPlayerOperations::SetSpeed(const std::string &method, ITransport
       else
         return InvalidParams;
 
-      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.m_pPlayer->GetPlaySpeed();
+      result["speed"] = g_application.m_pPlayer->IsPausedPlayback() ? 0 : (int)lrint(g_application.m_pPlayer->GetPlaySpeed());
       return OK;
 
     case Picture:
@@ -1229,7 +1229,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio:
-        result = g_application.m_pPlayer->IsPausedPlayback() ? 0 : g_application.m_pPlayer->GetPlaySpeed();
+        result = g_application.m_pPlayer->IsPausedPlayback() ? 0 : (int)lrint(g_application.m_pPlayer->GetPlaySpeed());
         break;
 
       case Picture:

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -602,12 +602,12 @@ bool CUPnPPlayer::OnAction(const CAction &action)
   }
 }
 
-void CUPnPPlayer::SetSpeed(int iSpeed)
+void CUPnPPlayer::SetSpeed(float speed)
 {
 
 }
 
-int CUPnPPlayer::GetSpeed()
+float CUPnPPlayer::GetSpeed()
 {
   if (IsPaused())
     return 0;

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -65,8 +65,8 @@ public:
   virtual void SeekTime(__int64 iTime = 0);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
-  virtual void SetSpeed(int iSpeed = 0) override;
-  virtual int GetSpeed() override;
+  virtual void SetSpeed(float speed = 0) override;
+  virtual float GetSpeed() override;
 
   virtual bool SkipNext(){return false;}
   virtual bool IsCaching() const {return false;};

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -361,7 +361,8 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 
 void CGUIWindowFullScreen::FrameMove()
 {
-  if (g_application.m_pPlayer->GetPlaySpeed() != 1)
+  float playspeed = g_application.m_pPlayer->GetPlaySpeed();
+  if (playspeed < 0.75 || playspeed > 1.55)
     g_infoManager.SetDisplayAfterSeek();
 
   if (!g_application.m_pPlayer->HasPlayer())


### PR DESCRIPTION
- make playspeed a floating point variable.
- allow speed with audio enabled between 0.8 and 1.5 of normal speed
- add commands "tempoup" and "tempodown" to PlayerControls
- add gui labels to enable skins to set tempo
  - "tempoenabled": bool to test if active player supports tempo
  - "istempo": bool to test if speed is not 1 but in range of 0.8 to 1.5
  - "playspeed": label that holds playspeed

PlayerControls can be used by skins or mapped to keys. 
Example:

```
<keymap>
  <global>
    <keyboard>
      <f mod="ctrl">xbmc.playercontrol(tempoup)</f>
      <r mod="ctrl">xbmc.playercontrol(tempodown)</r>
    </keyboard>
  </global>
</keymap>
```
