### PR TITLE
[epg] CEpg::UpdateEntry: Remove wrong error log. Not finding an epg e…

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -459,7 +459,6 @@ bool CEpg::UpdateEntry(const CEpgInfoTagPtr &tag, EPG_EVENT_STATE newState, bool
 
     if (it == m_tags.end())
     {
-      CLog::Log(LOGERROR, "EPG - %s - Error: EPG_EVENT_DELETED: uid %d not found.", __FUNCTION__, tag->UniqueBroadcastID());
       bRet = false;
     }
     else


### PR DESCRIPTION
…vent can be okay due to epg linger time contraints.
