### PR TITLE
show text on splash screen during migration tasks

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14643,7 +14643,19 @@ msgctxt "#24149"
 msgid "The following add-ons are incompatible with this version of Kodi and have been automatically disabled: %s."
 msgstr ""
 
-#empty strings from id 24150 to 24990
+#. Progress text on splash screen
+#: xbmc/Application.cpp
+msgctxt "#24150"
+msgid "Database migration in progress - please wait..."
+msgstr ""
+
+#. Progress text on splash screen
+#: xbmc/Application.cpp
+msgctxt "#24151"
+msgid "Add-on migration in progress - please wait..."
+msgstr ""
+
+#empty strings from id 24152 to 24990
 
 #. Used as error message in add-on browser when add-on repository data could not be downloaded
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -789,8 +789,7 @@ bool CApplication::CreateGUI()
   if (sav_res)
     CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP, true);
 
-  if (g_advancedSettings.m_splashImage)
-    CSplash::GetInstance().Show();
+  CSplash::GetInstance().Show();
 
   // The key mappings may already have been loaded by a peripheral
   CLog::Log(LOGINFO, "load keymapping");
@@ -1128,7 +1127,9 @@ bool CApplication::Initialize()
   g_curlInterface.Unload();
 
   // initialize (and update as needed) our databases
+  CSplash::GetInstance().Show(g_localizeStrings.Get(24150));
   CDatabaseManager::GetInstance().Initialize();
+  CSplash::GetInstance().Show();
 
   StartServices();
 
@@ -1140,17 +1141,12 @@ bool CApplication::Initialize()
     CSettings::GetInstance().GetSetting(CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF)->SetRequirementsMet(m_dpms->IsSupported());
 
     g_windowManager.CreateWindows();
-    /* window id's 3000 - 3100 are reserved for python */
 
-    // initialize splash window after splash screen disappears
-    // because we need a real window in the background which gets
-    // rendered while we load the main window or enter the master lock key
-    if (g_advancedSettings.m_splashImage)
-      g_windowManager.ActivateWindow(WINDOW_SPLASH);
-
+    CSplash::GetInstance().Show(g_localizeStrings.Get(24151));
     m_confirmSkinChange = false;
     m_incompatibleAddons = CAddonSystemSettings::GetInstance().MigrateAddons();
     m_confirmSkinChange = true;
+    CSplash::GetInstance().Show();
 
     std::string defaultSkin = ((const CSettingString*)CSettings::GetInstance().GetSetting(CSettings::SETTING_LOOKANDFEEL_SKIN))->GetDefault();
     if (!LoadSkin(CSettings::GetInstance().GetString(CSettings::SETTING_LOOKANDFEEL_SKIN)))
@@ -1162,6 +1158,12 @@ bool CApplication::Initialize()
         return false;
       }
     }
+
+    // initialize splash window after splash screen disappears
+    // because we need a real window in the background which gets
+    // rendered while we load the main window or enter the master lock key
+    if (g_advancedSettings.m_splashImage)
+      g_windowManager.ActivateWindow(WINDOW_SPLASH);
 
     if (CSettings::GetInstance().GetBool(CSettings::SETTING_MASTERLOCK_STARTUPLOCK) &&
         CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&

--- a/xbmc/utils/Splash.h
+++ b/xbmc/utils/Splash.h
@@ -20,9 +20,11 @@
  *
  */
 
+#include <memory>
 #include <string>
 
 class CGUIImage;
+class CGUITextLayout;
 
 class CSplash
 {
@@ -30,13 +32,15 @@ public:
   static CSplash& GetInstance();
 
   void Show();
+  void Show(const std::string& message);
 
 protected:
   CSplash();
   CSplash(const CSplash&);
   CSplash& operator=(CSplash const&);
-  virtual ~CSplash();
+  virtual ~CSplash() = default;
 
 private:
-  CGUIImage* m_image;
+  std::unique_ptr<CGUIImage> m_image;
+  std::unique_ptr<CGUITextLayout> m_messageLayout;
 };


### PR DESCRIPTION
This adds some very basic progress text to splash screen, currently for db and addon migration.  Based on LibreELEC/LibreELEC.tv/pull/537
