### PR TITLE
VideoPlayer: fix false positive drop detection for ffmpeg decoder

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -122,4 +122,20 @@ protected:
   double m_DAR;
   CDVDStreamInfo m_hints;
   CDVDCodecOptions m_options;
+
+  struct CDropControl
+  {
+    CDropControl();
+    void Reset(bool init);
+    void Process(int64_t pts, bool drop);
+
+    int64_t m_lastPTS;
+    int64_t m_diffPTS;
+    int m_count;
+    enum
+    {
+      INIT,
+      VALID
+    } m_state;
+  } m_dropCtrl;
 };


### PR DESCRIPTION
false positive drops results in a/v going out of sync

@fritsch mind testing this with you sample?
