### PR TITLE
fix warning on exit

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -405,7 +405,6 @@ bool CGUIWindowManager::DestroyWindows()
     Delete(WINDOW_WEATHER);
     Delete(WINDOW_DIALOG_GAME_CONTROLLERS);
 
-    Remove(WINDOW_SETTINGS_SYSTEM);
     Remove(WINDOW_SETTINGS_SERVICE);
     Remove(WINDOW_SETTINGS_MYPVR);
     Remove(WINDOW_SETTINGS_PLAYER);


### PR DESCRIPTION
don't try to remove a window that's already been deleted (https://github.com/xbmc/xbmc/blob/master/xbmc/guilib/GUIWindowManager.cpp#L392)

this gets rid of the warning when you exit kodi:
`15:44:25 T:140011849120128 WARNING: Attempted to remove window 10016 from the window manager when it didn't exist`
