### PR TITLE
[CEC] fix CECToggleState, screensaver looping etc. 

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -17,6 +17,7 @@
     <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
     <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
     <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011" />
+    <setting key="stop_on_tv_standby" type="enum" value="36044" label="36029" order="8" lvalues="36028|13005|36044" />
     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -25,7 +25,6 @@
     <setting key="connected_device" type="enum" label="36019" value="36037" lvalues="36037|36038" order="12" />
     <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
     <setting key="physical_address" type="string" label="36021" value="0" order="14" />
-    <setting key="port" type="string" value="" label="36022" order="15" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="Kodi" configurable="0" />

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1167,7 +1167,7 @@ void CPeripheralCecAdapter::CecSourceActivated(void *cbParam, const CEC::cec_log
     bool bShowingSlideshow = (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW);
     CGUIWindowSlideShow *pSlideShow = bShowingSlideshow ? (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW) : NULL;
     bool bPlayingAndDeactivated = activated == 0 && (
-        (pSlideShow && pSlideShow->IsPlaying()) || !g_application.m_pPlayer->IsPausedPlayback());
+        (pSlideShow && pSlideShow->IsPlaying()) || (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPausedPlayback()));
     bool bPausedAndActivated = activated == 1 && adapter->m_bPlaybackPaused && (
         (pSlideShow && pSlideShow->IsPaused()) || g_application.m_pPlayer->IsPausedPlayback());
     if (bPlayingAndDeactivated)
@@ -1185,12 +1185,12 @@ void CPeripheralCecAdapter::CecSourceActivated(void *cbParam, const CEC::cec_log
         // pause/resume player
         CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PAUSE);
     }
-    else if (bPlayingAndDeactivated
-      && adapter->GetSettingInt("pause_or_stop_playback_on_deactivate") == LOCALISED_ID_STOP)
+    else if (activated == 0 && adapter->GetSettingInt("pause_or_stop_playback_on_deactivate") == LOCALISED_ID_STOP)
     {
       if (pSlideShow)
         pSlideShow->OnAction(CAction(ACTION_STOP));
-      else
+      else if (g_application.m_pPlayer->IsPlaying())
+        // only when playing as TMSG_MEDIA_STOP will wake the screensaver, this can make the source active again
         CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
     }
   }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1778,7 +1778,8 @@ bool CPeripheralCecAdapter::ToggleDeviceState(CecStateChange mode /*= STATE_SWIT
 {
   if (!IsRunning())
     return false;
-  if (m_cecAdapter->IsLibCECActiveSource() && (mode == STATE_SWITCH_TOGGLE || mode == STATE_STANDBY))
+  if (m_cecAdapter->IsLibCECActiveSource() &&
+      ((mode == STATE_SWITCH_TOGGLE && m_cecAdapter->GetDevicePowerStatus(CECDEVICE_TV) == CEC_POWER_STATUS_ON) || mode == STATE_STANDBY))
   {
     CLog::Log(LOGDEBUG, "%s - putting CEC device on standby...", __FUNCTION__);
     StandbyDevices();


### PR DESCRIPTION
This one superseeds https://github.com/xbmc/xbmc/pull/10492 and contains only the most important code changes. Setting that don't apply for unsuspendable devices (RPI, IMX, etc.) are not shown to avoid user confusion.

Issues that should be solved now:
http://forum.kodi.tv/showthread.php?tid=225779
https://discourse.osmc.tv/t/control-tv-on-standby-toggle-using-cec-kodi-built-in-functions/3638/2

@opdenkamp
