### PR TITLE
TextureManager: We still need to free textures when playing video

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4510,8 +4510,7 @@ void CApplication::ProcessSlow()
   // check for any idle curl connections
   g_curlInterface.CheckIdle();
 
-  if (!m_pPlayer->IsPlayingVideo())
-    g_largeTextureManager.CleanupUnusedImages();
+  g_largeTextureManager.CleanupUnusedImages();
 
   g_TextureManager.FreeUnusedTextures(5000);
 


### PR DESCRIPTION
Currently if you background video and scroll through movie library we never release the textures resulting in a huge memory leak.

See: http://forum.kodi.tv/showthread.php?tid=228120
