### PR TITLE
[cmake/android] Fix startup without AML

### DIFF
--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -177,11 +177,14 @@ if(NOT CORE_SYSTEM_NAME STREQUAL windows)
                       GLUtils.h)
 endif()
 
+if(OPENGLES_FOUND)
+  list(APPEND SOURCES AMLUtils.cpp)
+  list(APPEND HEADERS AMLUtils.h)
+endif()
+
 if(AML_FOUND)
-  list(APPEND SOURCES AMLUtils.cpp
-                      ScreenshotAML.cpp)
-  list(APPEND HEADERS AMLUtils.h
-                      ScreenshotAML.h)
+  list(APPEND SOURCES ScreenshotAML.cpp)
+  list(APPEND HEADERS ScreenshotAML.h)
 endif()
 
 core_add_library(utils)

--- a/xbmc/windowing/egl/CMakeLists.txt
+++ b/xbmc/windowing/egl/CMakeLists.txt
@@ -13,19 +13,15 @@ endif()
 
 if(CORE_SYSTEM_NAME STREQUAL android)
   list(APPEND SOURCES EGLNativeTypeAndroid.cpp
-                      EGLNativeTypeRKAndroid.cpp)
+                      EGLNativeTypeRKAndroid.cpp
+                      EGLNativeTypeAmlAndroid.cpp)
   list(APPEND HEADERS EGLNativeTypeAndroid.h
-                      EGLNativeTypeRKAndroid.h)
-  if(AML_FOUND)
-    list(APPEND SOURCES EGLNativeTypeAmlAndroid.cpp)
-    list(APPEND HEADERS EGLNativeTypeAmlAndroid.h)
-  endif()
+                      EGLNativeTypeRKAndroid.h
+                      EGLNativeTypeAmlAndroid.h)
 endif()
 
-if(AML_FOUND)
-  list(APPEND SOURCES EGLNativeTypeAmlogic.cpp)
-  list(APPEND HEADERS EGLNativeTypeAmlogic.h)
-endif()
+list(APPEND SOURCES EGLNativeTypeAmlogic.cpp)
+list(APPEND HEADERS EGLNativeTypeAmlogic.h)
 
 if(MMAL_FOUND)
   list(APPEND SOURCES EGLNativeTypeRaspberryPI.cpp)


### PR DESCRIPTION
Attempt to fix startup due to missing AML related symbols on android.
Does what autotools does, might be a good idea to check if these aml related files are really needed if aml is disabled.

@MartijnKaijser My local build failed to install (complained that it was too big). Let's try the jenkins one.

--> jenkins.kodi.tv/job/Android-ARM/9125
