### PR TITLE
[Estuary][PVR] Recordings Info dialog: Fix 'Play recording' button.

### DIFF
--- a/addons/skin.estuary/1080i/DialogPVRInfo.xml
+++ b/addons/skin.estuary/1080i/DialogPVRInfo.xml
@@ -82,20 +82,12 @@
 					<param name="id" value="8" />
 					<param name="icon" value="icons/infodialogs/play_record.png" />
 					<param name="label" value="$LOCALIZE[19687]" />
-					<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
+					<param name="visible" value="Window.IsActive(PVRGuideInfo) | Window.IsActive(PVRRecordingInfo)" />
 				</include>
 				<include content="InfoDialogButton">
 					<param name="id" value="6" />
 					<param name="icon" value="icons/infodialogs/record.png" />
 					<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
-				</include>
-				<include content="InfoDialogButton">
-					<param name="id" value="5010" />
-					<param name="icon" value="icons/infodialogs/play_record.png" />
-					<param name="label" value="$LOCALIZE[19687]" />
-					<param name="onclick_1" value="Dialog.close(PVRRecordingInfo,true)" />
-					<param name="onclick_2" value="Action(select)" />
-					<param name="visible" value="Window.IsActive(PVRRecordingInfo)" />
 				</include>
 				<include content="InfoDialogButton">
 					<param name="id" value="440" />

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -19,12 +19,14 @@
  */
 
 #include "FileItem.h"
+#include "pvr/windows/GUIWindowPVRBase.h"
 
 #include "GUIDialogPVRRecordingInfo.h"
 
 using namespace PVR;
 
 #define CONTROL_BTN_OK  7
+#define CONTROL_BTN_PLAY_RECORDING  8
 
 CGUIDialogPVRRecordingInfo::CGUIDialogPVRRecordingInfo(void)
   : CGUIDialog(WINDOW_DIALOG_PVR_RECORDING_INFO, "DialogPVRInfo.xml")
@@ -34,18 +36,43 @@ CGUIDialogPVRRecordingInfo::CGUIDialogPVRRecordingInfo(void)
 
 bool CGUIDialogPVRRecordingInfo::OnMessage(CGUIMessage& message)
 {
-  if (message.GetMessage() == GUI_MSG_CLICKED)
+  switch (message.GetMessage())
   {
-    int iControl = message.GetSenderId();
-
-    if (iControl == CONTROL_BTN_OK)
-    {
-      Close();
-      return true;
-    }
+    case GUI_MSG_CLICKED:
+      return OnClickButtonOK(message) || OnClickButtonPlay(message);
   }
 
   return CGUIDialog::OnMessage(message);
+}
+
+bool CGUIDialogPVRRecordingInfo::OnClickButtonOK(CGUIMessage &message)
+{
+  bool bReturn = false;
+
+  if (message.GetSenderId() == CONTROL_BTN_OK)
+  {
+    Close();
+    bReturn = true;
+  }
+
+  return bReturn;
+}
+
+bool CGUIDialogPVRRecordingInfo::OnClickButtonPlay(CGUIMessage &message)
+{
+  bool bReturn = false;
+
+  if (message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
+  {
+    Close();
+
+    if (m_recordItem)
+      CGUIWindowPVRBase::PlayRecording(m_recordItem.get(), false /* don't play minimized */, true /* check resume */);
+
+    bReturn = true;
+  }
+
+  return bReturn;
 }
 
 bool CGUIDialogPVRRecordingInfo::OnInfo(int actionID)

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -36,6 +36,9 @@ namespace PVR
     void SetRecording(const CFileItem *item);
 
   protected:
+    bool OnClickButtonOK(CGUIMessage &message);
+    bool OnClickButtonPlay(CGUIMessage &message);
+
     CFileItemPtr m_recordItem;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -93,6 +93,8 @@ namespace PVR
     static bool DeleteTimerRule(CFileItem *item);
     static bool StopRecordFile(CFileItem *item);
 
+    static bool PlayRecording(CFileItem *item, bool bPlayMinimized = false, bool bCheckResume = true);
+
   protected:
     CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile);
 
@@ -109,13 +111,12 @@ namespace PVR
     virtual bool ActionDeleteChannel(CFileItem *item);
     virtual bool ActionInputChannelNumber(int input);
 
-    virtual bool PlayRecording(CFileItem *item, bool bPlayMinimized = false, bool bCheckResume = true);
     virtual bool PlayFile(CFileItem *item, bool bPlayMinimized = false, bool bCheckResume = true);
     virtual void ShowEPGInfo(CFileItem *item);
     virtual void ShowRecordingInfo(CFileItem *item);
     virtual bool UpdateEpgForChannel(CFileItem *item);
     virtual void UpdateSelectedItemPath();
-    bool CheckResumeRecording(CFileItem *item);
+    static bool CheckResumeRecording(CFileItem *item);
 
     bool OnContextButtonEditTimer(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonEditTimerRule(CFileItem *item, CONTEXT_BUTTON button);


### PR DESCRIPTION
Reported here: https://github.com/xbmc/xbmc/pull/10333#issuecomment-242981005

Broken after #10333 due to 'interesting' implementation of the 'play recording' button in Estuary. ;-)

@axbmcuser fyi
@Jalle19 mind doing the pvr code review?
@BigNoid for the review of the Estuary change?
