### PR TITLE
Peripheral API v1.1.0: Fix mapping D-pad on RPi for some controllers

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -2760,6 +2760,7 @@
 		5EF800FF1A97892A0035AA4D /* ReplayGain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplayGain.h; sourceTree = "<group>"; };
 		6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RumbleGenerator.cpp; path = joysticks/RumbleGenerator.cpp; sourceTree = "<group>"; };
 		6815C1401CC7BADB000DB91A /* RumbleGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RumbleGenerator.h; path = joysticks/RumbleGenerator.h; sourceTree = "<group>"; };
+		6819C8B61D76492500A60E30 /* IButtonMapCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IButtonMapCallback.h; path = joysticks/IButtonMapCallback.h; sourceTree = "<group>"; };
 		6838CF7F1D6665510057F17B /* DeadzoneFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeadzoneFilter.cpp; path = joysticks/DeadzoneFilter.cpp; sourceTree = "<group>"; };
 		6838CF801D6665510057F17B /* DeadzoneFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeadzoneFilter.h; path = joysticks/DeadzoneFilter.h; sourceTree = "<group>"; };
 		6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DriverReceiving.cpp; path = joysticks/generic/DriverReceiving.cpp; sourceTree = "<group>"; };
@@ -6154,6 +6155,7 @@
 				68AE5BAE1C9241DF00C4D527 /* DriverPrimitive.cpp */,
 				68AE5BAF1C9241DF00C4D527 /* DriverPrimitive.h */,
 				68AE5BB01C9241DF00C4D527 /* IButtonMap.h */,
+				6819C8B61D76492500A60E30 /* IButtonMapCallback.h */,
 				68AE5BB11C9241DF00C4D527 /* IButtonMapper.h */,
 				68AE5BB21C9241DF00C4D527 /* IDriverHandler.h */,
 				6861B9EC1CC248F600F62655 /* IDriverReceiver.h */,

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.22" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.23" provider-name="Team-Kodi">
 	<backwards-compatibility abi="1.0.19"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.24" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.19"/>
+<addon id="kodi.peripheral" version="1.1.0" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.1.0"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.23" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.24" provider-name="Team-Kodi">
 	<backwards-compatibility abi="1.0.19"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
@@ -166,12 +166,18 @@ extern "C"
                                unsigned int feature_count, JOYSTICK_FEATURE* features);
 
   /*!
+   * @brief Save the button map for the given joystick
+   * @param joystick      The device's joystick properties
+   */
+  void SaveButtonMap(const JOYSTICK_INFO* joystick);
+
+  /*!
    * @brief Reset the button map for the given joystick and controller profile ID
    * @param joystick      The device's joystick properties
    * @param controller_id The game controller profile being reset
    */
   void ResetButtonMap(const JOYSTICK_INFO* joystick, const char* controller_id);
-  
+
   /*!
    * @brief Powers off the given joystick if supported
    * @param index  The joystick's driver index
@@ -202,6 +208,7 @@ extern "C"
     pClient->GetFeatures                    = GetFeatures;
     pClient->FreeFeatures                   = FreeFeatures;
     pClient->MapFeatures                    = MapFeatures;
+    pClient->SaveButtonMap                  = SaveButtonMap;
     pClient->ResetButtonMap                 = ResetButtonMap;
     pClient->PowerOffJoystick               = PowerOffJoystick;
 #endif

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -51,7 +51,7 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.23"
+#define PERIPHERAL_API_VERSION "1.0.24"
 
 /* min. Peripheral API version */
 #define PERIPHERAL_MIN_API_VERSION "1.0.19"
@@ -251,42 +251,34 @@ extern "C"
     JOYSTICK_FEATURE_TYPE_MOTOR,
   } JOYSTICK_FEATURE_TYPE;
 
-  typedef struct JOYSTICK_FEATURE_SCALAR
+  typedef enum JOYSTICK_FEATURE_PRIMITIVE
   {
-    struct JOYSTICK_DRIVER_PRIMITIVE primitive;
-  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_SCALAR;
+    // Scalar feature
+    JOYSTICK_SCALAR_PRIMITIVE = 0,
 
-  typedef struct JOYSTICK_FEATURE_ANALOG_STICK
-  {
-    struct JOYSTICK_DRIVER_PRIMITIVE up;
-    struct JOYSTICK_DRIVER_PRIMITIVE down;
-    struct JOYSTICK_DRIVER_PRIMITIVE right;
-    struct JOYSTICK_DRIVER_PRIMITIVE left;
-  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_ANALOG_STICK;
+    // Analog stick
+    JOYSTICK_ANALOG_STICK_UP = 0,
+    JOYSTICK_ANALOG_STICK_DOWN = 1,
+    JOYSTICK_ANALOG_STICK_RIGHT = 2,
+    JOYSTICK_ANALOG_STICK_LEFT = 3,
 
-  typedef struct JOYSTICK_FEATURE_ACCELEROMETER
-  {
-    struct JOYSTICK_DRIVER_PRIMITIVE positive_x;
-    struct JOYSTICK_DRIVER_PRIMITIVE positive_y;
-    struct JOYSTICK_DRIVER_PRIMITIVE positive_z;
-  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_ACCELEROMETER;
+    // Accelerometer
+    JOYSTICK_ACCELEROMETER_POSITIVE_X = 0,
+    JOYSTICK_ACCELEROMETER_POSITIVE_Y = 1,
+    JOYSTICK_ACCELEROMETER_POSITIVE_Z = 2,
 
-  typedef struct JOYSTICK_FEATURE_MOTOR
-  {
-    struct JOYSTICK_DRIVER_PRIMITIVE primitive;
-  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_MOTOR;
+    // Motor
+    JOYSTICK_MOTOR_PRIMITIVE = 0,
+
+    // Maximum number of primitives
+    JOYSTICK_PRIMITIVE_MAX = 4,
+  } JOYSTICK_FEATURE_PRIMITIVE;
 
   typedef struct JOYSTICK_FEATURE
   {
     char*                                   name;
     JOYSTICK_FEATURE_TYPE                   type;
-    union
-    {
-      struct JOYSTICK_FEATURE_SCALAR        scalar;
-      struct JOYSTICK_FEATURE_ANALOG_STICK  analog_stick;
-      struct JOYSTICK_FEATURE_ACCELEROMETER accelerometer;
-      struct JOYSTICK_FEATURE_MOTOR         motor;
-    };
+    struct JOYSTICK_DRIVER_PRIMITIVE        primitives[JOYSTICK_PRIMITIVE_MAX];
   } ATTRIBUTE_PACKED JOYSTICK_FEATURE;
   ///}
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -51,7 +51,7 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.22"
+#define PERIPHERAL_API_VERSION "1.0.23"
 
 /* min. Peripheral API version */
 #define PERIPHERAL_MIN_API_VERSION "1.0.19"

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -51,10 +51,10 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.24"
+#define PERIPHERAL_API_VERSION "1.1.0"
 
 /* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.0.19"
+#define PERIPHERAL_MIN_API_VERSION "1.1.0"
 
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
@@ -305,6 +305,7 @@ extern "C"
     PERIPHERAL_ERROR (__cdecl* GetFeatures)(const JOYSTICK_INFO*, const char*, unsigned int*, JOYSTICK_FEATURE**);
     void             (__cdecl* FreeFeatures)(unsigned int, JOYSTICK_FEATURE*);
     PERIPHERAL_ERROR (__cdecl* MapFeatures)(const JOYSTICK_INFO*, const char*, unsigned int, JOYSTICK_FEATURE*);
+    void             (__cdecl* SaveButtonMap)(const JOYSTICK_INFO*);
     void             (__cdecl* ResetButtonMap)(const JOYSTICK_INFO*, const char*);
     void             (__cdecl* PowerOffJoystick)(unsigned int);
     ///}

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
@@ -638,9 +638,11 @@ namespace ADDON
 
     const std::string& Name(void) const { return m_name; }
     JOYSTICK_FEATURE_TYPE Type(void) const { return m_type; }
+    bool IsValid() const { return m_type != JOYSTICK_FEATURE_TYPE_UNKNOWN; }
 
     void SetName(const std::string& name) { m_name = name; }
     void SetType(JOYSTICK_FEATURE_TYPE type) { m_type = type; }
+    void SetInvalid(void) { m_type = JOYSTICK_FEATURE_TYPE_UNKNOWN; }
 
     // Scalar methods
     const DriverPrimitive& Primitive(void) const { return m_primitives[0]; }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
@@ -553,32 +553,10 @@ namespace ADDON
    * [1] All three driver primitives (buttons, hats and axes) have a state that
    *     can be represented using a single scalar value. For this reason,
    *     features that map to a single primitive are called "scalar features".
-   *
-   * Features can be mapped to a variable number of driver primitives. The names
-   * of the primitives for each feature are:
-   *
-   *    Scalar feature:
-   *       - primitive
-   *
-   *    Analog stick:
-   *       - up
-   *       - down
-   *       - right
-   *       - left
-   *
-   *    Accelerometer:
-   *       - positive X
-   *       - positive Y
-   *       - positive Z
-   *
-   *    Motor:
-   *       - primitive
    */
   class JoystickFeature
   {
   public:
-    enum { MAX_PRIMITIVES = 4 };
-
     JoystickFeature(const std::string& name = "", JOYSTICK_FEATURE_TYPE type = JOYSTICK_FEATURE_TYPE_UNKNOWN) :
       m_name(name),
       m_type(type)
@@ -594,28 +572,8 @@ namespace ADDON
       m_name(feature.name ? feature.name : ""),
       m_type(feature.type)
     {
-      switch (m_type)
-      {
-        case JOYSTICK_FEATURE_TYPE_SCALAR:
-          SetPrimitive(feature.scalar.primitive);
-          break;
-        case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
-          SetUp(feature.analog_stick.up);
-          SetDown(feature.analog_stick.down);
-          SetRight(feature.analog_stick.right);
-          SetLeft(feature.analog_stick.left);
-          break;
-        case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
-          SetPositiveX(feature.accelerometer.positive_x);
-          SetPositiveY(feature.accelerometer.positive_y);
-          SetPositiveZ(feature.accelerometer.positive_z);
-          break;
-        case JOYSTICK_FEATURE_TYPE_MOTOR:
-          SetPrimitive(feature.motor.primitive);
-          break;
-        default:
-          break;
-      }
+      for (unsigned int i = 0; i < JOYSTICK_PRIMITIVE_MAX; i++)
+        m_primitives[i] = feature.primitives[i];
     }
 
     JoystickFeature& operator=(const JoystickFeature& rhs)
@@ -644,58 +602,19 @@ namespace ADDON
     void SetType(JOYSTICK_FEATURE_TYPE type) { m_type = type; }
     void SetInvalid(void) { m_type = JOYSTICK_FEATURE_TYPE_UNKNOWN; }
 
-    // Scalar methods
-    const DriverPrimitive& Primitive(void) const { return m_primitives[0]; }
-    void SetPrimitive(const DriverPrimitive& primitive) { m_primitives[0] = primitive; }
+    const DriverPrimitive& Primitive(JOYSTICK_FEATURE_PRIMITIVE which) const { return m_primitives[which]; }
+    void SetPrimitive(JOYSTICK_FEATURE_PRIMITIVE which, const DriverPrimitive& primitive) { m_primitives[which] = primitive; }
 
-    // Analog stick methods
-    const DriverPrimitive& Up(void) const { return m_primitives[0]; }
-    const DriverPrimitive& Down(void) const { return m_primitives[1]; }
-    const DriverPrimitive& Right(void) const { return m_primitives[2]; }
-    const DriverPrimitive& Left(void) const { return m_primitives[3]; }
-    void SetUp(const DriverPrimitive& primitive) { m_primitives[0] = primitive; }
-    void SetDown(const DriverPrimitive& primitive) { m_primitives[1] = primitive; }
-    void SetRight(const DriverPrimitive& primitive) { m_primitives[2] = primitive; }
-    void SetLeft(const DriverPrimitive& primitive) { m_primitives[3] = primitive; }
-
-    // Accelerometer methods
-    const DriverPrimitive& PositiveX(void) const { return m_primitives[0]; }
-    const DriverPrimitive& PositiveY(void) const { return m_primitives[1]; }
-    const DriverPrimitive& PositiveZ(void) const { return m_primitives[2]; }
-    void SetPositiveX(const DriverPrimitive& primitive) { m_primitives[0] = primitive; }
-    void SetPositiveY(const DriverPrimitive& primitive) { m_primitives[1] = primitive; }
-    void SetPositiveZ(const DriverPrimitive& primitive) { m_primitives[2] = primitive; }
-
-    // Access primitives
-    std::array<DriverPrimitive, MAX_PRIMITIVES>& Primitives() { return m_primitives; }
-    const std::array<DriverPrimitive, MAX_PRIMITIVES>& Primitives() const { return m_primitives; }
+    std::array<DriverPrimitive, JOYSTICK_PRIMITIVE_MAX>& Primitives() { return m_primitives; }
+    const std::array<DriverPrimitive, JOYSTICK_PRIMITIVE_MAX>& Primitives() const { return m_primitives; }
 
     void ToStruct(JOYSTICK_FEATURE& feature) const
     {
       feature.name = new char[m_name.length() + 1];
       feature.type = m_type;
-      switch (m_type)
-      {
-        case JOYSTICK_FEATURE_TYPE_SCALAR:
-          Primitive().ToStruct(feature.scalar.primitive);
-          break;
-        case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
-          Up().ToStruct(feature.analog_stick.up);
-          Down().ToStruct(feature.analog_stick.down);
-          Right().ToStruct(feature.analog_stick.right);
-          Left().ToStruct(feature.analog_stick.left);
-          break;
-        case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
-          PositiveX().ToStruct(feature.accelerometer.positive_x);
-          PositiveY().ToStruct(feature.accelerometer.positive_y);
-          PositiveZ().ToStruct(feature.accelerometer.positive_z);
-          break;
-        case JOYSTICK_FEATURE_TYPE_MOTOR:
-          Primitive().ToStruct(feature.motor.primitive);
-          break;
-        default:
-          break;
-      }
+      for (unsigned int i = 0; i < JOYSTICK_PRIMITIVE_MAX; i++)
+        m_primitives[i].ToStruct(feature.primitives[i]);
+
       std::strcpy(feature.name, m_name.c_str());
     }
 
@@ -707,7 +626,7 @@ namespace ADDON
   private:
     std::string                  m_name;
     JOYSTICK_FEATURE_TYPE        m_type;
-    std::array<DriverPrimitive, MAX_PRIMITIVES> m_primitives;
+    std::array<DriverPrimitive, JOYSTICK_PRIMITIVE_MAX> m_primitives;
   };
 
   typedef PeripheralVector<JoystickFeature, JOYSTICK_FEATURE> JoystickFeatures;

--- a/xbmc/games/controllers/guicontrols/GUIAnalogStickButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIAnalogStickButton.cpp
@@ -84,19 +84,21 @@ bool CGUIAnalogStickButton::IsFinished(void) const
   return m_state >= STATE::FINISHED;
 }
 
-JOYSTICK::CARDINAL_DIRECTION CGUIAnalogStickButton::GetDirection(void) const
+JOYSTICK::ANALOG_STICK_DIRECTION CGUIAnalogStickButton::GetDirection(void) const
 {
+  using namespace JOYSTICK;
+
   switch (m_state)
   {
-    case STATE::ANALOG_STICK_UP:    return JOYSTICK::CARDINAL_DIRECTION::UP;
-    case STATE::ANALOG_STICK_RIGHT: return JOYSTICK::CARDINAL_DIRECTION::RIGHT;
-    case STATE::ANALOG_STICK_DOWN:  return JOYSTICK::CARDINAL_DIRECTION::DOWN;
-    case STATE::ANALOG_STICK_LEFT:  return JOYSTICK::CARDINAL_DIRECTION::LEFT;
+    case STATE::ANALOG_STICK_UP:    return ANALOG_STICK_DIRECTION::UP;
+    case STATE::ANALOG_STICK_RIGHT: return ANALOG_STICK_DIRECTION::RIGHT;
+    case STATE::ANALOG_STICK_DOWN:  return ANALOG_STICK_DIRECTION::DOWN;
+    case STATE::ANALOG_STICK_LEFT:  return ANALOG_STICK_DIRECTION::LEFT;
     default:
       break;
   }
 
-  return JOYSTICK::CARDINAL_DIRECTION::UNKNOWN;
+  return ANALOG_STICK_DIRECTION::UNKNOWN;
 }
 
 void CGUIAnalogStickButton::Reset(void)

--- a/xbmc/games/controllers/guicontrols/GUIAnalogStickButton.h
+++ b/xbmc/games/controllers/guicontrols/GUIAnalogStickButton.h
@@ -36,7 +36,7 @@ namespace GAME
     // implementation of IFeatureButton
     virtual bool PromptForInput(CEvent& waitEvent) override;
     virtual bool IsFinished(void) const override;
-    virtual JOYSTICK::CARDINAL_DIRECTION GetDirection(void) const override;
+    virtual JOYSTICK::ANALOG_STICK_DIRECTION GetDirection(void) const override;
     virtual void Reset(void) override;
 
   private:

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.h
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.h
@@ -44,7 +44,7 @@ namespace GAME
 
     // partial implementation of IFeatureButton
     virtual const CControllerFeature& Feature(void) const override { return m_feature; }
-    virtual JOYSTICK::CARDINAL_DIRECTION GetDirection(void) const override { return JOYSTICK::CARDINAL_DIRECTION::UNKNOWN; }
+    virtual JOYSTICK::ANALOG_STICK_DIRECTION GetDirection(void) const override { return JOYSTICK::ANALOG_STICK_DIRECTION::UNKNOWN; }
 
   protected:
     bool DoPrompt(const std::string& strPrompt, const std::string& strWarn, const std::string& strFeature, CEvent& waitEvent);

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -165,30 +165,14 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap, cons
       {
         case FEATURE_TYPE::SCALAR:
         {
-          bHandled = buttonMap->AddScalar(feature.Name(), primitive);
+          buttonMap->AddScalar(feature.Name(), primitive);
+          bHandled = true;
           break;
         }
         case FEATURE_TYPE::ANALOG_STICK:
         {
-          CDriverPrimitive up;
-          CDriverPrimitive down;
-          CDriverPrimitive right;
-          CDriverPrimitive left;
-
-          buttonMap->GetAnalogStick(feature.Name(), up, down, right, left);
-
-          switch (currentDirection)
-          {
-            case ANALOG_STICK_DIRECTION::UP:    up    = primitive; break;
-            case ANALOG_STICK_DIRECTION::DOWN:  down  = primitive; break;
-            case ANALOG_STICK_DIRECTION::RIGHT: right = primitive; break;
-            case ANALOG_STICK_DIRECTION::LEFT:  left  = primitive; break;
-            default:
-              break;
-          }
-
-          bHandled = buttonMap->AddAnalogStick(feature.Name(), up, down, right, left);
-
+          buttonMap->AddAnalogStick(feature.Name(), currentDirection, primitive);
+          bHandled = true;
           break;
         }
         default:

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -23,6 +23,7 @@
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
 #include "input/joysticks/IButtonMap.h"
+#include "input/joysticks/IButtonMapCallback.h"
 #include "input/InputManager.h"
 #include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
@@ -124,6 +125,9 @@ void CGUIConfigurationWizard::Process(void)
 
     m_currentButton = nullptr;
   }
+
+  if (ButtonMapCallback())
+    ButtonMapCallback()->SaveButtonMap();
 
   RemoveHooks();
 

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -41,7 +41,7 @@ CGUIConfigurationWizard::CGUIConfigurationWizard() :
 void CGUIConfigurationWizard::InitializeState(void)
 {
   m_currentButton = nullptr;
-  m_currentDirection = JOYSTICK::CARDINAL_DIRECTION::UNKNOWN;
+  m_currentDirection = JOYSTICK::ANALOG_STICK_DIRECTION::UNKNOWN;
   m_history.clear();
 }
 
@@ -151,7 +151,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap, cons
   {
     // Get the current state of the thread
     IFeatureButton* currentButton;
-    CARDINAL_DIRECTION currentDirection;
+    ANALOG_STICK_DIRECTION currentDirection;
     {
       CSingleLock lock(m_stateMutex);
       currentButton = m_currentButton;
@@ -179,10 +179,10 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap, cons
 
           switch (currentDirection)
           {
-            case CARDINAL_DIRECTION::UP:    up    = primitive; break;
-            case CARDINAL_DIRECTION::DOWN:  down  = primitive; break;
-            case CARDINAL_DIRECTION::RIGHT: right = primitive; break;
-            case CARDINAL_DIRECTION::LEFT:  left  = primitive; break;
+            case ANALOG_STICK_DIRECTION::UP:    up    = primitive; break;
+            case ANALOG_STICK_DIRECTION::DOWN:  down  = primitive; break;
+            case ANALOG_STICK_DIRECTION::RIGHT: right = primitive; break;
+            case ANALOG_STICK_DIRECTION::LEFT:  left  = primitive; break;
             default:
               break;
           }

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -77,7 +77,7 @@ namespace GAME
 
     // State variables and mutex
     IFeatureButton*                      m_currentButton;
-    JOYSTICK::CARDINAL_DIRECTION         m_currentDirection;
+    JOYSTICK::ANALOG_STICK_DIRECTION     m_currentDirection;
     std::set<JOYSTICK::CDriverPrimitive> m_history; // History to avoid repeated features
     CCriticalSection                     m_stateMutex;
 

--- a/xbmc/games/controllers/windows/IConfigurationWindow.h
+++ b/xbmc/games/controllers/windows/IConfigurationWindow.h
@@ -167,7 +167,7 @@ namespace GAME
      * \return The next direction to be prompted, or UNKNOWN if this isn't an
      *         analog stick or the prompt is finished
      */
-    virtual JOYSTICK::CARDINAL_DIRECTION GetDirection(void) const = 0;
+    virtual JOYSTICK::ANALOG_STICK_DIRECTION GetDirection(void) const = 0;
 
     /*!
      * \brief Reset button after prompting for input has finished

--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADERS DeadzoneFilter.h
             DefaultJoystick.h
             DriverPrimitive.h
             IButtonMap.h
+            IButtonMapCallback.h
             IButtonMapper.h
             IDriverHandler.h
             IDriverReceiver.h

--- a/xbmc/input/joysticks/DeadzoneFilter.cpp
+++ b/xbmc/input/joysticks/DeadzoneFilter.cpp
@@ -24,6 +24,8 @@
 #include "peripherals/devices/Peripheral.h"
 #include "utils/log.h"
 
+#include <vector>
+
 using namespace JOYSTICK;
 
 // Settings for analog sticks
@@ -53,22 +55,26 @@ float CDeadzoneFilter::FilterAxis(unsigned int axisIndex, float axisValue)
 
 bool CDeadzoneFilter::GetDeadzone(unsigned int axisIndex, float& deadzone, const char* featureName, const char* settingName)
 {
-  CDriverPrimitive up;
-  CDriverPrimitive down;
-  CDriverPrimitive right;
-  CDriverPrimitive left;
+  std::vector<ANALOG_STICK_DIRECTION> dirs = {
+    ANALOG_STICK_DIRECTION::UP,
+    ANALOG_STICK_DIRECTION::RIGHT,
+    ANALOG_STICK_DIRECTION::DOWN,
+    ANALOG_STICK_DIRECTION::LEFT,
+  };
 
-  if (m_buttonMap->GetAnalogStick(featureName, up, down, right, left))
+  CDriverPrimitive primitive;
+  for (auto dir : dirs)
   {
-    if (up.Index() == axisIndex ||
-        down.Index() == axisIndex ||
-        right.Index() == axisIndex ||
-        left.Index() == axisIndex)
+    if (m_buttonMap->GetAnalogStick(featureName, dir, primitive))
     {
-      deadzone = m_peripheral->GetSettingFloat(settingName);
-      return true;
+      if (primitive.Type() == PRIMITIVE_TYPE::SEMIAXIS && primitive.Index() == axisIndex)
+      {
+        deadzone = m_peripheral->GetSettingFloat(settingName);
+        return true;
+      }
     }
   }
+
   return false;
 }
 

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -54,10 +54,10 @@ bool CDefaultJoystick::HasFeature(const FeatureName& feature) const
     return true;
 
   // Try analog stick directions
-  if (GetKeyID(feature, CARDINAL_DIRECTION::UP)    != 0 ||
-      GetKeyID(feature, CARDINAL_DIRECTION::DOWN)  != 0 ||
-      GetKeyID(feature, CARDINAL_DIRECTION::RIGHT) != 0 ||
-      GetKeyID(feature, CARDINAL_DIRECTION::LEFT)  != 0)
+  if (GetKeyID(feature, ANALOG_STICK_DIRECTION::UP)    != 0 ||
+      GetKeyID(feature, ANALOG_STICK_DIRECTION::DOWN)  != 0 ||
+      GetKeyID(feature, ANALOG_STICK_DIRECTION::RIGHT) != 0 ||
+      GetKeyID(feature, ANALOG_STICK_DIRECTION::LEFT)  != 0)
     return true;
 
   return false;
@@ -108,13 +108,13 @@ bool CDefaultJoystick::OnButtonMotion(const FeatureName& feature, float magnitud
 bool CDefaultJoystick::OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs)
 {
   // Calculate the direction of the stick's position
-  const CARDINAL_DIRECTION analogStickDir = CJoystickTranslator::VectorToCardinalDirection(x, y);
+  const ANALOG_STICK_DIRECTION analogStickDir = CJoystickTranslator::VectorToAnalogStickDirection(x, y);
 
   // Calculate the magnitude projected onto that direction
   const float magnitude = std::max(std::abs(x), std::abs(y));
 
   // Deactivate directions in which the stick is not pointing first
-  for (std::vector<CARDINAL_DIRECTION>::const_iterator it = GetDirections().begin(); it != GetDirections().end(); ++it)
+  for (std::vector<ANALOG_STICK_DIRECTION>::const_iterator it = GetDirections().begin(); it != GetDirections().end(); ++it)
   {
     if (*it != analogStickDir)
       DeactivateDirection(feature, *it);
@@ -129,7 +129,7 @@ bool CDefaultJoystick::OnAccelerometerMotion(const FeatureName& feature, float x
   return false; //! @todo implement
 }
 
-bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir, unsigned int motionTimeMs)
+bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magnitude, ANALOG_STICK_DIRECTION dir, unsigned int motionTimeMs)
 {
   // Calculate the button key ID and input type for the analog stick's direction
   const unsigned int  keyId     = GetKeyID(feature, dir);
@@ -150,7 +150,7 @@ bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magni
   return false;
 }
 
-void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, CARDINAL_DIRECTION dir)
+void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, ANALOG_STICK_DIRECTION dir)
 {
   // Calculate the button key ID and input type for this direction
   const unsigned int  keyId     = GetKeyID(feature, dir);
@@ -166,7 +166,7 @@ void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, CARDINAL_
   }
 }
 
-unsigned int CDefaultJoystick::GetKeyID(const FeatureName& feature, CARDINAL_DIRECTION dir /* = CARDINAL_DIRECTION::UNKNOWN */)
+unsigned int CDefaultJoystick::GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir /* = ANALOG_STICK_DIRECTION::UNKNOWN */)
 {
   if      (feature == "a")             return KEY_JOYSTICK_BUTTON_A;
   else if (feature == "b")             return KEY_JOYSTICK_BUTTON_B;
@@ -189,10 +189,10 @@ unsigned int CDefaultJoystick::GetKeyID(const FeatureName& feature, CARDINAL_DIR
   {
     switch (dir)
     {
-      case CARDINAL_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_UP;
-      case CARDINAL_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_DOWN;
-      case CARDINAL_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_RIGHT;
-      case CARDINAL_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_LEFT;
+      case ANALOG_STICK_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_UP;
+      case ANALOG_STICK_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_DOWN;
+      case ANALOG_STICK_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_RIGHT;
+      case ANALOG_STICK_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_LEFT;
       default:
         break;
     }
@@ -201,10 +201,10 @@ unsigned int CDefaultJoystick::GetKeyID(const FeatureName& feature, CARDINAL_DIR
   {
     switch (dir)
     {
-      case CARDINAL_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_UP;
-      case CARDINAL_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_DOWN;
-      case CARDINAL_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_RIGHT;
-      case CARDINAL_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_LEFT;
+      case ANALOG_STICK_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_UP;
+      case ANALOG_STICK_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_DOWN;
+      case ANALOG_STICK_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_RIGHT;
+      case ANALOG_STICK_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_LEFT;
       default:
         break;
     }
@@ -214,15 +214,15 @@ unsigned int CDefaultJoystick::GetKeyID(const FeatureName& feature, CARDINAL_DIR
   return 0;
 }
 
-const std::vector<CARDINAL_DIRECTION>& CDefaultJoystick::GetDirections(void)
+const std::vector<ANALOG_STICK_DIRECTION>& CDefaultJoystick::GetDirections(void)
 {
-  static std::vector<CARDINAL_DIRECTION> directions;
+  static std::vector<ANALOG_STICK_DIRECTION> directions;
   if (directions.empty())
   {
-    directions.push_back(CARDINAL_DIRECTION::UP);
-    directions.push_back(CARDINAL_DIRECTION::DOWN);
-    directions.push_back(CARDINAL_DIRECTION::RIGHT);
-    directions.push_back(CARDINAL_DIRECTION::LEFT);
+    directions.push_back(ANALOG_STICK_DIRECTION::UP);
+    directions.push_back(ANALOG_STICK_DIRECTION::DOWN);
+    directions.push_back(ANALOG_STICK_DIRECTION::RIGHT);
+    directions.push_back(ANALOG_STICK_DIRECTION::LEFT);
   }
   return directions;
 }

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -64,8 +64,8 @@ namespace JOYSTICK
     void AbortRumble() { return m_rumbleGenerator.AbortRumble(); }
 
   private:
-    bool ActivateDirection(const FeatureName& feature, float magnitude, CARDINAL_DIRECTION dir, unsigned int motionTimeMs);
-    void DeactivateDirection(const FeatureName& feature, CARDINAL_DIRECTION dir);
+    bool ActivateDirection(const FeatureName& feature, float magnitude, ANALOG_STICK_DIRECTION dir, unsigned int motionTimeMs);
+    void DeactivateDirection(const FeatureName& feature, ANALOG_STICK_DIRECTION dir);
 
     /*!
      * \brief Get the keymap key, as defined in Key.h, for the specified
@@ -76,12 +76,12 @@ namespace JOYSTICK
      *
      * \return The key ID, or 0 if unknown
      */
-    static unsigned int GetKeyID(const FeatureName& feature, CARDINAL_DIRECTION dir = CARDINAL_DIRECTION::UNKNOWN);
+    static unsigned int GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN);
 
     /*!
      * \brief Return a vector of the four cardinal directions
      */
-    static const std::vector<CARDINAL_DIRECTION>& GetDirections(void);
+    static const std::vector<ANALOG_STICK_DIRECTION>& GetDirections(void);
 
     IKeymapHandler* const  m_handler;
 

--- a/xbmc/input/joysticks/IButtonMap.h
+++ b/xbmc/input/joysticks/IButtonMap.h
@@ -188,5 +188,10 @@ namespace JOYSTICK
       const CDriverPrimitive& positiveY,
       const CDriverPrimitive& positiveZ
     ) = 0;
+
+    /*!
+     * \brief Save the button map
+     */
+    virtual void SaveButtonMap() = 0;
   };
 }

--- a/xbmc/input/joysticks/IButtonMap.h
+++ b/xbmc/input/joysticks/IButtonMap.h
@@ -118,51 +118,39 @@ namespace JOYSTICK
      * \return True if the feature was updated, false if the feature is
      *         unchanged or failure occurs
      */
-    virtual bool AddScalar(
+    virtual void AddScalar(
       const FeatureName& feature,
       const CDriverPrimitive& primitive
     ) = 0;
 
     /*!
-     * \brief Get an analog stick from the button map
+     * \brief Get an analog stick direction from the button map
      *
-     * \param feature  Must be an analog stick or this will return false
-     * \param up       The primitive mapped to the up direction (possibly unknown)
-     * \param down     The primitive mapped to the down direction (possibly unknown)
-     * \param right    The primitive mapped to the right direction (possibly unknown)
-     * \param left     The primitive mapped to the left direction (possibly unknown)
+     * \param      feature   Must be an analog stick or this will return false
+     * \param      direction The direction whose primitive is to be retrieved
+     * \param[out] primitive The primitive mapped to the specified direction
      *
-     * \return True if the feature resolved to an analog stick with at least 1 known direction
+     * \return True if the feature and direction resolved to a driver primitive
      */
     virtual bool GetAnalogStick(
       const FeatureName& feature,
-      CDriverPrimitive& up,
-      CDriverPrimitive& down,
-      CDriverPrimitive& right,
-      CDriverPrimitive& left
+      ANALOG_STICK_DIRECTION direction,
+      CDriverPrimitive& primitive
     ) = 0;
 
     /*!
-     * \brief Add or update an analog stick
+     * \brief Add or update an analog stick direction
      *
-     * \param feature  Must be an analog stick or this will return false
-     * \param up       The driver primitive for the up direction
-     * \param down     The driver primitive for the down direction
-     * \param right    The driver primitive for the right direction
-     * \param left     The driver primitive for the left direction
-     *
-     * It is not required that these primitives be axes. If a primitive is a
-     * semiaxis, its opposite should point to the same axis index but with
-     * opposite direction.
+     * \param feature   Must be an analog stick or this will return false
+     * \param direction The direction being mapped
+     * \param primitive The driver primitive for the specified analog stick and direction
      *
      * \return True if the analog stick was updated, false otherwise
      */
-    virtual bool AddAnalogStick(
+    virtual void AddAnalogStick(
       const FeatureName& feature,
-      const CDriverPrimitive& up,
-      const CDriverPrimitive& down,
-      const CDriverPrimitive& right,
-      const CDriverPrimitive& left
+      ANALOG_STICK_DIRECTION direction,
+      const CDriverPrimitive& primitive
     ) = 0;
 
     /*!
@@ -194,7 +182,7 @@ namespace JOYSTICK
      *
      * \return True if the accelerometer was updated, false if unchanged or failure occurred
      */
-    virtual bool AddAccelerometer(
+    virtual void AddAccelerometer(
       const FeatureName& feature,
       const CDriverPrimitive& positiveX,
       const CDriverPrimitive& positiveY,

--- a/xbmc/input/joysticks/IButtonMapCallback.h
+++ b/xbmc/input/joysticks/IButtonMapCallback.h
@@ -1,0 +1,37 @@
+/*
+*      Copyright (C) 2016 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with this Program; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+#pragma once
+
+namespace JOYSTICK
+{
+  /*!
+  * \brief Interface for handling button maps
+  */
+  class IButtonMapCallback
+  {
+  public:
+    virtual ~IButtonMapCallback() = default;
+
+    /*!
+    * \brief Save the button map
+    */
+    virtual void SaveButtonMap() = 0;
+  };
+}

--- a/xbmc/input/joysticks/IButtonMapper.h
+++ b/xbmc/input/joysticks/IButtonMapper.h
@@ -25,6 +25,7 @@ namespace JOYSTICK
 {
   class CDriverPrimitive;
   class IButtonMap;
+  class IButtonMapCallback;
 
   /*!
    * \ingroup joysticks
@@ -37,6 +38,8 @@ namespace JOYSTICK
   class IButtonMapper
   {
   public:
+    IButtonMapper() : m_callback(nullptr) { }
+
     virtual ~IButtonMapper(void) { }
 
     /*!
@@ -55,5 +58,13 @@ namespace JOYSTICK
      * \return True if action was mapped to a feature
      */
     virtual bool MapPrimitive(IButtonMap* buttonMap, const CDriverPrimitive& primitive) = 0;
+
+    // Button map callback interface
+    void SetButtonMapCallback(IButtonMapCallback* callback) { m_callback = callback; }
+    void ResetButtonMapCallback(void) { m_callback = nullptr; }
+    IButtonMapCallback* ButtonMapCallback(void) { return m_callback; }
+
+  private:
+    IButtonMapCallback* m_callback;
   };
 }

--- a/xbmc/input/joysticks/JoystickTranslator.cpp
+++ b/xbmc/input/joysticks/JoystickTranslator.cpp
@@ -50,12 +50,12 @@ SEMIAXIS_DIRECTION CJoystickTranslator::PositionToSemiAxisDirection(float positi
   return SEMIAXIS_DIRECTION::ZERO;
 }
 
-CARDINAL_DIRECTION CJoystickTranslator::VectorToCardinalDirection(float x, float y)
+ANALOG_STICK_DIRECTION CJoystickTranslator::VectorToAnalogStickDirection(float x, float y)
 {
-  if      (y >= x && y >  -x) return CARDINAL_DIRECTION::UP;
-  else if (y <  x && y >= -x) return CARDINAL_DIRECTION::RIGHT;
-  else if (y <= x && y <  -x) return CARDINAL_DIRECTION::DOWN;
-  else if (y >  x && y <= -x) return CARDINAL_DIRECTION::LEFT;
+  if      (y >= x && y >  -x) return ANALOG_STICK_DIRECTION::UP;
+  else if (y <  x && y >= -x) return ANALOG_STICK_DIRECTION::RIGHT;
+  else if (y <= x && y <  -x) return ANALOG_STICK_DIRECTION::DOWN;
+  else if (y >  x && y <= -x) return ANALOG_STICK_DIRECTION::LEFT;
 
-  return CARDINAL_DIRECTION::UNKNOWN;
+  return ANALOG_STICK_DIRECTION::UNKNOWN;
 }

--- a/xbmc/input/joysticks/JoystickTranslator.h
+++ b/xbmc/input/joysticks/JoystickTranslator.h
@@ -53,9 +53,9 @@ namespace JOYSTICK
      * \param x  The x component of the vector
      * \param y  The y component of the vector
      *
-     * \return The closest cardinal directon (up, down, right or left), or unknown
-     *         if x and y are both 0.
+     * \return The closest analog stick direction (up, down, right or left), or
+     *         ANALOG_STICK_DIRECTION::UNKNOWN if x and y are both 0
      */
-    static CARDINAL_DIRECTION VectorToCardinalDirection(float x, float y);
+    static ANALOG_STICK_DIRECTION VectorToAnalogStickDirection(float x, float y);
   };
 }

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -64,9 +64,9 @@ namespace JOYSTICK
   };
 
   /*!
-   * \brief Generic typedef for cardinal directions
+   * \brief Typedef for analog stick directions
    */
-  typedef HAT_DIRECTION CARDINAL_DIRECTION;
+  typedef HAT_DIRECTION  ANALOG_STICK_DIRECTION;
 
   /*!
    * \brief States in which a hat can be
@@ -83,11 +83,6 @@ namespace JOYSTICK
     LEFTUP    = LEFT  | UP,
     LEFTDOWN  = LEFT  | DOWN,
   };
-
-  /*!
-   * \brief Generic typedef for intercardinal directions
-   */
-  typedef HAT_STATE  INTERCARDINAL_DIRECTION;
 
   /*!
    * \brief Directions in which a semiaxis can point

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -20,6 +20,7 @@
 
 #include "ButtonMapping.h"
 #include "input/joysticks/DriverPrimitive.h"
+#include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/IButtonMapper.h"
 #include "input/joysticks/JoystickTranslator.h"
 #include "input/joysticks/JoystickUtils.h"
@@ -110,6 +111,11 @@ void CButtonMapping::ProcessAxisMotions(void)
       MapPrimitive(semiaxis.driverPrimitive);
     }
   }
+}
+
+void CButtonMapping::SaveButtonMap()
+{
+  m_buttonMap->SaveButtonMap();
 }
 
 void CButtonMapping::MapPrimitive(const CDriverPrimitive& primitive)

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "input/joysticks/DriverPrimitive.h"
+#include "input/joysticks/IButtonMapCallback.h"
 #include "input/joysticks/IDriverHandler.h"
 
 #include <vector>
@@ -38,7 +39,8 @@ namespace JOYSTICK
    * Button mapping commands are deferred for a short while after an axis is
    * activated, and only one command will be invoked per activation.
    */
-  class CButtonMapping : public IDriverHandler
+  class CButtonMapping : public IDriverHandler,
+                         public IButtonMapCallback
   {
   public:
     /*
@@ -56,6 +58,9 @@ namespace JOYSTICK
     virtual bool OnHatMotion(unsigned int hatIndex, HAT_STATE state) override;
     virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
     virtual void ProcessAxisMotions(void) override;
+
+    // implementation of IButtonMapCallback
+    virtual void SaveButtonMap() override;
 
   private:
     void MapPrimitive(const CDriverPrimitive& primitive);

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -49,6 +49,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "GUIUserMessages.h"
+#include "input/joysticks/IButtonMapper.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
@@ -805,6 +806,8 @@ void CPeripherals::RegisterJoystickButtonMapper(IButtonMapper* mapper)
 
 void CPeripherals::UnregisterJoystickButtonMapper(IButtonMapper* mapper)
 {
+  mapper->ResetButtonMapCallback();
+
   std::vector<CPeripheral*> peripherals;
   GetPeripheralsWithFeature(peripherals, FEATURE_JOYSTICK);
 

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -222,6 +222,12 @@ void CAddonButtonMap::AddAccelerometer(const FeatureName& feature,
   Load();
 }
 
+void CAddonButtonMap::SaveButtonMap()
+{
+  if (auto addon = m_addon.lock())
+    addon->SaveButtonMap(m_device);
+}
+
 CAddonButtonMap::DriverMap CAddonButtonMap::CreateLookupTable(const FeatureMap& features)
 {
   using namespace JOYSTICK;

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -354,7 +354,7 @@ bool CAddonButtonMap::UnmapPrimitive(const CDriverPrimitive& primitive)
     {
       ADDON::JoystickFeature& addonFeature = itFeature->second;
       ResetPrimitive(addonFeature, CPeripheralAddonTranslator::TranslatePrimitive(primitive));
-      if (addonFeature.Type() == JOYSTICK_FEATURE_TYPE_UNKNOWN)
+      if (!addonFeature.IsValid())
         m_features.erase(itFeature);
       bModified = true;
     }
@@ -372,7 +372,7 @@ void CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDO
       if (primitive == feature.Primitive())
       {
         CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
-        feature.SetType(JOYSTICK_FEATURE_TYPE_UNKNOWN);
+        feature.SetInvalid();
       }
       break;
     }
@@ -409,7 +409,7 @@ void CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDO
             feature.Left().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
         {
           CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
-          feature.SetType(JOYSTICK_FEATURE_TYPE_UNKNOWN);
+          feature.SetInvalid();
         }
       }
       break;
@@ -444,7 +444,7 @@ void CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDO
             feature.PositiveZ().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
         {
           CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
-          feature.SetType(JOYSTICK_FEATURE_TYPE_UNKNOWN);
+          feature.SetInvalid();
         }
       }
       break;

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -363,10 +363,8 @@ bool CAddonButtonMap::UnmapPrimitive(const CDriverPrimitive& primitive)
   return bModified;
 }
 
-bool CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDON::DriverPrimitive& primitive)
+void CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDON::DriverPrimitive& primitive)
 {
-  bool bModified = false;
-
   switch (feature.Type())
   {
     case JOYSTICK_FEATURE_TYPE_SCALAR:
@@ -375,12 +373,13 @@ bool CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDO
       {
         CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
         feature.SetType(JOYSTICK_FEATURE_TYPE_UNKNOWN);
-        bModified = true;
       }
       break;
     }
     case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
     {
+      bool bModified = false;
+
       if (primitive == feature.Up())
       {
         feature.SetUp(ADDON::DriverPrimitive());
@@ -417,6 +416,8 @@ bool CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDO
     }
     case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
     {
+      bool bModified = false;
+
       if (primitive == feature.PositiveX() ||
           primitive == CPeripheralAddonTranslator::Opposite(feature.PositiveX()))
       {
@@ -451,5 +452,4 @@ bool CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDO
     default:
       break;
   }
-  return bModified;
 }

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 
 #include <assert.h>
+#include <vector>
 
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
@@ -110,7 +111,7 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
     if (addonFeature.Type() == JOYSTICK_FEATURE_TYPE_SCALAR ||
         addonFeature.Type() == JOYSTICK_FEATURE_TYPE_MOTOR)
     {
-      primitive = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive());
+      primitive = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive(JOYSTICK_SCALAR_PRIMITIVE));
       retVal = true;
     }
   }
@@ -118,39 +119,20 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
   return retVal;
 }
 
-bool CAddonButtonMap::AddScalar(const FeatureName& feature, const CDriverPrimitive& primitive)
+void CAddonButtonMap::AddScalar(const FeatureName& feature, const CDriverPrimitive& primitive)
 {
-  if (!primitive.IsValid())
-  {
-    FeatureMap::iterator it = m_features.find(feature);
-    if (it != m_features.end())
-      m_features.erase(it);
-  }
-  else
-  {
-    UnmapPrimitive(primitive);
+  const bool bMotor = (primitive.Type() == PRIMITIVE_TYPE::MOTOR);
 
-    const bool bMotor = (primitive.Type() == PRIMITIVE_TYPE::MOTOR);
-
-    ADDON::JoystickFeature scalar(feature, bMotor ? JOYSTICK_FEATURE_TYPE_MOTOR : JOYSTICK_FEATURE_TYPE_SCALAR);
-    scalar.SetPrimitive(CPeripheralAddonTranslator::TranslatePrimitive(primitive));
-
-    m_features[feature] = scalar;
-  }
-
-  m_driverMap = CreateLookupTable(m_features);
+  ADDON::JoystickFeature scalar(feature, bMotor ? JOYSTICK_FEATURE_TYPE_MOTOR : JOYSTICK_FEATURE_TYPE_SCALAR);
+  scalar.SetPrimitive(JOYSTICK_SCALAR_PRIMITIVE, CPeripheralAddonTranslator::TranslatePrimitive(primitive));
 
   if (auto addon = m_addon.lock())
-    return addon->MapFeatures(m_device, m_strControllerId, m_features);
-
-  return false;
+    addon->MapFeature(m_device, m_strControllerId, scalar);
 }
 
 bool CAddonButtonMap::GetAnalogStick(const FeatureName& feature,
-                                             CDriverPrimitive& up,
-                                             CDriverPrimitive& down,
-                                             CDriverPrimitive& right,
-                                             CDriverPrimitive& left)
+                                     JOYSTICK::ANALOG_STICK_DIRECTION direction,
+                                     JOYSTICK::CDriverPrimitive& primitive)
 {
   bool retVal(false);
 
@@ -161,63 +143,38 @@ bool CAddonButtonMap::GetAnalogStick(const FeatureName& feature,
 
     if (addonFeature.Type() == JOYSTICK_FEATURE_TYPE_ANALOG_STICK)
     {
-      up     = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Up());
-      down   = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Down());
-      right  = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Right());
-      left   = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Left());
-      retVal = true;
+      primitive = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive(GetPrimitiveIndex(direction)));
+      retVal = primitive.IsValid();
     }
   }
 
   return retVal;
 }
 
-bool CAddonButtonMap::AddAnalogStick(const FeatureName& feature,
-                                             const CDriverPrimitive& up,
-                                             const CDriverPrimitive& down,
-                                             const CDriverPrimitive& right,
-                                             const CDriverPrimitive& left)
+void CAddonButtonMap::AddAnalogStick(const FeatureName& feature,
+                                     JOYSTICK::ANALOG_STICK_DIRECTION direction,
+                                     const JOYSTICK::CDriverPrimitive& primitive)
 {
-  if (!up.IsValid() && !down.IsValid() && !right.IsValid() && !left.IsValid())
-  {
-    FeatureMap::iterator it = m_features.find(feature);
-    if (it != m_features.end())
-      m_features.erase(it);
-  }
-  else
-  {
-    ADDON::JoystickFeature analogStick(feature, JOYSTICK_FEATURE_TYPE_ANALOG_STICK);
+  using namespace JOYSTICK;
 
-    if (up.IsValid())
-    {
-      UnmapPrimitive(up);
-      analogStick.SetUp(CPeripheralAddonTranslator::TranslatePrimitive(up));
-    }
-    if (down.IsValid())
-    {
-      UnmapPrimitive(down);
-      analogStick.SetDown(CPeripheralAddonTranslator::TranslatePrimitive(down));
-    }
-    if (right.IsValid())
-    {
-      UnmapPrimitive(right);
-      analogStick.SetRight(CPeripheralAddonTranslator::TranslatePrimitive(right));
-    }
-    if (left.IsValid())
-    {
-      UnmapPrimitive(left);
-      analogStick.SetLeft(CPeripheralAddonTranslator::TranslatePrimitive(left));
-    }
+  JOYSTICK_FEATURE_PRIMITIVE primitiveIndex = GetPrimitiveIndex(direction);
+  ADDON::DriverPrimitive addonPrimitive = CPeripheralAddonTranslator::TranslatePrimitive(primitive);
 
-    m_features[feature] = analogStick;
-  }
+  ADDON::JoystickFeature analogStick(feature, JOYSTICK_FEATURE_TYPE_ANALOG_STICK);
 
-  m_driverMap = CreateLookupTable(m_features);
+  auto it = m_features.find(feature);
+  if (it != m_features.end())
+    analogStick = it->second;
+
+  const bool bModified = (primitive != CPeripheralAddonTranslator::TranslatePrimitive(analogStick.Primitive(primitiveIndex)));
+  if (bModified)
+    analogStick.SetPrimitive(primitiveIndex, addonPrimitive);
 
   if (auto addon = m_addon.lock())
-    return addon->MapFeatures(m_device, m_strControllerId, m_features);
+    addon->MapFeature(m_device, m_strControllerId, analogStick);
 
-  return false;
+  if (bModified)
+    Load();
 }
 
 bool CAddonButtonMap::GetAccelerometer(const FeatureName& feature,
@@ -234,9 +191,9 @@ bool CAddonButtonMap::GetAccelerometer(const FeatureName& feature,
 
     if (addonFeature.Type() == JOYSTICK_FEATURE_TYPE_ACCELEROMETER)
     {
-      positiveX = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.PositiveX());
-      positiveY = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.PositiveY());
-      positiveZ = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.PositiveZ());
+      positiveX = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_X));
+      positiveY = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y));
+      positiveZ = CPeripheralAddonTranslator::TranslatePrimitive(addonFeature.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z));
       retVal    = true;
     }
   }
@@ -244,52 +201,31 @@ bool CAddonButtonMap::GetAccelerometer(const FeatureName& feature,
   return retVal;
 }
 
-bool CAddonButtonMap::AddAccelerometer(const FeatureName& feature,
+void CAddonButtonMap::AddAccelerometer(const FeatureName& feature,
                                                const CDriverPrimitive& positiveX,
                                                const CDriverPrimitive& positiveY,
                                                const CDriverPrimitive& positiveZ)
 {
-  if (positiveX.IsValid() && positiveY.IsValid() && positiveZ.IsValid())
-  {
-    FeatureMap::iterator it = m_features.find(feature);
-    if (it != m_features.end())
-      m_features.erase(it);
-  }
-  else
-  {
-    ADDON::JoystickFeature accelerometer(feature, JOYSTICK_FEATURE_TYPE_ACCELEROMETER);
+  using namespace JOYSTICK;
 
-    if (positiveX.IsValid())
-    {
-      UnmapPrimitive(positiveX);
-      accelerometer.SetPositiveX(CPeripheralAddonTranslator::TranslatePrimitive(positiveX));
-    }
-    if (positiveY.IsValid())
-    {
-      UnmapPrimitive(positiveY);
-      accelerometer.SetPositiveY(CPeripheralAddonTranslator::TranslatePrimitive(positiveY));
-    }
-    if (positiveZ.IsValid())
-    {
-      UnmapPrimitive(positiveZ);
-      accelerometer.SetPositiveZ(CPeripheralAddonTranslator::TranslatePrimitive(positiveZ));
-    }
+  ADDON::JoystickFeature accelerometer(feature, JOYSTICK_FEATURE_TYPE_ACCELEROMETER);
 
-    //! @todo Unmap complementary semiaxes
+  accelerometer.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_X, CPeripheralAddonTranslator::TranslatePrimitive(positiveX));
+  accelerometer.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y, CPeripheralAddonTranslator::TranslatePrimitive(positiveY));
+  accelerometer.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z, CPeripheralAddonTranslator::TranslatePrimitive(positiveZ));
 
-    m_features[feature] = accelerometer;
-  }
-
-  m_driverMap = CreateLookupTable(m_features);
+  m_features[feature] = accelerometer;
 
   if (auto addon = m_addon.lock())
-    return addon->MapFeatures(m_device, m_strControllerId, m_features);
+    addon->MapFeature(m_device, m_strControllerId, accelerometer);
 
-  return false;
+  Load();
 }
 
 CAddonButtonMap::DriverMap CAddonButtonMap::CreateLookupTable(const FeatureMap& features)
 {
+  using namespace JOYSTICK;
+
   DriverMap driverMap;
 
   for (FeatureMap::const_iterator it = features.begin(); it != features.end(); ++it)
@@ -300,36 +236,41 @@ CAddonButtonMap::DriverMap CAddonButtonMap::CreateLookupTable(const FeatureMap& 
     {
       case JOYSTICK_FEATURE_TYPE_SCALAR:
       {
-        driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Primitive())] = it->first;
+        driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Primitive(JOYSTICK_SCALAR_PRIMITIVE))] = it->first;
         break;
       }
 
       case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
       {
-        driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Up())] = it->first;
-        driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Down())] = it->first;
-        driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Right())] = it->first;
-        driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Left())] = it->first;
+        std::vector<JOYSTICK_FEATURE_PRIMITIVE> primitives = {
+          JOYSTICK_ANALOG_STICK_UP,
+          JOYSTICK_ANALOG_STICK_DOWN,
+          JOYSTICK_ANALOG_STICK_RIGHT,
+          JOYSTICK_ANALOG_STICK_LEFT,
+        };
+
+        for (auto primitive : primitives)
+          driverMap[CPeripheralAddonTranslator::TranslatePrimitive(feature.Primitive(primitive))] = it->first;
         break;
       }
 
       case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
       {
-        CDriverPrimitive x_axis(CPeripheralAddonTranslator::TranslatePrimitive(feature.PositiveX()));
-        CDriverPrimitive y_axis(CPeripheralAddonTranslator::TranslatePrimitive(feature.PositiveY()));
-        CDriverPrimitive z_axis(CPeripheralAddonTranslator::TranslatePrimitive(feature.PositiveZ()));
+        std::vector<JOYSTICK_FEATURE_PRIMITIVE> primitives = {
+          JOYSTICK_ACCELEROMETER_POSITIVE_X,
+          JOYSTICK_ACCELEROMETER_POSITIVE_Y,
+          JOYSTICK_ACCELEROMETER_POSITIVE_Z,
+        };
 
-        driverMap[x_axis] = it->first;
-        driverMap[y_axis] = it->first;
-        driverMap[z_axis] = it->first;
+        for (auto primitive : primitives)
+        {
+          CDriverPrimitive translatedPrimitive = CPeripheralAddonTranslator::TranslatePrimitive(feature.Primitive(primitive));
+          driverMap[translatedPrimitive] = it->first;
 
-        CDriverPrimitive x_axis_opposite(x_axis.Index(), x_axis.SemiAxisDirection() * -1);
-        CDriverPrimitive y_axis_opposite(y_axis.Index(), y_axis.SemiAxisDirection() * -1);
-        CDriverPrimitive z_axis_opposite(z_axis.Index(), z_axis.SemiAxisDirection() * -1);
-
-        driverMap[x_axis_opposite] = it->first;
-        driverMap[y_axis_opposite] = it->first;
-        driverMap[z_axis_opposite] = it->first;
+          // Map opposite semiaxis
+          CDriverPrimitive oppositePrimitive = CDriverPrimitive(translatedPrimitive.Index(), translatedPrimitive.SemiAxisDirection() * -1);
+          driverMap[oppositePrimitive] = it->first;
+        }
         break;
       }
         
@@ -341,115 +282,18 @@ CAddonButtonMap::DriverMap CAddonButtonMap::CreateLookupTable(const FeatureMap& 
   return driverMap;
 }
 
-bool CAddonButtonMap::UnmapPrimitive(const CDriverPrimitive& primitive)
+JOYSTICK_FEATURE_PRIMITIVE CAddonButtonMap::GetPrimitiveIndex(JOYSTICK::ANALOG_STICK_DIRECTION dir)
 {
-  bool bModified = false;
+  using namespace JOYSTICK;
 
-  DriverMap::iterator it = m_driverMap.find(primitive);
-  if (it != m_driverMap.end())
+  switch (dir)
   {
-    const FeatureName& featureName = it->second;
-    FeatureMap::iterator itFeature = m_features.find(featureName);
-    if (itFeature != m_features.end())
-    {
-      ADDON::JoystickFeature& addonFeature = itFeature->second;
-      ResetPrimitive(addonFeature, CPeripheralAddonTranslator::TranslatePrimitive(primitive));
-      if (!addonFeature.IsValid())
-        m_features.erase(itFeature);
-      bModified = true;
-    }
+  case ANALOG_STICK_DIRECTION::UP:    return JOYSTICK_ANALOG_STICK_UP;
+  case ANALOG_STICK_DIRECTION::DOWN:  return JOYSTICK_ANALOG_STICK_DOWN;
+  case ANALOG_STICK_DIRECTION::RIGHT: return JOYSTICK_ANALOG_STICK_RIGHT;
+  case ANALOG_STICK_DIRECTION::LEFT:  return JOYSTICK_ANALOG_STICK_LEFT;
+  default: break;
   }
 
-  return bModified;
-}
-
-void CAddonButtonMap::ResetPrimitive(ADDON::JoystickFeature& feature, const ADDON::DriverPrimitive& primitive)
-{
-  switch (feature.Type())
-  {
-    case JOYSTICK_FEATURE_TYPE_SCALAR:
-    {
-      if (primitive == feature.Primitive())
-      {
-        CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
-        feature.SetInvalid();
-      }
-      break;
-    }
-    case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
-    {
-      bool bModified = false;
-
-      if (primitive == feature.Up())
-      {
-        feature.SetUp(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-      else if (primitive == feature.Down())
-      {
-        feature.SetDown(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-      else if (primitive == feature.Right())
-      {
-        feature.SetRight(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-      else if (primitive == feature.Left())
-      {
-        feature.SetLeft(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-
-      if (bModified)
-      {
-        if (feature.Up().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN &&
-            feature.Down().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN &&
-            feature.Right().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN &&
-            feature.Left().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
-        {
-          CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
-          feature.SetInvalid();
-        }
-      }
-      break;
-    }
-    case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
-    {
-      bool bModified = false;
-
-      if (primitive == feature.PositiveX() ||
-          primitive == CPeripheralAddonTranslator::Opposite(feature.PositiveX()))
-      {
-        feature.SetPositiveX(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-      else if (primitive == feature.PositiveY() ||
-               primitive == CPeripheralAddonTranslator::Opposite(feature.PositiveY()))
-      {
-        feature.SetPositiveY(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-      else if (primitive == feature.PositiveZ() ||
-               primitive == CPeripheralAddonTranslator::Opposite(feature.PositiveZ()))
-      {
-        feature.SetPositiveZ(ADDON::DriverPrimitive());
-        bModified = true;
-      }
-
-      if (bModified)
-      {
-        if (feature.PositiveX().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN &&
-            feature.PositiveY().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN &&
-            feature.PositiveZ().Type() == JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN)
-        {
-          CLog::Log(LOGDEBUG, "Removing \"%s\" from button map due to conflict", feature.Name().c_str());
-          feature.SetInvalid();
-        }
-      }
-      break;
-    }
-    default:
-      break;
-  }
+  return static_cast<JOYSTICK_FEATURE_PRIMITIVE>(0);
 }

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -89,6 +89,8 @@ namespace PERIPHERALS
       const JOYSTICK::CDriverPrimitive& positiveZ
     ) override;
 
+    virtual void SaveButtonMap() override;
+
   private:
     typedef std::map<JOYSTICK::CDriverPrimitive, JOYSTICK::FeatureName> DriverMap;
 

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -101,7 +101,7 @@ namespace PERIPHERALS
 
     bool UnmapPrimitive(const JOYSTICK::CDriverPrimitive& primitive);
 
-    static bool ResetPrimitive(ADDON::JoystickFeature& feature, const ADDON::DriverPrimitive& primitive);
+    static void ResetPrimitive(ADDON::JoystickFeature& feature, const ADDON::DriverPrimitive& primitive);
 
     CPeripheral* const  m_device;
     std::weak_ptr<CPeripheralAddon>  m_addon;

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -58,25 +58,21 @@ namespace PERIPHERALS
       JOYSTICK::CDriverPrimitive& primitive
     ) override;
 
-    virtual bool AddScalar(
+    virtual void AddScalar(
       const JOYSTICK::FeatureName& feature,
       const JOYSTICK::CDriverPrimitive& primitive
     ) override;
 
     virtual bool GetAnalogStick(
       const JOYSTICK::FeatureName& feature,
-      JOYSTICK::CDriverPrimitive& up,
-      JOYSTICK::CDriverPrimitive& down,
-      JOYSTICK::CDriverPrimitive& right,
-      JOYSTICK::CDriverPrimitive& left
+      JOYSTICK::ANALOG_STICK_DIRECTION direction,
+      JOYSTICK::CDriverPrimitive& primitive
     ) override;
 
-    virtual bool AddAnalogStick(
-      const JOYSTICK::FeatureName& feature,
-      const JOYSTICK::CDriverPrimitive& up,
-      const JOYSTICK::CDriverPrimitive& down,
-      const JOYSTICK::CDriverPrimitive& right,
-      const JOYSTICK::CDriverPrimitive& left
+    virtual void AddAnalogStick(
+        const JOYSTICK::FeatureName& feature,
+        JOYSTICK::ANALOG_STICK_DIRECTION direction,
+        const JOYSTICK::CDriverPrimitive& primitive
     ) override;
 
     virtual bool GetAccelerometer(
@@ -86,7 +82,7 @@ namespace PERIPHERALS
       JOYSTICK::CDriverPrimitive& positiveZ
     ) override;
 
-    virtual bool AddAccelerometer(
+    virtual void AddAccelerometer(
       const JOYSTICK::FeatureName& feature,
       const JOYSTICK::CDriverPrimitive& positiveX,
       const JOYSTICK::CDriverPrimitive& positiveY,
@@ -99,9 +95,7 @@ namespace PERIPHERALS
     // Utility functions
     static DriverMap CreateLookupTable(const FeatureMap& features);
 
-    bool UnmapPrimitive(const JOYSTICK::CDriverPrimitive& primitive);
-
-    static void ResetPrimitive(ADDON::JoystickFeature& feature, const ADDON::DriverPrimitive& primitive);
+    static JOYSTICK_FEATURE_PRIMITIVE GetPrimitiveIndex(JOYSTICK::ANALOG_STICK_DIRECTION dir);
 
     CPeripheral* const  m_device;
     std::weak_ptr<CPeripheralAddon>  m_addon;

--- a/xbmc/peripherals/addons/AddonButtonMapping.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMapping.cpp
@@ -39,7 +39,12 @@ CAddonButtonMapping::CAddonButtonMapping(CPeripheral* peripheral, IButtonMapper*
   {
     m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, mapper->ControllerID()));
     if (m_buttonMap->Load())
+    {
       m_driverHandler.reset(new CButtonMapping(mapper, m_buttonMap.get()));
+
+      // Allow the mapper to save our button map
+      mapper->SetButtonMapCallback(this);
+    }
     else
       m_buttonMap.reset();
   }
@@ -79,4 +84,10 @@ void CAddonButtonMapping::ProcessAxisMotions(void)
 {
   if (m_driverHandler)
     m_driverHandler->ProcessAxisMotions();
+}
+
+void CAddonButtonMapping::SaveButtonMap()
+{
+  if (m_buttonMap)
+    m_buttonMap->SaveButtonMap();
 }

--- a/xbmc/peripherals/addons/AddonButtonMapping.h
+++ b/xbmc/peripherals/addons/AddonButtonMapping.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include "input/joysticks/IButtonMapCallback.h"
 #include "input/joysticks/IDriverHandler.h"
 
 #include <memory>
@@ -33,7 +34,8 @@ namespace PERIPHERALS
 {
   class CPeripheral;
 
-  class CAddonButtonMapping : public JOYSTICK::IDriverHandler
+  class CAddonButtonMapping : public JOYSTICK::IDriverHandler,
+                              public JOYSTICK::IButtonMapCallback
   {
   public:
     CAddonButtonMapping(CPeripheral* peripheral, JOYSTICK::IButtonMapper* mapper);
@@ -45,6 +47,9 @@ namespace PERIPHERALS
     virtual bool OnHatMotion(unsigned int hatIndex, JOYSTICK::HAT_STATE state) override;
     virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
     virtual void ProcessAxisMotions(void) override;
+
+    // implementation of IButtonMapCallback
+    virtual void SaveButtonMap() override;
 
   private:
     std::unique_ptr<JOYSTICK::IDriverHandler> m_driverHandler;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -559,9 +559,9 @@ bool CPeripheralAddon::GetFeatures(const CPeripheral* device,
   return false;
 }
 
-bool CPeripheralAddon::MapFeatures(const CPeripheral* device,
-                                   const std::string& strControllerId,
-                                   const FeatureMap& features)
+bool CPeripheralAddon::MapFeature(const CPeripheral* device,
+                                  const std::string& strControllerId,
+                                  const ADDON::JoystickFeature& feature)
 {
   if (!m_bProvidesButtonMaps)
     return false;
@@ -574,17 +574,11 @@ bool CPeripheralAddon::MapFeatures(const CPeripheral* device,
   JOYSTICK_INFO joystickStruct;
   joystickInfo.ToStruct(joystickStruct);
 
-  std::vector<ADDON::JoystickFeature> featureVector;
-  for (FeatureMap::const_iterator it = features.begin(); it != features.end(); ++it)
-    featureVector.push_back(it->second);
-
-  unsigned int featureCount = featureVector.size();
-
-  JOYSTICK_FEATURE* pFeatures = NULL;
-  ADDON::JoystickFeatures::ToStructs(featureVector, &pFeatures);
+  JOYSTICK_FEATURE addonFeature;
+  feature.ToStruct(addonFeature);
 
   try { LogError(retVal = m_pStruct->MapFeatures(&joystickStruct, strControllerId.c_str(),
-                                                 featureCount, pFeatures), "MapFeatures()"); }
+                                                 1, &addonFeature), "MapFeatures()"); }
   catch (std::exception &e) { LogException(e, "MapFeatures()"); return false;  }
 
   if (retVal == PERIPHERAL_NO_ERROR)

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -590,6 +590,21 @@ bool CPeripheralAddon::MapFeature(const CPeripheral* device,
   return retVal == PERIPHERAL_NO_ERROR;
 }
 
+void CPeripheralAddon::SaveButtonMap(const CPeripheral* device)
+{
+  if (!m_bProvidesButtonMaps)
+    return;
+
+  ADDON::Joystick joystickInfo;
+  GetJoystickInfo(device, joystickInfo);
+
+  JOYSTICK_INFO joystickStruct;
+  joystickInfo.ToStruct(joystickStruct);
+
+  try { m_pStruct->SaveButtonMap(&joystickStruct); }
+  catch (std::exception &e) { LogException(e, "SaveMap()"); return; }
+}
+
 void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::string& strControllerId)
 {
   if (!m_bProvidesButtonMaps)

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -83,7 +83,7 @@ namespace PERIPHERALS
     bool GetJoystickProperties(unsigned int index, CPeripheralJoystick& joystick);
     bool HasButtonMaps(void) const { return m_bProvidesButtonMaps; }
     bool GetFeatures(const CPeripheral* device, const std::string& strControllerId, FeatureMap& features);
-    bool MapFeatures(const CPeripheral* device, const std::string& strControllerId, const FeatureMap& features);
+    bool MapFeature(const CPeripheral* device, const std::string& strControllerId, const ADDON::JoystickFeature& feature);
     void ResetButtonMap(const CPeripheral* device, const std::string& strControllerId);
     void PowerOffJoystick(unsigned int index);
     //@}

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -84,6 +84,7 @@ namespace PERIPHERALS
     bool HasButtonMaps(void) const { return m_bProvidesButtonMaps; }
     bool GetFeatures(const CPeripheral* device, const std::string& strControllerId, FeatureMap& features);
     bool MapFeature(const CPeripheral* device, const std::string& strControllerId, const ADDON::JoystickFeature& feature);
+    void SaveButtonMap(const CPeripheral* device);
     void ResetButtonMap(const CPeripheral* device, const std::string& strControllerId);
     void PowerOffJoystick(unsigned int index);
     //@}


### PR DESCRIPTION
Some controllers send both a button press and an axis change when the D-pad is pressed. To compensate for this, I added a "cooldown" to Kodi so that input arriving within 50ms would be ignored.

A design decision I made in #8807 was to save the button map to the disk after every button press (it simplified the API). When the button map was saved, it would trigger a refresh, and Kodi would hit the disk another few times to calculate the updated button map. I suspect these disk accesses were adding up to >50ms, which is why Kodi wasn't ignoring the second driver input.

This PR adds a SaveButtonMap() function to the peripheral API and only saves the button map when the button-mapping wizard comes to an end.

Also included is a pot-pourri of improvements, some of which the v1.1.0 bump relies on.

Corresponds to https://github.com/kodi-game/peripheral.joystick/pull/50
