### PR TITLE
Fix defect in CID 142067 and CID 142228

### DIFF
--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -37,7 +37,8 @@ using namespace JOYSTICK;
 
 CKeymapHandler::CKeymapHandler(void) :
     m_state(STATE_UNPRESSED),
-    m_lastButtonPress(0)
+    m_lastButtonPress(0),
+    m_lastDigitalActionMs(0)
 {
 }
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -774,8 +774,10 @@ PeripheralAddonPtr CPeripherals::GetAddon(const CPeripheral* device)
     if (busType == PERIPHERAL_BUS_ADDON)
     {
       // If device is from an add-on, use that add-on
+      PeripheralAddonPtr peripheralAddon;
       unsigned int index;
-      addonBus->SplitLocation(device->Location(), addon, index);
+      if (addonBus->SplitLocation(device->Location(), addon, index))
+        addon = std::move(peripheralAddon);
     }
     else
     {


### PR DESCRIPTION
Defect was:

```
*** CID 142067:  Error handling issues  (CHECKED_RETURN)

772       PeripheralBusType busType = device->GetBusType();
773
774       if (busType == PERIPHERAL_BUS_ADDON)
775       {
776         // If device is from an add-on, use that add-on
777         unsigned int index;
>>>   CID 142067:  Error handling issues  (CHECKED_RETURN)
>>>   Calling "SplitLocation" without checking return value (as is done elsewhere 4 out of 5 times).
778         addonBus->SplitLocation(device->Location(), addon, index);
779       }
780       else
781       {
782         // Otherwise, have the add-on bus find a suitable add-on
783         addonBus->GetAddonWithButtonMap(device, addon);
```

And:

```
*** CID 142228:  Uninitialized members  (UNINIT_CTOR)

36     using namespace JOYSTICK;
37
38     CKeymapHandler::CKeymapHandler(void) :
39         m_state(STATE_UNPRESSED),
40         m_lastButtonPress(0)
41     {
>>  CID 142228:  Uninitialized members  (UNINIT_CTOR)
>>  Non-static class member "m_lastDigitalActionMs" is not initialized in this constructor nor in any functions that it calls.
42     }
43
44     CKeymapHandler::~CKeymapHandler(void)
45     {
46     }
47
```
