### PR TITLE
Settings: make Peripherals a Standard setting, not Advanced

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2596,7 +2596,7 @@
     <category id="input" label="14125" help="36374">
       <group id="1" label="35000">
         <setting id="input.peripherals" type="action" label="35000" help="36375">
-          <level>2</level>
+          <level>1</level>
           <dependencies>
             <dependency type="enable" on="property" name="HasPeripherals" />
           </dependencies>


### PR DESCRIPTION
This change will avoid [this situation](http://forum.kodi.tv/showthread.php?tid=269814&pid=2395203#pid2395203) where new users have trouble configuring CEC which is hidden by default, as it's an "Expert" setting.

Ping @jjd-uk.
