### PR TITLE
Revert "VideoPlayer: move supported deinterlacing methods into ProcessInfo

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -506,7 +506,7 @@ void CDVDVideoCodecFFmpeg::SetFilters()
   // ask codec to do deinterlacing if possible
   EINTERLACEMETHOD mInt = CMediaSettings::GetInstance().GetCurrentVideoSettings().m_InterlaceMethod;
 
-  if (!m_processInfo.Supports(mInt))
+  if (mInt != VS_INTERLACEMETHOD_DEINTERLACE && mInt != VS_INTERLACEMETHOD_DEINTERLACE_HALF)
     mInt = m_processInfo.GetFallbackDeintMethod();
 
   unsigned int filters = 0;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -45,6 +45,16 @@ CProcessInfo::~CProcessInfo()
 
 }
 
+EINTERLACEMETHOD CProcessInfo::GetFallbackDeintMethod()
+{
+  return VS_INTERLACEMETHOD_DEINTERLACE;
+}
+
+bool CProcessInfo::AllowDTSHDDecode()
+{
+  return true;
+}
+
 void CProcessInfo::ResetVideoCodecInfo()
 {
   CSingleLock lock(m_videoCodecSection);
@@ -170,29 +180,6 @@ float CProcessInfo::GetVideoDAR()
   return m_videoDAR;
 }
 
-EINTERLACEMETHOD CProcessInfo::GetFallbackDeintMethod()
-{
-  return VS_INTERLACEMETHOD_DEINTERLACE;
-}
-
-void CProcessInfo::UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods)
-{
-  CSingleLock lock(m_videoCodecSection);
-
-  m_deintMethods = methods;
-}
-
-bool CProcessInfo::Supports(EINTERLACEMETHOD method)
-{
-  CSingleLock lock(m_videoCodecSection);
-
-  auto it = std::find(m_deintMethods.begin(), m_deintMethods.end(), method);
-  if (it != m_deintMethods.end())
-    return true;
-
-  return false;
-}
-
 // player audio info
 void CProcessInfo::ResetAudioCodecInfo()
 {
@@ -271,11 +258,6 @@ int CProcessInfo::GetAudioBitsPerSample()
   CSingleLock lock(m_audioCodecSection);
 
   return m_audioBitsPerSample;
-}
-
-bool CProcessInfo::AllowDTSHDDecode()
-{
-  return true;
 }
 
 void CProcessInfo::SetRenderClockSync(bool enabled)

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -21,7 +21,6 @@
 
 #include "cores/IPlayer.h"
 #include "threads/CriticalSection.h"
-#include <list>
 #include <string>
 
 class CProcessInfo
@@ -29,6 +28,8 @@ class CProcessInfo
 public:
   static CProcessInfo* CreateInstance();
   virtual ~CProcessInfo();
+  virtual EINTERLACEMETHOD GetFallbackDeintMethod();
+  virtual bool AllowDTSHDDecode();
 
   // player video info
   void ResetVideoCodecInfo();
@@ -45,9 +46,6 @@ public:
   float GetVideoFps();
   void SetVideoDAR(float dar);
   float GetVideoDAR();
-  virtual EINTERLACEMETHOD GetFallbackDeintMethod();
-  void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods);
-  bool Supports(EINTERLACEMETHOD method);
 
   // player audio info
   void ResetAudioCodecInfo();
@@ -59,7 +57,6 @@ public:
   int GetAudioSampleRate();
   void SetAudioBitsPerSample(int bitsPerSample);
   int GetAudioBitsPerSample();
-  virtual bool AllowDTSHDDecode();
 
   // render info
   void SetRenderClockSync(bool enabled);
@@ -77,7 +74,6 @@ protected:
   int m_videoHeight;
   float m_videoFPS;
   float m_videoDAR;
-  std::list<EINTERLACEMETHOD> m_deintMethods;
   CCriticalSection m_videoCodecSection;
 
   // player audio info

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5095,9 +5095,7 @@ bool CVideoPlayer::IsRenderingVideoLayer()
 
 bool CVideoPlayer::Supports(EINTERLACEMETHOD method)
 {
-  if (!m_processInfo)
-    return false;
-  return m_processInfo->Supports(method);
+  return m_renderManager.Supports(method);
 }
 
 bool CVideoPlayer::Supports(ESCALINGMETHOD method)
@@ -5145,11 +5143,6 @@ void CVideoPlayer::GetDebugInfo(std::string &audio, std::string &video, std::str
 void CVideoPlayer::UpdateClockSync(bool enabled)
 {
   m_processInfo->SetRenderClockSync(enabled);
-}
-
-void CVideoPlayer::UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods)
-{
-  m_processInfo->UpdateDeinterlacingMethods(methods);
 }
 
 // IDispResource interface

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -405,7 +405,6 @@ protected:
   virtual void VideoParamsChange() override;
   virtual void GetDebugInfo(std::string &audio, std::string &video, std::string &general) override;
   virtual void UpdateClockSync(bool enabled) override;
-  virtual void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods) override;
 
   void CreatePlayers();
   void DestroyPlayers();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -319,14 +319,6 @@ bool CRenderManager::Configure()
     m_renderState = STATE_CONFIGURED;
 
     CLog::Log(LOGDEBUG, "CRenderManager::Configure - %d", m_QueueSize);
-
-    std::list<EINTERLACEMETHOD> deintmethods;
-    for (int deint = EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE; deint != EINTERLACEMETHOD::VS_INTERLACEMETHOD_MAX; deint++)
-    {
-      if (m_pRenderer->Supports((EINTERLACEMETHOD)deint))
-        deintmethods.push_back((EINTERLACEMETHOD)deint);
-    }
-    m_playerPort->UpdateDeinterlacingMethods(deintmethods);
   }
   else
     m_renderState = STATE_UNCONFIGURED;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -58,7 +58,6 @@ protected:
   virtual void VideoParamsChange() = 0;
   virtual void GetDebugInfo(std::string &audio, std::string &video, std::string &general) = 0;
   virtual void UpdateClockSync(bool enabled) = 0;
-  virtual void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods) = 0;
 };
 
 class CRenderManager


### PR DESCRIPTION
This reverts commit 4a22da3fe41baab0c075b5626a73f89b63cf1398.

Sorry - I don't have the time currently to debug this issue properly. Whenever the first loop checks for deint methods, VAAPI Picture is not yet available, therefore the Supports method is not delegated to the proper class. We end up later with the Auto method only.
