### PR TITLE
Gl: drop finishPipeline

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -31,7 +31,6 @@
 #include "TextureManager.h"
 #include "input/InputManager.h"
 #include "GUIWindowManager.h"
-#include "ServiceBroker.h"
 
 using namespace KODI::MESSAGING;
 
@@ -979,9 +978,6 @@ void CGraphicContext::SetMediaDir(const std::string &strMediaDir)
 
 void CGraphicContext::Flip(bool rendered, bool videoLayer)
 {
-  if (IsFullScreenVideo() && CServiceBroker::GetDataCacheCore().IsRenderClockSync())
-    g_Windowing.FinishPipeline();
-
   g_Windowing.PresentRender(rendered, videoLayer);
 
   if(m_stereoMode != m_nextStereoMode)

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -106,8 +106,6 @@ public:
   virtual bool ClearBuffers(color_t color) = 0;
   virtual bool IsExtSupported(const char* extension) = 0;
 
-  virtual void FinishPipeline() {};
-
   virtual void SetViewPort(CRect& viewPort) = 0;
   virtual void GetViewPort(CRect& viewPort) = 0;
   virtual void RestoreViewPort() {};

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -297,7 +297,6 @@ void CRenderSystemGL::PresentRender(bool rendered, bool videoLayer)
     return;
 
   PresentRenderImpl(rendered);
-  m_latencyCounter++;
 
   if (!rendered)
     Sleep(40);
@@ -320,16 +319,6 @@ void CRenderSystemGL::SetVSync(bool enable)
   m_bVsyncInit = true;
 
   SetVSyncImpl(enable);
-}
-
-void CRenderSystemGL::FinishPipeline()
-{
-  // GL implementations are free to queue an undefined number of frames internally
-  // as a result video latency can be very high which is bad for a/v sync
-  // calling glFinish reduces latency to the number of back buffers
-  // in order to keep some elasticity, we call glFinish only every other cycle
-  if (m_latencyCounter & 0x01)
-    glFinish();
 }
 
 void CRenderSystemGL::CaptureStateBlock()

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -42,7 +42,6 @@ public:
 
   void SetVSync(bool vsync);
   void ResetVSync() { m_bVsyncInit = false; }
-  void FinishPipeline() override;
 
   void SetViewPort(CRect& viewPort) override;
   void GetViewPort(CRect& viewPort) override;
@@ -83,6 +82,4 @@ protected:
   int m_glslMinor = 0;
   
   GLint m_viewPort[4];
-
-  uint8_t m_latencyCounter = 0;
 };


### PR DESCRIPTION
the glFinish does more harm than any good, in particular on NVidia Linux. up-to-date Windowing systems like Wayland or Cocoa provide methods for querying presentation delay.
