### PR TITLE
[osx] media key: send also SDL_KEYUP

### DIFF
--- a/xbmc/platform/darwin/osx/SDLMain.mm
+++ b/xbmc/platform/darwin/osx/SDLMain.mm
@@ -434,6 +434,17 @@ static void setupWindowMenu(void)
   [pool release];
 }
 
+static void keyPress(SDLKey key)
+{
+  SDL_Event event;
+  memset(&event, 0, sizeof(event));
+  event.type = SDL_KEYDOWN;
+  event.key.keysym.sym = key;
+  SDL_PushEvent(&event);
+  event.type = SDL_KEYUP;
+  SDL_PushEvent(&event);
+}
+
 #define VK_SLEEP            0x143
 #define VK_VOLUME_MUTE      0xAD
 #define VK_VOLUME_DOWN      0xAE
@@ -447,81 +458,45 @@ static void setupWindowMenu(void)
 
 - (void)powerKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_SLEEP;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_SLEEP);
 }
 
 - (void)muteKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_VOLUME_MUTE;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_VOLUME_MUTE);
 }
 - (void)soundUpKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_VOLUME_UP;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_VOLUME_UP);
 }
 - (void)soundDownKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_VOLUME_DOWN;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_VOLUME_DOWN);
 }
 
 - (void)playPauseKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_MEDIA_PLAY_PAUSE;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_MEDIA_PLAY_PAUSE);
 }
 
 - (void)fastKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_FAST_FWD;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_FAST_FWD);
 }
 
 - (void)rewindKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_REWIND;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_REWIND);
 }
 
 - (void)nextKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_MEDIA_NEXT_TRACK;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_MEDIA_NEXT_TRACK);
 }
 
 - (void)previousKeyNotification
 {
-  SDL_Event event;
-  memset(&event, 0, sizeof(event));
-  event.type = SDL_KEYDOWN;
-  event.key.keysym.sym = (SDLKey)VK_MEDIA_PREV_TRACK;
-  SDL_PushEvent(&event);
+  keyPress((SDLKey)VK_MEDIA_PREV_TRACK);
 }
 
 @end


### PR DESCRIPTION
Without this PR the osx media keys are mapped to longpress actions if one exists.
Sine #10171 there exists a longpress action for `play_pause` and the play key doesn't do the expected thing.
