### PR TITLE
[darwin]: - fixed cpu usage reporting for all darwin platforms by hoo…

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -102,8 +102,6 @@
 
 #if defined(TARGET_DARWIN_OSX)
 #include "platform/darwin/osx/smc.h"
-#include "linux/LinuxResourceCounter.h"
-static CLinuxResourceCounter m_resourceCounter;
 #endif
 
 #ifdef TARGET_POSIX
@@ -9163,9 +9161,7 @@ std::string CGUIInfoManager::GetSystemHeatInfo(int info)
       text = StringUtils::Format("%i%%", m_fanSpeed * 2);
       break;
     case SYSTEM_CPU_USAGE:
-#if defined(TARGET_DARWIN_OSX)
-      text = StringUtils::Format("%4.2f%%", m_resourceCounter.GetCPUUsage());
-#elif defined(TARGET_DARWIN) || defined(TARGET_WINDOWS)
+#if defined(TARGET_DARWIN) || defined(TARGET_WINDOWS)
       text = StringUtils::Format("%d%%", g_cpuInfo.getUsedPercentage());
 #else
       text = StringUtils::Format("%s", g_cpuInfo.GetCoresUsageString().c_str());

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -34,6 +34,7 @@ typedef HANDLE PDH_HQUERY;
 typedef HANDLE PDH_HCOUNTER;
 #endif
 class CTemperature;
+class CLinuxResourceCounter;
 
 #define CPU_FEATURE_MMX      1 << 0
 #define CPU_FEATURE_MMX2     1 << 1
@@ -111,6 +112,9 @@ private:
   FILE* m_fProcTemperature;
   FILE* m_fCPUFreq;
   bool m_cpuInfoForFreq;
+#if defined(TARGET_DARWIN)
+  CLinuxResourceCounter *m_pResourceCounter;
+#endif
 #elif defined(TARGET_WINDOWS)
   PDH_HQUERY m_cpuQueryFreq;
   PDH_HQUERY m_cpuQueryLoad;


### PR DESCRIPTION
…king up LinuxResourceCounter int CPUInfo and use it on ios aswell (as it works perfectly fine not only on osx).

Tested on ios 5.1.1 32bit, ios 6.0.2 32bit, ios 9.3.3 64bit, tvos 9.2.2 64bit, osx 10.11.6 64bit

thx to @MrMC who had a POC of this burried in GUIInfoManager.cpp :)
