### PR TITLE
FFmpeg: Bump to 3.1.2-Krypton-Beta1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.1-Krypton-Beta1
+VERSION=3.1.2-Krypton-Beta1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.9


### PR DESCRIPTION
Bump to 3.1.2 which now includes our mp3 fix.
