### PR TITLE
Fixed: allow some basic HTTP headers to be passed on to ffmpeg

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -650,14 +650,36 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
 
       if (name == "seekable")
         av_dict_set(&options, "seekable", value.c_str(), 0);
+      // map some standard http headers to the ffmpeg related options
       else if (name == "user-agent")
       {
         av_dict_set(&options, "user-agent", value.c_str(), 0);
+        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option 'user-agent: %s'", value.c_str());
         hasUserAgent = true;
+      }
+      // other standard headers (see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields) are appended as actual headers
+      else if (name == "accept" || name == "accept-language" || name == "accept-datetime" || 
+        name == "authorization" || name == "cache-control" || name == "connection" || name == "content-md5" || 
+        name == "date" || name == "expect" || name == "forwarded" || name == "from" || name == "if-match" || 
+        name == "if-modified-since" || name == "if-none-match" || name == "if-range" || name == "if-unmodified-since" || name == "max-forwards" || 
+        name == "origin" || name == "pragma" || name == "range" || name == "referer" || name == "te" || name == "upgrade" || 
+        name == "via" || name == "warning" || name == "x-requested-with" || name == "dnt" || name == "x-forwarded-for" || name == "x-forwarded-host" || 
+        name == "x-forwarded-proto" || name == "front-end-https" || name == "x-http-method-override" || name == "x-att-deviceid" || 
+        name == "x-wap-profile" || name == "x-uidh" || name == "x-csrf-token" || name == "x-request-id" || name == "x-correlation-id")
+      {
+        if (name == "authorization")
+          CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding custom header option '%s: ***********'", it->first.c_str());
+        else
+          CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding custom header option '%s: %s'", it->first.c_str(), value.c_str());
+        headers.append(it->first).append(": ").append(value).append("\r\n");
       }
       // we don't add blindly all options to headers anymore
       // if anybody wants to pass options to ffmpeg, explicitly prefix those
       // to be identified here
+      else 
+      {
+        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() ignoring header option '%s: %s'", it->first.c_str(), value.c_str());
+      }
     }
     if (!hasUserAgent)
       // set default xbmc user-agent.

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -829,8 +829,29 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
           m_postdata = Base64::Decode(value);
           m_postdataset = true;
         }
-        else
+        // other standard headers (see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields)
+        else if (name == "accept" || name == "accept-language" || name == "accept-datetime" ||
+          name == "authorization" || name == "cache-control" || name == "connection" || name == "content-md5" || name == "content-type" || 
+          name == "date" || name == "expect" || name == "forwarded" || name == "from" || name == "if-match" || 
+          name == "if-modified-since" || name == "if-none-match" || name == "if-range" || name == "if-unmodified-since" || name == "max-forwards" || 
+          name == "origin" || name == "pragma" || name == "range" || name == "te" || name == "upgrade" || 
+          name == "via" || name == "warning" || name == "x-requested-with" || name == "dnt" || name == "x-forwarded-for" || name == "x-forwarded-host" || 
+          name == "x-forwarded-proto" || name == "front-end-https" || name == "x-http-method-override" || name == "x-att-deviceid" ||
+          name == "x-wap-profile" || name == "x-uidh" || name == "x-csrf-token" || name == "x-request-id" || name == "x-correlation-id")
+        {
           SetRequestHeader(it->first, value);
+          if (name == "authorization")
+            CLog::Log(LOGDEBUG, "CurlFile::ParseAndCorrectUrl() adding custom header option '%s: ***********'", it->first.c_str());
+          else
+            CLog::Log(LOGDEBUG, "CurlFile::ParseAndCorrectUrl() adding custom header option '%s: %s'", it->first.c_str(), value.c_str());
+        }
+        // we don't add blindly all options to headers anymore
+        // if anybody wants to pass options to ffmpeg, explicitly prefix those
+        // to be identified here
+        else
+        {
+          CLog::Log(LOGDEBUG, "CurlFile::ParseAndCorrectUrl() ignoring header option '%s: %s'", it->first.c_str(), value.c_str());
+        }
       }
     }
   }


### PR DESCRIPTION
As discussed with @FernetMenta  in https://github.com/xbmc/xbmc/pull/9330 this is my attempt to allow basic HTTP headers to be send to ffmpeg. I also update the `CurlFile.cpp` to filter out all but the standard HTTP headers so it behaves the same in both cases. 
