### PR TITLE
kodi.guilib: fix version in generated addon.xml

### DIFF
--- a/lib/addons/library.kodi.guilib/Makefile.in
+++ b/lib/addons/library.kodi.guilib/Makefile.in
@@ -14,8 +14,8 @@ LIB_SHARED=../../../addons/library.kodi.guilib/$(LIBNAME)-$(ARCH).so
 endif
 
 GENERATED_ADDON_GUILIB = ../../../addons/kodi.guilib/addon.xml
-LIB_VERSION := $(shell sed -n 's/.*KODI_GUILIB_API_VERSION\s*"\(.*\)"/\1/p' $(LIB_INTERFACE))
-LIB_VERSION_MIN := $(shell sed -n 's/.*KODI_GUILIB_MIN_API_VERSION\s*"\(.*\)"/\1/p' $(LIB_INTERFACE))
+LIB_VERSION := $(shell sed -n 's/.*KODI_GUILIB_API_VERSION[[:space:]]*"\(.*\)"/\1/p' $(LIB_INTERFACE))
+LIB_VERSION_MIN := $(shell sed -n 's/.*KODI_GUILIB_MIN_API_VERSION[[:space:]]*"\(.*\)"/\1/p' $(LIB_INTERFACE))
 
 all: $(LIB_SHARED) $(GENERATED_ADDON_GUILIB)
 


### PR DESCRIPTION
fix regex that extracts guilib version on OSX
required after dependency checking https://github.com/xbmc/xbmc/pull/10335
