### PR TITLE
[EPG] EPG grid: fix crash on grid update if selected item start datet…

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -500,7 +500,16 @@ void CGUIEPGGridContainer::UpdateItems()
 
     if (prevSelectedEpgTag->StartAsUTC().IsValid()) // "normal" tag selected
     {
-      newBlockIndex = (prevSelectedEpgTag->StartAsUTC() - m_gridModel->GetGridStart()).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
+      const CDateTime gridStart(m_gridModel->GetGridStart());
+      const CDateTime eventStart(prevSelectedEpgTag->StartAsUTC());
+
+      if (gridStart >= eventStart)
+      {
+        // start of previously selected event is before grid start
+        newBlockIndex = eventOffset;
+      }
+      else
+        newBlockIndex = (eventStart - gridStart).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
 
       const CPVRChannelPtr channel(prevSelectedEpgTag->ChannelTag());
       if (channel)
@@ -516,7 +525,16 @@ void CGUIEPGGridContainer::UpdateItems()
         const CEpgInfoTagPtr tag(prevItem->item->GetEPGInfoTag());
         if (tag && tag->EndAsUTC().IsValid())
         {
-          newBlockIndex = (tag->EndAsUTC() - m_gridModel->GetGridStart()).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
+          const CDateTime gridStart(m_gridModel->GetGridStart());
+          const CDateTime eventEnd(tag->EndAsUTC());
+
+          if (gridStart >= eventEnd)
+          {
+            // start of previously selected gap tag is before grid start
+            newBlockIndex = eventOffset;
+          }
+          else
+            newBlockIndex = (eventEnd - gridStart).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
 
           const CPVRChannelPtr channel(tag->ChannelTag());
           if (channel)


### PR DESCRIPTION
…ime is before grid start datetime. Happens quite often if epglingertime is set to zero. But can also occure with non-zero lingertime. Fixes trac#16751.

Reported in the forum: http://forum.kodi.tv/showthread.php?tid=287164
Trac ticket: http://trac.kodi.tv/ticket/16715

If you know what to do, quite easy to reproduce. Otherwise it can hit you out of the blue at any time when using epg grid... Actually a rather old bug. Should be merged asap.

@Jalle19 for a quick check?
