### PR TITLE
TestStopWatch: Take care if we get scheduled

### DIFF
--- a/xbmc/utils/test/TestStopwatch.cpp
+++ b/xbmc/utils/test/TestStopwatch.cpp
@@ -70,6 +70,7 @@ TEST(TestStopWatch, Reset)
   a.StartZero();
   thread.Sleep(2);
   EXPECT_GT(a.GetElapsedMilliseconds(), 1);
+  thread.Sleep(3);
   a.Reset();
-  EXPECT_LT(a.GetElapsedMilliseconds(), 1);
+  EXPECT_LT(a.GetElapsedMilliseconds(), 5);
 }


### PR DESCRIPTION
Make tests happy
## Description

The tests of our stopwatch are kind of foobar. Whenever the running process gets scheduled, there is no guarantee that the second method invocation happens < 1ms.
## Motivation and Context

Make tests green
## How Has This Been Tested?

Not at all - I want jenkins to test it.
## Types of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

[x] Self-Documenting
