### PR TITLE
[addons] add read of api level from addon.xml

### DIFF
--- a/addons/xbmc.addon/metadata.xsd
+++ b/addons/xbmc.addon/metadata.xsd
@@ -20,6 +20,7 @@
       <xs:attribute name="point" type="xs:string" use="required"/>
       <xs:attribute name="id" type="simpleIdentifier"/>
       <xs:attribute name="name" type="xs:string"/>
+      <xs:attribute name="apilevel" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:simpleType name="simpleIdentifier">

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -56,11 +56,12 @@ void OnPostUnInstall(const AddonPtr& addon);
 class AddonProps
 {
 public:
-  AddonProps() : type(ADDON_UNKNOWN), packageSize(0) {};
-  AddonProps(std::string id, TYPE type) : id(std::move(id)), type(type), packageSize(0) {}
+  AddonProps() : type(ADDON_UNKNOWN), apiLevel(-1), packageSize(0) {};
+  AddonProps(std::string id, TYPE type) : id(std::move(id)), type(type), apiLevel(-1), packageSize(0) {}
 
   std::string id;
   TYPE type;
+  int apiLevel;
   AddonVersion version{"0.0.0"};
   AddonVersion minversion{"0.0.0"};
   std::string name;
@@ -99,6 +100,7 @@ public:
   std::string ID() const override{ return m_props.id; }
   std::string Name() const override { return m_props.name; }
   bool IsInUse() const override{ return false; };
+  int APILevel() const override { return m_props.apiLevel; }
   AddonVersion Version() const override { return m_props.version; }
   AddonVersion MinVersion() const override { return m_props.minversion; }
   std::string Summary() const override { return m_props.summary; }

--- a/xbmc/addons/AddonBuilder.h
+++ b/xbmc/addons/AddonBuilder.h
@@ -45,6 +45,7 @@ public:
   void SetBroken(std::string broken) { m_props.broken = std::move(broken); }
   void SetPath(std::string path) { m_props.path = std::move(path); }
   void SetLibName(std::string libname) { m_props.libname = std::move(libname); }
+  void SetAPILevel(int apiLevel) { m_props.apiLevel = apiLevel; }
   void SetVersion(AddonVersion version) { m_props.version = std::move(version); }
   void SetMinVersion(AddonVersion minversion) { m_props.minversion = std::move(minversion); }
   void SetDependencies(ADDONDEPS dependencies) { m_props.dependencies = std::move(dependencies); }
@@ -58,6 +59,7 @@ public:
   void SetPackageSize(uint64_t size) { m_props.packageSize = size; }
 
   const std::string& GetId() const { return m_props.id; }
+  const int GetAPILevel() const { return m_props.apiLevel; }
   const AddonVersion& GetVersion() const { return m_props.version; }
 
 private:

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -116,6 +116,11 @@ bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder
     builder.SetType(TranslateType(ext->ext_point_id));
     builder.SetExtPoint(ext);
 
+    auto apilevel = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@apilevel");
+    if (apilevel.empty())
+      apilevel = "-1";
+    builder.SetAPILevel(atoi(apilevel.c_str()));
+
     auto libname = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@library");
     if (libname.empty())
       libname = CAddonMgr::GetInstance().GetPlatformLibraryName(ext->configuration);

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -98,6 +98,7 @@ namespace ADDON
     virtual std::string ID() const =0;
     virtual std::string Name() const =0;
     virtual bool IsInUse() const =0;
+    virtual int APILevel() const =0;
     virtual AddonVersion Version() const =0;
     virtual AddonVersion MinVersion() const =0;
     virtual std::string Summary() const =0;


### PR DESCRIPTION
This is the part from my addon system rework where the used API level becomes read on add-ons XML file.

Is currently not direct required, but good for me to do a review and may be to bring in to have all binary add-ons already with the value set for future usage.

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<addon
  id="audiodecoder.dumb"
  version="2.0.0"
  name="Modplug Audio Decoder"
  provider-name="spiff">
  <requires>
    <import addon="kodi.audiodecoder" version="1.0.0"/>
  </requires>
  <extension
    point="kodi.audiodecoder"
    apilevel="1" <!-- See here the set of used level -->
    name="dumb"
    extension=".it|.xm|.s3m"
    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
  <extension point="xbmc.addon.metadata">
    <summary lang="en">DUMB Audio Decoder</summary>
    <description lang="en">DUMB Audio Decoder</description>
    <platform>@PLATFORM@</platform>
  </extension>
</addon>
```
