### PR TITLE
Fix potential SQL constraint integrity violation in the PVR database

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -24,6 +24,7 @@
 
 #include "dbwrappers/dataset.h"
 #include "addons/PVRClient.h"
+#include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/PVRManager.h"
@@ -604,17 +605,15 @@ bool CPVRDatabase::Persist(CPVRChannelGroup &group)
 
 bool CPVRDatabase::Persist(CPVRChannel &channel)
 {
-  bool bReturn(false);
-
   /* invalid channel */
   if (channel.UniqueID() <= 0)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid channel uid: %d", __FUNCTION__, channel.UniqueID());
-    return bReturn;
+    return false;
   }
 
   std::string strQuery;
-  if (channel.ChannelID() <= 0)
+  if (!ChannelExists(channel.m_iClientId, channel.m_iUniqueId))
   {
     /* new channel */
     strQuery = PrepareSQL("INSERT INTO channels ("
@@ -625,31 +624,24 @@ bool CPVRDatabase::Persist(CPVRChannel &channel)
         channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
         channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
         channel.EpgID());
+
+    QueueInsertQuery(strQuery);
   }
   else
   {
     /* update channel */
-    strQuery = PrepareSQL("REPLACE INTO channels ("
-        "iUniqueId, bIsRadio, bIsHidden, bIsUserSetIcon, bIsUserSetName, bIsLocked, "
-        "sIconPath, sChannelName, bIsVirtual, bEPGEnabled, sEPGScraper, iLastWatched, iClientId, "
-        "idChannel, idEpg) "
-        "VALUES (%i, %i, %i, %i, %i, %i, '%s', '%s', %i, %i, '%s', %u, %i, %i, %i)",
-        channel.UniqueID(), (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
-        channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(), channel.ClientID(),
-        channel.ChannelID(),
-        channel.EpgID());
+    strQuery = PrepareSQL("UPDATE channels SET "
+        "bIsRadio = %i, bIsHidden = %i, bIsUserSetIcon = %i, bIsUserSetName = %i, bIsLocked = %i, "
+        "sIconPath= %s, sChannelName = %s, bIsVirtual = %i, bEPGEnabled = %i, sEPGScraper = %s, iLastWatched = %u, "
+        "idChannel = %i, idEpg = %i WHERE iUniqueId = %i AND iClientId = %i",
+        (channel.IsRadio() ? 1 :0), (channel.IsHidden() ? 1 : 0), (channel.IsUserSetIcon() ? 1 : 0), (channel.IsUserSetName() ? 1 : 0), (channel.IsLocked() ? 1 : 0),
+        channel.IconPath().c_str(), channel.ChannelName().c_str(), 0, (channel.EPGEnabled() ? 1 : 0), channel.EPGScraper().c_str(), channel.LastWatched(),
+        channel.ChannelID(), channel.EpgID(), channel.UniqueID(), channel.ClientID());
+
+    ExecuteQuery(strQuery);
   }
 
-  if (QueueInsertQuery(strQuery))
-  {
-    /* update the channel ID for new channels */
-    if (channel.ChannelID() <= 0)
-      channel.SetChannelID((int)m_pDS->lastinsertid());
-
-    bReturn = true;
-  }
-
-  return bReturn;
+  return true;
 }
 
 bool CPVRDatabase::UpdateLastWatched(const CPVRChannel &channel)
@@ -662,8 +654,19 @@ bool CPVRDatabase::UpdateLastWatched(const CPVRChannel &channel)
 
 bool CPVRDatabase::UpdateLastWatched(const CPVRChannelGroup &group)
 {
-  std::string strQuery = PrepareSQL("UPDATE channelgroups SET iLastWatched = %d WHERE idGroup = %d",
+  const std::string strQuery = PrepareSQL("UPDATE channelgroups SET iLastWatched = %d WHERE idGroup = %d",
     group.LastWatched(), group.GroupID());
 
   return ExecuteQuery(strQuery);
+}
+
+bool CPVRDatabase::ChannelExists(int iClientId, int iUniqueId)
+{
+  std::string strQuery = PrepareSQL("SELECT idChannel FROM channels WHERE iClientId = %d AND iUniqueId = %d",
+                                    iClientId, iUniqueId);
+
+  if (ResultQuery(strQuery))
+    return !m_pDS->eof();
+
+  return false;
 }

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -185,6 +185,14 @@ namespace PVR
     bool PersistChannels(CPVRChannelGroup &group);
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup &group);
+
+    /*!
+     * Checks whether the specified unique combination for a channel exists in the database
+     * @param iClientId
+     * @param iUniqueId
+     * @return
+     */
+    bool ChannelExists(int iClientId, int iUniqueId);
   };
 
   /*!


### PR DESCRIPTION
Supersedes https://github.com/xbmc/xbmc/pull/8953
Fixes trac #16031
Closes kodi-pvr/pvr.hts#172

This fixes the problem without bumping the database version so it should be more possibly to get it merged for V17.

Basically the code that persists channels has been made smarter. Instead of just blindly looking at the primary key stored in the object we query the database to check if a channel with the unique ID and client ID already exists. If it does, we update that channel, if not we create a new channel. There is more background information in the referenced PRs.

This fix also has the added side-effect that it increases database performance. While a new SELECT statement has been added, we now do an UPDATE instead of a REPLACE INTO which prevents indexes from having to be re-calculated (REPLACE INTO basically does a DELETE followed by an INSERT). This also means we don't need to worry about the channel ID changing after the channel has been updated (which was a side effect of using REPLACE INTO).

@ksooo now's a good time to test that new review feature, @Glenn-1990 can you runtime test this? I tested with your reproducible test case (change a channel's service from TV to radio while Kodi is off) and it seems to fix the issue.
