### PR TITLE
[OSX] - fixed regression (non working ir remote and not executed pref…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -415,7 +415,7 @@ void CApplication::Preflight()
 #if defined(TARGET_DARWIN_OSX)
   std::string install_path;
 
-  CUtil::GetHomePath(install_path);
+  install_path = CUtil::GetHomePath();
   setenv("KODI_HOME", install_path.c_str(), 0);
   install_path += "/tools/darwin/runtime/preflight";
   system(install_path.c_str());

--- a/xbmc/platform/darwin/osx/XBMCHelper.cpp
+++ b/xbmc/platform/darwin/osx/XBMCHelper.cpp
@@ -73,7 +73,7 @@ XBMCHelper::XBMCHelper()
 {
   // Compute the KODI_HOME path.
   std::string homePath;
-  CUtil::GetHomePath(homePath);
+  homePath = CUtil::GetHomePath();
   m_homepath = homePath;
 
   // Compute the helper filename.


### PR DESCRIPTION
…light script) introduced in behavior change of CUtil:GetHomePath in #10180.

What the title says ... will kick osx testbuilds as this is osx only.
