### PR TITLE
VideoPlayer: fix list of supported pixel formats given to ffmpeg

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
@@ -429,7 +429,7 @@ ERenderFormat CDVDCodecUtils::EFormatFromPixfmt(int fmt)
   return RENDER_FMT_NONE;
 }
 
-int CDVDCodecUtils::PixfmtFromEFormat(ERenderFormat fmt)
+AVPixelFormat CDVDCodecUtils::PixfmtFromEFormat(ERenderFormat fmt)
 {
   for(const EFormatMap *p = g_format_map; p->pix_fmt != AV_PIX_FMT_NONE; ++p)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.h
@@ -23,6 +23,10 @@
 #include "Video/DVDVideoCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFormats.h"
 
+extern "C" {
+#include "libavutil/pixfmt.h"
+}
+
 struct YV12Image;
 
 class CDVDCodecUtils
@@ -43,6 +47,6 @@ public:
   static double NormalizeFrameduration(double frameduration, bool *match = NULL);
 
   static ERenderFormat EFormatFromPixfmt(int fmt);
-  static int           PixfmtFromEFormat(ERenderFormat format);
+  static AVPixelFormat PixfmtFromEFormat(ERenderFormat format);
 };
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -310,9 +310,13 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
   m_iOrientation = hints.orientation;
 
+  m_formats.clear();
   for(std::vector<ERenderFormat>::iterator it = options.m_formats.begin(); it != options.m_formats.end(); ++it)
   {
-    m_formats.push_back((AVPixelFormat)CDVDCodecUtils::PixfmtFromEFormat(*it));
+    AVPixelFormat pixFormat = CDVDCodecUtils::PixfmtFromEFormat(*it);
+    if (pixFormat != AV_PIX_FMT_NONE)
+      m_formats.push_back(pixFormat);
+
     if(*it == RENDER_FMT_YUV420P)
       m_formats.push_back(AV_PIX_FMT_YUVJ420P);
   }


### PR DESCRIPTION
the array given to ffmpeg is terminated by AV_PIX_FMT_NONE. hence this format must not appear in the middle of the list. it did i.e. of RENDER_FMT_NV12
