### PR TITLE
[PVR] timersettings: show unknown when the current setting is unknown

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5944,6 +5944,7 @@ msgstr ""
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 #: xbmc/peripherals/devices/Peripheral.cpp
 #: xbmc/peripherals/bus/PeripheralBus.cpp
+#: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
 msgctxt "#13205"
 msgid "Unknown"
 msgstr ""

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -905,6 +905,21 @@ void CGUIDialogPVRTimerSettings::DupEpisodesFiller(
     list.clear();
     pThis->m_timerType->GetPreventDuplicateEpisodesValues(list);
     current = pThis->m_iPreventDupEpisodes;
+
+    auto it = list.begin();
+    while (it != list.end())
+    {
+      if (it->second == current)
+        break; // value already in list
+
+      ++it;
+    }
+
+    if (it == list.end())
+    {
+      // PVR backend supplied value is not in the list of predefined values. Insert it.
+      list.insert(it, std::make_pair(g_localizeStrings.Get(13205), current)); // "Unknown"
+    }
   }
   else
     CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::DupEpisodesFiller - No dialog");


### PR DESCRIPTION
When the duplicate setting for a timer rule is unknown to Kodi, an empty box is present. Other fields in timersettings already have a fall back, but the duplicate detection not. 
I know that the pvr addon should push all known types, but backends may change constantly while pvr addon updates are not so frequently. This PR just let the user known that the setting is unknown. This principle is the same as what is done with other settings as lifetime, priority, ... 

before PR:
![empty](https://cloud.githubusercontent.com/assets/2036512/18684063/1d8269f8-7f73-11e6-8ac5-70508b040f7f.png)

after PR:
![not_empty](https://cloud.githubusercontent.com/assets/2036512/18684069/24e4a832-7f73-11e6-8afe-9016a729e7eb.png)

@ksooo @Jalle19 
