### PR TITLE
[PVR] Fix epg data unload on application exit / log off.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1311,8 +1311,11 @@ void CApplication::StopPVRManager()
   CLog::Log(LOGINFO, "stopping PVRManager");
   if (g_PVRManager.IsPlaying())
     StopPlaying();
+  // stop pvr manager thread and clear all pvr data
   g_PVRManager.Stop();
+  // stop epg container thread and clear all epg data
   g_EpgContainer.Stop();
+  g_EpgContainer.Clear();
 }
 
 void CApplication::ReinitPVRManager()


### PR DESCRIPTION
This fixes a problem with epg data not properly re-initialized after switching user profile. Reported here http://forum.kodi.tv/showthread.php?tid=282907&pid=2418766#pid2418766

Fix is not only to stop the epg updater thread when logging off, but also to wipe all epg data.

@Jalle19 for review?
