### PR TITLE
 [pvr] show notification if no pvr addon is enabled while entering a pvr window

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10354,7 +10354,13 @@ msgctxt "#19295"
 msgid "Delete timer rule"
 msgstr ""
 
-#empty strings from id 19296 to 19498
+#. Label if no pvr addons are enabled
+#: xbmc/pvr/windows/GUIWindowPVRBase.cpp
+msgctxt "#19296"
+msgid "No PVR add-on enabled"
+msgstr ""
+
+#empty strings from id 19297 to 19498
 
 #: xbmc/epg/Epg.cpp
 msgctxt "#19499"

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -22,6 +22,7 @@
 #include "GUIWindowPVRRecordings.h"
 
 #include "Application.h"
+#include "addons/AddonManager.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"
@@ -339,8 +340,14 @@ void CGUIWindowPVRBase::SetInvalid()
 
 bool CGUIWindowPVRBase::CanBeActivated() const
 {
-  // No activation if PVR is not (yet) available.
-  return g_PVRManager.IsStarted();
+  // check if there is at least one enabled PVR add-on
+  if (!ADDON::CAddonMgr::GetInstance().HasAddons(ADDON::ADDON_PVRDLL))
+  {
+    CGUIDialogOK::ShowAndGetInput(CVariant{19296}, CVariant{19272}); // No PVR add-on enabled, You need a tuner, backend software...
+    return false;
+  }
+
+  return true;
 }
 
 bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog(void)

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -70,11 +70,6 @@ void CGUIWindowPVRChannels::UnregisterObservers(void)
   g_EpgContainer.UnregisterObserver(this);
 }
 
-bool CGUIWindowPVRChannels::CanBeActivated() const
-{
-  return true;
-}
-
 void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -29,7 +29,6 @@ namespace PVR
     CGUIWindowPVRChannels(bool bRadio);
     virtual ~CGUIWindowPVRChannels(void) {};
 
-    virtual bool CanBeActivated() const override;
     virtual bool OnMessage(CGUIMessage& message) override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -58,11 +58,6 @@ CGUIEPGGridContainer* CGUIWindowPVRGuide::GetGridControl()
   return dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
 }
 
-bool CGUIWindowPVRGuide::CanBeActivated() const
-{
-  return true;
-}
-
 void CGUIWindowPVRGuide::Init()
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -41,7 +41,6 @@ namespace PVR
     CGUIWindowPVRGuide(bool bRadio);
     virtual ~CGUIWindowPVRGuide(void);
 
-    virtual bool CanBeActivated() const override;
     virtual void OnInitWindow() override;
     virtual void OnDeinitWindow(int nextWindowID) override;
     virtual bool OnMessage(CGUIMessage& message) override;


### PR DESCRIPTION
This PR will show a notification dialog (DialogOK) if you enter a PVR window with no active/enabled PVR addon.

@ksooo @Jalle19 @ronie what do you think?
