### PR TITLE
[cmake] Don't allow undefined symbols in shared libraries

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -324,6 +324,7 @@ if(NOT CORE_SYSTEM_NAME STREQUAL android)
   add_executable(${APP_NAME_LC} ${CORE_MAIN_SOURCE} "${RESOURCES}" ${OTHER_FILES})
   add_dependencies(${APP_NAME_LC} ${APP_NAME_LC}-libraries export-files pack-skins)
 else()
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
   add_library(${APP_NAME_LC} SHARED ${CORE_MAIN_SOURCE} "${RESOURCES}" ${OTHER_FILES})
   # The libraries depend on the main shared library for wrapping. Because of this we cannot build
   # the libraries as a dependency. This requires to build the all target on android (and not only kodi).

--- a/tools/depends/target/mysql/07-no-endpwent.patch
+++ b/tools/depends/target/mysql/07-no-endpwent.patch
@@ -1,0 +1,12 @@
+--- mysys/mf_pack.c-org	2016-03-27 10:59:19.176558034 -0400
++++ mysys/mf_pack.c	2016-03-27 11:00:00.364557719 -0400
+@@ -381,7 +381,7 @@ static char * NEAR_F expand_tilde(char *
+ {
+   if (path[0][0] == FN_LIBCHAR)
+     return home_dir;			/* ~/ expanded to home */
+-#ifdef HAVE_GETPWNAM
++#if defined(HAVE_GETPWNAM) && defined(HAVE_GETPWENT)
+   {
+     char *str,save;
+     struct passwd *user_entry;
+

--- a/tools/depends/target/mysql/Makefile
+++ b/tools/depends/target/mysql/Makefile
@@ -34,8 +34,9 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../04-strnlen.patch
 	cd $(PLATFORM); patch -p1 < ../05-mysqlclient-ios64.patch
 	cd $(PLATFORM); patch -p0 < ../06-fixsslcheck.patch
+	cd $(PLATFORM); patch -p0 < ../07-no-endpwent.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
-	cd $(PLATFORM); $(CONFIGURE) 
+	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)/include


### PR DESCRIPTION
Prevents errors such as:
`dlopen failed: cannot locate symbol "_ZTV24CEGLNativeTypeAmlAndroid" referenced by "/data/app/org.xbmc.kodi-2/lib/arm/libkodi.so"...`

Needs to be rebased on the AML fix once that is done.
