### PR TITLE
[guilib] drop support for using hyphen as none value

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -62,7 +62,9 @@ void CTextureCache::Deinitialize()
 
 bool CTextureCache::IsCachedImage(const std::string &url) const
 {
-  if (url != "-" && !CURL::IsFullPath(url))
+  if (url.empty())
+    return false;
+  if (!CURL::IsFullPath(url))
     return true;
   if (URIUtils::PathHasParent(url, "special://skin", true) ||
       URIUtils::PathHasParent(url, "special://temp", true) ||
@@ -83,7 +85,8 @@ bool CTextureCache::HasCachedImage(const std::string &url)
 std::string CTextureCache::GetCachedImage(const std::string &image, CTextureDetails &details, bool trackUsage)
 {
   std::string url = CTextureUtils::UnwrapImageURL(image);
-
+  if (url.empty())
+    return "";
   if (IsCachedImage(url))
     return url;
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -819,7 +819,7 @@ std::string CEdl::GetInfo() const
   if (HasSceneMarker())
     strInfo += StringUtils::Format("s%" PRIuS, m_vecSceneMarkers.size());
 
-  return strInfo.empty() ? "-" : strInfo;
+  return strInfo;
 }
 
 bool CEdl::InCut(const int iSeek, Cut *pCut) const

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -355,7 +355,7 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
   const char *background = pNode->Attribute("background");
   if (background && strnicmp(background, "true", 4) == 0)
     image.useLarge = true;
-  image.filename = (pNode->FirstChild() && pNode->FirstChild()->ValueStr() != "-") ? pNode->FirstChild()->Value() : "";
+  image.filename = pNode->FirstChild() ? pNode->FirstChild()->Value() : "";
   return true;
 }
 
@@ -571,7 +571,7 @@ bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement *element, CG
     return false;
 
   std::string label = element->FirstChild()->Value();
-  if (label.empty() || label == "-")
+  if (label.empty())
     return false;
 
   std::string fallback = XMLUtils::GetAttribute(element, "fallback");
@@ -641,8 +641,6 @@ bool CGUIControlFactory::GetString(const TiXmlNode* pRootNode, const char *strTa
 {
   if (!XMLUtils::GetString(pRootNode, strTag, text))
     return false;
-  if (text == "-")
-    text.clear();
   if (StringUtils::IsNaturalNumber(text))
     text = g_localizeStrings.Get(atoi(text.c_str()));
   return true;

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -283,7 +283,7 @@ CGUIFont* GUIFontManager::GetFont(const std::string& strFontName, bool fallback 
       return pFont;
   }
   // fall back to "font13" if we have none
-  if (fallback && !strFontName.empty() && strFontName != "-" && !StringUtils::EqualsNoCase(strFontName, "font13"))
+  if (fallback && !strFontName.empty() && !StringUtils::EqualsNoCase(strFontName, "font13"))
     return GetFont("font13");
   return NULL;
 }

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -98,11 +98,11 @@ bool CGUIInfoColor::Update()
 
 void CGUIInfoColor::Parse(const std::string &label, int context)
 {
-  // Check for the standard $INFO[] block layout, and strip it if present
-  std::string label2 = label;
-  if (label == "-")
+  if (label.empty())
     return;
 
+  // Check for the standard $INFO[] block layout, and strip it if present
+  std::string label2 = label;
   if (StringUtils::StartsWithNoCase(label, "$var["))
   {
     label2 = label.substr(5, label.length() - 6);

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -239,7 +239,7 @@ CGUITextureManager::~CGUITextureManager(void)
 /************************************************************************/
 bool CGUITextureManager::CanLoad(const std::string &texturePath)
 {
-  if (texturePath == "-")
+  if (texturePath.empty())
     return false;
 
   if (!CURL::IsFullPath(texturePath))

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -429,8 +429,6 @@ void CGUIDialogMusicInfo::OnGetThumb()
     newThumb = localThumb;
   else if (CFile::Exists(result))
     newThumb = result;
-  else // none
-    newThumb = "-"; // force local thumbs to be ignored
 
   // update thumb in the database
   CMusicDatabase db;

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -317,7 +317,7 @@ void CGUIDialogSongInfo::OnGetThumb()
 
   std::string newThumb;
   if (result == "thumb://None")
-    newThumb = "-";
+    newThumb = "";
   else if (result == "thumb://allmusic.com")
     newThumb.clear();
   else if (result == "thumb://Local")

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -214,7 +214,7 @@ void CGUIWindowLoginScreen::Update()
       strLabel = StringUtils::Format(g_localizeStrings.Get(20112).c_str(), profile->getDate().c_str());
     item->SetLabel2(strLabel);
     item->SetArt("thumb", profile->getThumb());
-    if (profile->getThumb().empty() || profile->getThumb() == "-")
+    if (profile->getThumb().empty())
       item->SetArt("thumb", "DefaultUser.png");
     item->SetLabelPreformated(true);
     m_vecItems->Add(item);


### PR DESCRIPTION
There's currently many code paths that doesn't handle the "-" magic value. It's not clear to me why this value was used instead of empty values in the first place; which is commonly always handled...

We should probably schedule this v18 as it breaks all skins relying on "-" being interpreted as an empty value.
