### PR TITLE
Fix joystick input while app is in background

### DIFF
--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -22,6 +22,7 @@
 #include "KeymapHandler.h"
 #include "JoystickTranslator.h"
 #include "input/Key.h"
+#include "Application.h"
 
 #include <algorithm>
 #include <cmath>
@@ -56,6 +57,11 @@ bool CDefaultJoystick::HasFeature(const FeatureName& feature) const
     return true;
 
   return false;
+}
+
+bool CDefaultJoystick::AcceptsInput()
+{
+  return g_application.IsAppFocused();
 }
 
 INPUT_TYPE CDefaultJoystick::GetInputType(const FeatureName& feature) const

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -82,6 +82,12 @@ bool CDefaultJoystick::OnButtonPress(const FeatureName& feature, bool bPressed)
   return false;
 }
 
+void CDefaultJoystick::OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs)
+{
+  const unsigned int keyId = GetKeyID(feature);
+  m_handler->OnDigitalKey(keyId, true, holdTimeMs);
+}
+
 bool CDefaultJoystick::OnButtonMotion(const FeatureName& feature, float magnitude)
 {
   const unsigned int keyId = GetKeyID(feature);
@@ -95,7 +101,7 @@ bool CDefaultJoystick::OnButtonMotion(const FeatureName& feature, float magnitud
   return false;
 }
 
-bool CDefaultJoystick::OnAnalogStickMotion(const FeatureName& feature, float x, float y)
+bool CDefaultJoystick::OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs)
 {
   // Calculate the direction of the stick's position
   const CARDINAL_DIRECTION analogStickDir = CJoystickTranslator::VectorToCardinalDirection(x, y);
@@ -111,7 +117,7 @@ bool CDefaultJoystick::OnAnalogStickMotion(const FeatureName& feature, float x, 
   }
 
   // Now activate direction the analog stick is pointing
-  return ActivateDirection(feature, magnitude, analogStickDir);
+  return ActivateDirection(feature, magnitude, analogStickDir, motionTimeMs);
 }
 
 bool CDefaultJoystick::OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z)
@@ -119,7 +125,7 @@ bool CDefaultJoystick::OnAccelerometerMotion(const FeatureName& feature, float x
   return false; //! @todo implement
 }
 
-bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir)
+bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir, unsigned int motionTimeMs)
 {
   // Calculate the button key ID and input type for the analog stick's direction
   const unsigned int  keyId     = GetKeyID(feature, dir);
@@ -128,7 +134,7 @@ bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magni
   if (inputType == INPUT_TYPE::DIGITAL)
   {
     const bool bIsPressed = (magnitude >= ANALOG_DIGITAL_THRESHOLD);
-    m_handler->OnDigitalKey(keyId, bIsPressed);
+    m_handler->OnDigitalKey(keyId, bIsPressed, motionTimeMs);
     return true;
   }
   else if (inputType == INPUT_TYPE::ANALOG)

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -52,8 +52,11 @@ bool CDefaultJoystick::HasFeature(const FeatureName& feature) const
   if (GetKeyID(feature) != 0)
     return true;
 
-  // Try analog stick direction
-  if (GetKeyID(feature, CARDINAL_DIRECTION::UP) != 0)
+  // Try analog stick directions
+  if (GetKeyID(feature, CARDINAL_DIRECTION::UP)    != 0 ||
+      GetKeyID(feature, CARDINAL_DIRECTION::DOWN)  != 0 ||
+      GetKeyID(feature, CARDINAL_DIRECTION::RIGHT) != 0 ||
+      GetKeyID(feature, CARDINAL_DIRECTION::LEFT)  != 0)
     return true;
 
   return false;

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -48,12 +48,13 @@ namespace JOYSTICK
     virtual bool AcceptsInput(void) override;
     virtual INPUT_TYPE GetInputType(const FeatureName& feature) const override;
     virtual bool OnButtonPress(const FeatureName& feature, bool bPressed) override;
+    virtual void OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs) override;
     virtual bool OnButtonMotion(const FeatureName& feature, float magnitude) override;
-    virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y) override;
+    virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs = 0) override;
     virtual bool OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z) override;
 
   private:
-    bool ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir);
+    bool ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir, unsigned int motionTimeMs);
     void DeactivateDirection(const FeatureName& feature, CARDINAL_DIRECTION dir);
 
     /*!

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -45,6 +45,7 @@ namespace JOYSTICK
     // implementation of IInputHandler
     virtual std::string ControllerID(void) const override;
     virtual bool HasFeature(const FeatureName& feature) const override;
+    virtual bool AcceptsInput(void) override;
     virtual INPUT_TYPE GetInputType(const FeatureName& feature) const override;
     virtual bool OnButtonPress(const FeatureName& feature, bool bPressed) override;
     virtual bool OnButtonMotion(const FeatureName& feature, float magnitude) override;

--- a/xbmc/input/joysticks/IInputHandler.h
+++ b/xbmc/input/joysticks/IInputHandler.h
@@ -73,6 +73,17 @@ namespace JOYSTICK
     virtual bool OnButtonPress(const FeatureName& feature, bool bPressed) = 0;
 
     /*!
+    * \brief A digital button has been pressed for more than one event frame
+    *
+    * \param feature      The feature being held
+    * \param holdTimeMs   The time elapsed since the initial press (ms)
+    *
+    * If OnButtonPress() returns true for the initial press, then this callback
+    * is invoked on subsequent frames until the button is released.
+    */
+    virtual void OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs) = 0;
+
+    /*!
      * \brief An analog button (trigger or a pressure-sensitive button) has changed state
      *
      * \param feature      The feature changing state
@@ -89,10 +100,12 @@ namespace JOYSTICK
      * \param feature      The analog stick being moved
      * \param x            The x coordinate in the closed interval [-1, 1]
      * \param y            The y coordinate in the closed interval [-1, 1]
+     * \param motionTimeMs The time elapsed since this analog stick was centered,
+     *                     or 0 if the analog stick is centered
      *
      * \return True if the event was handled otherwise false
      */
-    virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y) = 0;
+    virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs = 0) = 0;
 
     /*!
      * \brief An accelerometer's state has changed

--- a/xbmc/input/joysticks/IInputHandler.h
+++ b/xbmc/input/joysticks/IInputHandler.h
@@ -40,7 +40,19 @@ namespace JOYSTICK
      */
     virtual std::string ControllerID(void) const = 0;
 
+    /*!
+     * \brief Return true if the input handler accepts the given feature
+     *
+     * \param feature A feature belonging to the controller specified by ControllerID()
+     *
+     * \return True if the feature is used for input, false otherwise
+     */
     virtual bool HasFeature(const FeatureName& feature) const = 0;
+
+    /*!
+     * \brief Return true if the input handler is currently accepting input
+     */
+    virtual bool AcceptsInput(void) = 0;
 
     /*!
      * \brief Get the type of input handled by the specified feature

--- a/xbmc/input/joysticks/IKeymapHandler.h
+++ b/xbmc/input/joysticks/IKeymapHandler.h
@@ -47,10 +47,11 @@ namespace JOYSTICK
     /*!
      * \brief A key mapped to a digital action has been pressed or released
      *
-     * \param keyId     The key ID from Key.h
-     * \param bPressed  true if the key's button/axis is activated, false if deactivated
+     * \param keyId      The key ID from Key.h
+     * \param bPressed   true if the key's button/axis is activated, false if deactivated
+     * \param holdTimeMs The held time in ms for pressed buttons, or 0 for released
      */
-    virtual void OnDigitalKey(unsigned int keyId, bool bPressed) = 0;
+    virtual void OnDigitalKey(unsigned int keyId, bool bPressed, unsigned int holdTimeMs = 0) = 0;
 
     /*!
      * \brief Callback for keys mapped to analog actions

--- a/xbmc/input/joysticks/KeymapHandler.h
+++ b/xbmc/input/joysticks/KeymapHandler.h
@@ -20,16 +20,12 @@
 #pragma once
 
 #include "input/joysticks/IKeymapHandler.h"
-#include "threads/CriticalSection.h"
-#include "threads/Event.h"
-#include "threads/Thread.h"
 
 #include <vector>
 
 namespace JOYSTICK
 {
-  class CKeymapHandler : public IKeymapHandler,
-                         protected CThread
+  class CKeymapHandler : public IKeymapHandler
   {
   public:
     CKeymapHandler(void);
@@ -38,12 +34,8 @@ namespace JOYSTICK
 
     // implementation of IKeymapHandler
     virtual INPUT_TYPE GetInputType(unsigned int keyId) const override;
-    virtual void OnDigitalKey(unsigned int keyId, bool bPressed) override;
+    virtual void OnDigitalKey(unsigned int keyId, bool bPressed, unsigned int holdTimeMs = 0) override;
     virtual void OnAnalogKey(unsigned int keyId, float magnitude) override;
-
-  protected:
-    // implementation of CThread
-    virtual void Process(void) override;
 
   private:
     enum BUTTON_STATE
@@ -53,7 +45,7 @@ namespace JOYSTICK
       STATE_BUTTON_HELD,
     };
 
-    bool ProcessButtonPress(unsigned int keyId);
+    void ProcessButtonPress(unsigned int keyId, unsigned int holdTimeMs);
     void ProcessButtonRelease(unsigned int keyId);
     bool IsPressed(unsigned int keyId) const;
 
@@ -62,8 +54,7 @@ namespace JOYSTICK
 
     BUTTON_STATE              m_state;
     unsigned int              m_lastButtonPress;
+    unsigned int              m_lastDigitalActionMs;
     std::vector<unsigned int> m_pressedButtons;
-    CEvent                    m_pressEvent;
-    CCriticalSection          m_digitalMutex;
   };
 }

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -33,8 +33,26 @@ using namespace JOYSTICK;
 CJoystickFeature::CJoystickFeature(const FeatureName& name, IInputHandler* handler, IButtonMap* buttonMap) :
   m_name(name),
   m_handler(handler),
-  m_buttonMap(buttonMap)
+  m_buttonMap(buttonMap),
+  m_bEnabled(m_handler->HasFeature(name))
 {
+}
+
+bool CJoystickFeature::AcceptsInput(bool bActivation)
+{
+  bool bAcceptsInput = false;
+
+  if (m_bEnabled)
+  {
+    if (m_handler->AcceptsInput())
+      bAcceptsInput = true;
+
+    // Avoid sticking
+    if (!bActivation)
+      bAcceptsInput = true;
+  }
+
+  return bAcceptsInput;
 }
 
 // --- CScalarFeature ----------------------------------------------------------
@@ -49,65 +67,61 @@ CScalarFeature::CScalarFeature(const FeatureName& name, IInputHandler* handler, 
 
 bool CScalarFeature::OnDigitalMotion(const CDriverPrimitive& source, bool bPressed)
 {
-  bool bHandled = false;
+  if (!AcceptsInput(bPressed))
+    return false;
 
   if (m_inputType == INPUT_TYPE::DIGITAL)
-  {
-    if (m_bDigitalState != bPressed)
-    {
-      m_bDigitalState = bPressed;
-      bHandled = OnDigitalMotion(bPressed);
-    }
-  }
+    OnDigitalMotion(bPressed);
   else if (m_inputType == INPUT_TYPE::ANALOG)
-  {
-    bHandled = OnAnalogMotion(source, bPressed ? 1.0f : 0.0f);
-  }
+    OnAnalogMotion(bPressed ? 1.0f : 0.0f);
 
-  return bHandled;
+  return true;
 }
 
 bool CScalarFeature::OnAnalogMotion(const CDriverPrimitive& source, float magnitude)
 {
-  bool bHandled = false;
+  if (!AcceptsInput(magnitude != 0.0f))
+    return false;
 
   if (m_inputType == INPUT_TYPE::DIGITAL)
-  {
-    bHandled = OnDigitalMotion(source, magnitude >= ANALOG_DIGITAL_THRESHOLD);
-  }
+    OnDigitalMotion(magnitude >= ANALOG_DIGITAL_THRESHOLD);
   else if (m_inputType == INPUT_TYPE::ANALOG)
-  {
-    if (m_analogState != 0.0f || magnitude != 0.0f)
-    {
-      m_analogState = magnitude;
-      bHandled = OnAnalogMotion(magnitude);
-    }
-  }
+    OnAnalogMotion(magnitude);
 
-  return bHandled;
+  return true;
 }
 
-bool CScalarFeature::OnDigitalMotion(bool bPressed)
+void CScalarFeature::OnDigitalMotion(bool bPressed)
 {
-  CLog::Log(LOGDEBUG, "Feature [ %s ] on %s %s",
-            m_name.c_str(), m_handler->ControllerID().c_str(), bPressed ? "pressed" : "released");
+  if (m_bDigitalState != bPressed)
+  {
+    m_bDigitalState = bPressed;
 
-  return m_handler->OnButtonPress(m_name, bPressed);
+    CLog::Log(LOGDEBUG, "Feature [ %s ] on %s %s", m_name.c_str(), m_handler->ControllerID().c_str(),
+              bPressed ? "pressed" : "released");
+
+    m_handler->OnButtonPress(m_name, bPressed);
+  }
 }
 
-bool CScalarFeature::OnAnalogMotion(float magnitude)
+void CScalarFeature::OnAnalogMotion(float magnitude)
 {
   const bool bActivated = (magnitude != 0.0f);
 
-  if (m_bDigitalState != bActivated)
+  if (m_analogState != 0.0f || magnitude != 0.0f)
   {
-    m_bDigitalState = bActivated;
+    m_analogState = magnitude;
 
-    CLog::Log(LOGDEBUG, "Feature [ %s ] on %s %s",
-              m_name.c_str(), m_handler->ControllerID().c_str(), bActivated ? "activated" : "deactivated");
+    if (m_bDigitalState != bActivated)
+    {
+      m_bDigitalState = bActivated;
+
+      CLog::Log(LOGDEBUG, "Feature [ %s ] on %s %s", m_name.c_str(), m_handler->ControllerID().c_str(),
+                bActivated ? "activated" : "deactivated");
+    }
+
+    m_handler->OnButtonMotion(m_name, magnitude);
   }
-
-  return m_handler->OnButtonMotion(m_name, magnitude);
 }
 
 // --- CAnalogStick ------------------------------------------------------------
@@ -126,6 +140,9 @@ bool CAnalogStick::OnDigitalMotion(const CDriverPrimitive& source, bool bPressed
 
 bool CAnalogStick::OnAnalogMotion(const CDriverPrimitive& source, float magnitude)
 {
+  if (!AcceptsInput(magnitude != 0.0f))
+    return false;
+
   CDriverPrimitive up;
   CDriverPrimitive down;
   CDriverPrimitive right;
@@ -156,8 +173,14 @@ void CAnalogStick::ProcessMotions(void)
   const float newVertState = m_vertAxis.GetPosition();
   const float newHorizState = m_horizAxis.GetPosition();
 
-  if (m_vertState != 0 || m_horizState != 0 ||
-      newVertState != 0 || newHorizState != 0)
+  const bool bActivated = (newVertState != 0.0f || newHorizState != 0.0f);
+
+  if (!AcceptsInput(bActivated))
+    return;
+
+  const bool bWasActivated = (m_vertState != 0.0f || m_horizState != 0.0f);
+
+  if (bActivated || bWasActivated)
   {
     m_vertState = newVertState;
     m_horizState = newHorizState;
@@ -182,6 +205,9 @@ bool CAccelerometer::OnDigitalMotion(const CDriverPrimitive& source, bool bPress
 
 bool CAccelerometer::OnAnalogMotion(const CDriverPrimitive& source, float magnitude)
 {
+  if (!AcceptsInput(magnitude != 0.0f))
+    return false;
+
   CDriverPrimitive positiveX;
   CDriverPrimitive positiveY;
   CDriverPrimitive positiveZ;
@@ -211,8 +237,14 @@ void CAccelerometer::ProcessMotions(void)
   const float newYAxis = m_yAxis.GetPosition();
   const float newZAxis = m_zAxis.GetPosition();
 
-  if (m_xAxisState != 0 || m_yAxisState != 0 || m_zAxisState != 0 ||
-      newXAxis != 0 || newYAxis != 0 || newZAxis)
+  const bool bActivated = (newXAxis != 0.0f || newYAxis != 0.0f || newZAxis != 0.0f);
+
+  if (!AcceptsInput(bActivated))
+    return;
+
+  const bool bWasActivated = (m_xAxisState != 0.0f || m_yAxisState != 0.0f || m_zAxisState != 0.0f);
+
+  if (bActivated || bWasActivated)
   {
     m_xAxisState = newXAxis;
     m_yAxisState = newYAxis;

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -203,6 +203,12 @@ void CAnalogStick::ProcessMotions(void)
 
   const bool bWasActivated = (m_vertState != 0.0f || m_horizState != 0.0f);
 
+  if (bActivated ^ bWasActivated)
+  {
+    CLog::Log(LOGDEBUG, "Feature [ %s ] on %s %s", m_name.c_str(), m_handler->ControllerID().c_str(),
+              bActivated ? "activated" : "deactivated");
+  }
+
   if (bActivated || bWasActivated)
   {
     m_vertState = newVertState;

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -76,10 +76,21 @@ namespace JOYSTICK
      */
     virtual void ProcessMotions(void) = 0;
 
+    /*!
+     * \brief Check if the input handler is accepting input
+     *
+     * \param bActivation True if the motion is activating (true or positive),
+     *                    false if the motion is deactivating (false or zero)
+     *
+     * \return True if input should be sent to the input handler, false otherwise
+     */
+    bool AcceptsInput(bool bActivation);
+
   protected:
-    const FeatureName            m_name;
+    const FeatureName    m_name;
     IInputHandler* const m_handler;
     IButtonMap* const    m_buttonMap;
+    const bool           m_bEnabled;
   };
 
   class CScalarFeature : public CJoystickFeature
@@ -94,8 +105,8 @@ namespace JOYSTICK
     virtual void ProcessMotions(void) override { } // Actions are dispatched immediately
 
   private:
-    bool OnDigitalMotion(bool bPressed);
-    bool OnAnalogMotion(float magnitude);
+    void OnDigitalMotion(bool bPressed);
+    void OnAnalogMotion(float magnitude);
 
     const INPUT_TYPE m_inputType;
     bool             m_bDigitalState;

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -102,7 +102,7 @@ namespace JOYSTICK
     // implementation of CJoystickFeature
     virtual bool OnDigitalMotion(const CDriverPrimitive& source, bool bPressed) override;
     virtual bool OnAnalogMotion(const CDriverPrimitive& source, float magnitude) override;
-    virtual void ProcessMotions(void) override { } // Actions are dispatched immediately
+    virtual void ProcessMotions(void) override;
 
   private:
     void OnDigitalMotion(bool bPressed);
@@ -110,6 +110,8 @@ namespace JOYSTICK
 
     const INPUT_TYPE m_inputType;
     bool             m_bDigitalState;
+    bool             m_bDigitalHandled;
+    unsigned int     m_holdStartTimeMs;
     float            m_analogState;
   };
 
@@ -194,6 +196,8 @@ namespace JOYSTICK
 
     float m_vertState;
     float m_horizState;
+
+    unsigned int m_motionStartTimeMs;
   };
 
   class CAccelerometer : public CJoystickFeature


### PR DESCRIPTION
This fixes joysticks being able to control Kodi when the app is unfocused.

A second fix is included. When Kodi's main thread freezes for > 0.5s, spurious button press events can appear. This was fixed by factoring the button handler to avoid using a separate thread.
