### PR TITLE
[PVR] Fix regression in CPVRRecordings::UpdateEpgTags.

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -451,7 +451,7 @@ void CPVRRecordings::UpdateEpgTags(void)
   for (const auto recording : m_recordings)
   {
     iEpgEvent = recording.second->BroadcastUid();
-    if (iEpgEvent != EPG_TAG_INVALID_UID && recording.second->IsDeleted())
+    if (iEpgEvent != EPG_TAG_INVALID_UID && !recording.second->IsDeleted())
     {
       channel = recording.second->Channel();
       if (channel)


### PR DESCRIPTION
Introduced by #9586, => https://github.com/xbmc/xbmc/commit/6ff0b2cf4ac1#diff-821f9fc69b834bb338f060b8fcb6e838R505

Symptoms: EPG tags for events which are still recording/got recorded had no recordings assigned after kodi restart (because due to the regression only deleted recording were ever assigned to epg tags.) Visible for example as missing play icon in epg grid.

@Jalle19 for review, please.
