### PR TITLE
[cmake] linux: the kodi wrapper script is arch dependent

### DIFF
--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -57,7 +57,7 @@ endif()
 install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}
                  ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME_LC}-standalone
         DESTINATION ${bindir}
-        COMPONENT kodi)
+        COMPONENT kodi-bin)
 
 # Install libraries
 foreach(library ${LIBRARY_FILES})


### PR DESCRIPTION
since kodi.sh includes our libdir now, it has become arch dependent and must be treated as such when installing.

Should fix kodi not starting on i386 when using our ubuntu nightly PPA
