### PR TITLE
Musicroles Menu Additional default nodes 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19464,7 +19464,31 @@ msgctxt "#38042"
 msgid "[Missing]"
 msgstr ""
 
-#empty strings from id 38043 to 38099
+#. Title album artists node
+#: system/library/music/musicroles/albumartists.xml
+msgctxt "#38043"
+msgid "Album artists"
+msgstr ""
+
+#. Title all artists node
+#: system/library/music/musicroles/allartists.xml
+msgctxt "#38044"
+msgid "Song & album artists"
+msgstr ""
+
+#. Title all contributors node (any role)
+#: system/library/music/musicroles/allcontributors.xml
+msgctxt "#38045"
+msgid "All contributors"
+msgstr ""
+
+#. Title all roles node
+#: system/library/music/musicroles/allroles.xml
+msgctxt "#38046"
+msgid "All roles"
+msgstr ""
+
+#empty strings from id 38047 to 38099
 
 #. Description of section #14200 "Player""
 #: system/settings/settings.xml

--- a/system/library/music/musicroles/albumartists.xml
+++ b/system/library/music/musicroles/albumartists.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="10" type="folder">
+	<label>38043</label>
+	<icon>DefaultMusicArtists.png</icon>
+	<path>musicdb://artists/?albumartistsonly=true</path>
+</node>

--- a/system/library/music/musicroles/allartists.xml
+++ b/system/library/music/musicroles/allartists.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="11" type="folder">
+	<label>38044</label>
+	<icon>DefaultMusicArtists.png</icon>
+	<path>musicdb://artists/?albumartistsonly=false</path>
+</node>

--- a/system/library/music/musicroles/allcontributors.xml
+++ b/system/library/music/musicroles/allcontributors.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="12" type="folder">
+	<label>38045</label>
+	<icon>DefaultMusicArtists.png</icon>
+	<path>musicdb://artists/?roleid=-1000</path>
+</node>

--- a/system/library/music/musicroles/allroles.xml
+++ b/system/library/music/musicroles/allroles.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<node order="15" type="folder">
+	<label>38046</label>
+	<icon>DefaultMusicRoles.png</icon>
+	<path>musicdb://roles/</path>
+</node>


### PR DESCRIPTION
I would like to add some more default nodes beneath the music roles submenu item in the music library menu. This will make some of the new music library features more accessible without cluttering the menu layout for those users that don't want any of this (or have not tagged their music with composers etc., musician credits or people invloved).

This submenu currently shows nodes for the standard roles - composer, conductor, orchestra, arranger, lyricist, DJmixer,  remixer. This change adds nodes:
a) all roles - standard roles, plus musician credits e.g. "piano",  and people involved e.g. engineer
b) all contributors - every artist that Kodi knows about regardless of role they contribute to the song
c) all artists  - song and album artists 
d) album artists only 

c ) and d)  are effectively the usual artists node  but independent of the "Show song and album artists" system setting.

@jjd-uk I thought this was a gentle step towards depricating the "Show song and album artists" system setting as we discussed - the ability to switch between seeing the song artists or not without going off to the settings menu.

@ronie or @phil65 care to check this for me.
