### PR TITLE
Added 2 view modes with zoom that depends on AR

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -393,6 +393,8 @@
 		7C5608C70F1754930056433A /* ExternalPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C5608C40F1754930056433A /* ExternalPlayer.cpp */; };
 		7C62F24210505BC7002AD2C1 /* Bookmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C62F24010505BC7002AD2C1 /* Bookmark.cpp */; };
 		7C62F45E1057A62D002AD2C1 /* DirectoryNodeSingles.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C62F45C1057A62D002AD2C1 /* DirectoryNodeSingles.cpp */; };
+		7C68401B1D87C6D400C55360 /* ViewModeSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C6840191D87C6D400C55360 /* ViewModeSettings.cpp */; };
+		7C68401C1D87C6D400C55360 /* ViewModeSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C6840191D87C6D400C55360 /* ViewModeSettings.cpp */; };
 		7C6EB330155BD1D40080368A /* ImageFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C6EB32E155BD1D40080368A /* ImageFile.cpp */; };
 		7C6EB6FA155F32C30080368A /* HTTPImageHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C6EB6F8155F32C30080368A /* HTTPImageHandler.cpp */; };
 		7C779E3A104A57E500F444C4 /* RenderSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E1F104A57E500F444C4 /* RenderSystem.cpp */; };
@@ -2941,6 +2943,8 @@
 		7C62F24110505BC7002AD2C1 /* Bookmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bookmark.h; sourceTree = "<group>"; };
 		7C62F45C1057A62D002AD2C1 /* DirectoryNodeSingles.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryNodeSingles.cpp; sourceTree = "<group>"; };
 		7C62F45D1057A62D002AD2C1 /* DirectoryNodeSingles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryNodeSingles.h; sourceTree = "<group>"; };
+		7C6840191D87C6D400C55360 /* ViewModeSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ViewModeSettings.cpp; sourceTree = "<group>"; };
+		7C68401A1D87C6D400C55360 /* ViewModeSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewModeSettings.h; sourceTree = "<group>"; };
 		7C6EB32E155BD1D40080368A /* ImageFile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageFile.cpp; sourceTree = "<group>"; };
 		7C6EB32F155BD1D40080368A /* ImageFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageFile.h; sourceTree = "<group>"; };
 		7C6EB6F8155F32C30080368A /* HTTPImageHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPImageHandler.cpp; sourceTree = "<group>"; };
@@ -6031,6 +6035,8 @@
 				F59876BE0FBA351D008EF4FB /* VideoReferenceClock.h */,
 				7CC30DBE16291C2C003E7579 /* VideoThumbLoader.cpp */,
 				7CC30DBF16291C2C003E7579 /* VideoThumbLoader.h */,
+				7C6840191D87C6D400C55360 /* ViewModeSettings.cpp */,
+				7C68401A1D87C6D400C55360 /* ViewModeSettings.h */,
 			);
 			path = video;
 			sourceTree = "<group>";
@@ -10113,6 +10119,7 @@
 				E38A06CE0D95AA5500FF8227 /* GUIDialogKaiToast.cpp in Sources */,
 				7C8E023D1BA35D0B0072E8B2 /* ProfileBuiltins.cpp in Sources */,
 				E3B53E7C0D97B08100021A96 /* DVDSubtitleParserMicroDVD.cpp in Sources */,
+				7C68401B1D87C6D400C55360 /* ViewModeSettings.cpp in Sources */,
 				E36C29DF0DA72429001F0C9D /* Artist.cpp in Sources */,
 				E36C29E00DA72429001F0C9D /* Album.cpp in Sources */,
 				E36C29E60DA72442001F0C9D /* DVDSubtitleParserSami.cpp in Sources */,
@@ -11451,6 +11458,7 @@
 				E49913AE174E5F3300741B6D /* UPnPPlayer.cpp in Sources */,
 				E49913AF174E5F3300741B6D /* UPnPRenderer.cpp in Sources */,
 				E49913B0174E5F3300741B6D /* UPnPServer.cpp in Sources */,
+				7C68401C1D87C6D400C55360 /* ViewModeSettings.cpp in Sources */,
 				E49913B1174E5F3300741B6D /* UPnPSettings.cpp in Sources */,
 				E49913B2174E5F3700741B6D /* WebSocket.cpp in Sources */,
 				E49913B3174E5F3700741B6D /* WebSocketManager.cpp in Sources */,

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19572,3 +19572,13 @@ msgstr ""
 msgctxt "#39007"
 msgid "This provides access to where picture sources can be added and otherwise managed."
 msgstr ""
+
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#39008"
+msgid "Zoom - 120% width"
+msgstr ""
+
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#39009"
+msgid "Zoom - 110% width"
+msgstr ""

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -224,7 +224,9 @@ enum ViewMode {
   ViewModeStretch16x9,
   ViewModeOriginal,
   ViewModeCustom,
-  ViewModeStretch16x9Nonlin
+  ViewModeStretch16x9Nonlin,
+  ViewModeZoom120Width,
+  ViewModeZoom110Width
 };
 
 class IPlayer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -428,7 +428,7 @@ void CBaseRenderer::ManageRenderArea()
 
 void CBaseRenderer::SetViewMode(int viewMode)
 {
-  if (viewMode < ViewModeNormal || viewMode > ViewModeStretch16x9Nonlin)
+  if (viewMode < ViewModeNormal || viewMode > ViewModeZoom110Width)
     viewMode = ViewModeNormal;
 
   CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = viewMode;
@@ -536,6 +536,18 @@ void CBaseRenderer::SetViewMode(int viewMode)
     CDisplaySettings::GetInstance().SetPixelRatio(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio);
     CDisplaySettings::GetInstance().SetNonLinearStretched(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomNonLinStretch);
     CDisplaySettings::GetInstance().SetVerticalShift(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift);
+  }
+  else if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode == ViewModeZoom120Width)
+  {
+    float fitHeightZoom = sourceFrameRatio * screenHeight / (info.fPixelRatio * screenWidth);
+    CDisplaySettings::GetInstance().SetPixelRatio(1.0f);
+    CDisplaySettings::GetInstance().SetZoomAmount(fitHeightZoom < 1.0f ? 1.0f : (fitHeightZoom > 1.2f ? 1.2f : fitHeightZoom));
+  }
+  else if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode == ViewModeZoom110Width)
+  {
+    float fitHeightZoom = sourceFrameRatio * screenHeight / (info.fPixelRatio * screenWidth);
+    CDisplaySettings::GetInstance().SetPixelRatio(1.0f);
+    CDisplaySettings::GetInstance().SetZoomAmount(fitHeightZoom < 1.0f ? 1.0f : (fitHeightZoom > 1.1f ? 1.1f : fitHeightZoom));
   }
   else // if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode == ViewModeNormal)
   {

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -94,7 +94,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
       scalingMethod = (int)VS_SCALINGMETHOD_LINEAR;
     m_defaultVideoSettings.m_ScalingMethod = (ESCALINGMETHOD)scalingMethod;
 
-    XMLUtils::GetInt(pElement, "viewmode", m_defaultVideoSettings.m_ViewMode, ViewModeNormal, ViewModeCustom);
+    XMLUtils::GetInt(pElement, "viewmode", m_defaultVideoSettings.m_ViewMode, ViewModeNormal, ViewModeZoom110Width);
     if (!XMLUtils::GetFloat(pElement, "zoomamount", m_defaultVideoSettings.m_CustomZoomAmount, 0.5f, 2.0f))
       m_defaultVideoSettings.m_CustomZoomAmount = 1.0f;
     if (!XMLUtils::GetFloat(pElement, "pixelratio", m_defaultVideoSettings.m_CustomPixelRatio, 0.5f, 2.0f))

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -10,7 +10,8 @@ set(SOURCES Bookmark.cpp
             VideoInfoTag.cpp
             VideoLibraryQueue.cpp
             VideoReferenceClock.cpp
-            VideoThumbLoader.cpp)
+            VideoThumbLoader.cpp
+            ViewModeSettings.cpp)
 
 set(HEADERS Bookmark.h
             ContextMenus.h

--- a/xbmc/video/Makefile
+++ b/xbmc/video/Makefile
@@ -11,6 +11,7 @@ SRCS=Bookmark.cpp \
      VideoLibraryQueue.cpp \
      VideoReferenceClock.cpp \
      VideoThumbLoader.cpp \
+     ViewModeSettings.cpp \
      
 LIB=video.a
 

--- a/xbmc/video/ViewModeSettings.cpp
+++ b/xbmc/video/ViewModeSettings.cpp
@@ -1,0 +1,111 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ViewModeSettings.h"
+
+#include "cores/IPlayer.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/VideoSettings.h"
+
+struct ViewModeProperties
+{
+  int stringIndex;
+  int viewMode;
+  bool hideFromQuickCycle;
+  bool hideFromList;
+};
+
+#define HIDE_ITEM true
+
+/** The list of all the view modes along with their properties
+ */
+static const ViewModeProperties viewModes[] =
+{
+  { 630,   ViewModeNormal },
+  { 631,   ViewModeZoom },
+  { 39008, ViewModeZoom120Width },
+  { 39009, ViewModeZoom110Width },
+  { 632,   ViewModeStretch4x3 },
+  { 633,   ViewModeWideZoom },
+  { 634,   ViewModeStretch16x9 },
+  { 644,   ViewModeStretch16x9Nonlin, HIDE_ITEM, HIDE_ITEM },
+  { 635,   ViewModeOriginal },
+  { 636,   ViewModeCustom, HIDE_ITEM, HIDE_ITEM }
+};
+
+#define NUMBER_OF_VIEW_MODES (sizeof(viewModes) / sizeof(viewModes[0]))
+
+/** Gets the index of a view mode
+ *
+ * @param viewMode The view mode
+ * @return The index of the view mode in the viewModes array
+ */
+static int GetViewModeIndex(int viewMode)
+{
+  size_t i;
+
+  // Find the current view mode
+  for (i = 0; i < NUMBER_OF_VIEW_MODES; i++)
+  {
+    if (viewModes[i].viewMode == viewMode)
+      return i;
+  }
+
+  return 0; // An invalid view mode will always return the first view mode
+}
+
+/** Gets the next view mode for quick cycling through the modes
+ *
+ * @param viewMode The current view mode
+ * @return The next view mode
+ */
+int CViewModeSettings::GetNextQuickCycleViewMode(int viewMode)
+{
+  // Find the next quick cycle view mode
+  for (size_t i = GetViewModeIndex(viewMode) + 1; i < NUMBER_OF_VIEW_MODES; i++)
+  {
+    if (!viewModes[i].hideFromQuickCycle)
+      return viewModes[i].viewMode;
+  }
+
+  return ViewModeNormal;
+}
+
+/** Gets the string index for the view mode
+ *
+ * @param viewMode The current view mode
+ * @return The string index
+ */
+int CViewModeSettings::GetViewModeStringIndex(int viewMode)
+{
+  return viewModes[GetViewModeIndex(viewMode)].stringIndex;
+}
+
+/** Fills the list with all visible view modes
+ */
+void CViewModeSettings::ViewModesFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+{
+  // Add all appropriate view modes to the list control
+  for (const auto &item : viewModes)
+  {
+    if (!item.hideFromList)
+      list.push_back(make_pair(g_localizeStrings.Get(item.stringIndex), item.viewMode));
+  }
+}

--- a/xbmc/video/ViewModeSettings.h
+++ b/xbmc/video/ViewModeSettings.h
@@ -1,0 +1,55 @@
+
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "settings/lib/Setting.h"
+
+class CViewModeSettings
+{
+private:
+  CViewModeSettings();
+  ~CViewModeSettings() {};
+
+public:
+  /** Gets the next view mode for quick cycling through the modes
+   *
+   * @param viewMode The current view mode
+   * @return The next view mode
+   */
+  static int GetNextQuickCycleViewMode(int viewMode);
+
+  /** Gets the string index for the view mode
+   *
+   * @param viewMode The current view mode
+   * @return The string index
+   */
+  static int GetViewModeStringIndex(int viewMode);
+
+  /** Fills the list with all visible view modes
+   */
+  static void ViewModesFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+
+};

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -38,6 +38,7 @@
 #include "Application.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
+#include "video/ViewModeSettings.h"
 
 #define SETTING_VIDEO_VIEW_MODE           "video.viewmode"
 #define SETTING_VIDEO_ZOOM                "video.zoom"
@@ -332,10 +333,7 @@ void CGUIDialogVideoSettings::InitializeSettings()
 
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_STRETCH) || g_application.m_pPlayer->Supports(RENDERFEATURE_PIXEL_RATIO))
   {
-    entries.clear();
-    for (int i = 0; i < 7; ++i)
-      entries.push_back(std::make_pair(630 + i, i));
-    AddSpinner(groupVideo, SETTING_VIDEO_VIEW_MODE, 629, 0, videoSettings.m_ViewMode, entries);
+    AddList(groupVideo, SETTING_VIDEO_VIEW_MODE, 629, 0, videoSettings.m_ViewMode, CViewModeSettings::ViewModesFiller, 629);
   }
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_ZOOM))
     AddSlider(groupVideo, SETTING_VIDEO_ZOOM, 216, 0, videoSettings.m_CustomZoomAmount, "%2.2f", 0.5f, 0.01f, 2.0f, 216, usePopup);
@@ -426,4 +424,3 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(const CSetting *setting, 
     current = -1;
   }
 }
-

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -43,6 +43,7 @@
 #include "windowing/WindowingFactory.h"
 #include "cores/IPlayer.h"
 #include "guiinfo/GUIInfoLabels.h"
+#include "video/ViewModeSettings.h"
 
 #include <stdio.h>
 #include <algorithm>
@@ -218,7 +219,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       if (m_bShowViewModeInfo)
       {
 #ifdef HAS_VIDEO_PLAYBACK
-        g_application.m_pPlayer->SetRenderViewMode(++CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
+        g_application.m_pPlayer->SetRenderViewMode(CViewModeSettings::GetNextQuickCycleViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode));
 #endif
       }
       m_bShowViewModeInfo = true;
@@ -383,7 +384,7 @@ void CGUIWindowFullScreen::FrameMove()
       // get the "View Mode" string
       std::string strTitle = g_localizeStrings.Get(629);
       const auto& settings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
-      int sId = settings.m_ViewMode == ViewModeStretch16x9Nonlin ? 644 : 630 + settings.m_ViewMode;
+      int sId = CViewModeSettings::GetViewModeStringIndex(settings.m_ViewMode);
       std::string strMode = g_localizeStrings.Get(sId);
       std::string strInfo = StringUtils::Format("%s : %s", strTitle.c_str(), strMode.c_str());
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW1);


### PR DESCRIPTION
I added 2 new video view modes that will attempt to zoom the video to match the screen height. If this zoom causes the width of the video to exceed the width of the screen by some percent (20% for one, 10% for the other), then the zoom is reduced to that amount. (This works well for 2.39:1 on a 16:9 screen or 16:9 videos on a 4:3 screen.) IMHO this provides a good compromise between using most of the screen and minimizing the amount of video cropped, while still maintaining the aspect ratio. (I couldn't find an easy way to do this currently without having to set a custom zoom for each video.)
