### PR TITLE
FFmpeg: Bump to 3.1.1-Krypton-Beta1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.1-Krypton-Alpha3
+VERSION=3.1.1-Krypton-Beta1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.9


### PR DESCRIPTION
This fixes bugs with mp3 playback that were introduced with ffmpeg 3.1. Furthermore it fixes several HLS streaming related issues.
