### PR TITLE
allow passing an alternative dyload library path

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -884,6 +884,10 @@ bool CApplication::InitDirectoriesLinux()
   else
     userHome = "/root";
 
+  std::string binaddonAltDir;
+  if (getenv("KODI_BINADDON_PATH"))
+    binaddonAltDir = getenv("KODI_BINADDON_PATH");
+
   std::string appPath;
   std::string appName = CCompileInfo::GetAppName();
   std::string dotLowerAppName = "." + appName;
@@ -922,6 +926,7 @@ bool CApplication::InitDirectoriesLinux()
   {
     // map our special drives
     CSpecialProtocol::SetXBMCBinPath(appBinPath);
+    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
     CSpecialProtocol::SetXBMCPath(appPath);
     CSpecialProtocol::SetHomePath(userHome + "/" + dotLowerAppName);
     CSpecialProtocol::SetMasterProfilePath(userHome + "/" + dotLowerAppName + "/userdata");
@@ -941,6 +946,7 @@ bool CApplication::InitDirectoriesLinux()
     URIUtils::AddSlashAtEnd(appPath);
 
     CSpecialProtocol::SetXBMCBinPath(appBinPath);
+    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
     CSpecialProtocol::SetXBMCPath(appPath);
     CSpecialProtocol::SetHomePath(URIUtils::AddFileToFolder(appPath, "portable_data"));
     CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(appPath, "portable_data/userdata"));

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -133,6 +133,7 @@ bool CAddonDll<TheDll, TheStruct, TheProps>::LoadDll()
     return true;
 
   std::string strFileName;
+  std::string strAltFileName;
   if (!m_bIsChild)
   {
     strFileName = LibPath();
@@ -175,6 +176,25 @@ bool CAddonDll<TheDll, TheStruct, TheProps>::LoadDll()
   }
 #endif
   if (!XFILE::CFile::Exists(strFileName))
+  {
+    std::string altbin = CSpecialProtocol::TranslatePath("special://xbmcaltbinaddons/");
+    if (!altbin.empty())
+    {
+      strAltFileName = altbin + m_props.libname;
+      if (!XFILE::CFile::Exists(strAltFileName))
+      {
+        std::string temp = CSpecialProtocol::TranslatePath("special://xbmc/addons/");
+        strAltFileName = strFileName;
+        strAltFileName.erase(0, temp.size());
+        strAltFileName = altbin + strAltFileName;
+     }
+      CLog::Log(LOGDEBUG, "ADDON: Trying to load %s", strAltFileName.c_str());
+    }
+  }
+
+  if (XFILE::CFile::Exists(strAltFileName))
+    strFileName = strAltFileName;
+  else
   {
     std::string temp = CSpecialProtocol::TranslatePath("special://xbmc/");
     std::string tempbin = CSpecialProtocol::TranslatePath("special://xbmcbin/");

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -55,6 +55,11 @@ void CSpecialProtocol::SetXBMCBinAddonPath(const std::string &dir)
   SetPath("xbmcbinaddons", dir);
 }
 
+void CSpecialProtocol::SetXBMCAltBinAddonPath(const std::string &dir)
+{
+  SetPath("xbmcaltbinaddons", dir);
+}
+
 void CSpecialProtocol::SetXBMCFrameworksPath(const std::string &dir)
 {
   SetPath("frameworks", dir);
@@ -164,6 +169,7 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
   else if (RootDir == "xbmc" ||
            RootDir == "xbmcbin" ||
            RootDir == "xbmcbinaddons" ||
+           RootDir == "xbmcaltbinaddons" ||
            RootDir == "home" ||
            RootDir == "envhome" ||
            RootDir == "userhome" ||
@@ -259,6 +265,7 @@ void CSpecialProtocol::LogPaths()
   CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetPath("xbmc").c_str());
   CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetPath("xbmcbin").c_str());
   CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetPath("xbmcbinaddons").c_str());
+  CLog::Log(LOGNOTICE, "special://xbmcaltbinaddons/ is mapped to: %s", GetPath("xbmcaltbinaddons").c_str());
   CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetPath("masterprofile").c_str());
 #if defined(TARGET_POSIX)
   CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -57,6 +57,7 @@ public:
   static void SetXBMCPath(const std::string &path);
   static void SetXBMCBinPath(const std::string &path);
   static void SetXBMCBinAddonPath(const std::string &path);
+  static void SetXBMCAltBinAddonPath(const std::string &path);
   static void SetXBMCFrameworksPath(const std::string &path);
   static void SetHomePath(const std::string &path);
   static void SetUserHomePath(const std::string &path);


### PR DESCRIPTION
it's only implemented for linux atm, but I'll happily add other platforms, if the general idea is accepted and also wanted on other platforms.

If the env var KODI_BINADDON_PATH is non empty, we first try to find shared libs in this path.
