### PR TITLE
Run testsuite with Valgrind when it is installed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -605,7 +605,7 @@ clean-externals: clean-codecs clean-eventclients clean-libs \
 
 ifeq (1,@GTEST_CONFIGURED@)
 check: testsuite
-	for check_program in $(CHECK_PROGRAMS); do $(CURDIR)/$$check_program; done
+	for check_program in $(CHECK_PROGRAMS); do (which valgrind && valgrind --trace-children=yes $(CURDIR)/$$check_program) || $(CURDIR)/$$check_program; done
 
 testsuite: $(CHECK_EXTENSIONS) $(CHECK_PROGRAMS)
 


### PR DESCRIPTION
Running the test with Valgrind helps spotting a range of bugs such as the following present in latest master:
...
[ RUN      ] TestThreadLocal.Stack
[       OK ] TestThreadLocal.Stack (3 ms)
[ RUN      ] TestThreadLocal.Heap
==30708== Thread 3 DumbThread:
==30708== Invalid read of size 4
==30708==    at 0x675EAA4: pthread_mutex_lock (pthread_mutex_lock.c:67)
==30708==    by 0x21C9BDE: lock (CriticalSection.h:49)
==30708==    by 0x21C9BDE: lock (Lockables.h:60)
==30708==    by 0x21C9BDE: UniqueLock (Lockables.h:127)
==30708==    by 0x21C9BDE: CSingleLock (SingleLock.h:38)
==30708==    by 0x21C9BDE: CEvent::Set() (Event.cpp:75)
==30708==    by 0x21CBF48: CThread::staticThread(void_) (Thread.cpp:137)
==30708==    by 0x675C463: start_thread (pthread_create.c:333)
==30708==    by 0xE7B030C: clone (clone.S:109)
==30708==  Address 0x2280d308 is 232 bytes inside a block of size 672 free'd
==30708==    at 0x4C2D2FB: operator delete(void_) (vg_replace_malloc.c:576)
==30708==    by 0x21AD58D: ~thread (TestHelpers.h:83)
==30708==    by 0x21AD58D: TestThreadLocal_Stack_Test::TestBody() (TestThreadLocal.cpp:113)
==30708==    by 0x2011EB3: HandleSehExceptionsInMethodIfSupported<testing::Test, void> (gtest.cc:2078)
==30708==    by 0x2011EB3: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test_, void (testing::Test::_)(), char const_) (gtest.cc:2114)
==30708==    by 0x200ABE9: testing::Test::Run() (gtest.cc:2151)
==30708==    by 0x200AD37: testing::TestInfo::Run() (gtest.cc:2326)
==30708==    by 0x200AE14: testing::TestCase::Run() (gtest.cc:2444)
==30708==    by 0x200B0C6: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4315)
==30708==    by 0x2012303: HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (gtest.cc:2078)
==30708==    by 0x2012303: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl_, bool (testing::internal::UnitTe
stImpl::_)(), char const_) (gtest.cc:2114)
==30708==    by 0x200B3CF: testing::UnitTest::Run() (gtest.cc:3926)
==30708==    by 0x938519: RUN_ALL_TESTS (gtest.h:2288)
==30708==    by 0x938519: main (xbmc-test.cpp:42)
==30708==  Block was alloc'd at
==30708==    at 0x4C2C23F: operator new(unsigned long) (vg_replace_malloc.c:334)
==30708==    by 0x21ACDFB: thread (TestHelpers.h:75)
==30708==    by 0x21ACDFB: TestThreadLocal_Stack_Test::TestBody() (TestThreadLocal.cpp:113)
==30708==    by 0x2011EB3: HandleSehExceptionsInMethodIfSupported<testing::Test, void> (gtest.cc:2078)
==30708==    by 0x2011EB3: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test_, void (testing::Test::_)(), char const_) (gtest.cc:2114)
==30708==    by 0x200ABE9: testing::Test::Run() (gtest.cc:2151)
==30708==    by 0x200AD37: testing::TestInfo::Run() (gtest.cc:2326)
==30708==    by 0x200AE14: testing::TestCase::Run() (gtest.cc:2444)
==30708==    by 0x200B0C6: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4315)
==30708==    by 0x2012303: HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (gtest.cc:2078)
==30708==    by 0x2012303: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl_, bool (testing::internal::UnitTe
stImpl::_)(), char const_) (gtest.cc:2114)
==30708==    by 0x200B3CF: testing::UnitTest::Run() (gtest.cc:3926)
==30708==    by 0x938519: RUN_ALL_TESTS (gtest.h:2288)
==30708==    by 0x938519: main (xbmc-test.cpp:42)
==30708== 
...
==30708== ERROR SUMMARY: 1561 errors from 22 contexts (suppressed: 0 from 0)
