### PR TITLE
[linux] fix datadir (KODI_HOME) detection

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -881,17 +881,19 @@ bool CApplication::InitDirectoriesLinux()
   const char* envAppTemp = "KODI_TEMP";
 
   auto appBinPath = CUtil::GetHomePath(envAppBinHome);
+  // overridden by user
   if (getenv(envAppHome))
     appPath = getenv(envAppHome);
   else
   {
-    appPath = appBinPath;
+    // use build time default
+    appPath = INSTALL_PATH;
     /* Check if binaries and arch independent data files are being kept in
      * separate locations. */
     if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
     {
       /* Attempt to locate arch independent data files. */
-      CUtil::GetHomePath(appPath);
+      appPath = CUtil::GetHomePath(appBinPath);
       if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
       {
         fprintf(stderr, "Unable to find path to %s data files!\n", appName.c_str());


### PR DESCRIPTION
fix "Unable to find path to Kodi data files" after https://github.com/xbmc/xbmc/commit/c027eaf0d4a8096d18c9ff00513a757cf9fbbf6e
reported in http://forum.kodi.tv/showthread.php?tid=285263
