### PR TITLE
[PVR] Add IsRecordable, IsPlayable, GetEpgTagUrl to PVRClient

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10500,7 +10500,13 @@ msgctxt "#19262"
 msgid "Parental control. Enter PIN:"
 msgstr ""
 
-#empty string with id 19263
+#. Label of a context menu entry to replay a programs
+#: xbmc/pvr/PVRContextMenuItem.cpp
+msgctxt "#19263"
+msgid "Replay program"
+msgstr ""
+
+#empty string with id 19264
 
 #. label for 'incorrect pin' error dialog header
 #: xbmc/pvr/PVRGUIActions.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10367,7 +10367,9 @@ msgctxt "#19239"
 msgid "Starting background threads"
 msgstr ""
 
-#empty string with id 19240
+msgctxt "#19240"
+msgid "Replay"
+msgstr ""
 
 #. Label for context menu entry to open settings dialog for a timer (read-only)
 #: xbmc/pvr/PVRContextMenus.cpp

--- a/addons/skin.estouchy/xml/DialogPVRInfo.xml
+++ b/addons/skin.estouchy/xml/DialogPVRInfo.xml
@@ -198,6 +198,13 @@
 				<label>19165</label>
 				<visible>Window.IsActive(PVRGuideInfo)</visible>
 			</control>
+			<control type="button" id="10">
+				<description>Replay Program</description>
+				<width>230</width>
+				<include>ButtonInfoDialogsCommonValues</include>
+				<label>19240</label>
+				<visible>Window.IsActive(PVRGuideInfo)</visible>
+			</control>
 			<control type="button" id="6">
 				<description>Record</description>
 				<width>230</width>

--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -72,6 +72,12 @@
 						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
 					</include>
 					<include content="InfoDialogButton">
+						<param name="id" value="10" />
+						<param name="icon" value="icons/infodialogs/update.png" />
+						<param name="label" value="$LOCALIZE[19240]" />
+						<param name="visible" value="Window.IsActive(PVRGuideInfo)" />
+					</include>
+					<include content="InfoDialogButton">
 						<param name="id" value="4" />
 						<param name="icon" value="icons/infodialogs/similar.png" />
 						<param name="label" value="$LOCALIZE[19003]" />

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -67,6 +67,8 @@ class CVariant;
 class CFileItemList;
 class CCueDocument;
 typedef std::shared_ptr<CCueDocument> CCueDocumentPtr;
+typedef std::map<std::string, std::string> CStringPropertyMap;
+typedef std::shared_ptr<CStringPropertyMap> CStringPropertyMapPtr;
 
 class IEvent;
 typedef std::shared_ptr<const IEvent> EventPtr;

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -682,6 +682,28 @@ PVR_ERROR CPVRClient::IsRecordable(const CConstPVREpgInfoTagPtr &tag, bool *isRe
   return retVal;
 }
 
+bool CPVRClient::IsPlayable(const CConstPVREpgInfoTagPtr &tag)
+{
+  if (!m_bReadyToUse)
+    return false;
+
+  EPG_TAG pvrTag;
+  WriteEpgTag(tag, pvrTag);
+  return m_struct.toAddon.IsPlayable(pvrTag);
+}
+
+const std::string CPVRClient::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag)
+{
+  if (!m_bReadyToUse)
+    return nullptr;
+
+  EPG_TAG pvrTag;
+  WriteEpgTag(tag, pvrTag);
+  char url[4096];
+  m_struct.toAddon.GetEpgTagUrl(pvrTag, url, sizeof(url));
+  return url;
+}
+
 void CPVRClient::CallMenuHook(const PVR_MENUHOOK &hook, const CFileItem *item)
 {
   if (!m_bReadyToUse)

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -692,7 +692,7 @@ bool CPVRClient::IsPlayable(const CConstPVREpgInfoTagPtr &tag)
   return m_struct.toAddon.IsPlayable(pvrTag);
 }
 
-const std::string CPVRClient::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag)
+const std::string CPVRClient::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag, const CStringPropertyMapPtr &properties)
 {
   if (!m_bReadyToUse)
     return nullptr;
@@ -700,7 +700,7 @@ const std::string CPVRClient::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag)
   EPG_TAG pvrTag;
   WriteEpgTag(tag, pvrTag);
   char url[4096];
-  m_struct.toAddon.GetEpgTagUrl(pvrTag, url, sizeof(url));
+  m_struct.toAddon.GetEpgTagUrl(pvrTag, url, sizeof(url), properties);
   return url;
 }
 

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -30,6 +30,8 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
+#include "pvr/epg/Epg.h"
+#include "pvr/epg/EpgInfoTag.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/AdvancedSettings.h"
@@ -369,6 +371,37 @@ void CPVRClient::WriteClientChannelInfo(const CPVRChannelPtr &xbmcChannel, PVR_C
   strncpy(addonChannel.strStreamURL, xbmcChannel->StreamURL().c_str(), sizeof(addonChannel.strStreamURL) - 1);
 }
 
+void CPVRClient::WriteEpgTag(const CConstPVREpgInfoTagPtr &tag, EPG_TAG &pvrTag)
+{
+  time_t t;
+  tag->StartAsUTC().GetAsTime(t);
+  pvrTag.startTime = t;
+  tag->EndAsUTC().GetAsTime(t);
+  pvrTag.endTime = t;
+  pvrTag.iParentalRating = tag->ParentalRating();
+  pvrTag.iUniqueBroadcastId = tag->UniqueBroadcastID();
+  pvrTag.bNotify = tag->Notify();
+  tag->FirstAiredAsUTC().GetAsTime(t);
+  pvrTag.firstAired = t;
+  pvrTag.iSeriesNumber = tag->SeriesNumber();
+  pvrTag.iEpisodeNumber = tag->EpisodeNumber();
+  pvrTag.iEpisodePartNumber = tag->EpisodePart();
+  pvrTag.iStarRating = tag->StarRating();
+  pvrTag.iYear = tag->Year();
+  pvrTag.iFlags = tag->Flags();
+  pvrTag.strTitle = tag->Title(true).c_str();
+  pvrTag.strPlotOutline = tag->PlotOutline().c_str();
+  pvrTag.strPlot = tag->Plot().c_str();
+  pvrTag.strOriginalTitle = tag->OriginalTitle(true).c_str();
+  pvrTag.strCast = tag->Cast().c_str();
+  pvrTag.strDirector = tag->Director().c_str();
+  pvrTag.strWriter = tag->Writer().c_str();
+  pvrTag.strIMDBNumber = tag->IMDBNumber().c_str();
+  pvrTag.strEpisodeName = tag->EpisodeName().c_str();
+  pvrTag.strIconPath = tag->Icon().c_str();
+  pvrTag.iChannelNumber = tag->ChannelTag()->ClientChannelNumber();
+}
+
 bool CPVRClient::GetAddonProperties(void)
 {
   std::string strBackendName, strConnectionString, strFriendlyName, strBackendVersion, strBackendHostname;
@@ -628,6 +661,24 @@ PVR_ERROR CPVRClient::RenameChannel(const CPVRChannelPtr &channel)
 
   PVR_ERROR retVal = m_struct.toAddon.RenameChannel(addonChannel);
   LogError(retVal, __FUNCTION__);
+  return retVal;
+}
+
+PVR_ERROR CPVRClient::IsRecordable(const CConstPVREpgInfoTagPtr &tag, bool *isRecordable)
+{
+  if (!m_bReadyToUse)
+    return PVR_ERROR_SERVER_ERROR;
+
+  if (!m_clientCapabilities.SupportsRecordings())
+    return PVR_ERROR_NOT_IMPLEMENTED;
+
+  PVR_ERROR retVal(PVR_ERROR_UNKNOWN);
+
+  EPG_TAG pvrTag;
+  WriteEpgTag(tag, pvrTag);
+  retVal = m_struct.toAddon.IsRecordable(pvrTag, isRecordable);
+  LogError(retVal, __FUNCTION__);
+
   return retVal;
 }
 

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -362,6 +362,14 @@ namespace PVR
      */
     PVR_ERROR RenameChannel(const CPVRChannelPtr &channel);
 
+    /*
+     * @brief Check if an epg tag can be recorded
+     * @param tag The epg tag
+     * @param isRecordable Set to true if the tag can be recorded
+     * @return PVR_ERROR_NO_ERROR if isRecordable was set by the addon
+     */
+    PVR_ERROR IsRecordable(const CConstPVREpgInfoTagPtr &tag, bool *isRecordable);
+
     /*!
      * @return True if this add-on has menu hooks, false otherwise.
      */
@@ -806,6 +814,13 @@ namespace PVR
      * @param addonChannel The channel on the addon's side.
      */
     static void WriteClientChannelInfo(const CPVRChannelPtr &xbmcChannel, PVR_CHANNEL &addonChannel);
+
+    /*!
+     * @brief Copy over epg info from CPVREpgInfoTag to EPG_TAG.
+     * @param tag The epg tag on Kodi's side.
+     * @param pvrTag The epg tag on the addon's side.
+     */
+    static void WriteEpgTag(const CConstPVREpgInfoTagPtr &tag, EPG_TAG &pvrTag);
 
     /*!
      * @brief Whether a channel can be played by this add-on

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -370,6 +370,24 @@ namespace PVR
      */
     PVR_ERROR IsRecordable(const CConstPVREpgInfoTagPtr &tag, bool *isRecordable);
 
+    /*
+     * Check if the given EPG tag can be played.
+     * @param tag The EPG tag
+     * @return True if the EPG tag can be played
+     * @remarks Required, always return false if not supported by the addon
+     *
+     */
+    bool IsPlayable(const CConstPVREpgInfoTagPtr &tag);
+
+    /*
+     * Get the URL to play a given EPG tag
+     * @param tag The EPG tag
+     * @return The url to play for the EPG tag, empty string if it cannot be played
+     * @remarks Required, always return empty string if not supported by the addon
+     *
+     */
+    const std::string GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag);
+
     /*!
      * @return True if this add-on has menu hooks, false otherwise.
      */

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -382,11 +382,12 @@ namespace PVR
     /*
      * Get the URL to play a given EPG tag
      * @param tag The EPG tag
+     * @param properties The properties to be provided to the file item
      * @return The url to play for the EPG tag, empty string if it cannot be played
      * @remarks Required, always return empty string if not supported by the addon
      *
      */
-    const std::string GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag);
+    const std::string GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag, const CStringPropertyMapPtr &properties);
 
     /*!
      * @return True if this add-on has menu hooks, false otherwise.

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -568,6 +568,26 @@ extern "C"
    */
   PVR_ERROR IsRecordable(const EPG_TAG &tag, bool *isRecordable);
 
+  /*
+   * Check if the given EPG tag can be played.
+   * @param tag The EPG tag
+   * @return True if the EPG tag can be played
+   * @remarks Required, always return false if not supported by the addon
+   *
+   */
+  bool IsPlayable(const EPG_TAG &tag);
+
+  /*
+   * Get the URL to play a given EPG tag
+   * @param tag The EPG tag
+   * @param url The url to be returnd
+   * @param urlLen The length of the url buffer
+   * @return The length of the url. -1 if the tag is not playable
+   * @remarks Required, always return -1 if not supported by the addon
+   *
+   */
+  int GetEpgTagUrl(const EPG_TAG &tag, char *url, int urlLen);
+
   /*!
    * @brief Notify the pvr addon that XBMC (un)paused the currently playing stream
    */
@@ -723,6 +743,9 @@ extern "C"
     pClient->toAddon.PositionRecordedStream         = PositionRecordedStream;
     pClient->toAddon.LengthRecordedStream           = LengthRecordedStream;
     pClient->toAddon.IsRecordable                   = IsRecordable;
+    pClient->toAddon.IsPlayable                     = IsPlayable;
+    pClient->toAddon.GetEpgTagUrl                   = GetEpgTagUrl;
+
 
     pClient->toAddon.DemuxReset                     = DemuxReset;
     pClient->toAddon.DemuxAbort                     = DemuxAbort;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -558,6 +558,16 @@ extern "C"
    */
   bool CanSeekStream();
 
+  /*
+   * Check if the given EPG tag can be recorded.
+   * @param tag the epg tag
+   * @param isRecordable Set to true if the tag can be recorded
+   * @return PVR_ERROR_NO_ERROR if isRecordable was set by the addon
+   * @remarks Optional, return PVR_ERROR_NOT_IMPLEMENTED to let kodi decide
+   *
+   */
+  PVR_ERROR IsRecordable(const EPG_TAG &tag, bool *isRecordable);
+
   /*!
    * @brief Notify the pvr addon that XBMC (un)paused the currently playing stream
    */
@@ -712,6 +722,7 @@ extern "C"
     pClient->toAddon.SeekRecordedStream             = SeekRecordedStream;
     pClient->toAddon.PositionRecordedStream         = PositionRecordedStream;
     pClient->toAddon.LengthRecordedStream           = LengthRecordedStream;
+    pClient->toAddon.IsRecordable                   = IsRecordable;
 
     pClient->toAddon.DemuxReset                     = DemuxReset;
     pClient->toAddon.DemuxAbort                     = DemuxAbort;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -582,11 +582,12 @@ extern "C"
    * @param tag The EPG tag
    * @param url The url to be returnd
    * @param urlLen The length of the url buffer
+   * @param properties The properties to be provided to the file item
    * @return The length of the url. -1 if the tag is not playable
    * @remarks Required, always return -1 if not supported by the addon
    *
    */
-  int GetEpgTagUrl(const EPG_TAG &tag, char *url, int urlLen);
+  int GetEpgTagUrl(const EPG_TAG &tag, char *url, int urlLen, const CStringPropertyMapPtr&);
 
   /*!
    * @brief Notify the pvr addon that XBMC (un)paused the currently playing stream

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -663,6 +663,8 @@ extern "C" {
     long long (__cdecl* PositionRecordedStream)(void);
     long long (__cdecl* LengthRecordedStream)(void);
     PVR_ERROR (__cdecl* IsRecordable)(const EPG_TAG&, bool*);
+    bool (__cdecl* IsPlayable)(const EPG_TAG&);
+    int (__cdecl* GetEpgTagUrl)(const EPG_TAG&, char*, int);
     void (__cdecl* DemuxReset)(void);
     void (__cdecl* DemuxAbort)(void);
     void (__cdecl* DemuxFlush)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -662,6 +662,7 @@ extern "C" {
     long long (__cdecl* SeekRecordedStream)(long long, int);
     long long (__cdecl* PositionRecordedStream)(void);
     long long (__cdecl* LengthRecordedStream)(void);
+    PVR_ERROR (__cdecl* IsRecordable)(const EPG_TAG&, bool*);
     void (__cdecl* DemuxReset)(void);
     void (__cdecl* DemuxAbort)(void);
     void (__cdecl* DemuxFlush)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -31,6 +31,8 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <map>
+#include <memory>
 
 #include "xbmc_addon_types.h"
 #include "xbmc_epg_types.h"
@@ -102,6 +104,10 @@ extern "C" {
     xbmc_codec_type_t codec_type;
     xbmc_codec_id_t   codec_id;
   } xbmc_codec_t;
+
+  typedef std::map<std::string, std::string> CStringPropertyMap;
+  typedef std::shared_ptr<CStringPropertyMap> CStringPropertyMapPtr;
+
 
   /*!
    * @brief numeric PVR timer type definitions (PVR_TIMER.iTimerType values)
@@ -664,7 +670,7 @@ extern "C" {
     long long (__cdecl* LengthRecordedStream)(void);
     PVR_ERROR (__cdecl* IsRecordable)(const EPG_TAG&, bool*);
     bool (__cdecl* IsPlayable)(const EPG_TAG&);
-    int (__cdecl* GetEpgTagUrl)(const EPG_TAG&, char*, int);
+    int (__cdecl* GetEpgTagUrl)(const EPG_TAG&, char*, int, const CStringPropertyMapPtr&);
     void (__cdecl* DemuxReset)(void);
     void (__cdecl* DemuxAbort)(void);
     void (__cdecl* DemuxFlush)(void);

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -56,6 +56,7 @@ namespace PVR
     };
 
     DECL_CONTEXTMENUITEM(ShowInformation);
+    DECL_STATICCONTEXTMENUITEM(ReplayProgram)
     DECL_STATICCONTEXTMENUITEM(FindSimilar);
     DECL_STATICCONTEXTMENUITEM(PlayRecording);
     DECL_STATICCONTEXTMENUITEM(StartRecording);
@@ -126,6 +127,23 @@ namespace PVR
     }
 
     ///////////////////////////////////////////////////////////////////////////////
+    // Replay program
+
+    bool ReplayProgram::IsVisible(const CFileItem &item) const
+    {
+      const CPVREpgInfoTagPtr epg(item.GetEPGInfoTag());
+      if (epg)
+        return epg->IsPlayable();
+
+      return false;
+    }
+
+    bool ReplayProgram::Execute(const CFileItemPtr &item) const
+    {
+      return CServiceBroker::GetPVRManager().GUIActions()->PlayEpgTag(item, false /* bPlayMinimized */, true /* bCheckResume */);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
     // Find similar
 
     bool FindSimilar::IsVisible(const CFileItem &item) const
@@ -183,7 +201,7 @@ namespace PVR
       const CPVREpgInfoTagPtr epg(item.GetEPGInfoTag());
       if (epg)
         return !epg->Timer() &&
-               epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime() &&
+               epg->IsRecordable() &&
                epg->ChannelTag() &&
                CServiceBroker::GetPVRManager().Clients()->GetClientCapabilities(epg->ChannelTag()->ClientID()).SupportsTimers();
 
@@ -525,6 +543,7 @@ namespace PVR
     m_items =
     {
       std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
+      std::make_shared<CONTEXTMENUITEM::ReplayProgram>(19263), /* Replay program */
       std::make_shared<CONTEXTMENUITEM::FindSimilar>(19003), /* Find similar */
       std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
       std::make_shared<CONTEXTMENUITEM::ToggleTimerState>(),

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1092,13 +1092,17 @@ namespace PVR
       if (!epgTag)
         return false;
 
-      std::string stream = epgTag->GetStreamUrl();
+      CStringPropertyMapPtr properties(new CStringPropertyMap());
+      std::string stream = epgTag->GetStreamUrl(properties);
       if (stream.empty())
       {
         return false;
       }
 
       item->SetPath(stream);
+      for (auto const &entry : *properties.get()) {
+        item->SetProperty(entry.first, entry.second);
+      }
 
       if (!bCheckResume || CheckResumeRecording(item))
         CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(*item)));

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1086,6 +1086,26 @@ namespace PVR
     return true;
   }
 
+  bool CPVRGUIActions::PlayEpgTag(const CFileItemPtr &item, bool bPlayMinimized, bool bCheckResume) const
+  {
+      const CPVREpgInfoTagPtr epgTag(CPVRItem(item).GetEpgInfoTag());
+      if (!epgTag)
+        return false;
+
+      std::string stream = epgTag->GetStreamUrl();
+      if (stream.empty())
+      {
+        return false;
+      }
+
+      item->SetPath(stream);
+
+      if (!bCheckResume || CheckResumeRecording(item))
+        CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(new CFileItem(*item)));
+
+      return true;
+    }
+
   bool CPVRGUIActions::SwitchToChannel(const CFileItemPtr &item, bool bCheckResume) const
   {
     return SwitchToChannel(item, bCheckResume, m_settings.GetBoolValue(CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN));

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -245,6 +245,15 @@ namespace PVR
     bool PlayRecording(const CFileItemPtr &item, bool bCheckResume) const;
 
     /*!
+     * @brief Play epg tag.
+     * @param item containing a an epg tag.
+     * @param bPlayMinimized controls whether the recording should be played fullscreen or in a window.
+     * @param bCheckResume controls resume check.
+     * @return true on success, false otherwise.
+     */
+    bool PlayEpgTag(const CFileItemPtr &item, bool bPlayMinimized, bool bCheckResume) const;
+
+    /*!
      * @brief Switch channel.
      * @param item containing a channel or an epg tag.
      * @param bCheckResume controls resume check in case a recording for the current epg event is present.

--- a/xbmc/pvr/PVRTypes.h
+++ b/xbmc/pvr/PVRTypes.h
@@ -64,6 +64,7 @@ namespace PVR
 
   class CPVREpgInfoTag;
   typedef std::shared_ptr<CPVREpgInfoTag> CPVREpgInfoTagPtr;
+  typedef std::shared_ptr<const CPVREpgInfoTag> CConstPVREpgInfoTagPtr;
 
 } // namespace PVR
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -28,6 +28,7 @@
 #include "ServiceBroker.h"
 #include "cores/IPlayer.h"
 #include "guilib/LocalizeStrings.h"
+#include "pvr/epg/EpgInfoTag.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/channels/PVRChannelGroups.h"
@@ -1213,6 +1214,21 @@ time_t CPVRClients::GetPlayingTime() const
   }
 
   return time;
+}
+
+bool CPVRClients::IsRecordable(const CConstPVREpgInfoTagPtr &tag) const
+{
+  PVR_CLIENT client;
+  bool isRecordable = false;
+
+  if (GetClient(tag->ChannelTag()->ClientID(), client))
+  {
+     if(client->IsRecordable(tag, &isRecordable) != PVR_ERROR_NO_ERROR) {
+       isRecordable = tag->EndAsLocalTime() > CDateTime::GetCurrentDateTime();
+     }
+  }
+
+  return isRecordable;
 }
 
 bool CPVRClients::IsTimeshifting(void) const

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1231,6 +1231,30 @@ bool CPVRClients::IsRecordable(const CConstPVREpgInfoTagPtr &tag) const
   return isRecordable;
 }
 
+bool CPVRClients::IsPlayable(const CConstPVREpgInfoTagPtr &tag)
+{
+  PVR_CLIENT client;
+
+  if (GetClient(tag->ChannelTag()->ClientID(), client))
+  {
+    return client->IsPlayable(tag);
+  }
+
+  return NULL;
+}
+
+const std::string CPVRClients::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag)
+{
+  PVR_CLIENT client;
+
+  if (GetClient(tag->ChannelTag()->ClientID(), client))
+  {
+    return client->GetEpgTagUrl(tag);
+  }
+
+  return "";
+}
+
 bool CPVRClients::IsTimeshifting(void) const
 {
   PVR_CLIENT client;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1243,13 +1243,13 @@ bool CPVRClients::IsPlayable(const CConstPVREpgInfoTagPtr &tag)
   return NULL;
 }
 
-const std::string CPVRClients::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag)
+const std::string CPVRClients::GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag, const CStringPropertyMapPtr &properties)
 {
   PVR_CLIENT client;
 
   if (GetClient(tag->ChannelTag()->ClientID(), client))
   {
-    return client->GetEpgTagUrl(tag);
+    return client->GetEpgTagUrl(tag, properties);
   }
 
   return "";

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -626,6 +626,8 @@ namespace PVR
 
     int GetClientId(const std::string& strId) const;
 
+    bool IsRecordable(const CConstPVREpgInfoTagPtr &tag) const;
+
     bool IsRealTimeStream() const;
 
     void ConnectionStateChange(CPVRClient *client, std::string &strConnectionString, PVR_CONNECTION_STATE newState,

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -630,7 +630,7 @@ namespace PVR
 
     bool IsPlayable(const CConstPVREpgInfoTagPtr &tag);
 
-    const std::string GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag);
+    const std::string GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag, const CStringPropertyMapPtr &properties);
 
     bool IsRealTimeStream() const;
 

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -628,6 +628,10 @@ namespace PVR
 
     bool IsRecordable(const CConstPVREpgInfoTagPtr &tag) const;
 
+    bool IsPlayable(const CConstPVREpgInfoTagPtr &tag);
+
+    const std::string GetEpgTagUrl(const CConstPVREpgInfoTagPtr &tag);
+
     bool IsRealTimeStream() const;
 
     void ConnectionStateChange(CPVRClient *client, std::string &strConnectionString, PVR_CONNECTION_STATE newState,

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -242,7 +242,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
       bHideRecord = false;
     }
   }
-  else if (CServiceBroker::GetPVRManager().Clients()->SupportsTimers() && m_progItem->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+  else if (CServiceBroker::GetPVRManager().Clients()->SupportsTimers() && m_progItem->IsRecordable())
   {
     SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264);     /* Record */
     bHideRecord = false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -49,7 +49,8 @@ using namespace KODI::MESSAGING;
 #define CONTROL_BTN_OK                  7
 #define CONTROL_BTN_PLAY_RECORDING      8
 #define CONTROL_BTN_ADD_TIMER           9
-#define CONTROL_BTN_CHANNEL_GUIDE       10
+#define CONTROL_BTN_PLAY_TAG            10
+#define CONTROL_BTN_CHANNEL_GUIDE       11
 
 CGUIDialogPVRGuideInfo::CGUIDialogPVRGuideInfo(void)
     : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_INFO, "DialogPVRInfo.xml")
@@ -152,13 +153,15 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(CGUIMessage &message)
 {
   bool bReturn = false;
 
-  if (message.GetSenderId() == CONTROL_BTN_SWITCH || message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
+  if (message.GetSenderId() == CONTROL_BTN_SWITCH || message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING || message.GetSenderId() == CONTROL_BTN_PLAY_TAG)
   {
     Close();
 
     const CFileItemPtr item(new CFileItem(m_progItem));
     if (message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
       CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(item, true /* bCheckResume */);
+    if (message.GetSenderId() == CONTROL_BTN_PLAY_TAG && m_progItem->IsPlayable())
+      CServiceBroker::GetPVRManager().GUIActions()->PlayEpgTag(item, false /* bPlayMinimized */, true /* bCheckResume */);
     else
       CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, true /* bCheckResume */);
 
@@ -224,6 +227,10 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
   {
     /* not recording. hide the play recording button */
     SET_CONTROL_HIDDEN(CONTROL_BTN_PLAY_RECORDING);
+  }
+
+  if (!m_progItem->IsPlayable()) {
+    SET_CONTROL_HIDDEN(CONTROL_BTN_PLAY_TAG);
   }
 
   bool bHideRecord(true);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -767,9 +767,15 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
       continue;
 
-    // Drop TimerTypes that aren't rules if end time is in the past
-    if (!type->IsTimerRule() && m_timerInfoTag->EndAsLocalTime() < CDateTime::GetCurrentDateTime())
-      continue;
+    // Drop TimerTypes that aren't rules and cannot be recorded
+    if (!type->IsTimerRule())
+    {
+      const CPVREpgInfoTagPtr epgTag(m_timerInfoTag->GetEpgInfoTag(false));
+      // If we have an epg tag, ask the pvr addon if recording is possible, else, use the current time
+      bool canRecord = epgTag ? epgTag->IsRecordable() : m_timerInfoTag->EndAsLocalTime() >= CDateTime::GetCurrentDateTime();
+      if (!canRecord)
+        continue;
+    }
 
     if (!bFoundThisType && *type == *m_timerType)
       bFoundThisType = true;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -247,9 +247,9 @@ bool CPVREpgInfoTag::IsPlayable(void) const
   return CServiceBroker::GetPVRManager().Clients()->IsPlayable(shared_from_this());
 }
 
-const std::string CPVREpgInfoTag::GetStreamUrl(void) const
+const std::string CPVREpgInfoTag::GetStreamUrl(CStringPropertyMapPtr &properties) const
 {
-  return CServiceBroker::GetPVRManager().Clients()->GetEpgTagUrl(shared_from_this());
+  return CServiceBroker::GetPVRManager().Clients()->GetEpgTagUrl(shared_from_this(), properties);
 }
 
 bool CPVREpgInfoTag::IsRecordable(void) const

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -242,6 +242,16 @@ bool CPVREpgInfoTag::WasActive(void) const
   return (m_endTime < now);
 }
 
+bool CPVREpgInfoTag::IsPlayable(void) const
+{
+  return CServiceBroker::GetPVRManager().Clients()->IsPlayable(shared_from_this());
+}
+
+const std::string CPVREpgInfoTag::GetStreamUrl(void) const
+{
+  return CServiceBroker::GetPVRManager().Clients()->GetEpgTagUrl(shared_from_this());
+}
+
 bool CPVREpgInfoTag::IsRecordable(void) const
 {
   return CServiceBroker::GetPVRManager().Clients()->IsRecordable(shared_from_this());
@@ -513,6 +523,11 @@ std::string CPVREpgInfoTag::Icon(void) const
 std::string CPVREpgInfoTag::Path(void) const
 {
   return m_strFileNameAndPath;
+}
+
+void CPVREpgInfoTag::SetPath(const std::string &path)
+{
+  m_strFileNameAndPath = path;
 }
 
 bool CPVREpgInfoTag::HasTimer(void) const

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -242,6 +242,11 @@ bool CPVREpgInfoTag::WasActive(void) const
   return (m_endTime < now);
 }
 
+bool CPVREpgInfoTag::IsRecordable(void) const
+{
+  return CServiceBroker::GetPVRManager().Clients()->IsRecordable(shared_from_this());
+}
+
 bool CPVREpgInfoTag::IsUpcoming(void) const
 {
   CDateTime now = GetCurrentPlayingTime();

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -38,7 +38,7 @@ namespace PVR
 {
   class CPVREpg;
 
-  class CPVREpgInfoTag : public ISerializable
+  class CPVREpgInfoTag : public ISerializable, public std::enable_shared_from_this<CPVREpgInfoTag>
   {
     friend class CPVREpg;
     friend class CPVREpgDatabase;
@@ -82,6 +82,11 @@ namespace PVR
      * @return True if it's active, false otherwise.
      */
     bool IsActive(void) const;
+
+    /* @brief Check if this event can be recorded
+     * @return True if it can be recorded.
+     */
+    bool IsRecordable(void) const;
 
     /*!
      * @return True when this event has already passed, false otherwise.
@@ -402,6 +407,11 @@ namespace PVR
      */
     bool IsSeries() const;
 
+    /*!
+     *  @brief Return the m_iFlags as an unsigned int bitfield (for database use).
+     */
+    unsigned int Flags() const { return m_iFlags; }
+
   private:
 
     /*!
@@ -420,11 +430,6 @@ namespace PVR
      * @brief Get current time, taking timeshifting into account.
      */
     CDateTime GetCurrentPlayingTime(void) const;
-
-    /*!
-     *  @brief Return the m_iFlags as an unsigned int bitfield (for database use).
-     */
-    unsigned int Flags() const { return m_iFlags; }
 
     bool                     m_bNotify;            /*!< notify on start */
 

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -94,9 +94,10 @@ namespace PVR
     bool IsPlayable(void) const;
 
     /* @brief Get the stream url for this event
+     * @param properties The properties to be provided to the file item
      * @return The stream url, empty string if playing is not possible
      */
-    const std::string GetStreamUrl(void) const;
+    const std::string GetStreamUrl(CStringPropertyMapPtr &properties) const;
 
     /*!
      * @return True when this event has already passed, false otherwise.

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -88,6 +88,16 @@ namespace PVR
      */
     bool IsRecordable(void) const;
 
+    /* @brief Check if this event can be played
+     * @return True if it can be played.
+     */
+    bool IsPlayable(void) const;
+
+    /* @brief Get the stream url for this event
+     * @return The stream url, empty string if playing is not possible
+     */
+    const std::string GetStreamUrl(void) const;
+
     /*!
      * @return True when this event has already passed, false otherwise.
      */
@@ -313,6 +323,12 @@ namespace PVR
      * @return The path.
      */
     std::string Path(void) const;
+
+    /*!
+     * @brief Set the path to this event.
+     * @param path The path
+     */
+    void SetPath(const std::string &path);
 
     /*!
      * @brief Set a timer for this event.

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -789,9 +789,9 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CPVREpgInfoTagPtr &tag
   }
 
   /* check if the epg end date is in the future */
-  if (tag->EndAsLocalTime() < CDateTime::GetCurrentDateTime() && !bCreateRule)
+  if (!tag->IsRecordable() && !bCreateRule)
   {
-    CLog::Log(LOGERROR, "%s - end time is in the past", __FUNCTION__);
+    CLog::Log(LOGERROR, "%s - is not recordable", __FUNCTION__);
     return CPVRTimerInfoTagPtr();
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -334,6 +334,8 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                       // past event
                       if (tag->HasRecording())
                         CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(pItem, true);
+                      if (tag->IsPlayable())
+                        CServiceBroker::GetPVRManager().GUIActions()->PlayEpgTag(pItem, false /* bPlayMinimized */, true /* bCheckResume */);
                       else
                         CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(pItem);
                     }


### PR DESCRIPTION
My IPTV provider allows recordings back in the past. As Kodi currently does not allow that, I would like to give the PVR addon the possibility to decide if a EPG entry can be recorded or not. If the addon does not implement the functions (returns PVR_ERROR_NOT_IMPLEMENTED), the old behaviour will be used.

Please let me know if there is a preferred way for this to be implemented. And lets hope I didn't touch a deferred feature again ;)
