### PR TITLE
[EPG] Fix limits for grid start value (must be 'now' - 30 minutes' latest).

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -42,7 +42,7 @@ using namespace EPG;
 #define SHORTGAP     5 // how many blocks is considered a short-gap in nav logic
 #define BLOCKJUMP    4 // how many blocks are jumped with each analogue scroll action
 static const int BLOCK_SCROLL_OFFSET = 60 / CGUIEPGGridContainerModel::MINSPERBLOCK; // how many blocks are jumped if we are at left/right edge of grid
-static const int PAGE_NOW_OFFSET     = 30 / CGUIEPGGridContainerModel::MINSPERBLOCK;
+static const int PAGE_NOW_OFFSET = CGUIEPGGridContainerModel::GRID_START_PADDING / CGUIEPGGridContainerModel::MINSPERBLOCK; // this is the 'now' block relative to page start  
 
 CGUIEPGGridContainer::CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width,
                                            float height, int scrollTime, int preloadItems, int timeBlocks, int rulerUnit,

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -108,15 +108,25 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
   /* check for invalid start and end time */
   if (gridStart >= gridEnd)
   {
-    // default to start "now minus 30 minutes" and end "start plus one page".
-    m_gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() - CDateTimeSpan(0, 0, 30, 0);
+    // default to start "now minus GRID_START_PADDING minutes" and end "start plus one page".
+    m_gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() - CDateTimeSpan(0, 0, GRID_START_PADDING, 0);
     m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * MINSPERBLOCK, 0);
+  }
+  else if (gridStart > (CDateTime::GetCurrentDateTime().GetAsUTCDateTime() - CDateTimeSpan(0, 0, GRID_START_PADDING, 0)))
+  {
+    // adjust to start "now minus GRID_START_PADDING minutes".
+    m_gridStart = CDateTime::GetCurrentDateTime().GetAsUTCDateTime() - CDateTimeSpan(0, 0, GRID_START_PADDING, 0);
+    m_gridEnd = gridEnd;
   }
   else
   {
-    m_gridStart = CDateTime(gridStart.GetYear(), gridStart.GetMonth(), gridStart.GetDay(), gridStart.GetHour(), gridStart.GetMinute() >= 30 ? 30 : 0, 0);
-    m_gridEnd = CDateTime(gridEnd.GetYear(), gridEnd.GetMonth(), gridEnd.GetDay(), gridEnd.GetHour(), gridEnd.GetMinute() >= 30 ? 30 : 0, 0);
+    m_gridStart = gridStart;
+    m_gridEnd = gridEnd;
   }
+
+  // roundup
+  m_gridStart = CDateTime(m_gridStart.GetYear(), m_gridStart.GetMonth(), m_gridStart.GetDay(), m_gridStart.GetHour(), m_gridStart.GetMinute() >= 30 ? 30 : 0, 0);
+  m_gridEnd = CDateTime(m_gridEnd.GetYear(), m_gridEnd.GetMonth(), m_gridEnd.GetDay(), m_gridEnd.GetHour(), m_gridEnd.GetMinute() >= 30 ? 30 : 0, 0);
 
   ////////////////////////////////////////////////////////////////////////
   // Create ruler items

--- a/xbmc/epg/GUIEPGGridContainerModel.h
+++ b/xbmc/epg/GUIEPGGridContainerModel.h
@@ -44,8 +44,9 @@ namespace EPG
   class CGUIEPGGridContainerModel
   {
   public:
-    static const int MINSPERBLOCK = 5; // minutes
-    static const int MAXBLOCKS    = 33 * 24 * 60 / MINSPERBLOCK; //! 33 days of 5 minute blocks (31 days for upcoming data + 1 day for past data + 1 day for fillers)
+    static const int MINSPERBLOCK       = 5; // minutes
+    static const int MAXBLOCKS          = 33 * 24 * 60 / MINSPERBLOCK; //! 33 days of 5 minute blocks (31 days for upcoming data + 1 day for past data + 1 day for fillers)
+    static const int GRID_START_PADDING = 30; // minutes; latest grid start 'now - GRID_START_PADDING', will be adjusted to this value if shall be set to later
 
     CGUIEPGGridContainerModel() : m_blocks(0) {}
     virtual ~CGUIEPGGridContainerModel() { Reset(); }


### PR DESCRIPTION
Just another small epg grid positioning bug I discovered while playing around with epg linger time set to 0.

Wrong event (off by 6 blocks or so) was selected when "going to now".

@Jalle19 good to go?
