### PR TITLE
vaapi: lock gfx context on pre-cleanup

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -659,6 +659,7 @@ long CDecoder::Release()
     if (g_advancedSettings.CanLogComponent(LOGVIDEO))
       CLog::Log(LOGDEBUG,"VAAPI::Release pre-cleanup");
 
+    CSingleLock lock1(g_graphicsContext);
     Message *reply;
     if (m_vaapiOutput.m_controlPort.SendOutMessageSync(COutputControlProtocol::PRECLEANUP,
                                                    &reply,


### PR DESCRIPTION
chance to fix http://trac.kodi.tv/ticket/16911

I have carried this in my repo for a long time and somehow forgot to submit it. VDPAU has the same lock.
