### PR TITLE
[AddonInstaller] - 1 year and 8 month after the last recursion fix fr…

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -345,10 +345,10 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     //! @todo should we assume that installed deps are OK?
     if (dep && std::find(preDeps.begin(), preDeps.end(), dep->ID()) == preDeps.end())
     {
+      preDeps.push_back(dep->ID());
       if (!CheckDependencies(dep, preDeps, database, failedDep))
       {
         database.Close();
-        preDeps.push_back(dep->ID());
         return false;
       }
     }


### PR DESCRIPTION
…om me - lets fix the recursion again.

Well my last try worked by accident i think:

https://github.com/xbmc/xbmc/commit/02d50b12aee4d8673d5083029ec09ba133358ad4

Not sure what the circular dependency was back then - but it was different.

Finally i think it makes most sense to add the current addon id whose dependencies are checked to the predeps list before checking its dependencies. Because this finally leads to the fact that we don't check an addon and its depends twice.

@akva2 and @tamland for a second thought.

Reproduction of the crash as follows:
1. remove any trace of script.module.t9.search, script.extendedinfo and script.module.kodi65 from addons folder
2. download and install http://mirrors.kodi.tv/addons/krypton/script.module.t9.search/script.module.t9.search-1.1.0.zip
3. This will fetch script.kodi65 1.1.0 from the repo as a dependency which is already a fixed version without circular dependency.
4. Downgrade that by downloading and installing http://mirrors.kodi.tv/addons/krypton/script.module.kodi65/script.module.kodi65-1.0.3.zip which is the version which has the circular dependency in it
5. After that - install script.extendedinfo from our repo
6. crash and burn in recursion

Apply this PR and see the crash goes away.

@MilhouseVH can you give this a try in libreelec please?
