### PR TITLE
Bump peripheral API - enable translating between controller profiles

### DIFF
--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.19" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.20" provider-name="Team-Kodi">
 	<backwards-compatibility abi="1.0.19"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.21" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.22" provider-name="Team-Kodi">
 	<backwards-compatibility abi="1.0.19"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.20" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.21" provider-name="Team-Kodi">
 	<backwards-compatibility abi="1.0.19"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>

--- a/lib/addons/library.kodi.peripheral/libKODI_peripheral.cpp
+++ b/lib/addons/library.kodi.peripheral/libKODI_peripheral.cpp
@@ -69,6 +69,13 @@ DLLEXPORT void PERIPHERAL_refresh_button_maps(AddonCB* frontend, CB_PeripheralLi
   return cb->RefreshButtonMaps(frontend->addonData, deviceName ? deviceName : "", controllerId ? controllerId : "");
 }
 
+DLLEXPORT unsigned int PERIPHERAL_feature_count(AddonCB* frontend, CB_PeripheralLib* cb, const char* controllerId, JOYSTICK_FEATURE_TYPE type)
+{
+  if (frontend == NULL || cb == NULL)
+    return 0;
+  return cb->FeatureCount(frontend->addonData, controllerId, type);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
@@ -19,8 +19,11 @@
  */
 
 #include "AddonCallbacksPeripheral.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerLayout.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/addons/PeripheralAddon.h"
+#include "peripherals/addons/PeripheralAddonTranslator.h"
 #include "utils/log.h"
 
 using namespace ADDON;
@@ -41,6 +44,7 @@ CAddonCallbacksPeripheral::CAddonCallbacksPeripheral(ADDON::CAddon* addon)
   /* write Kodi peripheral specific add-on function addresses to callback table */
   m_callbacks->TriggerScan               = TriggerScan;
   m_callbacks->RefreshButtonMaps         = RefreshButtonMaps;
+  m_callbacks->FeatureCount              = FeatureCount;
 }
 
 CAddonCallbacksPeripheral::~CAddonCallbacksPeripheral()
@@ -73,6 +77,24 @@ void CAddonCallbacksPeripheral::RefreshButtonMaps(void* addonData, const char* d
     return;
 
   peripheralAddon->RefreshButtonMaps(deviceName ? deviceName : "", controllerId ? controllerId : "");
+}
+
+unsigned int CAddonCallbacksPeripheral::FeatureCount(void* addonData, const char* controllerId, JOYSTICK_FEATURE_TYPE type)
+{
+  using namespace ADDON;
+  using namespace GAME;
+
+  unsigned int count = 0;
+
+  AddonPtr addon;
+  if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER))
+  {
+    ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+    if (controller->LoadLayout())
+      count = controller->Layout().FeatureCount(CPeripheralAddonTranslator::TranslateFeatureType(type));
+  }
+
+  return count;
 }
 
 } /* namespace Peripheral */

--- a/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.h
+++ b/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.h
@@ -47,6 +47,7 @@ public:
 
   static void TriggerScan(void* addonData);
   static void RefreshButtonMaps(void* addonData, const char* deviceName, const char* controllerId);
+  static unsigned int FeatureCount(void* addonData, const char* controllerId, JOYSTICK_FEATURE_TYPE type);
 
 private:
   static PERIPHERALS::CPeripheralAddon* GetPeripheralAddon(void* addonData, const char* strFunction);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_callbacks.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_callbacks.h
@@ -44,6 +44,16 @@ typedef struct CB_PeripheralLib
    */
   void (*RefreshButtonMaps)(void* addonData, const char* deviceName, const char* controllerId);
 
+  /*!
+   * @brief Return the number of features belonging to the specified controller
+   *
+   * @param controllerId    The controller ID to enumerate
+   * @param type[optional]  Type to filter by, or JOYSTICK_FEATURE_TYPE_UNKNOWN for all features
+   *
+   * @return The number of features matching the request parameters
+   */
+  unsigned int (*FeatureCount)(void* addonData, const char* controllerId, JOYSTICK_FEATURE_TYPE type);
+
 } CB_PeripheralLib;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -51,7 +51,7 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.21"
+#define PERIPHERAL_API_VERSION "1.0.22"
 
 /* min. Peripheral API version */
 #define PERIPHERAL_MIN_API_VERSION "1.0.19"

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -51,7 +51,7 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.20"
+#define PERIPHERAL_API_VERSION "1.0.21"
 
 /* min. Peripheral API version */
 #define PERIPHERAL_MIN_API_VERSION "1.0.19"
@@ -112,6 +112,7 @@ extern "C"
   typedef struct PERIPHERAL_CAPABILITIES
   {
     bool provides_joysticks;            /*!< @brief true if the add-on provides joysticks */
+    bool provides_buttonmaps;           /*!< @brief true if the add-on provides button maps */
   } ATTRIBUTE_PACKED PERIPHERAL_CAPABILITIES;
   ///}
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -1,3 +1,4 @@
+
 /*
  *      Copyright (C) 2014-2016 Team Kodi
  *      http://kodi.tv
@@ -50,7 +51,7 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.19"
+#define PERIPHERAL_API_VERSION "1.0.20"
 
 /* min. Peripheral API version */
 #define PERIPHERAL_MIN_API_VERSION "1.0.19"

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
@@ -664,6 +664,10 @@ namespace ADDON
     void SetPositiveY(const DriverPrimitive& primitive) { m_primitives[1] = primitive; }
     void SetPositiveZ(const DriverPrimitive& primitive) { m_primitives[2] = primitive; }
 
+    // Access primitives
+    std::array<DriverPrimitive, MAX_PRIMITIVES>& Primitives() { return m_primitives; }
+    const std::array<DriverPrimitive, MAX_PRIMITIVES>& Primitives() const { return m_primitives; }
+
     void ToStruct(JOYSTICK_FEATURE& feature) const
     {
       feature.name = new char[m_name.length() + 1];

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_peripheral.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_peripheral.h
@@ -105,6 +105,7 @@ public:
     if (!PERIPHERAL_REGISTER_SYMBOL(m_libKODI_peripheral, PERIPHERAL_unregister_me)) return false;
     if (!PERIPHERAL_REGISTER_SYMBOL(m_libKODI_peripheral, PERIPHERAL_trigger_scan)) return false;
     if (!PERIPHERAL_REGISTER_SYMBOL(m_libKODI_peripheral, PERIPHERAL_refresh_button_maps)) return false;
+    if (!PERIPHERAL_REGISTER_SYMBOL(m_libKODI_peripheral, PERIPHERAL_feature_count)) return false;
 
     m_callbacks = PERIPHERAL_register_me(m_handle);
     return m_callbacks != NULL;
@@ -120,11 +121,17 @@ public:
     return PERIPHERAL_refresh_button_maps(m_handle, m_callbacks, strDeviceName.c_str(), strControllerId.c_str());
   }
 
+  unsigned int FeatureCount(const std::string& strControllerId, JOYSTICK_FEATURE_TYPE type = JOYSTICK_FEATURE_TYPE_UNKNOWN)
+  {
+    return PERIPHERAL_feature_count(m_handle, m_callbacks, strControllerId.c_str(), type);
+  }
+
 protected:
     CB_PeripheralLib* (*PERIPHERAL_register_me)(void* handle);
     void (*PERIPHERAL_unregister_me)(void* handle, CB_PeripheralLib* cb);
     void (*PERIPHERAL_trigger_scan)(void* handle, CB_PeripheralLib* cb);
     void (*PERIPHERAL_refresh_button_maps)(void* handle, CB_PeripheralLib* cb, const char* deviceName, const char* controllerId);
+    unsigned int (*PERIPHERAL_feature_count)(void* handle, CB_PeripheralLib* cb, const char* controllerId, JOYSTICK_FEATURE_TYPE type);
 
 private:
   void*             m_handle;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -174,6 +174,13 @@ bool CPeripheralAddon::GetAddonProperties(void)
         m_bProvidesJoysticks ? "true" : "false", Author().c_str());
     return false;
   }
+  if (m_bProvidesButtonMaps != addonCapabilities.provides_buttonmaps)
+  {
+    CLog::Log(LOGERROR, "PERIPHERAL - Add-on '%s': provides_buttonmaps' (%s) in add-on DLL  doesn't match 'provides_buttonmaps' (%s) in addon.xml. Please contact the developer of this add-on: %s",
+        Name().c_str(), addonCapabilities.provides_buttonmaps ? "true" : "false",
+        m_bProvidesButtonMaps ? "true" : "false", Author().c_str());
+    return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
This is the change needed for https://github.com/kodi-game/peripheral.joystick/pull/45 (which i accidentally merged and reverted already) to be pulled into master.

This PR allows the user to map any controller profile and have it work in the GUI. For example, you could map just the SNES profile (if you have a SNES controller) and peripheral.joystick will derive how it should be mapped to a 360 controller.

Once this change is in, I'll take care of updating peripheral.joystick.
