### PR TITLE
Fix Music Roles Node passing of options string

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3615,9 +3615,11 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir, CFileItemList& i
       CFileItemPtr pItem(new CFileItem(labelValue));
       pItem->GetMusicInfoTag()->SetTitle(labelValue);
       pItem->GetMusicInfoTag()->SetDatabaseId(m_pDS->fv("role.idRole").get_asInt(), "role");
-
-      std::string artistrolepath = StringUtils::Format("musicdb://artists/?roleid=%i", m_pDS->fv("role.idRole").get_asInt());
-      pItem->SetPath(artistrolepath);
+      CMusicDbUrl itemUrl = musicUrl;
+      std::string strDir = StringUtils::Format("%i/", m_pDS->fv("role.idRole").get_asInt());
+      itemUrl.AppendPath(strDir);
+      itemUrl.AddOption("roleid", m_pDS->fv("role.idRole").get_asInt());
+      pItem->SetPath(itemUrl.ToString());
 
       pItem->m_bIsFolder = true;
       items.Add(pItem);
@@ -5187,6 +5189,11 @@ std::string CMusicDatabase::GetArtistById(int id)
   return GetSingleValue("artist", "strArtist", PrepareSQL("idArtist=%i", id));
 }
 
+std::string CMusicDatabase::GetRoleById(int id)
+{
+  return GetSingleValue("role", "strRole", PrepareSQL("idRole=%i", id));
+}
+
 std::string CMusicDatabase::GetAlbumById(int id)
 {
   return GetSingleValue("album", "strAlbum", PrepareSQL("idAlbum=%i", id));
@@ -5777,6 +5784,8 @@ std::string CMusicDatabase::GetItemById(const std::string &itemType, int id)
     return GetArtistById(id);
   else if (StringUtils::EqualsNoCase(itemType, "albums"))
     return GetAlbumById(id);
+  else if (StringUtils::EqualsNoCase(itemType, "roles"))
+    return GetRoleById(id);
 
   return "";
 }

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -276,6 +276,7 @@ public:
 
   std::string GetArtistById(int id);
   int GetArtistByName(const std::string& strArtist);
+  std::string GetRoleById(int id);
 
   /////////////////////////////////////////////////
   // Cuesheets


### PR DESCRIPTION
A simple fix to the Roles node, other options were not being correctly passed through in the way they are for the genres node etc. Not that anyone is using it yet to notice!

Addition of GetRoleById allows the select role to be displayed e.g. "Library - Roles - Composer" when drilling down to a list of aritsts with that role from the roles node (previously is just said "Artists")
