### PR TITLE
[cmake/win32] Fix coverity build

### DIFF
--- a/lib/libUPnP/CMakeLists.txt
+++ b/lib/libUPnP/CMakeLists.txt
@@ -81,7 +81,6 @@ else()
   list(APPEND SOURCES Neptune/Source/System/Win32/NptWin32Console.cpp
                       Neptune/Source/System/Win32/NptWin32Debug.cpp
                       Neptune/Source/System/Win32/NptWin32DynamicLibraries.cpp
-                      Neptune/Source/System/Win32/NptWin32File.cpp
                       Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
                       Neptune/Source/System/Win32/NptWin32Network.cpp
                       Neptune/Source/System/Win32/NptWin32Queue.cpp


### PR DESCRIPTION
Ok, this is a strange one:
The coverity build fails on Windows with this errors:

```
filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static char const * const NPT_FilePath::Separator" (?Separator@NPT_FilePath@@2QBDB) already defined in upnp.lib(NptWin32File.cpp.obj)

filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static int __cdecl NPT_File::GetRoots(class NPT_List<class NPT_String> &)" (?GetRoots@NPT_File@@SAHAAV?$NPT_List@VNPT_String@@@@@Z) already defined in upnp.lib(NptWin32File.cpp.obj)

filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static int __cdecl NPT_File::RemoveFile(char const *)" (?RemoveFile@NPT_File@@SAHPBD@Z) already defined in upnp.lib(NptWin32File.cpp.obj)

filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static int __cdecl NPT_File::RemoveDir(char const *)" (?RemoveDir@NPT_File@@SAHPBD@Z) already defined in upnp.lib(NptWin32File.cpp.obj)

filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static int __cdecl NPT_File::Rename(char const *,char const *)" (?Rename@NPT_File@@SAHPBD0@Z) already defined in upnp.lib(NptWin32File.cpp.obj)

filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static int __cdecl NPT_File::ListDir(char const *,class NPT_List<class NPT_String> &,unsigned int,unsigned int)" (?ListDir@NPT_File@@SAHPBDAAV?$NPT_List@VNPT_String@@@@II@Z) already defined in upnp.lib(NptWin32File.cpp.obj)

filesystem.lib(NptXbmcFile.cpp.obj) : error LNK2005: "public: static int __cdecl NPT_File::CreateDir(char const *)" (?CreateDir@NPT_File@@SAHPBD@Z) already defined in upnp.lib(NptWin32File.cpp.obj)

kodi.exe : fatal error LNK1169: one or more multiply defined symbols found
```

(http://jenkins.kodi.tv/view/Helpers/job/WIN-32-CoverityScan/101/console)

It seems to be related to 27ca9e19e9340792251f33b75dd8b5dc0b3c8c40 but that only affects the order in which things are built. 

As we ship our own filesystem/NptXbmcFile.cpp, there's no need to compile the one from platinum upnp and that also solves the issues with coverity: http://jenkins.kodi.tv/view/Helpers/job/WIN-32-CoverityScan/102/console

@Paxxi: any idea?
