### PR TITLE
[WIP] [skin.estuary] create custom system window + tidy up settings window

### DIFF
--- a/addons/skin.estuary/1080i/Custom_1110_System.xml
+++ b/addons/skin.estuary/1080i/Custom_1110_System.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window>
+<window id="1110">
 	<defaultcontrol always="true">9000</defaultcontrol>
 	<controls>
 		<include>DefaultBackground</include>
@@ -94,50 +94,30 @@
 			</focusedlayout>
 			<content>
 				<item>
-					<label>$LOCALIZE[14200]</label>
-					<onclick>ActivateWindow(PlayerSettings)</onclick>
-					<icon>icons/settings/video.png</icon>
+					<label>$LOCALIZE[24001]</label>
+					<onclick>ActivateWindow(AddonBrowser)</onclick>
+					<icon>icons/settings/addons.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14211]</label>
-					<onclick>ActivateWindow(MediaSettings)</onclick>
-					<icon>icons/settings/library.png</icon>
+					<label>$LOCALIZE[7]</label>
+					<onclick>ActivateWindow(filemanager)</onclick>
+					<icon>icons/settings/filemanager.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14204]</label>
-					<onclick>ActivateWindow(PVRSettings)</onclick>
-					<icon>icons/settings/livetv.png</icon>
+					<label>$LOCALIZE[14114]</label>
+					<onclick>ActivateWindow(eventlog)</onclick>
+					<icon>icons/settings/filemanager.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14036]</label>
-					<onclick>ActivateWindow(ServiceSettings)</onclick>
-					<icon>icons/settings/network.png</icon>
+					<label>$LOCALIZE[130]</label>
+					<onclick>ActivateWindow(10007)</onclick>
+					<icon>icons/settings/sysinfo.png</icon>
 				</item>
-				<item>
-					<label>$LOCALIZE[13000]</label>
-					<onclick>ActivateWindow(SystemSettings)</onclick>
-					<icon>icons/settings/system.png</icon>
-				</item>
-				<item>
-					<label>$LOCALIZE[14206]</label>
-					<onclick>ActivateWindow(InterfaceSettings)</onclick>
-					<icon>icons/settings/appearance.png</icon>
-				</item>
-				<item>
-					<label>$LOCALIZE[166]</label>
-					<onclick>ActivateWindow(SkinSettings)</onclick>
-					<icon>icons/settings/skin.png</icon>
-				</item>
-				<item>
-					<label>$LOCALIZE[13200]</label>
-					<onclick>ActivateWindow(Profiles)</onclick>
-					<icon>icons/settings/profiles.png</icon>
-				</item>
-			</content>
+				</content>
 		</control>
 		<include content="TopBar">
-			<param name="breadcrumbs_label" value="$LOCALIZE[5]" />
-			<param name="breadcrumbs_icon" value="icons/settings/settings.png" />
+			<param name="breadcrumbs_label" value="$LOCALIZE[13000]" />
+			<param name="breadcrumbs_icon" value="icons/settings/system.png"/>
 		</include>
 		<include>BottomBar</include>
 	</controls>

--- a/addons/skin.estuary/1080i/Home.xml
+++ b/addons/skin.estuary/1080i/Home.xml
@@ -1174,9 +1174,9 @@
 					</include>
 					<include content="BottomMainMenuItem">
 						<param name="control_id" value="801" />
-						<param name="onclick" value="ActivateWindow(filemanager)" />
+						<param name="onclick" value="ActivateWindow(1110)" />
 						<param name="icon" value="icons/filemanager.png" />
-						<param name="label" value="$LOCALIZE[10003]" />
+						<param name="label" value="$LOCALIZE[13000]" />
 					</include>
 				</control>
 			</control>


### PR DESCRIPTION
This something I wanted to discuss at Devcon, decided to put this up now so people not attending can comment and also to get early feedback from those that are.

The settings window has historically been a dumping ground for windows such the Add-on browser and System Info that don't fit else where, this seek to resolve this by creating a new custom System window containing:

Add-on browser - easy access to this is still needed in the event users turn off the Add-ons home menu item

File manager - I don't believe a place on the Home screen is merited for this.

Event Log - several have bemoaned that this is so hidden within the settings, this brings it an an easier to find place.

System Info - should not be in Settings window as there is nothing changeable within this window. 

![custom_system_window](https://cloud.githubusercontent.com/assets/5781142/18523558/a7f2baf0-7aac-11e6-99e0-124edc1d7e15.JPG)

This window is accessed by replacing the File Manager button on the Home window

![home_window](https://cloud.githubusercontent.com/assets/5781142/18523688/34d3c9f0-7aad-11e6-9f87-5741d51a31f1.JPG)

In addition removing System Info from Settings window allows tidy up there by dropping the addition settings wording after each Section name, so from

![image](https://cloud.githubusercontent.com/assets/5781142/18523616/ee4d7ff8-7aac-11e6-895f-ca68d4e4f396.png)

to

![settings_window](https://cloud.githubusercontent.com/assets/5781142/18523629/f6328dbc-7aac-11e6-8dc9-967e47fe400c.JPG)

Note - I did look see if I could code a new window in core so this is something all skins could have, but quickly got lost so that for the moment that is well above my skill level.

ping @HitcherUK @phil65 @ronie @BigNoid @MartijnKaijser @da-anda 
