### PR TITLE
[PVR] Fix flickering metadata labels in video osd when switching channels

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -666,6 +666,12 @@ bool CApplicationPlayer::SwitchChannel(const PVR::CPVRChannelPtr &channel)
   return (player && player->SwitchChannel(channel));
 }
 
+bool CApplicationPlayer::IsSwitchingChannels() const
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  return (player && player->IsSwitchingChannels());
+}
+
 void CApplicationPlayer::LoadPage(int p, int sp, unsigned char* buffer)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -176,6 +176,7 @@ public:
   void  SetVideoStream(int iStream);
   void  SetVolume(float volume);
   bool  SwitchChannel(const PVR::CPVRChannelPtr &channel);
+  bool  IsSwitchingChannels() const;
   void  SetSpeed(float speed);
   bool SupportsTempo();
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -134,7 +134,8 @@ public:
 };
 
 CGUIInfoManager::CGUIInfoManager(void) :
-    Observable()
+    Observable(),
+    m_bChannelPreview(false)
 {
   m_lastSysHeatInfoTime = -SYSHEATUPDATEINTERVAL;  // make sure we grab CPU temp on the first pass
   m_fanSpeed = 0;
@@ -10945,8 +10946,12 @@ bool CGUIInfoManager::IsPlayerChannelPreviewActive() const
 {
   return m_playerShowInfo &&
          g_application.m_pPlayer->IsPlaying() &&
-         (g_application.m_pPlayer->IsSwitchingChannels() ||
-          (m_currentFile->HasPVRChannelInfoTag() && !g_PVRManager.IsPlayingChannel(m_currentFile->GetPVRChannelInfoTag())));
+         (m_bChannelPreview || g_application.m_pPlayer->IsSwitchingChannels());
+}
+
+void CGUIInfoManager::SetPlayerChannelPreview(bool bSet)
+{
+  m_bChannelPreview = bSet;
 }
 
 CEpgInfoTagPtr CGUIInfoManager::GetEpgInfoTag() const

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10946,7 +10946,7 @@ bool CGUIInfoManager::IsPlayerChannelPreviewActive() const
 {
   return m_playerShowInfo &&
          g_application.m_pPlayer->IsPlaying() &&
-         (m_bChannelPreview || g_application.m_pPlayer->IsSwitchingChannels());
+         (m_bChannelPreview || /*g_application.m_pPlayer->IsSwitchingChannels()*/ !m_videoInfo.valid);
 }
 
 void CGUIInfoManager::SetPlayerChannelPreview(bool bSet)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10945,8 +10945,8 @@ bool CGUIInfoManager::IsPlayerChannelPreviewActive() const
 {
   return m_playerShowInfo &&
          g_application.m_pPlayer->IsPlaying() &&
-         m_currentFile->HasPVRChannelInfoTag() &&
-         !g_PVRManager.IsPlayingChannel(m_currentFile->GetPVRChannelInfoTag());
+         (g_application.m_pPlayer->IsSwitchingChannels() ||
+          (m_currentFile->HasPVRChannelInfoTag() && !g_PVRManager.IsPlayingChannel(m_currentFile->GetPVRChannelInfoTag())));
 }
 
 CEpgInfoTagPtr CGUIInfoManager::GetEpgInfoTag() const

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -201,6 +201,7 @@ public:
   bool GetShowInfo() const { return m_playerShowInfo; }
   bool ToggleShowInfo() { m_playerShowInfo = !m_playerShowInfo; return m_playerShowInfo; };
   bool IsPlayerChannelPreviewActive() const;
+  void SetPlayerChannelPreview(bool bSet);
 
   std::string GetSystemHeatInfo(int info);
   CTemperature GetGPUTemperature();
@@ -313,6 +314,7 @@ protected:
   CFileItem* m_currentFile;
   std::string m_currentMovieThumb;
   CFileItem* m_currentSlide;
+  bool m_bChannelPreview;
 
   // fan stuff
   unsigned int m_lastSysHeatInfoTime;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -350,6 +350,7 @@ public:
   virtual std::string GetPlayingTitle() { return ""; };
 
   virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) { return false; }
+  virtual bool IsSwitchingChannels() const { return false; }
 
   // Note: the following "OMX" methods are deprecated and will be removed in the future
   // They should be handled by the video renderer, not the player

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -110,6 +110,7 @@ struct SPlayerSubtitleStreamInfo
 
 struct SPlayerVideoStreamInfo
 {
+  bool valid;
   int bitrate;
   float videoAspectRatio;
   int height;
@@ -123,6 +124,7 @@ struct SPlayerVideoStreamInfo
 
   SPlayerVideoStreamInfo()
   {
+    valid = false;
     bitrate = 0;
     videoAspectRatio = 1.0f;
     height = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -644,6 +644,7 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
   m_caching = CACHESTATE_DONE;
   m_HasVideo = false;
   m_HasAudio = false;
+  m_bIsSwitchingChannels = false;
 
   memset(&m_SpeedState, 0, sizeof(m_SpeedState));
 
@@ -748,6 +749,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
   m_HasVideo = false;
   m_HasAudio = false;
   m_canTempo = false;
+  m_bIsSwitchingChannels = false;
 
   CLog::Log(LOGNOTICE, "VideoPlayer: finished waiting");
   m_renderManager.UnInit();
@@ -1068,6 +1070,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
         if(m_CurrentAudio.id < 0)
           m_HasAudio = false;
 
+        m_bIsSwitchingChannels = false;
         return true;
     }
 
@@ -4459,6 +4462,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
       {
         // Offset from key codes back to button number
         int channel = (int) action.GetAmount();
+        m_bIsSwitchingChannels = true;
         m_messenger.Put(new CDVDMsgInt(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER, channel));
         g_infoManager.SetDisplayAfterSeek();
         ShowPVRChannelInfo();
@@ -4999,10 +5003,17 @@ bool CVideoPlayer::SwitchChannel(const CPVRChannelPtr &channel)
   UpdateApplication(0);
   UpdatePlayState(0);
 
+  m_bIsSwitchingChannels = true;
+
   /* select the new channel */
   m_messenger.Put(new CDVDMsgType<CPVRChannelPtr>(CDVDMsg::PLAYER_CHANNEL_SELECT, channel));
 
   return true;
+}
+
+bool CVideoPlayer::IsSwitchingChannels() const
+{
+  return m_bIsSwitchingChannels;
 }
 
 void CVideoPlayer::FrameMove()

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -314,6 +314,7 @@ public:
   virtual std::string GetPlayingTitle();
 
   virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel);
+  virtual bool IsSwitchingChannels() const;
 
   virtual void FrameMove();
   virtual bool HasFrame();
@@ -550,6 +551,7 @@ protected:
 
   bool m_HasVideo;
   bool m_HasAudio;
+  bool m_bIsSwitchingChannels;
 
   std::atomic<bool> m_displayLost;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -431,6 +431,7 @@ protected:
 
   bool OpenInputStream();
   bool OpenDemuxStream();
+  void CloseDemuxer();
   void OpenDefaultStreams(bool reset = true);
 
   void UpdateApplication(double timeout);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1243,6 +1243,8 @@ bool CPVRManager::UpdateItem(CFileItem& item)
   }
 
   CSingleLock lock(m_critSection);
+  g_infoManager.SetPlayerChannelPreview(m_currentFile && m_currentFile->HasPVRChannelInfoTag() && !IsPlayingChannel(m_currentFile->GetPVRChannelInfoTag()));
+
   if (!m_currentFile || *m_currentFile->GetPVRChannelInfoTag() == *item.GetPVRChannelInfoTag())
     return false;
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -643,7 +643,7 @@ private:
     CEvent                          m_triggerEvent;                /*!< triggers an update */
     std::vector<CJob *>             m_pendingUpdates;              /*!< vector of pending pvr updates */
 
-    CFileItem *                     m_currentFile;                 /*!< the PVR file that is currently playing */
+    CFileItemPtr                    m_currentFile;                 /*!< the PVR file that is currently playing */
     CPVRDatabase *                  m_database;                    /*!< the database for all PVR related data */
     CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
     bool                            m_bFirstStart;                 /*!< true when the PVR manager was started first, false otherwise */
@@ -720,14 +720,14 @@ private:
   class CPVRChannelSwitchJob : public CJob
   {
   public:
-    CPVRChannelSwitchJob(CFileItem* previous, CFileItem* next) : m_previous(previous), m_next(next) {}
+    CPVRChannelSwitchJob(const CFileItemPtr &previous, const CFileItemPtr & next) : m_previous(previous), m_next(next) {}
     virtual ~CPVRChannelSwitchJob() {}
     virtual const char *GetType() const { return "pvr-channel-switch"; }
 
     virtual bool DoWork();
   private:
-    CFileItem* m_previous;
-    CFileItem* m_next;
+    CFileItemPtr m_previous;
+    CFileItemPtr m_next;
   };
 
   class CPVRSearchMissingChannelIconsJob : public CJob


### PR DESCRIPTION
@FernetMenta i have no idea whether this is a good approach, so i want to hear your opinion on this:

When switching channels using page up / page down / up / down the video osd pops up and there is a lot of flickering of the stream details 'buttons' until the new stream actually starts playing.

This PR fixes the problem with introduction and usage of a bool "switchingchannels" in VideoPlayer. The new bool will set when channel switching starts and reset when the new channel stream is detected.

![screenshot002](https://cloud.githubusercontent.com/assets/3226626/17368100/fe6a4bf4-5992-11e6-9446-086f4344c13e.png)

Don't be shy to tell me if this is bullshit and you have a better idea for a fix. ;-)
