### PR TITLE
Resolution: Choose most matching refreshrate

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -303,8 +303,21 @@ float CResolutionUtils::RefreshWeight(float refresh, float fps)
   float div   = refresh / fps;
   int   round = MathUtils::round_int(div);
 
+  float weight = 0.0f;
+
   if (round < 1)
-    return (fps - refresh) / fps;
+    weight = (fps - refresh) / fps;
   else
-    return (float)fabs(div / round - 1.0);
+    weight = (float)fabs(div / round - 1.0);
+
+  // punish higher refreshrates and prefer better matching
+  // e.g. 30 fps content at 60 hz is better than
+  // 30 fps at 120 hz - as we sometimes don't know if
+  // the content is interlaced at the start, only
+  // punish when refreshrate > 60 hz to not have to switch
+  // twice for 30i content
+  if (refresh > 60 && round > 1)
+    weight += round / 1000.0;
+
+  return weight;
 }


### PR DESCRIPTION
Admiral Schneider on the forum had an issue with his new 120 hz TV. This TV also has a 119.8804 mode which is used for 23.97608 content. Because our metric always ends with a distance measure of 0.0 if (refreshrate / video_fps) / round(refreshrate / video_fps) == 0.0. So basically every division without rest gets this 0.0

As we render with refreshrate 120 hz and this puts immense load for 24.0 fps content onto GPUs, we shall punish modes so that 24.0 gets a lower measure than 120 fps.

Another example: 30 fps
TV has: 30 hz, 60 hz and 120 hz

Before this PR:

w(30) == w(60) == w(120) = 0.0

After this PR:

w(30) < w(60) < w(120)

but still:

w(60) < w(59.94) < w(118.88)
