### PR TITLE
VideoPlayer: catch silly CRedirectException, fixes crash

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -147,11 +147,22 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
     {
       XFILE::CCurlFile url;
       // try opening the url to resolve all redirects if any
-      if (url.Open(finalFileitem.GetURL()))
+      try
       {
-        finalFileitem.SetPath(url.GetURL());
+        if (url.Open(finalFileitem.GetURL()))
+        {
+          finalFileitem.SetPath(url.GetURL());
+        }
+        url.Close();
       }
-      url.Close();
+      catch (XFILE::CRedirectException *pRedirectEx)
+      {
+        if (pRedirectEx)
+        {
+          delete pRedirectEx->m_pNewFileImp;
+          delete pRedirectEx;
+        }
+      }
     }
 
     if (finalFileitem.IsType(".m3u8"))


### PR DESCRIPTION
fix http://trac.kodi.tv/ticket/16874

We really should not deal with C++ exceptions as long catch blocks can't be forced.

@MilhouseVH /cc
