### PR TITLE
AESinkAUDIOTrack: Support what Android officially supports - nothing else

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -264,15 +264,17 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       if (!m_info.m_wantsIECPassthrough && CJNIAudioManager::GetSDKVersion() == 22 && m_sink_sampleRate > 48000)
         m_sink_sampleRate = 48000;
     }
+
+    // EAC3 needs real samplerate not the modulation
+    if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3)
+      m_sink_sampleRate = m_format.m_streamInfo.m_sampleRate;
+
     if (m_info.m_wantsIECPassthrough)
     {
       m_format.m_dataFormat     = AE_FMT_S16LE;
       if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_DTSHD ||
           m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
         m_sink_sampleRate = 192000;
-
-      if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3)
-        m_sink_sampleRate = m_format.m_streamInfo.m_sampleRate;
 
       // we are running on an old android version
       // that does neither know AC3, DTS or whatever
@@ -748,6 +750,10 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       m_info.m_dataFormats.push_back(AE_FMT_RAW);
       if (CJNIAudioFormat::ENCODING_AC3 != -1)
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+
+      // EAC3 working on shield, broken on FireTV
+      if (CJNIAudioFormat::ENCODING_E_AC3 != -1)
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
     }
     if (CJNIAudioManager::GetSDKVersion() >= 23)
     {
@@ -794,9 +800,6 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       }
       if (CJNIAudioManager::GetSDKVersion() >= 23)
       {
-        // here only 5.1 would work but we cannot correctly distinguish
-        // if (CJNIAudioFormat::ENCODING_E_AC3 != -1)
-        //   m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
         if (CJNIAudioFormat::ENCODING_DTS_HD != -1)
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
         if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -756,26 +756,21 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   if (!CXBMCApp::IsHeadsetPlugged())
   {
     m_info.m_deviceType = AE_DEVTYPE_HDMI;
-    if (CJNIAudioManager::GetSDKVersion() >= 21)
-    {
-      m_info.m_wantsIECPassthrough = false;
-      m_info.m_dataFormats.push_back(AE_FMT_RAW);
-      if (CJNIAudioFormat::ENCODING_AC3 != -1)
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+    m_info.m_wantsIECPassthrough = false;
+    m_info.m_dataFormats.push_back(AE_FMT_RAW);
+    if (CJNIAudioFormat::ENCODING_AC3 != -1)
+      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
 
-      // EAC3 working on shield, broken on FireTV
-      if (CJNIAudioFormat::ENCODING_E_AC3 != -1)
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-    }
-    if (CJNIAudioManager::GetSDKVersion() >= 23)
+    // EAC3 working on shield, broken on FireTV
+    if (CJNIAudioFormat::ENCODING_E_AC3 != -1)
+      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+
+    if (CJNIAudioFormat::ENCODING_DTS != -1)
     {
-      if (CJNIAudioFormat::ENCODING_DTS != -1)
-      {
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
-      }
+      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
+      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
+      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
+      m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
     }
 
 #if defined(HAS_LIBAMCODEC)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -742,12 +742,23 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   if (!CXBMCApp::IsHeadsetPlugged())
   {
     m_info.m_deviceType = AE_DEVTYPE_HDMI;
-    m_info.m_dataFormats.push_back(AE_FMT_RAW);
-    m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
-    m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
-    m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
-    m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
-    m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+    if (CJNIAudioManager::GetSDKVersion() >= 21)
+    {
+      m_info.m_wantsIECPassthrough = false;
+      m_info.m_dataFormats.push_back(AE_FMT_RAW);
+      if (CJNIAudioFormat::ENCODING_AC3 != -1)
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+    }
+    if (CJNIAudioManager::GetSDKVersion() >= 23)
+    {
+      if (CJNIAudioFormat::ENCODING_DTS != -1)
+      {
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+      }
+    }
 
 #if defined(HAS_LIBAMCODEC)
     if (aml_present())
@@ -783,17 +794,13 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       }
       if (CJNIAudioManager::GetSDKVersion() >= 23)
       {
-        m_info.m_wantsIECPassthrough = false;
         // here only 5.1 would work but we cannot correctly distinguish
-        // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-      }
-      if (StringUtils::StartsWithNoCase(CJNIBuild::DEVICE, "foster")) // SATV is ahead of API
-      {
-        m_info.m_wantsIECPassthrough = false;
-        if (CJNIAudioManager::GetSDKVersion() == 22)
+        // if (CJNIAudioFormat::ENCODING_E_AC3 != -1)
+        //   m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+        if (CJNIAudioFormat::ENCODING_DTS_HD != -1)
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+        if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)
+          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
       }
     }
     std::copy(m_sink_sampleRates.begin(), m_sink_sampleRates.end(), std::back_inserter(m_info.m_sampleRates));

--- a/xbmc/platform/android/jni/AudioFormat.cpp
+++ b/xbmc/platform/android/jni/AudioFormat.cpp
@@ -31,6 +31,7 @@ int CJNIAudioFormat::ENCODING_E_AC3                    = 0x00000006;
 int CJNIAudioFormat::ENCODING_DTS                      = 0x00000007;
 int CJNIAudioFormat::ENCODING_DTS_HD                   = 0x00000008;
 int CJNIAudioFormat::ENCODING_DOLBY_TRUEHD             = 0x00000009;
+int CJNIAudioFormat::ENCODING_IEC61937                 = 0x0000000d;
 
 int CJNIAudioFormat::CHANNEL_OUT_STEREO                = 0x0000000c;
 int CJNIAudioFormat::CHANNEL_OUT_5POINT1               = 0x000000fc;
@@ -107,6 +108,8 @@ void CJNIAudioFormat::PopulateStaticFields()
         GetStaticValue(c, value, "ENCODING_TRUEHD");
         if (value != -1)
           CJNIAudioFormat::ENCODING_DOLBY_TRUEHD = value;
+
+        GetStaticValue(c, CJNIAudioFormat::ENCODING_IEC61937, "ENCODING_IEC61937");
       }
     }
   }

--- a/xbmc/platform/android/jni/AudioFormat.h
+++ b/xbmc/platform/android/jni/AudioFormat.h
@@ -36,6 +36,7 @@ class CJNIAudioFormat
     static int ENCODING_DTS;
     static int ENCODING_DTS_HD;
     static int ENCODING_DOLBY_TRUEHD;
+    static int ENCODING_IEC61937;
 
     static int CHANNEL_OUT_STEREO;
     static int CHANNEL_OUT_5POINT1;

--- a/xbmc/platform/android/jni/AudioTrack.cpp
+++ b/xbmc/platform/android/jni/AudioTrack.cpp
@@ -75,7 +75,9 @@ CJNIAudioTrack::CJNIAudioTrack(int streamType, int sampleRateInHz, int channelCo
   }
 
   m_audioFormat = audioFormat;
-  if (m_audioFormat == CJNIAudioFormat::ENCODING_PCM_FLOAT)
+  if (m_audioFormat == CJNIAudioFormat::ENCODING_IEC61937)
+    m_buffer = jharray(xbmc_jnienv()->NewShortArray(bufferSizeInBytes / sizeof(short)));
+  else if (m_audioFormat == CJNIAudioFormat::ENCODING_PCM_FLOAT)
     m_buffer = jharray(xbmc_jnienv()->NewFloatArray(bufferSizeInBytes / sizeof(float)));
   else
     m_buffer = jharray(xbmc_jnienv()->NewByteArray(bufferSizeInBytes));
@@ -138,6 +140,11 @@ int CJNIAudioTrack::write(char* audioData, int offsetInBytes, int sizeInBytes)
     {
       written = call_method<int>(m_object, "write", "([FIII)I", m_buffer, (int)(offsetInBytes / sizeof(float)), (int)(sizeInBytes / sizeof(float)), CJNIAudioTrack::WRITE_BLOCKING);
       written *= sizeof(float);
+    }
+    else if (m_audioFormat == CJNIAudioFormat::ENCODING_IEC61937)
+    {
+      written = call_method<int>(m_object, "write", "([SIII)I", m_buffer, (int)(offsetInBytes / sizeof(short)), (int)(sizeInBytes / sizeof(short)), CJNIAudioTrack::WRITE_BLOCKING);
+      written *= sizeof(short);
     }
     else
     {


### PR DESCRIPTION
The PCM solution around there will kill user's ears, especially if the mixing "internally" is done in FLT format. Just give the users what Android wants them to have.

```
>= v21: AC3
shield: AC3, DTS, DTS-HD, TrueHD
>= v23: AC3, DTS, DTS-HD
```

EAC3 does not work as it should with this RAW API. Android N should have proper PT support again.
