### PR TITLE
settings: Add settings option to control atempo resampling

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6818,7 +6818,18 @@ msgctxt "#13516"
 msgid "Add art"
 msgstr ""
 
-#empty strings from id 13517 to 13549
+#: system/settings/settings.xml
+msgctxt "#13517"
+msgid "Threshold for pitch correction"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#13518"
+msgid "When the speed change exceeds this threshold, a pitch-correction filter will be applied. This avoids the \"chipmonk voices\" that normally result from speeding up a video"
+msgstr ""
+
+
+#empty strings from id 13519 to 13549
 
 #: system/settings/settings.xml
 msgctxt "#13550"

--- a/system/settings/rbp.xml
+++ b/system/settings/rbp.xml
@@ -92,6 +92,9 @@
         <setting id="audiooutput.processquality">
           <default>101</default> <!-- AE_QUALITY_GPU -->
         </setting>
+        <setting id="audiooutput.atempothreshold">
+          <default>100</default> <!-- disabled -->
+        </setting>
       </group>
       <group id="3">
         <setting id="audiooutput.ac3transcode" help="37024">

--- a/system/settings/rbp2.xml
+++ b/system/settings/rbp2.xml
@@ -18,6 +18,11 @@
       </group>
     </category>
     <category id="audio">
+      <group id="1">
+        <setting id="audiooutput.atempothreshold">
+          <default>2</default> <!-- 2% -->
+        </setting>
+      </group>
       <group id="3">
         <setting id="audiooutput.ac3transcode" help="36429">
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2370,6 +2370,16 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="audiooutput.atempothreshold" type="integer" label="13517" help="13518">
+          <level>3</level>
+          <default>2</default> <!-- 2% -->
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="edit" format="integer" />
+        </setting>
         <setting id="audiooutput.samplerate" type="integer" label="458" help="36523">
           <level>2</level>
           <default>48000</default>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -71,6 +71,7 @@ struct AudioSettings
   int guisoundmode;
   unsigned int samplerate;
   AEQuality resampleQuality;
+  double atempoThreshold;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -714,9 +714,9 @@ bool CActiveAEStreamBuffers::IsDrained()
     return false;
 }
 
-void CActiveAEStreamBuffers::SetRR(double rr)
+void CActiveAEStreamBuffers::SetRR(double rr, double atempoThreshold)
 {
-  if (rr < 1.02 && rr > 0.98)
+  if (fabs(rr - 1.0) < atempoThreshold)
   {
     m_resampleBuffers->SetRR(rr);
     m_atempoBuffers->SetTempo(1.0);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -103,7 +103,7 @@ public:
   void Flush();
   void SetDrain(bool drain);
   bool IsDrained();
-  void SetRR(double rr);
+  void SetRR(double rr, double atempoThreshold);
   double GetRR();
   void FillBuffer();
   bool DoesNormalize();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -354,6 +354,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_SAMPLERATE = "audiooutput.sampl
 const std::string CSettings::SETTING_AUDIOOUTPUT_STEREOUPMIX = "audiooutput.stereoupmix";
 const std::string CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME = "audiooutput.maintainoriginalvolume";
 const std::string CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY = "audiooutput.processquality";
+const std::string CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD = "audiooutput.atempothreshold";
 const std::string CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE = "audiooutput.streamsilence";
 const std::string CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED = "audiooutput.dspaddonsenabled";
 const std::string CSettings::SETTING_AUDIOOUTPUT_DSPSETTINGS = "audiooutput.dspsettings";
@@ -1063,6 +1064,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_CHANNELS);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_GUISOUNDMODE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STEREOUPMIX);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_AC3PASSTHROUGH);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -311,6 +311,7 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_STEREOUPMIX;
   static const std::string SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME;
   static const std::string SETTING_AUDIOOUTPUT_PROCESSQUALITY;
+  static const std::string SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD;
   static const std::string SETTING_AUDIOOUTPUT_STREAMSILENCE;
   static const std::string SETTING_AUDIOOUTPUT_DSPADDONSENABLED;
   static const std::string SETTING_AUDIOOUTPUT_DSPSETTINGS;


### PR DESCRIPTION
Atempo rsampling does increase cpu usage so may want to be disabled (e.g. on Pi 1).
The threshold when atempo resampling is used compared to normal resampling could be usefully changed.

This adds a setting for controlling this and defaults to disabled on Pi 1
