### PR TITLE
[skin.estuary] Fix broken addon message

### DIFF
--- a/addons/skin.estuary/1080i/DialogAddonInfo.xml
+++ b/addons/skin.estuary/1080i/DialogAddonInfo.xml
@@ -217,16 +217,16 @@
 				<include>OpenClose_Fade</include>
 				<control type="image">
 					<left>24</left>
-					<top>186</top>
-					<width>511</width>
-					<height>511</height>
+					<top>24</top>
+					<width>457</width>
+					<height>457</height>
 					<texture colordiffuse="AAFFFFFF">colors/black.png</texture>
 				</control>
 				<control type="textbox">
 					<left>24</left>
-					<top>186</top>
-					<width>511</width>
-					<height>511</height>
+					<top>24</top>
+					<width>457</width>
+					<height>457</height>
 					<align>center</align>
 					<aligny>center</aligny>
 					<label>$LOCALIZE[24096]</label>


### PR DESCRIPTION
Aligns the background texture and message with the addon icon.

![screenshot094](https://cloud.githubusercontent.com/assets/133808/17979401/42ffc724-6af2-11e6-88b4-eea81591d15f.png)

@BigNoid @ronie @MartijnKaijser
