### PR TITLE
Disable Travis autotools testing and addons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ compiler:
   - clang
 
 env:
-  - BUILD=Kodi TOOLS=Autotools
+#  - BUILD=Kodi TOOLS=Autotools
   - BUILD=Kodi TOOLS=CMake
   - ADDONS=adsp
   - ADDONS=audiodecoder

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,22 @@ compiler:
 env:
 #  - BUILD=Kodi TOOLS=Autotools
   - BUILD=Kodi TOOLS=CMake
-  - ADDONS=adsp
-  - ADDONS=audiodecoder
-  - ADDONS=audioencoder
-  - ADDONS=pvr
-  - ADDONS=screensaver
-  - ADDONS=visualization
+#  - ADDONS=adsp
+#  - ADDONS=audiodecoder
+#  - ADDONS=audioencoder
+#  - ADDONS=pvr
+#  - ADDONS=screensaver
+#  - ADDONS=visualization
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: ADDONS=adsp
-    - env: ADDONS=audiodecoder
-    - env: ADDONS=audioencoder
-    - env: ADDONS=pvr
-    - env: ADDONS=screensaver
-    - env: ADDONS=visualization
+#    - env: ADDONS=adsp
+#    - env: ADDONS=audiodecoder
+#    - env: ADDONS=audioencoder
+#    - env: ADDONS=pvr
+#    - env: ADDONS=screensaver
+#    - env: ADDONS=visualization
 
 # Prepare system
 #


### PR DESCRIPTION
We're already building cmake and we don't need to test the add-ons on each PR. Jenkins will do this anyway when it's triggered. Should stop the misleading failures.
