### PR TITLE
log failed texture loading

### DIFF
--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -49,6 +49,9 @@ bool CImageLoader::DoWork()
   std::string loadPath;
 
   std::string texturePath = g_TextureManager.GetTexturePath(m_path);
+  if (texturePath.empty())
+    return false;
+
   if (m_use_cache)
     loadPath = CTextureCache::GetInstance().CheckCachedImage(texturePath, needsChecking);
   else
@@ -209,6 +212,9 @@ void CGUILargeTextureManager::ReleaseImage(const std::string &path, bool immedia
 // queue the image, and start the background loader if necessary
 void CGUILargeTextureManager::QueueImage(const std::string &path, bool useCache)
 {
+  if (path.empty())
+    return;
+
   CSingleLock lock(m_listSection);
   for (queueIterator it = m_queued.begin(); it != m_queued.end(); ++it)
   {

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -114,18 +114,28 @@ std::string CTextureCache::CheckCachedImage(const std::string &url, bool &needsR
 
 void CTextureCache::BackgroundCacheImage(const std::string &url)
 {
+  if (url.empty())
+    return;
+
   CTextureDetails details;
   std::string path(GetCachedImage(url, details));
   if (!path.empty() && details.hash.empty())
     return; // image is already cached and doesn't need to be checked further
 
+  path = CTextureUtils::UnwrapImageURL(url);
+  if (path.empty())
+    return;
+
   // needs (re)caching
-  AddJob(new CTextureCacheJob(CTextureUtils::UnwrapImageURL(url), details.hash));
+  AddJob(new CTextureCacheJob(path, details.hash));
 }
 
 std::string CTextureCache::CacheImage(const std::string &image, CBaseTexture **texture /* = NULL */, CTextureDetails *details /* = NULL */)
 {
   std::string url = CTextureUtils::UnwrapImageURL(image);
+  if (url.empty())
+    return "";
+
   CSingleLock lock(m_processingSection);
   if (m_processinglist.find(url) == m_processinglist.end())
   {

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -256,6 +256,9 @@ bool CGUITextureManager::HasTexture(const std::string &textureName, std::string 
   if (size) *size = 0;
   if (path) *path = textureName;
 
+  if (textureName.empty())
+    return false;
+
   if (!CanLoad(textureName))
     return false;
 
@@ -293,6 +296,10 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
   static CTextureArray emptyTexture;
   int bundle = -1;
   int size = 0;
+
+  if (strTextureName.empty())
+    return emptyTexture;
+
   if (!HasTexture(strTextureName, &strPath, &bundle, &size))
     return emptyTexture;
 
@@ -638,6 +645,8 @@ std::string CGUITextureManager::GetTexturePath(const std::string &textureName, b
       }
     }
   }
+
+  CLog::Log(LOGERROR, "CGUITextureManager::GetTexturePath: could not find texture '%s'", textureName.c_str());
   return "";
 }
 


### PR DESCRIPTION
Currently the job manager is flooded with texture caching jobs trying to load an empty path. This should prevent that and actually log the error where it occurs. 

This doesn't fix the cause of the issue though (it still polls the filesystem) as I don't know what it is, but it seem to come from estuary attempting to lookup a texture named  '-'. <- @phil65 @BigNoid any ideas?
