### PR TITLE
Miscellaneous keymap cleanup

### DIFF
--- a/system/keymaps/customcontroller.AppleRemote.xml
+++ b/system/keymaps/customcontroller.AppleRemote.xml
@@ -1,33 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- This file contains the mapping of keys (gamepad,remote and keyboard) to actions within XBMC -->
-<!-- The <global> section is a fall through - they will only be used if the button is not        -->
-<!-- used in the current window's section.  Note that there is only handling                     -->
-<!-- for a single action per button at this stage.                                               -->
-<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox     -->
-<!-- gamepads.                                                                                   -->
-
-<!-- The format is:                                                                              -->
-<!--    <device>                                                                                 -->
-<!--      <button id=""#>xbmc action</button>                                                    -->
-<!--    </device>                                                                                -->
-
-<!-- To map keys from other remotes using the RCA protocol, you may add <customcontroller name="AppleRemote"> blocks -->
-<!-- In this case, the tags used are <button id=""#> where # is the original button code (OBC) of the key -->
-<!-- You set it up by adding a <customcontroller name="AppleRemote"> block to the window or <global> section:        -->
-<!--    <customcontroller name="AppleRemote">                                                                        -->
-<!--       <button id="45">Stop</button>                                                          -->
-<!--    </customcontroller>                                                                       -->
-
-<!-- Note that the action can be a built-in function.                                            -->
-<!--            eg <button id="6">ActivateWindow(Favourites)</button>                            -->
-<!-- would bring up Favourites when the button with the id of 6 is press. In this case, "Menu"   -->
-
-<!--                                                                                             -->
-<!--  Button Ids:                                                                                -->
-<!--  'id' is the button ID used by SDL. The key ids recognized from your remote appears      -->
-<!--  in /var/log/syslog on the ATV2 for each button pressed and when debug mode is enabled      -->
-<!--  Use your log to discover and map custom buttons to actions.                                -->
-
+<!-- This file contains the mapping of keys to actions within Kodi.                       -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <button>action</button>                                                         -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <button id="6">ActivateWindow(Music)</button>                                    -->
+<!-- would automatically go to Music on the press of the "Menu" button.                   -->
+<!--                                                                                      -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
+<!--                                                                                      -->
+<!-- To map keys from other remotes using the RCA protocol, you may add                   -->
+<!--   <customcontroller name="AppleRemote"> blocks.                                      -->
+<!-- In this case, the tags used are <button id=""#> where # is the original button code  -->
+<!-- (OBC) of the key.                                                                    -->
+<!-- You set it up by adding a <customcontroller name="AppleRemote"> block to the window  -->
+<!-- or <global> section:                                                                 -->
+<!--    <customcontroller name="AppleRemote">                                             -->
+<!--       <button id="45">Stop</button>                                                  -->
+<!--    </customcontroller>                                                               -->
+<!--                                                                                      -->
+<!--  Button Ids:                                                                         -->
+<!--  'id' is the button ID used by SDL. The key ids recognized from your remote appears  -->
+<!--  in the log file for each button pressed and when debug mode is enabled.             -->
+<!--  Use your log to discover and map custom buttons to actions.                         -->
 <keymap>
   <global>
     <customcontroller name="AppleRemote">

--- a/system/keymaps/customcontroller.Harmony.xml
+++ b/system/keymaps/customcontroller.Harmony.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- This file contains the mapping of keys (gamepad, remote, and keyboard) to actions within XBMC -->
-<!-- The <global> section is a fall through - they will only be used if the button is not          -->
-<!-- used in the current window's section.  Note that there is only handling                       -->
-<!-- for a single action per button at this stage.                                                 -->
-<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox       -->
-<!-- gamepads.                                                                                     -->
-
-<!-- The format is:                      -->
-<!--    <device>                         -->
-<!--      <button>action</key>        -->
-<!--    </device>                        -->
-
-<!-- To map keys from other remotes using the RCA protocol, you may add <customcontroller name="Harmony"> blocks -->
-<!-- In this case, the tags used are <button id=""#> where # is the original button code (OBC) of the key -->
-<!-- You set it up by adding a <customcontroller name="Harmony"> block to the window or <global> section:       -->
-<!--    <customcontroller name="Harmony">             -->
-<!--       <button id="45">Stop</button>            -->
-<!--    </customcontroller>            -->
-
-<!-- Note that the action can be a built-in function.                 -->
-<!--  eg <B>ActivateWindow(Music)</B>                         -->
-<!-- would automatically go to My Music on the press of the B button. -->
-
-<!-- Joysticks / Gamepads:                                                                    -->
-<!--   See the sample PS3 controller configuration below for the format.                      -->
-<!--                                                                                          -->
-<!--  Joystick Name:                                                                          -->
-<!--   Do 'cat /proc/bus/input/devices' or see your xbmc log file  to find the names of       -->
-<!--   detected joysticks. The name used in the configuration should match the detected name. -->
-<!--                                                                                          -->
-<!--  Button Ids:                                                                             -->
-<!--   'id' is the button ID used by SDL. Joystick key ids of connected joysticks appear   -->
-<!--   in xbmc.log when they are pressed. Use your log to map custom buttons to actions.      -->
-<!--                                                                                          -->
-<!--  Axis Ids / Analog Controls                                                              -->
-<!--   Coming soon.                                                                           -->
+<!-- This file contains the mapping of keys to actions within Kodi.                       -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <button>action</button>                                                         -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <button id="6">ActivateWindow(Music)</button>                                    -->
+<!-- would automatically go to Music on the press of the "Menu" button.                   -->
+<!--                                                                                      -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
+<!--                                                                                      -->
+<!-- To map keys from other remotes using the RCA protocol, you may add                   -->
+<!--   <customcontroller name="Harmony"> blocks.                                          -->
+<!-- In this case, the tags used are <button id=""#> where # is the original button code  -->
+<!-- (OBC) of the key.                                                                    -->
+<!-- You set it up by adding a <customcontroller name="Harmony"> block to the window      -->
+<!-- or <global> section:                                                                 -->
+<!--    <customcontroller name="Harmony">                                                 -->
+<!--       <button id="45">Stop</button>                                                  -->
+<!--    </customcontroller>                                                               -->
+<!--                                                                                      -->
+<!--  Button Ids:                                                                         -->
+<!--  'id' is the button ID used by SDL. The key ids recognized from your remote appears  -->
+<!--  in the log file for each button pressed and when debug mode is enabled.             -->
+<!--  Use your log to discover and map custom buttons to actions.                         -->
 <keymap>
   <global>
     <customcontroller name="Harmony">
@@ -126,13 +126,13 @@
       <!-- * clear 	-->      <button id="145">Delete</button>
     </customcontroller>
   </FileManager>
-  <MyMusicPlaylist>
+  <MusicPlaylist>
     <customcontroller name="Harmony">
       <!-- * clear 	-->      <button id="145">Delete</button>
       <!-- Channel Up  	-->      <button id="171">MoveItemUp</button>
       <!-- Channel Down -->      <button id="172">MoveItemDown</button>
     </customcontroller>
-  </MyMusicPlaylist>
+  </MusicPlaylist>
   <Music>
     <customcontroller name="Harmony">
       <!-- 1 		-->      <button id="111">number1</button>
@@ -289,13 +289,13 @@
       <!-- 9 		-->      <button id="143">JumpSMS9</button>
     </customcontroller>
   </Videos>
-  <MyVideoPlaylist>
+  <VideoPlaylist>
     <customcontroller name="Harmony">
       <!-- * clear 	-->      <button id="145">Delete</button>
       <!-- Channel Up  	-->      <button id="171">MoveItemUp</button>
       <!-- Channel Down -->      <button id="172">MoveItemDown</button>
     </customcontroller>
-  </MyVideoPlaylist>
+  </VideoPlaylist>
   <VirtualKeyboard>
     <customcontroller name="Harmony">
       <!-- Prev		-->      <button id="132">BackSpace</button>

--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -1,41 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- This file contains the mapping of keys (gamepad, remote, and keyboard) to actions within XBMC -->
-<!-- The <global> section is a fall through - they will only be used if the button is not          -->
-<!-- used in the current window's section.  Note that there is only handling                       -->
-<!-- for a single action per button at this stage.                                                 -->
-<!-- For joystick/gamepad configuration under linux/win32, see below as it differs from xbox       -->
-<!-- gamepads.                                                                                     -->
-
-<!-- The format is:                      -->
-<!--    <device>                         -->
-<!--      <button>action</button>        -->
-<!--    </device>                        -->
-
-<!-- To map keys from other remotes using the RCA protocol, you may add <universalremote> blocks -->
-<!-- In this case, the tags used are <obc#> where # is the original button code (OBC) of the key -->
-<!-- You set it up by adding a <universalremote> block to the window or <global> section:       -->
-<!--    <universalremote>             -->
-<!--       <obc45>Stop</obc45>         -->
-<!--    </universalremote>            -->
-
-<!-- Note that the action can be a built-in function.                                         -->
-<!--  eg <B>ActivateWindow(Music)</B>                                                       -->
-<!-- would automatically go to My Music on the press of the B button.                         -->
-<!-- An empty action removes the corresponding mapping from the default keymap                -->
-
-<!-- Joysticks / Gamepads:                                                                    -->
-<!--   See the sample PS3 controller configuration below for the format.                      -->
-<!--                                                                                          -->
-<!--  Joystick Name:                                                                          -->
-<!--   Do 'cat /proc/bus/input/devices' or see your xbmc log file  to find the names of       -->
-<!--   detected joysticks. The name used in the configuration should match the detected name. -->
-<!--                                                                                          -->
-<!--  Button Ids:                                                                             -->
-<!--   'id' is the button ID used by SDL. Joystick button ids of connected joysticks appear   -->
-<!--   in xbmc.log when they are pressed. Use your log to map custom buttons to actions.      -->
-<!--                                                                                          -->
-<!--  Axis Ids / Analog Controls                                                              -->
-<!--   Coming soon.                                                                           -->
+<!-- This file contains the mapping of keys to actions within Kodi.                       -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <button>action</button>                                                         -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <B>ActivateWindow(Music)</B>                                                     -->
+<!-- would automatically go to Music on the press of the B button.                        -->
+<!--                                                                                      -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
 <keymap>
   <global>
     <gamepad>
@@ -66,17 +50,17 @@
       <Y>Highlight</Y>
     </gamepad>
   </FileManager>
-  <MyMusicPlaylist>
+  <MusicPlaylist>
     <gamepad>
       <Y>Delete</Y>
       <black>Back</black>
     </gamepad>
-  </MyMusicPlaylist>
-  <MyMusicPlaylistEditor>
+  </MusicPlaylist>
+  <MusicPlaylistEditor>
     <gamepad>
       <Y>Queue</Y>
     </gamepad>
-  </MyMusicPlaylistEditor>
+  </MusicPlaylistEditor>
   <Music>
     <gamepad>
       <Y>Queue</Y>
@@ -260,12 +244,12 @@
       <black>Delete</black>
     </gamepad>
   </Videos>
-  <MyVideoPlaylist>
+  <VideoPlaylist>
     <gamepad>
       <Y>Delete</Y>
       <black>Back</black>
     </gamepad>
-  </MyVideoPlaylist>
+  </VideoPlaylist>
   <VirtualKeyboard>
     <gamepad>
       <start>Enter</start>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- This file contains the mapping of keys to actions within Kodi.                       -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <button>action</button>                                                         -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <B>ActivateWindow(Music)</B>                                                     -->
+<!-- would automatically go to Music on the press of the B button.                        -->
+<!--                                                                                      -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
 <keymap>
   <global>
     <joystick>
@@ -7,7 +28,7 @@
       <x>ContextMenu</x>
       <y>FullScreen</y>
       <start>ActivateWindow(PlayerControls)</start>
-      <back>Back</back>
+      <back>PreviousMenu</back>
       <guide>ActivateWindow(Home)</guide>
       <up>Up</up>
       <down>Down</down>
@@ -34,11 +55,11 @@
       <rightbumper>Highlight</rightbumper>
     </joystick>
   </FileManager>
-  <MyMusicPlaylist>
+  <MusicPlaylist>
     <joystick>
       <leftbumper>Delete</leftbumper>
     </joystick>
-  </MyMusicPlaylist>
+  </MusicPlaylist>
   <Music>
   </Music>
   <FullscreenVideo>
@@ -200,11 +221,11 @@
   </VideoBookmarks>
   <Videos>
   </Videos>
-  <MyVideoPlaylist>
+  <VideoPlaylist>
     <joystick>
       <leftbumper>Delete</leftbumper>
     </joystick>
-  </MyVideoPlaylist>
+  </VideoPlaylist>
   <VirtualKeyboard>
     <joystick>
       <b>BackSpace</b>
@@ -220,11 +241,6 @@
       <b>Close</b>
     </joystick>
   </ContextMenu>
-  <Programs>
-    <joystick>
-      <x>ContextMenu</x>
-    </joystick>
-  </Programs>
   <Settings>
     <joystick>
       <b>PreviousMenu</b>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -41,16 +41,19 @@
       <pagedown>PageDown</pagedown>
       <return>Select</return>
       <return mod="longpress">ContextMenu</return>
+      <return mod="ctrl">Enter</return>
       <enter>Select</enter>
       <enter mod="longpress">ContextMenu</enter>
+      <enter mod="ctrl">Enter</enter>
       <backspace>Back</backspace>
       <browser_back>Back</browser_back>
       <browser_back mod="longpress">ActivateWindow(Home)</browser_back>
       <key id='65446'>Back</key>
       <m>Menu</m>
       <n mod="ctrl">ActivateWindow(PlayerControls)</n>
-      <s>ActivateWindow(shutdownmenu)</s>
+      <s>ActivateWindow(ShutdownMenu)</s>
       <escape>PreviousMenu</escape>
+      <escape mod="longpress">Back</escape>
       <i>Info</i>
       <menu>ContextMenu</menu>
       <menu mod="longpress">Menu</menu>
@@ -91,8 +94,8 @@
       <backslash>ToggleFullScreen</backslash>
       <home>FirstPage</home>
       <end>LastPage</end>
-      <power>ActivateWindow(shutdownmenu)</power>
-      <sleep>ActivateWindow(shutdownmenu)</sleep>
+      <power>ActivateWindow(ShutdownMenu)</power>
+      <sleep>ActivateWindow(ShutdownMenu)</sleep>
       <!-- PVR windows -->
       <e>ActivateWindow(TVGuide)</e>
       <epg>ActivateWindow(TVGuide)</epg>
@@ -156,8 +159,8 @@
       <m mod="ctrl,shift">PlayerControl(ShowVideoMenu)</m>         <!-- MCE DVD menu -->
       <o mod="ctrl">ActivateWindow(TVRecordings)</o>  <!-- MCE Recorded TV -->
       <t mod="ctrl">ActivateWindow(TVChannels)</t>  <!-- MCE Live TV  -->
-      <t mod="ctrl,shift">ActivateWindow(TVChannels)</t>  <!-- MCE My TV -->
-      <a mod="ctrl">ActivateWindow(RadioChannels)</a>  <!-- MCE My Radio -->
+      <t mod="ctrl,shift">ActivateWindow(TVChannels)</t>  <!-- MCE TV -->
+      <a mod="ctrl">ActivateWindow(RadioChannels)</a>  <!-- MCE Radio -->
       <!-- MCE keypresses without an obvious use in Kodi -->
       <u mod="ctrl">Notification(MCEKeypress, DVD subtitle, 3)</u>
       <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
@@ -192,13 +195,13 @@
       <play_pause mod="longpress">Enter</play_pause>
     </keyboard>
   </VirtualKeyboard>
-  <MyTVChannels>
+  <TVChannels>
     <keyboard>
       <m mod="ctrl">Move</m>
       <h>PreviousMenu</h>
     </keyboard>
-  </MyTVChannels>
-  <MyTVRecordings>
+  </TVChannels>
+  <TVRecordings>
     <keyboard>
       <delete>Delete</delete>
       <r>Rename</r>
@@ -208,8 +211,8 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </keyboard>
-  </MyTVRecordings>
-  <MyTVTimers>
+  </TVRecordings>
+  <TVTimers>
     <keyboard>
       <delete>Delete</delete>
       <r>Rename</r>
@@ -219,21 +222,34 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </keyboard>
-  </MyTVTimers>
+  </TVTimers>
+  <TVTimerRules>
+    <keyboard>
+      <delete>Delete</delete>
+      <r>Rename</r>
+      <b>PreviousMenu</b>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
+    </keyboard>
+  </TVTimerRules>
   <TVGuide>
     <keyboard>
       <e>PreviousMenu</e>
       <t>ShowTimerRule</t>
       <epg>PreviousMenu</epg>
+      <backspace mod="longpress">Number0</backspace> <!-- 0 key goes to "now" on EPG timeline -->
+      <browser_back mod="longpress">Number0</browser_back> <!-- 0 key goes to "now" on EPG timeline -->
     </keyboard>
   </TVGuide>
-  <MyRadioChannels>
+  <RadioChannels>
     <keyboard>
       <m mod="ctrl">Move</m>
       <j>PreviousMenu</j>
     </keyboard>
-  </MyRadioChannels>
-  <MyRadioRecordings>
+  </RadioChannels>
+  <RadioRecordings>
     <keyboard>
       <delete>Delete</delete>
       <r>Rename</r>
@@ -242,8 +258,8 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </keyboard>
-  </MyRadioRecordings>
-  <MyRadioTimers>
+  </RadioRecordings>
+  <RadioTimers>
     <keyboard>
       <delete>Delete</delete>
       <r>Rename</r>
@@ -252,11 +268,23 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </keyboard>
-  </MyRadioTimers>
+  </RadioTimers>
+  <RadioTimerRules>
+    <keyboard>
+      <delete>Delete</delete>
+      <r>Rename</r>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
+    </keyboard>
+  </RadioTimerRules>
   <RadioGuide>
     <keyboard>
       <e>PreviousMenu</e>
       <t>ShowTimerRule</t>
+      <backspace mod="longpress">Number0</backspace> <!-- 0 key goes to "now" on EPG timeline -->
+      <browser_back mod="longpress">Number0</browser_back> <!-- 0 key goes to "now" on EPG timeline -->
     </keyboard>
   </RadioGuide>
   <FileManager>
@@ -269,7 +297,7 @@
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </FileManager>
-  <MyMusicPlaylist>
+  <MusicPlaylist>
     <keyboard>
       <n>Back</n>
       <delete>Delete</delete>
@@ -277,15 +305,15 @@
       <d>MoveItemDown</d>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyMusicPlaylist>
-  <MyMusicPlaylistEditor>
+  </MusicPlaylist>
+  <MusicPlaylistEditor>
     <keyboard>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
       <delete>Delete</delete>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyMusicPlaylistEditor>
+  </MusicPlaylistEditor>
   <Music>
     <keyboard>
       <n>Playlist</n>
@@ -314,6 +342,7 @@
       <menu>OSD</menu>
       <i>Info</i>
       <o>PlayerProcessInfo</o>
+      <o mod="ctrl,shift">PlayerDebug</o>
       <z>AspectRatio</z>
       <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
@@ -325,7 +354,10 @@
       <down>ChapterOrBigStepBack</down>
       <up mod="longpress">AudioNextLanguage</up>
       <down mod="longpress">NextSubtitle</down>
+      <left mod="ctrl">PlayerControl(tempodown)</left>
+      <right mod="ctrl">PlayerControl(tempoup)</right>
       <a>AudioDelay</a>
+      <a mod="ctrl">AudioNextLanguage</a>
       <escape>Fullscreen</escape>
       <c>Playlist</c>
       <v>ActivateWindow(Teletext)</v>
@@ -334,6 +366,11 @@
       <down mod="ctrl">SubtitleShiftDown</down>
       <pageup>SkipNext</pageup>
       <pagedown>SkipPrevious</pagedown>
+      <plus mod="ctrl">VolAmpUp</plus>
+      <equals mod="ctrl">VolAmpUp</equals>
+      <minus mod="ctrl">VolAmpDown</minus>
+      <b mod="ctrl">CreateBookmark</b>
+      <b mod="alt">CreateEpisodeBookmark</b>
     </keyboard>
   </FullscreenVideo>
   <VideoTimeSeek>
@@ -519,7 +556,7 @@
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </Videos>
-  <MyVideoPlaylist>
+  <VideoPlaylist>
     <keyboard>
       <n>Back</n>
       <delete>Delete</delete>
@@ -527,13 +564,13 @@
       <d>MoveItemDown</d>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyVideoPlaylist>
-  <MyPictures>
+  </VideoPlaylist>
+  <Pictures>
     <keyboard>
       <delete>Delete</delete>
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
-  </MyPictures>
+  </Pictures>
   <ContextMenu>
     <keyboard>
       <c>Back</c>

--- a/system/keymaps/mouse.xml
+++ b/system/keymaps/mouse.xml
@@ -1,11 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!--  Button Ids:                                                                             -->
-<!--    0: left                                                                               -->
-<!--    1: right                                                                              -->
-<!--    2: middle                                                                             -->
-<!--    3/4/5/6: extra                                                                        -->
-
+<!-- This file contains the mapping of mouse keys to actions within Kodi.                 -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <button>action</button>                                                         -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <middleclick>ActivateWindow(Music)</middleclick>                                 -->
+<!-- would automatically go to Music on the press of the middle mouse button.             -->
+<!--                                                                                      -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!--  Button Ids:                                                                         -->
+<!--    0: left                                                                           -->
+<!--    1: right                                                                          -->
+<!--    2: middle                                                                         -->
+<!--    3/4/5/6: extra                                                                    -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
 <keymap>
   <global>
     <mouse>
@@ -14,7 +34,6 @@
       <middleclick>middleclick</middleclick>
       <doubleclick id="0">doubleclick</doubleclick>
       <longclick id="0">contextmenu</longclick>
-
       <wheeldown>wheeldown</wheeldown>
       <wheelup>wheelup</wheelup>
       <mousedrag>mousedrag</mousedrag>
@@ -34,6 +53,4 @@
       <rightclick>Info</rightclick>
     </mouse>
   </FullscreenVideo>
-
-
 </keymap>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -15,10 +15,6 @@
 <!--  eg <B>ActivateWindow(Music)</B>                                                     -->
 <!-- would automatically go to Music on the press of the B button.                        -->
 <!--                                                                                      -->
-<!--  Long presses                                                                        -->
-<!--   A limitation is that if a single press is mapped in a section, a global "longpress"-->
-<!--   will be ignored. The workaround is to duplicate the long mapping in the section.   -->
-<!--                                                                                      -->
 <!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
 <!-- This is different from a "noop" action, which disables a button.                     -->
 <!--                                                                                      -->
@@ -88,7 +84,7 @@
       <hash>ActivateWindow(Settings)</hash>
     </remote>
   </Home>
-  <MyTVRecordings>
+  <TVRecordings>
     <remote>
       <clear>Delete</clear>
       <red>Red</red>
@@ -96,8 +92,8 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </remote>
-  </MyTVRecordings>
-  <MyTVTimers>
+  </TVRecordings>
+  <TVTimers>
     <remote>
       <clear>Delete</clear>
       <red>Red</red>
@@ -105,8 +101,8 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </remote>
-  </MyTVTimers>
-  <MyRadioRecordings>
+  </TVTimers>
+  <TVTimerRules>
     <remote>
       <clear>Delete</clear>
       <red>Red</red>
@@ -114,8 +110,8 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </remote>
-  </MyRadioRecordings>
-  <MyRadioTimers>
+  </TVTimerRules>
+  <RadioRecordings>
     <remote>
       <clear>Delete</clear>
       <red>Red</red>
@@ -123,7 +119,25 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
     </remote>
-  </MyRadioTimers>
+  </RadioRecordings>
+  <RadioTimers>
+    <remote>
+      <clear>Delete</clear>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
+    </remote>
+  </RadioTimers>
+  <RadioTimerRules>
+    <remote>
+      <clear>Delete</clear>
+      <red>Red</red>
+      <green>Green</green>
+      <yellow>Yellow</yellow>
+      <blue>Blue</blue>
+    </remote>
+  </RadioTimerRules>
   <FileManager>
     <remote>
       <clear>Delete</clear>
@@ -132,28 +146,28 @@
       <hash>Rename</hash>
     </remote>
   </FileManager>
-  <MyMusicPlaylist>
+  <MusicPlaylist>
     <remote>
       <clear>Delete</clear>
       <zero>Delete</zero>
     </remote>
-  </MyMusicPlaylist>
-  <MyMusicPlaylistEditor>
+  </MusicPlaylist>
+  <MusicPlaylistEditor>
     <remote>
       <zero>Queue</zero>
     </remote>
-  </MyMusicPlaylistEditor>
+  </MusicPlaylistEditor>
   <Music>
     <remote>
       <zero>Queue</zero>
       <star>Queue</star>
     </remote>
   </Music>
-  <MyPictures>
+  <Pictures>
     <remote>
       <clear>Delete</clear>
     </remote>
-  </MyPictures>
+  </Pictures>
   <FullscreenVideo>
     <remote>
       <zero>Number0</zero>
@@ -341,12 +355,12 @@
       <clear>Delete</clear>
     </remote>
   </Videos>
-  <MyVideoPlaylist>
+  <VideoPlaylist>
     <remote>
       <clear>Delete</clear>
       <zero>Delete</zero>
     </remote>
-  </MyVideoPlaylist>
+  </VideoPlaylist>
   <VirtualKeyboard>
     <remote>
       <back>Back</back>

--- a/system/keymaps/touchscreen.xml
+++ b/system/keymaps/touchscreen.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- This file contains the mapping of touch gestures to actions within Kodi.             -->
+<!--                                                                                      -->
+<!-- The format is:                                                                       -->
+<!--  <window>                                                                            -->
+<!--    <device>                                                                          -->
+<!--      <gesture>action</gesture>                                                       -->
+<!--    </device>                                                                         -->
+<!--  </window>                                                                           -->
+<!--                                                                                      -->
+<!-- The <global> section is a fall through - they will only be used if the button is     -->
+<!-- not used in the current window's section.                                            -->
+<!--                                                                                      -->
+<!-- Actions can be built-in functions.                                                   -->
+<!--  eg <tap pointers="2">ActivateWindow(Music)</tap>                                    -->
+<!-- would automatically go to Music when two fingers tap the screen at once.             -->
+<!--                                                                                      -->
+<!--                                                                                      -->
+<!-- An empty action removes the corresponding mapping from default and parent keymaps.   -->
+<!-- This is different from a "noop" action, which disables a button.                     -->
+<!--                                                                                      -->
+<!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
 <keymap>
   <global>
     <touch>
@@ -28,7 +49,6 @@
       <swipe direction="right">StepForward</swipe>
       <swipe direction="up">ChapterOrBigStepForward</swipe>
       <swipe direction="down">ChapterOrBigStepBack</swipe>
-      <swipe direction="left" pointers="2">Seek(-7)</swipe>
       <swipe direction="up" pointers="2">SkipNext</swipe>
       <swipe direction="down" pointers="2">SkipPrevious</swipe>
       <tap pointers="2">Playlist</tap>


### PR DESCRIPTION
These are all the little things I've changed that didn't seem big enough for their own PR:

Updated the header area to finally remove all those lingering XBMC references (some even mentioned the xbox!)

touchscreen.xml - Removed two-finger-swipe-left = seek(-7). It will now always be "back". This was originally added when remote.xml used to do smallstepback, but JMarshall thought back should always be back, and I agree. I just forgot to change touchscreen.xml

Joystick keymap had an unneeded < programs > section that was left over from a previous fix.

Added a couple of mod-combo actions to keyboard.xml for the sake of users who can't use longpress (Flirc, etc).
