### PR TITLE
[estuary] revert addition of repository widget on home screen

### DIFF
--- a/addons/skin.estuary/1080i/Home.xml
+++ b/addons/skin.estuary/1080i/Home.xml
@@ -450,24 +450,10 @@
 							<param name="sortorder" value="descending"/>
 							<param name="list_id" value="8500"/>
 							<param name="onup_id" value="8400"/>
-							<param name="ondown_id" value="8600"/>
-							<param name="single_label" value="$INFO[ListItem.Label]"/>
-							<param name="main_label" value=""/>
-							<param name="sub_label" value=""/>
-						</include>
-						<include content="WidgetListSquare">
-							<param name="content_path" value="addons://repository.xbmc.org/"/>
-							<param name="widget_header" value="Kodi $LOCALIZE[24011]"/>
-							<param name="widget_target" value="addonbrowser"/>
-							<param name="sortby" value="label"/>
-							<param name="sortorder" value="ascending"/>
-							<param name="list_id" value="8600"/>
-							<param name="onup_id" value="8500"/>
 							<param name="ondown_id" value="20001"/>
 							<param name="single_label" value="$INFO[ListItem.Label]"/>
 							<param name="main_label" value=""/>
 							<param name="sub_label" value=""/>
-							<param name="widget_limit" value="20"/>
 						</include>
 					</control>
 				</control>


### PR DESCRIPTION
Reverting because:
-there's no refresh logic implement
-causes 'random' modal popus on home screen 
-it violate the update policy setting user has set

As mentioned in #10253 this path is solely intended for internal use in the addon browser. That's why it behaves this way. A new endpoint retrieving the repository content have to be added and designed for use in directory providers; we cant just throw arbitrary urls in it.
