### PR TITLE
Use uint64_t to represent times for seeking

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3677,7 +3677,7 @@ void CApplication::OnPlayBackSpeedChanged(int iSpeed)
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnSpeedChanged", m_itemCurrentFile, param);
 }
 
-void CApplication::OnPlayBackSeek(int iTime, int seekOffset)
+void CApplication::OnPlayBackSeek(uint64_t iTime, int seekOffset)
 {
 #ifdef HAS_PYTHON
   g_pythonParser.OnPlayBackSeek(iTime, seekOffset);

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -175,7 +175,7 @@ public:
   virtual void OnPlayBackResumed() override;
   virtual void OnPlayBackStopped() override;
   virtual void OnQueueNextItem() override;
-  virtual void OnPlayBackSeek(int iTime, int seekOffset) override;
+  virtual void OnPlayBackSeek(uint64_t iTime, int seekOffset) override;
   virtual void OnPlayBackSeekChapter(int iChapter) override;
   virtual void OnPlayBackSpeedChanged(int iSpeed) override;
 

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -280,7 +280,7 @@ bool CApplicationPlayer::SeekScene(bool bPlus)
   return (player && player->SeekScene(bPlus));
 }
 
-void CApplicationPlayer::SeekTime(int64_t iTime)
+void CApplicationPlayer::SeekTime(uint64_t iTime)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
@@ -295,7 +295,7 @@ void CApplicationPlayer::SeekTimeRelative(int64_t iTime)
     // use relative seeking if implemented by player
     if (!player->SeekTimeRelative(iTime))
     {
-      int64_t abstime = player->GetTime() + iTime;
+      uint64_t abstime = player->GetTime() + iTime;
       player->SeekTime(abstime);
     }
   }

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -161,7 +161,7 @@ public:
   int   SeekChapter(int iChapter);
   void  SeekPercentage(float fPercent = 0);
   bool  SeekScene(bool bPlus = true);
-  void  SeekTime(int64_t iTime = 0);
+  void  SeekTime(uint64_t iTime = 0);
   void  SeekTimeRelative(int64_t iTime = 0);
   void  SetAudioStream(int iStream);
   void  SetAVDelay(float fValue = 0.0f);

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -301,7 +301,7 @@ int CInputStream::GetTime()
 }
 
 // IPosTime
-bool CInputStream::PosTime(int ms)
+bool CInputStream::PosTime(uint64_t ms)
 {
   bool ret = false;
   try
@@ -493,7 +493,7 @@ DemuxPacket* CInputStream::ReadDemux()
   return pPacket;
 }
 
-bool CInputStream::SeekTime(int time, bool backward, double* startpts)
+bool CInputStream::SeekTime(uint64_t time, bool backward, double* startpts)
 {
   bool ret = false;
   try

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -68,14 +68,14 @@ namespace ADDON
     int GetTime();
 
     // IPosTime
-    bool PosTime(int ms);
+    bool PosTime(uint64_t ms);
 
     // demux
     int GetNrOfStreams() const;
     CDemuxStream* GetStream(int iStreamId);
     std::vector<CDemuxStream*> GetStreams() const;
     DemuxPacket* ReadDemux();
-    bool SeekTime(int time, bool backward, double* startpts);
+    bool SeekTime(uint64_t time, bool backward, double* startpts);
     void AbortDemux();
     void FlushDemux();
     void SetSpeed(int iSpeed);

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1383,7 +1383,7 @@ int64_t CPVRClient::SeekStream(int64_t iFilePosition, int iWhence/* = SEEK_SET*/
   return -EINVAL;
 }
 
-bool CPVRClient::SeekTime(int time, bool backwards, double *startpts)
+bool CPVRClient::SeekTime(uint64_t time, bool backwards, double *startpts)
 {
   if (IsPlaying())
   {

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -515,7 +515,7 @@ namespace PVR
      * @return True if the seek operation was possible
      * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
      */
-    bool SeekTime(int time, bool backwards, double *startpts);
+    bool SeekTime(uint64_t time, bool backwards, double *startpts);
 
     /*!
      * Notify the pvr addon/demuxer that XBMC wishes to change playback speed

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
@@ -122,7 +122,7 @@ extern "C"
    * @return True if the seek operation was possible
    * @remarks Optional, and only used if addon has its own demuxer.
    */
-  bool DemuxSeekTime(int time, bool backwards, double *startpts);
+  bool DemuxSeekTime(uint64_t time, bool backwards, double *startpts);
 
   /*!
    * Notify the InputStream addon/demuxer that XBMC wishes to change playback speed
@@ -153,7 +153,7 @@ extern "C"
    * Positions inputstream to playing time given in ms
    * @remarks
    */
-  bool PosTime(int ms);
+  bool PosTime(uint64_t ms);
 
 
   /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -140,7 +140,7 @@ extern "C" {
     void (__cdecl* DemuxAbort)(void);
     void (__cdecl* DemuxFlush)(void);
     DemuxPacket* (__cdecl* DemuxRead)(void);
-    bool (__cdecl* DemuxSeekTime)(int, bool, double*);
+    bool (__cdecl* DemuxSeekTime)(uint64_t, bool, double*);
     void (__cdecl* DemuxSetSpeed)(int);
     void (__cdecl* SetVideoResolution)(int, int);
 
@@ -149,7 +149,7 @@ extern "C" {
     int (__cdecl* GetTime)(void);
 
     // IPosTime
-    bool (__cdecl* PosTime)(int);
+    bool (__cdecl* PosTime)(uint64_t);
 
     // Seekable (mandatory)
     bool (__cdecl* CanPauseStream)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -589,7 +589,7 @@ extern "C"
    * @return True if the seek operation was possible
    * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
    */
-  bool SeekTime(int time, bool backwards, double *startpts);
+  bool SeekTime(uint64_t time, bool backwards, double *startpts);
 
   /*!
    * Notify the pvr addon/demuxer that XBMC wishes to change playback speed

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -565,7 +565,7 @@ float CExternalPlayer::GetSubTitleDelay()
   return 0.0;
 }
 
-void CExternalPlayer::SeekTime(int64_t iTime)
+void CExternalPlayer::SeekTime(uint64_t iTime)
 {
 }
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -64,7 +64,7 @@ public:
   virtual void SetSubTitleDelay(float fValue = 0.0f);
   virtual float GetSubTitleDelay();
 
-  virtual void SeekTime(int64_t iTime);
+  virtual void SeekTime(uint64_t iTime);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
   virtual void SetSpeed(float iSpeed) override;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -299,7 +299,7 @@ public:
   virtual int  SeekChapter(int iChapter)                       { return -1; }
 //  virtual bool GetChapterInfo(int chapter, SChapterInfo &info) { return false; }
 
-  virtual void SeekTime(int64_t iTime = 0){};
+  virtual void SeekTime(uint64_t iTime = 0){};
   /*
    \brief seek relative to current time, returns false if not implemented by player
    \param iTime The time in milliseconds to seek. A positive value will seek forward, a negative backward.

--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -30,7 +30,7 @@ public:
   virtual void OnPlayBackResumed() {};
   virtual void OnPlayBackStopped() = 0;
   virtual void OnQueueNextItem() = 0;
-  virtual void OnPlayBackSeek(int iTime, int seekOffset) {};
+  virtual void OnPlayBackSeek(uint64_t iTime, int seekOffset) {};
   virtual void OnPlayBackSeekChapter(int iChapter) {};
   virtual void OnPlayBackSpeedChanged(int iSpeed) {};
 };

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -28,7 +28,7 @@
 #define DVD_TIME_BASE 1000000
 #define DVD_NOPTS_VALUE 0xFFF0000000000000
 
-#define DVD_TIME_TO_MSEC(x) ((int)((double)(x) * 1000 / DVD_TIME_BASE))
+#define DVD_TIME_TO_MSEC(x) ((int64_t)((double)(x) * 1000 / DVD_TIME_BASE))
 #define DVD_SEC_TO_TIME(x)  ((double)(x) * DVD_TIME_BASE)
 #define DVD_MSEC_TO_TIME(x) ((double)(x) * DVD_TIME_BASE / 1000)
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -259,7 +259,7 @@ public:
   /*
    * Seek, time in msec calculated from stream start
    */
-  virtual bool SeekTime(int time, bool backwords = false, double* startpts = NULL) = 0;
+  virtual bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL) = 0;
 
   /*
    * Seek to a specified chapter.

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
@@ -64,7 +64,7 @@ public:
   void Abort();
   void Flush();
   DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) { return false; }
+  bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL) { return false; }
   void SetSpeed(int iSpeed) {};
   int GetStreamLength() { return (int)m_header.durationMs; }
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -35,7 +35,7 @@ public:
   virtual void Abort() {};
   virtual void Flush() {};
   virtual DemuxPacket* Read() { return NULL; };
-  virtual bool SeekTime(int time, bool backwords = false, double* startpts = NULL) {return true;};
+  virtual bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL) {return true;};
   virtual void SetSpeed(int iSpeed) {};
   virtual int GetStreamLength() {return 0;};
   virtual CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -136,14 +136,14 @@ DemuxPacket* CDVDDemuxCDDA::Read()
   return pPacket;
 }
 
-bool CDVDDemuxCDDA::SeekTime(int time, bool backwords, double* startpts)
+bool CDVDDemuxCDDA::SeekTime(uint64_t time, bool backwords, double* startpts)
 {
   int bytes_per_second = m_stream->iBitRate>>3;
   // clamp seeks to bytes per full sample
   int clamp_bytes = (m_stream->iBitsPerSample>>3) * m_stream->iChannels;
 
   // time is in milliseconds
-  int64_t seekPos = m_pInput->Seek((((int64_t)time * bytes_per_second / 1000) / clamp_bytes ) * clamp_bytes, SEEK_SET) > 0;
+  int64_t seekPos = m_pInput->Seek(((time * bytes_per_second / 1000) / clamp_bytes ) * clamp_bytes, SEEK_SET) > 0;
   if (seekPos > 0)
     m_bytes = seekPos;
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -45,7 +45,7 @@ public:
   void Abort();
   void Flush();
   DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL);
   void SetSpeed(int iSpeed) {};
   int GetStreamLength() ;
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -586,7 +586,7 @@ std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
   return strName;
 }
 
-bool CDVDDemuxClient::SeekTime(int timems, bool backwards, double *startpts)
+bool CDVDDemuxClient::SeekTime(uint64_t timems, bool backwards, double *startpts)
 {
   if (m_IDemux)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -41,7 +41,7 @@ public:
   void Abort() override;
   void Flush() override;
   DemuxPacket* Read() override;
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
+  bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL) override;
   void SetSpeed(int iSpeed) override;
   int GetStreamLength() override { return 0; }
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1002,7 +1002,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
   return pPacket;
 }
 
-bool CDVDDemuxFFmpeg::SeekTime(int time, bool backwords, double *startpts)
+bool CDVDDemuxFFmpeg::SeekTime(uint64_t time, bool backwords, double *startpts)
 {
   bool hitEnd = false;
 
@@ -1042,7 +1042,7 @@ bool CDVDDemuxFFmpeg::SeekTime(int time, bool backwords, double *startpts)
     return false;
   }
 
-  int64_t seek_pts = (int64_t)time * (AV_TIME_BASE / 1000);
+  int64_t seek_pts = time * (AV_TIME_BASE / 1000);
   bool ismp3 = m_pFormatContext->iformat && (strcmp(m_pFormatContext->iformat->name, "mp3") == 0);
   if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE && !ismp3)
     seek_pts += m_pFormatContext->start_time;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -100,7 +100,7 @@ public:
 
   DemuxPacket* Read() override;
 
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
+  bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL) override;
   bool SeekByte(int64_t pos);
   int GetStreamLength() override;
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -141,7 +141,7 @@ void CDVDDemuxVobsub::Flush()
   m_Demuxer->Flush();
 }
 
-bool CDVDDemuxVobsub::SeekTime(int time, bool backwords, double* startpts)
+bool CDVDDemuxVobsub::SeekTime(uint64_t time, bool backwords, double* startpts)
 {
   double pts = DVD_MSEC_TO_TIME(time);
   m_Timestamp = m_Timestamps.begin();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -39,7 +39,7 @@ public:
   virtual void          Abort() {};
   virtual void          Flush();
   virtual DemuxPacket*  Read();
-  virtual bool          SeekTime(int time, bool backwords, double* startpts = NULL);
+  virtual bool          SeekTime(uint64_t time, bool backwords, double* startpts = NULL);
   virtual void          SetSpeed(int speed) {}
   virtual CDemuxStream* GetStream(int index) const override { return m_Streams[index]; }
   virtual std::vector<CDemuxStream*> GetStreams() const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
@@ -203,7 +203,7 @@ DemuxPacket* CDemuxMultiSource::Read()
   return packet;
 }
 
-bool CDemuxMultiSource::SeekTime(int time, bool backwords, double* startpts)
+bool CDemuxMultiSource::SeekTime(uint64_t time, bool backwords, double* startpts)
 {
   DemuxQueue demuxerQueue = DemuxQueue();
   bool ret = false;
@@ -212,12 +212,12 @@ bool CDemuxMultiSource::SeekTime(int time, bool backwords, double* startpts)
     if (iter.second->SeekTime(time, false, startpts))
     {
       demuxerQueue.push(std::make_pair(*startpts, iter.second));
-      CLog::Log(LOGDEBUG, "%s - starting demuxer from: %d", __FUNCTION__, time);
+      CLog::Log(LOGDEBUG, "%s - starting demuxer from: %lu", __FUNCTION__, time);
       ret = true;
     }
     else
     {
-      CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %d", __FUNCTION__, time);
+      CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %lu", __FUNCTION__, time);
     }
   }
   m_demuxerQueue = demuxerQueue;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
@@ -59,7 +59,7 @@ public:
   bool Open(CDVDInputStream* pInput);
   DemuxPacket* Read();
   void Reset();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  bool SeekTime(uint64_t time, bool backwords = false, double* startpts = NULL);
   virtual void SetSpeed(int iSpeed) {};
 
 private:

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -74,7 +74,7 @@ public:
   {
     public:
     virtual ~IPosTime() {};
-    virtual bool PosTime(int ms) = 0;
+    virtual bool PosTime(uint64_t ms) = 0;
   };
 
   class IChapter
@@ -125,7 +125,7 @@ public:
     virtual void EnableStream(int iStreamId, bool enable) = 0;
     virtual int GetNrOfStreams() const = 0;
     virtual void SetSpeed(int iSpeed) = 0;
-    virtual bool SeekTime(int time, bool backward = false, double* startpts = NULL) = 0;
+    virtual bool SeekTime(uint64_t time, bool backward = false, double* startpts = NULL) = 0;
     virtual void AbortDemux() = 0;
     virtual void FlushDemux() = 0;
     virtual void SetVideoResolution(int width, int height) {};

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -905,7 +905,7 @@ int CDVDInputStreamBluray::GetTime()
   return m_dispTimeBeforeRead;
 }
 
-bool CDVDInputStreamBluray::PosTime(int ms)
+bool CDVDInputStreamBluray::PosTime(uint64_t ms)
 {
   if(m_dll->bd_seek_time(m_bd, ms * 90) < 0)
     return false;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -106,7 +106,7 @@ public:
   int GetTime() override;
 
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
-  bool PosTime(int ms);
+  bool PosTime(uint64_t ms);
 
   void GetStreamInfo(int pid, char* language);
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1189,7 +1189,7 @@ int CDVDInputStreamNavigator::GetTime()
   return m_iTime;
 }
 
-bool CDVDInputStreamNavigator::PosTime(int iTimeInMsec)
+bool CDVDInputStreamNavigator::PosTime(uint64_t iTimeInMsec)
 {
   if( m_dll.dvdnav_jump_to_sector_by_time(m_dvdnav, iTimeInMsec * 90, 0) == DVDNAV_STATUS_ERR )
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -174,7 +174,7 @@ public:
   float GetVideoAspectRatio();
 
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
-  bool PosTime(int iTimeInMsec); //seek within current pg(c)
+  bool PosTime(uint64_t iTimeInMsec); //seek within current pg(c)
 
   std::string GetDVDTitleString();
   std::string GetDVDSerialString();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -554,7 +554,7 @@ void CDVDInputStreamPVRManager::SetSpeed(int Speed)
   }
 }
 
-bool CDVDInputStreamPVRManager::SeekTime(int timems, bool backwards, double *startpts)
+bool CDVDInputStreamPVRManager::SeekTime(uint64_t timems, bool backwards, double *startpts)
 {
   PVR_CLIENT client;
   if (g_PVRClients->GetPlayingClient(client))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -101,7 +101,7 @@ public:
   virtual std::vector<CDemuxStream*> GetStreams() const override;
   virtual int GetNrOfStreams() const override;
   virtual void SetSpeed(int iSpeed) override;
-  virtual bool SeekTime(int time, bool backward = false, double* startpts = NULL) override;
+  virtual bool SeekTime(uint64_t time, bool backward = false, double* startpts = NULL) override;
   virtual void AbortDemux() override;
   virtual void FlushDemux() override;
   virtual void EnableStream(int iStreamId, bool enable) override {};

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -143,7 +143,7 @@ CDVDInputStream::IPosTime* CInputStreamAddon::GetIPosTime()
   return this;
 }
 
-bool CInputStreamAddon::PosTime(int ms)
+bool CInputStreamAddon::PosTime(uint64_t ms)
 {
   if (!m_addon)
     return false;
@@ -221,7 +221,7 @@ void CInputStreamAddon::SetSpeed(int iSpeed)
   m_addon->SetSpeed(iSpeed);
 }
 
-bool CInputStreamAddon::SeekTime(int time, bool backward, double* startpts)
+bool CInputStreamAddon::SeekTime(uint64_t time, bool backward, double* startpts)
 {
   if (!m_addon)
     return false;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -70,7 +70,7 @@ public:
 
   // IPosTime
   virtual CDVDInputStream::IPosTime* GetIPosTime() override;
-  virtual bool PosTime(int ms) override;
+  virtual bool PosTime(uint64_t ms) override;
 
   //IDemux
   CDVDInputStream::IDemux* GetIDemux() override;
@@ -81,7 +81,7 @@ public:
   virtual void EnableStream(int iStreamId, bool enable) override;
   virtual int GetNrOfStreams() const override;
   virtual void SetSpeed(int iSpeed) override;
-  virtual bool SeekTime(int time, bool backward = false, double* startpts = NULL) override;
+  virtual bool SeekTime(uint64_t time, bool backward = false, double* startpts = NULL) override;
   virtual void AbortDemux() override;
   virtual void FlushDemux() override;
   virtual void SetVideoResolution(int width, int height) override;

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -216,7 +216,7 @@ private:
 class CDVDMsgPlayerSeek : public CDVDMsg
 {
 public:
-  CDVDMsgPlayerSeek(int time, bool backward, bool flush = true, bool accurate = true, bool restore = true, bool trickplay = false, bool sync = true)
+  CDVDMsgPlayerSeek(uint64_t time, bool backward, bool flush = true, bool accurate = true, bool restore = true, bool trickplay = false, bool sync = true)
     : CDVDMsg(PLAYER_SEEK)
     , m_time(time)
     , m_backward(backward)
@@ -226,7 +226,7 @@ public:
     , m_trickplay(trickplay)
     , m_sync(sync)
   {}
-  int  GetTime()              { return m_time; }
+  uint64_t  GetTime()         { return m_time; }
   bool GetBackward()          { return m_backward; }
   bool GetFlush()             { return m_flush; }
   bool GetAccurate()          { return m_accurate; }
@@ -234,7 +234,7 @@ public:
   bool GetTrickPlay()         { return m_trickplay; }
   bool GetSync()              { return m_sync; }
 private:
-  int  m_time;
+  uint64_t  m_time;
   bool m_backward;
   bool m_flush;
   bool m_accurate;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1956,7 +1956,7 @@ void CVideoPlayer::HandlePlaySpeed()
           {
             CLog::Log(LOGDEBUG,"CVideoPlayer::HandlePlaySpeed - audio stream stalled, triggering re-sync");
             FlushBuffers(false);
-            m_messenger.Put(new CDVDMsgPlayerSeek((int) GetTime(), false, true, true, true, true));
+            m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), false, true, true, true, true));
           }
         }
       }
@@ -2521,7 +2521,7 @@ void CVideoPlayer::HandleMessages()
 
         double start = DVD_NOPTS_VALUE;
 
-        int time = msg.GetRestore() ? m_Edl.RestoreCutTime(msg.GetTime()) : msg.GetTime();
+        uint64_t time = msg.GetRestore() ? m_Edl.RestoreCutTime(msg.GetTime()) : msg.GetTime();
 
         // if input stream doesn't support ISeekTime, convert back to pts
         //! @todo
@@ -2532,14 +2532,14 @@ void CVideoPlayer::HandleMessages()
         if (m_pInputStream->GetIPosTime() == nullptr)
           time -= DVD_TIME_TO_MSEC(m_State.time_offset);
 
-        CLog::Log(LOGDEBUG, "demuxer seek to: %d", time);
+        CLog::Log(LOGERROR, "demuxer seek to: %lu", time);
         if (m_pDemuxer && m_pDemuxer->SeekTime(time, msg.GetBackward(), &start))
         {
-          CLog::Log(LOGDEBUG, "demuxer seek to: %d, success", time);
+          CLog::Log(LOGDEBUG, "demuxer seek to: %lu, success", time);
           if(m_pSubtitleDemuxer)
           {
             if(!m_pSubtitleDemuxer->SeekTime(time, msg.GetBackward()))
-              CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
+              CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %lu, success", time);
           }
           // dts after successful seek
           if (start == DVD_NOPTS_VALUE)
@@ -2620,7 +2620,7 @@ void CVideoPlayer::HandleMessages()
             {
               m_dvd.iSelectedAudioStream = -1;
               CloseStream(m_CurrentAudio, false);
-              m_messenger.Put(new CDVDMsgPlayerSeek((int) GetTime(), true, true, true, true, true));
+              m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
             }
           }
           else
@@ -2629,7 +2629,7 @@ void CVideoPlayer::HandleMessages()
             OpenStream(m_CurrentAudio, st.demuxerId, st.id, st.source);
             AdaptForcedSubtitles();
             
-            m_messenger.Put(new CDVDMsgPlayerSeek((int) GetTime(), true, true, true, true, true));
+            m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
           }
         }
       }
@@ -2646,14 +2646,14 @@ void CVideoPlayer::HandleMessages()
             if (pStream->SetAngle(st.id))
             {
               m_dvd.iSelectedVideoStream = st.id;
-              m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
+              m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
             }
           }
           else
           {
             CloseStream(m_CurrentVideo, false);
             OpenStream(m_CurrentVideo, st.demuxerId, st.id, st.source);
-            m_messenger.Put(new CDVDMsgPlayerSeek((int)GetTime(), true, true, true, true, true));
+            m_messenger.Put(new CDVDMsgPlayerSeek(GetTime(), true, true, true, true, true));
           }
         }
       }
@@ -3141,10 +3141,10 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
     return;
   }
 
-  m_messenger.Put(new CDVDMsgPlayerSeek((int)seek, !bPlus, true, false, restore));
+  m_messenger.Put(new CDVDMsgPlayerSeek(seek, !bPlus, true, false, restore));
   SynchronizeDemuxer(100);
   if (seek < 0) seek = 0;
-  m_callback.OnPlayBackSeek((int)seek, (int)(seek - time));
+  m_callback.OnPlayBackSeek(seek, (int)(seek - time));
 }
 
 bool CVideoPlayer::SeekScene(bool bPlus)
@@ -3451,20 +3451,20 @@ std::string CVideoPlayer::GetRadioText(unsigned int line)
   return m_VideoPlayerRadioRDS->GetRadioText(line);
 }
 
-void CVideoPlayer::SeekTime(int64_t iTime)
+void CVideoPlayer::SeekTime(uint64_t iTime)
 {
   int seekOffset = (int)(iTime - GetTime());
   m_messenger.Put(new CDVDMsgPlayerSeek((int)iTime, true, true, true));
   SynchronizeDemuxer(100);
-  m_callback.OnPlayBackSeek((int)iTime, seekOffset);
+  m_callback.OnPlayBackSeek(iTime, seekOffset);
 }
 
 bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
 {
   int64_t abstime = GetTime() + iTime;
-  m_messenger.Put(new CDVDMsgPlayerSeek((int)abstime, (iTime < 0) ? true : false, true, false));
+  m_messenger.Put(new CDVDMsgPlayerSeek(abstime, (iTime < 0) ? true : false, true, false));
   SynchronizeDemuxer(100);
-  m_callback.OnPlayBackSeek((int)abstime, iTime);
+  m_callback.OnPlayBackSeek(abstime, iTime);
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -347,7 +347,7 @@ public:
   virtual int64_t GetChapterPos(int chapterIdx=-1);
   virtual int  SeekChapter(int iChapter);
 
-  virtual void SeekTime(int64_t iTime);
+  virtual void SeekTime(uint64_t iTime);
   virtual bool SeekTimeRelative(int64_t iTime);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -1086,7 +1086,7 @@ void PAPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   SeekTime(seek);
 }
 
-void PAPlayer::SeekTime(int64_t iTime /*=0*/)
+void PAPlayer::SeekTime(uint64_t iTime /*=0*/)
 {
   if (!CanSeek()) return;
 
@@ -1099,8 +1099,8 @@ void PAPlayer::SeekTime(int64_t iTime /*=0*/)
   if (m_playbackSpeed != 1)
     SetSpeed(1);
 
-  m_currentStream->m_seekFrame = (int)((float)m_currentStream->m_audioFormat.m_sampleRate * ((float)iTime + (float)m_currentStream->m_startOffset) / 1000.0f);
-  m_callback.OnPlayBackSeek((int)iTime, seekOffset);
+  m_currentStream->m_seekFrame = (int)((float)m_currentStream->m_audioFormat.m_sampleRate * ((double)iTime + (double)m_currentStream->m_startOffset) / 1000.0f);
+  m_callback.OnPlayBackSeek(iTime, seekOffset);
 }
 
 void PAPlayer::SeekPercentage(float fPercent /*=0*/)

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -69,7 +69,7 @@ public:
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
   virtual int64_t GetTime();
   virtual void SetTime(int64_t time);
-  virtual void SeekTime(int64_t iTime = 0);
+  virtual void SeekTime(uint64_t iTime = 0);
   virtual bool SkipNext();
   virtual void GetAudioCapabilities(std::vector<int> &audioCaps) {}
 

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -226,10 +226,10 @@ namespace XBMCAddon
       invokeCallback(new CallbackFunction<Player,int>(this,&Player::onPlayBackSpeedChanged,speed));
     }
 
-    void Player::OnPlayBackSeek(int time, int seekOffset)
+    void Player::OnPlayBackSeek(uint64_t time, int seekOffset)
     { 
       XBMC_TRACE;
-      invokeCallback(new CallbackFunction<Player,int,int>(this,&Player::onPlayBackSeek,time,seekOffset));
+      invokeCallback(new CallbackFunction<Player,long long,int>(this,&Player::onPlayBackSeek,time,seekOffset));
     }
 
     void Player::OnPlayBackSeekChapter(int chapter)
@@ -273,7 +273,7 @@ namespace XBMCAddon
       XBMC_TRACE;
     }
 
-    void Player::onPlayBackSeek(int time, int seekOffset)
+    void Player::onPlayBackSeek(long long time, int seekOffset)
     { 
       XBMC_TRACE;
     }

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -328,7 +328,7 @@ namespace XBMCAddon
       ///
       onPlayBackSeek(...);
 #else
-      virtual void onPlayBackSeek(int time, int seekOffset);
+      virtual void onPlayBackSeek(long long time, int seekOffset);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -708,7 +708,7 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL void OnPlayBackResumed();
       SWIGHIDDENVIRTUAL void OnQueueNextItem();
       SWIGHIDDENVIRTUAL void    OnPlayBackSpeedChanged(int iSpeed);
-      SWIGHIDDENVIRTUAL void    OnPlayBackSeek(int iTime, int seekOffset);
+      SWIGHIDDENVIRTUAL void    OnPlayBackSeek(uint64_t iTime, int seekOffset);
       SWIGHIDDENVIRTUAL void    OnPlayBackSeekChapter(int iChapter);
 #endif
 

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -194,7 +194,7 @@ void XBPython::OnPlayBackSpeedChanged(int iSpeed)
 }
 
 // message all registered callbacks that player is seeking
-void XBPython::OnPlayBackSeek(int iTime, int seekOffset)
+void XBPython::OnPlayBackSeek(uint64_t iTime, int seekOffset)
 {
   XBMC_TRACE;
   LOCK_AND_COPY(std::vector<PVOID>,tmp,m_vecPlayerCallbackList);

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -74,7 +74,7 @@ public:
   virtual void OnPlayBackResumed();
   virtual void OnPlayBackStopped();
   virtual void OnPlayBackSpeedChanged(int iSpeed);
-  virtual void OnPlayBackSeek(int iTime, int seekOffset);
+  virtual void OnPlayBackSeek(uint64_t iTime, int seekOffset);
   virtual void OnPlayBackSeekChapter(int iChapter);
   virtual void OnQueueNextItem();
 


### PR DESCRIPTION
There are live streams out there (in my case Zattoo) where the PTS is the time in msec since 1970.  Therefore the "current time in msec" of the stream does not fit into a 32-bit integer.
This causes problems with seeking in case all the seeking functions use 32-bit integer instead of 64-bit.

It is probably too late to get such a change into v17 but can it be considered for v18?
If no, is there any alternative solution for such cases?
If yes, I most probably have missed impacted sections/functions. Please let me know what else would be required.
