### PR TITLE
Lang: Refine Allow passthrough vs. enable passthrough

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1581,7 +1581,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#348"
-msgid "Enable passthrough"
+msgid "Allow passthrough"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -17943,7 +17943,7 @@ msgstr ""
 #. Description of setting with label #348 "Enable passthrough"
 #: system/settings/settings.xml
 msgctxt "#36368"
-msgid "Select to enable the passthrough audio options for playback of encoded audio such as Dolby Digital (AC3), DTS, etc."
+msgid "Select to allow passthrough audio for playback of compressed audio such as Dolby Digital (AC3), DTS, etc. The Client of the AudioEngine, for example Videoplayer, might decide to decode the audio stream under certain conditions. In Videoplayer case, passthrough won't be used for live streams and when you sync playback to display."
 msgstr ""
 
 #. Description of setting with label #349 "TrueHD capable receiver"


### PR DESCRIPTION
So - this changes something users often confuse. When ticking "Enable Passthrough" - they assume that we will output passthrough. But this is not the case.

"Enable Passthrough" should instead be an "Allow Passthrough". It is a service offered by AudioEngine - while clients can decide if they want to have PT or if they don't want to have it.

In current implementation, one of the biggest clients of AE (namely VideoPlayer) does not want Passthrough if we are playing a LiveStream or if we sync playback to Display. Here it tells AE (our service hoster): AE thanks for your offer, but not this time please - I want it decoded not raw.
