### PR TITLE
Ticket #16906 - Fix iEndOffset property when parsing cue files

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -324,7 +324,7 @@ bool CCueDocument::Parse(CueReader& reader, const std::string& strFile)
         CLog::Log(LOGERROR, "Mangled Time in INDEX 0x tag in CUE file!");
         return false;
       }
-      if (totalTracks > 0) // Set the end time of the last track
+      if (totalTracks > 0 && m_tracks[totalTracks - 1].strFile == strCurrentFile) // Set the end time of the last track
         m_tracks[totalTracks - 1].iEndTime = time;
 
       if (totalTracks >= 0) // start time of the next track


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

When CueDocument is parsing the cue file and generating the data, it blindly sets "iEndOffset" by assuming that the last track ends when the current one starts. This assumption is only right if the 'FILE' pointed by this cue sheet does not change. In the current case, each 'TRACK' has its own flac file, so this assumption is not right and PAPlayer will act on this data. Therefore, the files won't play since they will end shortly (immediately) after being started.
## Motivation and Context

http://trac.kodi.tv/ticket/16906
## How Has This Been Tested?

Once patched and the library re-imported, the album used for debugging could be played without problems.
## Screenshots (if appropriate):
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
