### PR TITLE
Break out joystick improvements from #10364

### DIFF
--- a/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
@@ -76,7 +76,7 @@ void CAddonCallbacksPeripheral::RefreshButtonMaps(void* addonData, const char* d
   if (!peripheralAddon)
     return;
 
-  peripheralAddon->RefreshButtonMaps(deviceName ? deviceName : "", controllerId ? controllerId : "");
+  peripheralAddon->RefreshButtonMaps(deviceName ? deviceName : "");
 }
 
 unsigned int CAddonCallbacksPeripheral::FeatureCount(void* addonData, const char* controllerId, JOYSTICK_FEATURE_TYPE type)

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -54,13 +54,6 @@ std::string CController::ImagePath(void) const
   return "";
 }
 
-std::string CController::OverlayPath(void) const
-{
-  if (!m_layout.Overlay().empty())
-    return URIUtils::AddFileToFolder(URIUtils::GetDirectory(LibPath()), m_layout.Overlay());
-  return "";
-}
-
 bool CController::LoadLayout(void)
 {
   if (!m_bLoaded)

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -41,7 +41,6 @@ public:
 
   std::string Label(void);
   std::string ImagePath(void) const;
-  std::string OverlayPath(void) const;
 
   bool LoadLayout(void);
 

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -96,11 +96,6 @@ bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CControl
   if (m_strImage.empty())
     CLog::Log(LOGDEBUG, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_IMAGE);
 
-  // Overlay
-  m_strOverlay = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_OVERLAY);
-  if (m_strOverlay.empty())
-    CLog::Log(LOGDEBUG, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_OVERLAY);
-
   // Features
   for (const TiXmlElement* pGroup = pElement->FirstChildElement(); pGroup != nullptr; pGroup = pGroup->NextSiblingElement())
   {

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -38,7 +38,6 @@ public:
 
   unsigned int       Label(void) const   { return m_label; }
   const std::string& Image(void) const   { return m_strImage; }
-  const std::string& Overlay(void) const { return m_strOverlay; }
   unsigned int       Width(void) const   { return m_width; }
   unsigned int       Height(void) const  { return m_height; }
 

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -590,7 +590,7 @@ bool CPeripheralAddon::MapFeatures(const CPeripheral* device,
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     // Notify observing button maps
-    RefreshButtonMaps(device->DeviceName(), strControllerId);
+    RefreshButtonMaps(device->DeviceName());
   }
 
   return retVal == PERIPHERAL_NO_ERROR;
@@ -638,16 +638,12 @@ void CPeripheralAddon::UnregisterButtonMap(IButtonMap* buttonMap)
   }
 }
 
-void CPeripheralAddon::RefreshButtonMaps(const std::string& strDeviceName /* = "" */,
-                                         const std::string& strControllerId /* = "" */)
+void CPeripheralAddon::RefreshButtonMaps(const std::string& strDeviceName /* = "" */)
 {
   for (auto it = m_buttonMaps.begin(); it != m_buttonMaps.end(); ++it)
   {
-    if ((strDeviceName.empty() || strDeviceName == it->first->DeviceName()) &&
-        (strControllerId.empty() || strControllerId == it->second->ControllerID()))
-    {
+    if (strDeviceName.empty() || strDeviceName == it->first->DeviceName())
       it->second->Load();
-    }
   }
 }
 

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -347,7 +347,7 @@ void CPeripheralAddon::GetDirectory(const std::string &strPath, CFileItemList &i
     peripheralFile->SetProperty("location", peripheral->Location());
     peripheralFile->SetProperty("class", PeripheralTypeTranslator::TypeToString(peripheral->Type()));
     peripheralFile->SetProperty("version", peripheral->GetVersionInfo());
-    peripheralFile->SetIconImage("DefaultAddon.png");
+    peripheralFile->SetIconImage(peripheral->GetIcon());
     items.Add(peripheralFile);
   }
 }

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -90,7 +90,7 @@ namespace PERIPHERALS
 
     void RegisterButtonMap(CPeripheral* device, JOYSTICK::IButtonMap* buttonMap);
     void UnregisterButtonMap(JOYSTICK::IButtonMap* buttonMap);
-    void RefreshButtonMaps(const std::string& strDeviceName = "", const std::string& strControllerId = "");
+    void RefreshButtonMaps(const std::string& strDeviceName = "");
 
   protected:
     /*!

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -24,6 +24,8 @@
 
 #include "guilib/LocalizeStrings.h"
 #include "input/joysticks/IInputHandler.h"
+#include "peripherals/addons/PeripheralAddon.h"
+#include "peripherals/bus/virtual/PeripheralBusAddon.h"
 #include "peripherals/Peripherals.h"
 #include "settings/lib/Setting.h"
 #include "peripherals/addons/AddonButtonMapping.h"
@@ -595,6 +597,27 @@ void CPeripheral::UnregisterJoystickButtonMapper(IButtonMapper* mapper)
     delete it->second;
     m_buttonMappers.erase(it);
   }
+}
+
+std::string CPeripheral::GetIcon() const
+{
+  std::string icon = "DefaultAddon.png";
+
+  if (m_busType == PERIPHERAL_BUS_ADDON)
+  {
+    CPeripheralBusAddon* bus = static_cast<CPeripheralBusAddon*>(m_bus);
+
+    PeripheralAddonPtr addon;
+    unsigned int index;
+    if (bus->SplitLocation(m_strLocation, addon, index))
+    {
+      std::string addonIcon = addon->Icon();
+      if (!addonIcon.empty())
+        icon = std::move(addonIcon);
+    }
+  }
+
+  return icon;
 }
 
 bool CPeripheral::operator ==(const PeripheralScanResult& right) const

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -569,6 +569,8 @@ void CPeripheral::RegisterJoystickInputHandler(IInputHandler* handler)
 
 void CPeripheral::UnregisterJoystickInputHandler(IInputHandler* handler)
 {
+  handler->ResetInputReceiver();
+
   auto it = m_inputHandlers.find(handler);
   if (it != m_inputHandlers.end())
   {

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -75,6 +75,12 @@ namespace PERIPHERALS
     const std::string &GetVersionInfo(void) const   { return m_strVersionInfo; }
 
     /*!
+     * @brief Get an icon for this peripheral
+     * @return Path to an icon, or skin icon file name
+     */
+    virtual std::string GetIcon() const;
+
+    /*!
      * @brief Check whether this device has the given feature.
      * @param feature The feature to check for.
      * @return True when the device has the feature, false otherwise.


### PR DESCRIPTION
This PR breaks out the changes that the fix in #10364 doesn't depend on.

One cool change is that the add-on icon is shown in the peripherals dialog. This won't have any effect until X-Arcade Tankstick and Steam Controller support is finished, but in the future we can look forward to this:

![peripheral icons](https://cloud.githubusercontent.com/assets/531482/18112343/ab6a84a6-6edb-11e6-8a20-ca17c7a59e47.jpg)
