### PR TITLE
[PVR] Fix epg tag <-> recording association

### DIFF
--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -28,6 +28,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/PVRManager.h"
+#include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -160,6 +161,7 @@ void CEpg::Cleanup(const CDateTime &Time)
         m_nowActiveStart.SetValid(false);
 
       it->second->ClearTimer();
+      it->second->ClearRecording();
       it = m_tags.erase(it);
     }
     else
@@ -306,6 +308,7 @@ void CEpg::AddEntry(const CEpgInfoTag &tag)
     newTag->SetPVRChannel(m_pvrChannel);
     newTag->SetEpg(this);
     newTag->SetTimer(g_PVRTimers->GetTimerForEpgTag(newTag));
+    newTag->SetRecording(g_PVRRecordings->GetRecordingForEpgTag(newTag));
   }
 }
 
@@ -430,6 +433,7 @@ bool CEpg::UpdateEntry(const CEpgInfoTagPtr &tag, bool bUpdateDatabase /* = fals
   infoTag->SetEpg(this);
   infoTag->SetPVRChannel(m_pvrChannel);
   infoTag->SetTimer(g_PVRTimers->GetTimerForEpgTag(infoTag));
+  infoTag->SetRecording(g_PVRRecordings->GetRecordingForEpgTag(infoTag));
 
   if (bUpdateDatabase)
     m_changedTags.insert(std::make_pair(infoTag->UniqueBroadcastID(), infoTag));
@@ -471,6 +475,7 @@ bool CEpg::UpdateEntry(const CEpgInfoTagPtr &tag, EPG_EVENT_STATE newState, bool
           m_deletedTags.insert(std::make_pair(it->second->UniqueBroadcastID(), it->second));
 
         it->second->ClearTimer();
+        it->second->ClearRecording();
         m_tags.erase(it);
       }
       else
@@ -671,6 +676,7 @@ bool CEpg::FixOverlappingEvents(bool bUpdateDb /* = false */)
         m_nowActiveStart.SetValid(false);
 
       it->second->ClearTimer();
+      it->second->ClearRecording();
       m_tags.erase(it++);
     }
     else if (previousTag->EndAsUTC() > currentTag->StartAsUTC())

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -692,9 +692,6 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   }
   else
   {
-    if (g_PVRManager.IsStarted())
-      g_PVRManager.Recordings()->UpdateEpgTags();
-
     CSingleLock lock(m_critSection);
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgUpdate);
     m_iNextEpgUpdate += g_advancedSettings.m_iEpgUpdateCheckInterval;

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -19,10 +19,19 @@
  *
  */
 
+#include <memory>
+#include <map>
+
 #include "FileItem.h"
 #include "video/VideoDatabase.h"
 
 #include "PVRRecording.h"
+
+namespace EPG
+{
+  class CEpgInfoTag;
+  typedef std::shared_ptr<EPG::CEpgInfoTag> CEpgInfoTagPtr;
+}
 
 namespace PVR
 {
@@ -78,7 +87,6 @@ namespace PVR
     int Load();
     void Clear();
     void UpdateFromClient(const CPVRRecordingPtr &tag);
-    void UpdateEpgTags(void);
 
     /**
      * @brief refresh the recordings list from the clients.
@@ -107,5 +115,12 @@ namespace PVR
     CPVRRecordingPtr GetById(int iClientId, const std::string &strRecordingId) const;
     void GetAll(CFileItemList &items, bool bDeleted = false);
     CFileItemPtr GetById(unsigned int iId) const;
+
+    /*!
+     * @brief Get the recording for the given epg tag, if any.
+     * @param epgTag The epg tag.
+     * @return The requested recording, or an empty recordingptr if none was found.
+     */
+    CPVRRecordingPtr GetRecordingForEpgTag(const EPG::CEpgInfoTagPtr &epgTag) const;
   };
 }


### PR DESCRIPTION
Fix epg tag <-> recording association (epg tags had not always the right recordings assigned).

Goto TV Guide, start a recording that will last some more minutes (at least)
=> resp. epg event gets marked with 'recording' icon
Quit Kodi, immediately restart Kodi
Goto TV Guide
=> resp. epg event does not have the 'recording' icon (although it still gets recorded)

Happens only in combination with async epg transfer (currently only supported by pvr.hts).

@Jalle19 I fixed the same problem for timer icons months ago, did forget about recordings at that time. Good to go?
