### PR TITLE
Fix spelling error in german skin.estuary strings.po

### DIFF
--- a/addons/skin.estuary/language/resource.language.de_de/strings.po
+++ b/addons/skin.estuary/language/resource.language.de_de/strings.po
@@ -78,7 +78,7 @@ msgstr "Ungespielte Alben"
 
 msgctxt "#31015"
 msgid "Recent recordings"
-msgstr "Zeletzt gemachte Aufnahmen"
+msgstr "Zuletzt gemachte Aufnahmen"
 
 msgctxt "#31016"
 msgid "Recently played channels"


### PR DESCRIPTION
A small fix for a spelling error in german translation file for the estuary skin.
