### PR TITLE
[cmake/packaging/android] Fix packaging of Python PIL

### DIFF
--- a/project/cmake/scripts/android/Install.cmake
+++ b/project/cmake/scripts/android/Install.cmake
@@ -46,6 +46,7 @@ add_custom_target(bundle
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CORE_SOURCE_DIR}/tools/android/packaging/xbmc/res
                                                ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEPENDS_PATH}/lib/python2.7 ${libdir}/python2.7
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEPENDS_PATH}/share/${APP_NAME_LC} ${datadir}/${APP_NAME_LC}
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${APP_NAME_LC}>
                                      ${libdir}/${APP_NAME_LC}/$<TARGET_FILE_NAME:${APP_NAME_LC}>)
 add_dependencies(bundle ${APP_NAME_LC})


### PR DESCRIPTION
Fix error reported in http://forum.kodi.tv/showthread.php?pid=2391222#pid2391222.
Testbuild: http://jenkins.kodi.tv/job/Android-ARM/8932/ - http://mirrors.kodi.tv/test-builds/android/arm/kodi-20160810-0530866-cmake_python_pil-armeabi-v7a.apk
