### PR TITLE
[processInfo] reset audio/video codec info

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -928,7 +928,10 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
     }
   }
   if(!valid)
+  {
     CloseStream(m_CurrentVideo, true);
+    m_processInfo->ResetVideoCodecInfo();
+  }
 
   // open audio stream
   valid   = false;
@@ -945,7 +948,10 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
   }
 
   if(!valid)
+  {
     CloseStream(m_CurrentAudio, true);
+    m_processInfo->ResetAudioCodecInfo();
+  }
 
   // enable  or disable subtitles
   bool visible = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleOn;


### PR DESCRIPTION
(if particular stream type is missing within the stream, process info
values won't be initialised)
