### PR TITLE
[contextmenu] refactor addon loading/initialization

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -23,6 +23,7 @@
 #include "addons/AddonManager.h"
 #include "addons/ContextMenuAddon.h"
 #include "addons/IAddon.h"
+#include "GUIInfoManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"
 #include "interfaces/python/XBPython.h"
@@ -31,7 +32,12 @@
 
 bool CContextMenuItem::IsVisible(const CFileItem& item) const
 {
-  return IsGroup() || (m_condition && m_condition->Get(&item));
+  if (!m_infoBoolRegistered)
+  {
+    m_infoBool = g_infoManager.Register(m_visibilityCondition, 0);
+    m_infoBoolRegistered = true;
+  }
+  return IsGroup() || (m_infoBool && m_infoBool->Get(&item));
 }
 
 bool CContextMenuItem::IsParentOf(const CContextMenuItem& other) const
@@ -90,13 +96,13 @@ CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const s
 }
 
 CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const std::string& parent,
-    const std::string& library, const INFO::InfoPtr& condition, const std::string& addonId)
+    const std::string& library, const std::string& condition, const std::string& addonId)
 {
   CContextMenuItem menuItem;
   menuItem.m_label = label;
   menuItem.m_parent = parent;
   menuItem.m_library = library;
-  menuItem.m_condition = condition;
+  menuItem.m_visibilityCondition = condition;
   menuItem.m_addonId = addonId;
   return menuItem;
 }

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -79,7 +79,7 @@ public:
     const std::string& label,
     const std::string& parent,
     const std::string& library,
-    const INFO::InfoPtr& condition,
+    const std::string& condition,
     const std::string& addonId);
 
   friend class ADDON::CContextMenuAddon;
@@ -89,6 +89,9 @@ private:
   std::string m_parent;
   std::string m_groupId;
   std::string m_library;
-  INFO::InfoPtr m_condition;
   std::string m_addonId; // The owner of this menu item
+
+  std::string m_visibilityCondition;
+  mutable INFO::InfoPtr m_infoBool;
+  mutable bool m_infoBoolRegistered{false};
 };

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -35,34 +35,31 @@ public:
   static const CContextMenuItem MAIN;
   static const CContextMenuItem MANAGE;
 
+  CContextMenuManager(ADDON::CAddonMgr& addonMgr);
+  ~CContextMenuManager();
   static CContextMenuManager& GetInstance();
+
+  void Init();
 
   ContextMenuView GetItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
   ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
-  /*!
-   * \brief Adds a context item to this manager.
-   * NOTE: only 'enabled' context addons should be added.
-   */
-  void Register(const ADDON::ContextItemAddonPtr& cm);
-
-  /*!
-   * \brief Removes a context addon from this manager.
-   */
-  bool Unregister(const ADDON::ContextItemAddonPtr& cm);
+  bool Unload(const ADDON::CContextMenuAddon& addon);
 
 private:
-  CContextMenuManager();
   CContextMenuManager(const CContextMenuManager&);
   CContextMenuManager const& operator=(CContextMenuManager const&);
-  virtual ~CContextMenuManager() {}
 
-  void Init();
   bool IsVisible(
     const CContextMenuItem& menuItem,
     const CContextMenuItem& root,
     const CFileItem& fileItem) const;
+
+  void ReloadAddonItems();
+  void OnEvent(const ADDON::AddonEvent& event);
+
+  ADDON::CAddonMgr& m_addonMgr;
 
   CCriticalSection m_criticalSection;
   std::vector<CContextMenuItem> m_addonItems;

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -51,6 +51,11 @@ ActiveAE::CActiveAEDSP &CServiceBroker::GetADSP()
   return g_application.m_ServiceManager->GetADSPManager();
 }
 
+CContextMenuManager& CServiceBroker::GetContextMenuManager()
+{
+  return g_application.m_ServiceManager->GetContextMenuManager();
+}
+
 CDataCacheCore &CServiceBroker::GetDataCacheCore()
 {
   return g_application.m_ServiceManager->GetDataCacheCore();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -39,6 +39,7 @@ namespace PVR
   class CPVRManager;
 }
 
+class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
 
@@ -51,5 +52,6 @@ public:
   static XBPython &GetXBPython();
   static PVR::CPVRManager &GetPVRManager();
   static ActiveAE::CActiveAEDSP& GetADSP();
+  static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -20,6 +20,7 @@
 
 #include "ServiceManager.h"
 #include "addons/BinaryAddonCache.h"
+#include "ContextMenuManager.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "cores/DataCacheCore.h"
 #include "utils/log.h"
@@ -59,6 +60,8 @@ bool CServiceManager::Init2()
   m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
 
+  m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));
+
   return true;
 }
 
@@ -66,12 +69,14 @@ bool CServiceManager::Init3()
 {
   m_ADSPManager->Init();
   m_PVRManager->Init();
+  m_contextMenuManager->Init();
 
   return true;
 }
 
 void CServiceManager::Deinit()
 {
+  m_contextMenuManager.reset();
   m_binaryAddonCache.reset();
   m_PVRManager.reset();
   m_ADSPManager.reset();
@@ -111,6 +116,11 @@ ActiveAE::CActiveAEDSP& CServiceManager::GetADSPManager()
   return *m_ADSPManager;
 }
 
+CContextMenuManager& CServiceManager::GetContextMenuManager()
+{
+  return *m_contextMenuManager;
+}
+
 CDataCacheCore& CServiceManager::GetDataCacheCore()
 {
   return *m_dataCacheCore;
@@ -123,6 +133,11 @@ CPlatform& CServiceManager::GetPlatform()
 
 // deleters for unique_ptr
 void CServiceManager::delete_dataCacheCore::operator()(CDataCacheCore *p) const
+{
+  delete p;
+}
+
+void CServiceManager::delete_contextMenuManager::operator()(CContextMenuManager *p) const
 {
   delete p;
 }

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -42,6 +42,7 @@ namespace PVR
 class CPVRManager;
 }
 
+class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
 
@@ -58,6 +59,7 @@ public:
   XBPython& GetXBPython();
   PVR::CPVRManager& GetPVRManager();
   ActiveAE::CActiveAEDSP& GetADSPManager();
+  CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();
   /**\brief Get the platform object. This is save to be called after Init1() was called
    */
@@ -69,12 +71,18 @@ protected:
     void operator()(CDataCacheCore *p) const;
   };
 
+  struct delete_contextMenuManager
+  {
+    void operator()(CContextMenuManager *p) const;
+  };
+
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
   std::unique_ptr<ADDON::CBinaryAddonCache> m_binaryAddonCache;
   std::unique_ptr<ANNOUNCEMENT::CAnnouncementManager> m_announcementManager;
   std::unique_ptr<XBPython> m_XBPython;
   std::unique_ptr<PVR::CPVRManager> m_PVRManager;
   std::unique_ptr<ActiveAE::CActiveAEDSP> m_ADSPManager;
+  std::unique_ptr<CContextMenuManager, delete_contextMenuManager> m_contextMenuManager;
   std::unique_ptr<CDataCacheCore, delete_dataCacheCore> m_dataCacheCore;
   std::unique_ptr<CPlatform> m_Platform;
 };

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -32,6 +32,7 @@
 #include "filesystem/File.h"
 #include "RepositoryUpdater.h"
 #include "settings/Settings.h"
+#include "ServiceBroker.h"
 #include "system.h"
 #include "URL.h"
 #include "Util.h"
@@ -350,9 +351,6 @@ void OnEnabled(const std::string& id)
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_SERVICE))
     std::static_pointer_cast<CService>(addon)->Start();
 
-  if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::GetInstance().Register(std::static_pointer_cast<CContextMenuAddon>(addon));
-
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_REPOSITORY))
     CRepositoryUpdater::GetInstance().ScheduleUpdate(); //notify updater there is a new addon
 }
@@ -368,7 +366,7 @@ void OnDisabled(const std::string& id)
     std::static_pointer_cast<CService>(addon)->Stop();
 
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_CONTEXT_ITEM, false))
-    CContextMenuManager::GetInstance().Unregister(std::static_pointer_cast<CContextMenuAddon>(addon));
+    CContextMenuManager::GetInstance().Unload(*std::static_pointer_cast<CContextMenuAddon>(addon));
 }
 
 void OnPreInstall(const AddonPtr& addon)
@@ -380,7 +378,7 @@ void OnPreInstall(const AddonPtr& addon)
     std::static_pointer_cast<CService>(localAddon)->Stop();
 
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::GetInstance().Unregister(std::static_pointer_cast<CContextMenuAddon>(localAddon));
+    CContextMenuManager::GetInstance().Unload(*std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
   //Fallback to the pre-install callback in the addon.
   //! @bug If primary extension point have changed we're calling the wrong method.
@@ -392,9 +390,6 @@ void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
   AddonPtr localAddon;
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_SERVICE))
     std::static_pointer_cast<CService>(localAddon)->Start();
-
-  if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::GetInstance().Register(std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_REPOSITORY))
     CRepositoryUpdater::GetInstance().ScheduleUpdate(); //notify updater there is a new addon or version
@@ -409,7 +404,7 @@ void OnPreUnInstall(const AddonPtr& addon)
     std::static_pointer_cast<CService>(localAddon)->Stop();
 
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_CONTEXT_ITEM))
-    CContextMenuManager::GetInstance().Unregister(std::static_pointer_cast<CContextMenuAddon>(localAddon));
+    CContextMenuManager::GetInstance().Unload(*std::static_pointer_cast<CContextMenuAddon>(localAddon));
 
   addon->OnPreUnInstall();
 }

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -22,8 +22,6 @@
 #include "AddonManager.h"
 #include "ContextMenuManager.h"
 #include "ContextMenuItem.h"
-#include "GUIInfoManager.h"
-#include "interfaces/info/InfoBool.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include <sstream>
@@ -73,7 +71,7 @@ void CContextMenuAddon::ParseMenu(
       if (!label.empty() && !library.empty() && !visCondition.empty())
       {
         auto menu = CContextMenuItem::CreateItem(label, menuId,
-            URIUtils::AddFileToFolder(props.path, library), g_infoManager.Register(visCondition, 0), props.id);
+            URIUtils::AddFileToFolder(props.path, library), visCondition, props.id);
         items.push_back(menu);
       }
     }
@@ -110,8 +108,7 @@ std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(AddonProps p
         label = g_localizeStrings.GetAddonString(props.id, atoi(label.c_str()));
 
       CContextMenuItem menuItem = CContextMenuItem::CreateItem(label, parent,
-          URIUtils::AddFileToFolder(props.path, props.libname),
-          g_infoManager.Register(visCondition, 0), props.id);
+          URIUtils::AddFileToFolder(props.path, props.libname), visCondition, props.id);
 
       items.push_back(menuItem);
     }

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -122,9 +122,4 @@ CContextMenuAddon::CContextMenuAddon(AddonProps props, std::vector<CContextMenuI
 {
 }
 
-std::vector<CContextMenuItem> CContextMenuAddon::GetItems() const
-{
-  return m_items;
-}
-
 }

--- a/xbmc/addons/ContextMenuAddon.h
+++ b/xbmc/addons/ContextMenuAddon.h
@@ -40,7 +40,7 @@ namespace ADDON
     explicit CContextMenuAddon(AddonProps props) : CAddon(std::move(props)) {}
     CContextMenuAddon(AddonProps props, std::vector<CContextMenuItem> items);
 
-    std::vector<CContextMenuItem> GetItems() const;
+    const std::vector<CContextMenuItem>& GetItems() const { return m_items; };
 
   private:
     static void ParseMenu(const AddonProps& props, cp_cfg_element_t* elem, const std::string& parent,

--- a/xbmc/addons/ContextMenuAddon.h
+++ b/xbmc/addons/ContextMenuAddon.h
@@ -48,6 +48,4 @@ namespace ADDON
 
     std::vector<CContextMenuItem> m_items;
   };
-
-  typedef std::shared_ptr<const CContextMenuAddon> ContextItemAddonPtr;
 }


### PR DESCRIPTION
Due to some recent refactoring every info bool for addons in the repository are registered when reading the repository index (whoops!). This should fix that and that initialization issues encountered in #10335.
