### PR TITLE
use final redirected path for internet streams

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1753,6 +1753,11 @@ std::string CCurlFile::GetServerReportedCharset(void)
   return m_state->m_httpheader.GetCharset();
 }
 
+std::string CCurlFile::GetURL(void)
+{
+  return m_url;
+}
+
 /* STATIC FUNCTIONS */
 bool CCurlFile::GetHttpHeader(const CURL &url, CHttpHeader &headers)
 {

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -94,6 +94,7 @@ namespace XFILE
 
       const CHttpHeader& GetHttpHeader() const { return m_state->m_httpheader; }
       std::string GetServerReportedCharset(void);
+      std::string GetURL(void);
 
       /* static function that will get content type of a file */
       static bool GetHttpHeader(const CURL &url, CHttpHeader &headers);


### PR DESCRIPTION
This PR makes sure input streams use the final redirected url for internet based streams.

Currently, even in some cases when the stream seems to successfully open, subsequent requests use the base path of the original url rather than the final redirected one. For example load balancer urls for HLS streams.

There may be a better way for handling this, but it's the broadest, yet simplest way that I could find.
