### PR TITLE
[RDS] enable internal announcements by default

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15248,18 +15248,6 @@ msgctxt "#29985"
 msgid "If traffic advisory is send from RDS, volume is increased"
 msgstr ""
 
-#. Boolean value on settings
-#: system/settings/settings.xml
-msgctxt "#29986"
-msgid "Publicate traffic messages"
-msgstr ""
-
-#. Help text of boolean on/off value
-#: system/settings/settings.xml
-msgctxt "#29987"
-msgid "Send present traffic messages around and can be handled from add-ons (nothing inside Kodi)"
-msgstr ""
-
 #. Music role category
 #: system/library/music/musicroles/Arrangers.xml
 msgctxt "#29988"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1477,11 +1477,6 @@
             <dependency type="enable" setting="pvrplayback.trafficadvisory">true</dependency>
           </dependencies>
         </setting>
-        <setting id="pvrplayback.sendrdstrafficmsg" type="boolean" label="29986" help="29987">
-          <level>2</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
       </group>
     </category>
     <category id="pvrrecord" label="19043" help="36233">

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -1730,9 +1730,6 @@ unsigned int CDVDRadioRDSData::DecodeTDC(uint8_t *msgElement, unsigned int len)
 
 void CDVDRadioRDSData::SendTMCSignal(unsigned int flags, uint8_t *data)
 {
-  if (!CSettings::GetInstance().GetBool("pvrplayback.sendrdstrafficmsg"))
-    return;
-
   if (!(flags & 0x80) && (memcmp(data, m_TMC_LastData, 5) == 0))
     return;
 


### PR DESCRIPTION
remove the setting to enable internal RDS announcement messages.
i don't think we should bother users with low-level stuff like this. just enable it by default.

afaik none of the other messages send to the AnnouncementManager are user-configurable.

http://forum.kodi.tv/showthread.php?tid=290588

ping @AlwinEsch 
