### PR TITLE
[PVR] Fix PVR channels not working as Kodi startup window

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10181,7 +10181,17 @@ msgctxt "#19272"
 msgid "You need a tuner, backend software, and an add-on for the backend to be able to use PVR. Please visit http://kodi.wiki/view/PVR to learn more."
 msgstr ""
 
-#empty strings from id 19273 to 19274
+#. Settings -> Interface -> Other -> Startup window
+#: system/settings/settings.xml
+msgctxt "#19273"
+msgid "TV guide"
+msgstr ""
+
+#. Settings -> Interface -> Other -> Startup window
+#: system/settings/settings.xml
+msgctxt "#19274"
+msgid "Radio guide"
+msgstr ""
 
 #: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19275"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9742,9 +9742,10 @@ msgctxt "#19179"
 msgid "Deleted"
 msgstr ""
 
+#. Settings -> Interface -> Other -> Startup window
 #: system/settings/settings.xml
 msgctxt "#19180"
-msgid "TV"
+msgid "TV channels"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -9757,9 +9758,10 @@ msgctxt "#19182"
 msgid "Days to display"
 msgstr ""
 
+#. Settings -> Interface -> Other -> Startup window
 #: system/settings/settings.xml
 msgctxt "#19183"
-msgid "Radio"
+msgid "Radio channels"
 msgstr ""
 
 #. Used on pvr recordings as button to show of them

--- a/addons/skin.estuary/1080i/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/1080i/Includes_MediaMenu.xml
@@ -253,13 +253,10 @@
 	<include name="MediaMenuCommon">
 		<include>OpenClose_Left</include>
 		<depth>DepthSideBlade</depth>
-		<animation type="Conditional" condition="$EXP[sidebar_focused]">
+		<left>-484</left>
+		<animation type="Conditional" condition="$EXP[sidebar_focused]" reversible="true">
 			<effect type="fade" start="0" end="100" time="300" tween="sine" easing="out" />
-			<effect type="slide" start="-320" end="0" time="400" tween="cubic" easing="out" />
-		</animation>
-		<animation type="Conditional" condition="!$EXP[sidebar_focused]">
-			<effect type="fade" start="100" end="0" time="300" tween="sine" easing="in" />
-			<effect type="slide" start="0" end="-320" time="300" tween="cubic" easing="in" />
+			<effect type="slide" start="0" end="484" time="400" tween="cubic" easing="out" />
 		</animation>
 		<control type="image">
 			<left>0</left>

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -305,7 +305,9 @@ bool CSkinInfo::LoadStartupWindows(const cp_extension_t *ext)
   m_startupWindows.clear();
   m_startupWindows.emplace_back(WINDOW_HOME, "513");
   m_startupWindows.emplace_back(WINDOW_TV_CHANNELS, "19180");
+  m_startupWindows.emplace_back(WINDOW_TV_GUIDE, "19273");
   m_startupWindows.emplace_back(WINDOW_RADIO_CHANNELS, "19183");
+  m_startupWindows.emplace_back(WINDOW_RADIO_GUIDE, "19274");
   m_startupWindows.emplace_back(WINDOW_PROGRAMS, "0");
   m_startupWindows.emplace_back(WINDOW_PICTURES, "1");
   m_startupWindows.emplace_back(WINDOW_MUSIC_NAV, "2");

--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -60,11 +60,11 @@ bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   CLog::Log(LOGDEBUG, "CPVRDirectory::GetDirectory(%s)", base.c_str());
   items.SetCacheToDisc(CFileItemList::CACHE_NEVER);
 
-  if (!g_PVRManager.IsStarted())
-    return false;
-
   if (fileName == "")
   {
+    if (!g_PVRManager.IsStarted())
+      return false;
+
     CFileItemPtr item;
 
     item.reset(new CFileItem(base + "channels/", true));
@@ -89,16 +89,25 @@ bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   }
   else if (StringUtils::StartsWith(fileName, "recordings"))
   {
+    if (!g_PVRManager.IsStarted())
+      return false;
+
     const std::string pathToUrl(url.Get());
     return g_PVRRecordings->GetDirectory(pathToUrl, items);
   }
   else if (StringUtils::StartsWith(fileName, "channels"))
   {
+    if (!g_PVRChannelGroups || !g_PVRChannelGroups->Loaded())
+      return false;
+
     const std::string pathToUrl(url.Get());
     return g_PVRChannelGroups->GetDirectory(pathToUrl, items);
   }
   else if (StringUtils::StartsWith(fileName, "timers"))
   {
+    if (!g_PVRManager.IsStarted())
+      return false;
+
     const std::string pathToUrl(url.Get());
     return g_PVRTimers->GetDirectory(pathToUrl, items);
   }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -651,9 +651,11 @@ void CGUIWindowManager::PreviousWindow()
   }
   // get the previous window in our stack
   if (m_windowHistory.size() < 2)
-  { // no previous window history yet - check if we should just activate home
+  {
+    // no previous window history yet - check if we should just activate home
     if (GetActiveWindow() != WINDOW_INVALID && GetActiveWindow() != WINDOW_HOME)
     {
+      CloseWindowSync(pCurrentWindow);
       ClearWindowHistory();
       ActivateWindow(WINDOW_HOME);
     }
@@ -667,6 +669,7 @@ void CGUIWindowManager::PreviousWindow()
   if (!pNewWindow)
   {
     CLog::Log(LOGERROR, "Unable to activate the previous window");
+    CloseWindowSync(pCurrentWindow);
     ClearWindowHistory();
     ActivateWindow(WINDOW_HOME);
     return;
@@ -1500,8 +1503,10 @@ void CGUIWindowManager::AddToWindowHistory(int newWindowID)
   { // found window in history
     m_windowHistory = historySave;
   }
-  else
-  { // didn't find window in history - add it to the stack
+  else if (newWindowID != WINDOW_SPLASH)
+  {
+    // didn't find window in history - add it to the stack
+    // but do not add the splash window to history, as we never want to travel back to it
     m_windowHistory.push(newWindowID);
   }
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -509,6 +509,9 @@ bool CPVRManager::Load(bool bShowProgress)
   if (!m_channelGroups->Load() || !IsInitialising())
     return false;
 
+  SetChanged();
+  NotifyObservers(ObservableMessageChannelGroupsLoaded);
+
   /* get timers from the backends */
   if (bShowProgress)
     ShowProgressDialog(g_localizeStrings.Get(19237), 50); // Loading timers from clients

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -566,6 +566,18 @@ private:
      */
     CEventStream<ManagerState>& Events() { return m_events; }
 
+    /*!
+     * @brief Show or update the progress dialog.
+     * @param strText The current status.
+     * @param iProgress The current progress in %.
+     */
+    void ShowProgressDialog(const std::string &strText, int iProgress);
+
+    /*!
+     * @brief Hide the progress dialog if it's visible.
+     */
+    void HideProgressDialog(void);
+
   protected:
     /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
@@ -605,18 +617,6 @@ private:
      * @return True if playback was continued, false otherwise.
      */
     bool ContinueLastChannel(void);
-
-    /*!
-     * @brief Show or update the progress dialog.
-     * @param strText The current status.
-     * @param iProgress The current progress in %.
-     */
-    void ShowProgressDialog(const std::string &strText, int iProgress);
-
-    /*!
-     * @brief Hide the progress dialog if it's visible.
-     */
-    void HideProgressDialog(void);
 
     void ExecutePendingJobs(void);
 

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -35,7 +35,8 @@ CPVRChannelGroupsContainer::CPVRChannelGroupsContainer(void) :
     m_groupsRadio(new CPVRChannelGroups(true)),
     m_groupsTV(new CPVRChannelGroups(false)),
     m_bUpdateChannelsOnly(false),
-    m_bIsUpdating(false)
+    m_bIsUpdating(false),
+    m_bLoaded(false)
 {
 }
 
@@ -68,15 +69,20 @@ bool CPVRChannelGroupsContainer::Update(bool bChannelsOnly /* = false */)
 bool CPVRChannelGroupsContainer::Load(void)
 {
   Unload();
+  m_bLoaded = m_groupsRadio->Load() && m_groupsTV->Load();
+  return m_bLoaded;
+}
 
-  return m_groupsRadio->Load() &&
-         m_groupsTV->Load();
+bool CPVRChannelGroupsContainer::Loaded(void) const
+{
+  return m_bLoaded;
 }
 
 void CPVRChannelGroupsContainer::Unload(void)
 {
   m_groupsRadio->Clear();
   m_groupsTV->Clear();
+  m_bLoaded = false;
 }
 
 CPVRChannelGroups *CPVRChannelGroupsContainer::Get(bool bRadio) const

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -56,8 +56,7 @@ bool CPVRChannelGroupsContainer::Update(bool bChannelsOnly /* = false */)
   lock.Leave();
 
   CLog::Log(LOGDEBUG, "CPVRChannelGroupsContainer - %s - updating %s", __FUNCTION__, bChannelsOnly ? "channels" : "channel groups");
-  bool bReturn = m_groupsRadio->Update(bChannelsOnly) &&
-       m_groupsTV->Update(bChannelsOnly);
+  bool bReturn = m_groupsTV->Update(bChannelsOnly) && m_groupsRadio->Update(bChannelsOnly);
 
   lock.Enter();
   m_bIsUpdating = false;
@@ -69,7 +68,7 @@ bool CPVRChannelGroupsContainer::Update(bool bChannelsOnly /* = false */)
 bool CPVRChannelGroupsContainer::Load(void)
 {
   Unload();
-  m_bLoaded = m_groupsRadio->Load() && m_groupsTV->Load();
+  m_bLoaded = m_groupsTV->Load() && m_groupsRadio->Load();
   return m_bLoaded;
 }
 
@@ -269,8 +268,7 @@ CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetLastPlayedGroup(int iChannelI
 
 bool CPVRChannelGroupsContainer::CreateChannelEpgs(void)
 {
-  return m_groupsRadio->CreateChannelEpgs() &&
-         m_groupsTV->CreateChannelEpgs();
+  return m_groupsTV->CreateChannelEpgs() && m_groupsRadio->CreateChannelEpgs();
 }
 
 CPVRChannelGroupPtr CPVRChannelGroupsContainer::GetPreviousPlayedGroup(void)

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -53,6 +53,12 @@ namespace PVR
     bool Load(void);
 
     /*!
+     * @brief Checks whether groups were already loaded.
+     * @return True if groups were successfully loaded, false otherwise.
+     */
+    bool Loaded(void) const;
+
+    /*!
      * @brief Unload and destruct all channel groups and all channels in them.
      */
     void Unload(void);
@@ -209,5 +215,7 @@ namespace PVR
   private :
     CPVRChannelGroupsContainer& operator=(const CPVRChannelGroupsContainer&);
     CPVRChannelGroupsContainer(const CPVRChannelGroupsContainer&);
+
+    bool m_bLoaded;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -209,32 +209,6 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
   return bReturn || CGUIMediaWindow::OnMessage(message);
 }
 
-bool CGUIWindowPVRBase::IsValidMessage(CGUIMessage& message)
-{
-  bool bReturn = false;
-
-  // we need to protect the pvr windows against certain messages
-  // if the pvr manager is not started yet. we only want to support
-  // that the window can be loaded to show the user an info about
-  // the manager startup. Any other interactions with the windows
-  // would cause access violations.
-  switch (message.GetMessage())
-  {
-    // valid messages
-    case GUI_MSG_WINDOW_LOAD:
-    case GUI_MSG_WINDOW_INIT:
-    case GUI_MSG_WINDOW_DEINIT:
-      bReturn = true;
-      break;
-    default:
-      if (g_PVRManager.IsStarted())
-        bReturn = true;
-      break;
-  }
-
-  return bReturn;
-}
-
 bool CGUIWindowPVRBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   bool bReturn = false;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -96,6 +96,8 @@ namespace PVR
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);
 
     virtual std::string GetDirectoryPath(void) = 0;
+
+    bool InitGroup(void);
     virtual CPVRChannelGroupPtr GetGroup(void);
     virtual void SetGroup(const CPVRChannelGroupPtr &group);
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -73,7 +73,7 @@ namespace PVR
     virtual void UpdateButtons(void) override;
     virtual bool OnAction(const CAction &action) override;
     virtual bool OnBack(int actionID) override;
-    virtual bool OpenGroupSelectionDialog(void);
+    virtual bool OpenChannelGroupSelectionDialog(void);
     virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
     virtual void SetInvalid() override;
     virtual bool CanBeActivated() const override;
@@ -97,9 +97,9 @@ namespace PVR
 
     virtual std::string GetDirectoryPath(void) = 0;
 
-    bool InitGroup(void);
-    virtual CPVRChannelGroupPtr GetGroup(void);
-    virtual void SetGroup(const CPVRChannelGroupPtr &group);
+    bool InitChannelGroup(void);
+    virtual CPVRChannelGroupPtr GetChannelGroup(void);
+    virtual void SetChannelGroup(const CPVRChannelGroupPtr &group);
 
     virtual bool ActionShowTimerRule(CFileItem *item);
     virtual bool ActionToggleTimer(CFileItem *item);
@@ -151,7 +151,7 @@ namespace PVR
     static bool DeleteTimer(CFileItem *item, bool bIsRecording, bool bDeleteRule);
     static bool AddTimer(CFileItem *item, bool bCreateRule, bool bShowTimerSettings);
 
-    CPVRChannelGroupPtr m_group;
+    CPVRChannelGroupPtr m_channelGroup;
     XbmcThreads::EndTime m_refreshTimeout;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -112,7 +112,6 @@ namespace PVR
     virtual void ShowRecordingInfo(CFileItem *item);
     virtual bool UpdateEpgForChannel(CFileItem *item);
     virtual void UpdateSelectedItemPath();
-    virtual bool IsValidMessage(CGUIMessage& message);
     bool CheckResumeRecording(CFileItem *item);
 
     bool OnContextButtonEditTimer(CFileItem *item, CONTEXT_BUTTON button);

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -70,6 +70,11 @@ void CGUIWindowPVRChannels::UnregisterObservers(void)
   g_EpgContainer.UnregisterObserver(this);
 }
 
+bool CGUIWindowPVRChannels::CanBeActivated() const
+{
+  return true;
+}
+
 void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -176,9 +176,6 @@ bool CGUIWindowPVRChannels::OnAction(const CAction &action)
 
 bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
 {
-  if (!IsValidMessage(message))
-    return false;
-
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -109,7 +109,7 @@ std::string CGUIWindowPVRChannels::GetDirectoryPath(void)
 {
   return StringUtils::Format("pvr://channels/%s/%s/",
       m_bRadio ? "radio" : "tv",
-      m_bShowHiddenChannels ? ".hidden" : GetGroup()->GroupName().c_str());
+      m_bShowHiddenChannels ? ".hidden" : GetChannelGroup()->GroupName().c_str());
 }
 
 bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
@@ -156,7 +156,7 @@ void CGUIWindowPVRChannels::UpdateButtons(void)
   }
 
   CGUIWindowPVRBase::UpdateButtons();
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022) : GetGroup()->GroupName());
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022) : GetChannelGroup()->GroupName());
 }
 
 bool CGUIWindowPVRChannels::OnAction(const CAction &action)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -29,6 +29,7 @@ namespace PVR
     CGUIWindowPVRChannels(bool bRadio);
     virtual ~CGUIWindowPVRChannels(void) {};
 
+    virtual bool CanBeActivated() const override;
     virtual bool OnMessage(CGUIMessage& message) override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -244,7 +244,7 @@ void CGUIWindowPVRGuide::UpdateButtons(void)
       break;
   }
 
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetGroup()->GroupName());
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetChannelGroup()->GroupName());
 }
 
 bool CGUIWindowPVRGuide::GetDirectory(const std::string &strDirectory, CFileItemList &items)
@@ -467,7 +467,7 @@ void CGUIWindowPVRGuide::GetViewChannelItems(CFileItemList &items)
 void CGUIWindowPVRGuide::GetViewNowItems(CFileItemList &items)
 {
   items.Clear();
-  int iEpgItems = GetGroup()->GetEPGNow(items);
+  int iEpgItems = GetChannelGroup()->GetEPGNow(items);
 
   if (iEpgItems == 0)
   {
@@ -482,7 +482,7 @@ void CGUIWindowPVRGuide::GetViewNowItems(CFileItemList &items)
 void CGUIWindowPVRGuide::GetViewNextItems(CFileItemList &items)
 {
   items.Clear();
-  int iEpgItems = GetGroup()->GetEPGNext(items);
+  int iEpgItems = GetChannelGroup()->GetEPGNext(items);
 
   if (iEpgItems)
   {
@@ -503,7 +503,7 @@ bool CGUIWindowPVRGuide::RefreshTimelineItems()
     CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (epgGridContainer)
     {
-      const CPVRChannelGroupPtr group(GetGroup());
+      const CPVRChannelGroupPtr group(GetChannelGroup());
       std::unique_ptr<CFileItemList> timeline(new CFileItemList);
 
       // can be very expensive. never call with lock acquired.
@@ -544,7 +544,7 @@ void CGUIWindowPVRGuide::GetViewTimelineItems(CFileItemList &items)
   CSingleLock lock(m_critSection);
 
   // group change detected reset grid coordinates and refresh grid items
-  if (!m_bRefreshTimelineItems && *m_cachedChannelGroup != *GetGroup())
+  if (!m_bRefreshTimelineItems && *m_cachedChannelGroup != *GetChannelGroup())
   {
     CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (!epgGridContainer)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -58,11 +58,13 @@ CGUIEPGGridContainer* CGUIWindowPVRGuide::GetGridControl()
   return dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
 }
 
-void CGUIWindowPVRGuide::OnInitWindow()
+bool CGUIWindowPVRGuide::CanBeActivated() const
 {
-  if (m_guiState.get())
-    m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
+  return true;
+}
 
+void CGUIWindowPVRGuide::Init()
+{
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
   {
@@ -72,6 +74,15 @@ void CGUIWindowPVRGuide::OnInitWindow()
 
   m_bRefreshTimelineItems = true;
   StartRefreshTimelineItemsThread();
+}
+
+void CGUIWindowPVRGuide::OnInitWindow()
+{
+  if (m_guiState.get())
+    m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
+
+  if (InitChannelGroup()) // no channels -> lazy init
+    Init();
 
   CGUIWindowPVRBase::OnInitWindow();
 }
@@ -402,6 +413,13 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
     case GUI_MSG_REFRESH_LIST:
       switch(message.GetParam1())
       {
+        case ObservableMessageChannelGroupsLoaded:
+        {
+          // late init
+          InitChannelGroup();
+          Init();
+          break;
+        }
         case ObservableMessageChannelGroupReset:
         case ObservableMessageChannelGroup:
         case ObservableMessageEpg:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -294,9 +294,6 @@ bool CGUIWindowPVRGuide::OnAction(const CAction &action)
 
 bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
 {
-  if (!IsValidMessage(message))
-    return false;
-  
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -41,6 +41,7 @@ namespace PVR
     CGUIWindowPVRGuide(bool bRadio);
     virtual ~CGUIWindowPVRGuide(void);
 
+    virtual bool CanBeActivated() const override;
     virtual void OnInitWindow() override;
     virtual void OnDeinitWindow(int nextWindowID) override;
     virtual bool OnMessage(CGUIMessage& message) override;
@@ -61,6 +62,8 @@ namespace PVR
     virtual void UnregisterObservers(void) override;
 
   private:
+    void Init();
+
     EPG::CGUIEPGGridContainer* GetGridControl();
 
     bool SelectPlayingFile(void);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -237,9 +237,6 @@ void CGUIWindowPVRRecordings::UpdateButtons(void)
 
 bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
 {
-  if (!IsValidMessage(message))
-    return false;
-  
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -206,9 +206,6 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
 
 bool CGUIWindowPVRSearch::OnMessage(CGUIMessage &message)
 {
-  if (!IsValidMessage(message))
-    return false;
-  
   if (message.GetMessage() == GUI_MSG_CLICKED)
   {
     if (message.GetSenderId() == m_viewControl.GetCurrentControl())

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -172,9 +172,6 @@ void CGUIWindowPVRTimersBase::UpdateButtons(void)
 
 bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage &message)
 {
-  if (!IsValidMessage(message))
-    return false;
-  
   bool bReturn = false;
   switch (message.GetMessage())
   {

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -41,7 +41,8 @@ typedef enum
   ObservableMessageTimers,
   ObservableMessageTimersReset,
   ObservableMessageRecordings,
-  ObservableMessagePeripheralsChanged
+  ObservableMessagePeripheralsChanged,
+  ObservableMessageChannelGroupsLoaded
 } ObservableMessage;
 
 class Observer


### PR DESCRIPTION
Fixes http://trac.kodi.tv/ticket/16765

Note: currently only radio and tv channel window will work as startup window. Only these windows can be activated as startup windows in Kodi settings GUI. This has always been the case, as not changed by this PR (only wording in the UI), although it also makes sense to use the guide window as startup window. But this will be some more work and thus will be done in another PR.

Settings: 
![screenshot004](https://cloud.githubusercontent.com/assets/3226626/17620147/8df97c24-608a-11e6-9ca4-492b8c3174df.png)

Video, to get an impression how it looks like: https://www.dropbox.com/s/5molkfr0b3xicde/IMG_2229.MOV

@Jalle19 @BigNoid for review?

EDIT: Compared to the solution we had before PVRManager Krypton rework (that broke the old solution, btw) the new approach does not need any busy waiting dialogs until PVR has been started which makes it technically "correct" now, imo.

EDIT2: guide windows now also can be used as start windows; was less work than expected. :-)
