### PR TITLE
File extension support for input stream

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -186,6 +186,21 @@ bool CInputStream::Supports(const CFileItem &fileitem)
       return true;
   }
 
+  // check extensions
+  for (auto ext : m_extensionsList)
+  {
+    if (ext.empty())
+      continue;
+
+    if (StringUtils::EndsWith(fileitem.GetPath(), ext)) {
+      return true;
+    }
+
+    if ((protocol == "http" || protocol == "https") && fileitem.GetPath().find(ext + "?") != std::string::npos) {
+      return true;
+    }
+  }
+
   // check paths
   CSingleLock lock(m_parentSection);
   auto it = m_configMap.find(ID());

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -77,7 +77,13 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
       if (status == ADDON_STATUS_OK)
       {
         unsigned int videoWidth, videoHeight;
-        pPlayer->GetVideoResolution(videoWidth, videoHeight);
+        if (pPlayer) {
+          pPlayer->GetVideoResolution(videoWidth, videoHeight);
+        } else {
+          //Thumbnail creation
+          videoWidth = 1920;
+          videoHeight = 1080;
+        }
         addon->SetVideoResolution(videoWidth, videoHeight);
 
         return new CInputStreamAddon(fileitem, addon);


### PR DESCRIPTION
I'm not sure about the change in DVDFactoryInputStream.cpp.
It was required as the function is called without a player from VideoPlayerCodec::Init
m_pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, fileitem);
