### PR TITLE
[PVR] Fix home screen channel widget context menu.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -733,8 +733,13 @@ bool CFileItem::IsVideo() const
   if (HasPictureInfoTag())
     return false;
 
+  // only tv recordings are videos...
   if (IsPVRRecording())
-    return true;
+    return !GetPVRRecordingInfoTag()->IsRadio();
+
+  // ... all other PVR items are not.
+  if (IsPVR())
+    return false;
 
   if (URIUtils::IsDVD(m_strPath))
     return true;


### PR DESCRIPTION
CFileItem::IsVideo must not return true for any PVR item except tv recordings. Fixes wrong context menu entries for homescreen channel widget.

Note: currently the channel widget items have no context menu items. Those are still about to be implemented. Will do later, when i find the time.

@Jalle19 good to go?
