### PR TITLE
AE: CActiveAEResampleFFMPEG check for resampling being active before …

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.h
@@ -50,6 +50,7 @@ public:
 
 protected:
   bool m_loaded;
+  bool m_doesResample;
   uint64_t m_src_chan_layout, m_dst_chan_layout;
   int m_src_rate, m_dst_rate;
   int m_src_channels, m_dst_channels;


### PR DESCRIPTION
…calling swr_set_compensation

fix http://trac.kodi.tv/ticket/16897

@MilhouseVH /cc
