### PR TITLE
Support input streams having their own demuxer for the "OtherStream" …

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -96,7 +96,7 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(CDVDInputStream* pInputStream, bool
         if(demuxer->Open(pOtherStream))
           return demuxer.release();
         else
-           return nullptr;
+          return nullptr;
       }
 
       /* Used for MediaPortal PVR addon (uses PVR otherstream for playback of rtsp streams) */

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -90,6 +90,15 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(CDVDInputStream* pInputStream, bool
 
     if (pOtherStream)
     {
+      if (pOtherStream->GetIDemux())
+      {
+        std::unique_ptr<CDVDDemuxClient> demuxer(new CDVDDemuxClient());
+        if(demuxer->Open(pOtherStream))
+          return demuxer.release();
+        else
+           return nullptr;
+      }
+
       /* Used for MediaPortal PVR addon (uses PVR otherstream for playback of rtsp streams) */
       if (pOtherStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
       {


### PR DESCRIPTION
…of CDVDInputStreamPVRManager

This allows the use of inputstream.mpd for PVR addons by simply passing the manifest URL
