### PR TITLE
[cmake] Fixes: in-tree addon builds and CMAKE_INSTALL_PREFIX inconsistency

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -408,10 +408,13 @@ if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 endif()
 
 # Prepare add-on build env
-foreach(binding ${addon_bindings})
-  get_filename_component(file ${binding} NAME)
-  set(BINDING_TARGET ${CORE_BUILD_DIR}/include/${APP_NAME_LC}/${file})
-  configure_file(${binding} ${BINDING_TARGET} COPYONLY)
+core_file_read_filtered(bindings ${CORE_SOURCE_DIR}/xbmc/addons/addon-bindings.mk)
+foreach(binding ${bindings})
+  string(REPLACE " =" ";" binding "${binding}")
+  string(REPLACE "+=" ";" binding "${binding}")
+  list(GET binding 1 header)
+  get_filename_component(file ${header} NAME)
+  configure_file(${CORE_SOURCE_DIR}/${header} ${CORE_BUILD_DIR}/include/${APP_NAME_LC}/${file} COPYONLY)
 endforeach()
 
 set(APP_LIB_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/${APP_NAME_LC})

--- a/project/cmake/cpack/CPackConfigDEB.cmake
+++ b/project/cmake/cpack/CPackConfigDEB.cmake
@@ -12,6 +12,9 @@ if(NOT CPACK_PACKAGE_DIRECTORY)
   set(CPACK_PACKAGE_DIRECTORY ${CMAKE_BINARY_DIR}/packages)
 endif()
 
+# force CPack generated DEBs to use the same path as CMAKE_INSTALL_PREFIX
+set(CPACK_SET_DESTDIR true)
+
 # set architecture
 if(NOT CPACK_SYSTEM_NAME)
   set(CPACK_SYSTEM_NAME ${CMAKE_SYSTEM_PROCESSOR})

--- a/project/cmake/scripts/common/PrepareEnv.cmake
+++ b/project/cmake/scripts/common/PrepareEnv.cmake
@@ -37,14 +37,13 @@ file(COPY ${CORE_SOURCE_DIR}/project/cmake/scripts/common/AddonHelpers.cmake
 
 ### copy all the addon binding header files to include/kodi
 # parse addon-bindings.mk to get the list of header files to copy
-file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/addon-bindings.mk bindings)
-string(REPLACE "\n" ";" bindings "${bindings}")
+core_file_read_filtered(bindings ${CORE_SOURCE_DIR}/xbmc/addons/addon-bindings.mk)
 foreach(binding ${bindings})
   string(REPLACE " =" ";" binding "${binding}")
   string(REPLACE "+=" ";" binding "${binding}")
   list(GET binding 1 header)
   # copy the header file to include/kodi
-  file(COPY ${CORE_SOURCE_DIR}/${header} DESTINATION ${APP_INCLUDE_DIR})
+  configure_file(${CORE_SOURCE_DIR}/${header} ${APP_INCLUDE_DIR} COPYONLY)
 endforeach()
 
 ### on windows we need a "patch" binary to be able to patch 3rd party sources

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -1,3 +1,6 @@
+# Please also update bindings in ../../project/cmake/scripts/linux/Install.cmake
+# TODO: Cleanup file after autotools is gone
+
 BINDINGS =xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_cpp_dll.h
 BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
 BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_types.h


### PR DESCRIPTION
Fix in-tree addon build env after 4a65001. See [comment](https://github.com/xbmc/xbmc/commit/4a65001cafb54f8c925498d6c90d28a5793a068e#commitcomment-18689259)

Fix CMAKE_INSTALL_PREFIX not being honored by CPack generated DEBs if script is called without -DCMAKE_INSTALL_PREFIX=chihuahua, leading to CMake assuming default value (/usr/local for linux).

Second one costed me 2h until I realized what the ***\* was going on and went digging in docs to find CPACK_SET_DESTDIR. 
