### PR TITLE
[settings] make skin settings button more obvious

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7771,7 +7771,12 @@ msgctxt "#14260"
 msgid "Debug"
 msgstr ""
 
-#empty strings from id 14261 to 14269
+#: system/settings/settings.xml
+msgctxt "#14261"
+msgid "Configure skin..."
+msgstr ""
+
+#empty strings from id 14262 to 14269
 
 #: system/settings/settings.xml
 msgctxt "#14270"
@@ -14685,6 +14690,7 @@ msgid "Manage dependencies"
 msgstr ""
 
 #: xbmc/filesystem/AddonsDirectory.cpp
+#: system/settings/settings.xml
 msgctxt "#24997"
 msgid "Look and feel"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3016,7 +3016,7 @@
   </section>
   <section id="interface" label="14206" help="38102">
     <category id="skin" label="166" help="36102">
-      <group id="1" label="16000">
+      <group id="1" label="24997">
         <setting id="lookandfeel.skin" type="addon" label="166" help="36103">
           <level>0</level>
           <default>skin.estuary</default>
@@ -3027,7 +3027,7 @@
             <show more="true" details="true">installed</show>
           </control>
         </setting>
-        <setting id="lookandfeel.skinsettings" type="action" parent="lookandfeel.skin" label="21417" help="36104">
+        <setting id="lookandfeel.skinsettings" type="action" parent="lookandfeel.skin" label="14261" help="36104">
           <level>0</level>
           <dependencies>
             <dependency type="enable" on="property" name="AddonHasSettings" setting="lookandfeel.skin" />
@@ -3046,7 +3046,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="lookandfeel.skincolors" type="string" parent="lookandfeel.skin" label="14078" help="36106">
-          <level>2</level>
+          <level>1</level>
           <default>SKINDEFAULT</default>
           <constraints>
             <options>skincolors</options>
@@ -3057,7 +3057,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="lookandfeel.font" type="string" parent="lookandfeel.skin" label="13303" help="36107">
-          <level>2</level>
+          <level>1</level>
           <default>Default</default>
           <constraints>
             <options>skinfonts</options>
@@ -3068,7 +3068,7 @@
           <control type="list" format="string" />
         </setting>
         <setting id="lookandfeel.skinzoom" type="integer" parent="lookandfeel.skin" label="20109" help="36108">
-          <level>2</level>
+          <level>1</level>
           <default>0</default>
           <constraints>
             <minimum>-20</minimum>


### PR DESCRIPTION
There's been a number of comments over the years that access to the skin specific settings is not obvious enough to a new users, thus they miss out on the options to configure what's shown on main menu for example.

I've tried to do this in as low impact way as possible, so as I see it there are two options:

1) A simple labelling to "Configure skin settings.." so the wording points it's something to be selected, plus the UI convention of have three trailing dots "..." to suggest there's something more.

![image](https://cloud.githubusercontent.com/assets/5781142/17462470/03ef8088-5ca6-11e6-91a0-f713ea5c9223.png)

2) Move this setting to it's own Group then similar to above have a "Configure..." label for the button to suggest something to be selected.

![image](https://cloud.githubusercontent.com/assets/5781142/17462483/56965398-5ca6-11e6-914a-f444e40ad735.png)

For easy comparison this PR currently contains both options.

As well as trying to make access to these settings more obvious in "Interface" -> "Skin", I've personally got a dislike for Estuary having skin settings in two locations, and I can see that being a source of user confusion as to why we have 

![image](https://cloud.githubusercontent.com/assets/5781142/17462494/dde001aa-5ca6-11e6-82ab-e44038a6a5f4.png)

as well as "Interface" -> "Skin". Thus if this goes in using one of the options I've given, then there's the possiblity the "Skin settings" shortcut is no longer need in the main settings window. That decision would of course be up to the skinners.

What are peoples thought? @MartijnKaijser @phil65 @ronie @BigNoid @HitcherUK 
