### PR TITLE
[PVR] CDirectoryProvider now supports async PVR startup. Fixes favori…

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -2597,6 +2597,7 @@
 		2AC7EB591C21F6BA00BDAA95 /* GUIWindowPVRTimersBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowPVRTimersBase.h; sourceTree = "<group>"; };
 		2AC7EB5E1C34892100BDAA95 /* PVRRecordingsPath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PVRRecordingsPath.h; sourceTree = "<group>"; };
 		2AC7EB5F1C34893700BDAA95 /* PVRRecordingsPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PVRRecordingsPath.cpp; sourceTree = "<group>"; };
+		2AE16B7A1D58B11B005C20EB /* PVRManagerState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PVRManagerState.h; sourceTree = "<group>"; };
 		2AFBB94A1CC6088000BAB340 /* GUIEPGGridContainerModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIEPGGridContainerModel.h; sourceTree = "<group>"; };
 		2AFBB94B1CC608A200BAB340 /* GUIEPGGridContainerModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIEPGGridContainerModel.cpp; sourceTree = "<group>"; };
 		2F4564D31970129A00396109 /* GUIFontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIFontCache.cpp; sourceTree = "<group>"; };
@@ -6974,6 +6975,7 @@
 				C848289E156CFCD8005A996F /* PVRGUIInfo.h */,
 				C848289F156CFCD8005A996F /* PVRManager.cpp */,
 				C84828A0156CFCD8005A996F /* PVRManager.h */,
+				2AE16B7A1D58B11B005C20EB /* PVRManagerState.h */,
 				2A7B2BDB1BD6F16600044BCD /* PVRSettings.cpp */,
 				2A7B2BDE1BD6F18B00044BCD /* PVRSettings.h */,
 			);

--- a/addons/skin.estuary/1080i/Home.xml
+++ b/addons/skin.estuary/1080i/Home.xml
@@ -570,8 +570,10 @@
 							<param name="item7_vis" value="False" />
 							<param name="item8_vis" value="False" />
 						</include>
-						<include content="WidgetListChannels" condition="PVR.HasTVChannels">
+						<include content="WidgetListChannels">
 							<param name="content_path" value="pvr://channels/tv/All channels/"/>
+							<param name="sortby" value="lastplayed"/>
+							<param name="sortorder" value="descending"/>
 							<param name="widget_header" value="$LOCALIZE[31016]"/>
 							<param name="widget_target" value="pvr"/>
 							<param name="list_id" value="12200"/>
@@ -650,8 +652,10 @@
 							<param name="item7_vis" value="False" />
 							<param name="item8_vis" value="False" />
 						</include>
-						<include content="WidgetListChannels" condition="PVR.HasRadioChannels">
+						<include content="WidgetListChannels">
 							<param name="content_path" value="pvr://channels/radio/All channels/"/>
+							<param name="sortby" value="lastplayed"/>
+							<param name="sortorder" value="descending"/>
 							<param name="widget_header" value="$LOCALIZE[31018]"/>
 							<param name="widget_target" value="files"/>
 							<param name="list_id" value="13200"/>

--- a/addons/skin.estuary/1080i/Includes_Home.xml
+++ b/addons/skin.estuary/1080i/Includes_Home.xml
@@ -905,7 +905,7 @@
 							<top>350</top>
 							<width>260</width>
 							<height>100</height>
-							<label>[COLOR button_focus]$INFO[ListItem.StartTime] - $INFO[ListItem.EndTime][/COLOR][CR]$INFO[ListItem.Title]</label>
+							<label>[COLOR button_focus]$INFO[ListItem.StartTime,, - ]$INFO[ListItem.EndTime][/COLOR][CR]$INFO[ListItem.Title]</label>
 							<font>font12</font>
 							<shadowcolor>text_shadow</shadowcolor>
 							<align>center</align>
@@ -957,7 +957,7 @@
 								<top>350</top>
 								<width>260</width>
 								<height>100</height>
-								<label>[COLOR button_focus]$INFO[ListItem.StartTime] - $INFO[ListItem.EndTime][/COLOR][CR]$INFO[ListItem.Title]</label>
+								<label>[COLOR button_focus]$INFO[ListItem.StartTime,, - ]$INFO[ListItem.EndTime][/COLOR][CR]$INFO[ListItem.Title]</label>
 								<font>font12</font>
 								<shadowcolor>text_shadow</shadowcolor>
 								<align>center</align>

--- a/addons/skin.estuary/1080i/Includes_Home.xml
+++ b/addons/skin.estuary/1080i/Includes_Home.xml
@@ -277,7 +277,7 @@
 						</control>
 					</control>
 				</focusedlayout>
-				<content target="$PARAM[widget_target]" limit="10">$PARAM[content_path]</content>
+				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="10">$PARAM[content_path]</content>
 			</control>
 		</control>
 	</include>
@@ -965,7 +965,7 @@
 							</control>
 						</control>
 					</focusedlayout>
-					<content target="$PARAM[widget_target]" limit="$PARAM[item_limit]">$PARAM[content_path]</content>
+					<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[item_limit]">$PARAM[content_path]</content>
 				</control>
 			</control>
 		</definition>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10092,7 +10092,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     if (item->HasPVRChannelInfoTag())
     {
       CEpgInfoTagPtr tag(item->GetPVRChannelInfoTag()->GetEPGNow());
-      return tag ? tag->StartAsLocalTime().GetAsLocalizedTime("", false) : CDateTime::GetCurrentDateTime().GetAsLocalizedTime("", false);
+      if (tag)
+        return tag->StartAsLocalTime().GetAsLocalizedTime("", false);
     }
     if (item->HasEPGInfoTag())
       return item->GetEPGInfoTag()->StartAsLocalTime().GetAsLocalizedTime("", false);
@@ -10115,7 +10116,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     if (item->HasPVRChannelInfoTag())
     {
       CEpgInfoTagPtr tag(item->GetPVRChannelInfoTag()->GetEPGNow());
-      return tag ? tag->EndAsLocalTime().GetAsLocalizedTime("", false) : CDateTime::GetCurrentDateTime().GetAsLocalizedTime("", false);
+      if (tag)
+        return tag->EndAsLocalTime().GetAsLocalizedTime("", false);
     }
     else if (item->HasEPGInfoTag())
       return item->GetEPGInfoTag()->EndAsLocalTime().GetAsLocalizedTime("", false);
@@ -10133,7 +10135,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     if (item->HasPVRChannelInfoTag())
     {
       CEpgInfoTagPtr tag(item->GetPVRChannelInfoTag()->GetEPGNow());
-      return tag ? tag->StartAsLocalTime().GetAsLocalizedDate(true) : CDateTime::GetCurrentDateTime().GetAsLocalizedDate(true);
+      if (tag)
+        return tag->StartAsLocalTime().GetAsLocalizedDate(true);
     }
     if (item->HasEPGInfoTag())
       return item->GetEPGInfoTag()->StartAsLocalTime().GetAsLocalizedDate(true);
@@ -10148,7 +10151,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     if (item->HasPVRChannelInfoTag())
     {
       CEpgInfoTagPtr tag(item->GetPVRChannelInfoTag()->GetEPGNow());
-      return tag ? tag->EndAsLocalTime().GetAsLocalizedDate(true) : CDateTime::GetCurrentDateTime().GetAsLocalizedDate(true);
+      if (tag)
+        return tag->EndAsLocalTime().GetAsLocalizedDate(true);
     }
     if (item->HasEPGInfoTag())
       return item->GetEPGInfoTag()->EndAsLocalTime().GetAsLocalizedDate(true);

--- a/xbmc/epg/EpgContainer.h
+++ b/xbmc/epg/EpgContainer.h
@@ -297,7 +297,10 @@ namespace EPG
     CCriticalSection               m_critSection;    /*!< a critical section for changes to this container */
     CEvent                         m_updateEvent;    /*!< trigger when an update finishes */
 
-    std::list<SUpdateRequest> m_updateRequests; /*!< list of update requests triggered by addon*/
-    CCriticalSection m_updateRequestsLock;      /*!< protect update requests*/
+    std::list<SUpdateRequest> m_updateRequests; /*!< list of update requests triggered by addon */
+    CCriticalSection m_updateRequestsLock;      /*!< protect update requests */
+
+  private:
+    bool m_bUpdateNotificationPending; /*!< true while an epg updated notification to observers is pending. */
   };
 }

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -25,6 +25,7 @@
 #include "addons/AddonEvents.h"
 #include "IListProvider.h"
 #include "guilib/GUIStaticItem.h"
+#include "pvr/PVRManagerState.h"
 #include "utils/Job.h"
 #include "threads/CriticalSection.h"
 #include "interfaces/IAnnouncer.h"
@@ -87,5 +88,6 @@ private:
   bool UpdateURL();
   bool UpdateLimit();
   bool UpdateSort();
-  void OnEvent(const ADDON::AddonEvent& event);
+  void OnAddonEvent(const ADDON::AddonEvent& event);
+  void OnPVRManagerEvent(const PVR::ManagerState& event);
 };

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS PVRActionListener.h
             PVRDatabase.h
             PVRGUIInfo.h
             PVRManager.h
+            PVRManagerState.h
             PVRSettings.h)
 
 core_add_library(pvr)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -361,17 +361,12 @@ ManagerState CPVRManager::GetState(void) const
 
 void CPVRManager::SetState(ManagerState state)
 {
-  {
-    CSingleLock lock(m_managerStateMutex);
-    if (m_managerState == state)
-      return;
+  CSingleLock lock(m_managerStateMutex);
+  if (m_managerState == state)
+    return;
 
-    m_managerState = state;
-    m_events.Publish(m_managerState);
-    SetChanged();
-  }
-
-  NotifyObservers(ObservableMessageManagerStateChanged);
+  m_managerState = state;
+  m_events.Publish(m_managerState);
 }
 
 void CPVRManager::Process(void)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -363,7 +363,11 @@ void CPVRManager::SetState(ManagerState state)
 {
   {
     CSingleLock lock(m_managerStateMutex);
+    if (m_managerState == state)
+      return;
+
     m_managerState = state;
+    m_events.Publish(m_managerState);
     SetChanged();
   }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -29,6 +29,7 @@
 #include "utils/JobManager.h"
 #include "utils/Observer.h"
 
+#include "pvr/PVRManagerState.h"
 #include "pvr/recordings/PVRRecording.h"
 
 #include <map>
@@ -60,16 +61,6 @@ namespace PVR
   class CPVRGUIInfo;
   class CPVRDatabase;
   class CGUIWindowPVRCommon;
-
-  enum ManagerState
-  {
-    ManagerStateError = 0,
-    ManagerStateStopped,
-    ManagerStateStarting,
-    ManagerStateStopping,
-    ManagerStateInterrupted,
-    ManagerStateStarted
-  };
 
   enum PlaybackType
   {

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -25,6 +25,7 @@
 #include "settings/lib/ISettingCallback.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
+#include "utils/EventStream.h"
 #include "utils/JobManager.h"
 #include "utils/Observer.h"
 
@@ -569,6 +570,11 @@ private:
      */
     bool IsChannelPreview() const;
 
+    /*!
+     * @brief Query the events available for CEventStream
+     */
+    CEventStream<ManagerState>& Events() { return m_events; }
+
   protected:
     /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
@@ -667,6 +673,7 @@ private:
     static const int                m_pvrWindowIds[12];
 
     std::atomic_bool m_isChannelPreview;
+    CEventSource<ManagerState> m_events;
   };
 
   class CPVRStartupJob : public CJob

--- a/xbmc/pvr/PVRManagerState.h
+++ b/xbmc/pvr/PVRManagerState.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2012-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace PVR
+{
+  enum ManagerState
+  {
+    ManagerStateError = 0,
+    ManagerStateStopped,
+    ManagerStateStarting,
+    ManagerStateStopping,
+    ManagerStateInterrupted,
+    ManagerStateStarted
+  };
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -54,7 +54,7 @@ CPVRChannelGroupInternal::CPVRChannelGroupInternal(const CPVRChannelGroup &group
 CPVRChannelGroupInternal::~CPVRChannelGroupInternal(void)
 {
   Unload();
-  g_PVRManager.UnregisterObserver(this);
+  g_PVRManager.Events().Unsubscribe(this);
 }
 
 bool CPVRChannelGroupInternal::Load(void)
@@ -62,8 +62,7 @@ bool CPVRChannelGroupInternal::Load(void)
   if (CPVRChannelGroup::Load())
   {
     UpdateChannelPaths();
-    g_PVRManager.RegisterObserver(this);
-
+    g_PVRManager.Events().Subscribe(this, &CPVRChannelGroupInternal::OnPVRManagerEvent);
     return true;
   }
 
@@ -348,10 +347,8 @@ bool CPVRChannelGroupInternal::CreateChannelEpgs(bool bForce /* = false */)
   return true;
 }
 
-void CPVRChannelGroupInternal::Notify(const Observable &obs, const ObservableMessage msg)
+void CPVRChannelGroupInternal::OnPVRManagerEvent(const PVR::ManagerState& event)
 {
-  if (msg == ObservableMessageManagerStateChanged)
-  {
+  if (event == ManagerStateStarted)
     g_PVRManager.TriggerEpgsCreate();
-  }
 }

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include "utils/Observer.h"
+#include "pvr/PVRManagerState.h"
 
 #include "PVRChannelGroup.h"
 
@@ -30,7 +30,7 @@ namespace PVR
 
   /** XBMC's internal group, the group containing all channels */
 
-  class CPVRChannelGroupInternal : public CPVRChannelGroup, public Observer
+  class CPVRChannelGroupInternal : public CPVRChannelGroup
   {
     friend class CPVRChannelGroups;
     friend class CPVRDatabase;
@@ -45,8 +45,6 @@ namespace PVR
     CPVRChannelGroupInternal(const CPVRChannelGroup &group);
 
     virtual ~CPVRChannelGroupInternal(void);
-
-    virtual void Notify(const Observable &obs, const ObservableMessage msg);
 
     /**
      * @brief The amount of channels in this container.
@@ -154,5 +152,8 @@ namespace PVR
     void CreateChannelEpg(CPVRChannelPtr channel, bool bForce = false);
 
     size_t m_iHiddenChannels; /*!< the amount of hidden channels in this container */
+
+  private:
+    void OnPVRManagerEvent(const PVR::ManagerState& event);
   };
 }

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -40,8 +40,7 @@ typedef enum
   ObservableMessageTimers,
   ObservableMessageTimersReset,
   ObservableMessageRecordings,
-  ObservableMessagePeripheralsChanged,
-  ObservableMessageManagerStateChanged
+  ObservableMessagePeripheralsChanged
 } ObservableMessage;
 
 class Observer


### PR DESCRIPTION
…te tv and radio channels not appearing on Home screen, sort method and order, item re-selection after update, start and end time when no epg.

Currently, Estuary's favorite tv and radio channels widget gets not filled on initial Kodi startup. One needs to open any other window and to go back to home screen to get the widgets populated. This is due to the related directoty list providers not respecting asynchronous pvr startup.

The problem is similar to and the solution is logically the same as for #10203  

Important: This also needs a skin fix to work properly.

@da-anda fyi
@Jalle19 for review?
