### PR TITLE
Check if core_pattern contains a pipe to a program

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -119,7 +119,10 @@ print_crash_report()
     # find in userdata dir
     single_stacktrace "$HOME" 5
     # try /proc/sys/kernel/core_pattern
-    [ -d $(dirname $(cat /proc/sys/kernel/core_pattern)) ] && single_stacktrace $(dirname $(cat /proc/sys/kernel/core_pattern)) 1
+    # Check if it does not contain a pipe to a program (see man 5 core)
+    if [ "$(cat /proc/sys/kernel/core_pattern | cut -c 1)" != "|" ]; then
+      [ -d "$(dirname $(cat /proc/sys/kernel/core_pattern))" ] && single_stacktrace "$(dirname $(cat /proc/sys/kernel/core_pattern))" 1
+    fi
   else
     echo "gdb not installed, can't get stack trace." >> $FILE
   fi


### PR DESCRIPTION
## Description

When kodi crashed I accidentally noticed an error in the terminal which is the result of unexpected content of core_pattern

For Ubuntu 16.04 core_pattern contains `|/usr/share/apport/apport %p %s %c %P`
For Arch Linux core_pattern contains `|/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %e`

Both contain a 'pipe to a program' (see http://man7.org/linux/man-pages/man5/core.5.html) and cannot be used.
## Motivation and Context

Besides core_pattern not usable, the error is a result of the `|` character, which is interpreted as a pipe.
The the test line (in the script) becomes something like

```
[ -d |blahblah ] 
```

and the `|` acts as an actual pipe (due to the lack of quotes around `$(dirname blah )`)

This PR fixes
- The unusable 'pipe to a program'
- The lack of quotes (making unexpected situations less error prone)
## How Has This Been Tested?

I tested the commands in a terminal (as I cannot let kodi crash on command...)

```
$ if [[ "$(cat /proc/sys/kernel/core_pattern)" != \|* ]]; then echo 1; else echo 0; fi
0
```

Where 0 means that the test failed and core_pattern is not used to gather a core dump
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
