### PR TITLE
remove window type, id and zorder defenitions

### DIFF
--- a/addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+++ b/addons/skin.estuary/1080i/DialogAudioDSPManager.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog">
-	<zorder>1</zorder>
+<window>
 	<defaultcontrol always="true">9000</defaultcontrol>
 	<include>Animation_DialogPopupOpenClose</include>
 	<coordinates>

--- a/addons/skin.estuary/1080i/DialogButtonMenu.xml
+++ b/addons/skin.estuary/1080i/DialogButtonMenu.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="buttonMenu">
+<window>
 	<defaultcontrol>9000</defaultcontrol>
 	<coordinates>
 		<left>710</left>

--- a/addons/skin.estuary/1080i/DialogFavourites.xml
+++ b/addons/skin.estuary/1080i/DialogFavourites.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<window type="dialog" id="134">
+<window>
 	<defaultcontrol always="true">450</defaultcontrol>
 	<coordinates>
 		<left>210</left>

--- a/addons/skin.estuary/1080i/DialogSelect.xml
+++ b/addons/skin.estuary/1080i/DialogSelect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog">
+<window>
 	<defaultcontrol always="true">3</defaultcontrol>
 	<coordinates>
 		<left>350</left>

--- a/addons/skin.estuary/1080i/DialogSubtitles.xml
+++ b/addons/skin.estuary/1080i/DialogSubtitles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog">
+<window>
 	<coordinates>
 		<left>100</left>
 		<top>110</top>

--- a/addons/skin.estuary/1080i/DialogVolumeBar.xml
+++ b/addons/skin.estuary/1080i/DialogVolumeBar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window>
-    <zorder>4</zorder>
+	<zorder>1</zorder>
     <controls>
         <control type="progress" id="20">
             <include>HiddenObject</include>

--- a/addons/skin.estuary/1080i/Pointer.xml
+++ b/addons/skin.estuary/1080i/Pointer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window id="105">
+<window>
 	<controls>
 		<control type="image" id="1">
 			<description>Pointer</description>

--- a/addons/skin.estuary/1080i/VideoOSD.xml
+++ b/addons/skin.estuary/1080i/VideoOSD.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<window type="dialog" id="2901">
+<window>
 	<onload>Dialog.Close(fullscreeninfo)</onload>
 	<onload condition="VideoPlayer.Content(LiveTV) + !Player.PauseEnabled">SetFocus(603)</onload>
 	<depth>DepthOSD</depth>


### PR DESCRIPTION
remove old,  deprecated code.
the need for skins to specify window type/id was removed ages ago.
