### PR TITLE
FIX: [droid] ignore wifi-direct net intf (p2p)

### DIFF
--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -116,6 +116,12 @@ bool CNetworkInterfaceLinux::IsEnabled()
 
 bool CNetworkInterfaceLinux::IsConnected()
 {
+#ifdef TARGET_ANDROID
+   // ignore wifi direct interfaces
+  if (StringUtils::StartsWithNoCase(m_interfaceName, "p2p"))
+    return false;
+#endif
+
    struct ifreq ifr;
    int zero = 0;
    memset(&ifr,0,sizeof(struct ifreq));


### PR DESCRIPTION
For Android. The class is full of ifdeffery so it does not really matter.
