### PR TITLE
[estouchy] exit button should execute the selected shutdown function

### DIFF
--- a/addons/skin.estouchy/xml/Home.xml
+++ b/addons/skin.estouchy/xml/Home.xml
@@ -211,7 +211,7 @@
 				<content>
 					<item>
 						<label>13012</label>
-						<onclick>Quit</onclick>
+						<onclick>Shutdown</onclick>
 						<icon>icon_button_shutdown.png</icon>
 					</item>
 					<item>


### PR DESCRIPTION
quit may not be applicable on some platforms, use the selected shutdown function instead.

http://forum.kodi.tv/showthread.php?tid=262145&pid=2418740#pid2418740
