### PR TITLE
CGUIDialogContentSettings: fix crash when choosing a scraper and no scraper is set yet

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -249,10 +249,13 @@ void CGUIDialogContentSettings::OnSettingAction(const CSetting *setting)
   else if (settingId == SETTING_SCRAPER_LIST)
   {
     ADDON::TYPE type = ADDON::ScraperTypeFromContent(m_content);
-    std::string selectedAddonId = m_scraper->ID();
+    std::string currentScraperId;
+    if (m_scraper != nullptr)
+      currentScraperId = m_scraper->ID();
+    std::string selectedAddonId = currentScraperId;
 
     if (CGUIWindowAddonBrowser::SelectAddonID(type, selectedAddonId, false) == 1
-        && selectedAddonId != m_scraper->ID())
+        && selectedAddonId != currentScraperId)
     {
       AddonPtr scraperAddon;
       CAddonMgr::GetInstance().GetAddon(selectedAddonId, scraperAddon);


### PR DESCRIPTION
This fixes a crash I came across after deleting my MyVideosXXX.db file and setting up my sources from scratch. When I tried to choose a scraper for my music videos Kodi crashed on me because it tries to access `m_scraper->ID()` even though `m_scraper` is an empty `std::shared_ptr`. I checked all the other places in the file and they all already have the proper checks in place.
