### PR TITLE
EGLNativeTypeAmlogic: Enable GUI scaling when framebuffer size is less than output res

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -133,6 +133,8 @@ bool CEGLNativeTypeAmlogic::GetNativeResolution(RESOLUTION_INFO *res) const
 
 bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
 {
+  bool result = false;
+
 #if defined(_FBDEV_WINDOW_H_)
   if (m_nativeWindow)
   {
@@ -144,10 +146,12 @@ bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
   // Don't set the same mode as current
   std::string mode;
   SysfsUtils::GetString("/sys/class/display/mode", mode);
-  if (res.strId == mode)
-    return false;
+  if (res.strId != mode)
+    result = SetDisplayResolution(res.strId.c_str());
 
-  return SetDisplayResolution(res.strId.c_str());
+  DealWithScale(res);
+
+  return result;
 }
 
 bool CEGLNativeTypeAmlogic::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
@@ -218,6 +222,29 @@ void CEGLNativeTypeAmlogic::SetupVideoScaling(const char *mode)
   }
 
   SysfsUtils::SetInt("/sys/class/graphics/fb0/blank", 0);
+}
+
+void CEGLNativeTypeAmlogic::DealWithScale(const RESOLUTION_INFO &res)
+{
+  if (res.iScreenWidth > res.iWidth && res.iScreenHeight > res.iHeight)
+    EnableFreeScale(res);
+  else
+    DisableFreeScale();
+}
+
+void CEGLNativeTypeAmlogic::EnableFreeScale(const RESOLUTION_INFO &res)
+{
+  char fsaxis_str[256] = {0};
+  sprintf(fsaxis_str, "0 0 %d %d", res.iWidth-1, res.iHeight-1);
+  char waxis_str[256] = {0};
+  sprintf(waxis_str, "0 0 %d %d", res.iScreenWidth-1, res.iScreenHeight-1);
+
+  SysfsUtils::SetInt("/sys/class/graphics/fb0/free_scale", 0);
+  SysfsUtils::SetString("/sys/class/graphics/fb0/free_scale_axis", fsaxis_str);
+  SysfsUtils::SetString("/sys/class/graphics/fb0/window_axis", waxis_str);
+  SysfsUtils::SetInt("/sys/class/graphics/fb0/scale_width", res.iWidth);
+  SysfsUtils::SetInt("/sys/class/graphics/fb0/scale_height", res.iHeight);
+  SysfsUtils::SetInt("/sys/class/graphics/fb0/free_scale", 0x10001);
 }
 
 void CEGLNativeTypeAmlogic::DisableFreeScale()

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
@@ -53,6 +53,8 @@ public:
 protected:
   bool SetDisplayResolution(const char *resolution);
   void SetupVideoScaling(const char *mode);
+  void DealWithScale(const RESOLUTION_INFO &res);
+  void EnableFreeScale(const RESOLUTION_INFO &res);
   void DisableFreeScale();
 
 private:


### PR DESCRIPTION
For 4K output Kodi renders GUI at 1080p and this results in GUI covering only 1/4 screen.

Example: https://forum.libreelec.tv/thread-1355-post-9983.html#pid9983

This patch enables hardware upscaling if output resolution is greater than rendered GUI resolution.

Another solution would be to render GUI at full resolution but there are 2 disadvantages:
- more reserved memory is needed for framebuffer
- rendering performance is not satisfactory at 4K
