### PR TITLE
Fix "Custom" view mode not showing in view mode list

### DIFF
--- a/xbmc/video/ViewModeSettings.cpp
+++ b/xbmc/video/ViewModeSettings.cpp
@@ -47,7 +47,7 @@ static const ViewModeProperties viewModes[] =
   { 634,   ViewModeStretch16x9 },
   { 644,   ViewModeStretch16x9Nonlin, HIDE_ITEM, HIDE_ITEM },
   { 635,   ViewModeOriginal },
-  { 636,   ViewModeCustom, HIDE_ITEM, HIDE_ITEM }
+  { 636,   ViewModeCustom, HIDE_ITEM }
 };
 
 #define NUMBER_OF_VIEW_MODES (sizeof(viewModes) / sizeof(viewModes[0]))


### PR DESCRIPTION
This fixes at least part of http://trac.kodi.tv/ticket/16904. I'm not sure it's feasible to show the "Custom" label without putting it in the list. If somebody knows otherwise, let me know.
