### PR TITLE
[cmake] Fix skin packaging for windows

### DIFF
--- a/project/cmake/installdata/common/addons.txt
+++ b/project/cmake/installdata/common/addons.txt
@@ -1,5 +1,4 @@
 addons/audioencoder.xbmc.builtin.aac/*
-addons/audioencoder.xbmc.builtin.wav/*
 addons/audioencoder.xbmc.builtin.wma/*
 addons/game.controller.default/*
 addons/kodi.adsp/*
@@ -32,10 +31,15 @@ addons/screensaver.xbmc.builtin.dim/*
 addons/screensaver.xbmc.builtin.black/*
 addons/script.module.pil/*
 addons/script.module.pysqlite/*
+addons/audioencoder.xbmc.builtin.aac/*
+addons/audioencoder.xbmc.builtin.wav/*
+addons/audioencoder.xbmc.builtin.wma/*
 addons/resource.language.en_gb/*
 addons/resource.uisounds.confluence/*
 addons/resource.images.weathericons.default/*
 addons/service.xbmc.versioncheck/*
+addons/skin.estuary/*
+addons/skin.estouchy/*
 addons/metadata.local/*
 addons/metadata.album.universal/*
 addons/metadata.artists.universal/*


### PR DESCRIPTION
This reverts commit fc70dc26dd87977129f990fd20e371fbc208b549 as it might have broken skin packaging on windows.

If that fixes it, we need a proper fix for the double installation on linux.

@MartijnKaijser: Triggerd jenkins build: jenkins.kodi.tv/job/WIN-32/9924
