### PR TITLE
Add possibility to get information from both .nfo and scraper

### DIFF
--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -41,14 +41,15 @@ public:
     FULL_NFO     = 1,
     URL_NFO      = 2,
     COMBINED_NFO = 3,
-    ERROR_NFO    = 4
+    ERROR_NFO    = 4,
+    PARTIAL_NFO  = 5
   };
 
   NFOResult Create(const std::string&, const ADDON::ScraperPtr&, int episode=-1);
   template<class T>
-    bool GetDetails(T& details,const char* document=NULL, bool prioritise=false)
+    bool GetDetails(T& details, const char* document=NULL,
+                    bool prioritise=false)
   {
-
     CXBMCTinyXML doc;
     if (document)
       doc.Parse(document, TIXML_ENCODING_UNKNOWN);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1113,7 +1113,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
       scraper.GetAlbums().clear();
       scraper.GetAlbums().push_back(albumNfo);
     }
-    else
+    else if (result != CNfoFile::PARTIAL_NFO)
       CLog::Log(LOGERROR,"Unable to find an url in nfo file: %s", strNfo.c_str());
   }
 
@@ -1140,7 +1140,8 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
 
   CGUIDialogSelect *pDlg = NULL;
   int iSelectedAlbum=0;
-  if (result == CNfoFile::NO_NFO && !bMusicBrainz)
+  if ((result == CNfoFile::NO_NFO || result == CNfoFile::PARTIAL_NFO)
+      && !bMusicBrainz)
   {
     iSelectedAlbum = -1; // set negative so that we can detect a failure
     if (scraper.Succeeded() && scraper.GetAlbumCount() >= 1)
@@ -1258,7 +1259,7 @@ INFO_RET CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album, const ADDON::
 
   albumInfo = scraper.GetAlbum(iSelectedAlbum);
   
-  if (result == CNfoFile::COMBINED_NFO)
+  if (result == CNfoFile::COMBINED_NFO || result == CNfoFile::PARTIAL_NFO)
     nfoReader.GetDetails(albumInfo.GetAlbum(), NULL, true);
   
   return INFO_ADDED;

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -102,8 +102,8 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
 
       // if we are performing a forced refresh ask the user to choose between using a valid NFO and a valid scraper
-      if (needsRefresh && IsModal() && !scraper->IsNoop() &&
-         (nfoResult == CNfoFile::URL_NFO || nfoResult == CNfoFile::COMBINED_NFO || nfoResult == CNfoFile::FULL_NFO))
+      if (needsRefresh && IsModal() && !scraper->IsNoop()
+          && nfoResult != CNfoFile::ERROR_NFO)
       {
         int heading = 20159;
         if (scraper->Content() == CONTENT_MOVIES)
@@ -292,7 +292,10 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     }
 
     // finally download the information for the item
-    if (!scanner.RetrieveVideoInfo(items, scanSettings.parent_name, scraper->Content(), !ignoreNfo, &scraperUrl, m_refreshAll, GetProgressDialog()))
+    if (!scanner.RetrieveVideoInfo(items, scanSettings.parent_name,
+                                   scraper->Content(), !ignoreNfo,
+                                   scraperUrl.m_url.empty() ? NULL : &scraperUrl,
+                                   m_refreshAll, GetProgressDialog()))
     {
       // something went wrong
       MarkFinished();


### PR DESCRIPTION
This is my first contribution to kodi and I have not much coding and open source development experience in general. I think I comply with your contributing guidelines, but mistakes can happen and I appreciate any feedback.

**What does this do:**
This extends the functionality of a combined nfo file ([3 Video .nfo files containing a mix of XML and URL](http://kodi.wiki/view/NFO_files/movies#Video_.nfo_files_containing_a_mix_of_XML_and_URL). The present behavior requires that the user manually finds the URL and adds it to the nfo file to complete his manually provided information with scraper information. With this patch one can insert `[scrape url]` instead of an actual url at the end of the file. The usual procedure is used to find a suitable link, otherwise it is treated as if a link was given.

**Use case:**
I simply want to add a genre to some of my movies. Without this change this means I have to find the appropriate link for every movie to make that simple addition. Now I can simply add `[scrape url]` at the end of the nfo.

**Implementation:**
The changes should be fairly self explanatory. I detect the presence of the `[scrape url]` line simply using  `string.find` on the nfo file string. While doing the necessary changes I added or changed some debugging messages, corrected smaller mistakes and made readability improvements (at places relevant to this PR).
