### PR TITLE
[settings] - increase possible skinzoom from +-20 to +-30 percent.

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3071,9 +3071,9 @@
           <level>1</level>
           <default>0</default>
           <constraints>
-            <minimum>-20</minimum>
+            <minimum>-30</minimum>
             <step>2</step>
-            <maximum>20</maximum>
+            <maximum>30</maximum>
           </constraints>
           <dependencies>
             <dependency type="update" setting="lookandfeel.skin" />


### PR DESCRIPTION
This allows some special setups like having a 16:9 projector projecting to a 2.35:1 screen. Combining the optical zoom on the projector with the skin zoom allows proper alignment with good quality.

for reference (ignore ned scott in that thread - he missed the point)

http://forum.kodi.tv/showthread.php?tid=291404
