### PR TITLE
[cmake] Fix FindCCACHE module

### DIFF
--- a/project/cmake/modules/FindCCache.cmake
+++ b/project/cmake/modules/FindCCache.cmake
@@ -7,7 +7,11 @@
 # See: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 
 find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CCACHE REQUIRED_VARS CCACHE_PROGRAM)
+
+if(CCACHE_FOUND)
   # Supports Unix Makefiles and Ninja
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")


### PR DESCRIPTION
@wsnipex, @fritsch followup on yesterdays slack discussion

Clean build with empty ccache:
2127.38user 227.17system 5:10.50elapsed 758%CPU (0avgtext+0avgdata 745860maxresident)k
10040inputs+8928728outputs (381major+39179319minor)pagefaults 0swaps

Clean build with ccache enabled:
751.87user 59.98system 1:56.25elapsed 698%CPU (0avgtext+0avgdata 745836maxresident)k
80inputs+4412512outputs (348major+19134578minor)pagefaults 0swaps
