### PR TITLE
[audio settings] change visible tags to enable tags + introduce sync …

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1581,7 +1581,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#348"
-msgid "Enable passthrough"
+msgid "Allow passthrough"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -16870,7 +16870,7 @@ msgstr ""
 #. Description of setting with label #13510 "Sync playback to display"
 #: system/settings/settings.xml
 msgctxt "#36166"
-msgid "Synchronise video and audio to the refresh rate of the monitor. VideoPlayer won't use passthrough audio in this case because resampling may be required."
+msgid "Synchronise video and audio to the refresh rate of the connected display. Since this function may require the resampling of audio, when this setting is enabled the \"Allow passthrough\" audio setting is disabled."
 msgstr ""
 
 #. Description of setting with label #14107 "Time format"
@@ -17940,10 +17940,10 @@ msgctxt "#36367"
 msgid "Select the maximum number of audio channels / speakers available for decoded audio. If optical / coax digital outputs are used, this must be set to 2.0"
 msgstr ""
 
-#. Description of setting with label #348 "Enable passthrough"
+#. Description of setting with label #348 "Allow  passthrough"
 #: system/settings/settings.xml
 msgctxt "#36368"
-msgid "Select to enable the passthrough audio options for playback of encoded audio such as Dolby Digital (AC3), DTS, etc."
+msgid "Select to allow passthrough of audio such as Dolby Digital (AC3) & DTS to another device such as AVR, however under certain conditions the audio may still be decoded to PCM, for example when playing Live TV. Since passthrough requires audio to be sent unaltered, when this setting is enabled the \"Sync playback to display\" setting will be disabled."
 msgstr ""
 
 #. Description of setting with label #349 "TrueHD capable receiver"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -49,6 +49,9 @@
         <setting id="videoplayer.usedisplayasclock" type="boolean" label="13510" help="36166">
           <level>1</level>
           <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">false</dependency>
+          </dependencies>
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.errorinaspect" type="integer" label="22021" help="36170">
@@ -2313,7 +2316,7 @@
           <level>0</level>
           <default>1</default> <!-- AE_CH_LAYOUT_2_0 -->
           <dependencies>
-            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.audiodevice">audiooutput.channels</dependency>
+            <dependency type="enable" on="property" name="aesettingvisible" setting="audiooutput.audiodevice">audiooutput.channels</dependency>
           </dependencies>
           <constraints>
             <options>
@@ -2389,7 +2392,7 @@
           <level>2</level>
           <default>48000</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.audiodevice">audiooutput.samplerate</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.samplerate</condition>
@@ -2449,12 +2452,13 @@
           <level>1</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.audiodevice">audiooutput.passthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
               </and>
             </dependency>
+            <dependency type="enable" setting="videoplayer.usedisplayasclock" operator="is">false</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2462,7 +2466,7 @@
           <level>1</level>
           <default>Default</default> <!-- will be properly set on startup -->
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthrough">audiooutput.passthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
@@ -2479,7 +2483,7 @@
           <level>2</level>
           <default>true</default>
           <dependencies>
-            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
+            <dependency type="enable" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
             <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
@@ -2494,7 +2498,7 @@
                 <condition setting="audiooutput.ac3passthrough" operator="is">true</condition>
               </and>
             </dependency>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.ac3transcode</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.channels">audiooutput.ac3transcode</condition>
@@ -2507,7 +2511,7 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.eac3passthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.eac3passthrough</condition>
@@ -2521,7 +2525,7 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
+            <dependency type="enable" on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</dependency>
             <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
@@ -2530,7 +2534,7 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.truehdpassthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.truehdpassthrough</condition>
@@ -2544,7 +2548,7 @@
           <level>2</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <and>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.dtshdpassthrough</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthroughdevice">audiooutput.dtshdpassthrough</condition>
@@ -2560,7 +2564,7 @@
           <level>3</level>
           <default>false</default>
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <or>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.passthrough">audiooutput.dspaddonsenabled</condition>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.ac3passthrough">audiooutput.dspaddonsenabled</condition>
@@ -2573,7 +2577,7 @@
           <level>3</level>
           <control type="button" format="action" />
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <or>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.dspaddonsenabled">audiooutput.dspsettings</condition>
               </or>
@@ -2584,7 +2588,7 @@
           <level>3</level>
           <control type="button" format="action" />
           <dependencies>
-            <dependency type="visible">
+            <dependency type="enable">
               <or>
                 <condition on="property" name="aesettingvisible" setting="audiooutput.dspaddonsenabled">audiooutput.dspresetdb</condition>
               </or>

--- a/system/settings/win32.xml
+++ b/system/settings/win32.xml
@@ -22,31 +22,13 @@
     </category>
     <category id="audio">
       <group id="1">
-        <setting id="audiooutput.audiodevice" type="string" label="545" help="36371">
-          <level>0</level>
+        <setting id="audiooutput.audiodevice">
           <default>DIRECTSOUND:default</default>
-          <constraints>
-            <options>audiodevices</options>
-          </constraints>
-          <control type="list" format="string" />
         </setting>
       </group>
       <group id="3">
-        <setting id="audiooutput.passthroughdevice" type="string" label="546" help="36372">
-          <level>1</level>
+        <setting id="audiooutput.passthroughdevice">
           <default>DIRECTSOUND:default</default>
-          <constraints>
-            <options>audiodevicespassthrough</options>
-          </constraints>
-          <dependencies>
-            <dependency type="visible">
-              <and>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.audiodevice">audiooutput.passthrough</condition>
-                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
-              </and>
-            </dependency>
-          </dependencies>
-          <control type="list" format="string" />
         </setting>
       </group>
     </category>


### PR DESCRIPTION
…to display & passthrough dependency + adjust language strings for sync to display & passthrough

@fritsch @FernetMenta @da-anda 

fritsch, since I know you don't enjoy dealing with the language stuff, here's my take on https://github.com/xbmc/xbmc/pull/10433 along with a few other things I was considering which also required language changes, but had been waiting for Devcon to discuss.

I've felt for a while that hiding settings using the visible tag was confusing for users, what brought it back to the forefront my thoughts again was this http://forum.kodi.tv/showthread.php?tid=289258&pid=2406704#pid2406704 . After this all the audio settings for the appropriate Setting level will be displayed, with the setting dependencies governing whether they are greyed out or available for selection.

Also since we can't have "Sync to display" and passthrough audio at the same time, I've introduced a couple of new dependencies, so if "Sync to display" is enabled then "Allow passthrough" can't be selected and visa versa. To me it's confusing having something available for selection if it can't be used, unless there was a reason for doing like that I've not thought of.
