### PR TITLE
DVDAudioCodecPassthrough: Fix memory leak after 

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -148,6 +148,7 @@ int CDVDAudioCodecPassthrough::Decode(uint8_t* pData, int iSize, double dts, dou
     skip = iSize - pkt.size;
     pData = pkt.data;
     iSize = pkt.size;
+    av_packet_free_side_data(&pkt);
   }
 
   if (pData && !m_backlogSize)


### PR DESCRIPTION
14af37aac18b0f471694ac7c65a96d39afaf327

av_packet_split_side_data(&pkt); allocates own buffers which are not freed properly

This only fixes the memleak, it does not care for the unsmooth seeking with that PR users reported.
