### PR TITLE
[cmake] linux: install missing peripheral and vfs addon headers

### DIFF
--- a/project/cmake/cpack/deb/packages/kodi-peripheral-dev.txt.in
+++ b/project/cmake/cpack/deb/packages/kodi-peripheral-dev.txt.in
@@ -1,0 +1,24 @@
+# kodi-peripheral-dev debian package metadata
+#
+# Setting PACKAGE_SHLIBDEPS to 'ON' will cause CPack to ignore PACKAGE_DEPENDS
+# content and use dpkg-shlibdeps to automatically generate the package dependency
+# list. Only useful for packages that contain binaries.
+#
+# PACKAGE_ARCHITECTURE should be set to 'all' only if package contains
+# architecture agnostic data. CPack will set proper architecture (amd64/i386/etc)
+# based on build options.
+#
+# Remaining settings are (hopefully) self-explanatory.
+
+PACKAGE_NAME @APP_NAME_LC@-peripheral-dev
+PACKAGE_ARCHITECTURE all
+PACKAGE_SECTION libdevel
+PACKAGE_PRIORITY optional
+PACKAGE_SHLIBDEPS
+PACKAGE_DEPENDS @APP_NAME_LC@-addon-dev
+PACKAGE_RECOMMENDS
+PACKAGE_SUGGESTS
+PACKAGE_BREAKS
+PACKAGE_REPLACES
+PACKAGE_DESCRIPTION_HEADER @APP_NAME@ Media Center (peripheral add-ons dev package)
+PACKAGE_DESCRIPTION_FOOTER This is the development package for @APP_NAME@'s peripheral add-ons.

--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -139,6 +139,7 @@ install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/texturepacker/TexturePack
 
 # Install kodi-addon-dev headers
 install(FILES ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h
+              ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_utils.hpp
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_adsp.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_audioengine.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
@@ -296,6 +297,14 @@ install(FILES ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbm
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_types.h
         DESTINATION ${includedir}/${APP_NAME_LC}
         COMPONENT kodi-visualization-dev)
+
+# Install kodi-peripheral-dev
+install(FILES ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_callbacks.h
+              ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+              ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+              ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp
+        DESTINATION ${includedir}/${APP_NAME_LC}
+        COMPONENT kodi-peripheral-dev)
 
 # Install XBT skin files
 foreach(texture ${XBT_FILES})


### PR DESCRIPTION
fixes missing headers after install on linux.

pre-req for https://github.com/kodi-game/peripheral.joystick/pull/51
