### PR TITLE
AESinkAUDIOTrack: Workarounds for AML chips in non AML mode

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -537,13 +537,12 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   }
   uint64_t normHead_pos = m_headPos - m_offset;
 
-#if defined(HAS_LIBAMCODEC)
-  if (aml_present() &&
+  // this makes EAC3 working even when AML is not enabled
+  if (aml_present() && m_info.m_wantsIECPassthrough &&
       (m_encoding == CJNIAudioFormat::ENCODING_DTS_HD ||
        m_encoding == CJNIAudioFormat::ENCODING_E_AC3 ||
        m_encoding == CJNIAudioFormat::ENCODING_DOLBY_TRUEHD))
     normHead_pos /= m_sink_frameSize;  // AML wants sink in 48k but returns pos in 192k
-#endif
 
   if (m_passthrough && !m_info.m_wantsIECPassthrough)
   {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -314,9 +314,9 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   }
 
   int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(m_format.m_channelLayout);
+  m_format.m_channelLayout  = AUDIOTRACKChannelMaskToAEChannelMap(atChannelMask);
   if (m_encoding == CJNIAudioFormat::ENCODING_IEC61937)
     atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
-  m_format.m_channelLayout  = AUDIOTRACKChannelMaskToAEChannelMap(atChannelMask);
 
 #if defined(HAS_LIBAMCODEC)
   if (aml_present() && m_passthrough)
@@ -817,27 +817,24 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
         if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
       }
-      // Android v24 can do real IEC API
-      if (CJNIAudioManager::GetSDKVersion() >= 24)
+      // Android v24 and backports can do real IEC API
+      if (CJNIAudioFormat::ENCODING_IEC61937 != -1)
       {
-        if (CJNIAudioFormat::ENCODING_IEC61937 != -1)
-        {
-          m_info.m_wantsIECPassthrough = true;
-          m_info.m_streamTypes.clear();
-          m_info.m_dataFormats.push_back(AE_FMT_RAW);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+        m_info.m_wantsIECPassthrough = true;
+        m_info.m_streamTypes.clear();
+        m_info.m_dataFormats.push_back(AE_FMT_RAW);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
 
-          if (supports_192khz)
-          {
-            m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-            // not working yet
-            // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-            // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
-          }
+        if (supports_192khz)
+        {
+          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+          // not working yet
+          // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+          // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
         }
       }
     }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -318,10 +318,8 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   if (m_encoding == CJNIAudioFormat::ENCODING_IEC61937)
     atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
 
-#if defined(HAS_LIBAMCODEC)
-  if (aml_present() && m_passthrough)
+  if (aml_present() && m_passthrough && m_info.m_wantsIECPassthrough)
     atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
-#endif
 
   while (!m_at_jni)
   {
@@ -774,8 +772,7 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
     }
 
-#if defined(HAS_LIBAMCODEC)
-    if (aml_present())
+    if (aml_present() && CJNIAudioManager::GetSDKVersion() < 23)
     {
       // passthrough
       m_info.m_wantsIECPassthrough = true;
@@ -791,7 +788,6 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       }
     }
     else
-#endif
     {
       bool supports_192khz = false;
       int test_sample[] = { 32000, 44100, 48000, 96000, 192000 };
@@ -839,12 +835,6 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
     }
     std::copy(m_sink_sampleRates.begin(), m_sink_sampleRates.end(), std::back_inserter(m_info.m_sampleRates));
   }
-
-// Take care for old AML devices when they run official API they do
-// really strange things as they define passthrough formats
-  if (aml_present() && CJNIAudioManager::GetSDKVersion() < 23)
-    m_info.m_wantsIECPassthrough = true;
-
   list.push_back(m_info);
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -31,9 +31,7 @@
 #include "platform/android/jni/Build.h"
 #include "utils/TimeUtils.h"
 
-#if defined(HAS_LIBAMCODEC)
 #include "utils/AMLUtils.h"
-#endif
 
 //#define DEBUG_VERBOSE 1
 
@@ -845,6 +843,11 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
     }
     std::copy(m_sink_sampleRates.begin(), m_sink_sampleRates.end(), std::back_inserter(m_info.m_sampleRates));
   }
+
+// Take care for old AML devices when they run official API they do
+// really strange things as they define passthrough formats
+  if (aml_present() && CJNIAudioManager::GetSDKVersion() < 23)
+    m_info.m_wantsIECPassthrough = true;
 
   list.push_back(m_info);
 }

--- a/xbmc/platform/android/jni/AudioTrack.cpp
+++ b/xbmc/platform/android/jni/AudioTrack.cpp
@@ -143,7 +143,10 @@ int CJNIAudioTrack::write(char* audioData, int offsetInBytes, int sizeInBytes)
     }
     else if (m_audioFormat == CJNIAudioFormat::ENCODING_IEC61937)
     {
-      written = call_method<int>(m_object, "write", "([SIII)I", m_buffer, (int)(offsetInBytes / sizeof(short)), (int)(sizeInBytes / sizeof(short)), CJNIAudioTrack::WRITE_BLOCKING);
+      if (CJNIBase::GetSDKVersion() >= 23)
+        written = call_method<int>(m_object, "write", "([SIII)I", m_buffer, (int)(offsetInBytes / sizeof(short)), (int)(sizeInBytes / sizeof(short)), CJNIAudioTrack::WRITE_BLOCKING);
+      else
+       written = call_method<int>(m_object, "write", "([SII)I", m_buffer, (int)(offsetInBytes / sizeof(short)), (int)(sizeInBytes / sizeof(short)));
       written *= sizeof(short);
     }
     else

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -178,7 +178,7 @@ if(NOT CORE_SYSTEM_NAME STREQUAL windows)
                       GLUtils.h)
 endif()
 
-if(AML_FOUND)
+if(CORE_SYSTEM_NAME STREQUAL android OR AML_FOUND)
   list(APPEND SOURCES AMLUtils.cpp
                       ScreenshotAML.cpp)
   list(APPEND HEADERS AMLUtils.h


### PR DESCRIPTION
This PR does two things:

a) if new IEC API is defined, use that to support backported code
b) if we run on AML hardware and don't enable AML - these device redefine (!) public API fields, e.g. AC3, DTS, DTS-HD and so on and don't take the RAW format, but want IEC instead.  This is a major issue, just not implementing public API but also replacing given API streams and their meaning is a huge issue.
