### PR TITLE
[KODI_HOME] fix after c9bd52302a6451a4b8822562a13880ca0a7a1eae

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -891,7 +891,7 @@ bool CApplication::InitDirectoriesLinux()
     if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
     {
       /* Attempt to locate arch independent data files. */
-      CUtil::GetHomePath(appPath);
+      appPath = CUtil::GetHomePath("");
       if (!CDirectory::Exists(URIUtils::AddFileToFolder(appPath, "userdata")))
       {
         fprintf(stderr, "Unable to find path to %s data files!\n", appName.c_str());


### PR DESCRIPTION
kodi not starting with error "Unable to find path to %s data files!",
failing to identify /XXX/share vs. /XXX/lib.
