### PR TITLE
[cmake/win32] Bump minimum CMake version to 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ init:
 install:
   - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
   - bash -lc "pacman --needed --noconfirm -Sy"
-  - bash -lc "pacman --needed --noconfirm -S curl"
   - mklink /j %APPVEYOR_BUILD_FOLDER%\project\BuildDependencies\msys64 C:\msys64
 
 build_script:
@@ -44,10 +43,10 @@ build_script:
         # Download precompiled mingw32 libraries
         # To run make-mingwlibs.bat on AppVeyor takes too long, 
         # we must use precompiled libs to speed up build
-        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-ffmpeg-3.1.1-1-any.pkg.tar.xz | tar xJv"
-        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdcss-1.4.0-1-any.pkg.tar.xz | tar xJv"
-        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdnav-5.0.3-1-any.pkg.tar.xz | tar xJv"
-        bash -c "curl http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdread-5.0.3-1-any.pkg.tar.xz | tar xJv"
+        bash -c "wget -O - http://repo.msys2.org/mingw/i686/mingw-w64-i686-ffmpeg-3.1.1-1-any.pkg.tar.xz | tar xJv"
+        bash -c "wget -O - http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdcss-1.4.0-1-any.pkg.tar.xz | tar xJv"
+        bash -c "wget -O - http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdnav-5.0.3-1-any.pkg.tar.xz | tar xJv"
+        bash -c "wget -O - http://repo.msys2.org/mingw/i686/mingw-w64-i686-libdvdread-5.0.3-1-any.pkg.tar.xz | tar xJv"
         # Rename all precompiled lib*.dll.a -> *.lib, so MSVC will find them
         Get-ChildItem mingw32\lib\lib*.dll.a | %{
           $new_name = $_.Name.SubString(3) -replace ".dll.a", ".lib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,8 +57,8 @@ build_script:
         # Build  
         mkdir $env:APPVEYOR_BUILD_FOLDER\kodi-build
         cd $env:APPVEYOR_BUILD_FOLDER\kodi-build
-        cmake -G "Visual Studio 14" ..\project\cmake
-        cmake --build . --target all_build --config RelWithDebInfo
+        cmd /c 'cmake -G "Visual Studio 14" ..\project\cmake 2>&1'
+        cmd /c 'cmake --build . --target all_build --config RelWithDebInfo 2>&1'
       }
   
   #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ environment:
     # - ADDONS: screensaver
     # - ADDONS: visualization
 
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 install:
   - SET PATH=C:\Program Files (x86)\CMake\bin;C:\msys64\bin;C:\msys64\usr\bin;%PATH%
   - bash -lc "pacman --needed --noconfirm -Sy"

--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -59,7 +59,7 @@ IF EXIST %1 (
 ) ELSE (
   CALL :setSubStageName Downloading %1...
   SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
-  %WGET% "!DOWNLOAD_URL!" || ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST% && EXIT /B 7
+  %WGET% "!DOWNLOAD_URL!" 2>&1 || ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST% && EXIT /B 7
   TITLE Getting %1
 )
 

--- a/project/cmake/scripts/common/GeneratorSetup.cmake
+++ b/project/cmake/scripts/common/GeneratorSetup.cmake
@@ -38,6 +38,11 @@ if(APPLE AND CMAKE_VERSION VERSION_LESS 3.4)
                   "or the usage of the patched version in depends.")
 endif()
 
+# Windows needs CMake 3.6 (VS_STARTUP_PROJECT)
+if(WIN32 AND CMAKE_VERSION VERSION_LESS 3.6)
+  message(FATAL_ERROR "Build on Windows needs CMake 3.6 or later")
+endif()
+
 # Ninja needs CMake 3.2 due to ExternalProject BUILD_BYPRODUCTS usage
 if(CMAKE_GENERATOR STREQUAL Ninja AND CMAKE_VERSION VERSION_LESS 3.2)
   message(FATAL_ERROR "Generator: Ninja requires CMake 3.2 or later")


### PR DESCRIPTION
There seem to be some issues with older CMake versions on windows (< 3.4).
Therefore let's bump the minimum required version to 3.6 which introduced the VS_STARTUP_PROJECT var. We use that to allow users to directly build and run Kodi with F5. (older versions would have the ALL_BUILD target preselected which builds everything including tests and doesn't start kodi).

On windows this bump should be non-intrusive, because devs have to download and install CMake anyways manually, so let's save us some troubles.

ping: @Paxxi
