### PR TITLE
[PVR] Recordings window: Fix addional 'resume'/'play' context menu po…

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -465,7 +465,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonPlay(CFileItem *item, CONTEXT_BUTTO
       (button == CONTEXT_BUTTON_RESUME_ITEM))
   {
     item->m_lStartOffset = button == CONTEXT_BUTTON_RESUME_ITEM ? STARTOFFSET_RESUME : 0;
-    bReturn = PlayFile(item, false); /* play recording */
+    bReturn = PlayFile(item, false, false); /* play recording, don't check resume */
   }
 
   return bReturn;


### PR DESCRIPTION
…pping up after selecting 'resume' or 'play' from recording's context menu

Open Recordings window
Open context menu of an item which has a bookmark ('resume from ... avail in ctx menu)
Select either 'play' or 'resume'
=> instead of instantly playing/resuming another context menu containing 'play' and 'resume' appears

Issue reported here: http://forum.kodi.tv/showthread.php?tid=287844

@Jalle19 good to go?
