### PR TITLE
rename librarysettings to mediasettings

### DIFF
--- a/addons/skin.estuary/1080i/Variables.xml
+++ b/addons/skin.estuary/1080i/Variables.xml
@@ -321,7 +321,7 @@
 	</variable>
 	<variable name="SettingsSectionIcon">
 		<value condition="Window.IsActive(playersettings)">icons/settings/video.png</value>
-		<value condition="Window.IsActive(librarysettings)">icons/settings/library.png</value>
+		<value condition="Window.IsActive(mediasettings)">icons/settings/library.png</value>
 		<value condition="Window.IsActive(pvrsettings)">icons/settings/livetv.png</value>
 		<value condition="Window.IsActive(servicesettings)">icons/settings/network.png</value>
 		<value condition="Window.IsActive(interfacesettings)">icons/settings/appearance.png</value>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -427,11 +427,11 @@
       <back>PreviousMenu</back>
     </remote>
   </PlayerSettings>
-  <LibrarySettings>
+  <MediaSettings>
     <remote>
       <back>PreviousMenu</back>
     </remote>
-  </LibrarySettings>
+  </MediaSettings>
   <SystemSettings>
     <remote>
       <back>PreviousMenu</back>


### PR DESCRIPTION
fix a few leftovers that were missed during the window renaming.

@jjd-uk
