### PR TITLE
Make "Next" visible for chapters in Estuary's OSD

### DIFF
--- a/addons/skin.estuary/1080i/VideoOSD.xml
+++ b/addons/skin.estuary/1080i/VideoOSD.xml
@@ -102,7 +102,7 @@
 								<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 							</include>
 							<onclick>PlayerControl(Next)</onclick>
-							<visible>!VideoPlayer.Content(livetv) + Integer.IsGreater(Playlist.Length(video),1)</visible>
+							<visible>!VideoPlayer.Content(livetv) + [Player.ChapterCount | Integer.IsGreater(Playlist.Length(video),1)]</visible>
 						</control>
 						<control type="radiobutton" id="804">
 							<include content="OSDButton">


### PR DESCRIPTION
Thanks to Guilouz and the users on the forum for catching this.

"Previous" on the OSD for Estuary is always visible (I assume because it can be used to "restart" a video), but "Next" has a condition to only show when there is a playlist with more than one item. I think this is a simple error, and it was forgotten that next/prev buttons are also used for chapter skipping, rather than an intentional design decision.

EDIT: updated to only show up for when there are chapters or playlists
