### PR TITLE
VideoPlayer: ffmpeg, ignore pics before first key frame

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -201,21 +201,12 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
     CDVDStreamInfo hint(*pDemuxer->GetStream(demuxerId, nVideoStream), true);
     hint.software = true;
 
-    if (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_MPEG1VIDEO)
-    {
-      // libmpeg2 is not thread safe so use ffmepg for mpeg2/mpeg1 thumb extraction
-      CDVDCodecOptions dvdOptions;
-      pVideoCodec = CDVDFactoryCodec::OpenCodec(new CDVDVideoCodecFFmpeg(*pProcessInfo), hint, dvdOptions);
-    }
-    else
-    {
-      pVideoCodec = CDVDFactoryCodec::CreateVideoCodec(hint, *pProcessInfo);
-    }
+    pVideoCodec = CDVDFactoryCodec::CreateVideoCodec(hint, *pProcessInfo);
 
     if (pVideoCodec)
     {
       int nTotalLen = pDemuxer->GetStreamLength();
-      int nSeekTo = (pos==-1?nTotalLen / 3:pos);
+      int nSeekTo = (pos==-1) ? nTotalLen / 3 : pos;
 
       CLog::Log(LOGDEBUG,"%s - seeking to pos %dms (total: %dms) in %s", __FUNCTION__, nSeekTo, nTotalLen, redactPath.c_str());
       if (pDemuxer->SeekTime(nSeekTo, true))


### PR DESCRIPTION
fix for http://trac.kodi.tv/ticket/16803
