### PR TITLE
VideoPlayer: drop IsCaching, useless and not thread safe

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -319,12 +319,6 @@ int64_t CApplicationPlayer::GetTime() const
     return 0;
 }
 
-bool CApplicationPlayer::IsCaching() const
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  return (player && player->IsCaching());
-}
-
 bool CApplicationPlayer::IsInMenu() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -141,7 +141,6 @@ public:
   bool  HasMenu() const;
   bool  HasVideo() const;
   bool  HasRDS() const;
-  bool  IsCaching() const;
   bool  IsInMenu() const;
   bool  IsPaused();
   bool  IsPausedPlayback();

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7039,7 +7039,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = GetDisplayAfterSeek();
     break;
     case PLAYER_CACHING:
-      bReturn = g_application.m_pPlayer->IsCaching();
+      bReturn = false;
     break;
     case PLAYER_SEEKBAR:
       {

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -336,8 +336,6 @@ public:
   // Skip to next track/item inside the current media (if supported).
   virtual bool SkipNext(){return false;}
 
-  //Returns true if not playback (paused or stopped beeing filled)
-  virtual bool IsCaching() const {return false;};
   //Cache filled in Percent
   virtual int GetCacheLevel() const {return -1;};
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -338,22 +338,21 @@ public:
   virtual void OnLostDisplay();
   virtual void OnResetDisplay();
 
-  enum ECacheState
-  { CACHESTATE_DONE = 0
-  , CACHESTATE_FULL     // player is filling up the demux queue
-  , CACHESTATE_INIT     // player is waiting for first packet of each stream
-  , CACHESTATE_PLAY     // player is waiting for players to not be stalled
-  , CACHESTATE_FLUSH    // temporary state player will choose startup between init or full
-  };
-
-  virtual bool IsCaching() const { return m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY; }
-  virtual int GetCacheLevel() const ;
+  virtual int GetCacheLevel() const override;
 
   virtual int OnDVDNavResult(void* pData, int iMessage) override;
   void GetVideoResolution(unsigned int &width, unsigned int &height) override;
 
 protected:
   friend class CSelectionStreams;
+  enum ECacheState
+  {
+    CACHESTATE_DONE = 0,
+    CACHESTATE_FULL,     // player is filling up the demux queue
+    CACHESTATE_INIT,     // player is waiting for first packet of each stream
+    CACHESTATE_PLAY,     // player is waiting for players to not be stalled
+    CACHESTATE_FLUSH,    // temporary state player will choose startup between init or full
+  };
 
   virtual void OnStartup();
   virtual void OnExit();

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -1153,10 +1153,6 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
       responseBody = StringUtils::Format(PLAYBACK_INFO, duration, cachePosition, position, (playing ? 1 : 0), duration);
       responseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
 
-      if (g_application.m_pPlayer->IsCaching())
-      {
-        CAirPlayServer::ServerInstance->AnnounceToClients(EVENT_LOADING);
-      }
     }
     else
     {


### PR DESCRIPTION
see title

@HitcherUK @BigNoid @ronie @phil65 
the gui label will be still there for a while. I suggest that you drop usage of this label from skins.
