### PR TITLE
[PVR] Guide window: Fix selcting channel via channel number input, if…

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1374,8 +1374,15 @@ void CGUIEPGGridContainer::GoToChannel(int channelIndex)
 {
   if (channelIndex > m_gridModel->ChannelItemsSize() - m_channelsPerPage)
   {
+    // last page
     ScrollToChannelOffset(m_gridModel->ChannelItemsSize() - m_channelsPerPage);
     SetChannel(channelIndex - (m_gridModel->ChannelItemsSize() - m_channelsPerPage), false);
+  }
+  else if (channelIndex < m_channelsPerPage)
+  {
+    // first page
+    ScrollToChannelOffset(0);
+    SetChannel(channelIndex, false);
   }
   else
   {
@@ -1388,8 +1395,15 @@ void CGUIEPGGridContainer::GoToBlock(int blockIndex)
 {
   if (blockIndex > m_gridModel->GetBlockCount() - m_blocksPerPage)
   {
+    // last block
     ScrollToBlockOffset(m_gridModel->GetBlockCount() - m_blocksPerPage);
     SetBlock(blockIndex - (m_gridModel->GetBlockCount() - m_blocksPerPage));
+  }
+  else if (blockIndex < m_blocksPerPage)
+  {
+    // first block
+    ScrollToBlockOffset(0);
+    SetBlock(blockIndex);
   }
   else
   {


### PR DESCRIPTION
… target channel is on first epg page (channel 1 to 8 for Estuary and Confluence).

In Guide window, one can type in numbers to jump to the given channel row in the epg grid. If the target channel row is on the first page of the grid, this did not work. The wrong channel row got selected. This PR fixes this bug.

@Jalle19 for review? Note: The respective methods of the epg grid container control simply had no handling for this special case.
