### PR TITLE
[cmake/win32] Remove BUILDING_WITH_CMAKE ifdeffery

### DIFF
--- a/project/cmake/scripts/windows/ArchSetup.cmake
+++ b/project/cmake/scripts/windows/ArchSetup.cmake
@@ -27,7 +27,6 @@ set(SYSTEM_DEFINES -DNOMINMAX -D_USE_32BIT_TIME_T -DHAS_DX -D__STDC_CONSTANT_MAC
                    -DTAGLIB_STATIC -DNPT_CONFIG_ENABLE_LOGGING
                    -DPLT_HTTP_DEFAULT_USER_AGENT="UPnP/1.0 DLNADOC/1.50 Kodi"
                    -DPLT_HTTP_DEFAULT_SERVER="UPnP/1.0 DLNADOC/1.50 Kodi"
-                   -DBUILDING_WITH_CMAKE
                    $<$<CONFIG:Debug>:-DD3D_DEBUG_INFO -D_ITERATOR_DEBUG_LEVEL=0>)
 
 # Make sure /FS is set for Visual Studio in order to prevent simultanious access to pdb files.

--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -21,10 +21,6 @@
 #include "CompileInfo.h"
 #include <cstddef>
 
-#if defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE) && !defined(_DEBUG)
-#include "../git_revision.h" // generated file
-#endif
-
 
 int CCompileInfo::GetMajor()
 {
@@ -48,12 +44,5 @@ const char* CCompileInfo::GetSuffix()
 
 const char* CCompileInfo::GetSCMID()
 {
-#if defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE)
-#ifdef GIT_REV
-  return GIT_REV;
-#else
-  return "Unknown";
-#endif
-#endif
   return "@APP_SCMID@";
 }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -32,9 +32,6 @@
 #ifdef HAS_MYSQL
 #include "mysqldataset.h"
 #include "mysql/errmsg.h"
-#if defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE)
-#pragma comment(lib, "libmysql.lib")
-#endif
 
 #ifdef TARGET_POSIX
 #include "linux/ConvUtils.h"

--- a/xbmc/filesystem/FTPParse.cpp
+++ b/xbmc/filesystem/FTPParse.cpp
@@ -22,14 +22,6 @@
   #include "config.h"
 #endif
 
-#if defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE)
-#define PCRE_STATIC 1
-#ifdef _DEBUG
-#pragma comment(lib, "pcrecppd.lib")
-#else  // ! _DEBUG
-#pragma comment(lib, "pcrecpp.lib")
-#endif // ! _DEBUG
-#endif // defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE)
 #include <pcrecpp.h>
 #include <cmath>
 #include "FTPParse.h"

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -33,14 +33,6 @@
 namespace PCRE {
 struct real_pcre_jit_stack; // forward declaration for PCRE without JIT
 typedef struct real_pcre_jit_stack pcre_jit_stack;
-#if defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE)
-#define PCRE_STATIC 1
-#ifdef _DEBUG
-#pragma comment(lib, "pcred.lib")
-#else  // ! _DEBUG
-#pragma comment(lib, "pcre.lib")
-#endif // ! _DEBUG
-#endif // defined(TARGET_WINDOWS) && !defined(BUILDING_WITH_CMAKE)
 #include <pcre.h>
 }
 

--- a/xbmc/utils/XBMCTinyXML.h
+++ b/xbmc/utils/XBMCTinyXML.h
@@ -23,16 +23,7 @@
 #if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
   #include "config.h"
 #endif
-#ifdef TARGET_WINDOWS
-#ifndef BUILDING_WITH_CMAKE
-#define TIXML_USE_STL
-#ifdef _DEBUG
-#pragma comment(lib, "tinyxmlSTLd.lib")
-#else
-#pragma comment(lib, "tinyxmlSTL.lib")
-#endif
-#endif
-#else
+#ifndef TARGET_WINDOWS
 //compile fix for TinyXml < 2.6.0
 #define DOCUMENT    TINYXML_DOCUMENT
 #define ELEMENT     TINYXML_ELEMENT


### PR DESCRIPTION
Commit 76757a5e19411592d843c269e198dd4457563f7e introduced a temporary define BUILDING_WITH_CMAKE in order to compile out some parts that are not necessary anymore with CMake. This parts was mostly "#pragma comment(lib)" and other defines that are better kept in the buildsys.

Now that the VS project has been dropped, this can be completely removed.

Ping: @Paxxi 
