### PR TITLE
[PVR] Recordings window context menu fixes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -923,6 +923,7 @@ msgctxt "#207"
 msgid "Plot"
 msgstr ""
 
+#: xbmc/pvr/windows/PVRGUIWindowRecordings.cpp
 #: xbmc/dialogs/GUIDialogPlayEject.cpp
 #: system/settings/settings.xml
 msgctxt "#208"
@@ -5176,6 +5177,8 @@ msgctxt "#12022"
 msgid "Resume from %s"
 msgstr ""
 
+#. Label of video/recordings context menu items
+#: xbmc/pvr/windows/PVRGUIWindowRecordings.cpp
 #: xbmc/video/ContextMenus.cpp
 msgctxt "#12023"
 msgid "Play from beginning"

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -254,58 +254,12 @@ bool CPVRRecordings::DeleteAllRecordingsFromTrash()
 
 bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
 {
-  bool bResult = false;
+  return ChangeRecordingsPlayCount(item, count);
+}
 
-  if (m_database.IsOpen())
-  {
-    bResult = true;
-
-    CLog::Log(LOGDEBUG, "CPVRRecordings - %s - item path %s", __FUNCTION__, item->GetPath().c_str());
-    CFileItemList items;
-    if (item->m_bIsFolder)
-    {
-      XFILE::CDirectory::GetDirectory(item->GetPath(), items);
-    }
-    else
-      items.Add(item);
-
-    CLog::Log(LOGDEBUG, "CPVRRecordings - %s - will set watched for %d items", __FUNCTION__, items.Size());
-    for (int i=0;i<items.Size();++i)
-    {
-      CLog::Log(LOGDEBUG, "CPVRRecordings - %s - setting watched for item %d", __FUNCTION__, i);
-
-      CFileItemPtr pItem=items[i];
-      if (pItem->m_bIsFolder)
-      {
-        CLog::Log(LOGDEBUG, "CPVRRecordings - %s - path %s is a folder, will call recursively", __FUNCTION__, pItem->GetPath().c_str());
-        if (pItem->GetLabel() != "..")
-        {
-          SetRecordingsPlayCount(pItem, count);
-        }
-        continue;
-      }
-
-      if (!pItem->HasPVRRecordingInfoTag())
-        continue;
-
-      const CPVRRecordingPtr recording = pItem->GetPVRRecordingInfoTag();
-      if (recording)
-      {
-        recording->SetPlayCount(count);
-
-        // Clear resume bookmark
-        if (count > 0)
-        {
-          m_database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
-          recording->SetLastPlayedPosition(0);
-        }
-
-        m_database.SetPlayCount(*pItem, count);
-      }
-    }
-  }
-
-  return bResult;
+bool CPVRRecordings::IncrementRecordingsPlayCount(const CFileItemPtr &item)
+{
+  return ChangeRecordingsPlayCount(item, INCREMENT_PLAY_COUNT);
 }
 
 bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &items)
@@ -508,4 +462,66 @@ void CPVRRecordings::UpdateEpgTags(void)
       }
     }
   }
+}
+
+bool CPVRRecordings::ChangeRecordingsPlayCount(const CFileItemPtr &item, int count)
+{
+  bool bResult = false;
+
+  if (m_database.IsOpen())
+  {
+    bResult = true;
+
+    CLog::Log(LOGDEBUG, "CPVRRecordings - %s - item path %s", __FUNCTION__, item->GetPath().c_str());
+    CFileItemList items;
+    if (item->m_bIsFolder)
+    {
+      XFILE::CDirectory::GetDirectory(item->GetPath(), items);
+    }
+    else
+      items.Add(item);
+
+    CLog::Log(LOGDEBUG, "CPVRRecordings - %s - will set watched for %d items", __FUNCTION__, items.Size());
+    for (int i=0;i<items.Size();++i)
+    {
+      CLog::Log(LOGDEBUG, "CPVRRecordings - %s - setting watched for item %d", __FUNCTION__, i);
+
+      CFileItemPtr pItem=items[i];
+      if (pItem->m_bIsFolder)
+      {
+        CLog::Log(LOGDEBUG, "CPVRRecordings - %s - path %s is a folder, will call recursively", __FUNCTION__, pItem->GetPath().c_str());
+        if (pItem->GetLabel() != "..")
+        {
+          ChangeRecordingsPlayCount(pItem, count);
+        }
+        continue;
+      }
+
+      if (!pItem->HasPVRRecordingInfoTag())
+        continue;
+
+      const CPVRRecordingPtr recording = pItem->GetPVRRecordingInfoTag();
+      if (recording)
+      {
+        if (count == INCREMENT_PLAY_COUNT)
+          recording->IncrementPlayCount();
+        else
+          recording->SetPlayCount(count);
+
+        // Clear resume bookmark
+        if (recording->m_playCount > 0)
+        {
+          m_database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
+          recording->SetLastPlayedPosition(0);
+        }
+
+        if (count == INCREMENT_PLAY_COUNT)
+          m_database.IncrementPlayCount(*pItem);
+        else
+          m_database.SetPlayCount(*pItem, count);
+      }
+    }
+  }
+
+  return bResult;
 }

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -58,6 +58,19 @@ namespace PVR
     bool DeleteDirectory(const CFileItem &item);
     bool DeleteRecording(const CFileItem &item);
 
+    /**
+     * @brief special value for parameter count of method ChangeRecordingsPlayCount
+     */
+    static const int INCREMENT_PLAY_COUNT = -1;
+
+    /**
+     * @brief change the playcount of the given recording or recursively of all children of the given recordings folder
+     * @param item the recording or directory containing recordings
+     * @param count the new playcount or INCREMENT_PLAY_COUNT to denote that the current playcount(s) are to be incremented by one
+     * @return true if all playcounts were changed
+     */
+    bool ChangeRecordingsPlayCount(const CFileItemPtr &item, int count);
+
   public:
     CPVRRecordings(void);
     virtual ~CPVRRecordings(void);
@@ -87,6 +100,7 @@ namespace PVR
     bool DeleteAllRecordingsFromTrash();
     bool RenameRecording(CFileItem &item, std::string &strNewName);
     bool SetRecordingsPlayCount(const CFileItemPtr &item, int count);
+    bool IncrementRecordingsPlayCount(const CFileItemPtr &item);
 
     bool GetDirectory(const std::string& strPath, CFileItemList &items);
     CFileItemPtr GetByPath(const std::string &path);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -123,10 +123,17 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
     if (!isDeletedRecording)
     {
       buttons.Add(CONTEXT_BUTTON_FIND, 19003);      /* Find similar */
-      buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 12021); /* Start from beginning */
+
       std::string resumeString = GetResumeString(*pItem);
-      if (!resumeString.empty())
-        buttons.Add(CONTEXT_BUTTON_RESUME_ITEM, resumeString);
+      if (resumeString.empty())
+      {
+        buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208); /* Play */
+      }
+      else
+      {
+        buttons.Add(CONTEXT_BUTTON_RESUME_ITEM, resumeString); /* Resume from HH:MM:SS */
+        buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 12023); /* Play from beginning */
+      }
     }
     else
     {

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -488,14 +488,16 @@ bool CGUIWindowPVRRecordings::OnContextButtonMarkWatched(const CFileItemPtr &ite
 
   if (button == CONTEXT_BUTTON_MARK_WATCHED || button == CONTEXT_BUTTON_MARK_UNWATCHED)
   {
-    int playCount = button == CONTEXT_BUTTON_MARK_WATCHED ? 1 : 0;
+    if (button == CONTEXT_BUTTON_MARK_WATCHED)
+      bReturn = g_PVRRecordings->IncrementRecordingsPlayCount(item);
+    else
+      bReturn = g_PVRRecordings->SetRecordingsPlayCount(item, 0);
 
-    if (g_PVRRecordings->SetRecordingsPlayCount(item, playCount))
+    if (bReturn)
     {
       // Advance the selected item one notch
       m_viewControl.SetSelectedItem(m_viewControl.GetSelectedItem() + 1);
       Refresh(true);
-      bReturn = true;
     }
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -101,7 +101,7 @@ std::string CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
 
     // Suppress resume from 0
     if (positionInSeconds > 0)
-      resumeString = StringUtils::Format(g_localizeStrings.Get(12022).c_str(), StringUtils::SecondsToTimeString(positionInSeconds).c_str());
+      resumeString = StringUtils::Format(g_localizeStrings.Get(12022).c_str(), StringUtils::SecondsToTimeString(positionInSeconds, TIME_FORMAT_HH_MM_SS).c_str());
   }
   return resumeString;
 }

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -33,6 +33,8 @@ CVideoInfo::CVideoInfo(MediaType mediaType)
 
 bool CVideoInfo::IsVisible(const CFileItem& item) const
 {
+  if (item.IsPVR())
+    return false; // pvr has its own implementation for this
   return item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_type == m_mediaType;
 }
 
@@ -46,6 +48,8 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
 {
   if (!item.HasVideoInfoTag())
     return false;
+  if (item.IsPVR())
+    return false; // pvr has its own implementation for this
   if (item.m_bIsFolder) //Only allow db content to be updated recursively
     return item.IsVideoDb();
   return item.GetVideoInfoTag()->m_playCount == 0;
@@ -61,6 +65,8 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
 {
   if (!item.HasVideoInfoTag())
     return false;
+  if (item.IsPVR())
+    return false; // pvr has its own implementation for this
   if (item.m_bIsFolder) //Only allow db content to be updated recursively
     return item.IsVideoDb();
   return item.GetVideoInfoTag()->m_playCount > 0;
@@ -79,6 +85,8 @@ std::string CResume::GetLabel(const CFileItem& item) const
 
 bool CResume::IsVisible(const CFileItem& item) const
 {
+  if (item.IsPVR())
+    return false; // pvr has its own implementation for this
   return CGUIWindowVideoBase::HasResumeItemOffset(&item);
 }
 
@@ -116,6 +124,8 @@ bool CPlay::IsVisible(const CFileItem& item) const
 {
   if (item.m_bIsFolder)
     return false; //! @todo implement
+  if (item.IsPVR())
+    return false; // pvr has its own implementation for this
   return item.IsVideo() || item.IsDVD() || item.IsCDDA();
 }
 


### PR DESCRIPTION
4 fixes:

1) 'Mark as watched': must not set play count to one, unconditionally, but increment it.
2) Fix duplicate context menu entries (regression introduced by non-pvr krypton context menu rework) 
3) 'Resume from ...': Fix time format to be aligned with format used for non-pvr videos
4) 'Play / Play from beginning': Fix wording to be aligned with strings used for non-pvr videos

before:
![screenshot005](https://cloud.githubusercontent.com/assets/3226626/17790372/67bafef0-6596-11e6-886f-a8022f3beb0e.png)

after:
![screenshot007](https://cloud.githubusercontent.com/assets/3226626/17790597/7fc2be06-6597-11e6-8c23-a41dc2f2dcb3.png)

@Jalle19 objections?
