### PR TITLE
Mention-Bot: Let's use a more sensible default

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,18 @@
+{
+  "maxReviewers": 3, // Maximum  number of people to ping in the PR message, default is 3
+  "numFilesToCheck": 5, // Number of files to check against, default is 5
+  "message": "@pullRequester, thank you for improving kodi! According to the last 5 commits, we found the potential reviewers: @reviewers . Final approval needs to be given by the componenent maintainer.",
+  "findPotentialReviewers": true, // mention-bot will try to find potential reviewers based on files history, if disabled, `alwaysNotifyForPaths` is used instead
+  "userBlacklist": [ fernetmenta ], // users in this list will never be mentioned by mention-bot
+  "userBlacklistForPR": [], // PR made by users in this list will be ignored
+  "requiredOrgs": [], // mention-bot will only mention user who are a member of one of these organizations
+  "actions": ["opened"], // List of PR actions that mention-bot will listen to, default is "opened"
+  "skipAlreadyAssignedPR": true, // mention-bot will ignore already assigned PR's
+  "skipAlreadyMentionedPR": true, // mention-bot will ignore if there is already existing an exact mention
+  "assignToReviewer": false, // mention-bot assigns the most appropriate reviewer for PR
+  "skipTitle": "", // mention-bot will ignore PR that includes text in the title,
+  "withLabel": "", // mention-bot will only consider PR's with this label. Must set actions to ["labeled"].
+  "delayed": false, // mention-bot will wait to comment until specified time in `delayedUntil` value
+  "delayedUntil": "3d", // Used if delayed is equal true, permitted values are: minutes, hours, or days, e.g.: '3 days', '40 minutes', '1 hour', '3d', '1h', '10m'
+  "skipCollaboratorPR": false, // mention-bot will ignore if PR is made by collaborator
+}


### PR DESCRIPTION
More sensible defaults for Mention-Bot:
- blacklist fernetmenta, he does not want to receive messages
  ~~-only send messages to xbmc team members~~ <- let's try it first to also get new devs from outside that contributed before
