### PR TITLE
[PVR] Add timer/timer rule: display error box in case pvr addon does …

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9361,7 +9361,19 @@ msgctxt "#19093"
 msgid "Instant recording: %s"
 msgstr ""
 
-#empty strings from id 19094 to 19096
+#. error message displayed in case adding a timer failed because no suitable epg-based timer type could be found.
+#: xbmc/pvr/windows/GUIWindowPVRBase.cpp
+msgctxt "#19094"
+msgid "Timer creation failed. The PVR add-on does not support a suitable timer type."
+msgstr ""
+
+#. error message displayed in case adding a timer rule failed because no suitable epg-based timer rule type could be found.
+#: xbmc/pvr/windows/GUIWindowPVRBase.cpp
+msgctxt "#19095"
+msgid "Timer rule creation failed. The PVR add-on does not support a suitable timer rule type."
+msgstr ""
+
+#empty string with id 19096
 
 msgctxt "#19097"
 msgid "Enter the name for the recording"

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -567,7 +567,10 @@ bool CGUIWindowPVRBase::AddTimer(CFileItem *item, bool bCreateRule, bool bShowTi
   CPVRTimerInfoTagPtr newTimer(epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, bCreateRule) : CPVRTimerInfoTag::CreateInstantTimerTag(channel));
   if (!newTimer)
   {
-    CLog::Log(LOGERROR, "CGUIWindowPVRBase - %s - unable to create timer for epg tag!", __FUNCTION__);
+    CGUIDialogOK::ShowAndGetInput(CVariant{19033},
+                                  bCreateRule
+                                    ? CVariant{19095} // "Information", "Timer rule creation failed. The PVR add-on does not support a suitable timer rule type."
+                                    : CVariant{19094}); // "Information", "Timer creation failed. The PVR add-on does not support a suitable timer type."
     return false;
   }
 


### PR DESCRIPTION
…not support a suitable timer type.

Problem reported here: http://forum.kodi.tv/showthread.php?tid=261847&pid=2407997#pid2407997 => "when I open the EPG and select "add timer" from the context menu I don't get any response at all."

The root cause for this particular problem is a small bug in pvr.vdr.vnsi (https://github.com/kodi-pvr/pvr.vdr.vnsi/pull/89) , but not every addon must support all kind of timer types, thus the "error" may occure even if pvr addon is not buggy, thus user should be informed.

@Jalle19 no-brainer. Any objections?
