### PR TITLE
[PVR] Recordings: Prevent thumbnail extraction (as it cannot work pro…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -103,10 +103,6 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
   unsigned int nTime = XbmcThreads::SystemClockMillis();
   CFileItem item(strPath, false);
 
-  if (item.IsDiscImage() ||
-      item.IsPVR())
-    return false;
-
   item.SetMimeTypeForInternetFile();
   CDVDInputStream *pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, item);
   if (!pInputStream)

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -86,6 +86,9 @@ bool CThumbExtractor::operator==(const CJob* job) const
 bool CThumbExtractor::DoWork()
 {
   if (m_item.IsLiveTV()
+  // Due to a pvr addon api design flaw (no support for multiple concurrent streams
+  // per addon instance), pvr recording thumbnail extraction does not work (reliably).
+  ||  m_item.IsPVRRecording()
   ||  URIUtils::IsUPnP(m_item.GetPath())
   ||  URIUtils::IsBluray(m_item.GetPath())
   ||  m_item.IsBDFile()


### PR DESCRIPTION
…perly without major pvr addon api changes).

Fixes the ugly problem reported here: https://github.com/xbmc/xbmc/pull/10333#issuecomment-243210489

@Jalle19, @FernetMenta good to go? I think I now found a good place for the "pvr recording check"... 
