### PR TITLE
VideoPlayer: drop obsolete player method HasFrame, fix subs for bypas…

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -762,15 +762,6 @@ void CApplicationPlayer::FrameMove()
     player->FrameMove();
 }
 
-bool CApplicationPlayer::HasFrame()
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->HasFrame();
-  else
-    return false;
-}
-
 void CApplicationPlayer::Render(bool clear, uint32_t alpha, bool gui)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -83,7 +83,6 @@ public:
   void SetPlaySpeed(float speed);
 
   void FrameMove();
-  bool HasFrame();
   void Render(bool clear, uint32_t alpha = 255, bool gui = true);
   void FlushRenderer();
   void SetRenderViewMode(int mode);

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -389,8 +389,6 @@ public:
    */
   virtual void FrameMove() {};
 
-  virtual bool HasFrame() { return false; };
-
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true) {};
 
   virtual void FlushRenderer() {};

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5039,11 +5039,6 @@ void CVideoPlayer::FrameMove()
   m_renderManager.FrameMove();
 }
 
-bool CVideoPlayer::HasFrame()
-{
-  return m_renderManager.HasFrame();
-}
-
 void CVideoPlayer::Render(bool clear, uint32_t alpha, bool gui)
 {
   m_renderManager.Render(clear, 0, alpha, gui);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -368,7 +368,6 @@ public:
   virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel);
 
   virtual void FrameMove();
-  virtual bool HasFrame();
   virtual void Render(bool clear, uint32_t alpha = 255, bool gui = true);
   virtual void FlushRenderer();
   virtual void SetRenderViewMode(int mode);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -960,7 +960,8 @@ bool CRenderManager::IsGuiLayer()
     if (!m_pRenderer)
       return false;
 
-    if (m_pRenderer->IsGuiLayer() || m_renderedOverlay || m_overlays.HasOverlay(m_presentsource))
+    if ((m_pRenderer->IsGuiLayer() && HasFrame()) ||
+        m_renderedOverlay || m_overlays.HasOverlay(m_presentsource))
       return true;
 
     if (m_renderDebug && m_debugTimer.IsTimePast())

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -485,7 +485,7 @@ void CGUIWindowFullScreen::FrameMove()
 
 void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &dirtyregion)
 {
-  if (g_application.m_pPlayer->IsRenderingGuiLayer() && g_application.m_pPlayer->HasFrame())
+  if (g_application.m_pPlayer->IsRenderingGuiLayer())
     MarkDirtyRegion();
 
   CGUIWindow::Process(currentTime, dirtyregion);


### PR DESCRIPTION
follow-up from https://github.com/xbmc/xbmc/pull/10500

@popcornmix I think this is a cleaner fix
