### PR TITLE
DVDVideoCodecFFmpeg: Do not confuse users with our fallback deinterlacer

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -506,7 +506,7 @@ void CDVDVideoCodecFFmpeg::SetFilters()
   // ask codec to do deinterlacing if possible
   EINTERLACEMETHOD mInt = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_InterlaceMethod;
 
-  if (mInt != VS_INTERLACEMETHOD_DEINTERLACE && mInt != VS_INTERLACEMETHOD_DEINTERLACE_HALF)
+  if (mInt != VS_INTERLACEMETHOD_NONE && mInt != VS_INTERLACEMETHOD_DEINTERLACE && mInt != VS_INTERLACEMETHOD_DEINTERLACE_HALF)
     mInt = m_processInfo.GetFallbackDeintMethod();
 
   unsigned int filters = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1027,7 +1027,7 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const std::string& filters, bool scale)
 
     if (filters.compare(0,5,"yadif") == 0)
     {
-      m_processInfo.SetVideoDeintMethod(filters);
+      m_processInfo.SetVideoDeintMethod(filters + " (input adaptive)");
     }
   }
   else


### PR DESCRIPTION
When sw decoding we create a filter chain where we add our yadif deinterlacer which does nothing with frames that are not interlaced, but it is written in ProcessInfo and users are confused.

This just write "none" if we are not interlaced. It would be better to not create the filter_graph at all I think.
