### PR TITLE
[PVR] Fix PVR not working after using kodi login screen (trac#16813)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1327,6 +1327,12 @@ void CApplication::StopPVRManager()
   g_EpgContainer.Stop();
 }
 
+void CApplication::ReinitPVRManager()
+{
+  CLog::Log(LOGINFO, "restarting PVRManager");
+  g_PVRManager.Reinit();
+}
+
 void CApplication::StartServices()
 {
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -158,6 +158,7 @@ public:
   bool StartServer(enum ESERVERS eServer, bool bStart, bool bWait = false);
 
   void StopPVRManager();
+  void ReinitPVRManager();
   bool IsCurrentThread() const;
   void Stop(int exitCode);
   void RestartApp();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -75,21 +75,6 @@ using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
-const int CPVRManager::m_pvrWindowIds[12] = {
-    WINDOW_TV_CHANNELS,
-    WINDOW_TV_GUIDE,
-    WINDOW_TV_RECORDINGS,
-    WINDOW_TV_SEARCH,
-    WINDOW_TV_TIMERS,
-    WINDOW_TV_TIMER_RULES,
-    WINDOW_RADIO_CHANNELS,
-    WINDOW_RADIO_GUIDE,
-    WINDOW_RADIO_RECORDINGS,
-    WINDOW_RADIO_SEARCH,
-    WINDOW_RADIO_TIMERS,
-    WINDOW_RADIO_TIMER_RULES
-};
-
 CPVRManager::CPVRManager(void) :
     CThread("PVRManager"),
     m_triggerEvent(true),
@@ -523,15 +508,6 @@ bool CPVRManager::Load(bool bShowProgress)
     return false;
 
   CLog::Log(LOGDEBUG, "PVRManager - %s - active clients found. continue to start", __FUNCTION__);
-
-  /* reset observer for pvr windows */
-  for (std::size_t i = 0; i != ARRAY_SIZE(m_pvrWindowIds); i++)
-  {
-    CSingleExit exit(m_critSection);
-    CGUIWindowPVRBase *pWindow = (CGUIWindowPVRBase *) g_windowManager.GetWindow(m_pvrWindowIds[i]);
-    if (pWindow)
-      pWindow->ResetObservers();
-  }
 
   /* load all channels and groups */
   if (bShowProgress)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -677,7 +677,6 @@ private:
     CCriticalSection                m_managerStateMutex;
     ManagerState                    m_managerState;
     std::unique_ptr<CStopWatch>     m_parentalTimer;
-    static const int                m_pvrWindowIds[12];
 
     std::atomic_bool m_isChannelPreview;
     CEventSource<PVREvent> m_events;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -155,6 +155,11 @@ private:
     void Init(void);
 
     /*!
+     * @brief Reinit PVRManager.
+     */
+    void Reinit(void);
+
+    /*!
      * @brief Stop the PVRManager and destroy all objects it created.
      */
     void Stop(void);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -577,18 +577,6 @@ private:
      */
     void PublishEvent(PVREvent state);
 
-    /*!
-     * @brief Show or update the progress dialog.
-     * @param strText The current status.
-     * @param iProgress The current progress in %.
-     */
-    void ShowProgressDialog(const std::string &strText, int iProgress);
-
-    /*!
-     * @brief Hide the progress dialog if it's visible.
-     */
-    void HideProgressDialog(void);
-
   protected:
     /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
@@ -601,6 +589,18 @@ private:
     virtual void Process(void) override;
 
   private:
+    /*!
+     * @brief Show or update the progress dialog.
+     * @param strText The current status.
+     * @param iProgress The current progress in %.
+     */
+    void ShowProgressDialog(const std::string &strText, int iProgress);
+
+    /*!
+     * @brief Hide the progress dialog if it's visible.
+     */
+    void HideProgressDialog(void);
+
     /*!
      * @brief Load at least one client and load all other PVR data after loading the client.
      * If some clients failed to load here, the pvrmanager will retry to load them every second.

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -115,6 +115,9 @@ void CGUIWindowPVRBase::UnregisterObservers(void)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
+  if (msg == ObservableMessageManagerStopped)
+    ClearData();
+
   if (IsActive())
   {
     CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
@@ -150,6 +153,12 @@ bool CGUIWindowPVRBase::OnBack(int actionID)
       return CGUIWindow::OnBack(actionID);
   }
   return CGUIMediaWindow::OnBack(actionID);
+}
+
+void CGUIWindowPVRBase::ClearData()
+{
+  CSingleLock lock(m_critSection);
+  m_channelGroup.reset();
 }
 
 void CGUIWindowPVRBase::OnInitWindow(void)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -98,6 +98,8 @@ namespace PVR
 
     virtual std::string GetDirectoryPath(void) = 0;
 
+    virtual void ClearData();
+
     bool InitChannelGroup(void);
     virtual CPVRChannelGroupPtr GetChannelGroup(void);
     virtual void SetChannelGroup(const CPVRChannelGroupPtr &group);

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -35,6 +35,8 @@
 #define CONTROL_LABEL_HEADER1             29
 #define CONTROL_LABEL_HEADER2             30
 
+class CGUIDialogProgressBarHandle;
+
 namespace PVR
 {
   enum EpgGuideView
@@ -150,10 +152,23 @@ namespace PVR
      */
     static bool ConfirmStopRecording(const CPVRTimerInfoTagPtr &timer);
 
+    /*!
+     * @brief Show or update the progress dialog.
+     * @param strText The current status.
+     * @param iProgress The current progress in %.
+     */
+    void ShowProgressDialog(const std::string &strText, int iProgress);
+
+    /*!
+     * @brief Hide the progress dialog if it's visible.
+     */
+    void HideProgressDialog(void);
+
     static bool DeleteTimer(CFileItem *item, bool bIsRecording, bool bDeleteRule);
     static bool AddTimer(CFileItem *item, bool bCreateRule, bool bShowTimerSettings);
 
     CPVRChannelGroupPtr m_channelGroup;
     XbmcThreads::EndTime m_refreshTimeout;
+    CGUIDialogProgressBarHandle *m_progressHandle; /*!< progress dialog that is displayed while the pvr manager is loading */
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -79,8 +79,6 @@ namespace PVR
     virtual void SetInvalid() override;
     virtual bool CanBeActivated() const override;
 
-    void ResetObservers(void);
-
     static std::string GetSelectedItemPath(bool bRadio);
     static void SetSelectedItemPath(bool bRadio, const std::string &path);
 
@@ -122,8 +120,8 @@ namespace PVR
     bool OnContextButtonEditTimerRule(CFileItem *item, CONTEXT_BUTTON button);
     bool OnContextButtonDeleteTimerRule(CFileItem *item, CONTEXT_BUTTON button);
 
-    virtual void RegisterObservers(void);
-    virtual void UnregisterObservers(void);
+    void RegisterObservers(void);
+    void UnregisterObservers(void);
 
     static CCriticalSection m_selectedItemPathsLock;
     static std::string m_selectedItemPaths[2];

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -50,23 +50,13 @@ CGUIWindowPVRChannels::CGUIWindowPVRChannels(bool bRadio) :
   CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_CHANNELS : WINDOW_TV_CHANNELS, "MyPVRChannels.xml"),
   m_bShowHiddenChannels(false)
 {
-}
-
-void CGUIWindowPVRChannels::RegisterObservers(void)
-{
-  CSingleLock lock(m_critSection);
   g_EpgContainer.RegisterObserver(this);
-  g_PVRManager.RegisterObserver(this);
   g_infoManager.RegisterObserver(this);
-  CGUIWindowPVRBase::RegisterObservers();
 }
 
-void CGUIWindowPVRChannels::UnregisterObservers(void)
+CGUIWindowPVRChannels::~CGUIWindowPVRChannels()
 {
-  CSingleLock lock(m_critSection);
-  CGUIWindowPVRBase::UnregisterObservers();
   g_infoManager.UnregisterObserver(this);
-  g_PVRManager.UnregisterObserver(this);
   g_EpgContainer.UnregisterObserver(this);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -27,7 +27,7 @@ namespace PVR
   {
   public:
     CGUIWindowPVRChannels(bool bRadio);
-    virtual ~CGUIWindowPVRChannels(void) {};
+    virtual ~CGUIWindowPVRChannels(void);
 
     virtual bool OnMessage(CGUIMessage& message) override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
@@ -38,8 +38,6 @@ namespace PVR
 
   protected:
     virtual std::string GetDirectoryPath(void) override;
-    virtual void RegisterObservers(void) override;
-    virtual void UnregisterObservers(void) override;
 
   private:
     bool OnContextButtonAdd(CFileItem *item, CONTEXT_BUTTON button);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -73,6 +73,17 @@ void CGUIWindowPVRGuide::Init()
   StartRefreshTimelineItemsThread();
 }
 
+void CGUIWindowPVRGuide::ClearData()
+{
+  {
+    CSingleLock lock(m_critSection);
+    m_cachedChannelGroup.reset(new CPVRChannelGroup);
+    m_newTimeline.reset();
+  }
+
+  CGUIWindowPVRBase::ClearData();
+}
+
 void CGUIWindowPVRGuide::OnInitWindow()
 {
   if (m_guiState.get())

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -46,10 +46,12 @@ CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
   m_cachedChannelGroup(new CPVRChannelGroup)
 {
   m_bRefreshTimelineItems = false;
+  g_EpgContainer.RegisterObserver(this);
 }
 
 CGUIWindowPVRGuide::~CGUIWindowPVRGuide(void)
 {
+  g_EpgContainer.UnregisterObserver(this);
   StopRefreshTimelineItemsThread();
 }
 
@@ -101,25 +103,10 @@ void CGUIWindowPVRGuide::StopRefreshTimelineItemsThread()
   m_refreshTimelineItemsThread->StopThread(false);
 }
 
-void CGUIWindowPVRGuide::RegisterObservers(void)
-{
-  CSingleLock lock(m_critSection);
-  g_EpgContainer.RegisterObserver(this);
-  g_PVRManager.RegisterObserver(this);
-  CGUIWindowPVRBase::RegisterObservers();
-}
-
-void CGUIWindowPVRGuide::UnregisterObservers(void)
-{
-  CSingleLock lock(m_critSection);
-  CGUIWindowPVRBase::UnregisterObservers();
-  g_PVRManager.UnregisterObserver(this);
-  g_EpgContainer.UnregisterObserver(this);
-}
-
 void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  if (m_viewControl.GetCurrentControl() == GUIDE_VIEW_TIMELINE &&
+  if (IsActive() &&
+      m_viewControl.GetCurrentControl() == GUIDE_VIEW_TIMELINE &&
       (msg == ObservableMessageEpg ||
        msg == ObservableMessageEpgContainer ||
        msg == ObservableMessageChannelGroupReset ||

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -58,6 +58,8 @@ namespace PVR
     virtual std::string GetDirectoryPath(void) override { return ""; }
     virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
 
+    void ClearData() override;
+
   private:
     void Init();
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -57,8 +57,6 @@ namespace PVR
     virtual void UpdateSelectedItemPath() override;
     virtual std::string GetDirectoryPath(void) override { return ""; }
     virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
-    virtual void RegisterObservers(void) override;
-    virtual void UnregisterObservers(void) override;
 
   private:
     void Init();

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -48,22 +48,12 @@ CGUIWindowPVRRecordings::CGUIWindowPVRRecordings(bool bRadio) :
   CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_RECORDINGS : WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml") ,
   m_bShowDeletedRecordings(false)
 {
-}
-
-void CGUIWindowPVRRecordings::RegisterObservers(void)
-{
-  CSingleLock lock(m_critSection);
-  g_PVRManager.RegisterObserver(this);
   g_infoManager.RegisterObserver(this);
-  CGUIWindowPVRBase::RegisterObservers();
 }
 
-void CGUIWindowPVRRecordings::UnregisterObservers(void)
+CGUIWindowPVRRecordings::~CGUIWindowPVRRecordings()
 {
-  CSingleLock lock(m_critSection);
-  CGUIWindowPVRBase::UnregisterObservers();
   g_infoManager.UnregisterObserver(this);
-  g_PVRManager.UnregisterObserver(this);
 }
 
 void CGUIWindowPVRRecordings::OnWindowLoaded()

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -30,7 +30,7 @@ namespace PVR
   {
   public:
     CGUIWindowPVRRecordings(bool bRadio);
-    virtual ~CGUIWindowPVRRecordings(void) {};
+    virtual ~CGUIWindowPVRRecordings(void);
 
     static std::string GetResumeString(const CFileItem& item);
 
@@ -45,8 +45,6 @@ namespace PVR
   protected:
     virtual std::string GetDirectoryPath(void) override;
     virtual void OnPrepareFileItems(CFileItemList &items) override;
-    virtual void RegisterObservers(void) override;
-    virtual void UnregisterObservers(void) override;
 
   private:
     bool ActionDeleteRecording(CFileItem *item);

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -43,22 +43,12 @@ using namespace PVR;
 CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string &xmlFile) :
   CGUIWindowPVRBase(bRadio, id, xmlFile)
 {
-}
-
-void CGUIWindowPVRTimersBase::RegisterObservers(void)
-{
-  CSingleLock lock(m_critSection);
-  g_PVRManager.RegisterObserver(this);
   g_infoManager.RegisterObserver(this);
-  CGUIWindowPVRBase::RegisterObservers();
 }
 
-void CGUIWindowPVRTimersBase::UnregisterObservers(void)
+CGUIWindowPVRTimersBase::~CGUIWindowPVRTimersBase()
 {
-  CSingleLock lock(m_critSection);
-  CGUIWindowPVRBase::UnregisterObservers();
   g_infoManager.UnregisterObserver(this);
-  g_PVRManager.UnregisterObserver(this);
 }
 
 void CGUIWindowPVRTimersBase::GetContextButtons(int itemNumber, CContextButtons &buttons)

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
@@ -32,17 +32,13 @@ namespace PVR
   {
   public:
     CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string &xmlFile);
-    virtual ~CGUIWindowPVRTimersBase(void) {};
+    virtual ~CGUIWindowPVRTimersBase(void);
 
     bool OnMessage(CGUIMessage& message);
     bool OnAction(const CAction &action);
     void GetContextButtons(int itemNumber, CContextButtons &buttons);
     bool OnContextButton(int itemNumber, CONTEXT_BUTTON button);
     void UpdateButtons(void);
-
-  protected:
-    virtual void RegisterObservers(void);
-    virtual void UnregisterObservers(void);
 
   private:
     bool ActionDeleteTimer(CFileItem *item);

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -42,7 +42,8 @@ typedef enum
   ObservableMessageTimersReset,
   ObservableMessageRecordings,
   ObservableMessagePeripheralsChanged,
-  ObservableMessageChannelGroupsLoaded
+  ObservableMessageChannelGroupsLoaded,
+  ObservableMessageManagerStopped
 } ObservableMessage;
 
 class Observer

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -322,6 +322,9 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   JSONRPC::CJSONRPC::Initialize();
 #endif
 
+  // restart PVR services
+  g_application.ReinitPVRManager();
+
   // start services which should run on login
   ADDON::CAddonMgr::GetInstance().StartServices(false);
 


### PR DESCRIPTION
Problem reported in trac http://trac.kodi.tv/ticket/16813 and the forum http://forum.kodi.tv/showthread.php?tid=282907&pid=2378582#pid2378582

Cause: Regression introduced by PVRManager refactoring for Krypton.
- first commit is basically preparation for the actual bug fix, to be able to do it in clean way
- second commit is the fix
- third commit fixes a race/deadlock that showed up after the login screen bug was fixed

@Jalle19 mind taking a look.
