### PR TITLE
[CEC] fixes and inconsistencies [WIP]

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16264,12 +16264,12 @@ msgstr ""
 
 #: system/peripherals.xml
 msgctxt "#36007"
-msgid "Devices to power on during startup"
+msgid "Allowed devices to power on"
 msgstr ""
 
 #: system/peripherals.xml
 msgctxt "#36008"
-msgid "Devices to power off during shutdown"
+msgid "Allowed devices to power off"
 msgstr ""
 
 #: system/peripherals.xml
@@ -16321,7 +16321,7 @@ msgstr ""
 
 #: system/peripherals.xml
 msgctxt "#36020"
-msgid "Switch source to this device on startup"
+msgid "Switch source to this device on startup/media playback"
 msgstr ""
 
 #: system/peripherals.xml
@@ -16351,7 +16351,7 @@ msgstr ""
 
 #: system/peripherals.xml
 msgctxt "#36026"
-msgid "Devices to also put in standby mode"
+msgid "Put devices in standby mode when this system enters standby mode"
 msgstr ""
 
 #: xbmc/peripherals/devices/PeripheralCecAdapter.cpp

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -10,28 +10,31 @@
 
   <peripheral bus="cec" name="CEC Adapter" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" order="1" />
-    <setting key="activate_source" type="bool" value="1" label="36020" order="2" />
-    <setting key="wake_devices" type="enum" value="36037" label="36007" lvalues="36037|36038|36039|231" order="3" />
-    <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="4" />
-    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
-    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
-    <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011" />
-    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
-    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
-    <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
-    <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="11" lvalues="231|36044|36045" />
-    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="12" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
+    <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="2" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="3" />
+    <!-- Settings to control CEC devices with Kodi -->
+    <setting key="wake_devices" type="enum" value="36037" label="36007" lvalues="36037|36038|36039|231" order="4" />
+    <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="5" />
+    <setting key="activate_source" type="bool" value="1" label="36020" order="6" />
+    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="7" />
+    <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="8" />
+    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="9" />
+    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="10" />
+    <!-- Settings to control Kodi from CEC devices -->
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="11" lvalues="36028|13005|13011" />
+    <setting key="pause_or_stop_playback_on_deactivate" type="enum" value="231" label="36033" order="12" lvalues="231|36044|36045" />
+    <!-- Advanced settings -->
+    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="13" />
     <setting key="physical_address" type="string" label="36021" value="0" order="14" />
     <setting key="port" type="string" value="" label="36022" order="15" />
-
+    <!-- Invisible advanced settings -->
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="Kodi" configurable="0" />
     <setting key="device_type" type="int" value="1" configurable="0" />
     <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
     <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
     <setting key="double_tap_timeout_ms" type="int" min="0" value="300" configurable="0" />
+    <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001,2548:1002" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -26,7 +26,6 @@
     <!-- Advanced settings -->
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="13" />
     <setting key="physical_address" type="string" label="36021" value="0" order="14" />
-    <setting key="port" type="string" value="" label="36022" order="15" />
     <!-- Invisible advanced settings -->
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="Kodi" configurable="0" />

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1534,7 +1534,7 @@ bool CPeripheralCecAdapterUpdateThread::UpdateConfiguration(libcec_configuration
 bool CPeripheralCecAdapterUpdateThread::WaitReady(void)
 {
   // don't wait if we're not powering up anything
-  if (m_configuration.wakeDevices.IsEmpty() && m_configuration.bActivateSource == 0)
+  if (m_configuration.bActivateSource == 0)
     return true;
 
   // wait for the TV if we're configured to become the active source.
@@ -1610,7 +1610,7 @@ bool CPeripheralCecAdapterUpdateThread::SetInitialConfiguration(void)
   // devices to wake are set
   cec_logical_addresses tvOnly;
   tvOnly.Clear(); tvOnly.Set(CECDEVICE_TV);
-  if (!m_configuration.wakeDevices.IsEmpty() && (m_configuration.wakeDevices != tvOnly || m_configuration.bActivateSource == 0))
+  if (!m_configuration.wakeDevices.IsEmpty() && m_configuration.wakeDevices != tvOnly && m_configuration.bActivateSource == 1)
     m_adapter->m_cecAdapter->PowerOnDevices(CECDEVICE_BROADCAST);
 
   // wait until devices are powered up

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -397,7 +397,7 @@ void CPeripheralCecAdapter::Process(void)
     bSendStandbyCommands = m_iExitCode != EXITCODE_REBOOT &&
                            m_iExitCode != EXITCODE_RESTARTAPP &&
                            !m_bDeviceRemoved &&
-                           (!m_bGoingToStandby || GetSettingBool("standby_tv_on_pc_standby")) &&
+                           (!m_bGoingToStandby || m_configuration.bPowerOffDevicesOnStandby == 1) &&
                            GetSettingBool("enabled");
 
     if (m_bGoingToStandby)
@@ -1312,6 +1312,9 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
   m_configuration.bSendInactiveSource = config.bSendInactiveSource;
   bChanged |= SetSetting("send_inactive_source", m_configuration.bSendInactiveSource == 1);
 
+  m_configuration.bPowerOffDevicesOnStandby = config.bPowerOffDevicesOnStandby;
+  bChanged |= SetSetting("standby_tv_on_pc_standby", m_configuration.bPowerOffDevicesOnStandby == 1);
+
   m_configuration.iFirmwareVersion = config.iFirmwareVersion;
   m_configuration.bShutdownOnStandby = config.bShutdownOnStandby;
 
@@ -1398,11 +1401,12 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
     ReadLogicalAddresses(GetSettingInt("standby_devices"), m_configuration.powerOffDevices);
 
   // read the boolean settings
-  m_configuration.bUseTVMenuLanguage   = GetSettingBool("use_tv_menu_language") ? 1 : 0;
-  m_configuration.bActivateSource      = GetSettingBool("activate_source") ? 1 : 0;
-  m_configuration.bPowerOffScreensaver = GetSettingBool("cec_standby_screensaver") ? 1 : 0;
-  m_configuration.bPowerOnScreensaver  = GetSettingBool("cec_wake_screensaver") ? 1 : 0;
-  m_configuration.bSendInactiveSource  = GetSettingBool("send_inactive_source") ? 1 : 0;
+  m_configuration.bUseTVMenuLanguage        = GetSettingBool("use_tv_menu_language") ? 1 : 0;
+  m_configuration.bActivateSource           = GetSettingBool("activate_source") ? 1 : 0;
+  m_configuration.bPowerOffScreensaver      = GetSettingBool("cec_standby_screensaver") ? 1 : 0;
+  m_configuration.bPowerOnScreensaver       = GetSettingBool("cec_wake_screensaver") ? 1 : 0;
+  m_configuration.bSendInactiveSource       = GetSettingBool("send_inactive_source") ? 1 : 0;
+  m_configuration.bPowerOffDevicesOnStandby = GetSettingBool("standby_tv_on_pc_standby") ? 1 : 0;
 
   // read the mutually exclusive boolean settings
   int iStandbyAction(GetSettingInt("standby_pc_on_tv_standby"));

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -203,7 +203,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
         bActivate = m_bActiveSourceBeforeStandby;
         m_bActiveSourceBeforeStandby = false;
       }
-      if (bActivate)
+      if (bActivate && m_configuration.bActivateSource == 1)
         ActivateSource();
     }
   }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -167,8 +167,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
       if (bIgnoreDeactivate)
         CLog::Log(LOGDEBUG, "%s - ignoring OnScreensaverDeactivated for power action", __FUNCTION__);
     }
-    if (m_configuration.bPowerOnScreensaver == 1 && !bIgnoreDeactivate &&
-        m_configuration.bActivateSource == 1)
+    if (m_configuration.bPowerOnScreensaver == 1 && !bIgnoreDeactivate)
     {
       ActivateSource();
     }


### PR DESCRIPTION
Current problems with cec implementation:
1) built in function "CECStandby" not working when the option to power down devices on startup isn't set. 
2) built in function "CECToggleState" not working
3) many low power devices can't suspend although we try to do that when the TV powers off
4) resuming from standby ignores the activate source setting and 
5) "bPowerOnScreensaver" is behaving different than "bPowerOffScreensaver"  as "bPowerOnScreensaver" is only working when the activate source option is enabled
6) "bPowerOffDevicesOnStandby" is not sent to libcec
7) According to libcec, "wakedevices" should not power on devices when starting. Wakedevices defines a list of devices allowed to power op when calling "PowerOnDevices()".
8) Strings in settings dialog are sometimes unclear and not ordered properly.
example: the "WakeDevices" setting is listed as "Devices to power off during shutdown" in Kodi while it actually means "List of devices to power off when calling StandbyDevices() without any parameter" according to libcec. So basically this is a list of devices which may be powered down.
9) COM port setting in the settings dialog isn't used in Kodi.
10) when the screensaver and stop playback on inactive source settings are enabled (power on/off devices disabled), the following looping occurs: screensaver activates and sending inactive source -> tv sending source deactivated -> kodi send stop command -> stop command wakes screenserver -> source becomes active again -> screensaver becomes active again -> ...
11) The activate source setting will also wake up TV's regardless of the "wakedevices" setting in libcec. in the other hand, the inactive source setting does not power off the TV -> inconsistency 
12) sometimes a Kodi restart is needed in order to pickup changed settings

What is changed with this PR:
1) renamed and changed "PowerOffDevices" setting like it should be according to libcec, it should define what devices we may power down. 
2) base the toggle action on the power state of the TV when this one is set in "poweroffdevices". When power off isn't allowed, toggle will activate/deactivate the source.
3) When suspend isn't possible, the existing pause/stop media playback will be used.
4) add check for this setting
5) Removed activate source check
6) "bPowerOffDevicesOnStandby" will be sent to libcec now
7) renamed and changed "wakedevices" setting like it should be according to libcec, it should define what devices we may power up. Currently Kodi was misusing this setting as a "power up these devices on Kodi startup" functionality. The activate source setting will be used for that.
8) 9) reworked strings and settings order
10) fixed
11) Not fixed, not sure what to do here...
Libcec says "Make libCEC the active source when starting the client application", but currently kodi will not only activate but also power up devices. We can check for the power status or such.
12) not fixed

@opdenkamp 
Several questions for you:
a) PowerOnDevices(CECDEVICE_BROADCAST) will power on devices listed in "wakedevices" but what will ActivateSource() do, only wake up the TV or multiple devices? And should it power up devices when "wakedevices" is empty.
b) What do you think about issue 11?
c) Do you agree that "poweroffdevices" and "wakedevices" should define the devices which can be powered up/down by Kodi. So when these are set, the built in commands CECToggleState and such should work properly independent from other settings. Also setting these should not lead to powering up/down devices automatically when all other settings (activate/deactivate source, screensaver, standby,..) are unset? 

PR was tested on raspbian with a LG, Sony and Philips TV (without AVR). PR not ready to merge as some issues are not resolved yet.
