### PR TITLE
unify language select with other addon select dialogs

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3111,7 +3111,7 @@
             <addontype>kodi.resource.language</addontype>
           </constraints>
           <control type="button" format="addon">
-            <show more="false" details="false">all</show>
+            <show more="true" details="true">installed</show>
           </control>
         </setting>
         <setting id="locale.charset" type="string" label="14091" help="36116">


### PR DESCRIPTION
Why does language select have to have its own special dialog..? I've always disliked that this dialog shows a bunch of languages I don't care about and that it hides the fact that selecting one involves downloading and installing an addon.
