### PR TITLE
require click action to activate slider controls

### DIFF
--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -81,6 +81,8 @@ void CGUIDialogSlider::SetSlider(const std::string &label, float value, float mi
   m_callbackData = callbackData;
   if (slider)
   {
+    slider->SetActive();
+    slider->KeepActive();
     slider->SetType(SLIDER_CONTROL_TYPE_FLOAT);
     slider->SetFloatRange(min, max);
     slider->SetFloatInterval(delta);

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -59,6 +59,8 @@ CGUISliderControl::CGUISliderControl(int parentID, int controlID, float posX, fl
   m_iInfoCode = 0;
   m_dragging = false;
   m_action = NULL;
+  m_active = false;
+  m_keepactive = false;
 }
 
 CGUISliderControl::~CGUISliderControl(void)
@@ -85,7 +87,7 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
   dirty |= m_guiBackground.SetWidth(m_width);
   dirty |= m_guiBackground.Process(currentTime);
 
-  CGUITexture &nibLower = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
+  CGUITexture &nibLower = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
   float fScale;
   if (m_orientation == HORIZONTAL)
     fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
@@ -95,7 +97,7 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
   dirty |= ProcessSelector(nibLower, currentTime, fScale, RangeSelectorLower);
   if (m_rangeSelection)
   {
-    CGUITexture &nibUpper = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
+    CGUITexture &nibUpper = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
     if (m_orientation == HORIZONTAL)
       fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
     else
@@ -157,11 +159,11 @@ bool CGUISliderControl::ProcessSelector(CGUITexture &nib, unsigned int currentTi
 void CGUISliderControl::Render()
 {
   m_guiBackground.Render();
-  CGUITexture &nibLower = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
+  CGUITexture &nibLower = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
   nibLower.Render();
   if (m_rangeSelection)
   {
-    CGUITexture &nibUpper = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
+    CGUITexture &nibUpper = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
     nibUpper.Render();
   }
   CGUIControl::Render();
@@ -196,7 +198,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
   switch ( action.GetID() )
   {
   case ACTION_MOVE_LEFT:
-    if (m_orientation == HORIZONTAL)
+    if (m_active && m_orientation == HORIZONTAL)
     {
       Move(-1);
       return true;
@@ -204,7 +206,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_RIGHT:
-    if (m_orientation == HORIZONTAL)
+    if (m_active && m_orientation == HORIZONTAL)
     {
       Move(1);
       return true;
@@ -212,7 +214,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_UP:
-    if (m_orientation == VERTICAL)
+    if (m_active && m_orientation == VERTICAL)
     {
       Move(1);
       return true;
@@ -220,7 +222,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_DOWN:
-    if (m_orientation == VERTICAL)
+    if (m_active && m_orientation == VERTICAL)
     {
       Move(-1);
       return true;
@@ -228,15 +230,29 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_SELECT_ITEM:
+    if (!m_active)
+      m_active = true;
     // switch between the two sliders
-    if (m_rangeSelection)
+    else if (m_rangeSelection && m_currentSelector == RangeSelectorLower)
       SwitchRangeSelector();
+    else
+    {
+      m_active = false;
+      if (m_rangeSelection)
+        SwitchRangeSelector();
+    }
     return true;
 
   default:
     break;
   }
   return CGUIControl::OnAction(action);
+}
+
+void CGUISliderControl::OnUnFocus()
+{
+  if (!m_keepactive)
+    m_active = false;
 }
 
 void CGUISliderControl::Move(int iNumSteps)
@@ -489,6 +505,17 @@ void CGUISliderControl::SetFloatRange(float fStart, float fEnd)
   }
 }
 
+void CGUISliderControl::SetActive()
+{
+  m_active = true;
+}
+
+
+void CGUISliderControl::KeepActive()
+{
+  m_keepactive = true;
+}
+
 void CGUISliderControl::FreeResources(bool immediately)
 {
   CGUIControl::FreeResources(immediately);
@@ -586,6 +613,7 @@ void CGUISliderControl::SetFromPosition(const CPoint &point, bool guessSelector 
 
 EVENT_RESULT CGUISliderControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
+  m_active = true;
   m_dragging = false;
   if (event.m_id == ACTION_MOUSE_DRAG)
   {

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -63,12 +63,15 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
+  virtual void OnUnFocus() override;
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void DynamicResourceAlloc(bool bOnOff);
   virtual void SetInvalid();
   virtual void SetRange(int iStart, int iEnd);
   virtual void SetFloatRange(float fStart, float fEnd);
+  virtual void SetActive();
+  virtual void KeepActive();
   virtual bool OnMessage(CGUIMessage& message);
   bool ProcessSelector(CGUITexture &nib, unsigned int currentTime, float fScale, RangeSelector selector);
   void SetRangeSelection(bool rangeSelection);
@@ -129,6 +132,8 @@ protected:
   std::string m_textValue; ///< Allows overriding of the text value to be displayed (parent must update when the slider updates)
   const SliderAction *m_action; ///< Allows the skin to configure the action of a click on the slider \sa SendClick
   bool m_dragging; ///< Whether we're in a (mouse/touch) drag operation or not - some actions are sent only on release.
+  bool m_active; ///< Whether the slider has been activated by a click.
+  bool m_keepactive; ///< Whether the slider should be deactivated when losing focus.
   ORIENTATION m_orientation;
 };
 #endif


### PR DESCRIPTION
require slider controls to be activated before you can move the slider(s).

this fixes the problem of being unable to navigate to other controls (left/right) when a slider control is focused.
for example: http://forum.kodi.tv/showthread.php?tid=262373&pid=2410300#pid2410300

ping @Montellese @HitcherUK @BigNoid @phil65 
