### PR TITLE
fixed: remove accidentially added Makefile.in from header list

### DIFF
--- a/xbmc/platform/android/jni/CMakeLists.txt
+++ b/xbmc/platform/android/jni/CMakeLists.txt
@@ -97,7 +97,6 @@ set(HEADERS Activity.h
             KeyCharacterMap.h
             KeyEvent.h
             List.h
-            Makefile.in
             MediaCodecBufferInfo.h
             MediaCodecCryptoInfo.h
             MediaCodec.h


### PR DESCRIPTION
I assume this is a woopsie. If not, it should be in others, not HEADERS. ref http://jenkins.kodi.tv/job/Android-X86/8241/console
