### PR TITLE
VideoPlayer: make processInfo a smart pointer, fixes mem leak

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -663,7 +663,7 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
 
   m_SkipCommercials = true;
 
-  m_processInfo = CProcessInfo::CreateInstance();
+  m_processInfo.reset(CProcessInfo::CreateInstance());
   CreatePlayers();
 
   m_displayLost = false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -21,6 +21,7 @@
  */
 
 #include <atomic>
+#include <memory>
 #include <utility>
 #include <vector>
 #include "cores/IPlayer.h"
@@ -503,7 +504,7 @@ protected:
   XbmcThreads::EndTime m_cachingTimer;
   CFileItem    m_item;
   XbmcThreads::EndTime m_ChannelEntryTimeOut;
-  CProcessInfo *m_processInfo;
+  std::unique_ptr<CProcessInfo> m_processInfo;
 
   CCurrentStream m_CurrentAudio;
   CCurrentStream m_CurrentVideo;


### PR DESCRIPTION
fix mem leak

credits to @popcornmix for bringing this up
