### PR TITLE
ActiveAE: Increase timeout for sink init to 60 seconds

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2567,7 +2567,7 @@ bool CActiveAE::Initialize()
   Message *reply;
   if (m_controlPort.SendOutMessageSync(CActiveAEControlProtocol::INIT,
                                                  &reply,
-                                                 10000))
+                                                 60000))
   {
     bool success = reply->signal == CActiveAEControlProtocol::ACC;
     reply->Release();


### PR DESCRIPTION
That's our usual commit that was done prior to v16 and prior to v15 iirc. Neither @FernetMenta nor me have time to implement a proper method (whatever that might be) for those 5 windows users with 30 virtual audio devices affected.
