### PR TITLE
[PVR] add support for streams provided by inputstreamaddons

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -99,6 +99,15 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(CDVDInputStream* pInputStream, bool
         else
           return nullptr;
       }
+      /* Used in case PVR addon opens an inputstream */
+      else if (pOtherStream->GetIDemux())
+      {
+        std::unique_ptr<CDVDDemuxClient> demuxer(new CDVDDemuxClient());
+        if(demuxer->Open(pOtherStream))
+          return demuxer.release();
+        else
+          return nullptr;
+      }
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -78,8 +78,11 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
       if (status == ADDON_STATUS_OK)
       {
         unsigned int videoWidth, videoHeight;
-        pPlayer->GetVideoResolution(videoWidth, videoHeight);
-        addon->SetVideoResolution(videoWidth, videoHeight);
+        if (pPlayer)
+        {
+          pPlayer->GetVideoResolution(videoWidth, videoHeight);
+          addon->SetVideoResolution(videoWidth, videoHeight);
+        }
 
         return new CInputStreamAddon(fileitem, addon);
       }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -26,6 +26,7 @@
 #include "pvr/channels/PVRChannel.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "filesystem/PluginDirectory.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
@@ -157,7 +158,21 @@ bool CDVDInputStreamPVRManager::Open()
     m_isOtherStreamHack = true;
     
     m_item.SetPath(transFile);
-    m_item.SetMimeTypeForInternetFile();
+    if(transFile.substr(0, 9) == "plugin://")
+    {
+      // plugin://
+      // call a plugin to set path and properties
+      // enables live channels provided by inputstreamaddons 
+      if (!XFILE::CPluginDirectory::GetPluginResult(transFile, m_item))
+      {
+        CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - unable to create input stream from plugin [%s]", transFile.c_str());
+        return false;
+      }
+    }
+    else
+    {
+      m_item.SetMimeTypeForInternetFile();
+    }
 
     m_pOtherStream = CDVDFactoryInputStream::CreateInputStream(m_pPlayer, m_item);
     if (!m_pOtherStream)


### PR DESCRIPTION
There are several plugins available providing iptv channels through inputstreamaddons (smoothstream, mpd ...) which can't be accessed by the pvr addons yet. With this simple solution it's possible to use a plugin url given as strStreamUrl which will then call the plugin and have the path and properties set to support an inputstream addon. So basically this means that "setResolvedUrl" called by a plugin can be used even for PVR addons/content. The main use case for this right now would be the Simple IPTV Client addon where one would be able to add "plugin://" paths to the m3u playlist.

I tested this with the IPTV Simple Client and the SkyGo plugin (german version) and other plugins providing content through inputstreamaddons (free and drm content) and it works flawlessly.
