### PR TITLE
[osx] - add support for Xcode 8

### DIFF
--- a/docs/README.osx
+++ b/docs/README.osx
@@ -32,7 +32,8 @@ codecs that support a multitude of music and video formats.
 
 On Mavericks (OSX 10.9.x) we recommend using Xcode 6.1.
 On Yosemite (OSX 10.10.x) we recommend using Xcode 6.4.
-On El Capitan (OSX 10.11.x) we recommend using Xcode 7.2.
+On El Capitan (OSX 10.11.x) we recommend using Xcode 7.x or Xcode 8.x.
+On Sierra (macOS 10.12.x) we recomment using Xcode 8.x.
 
 NOTE TO NEW OS X USERS: All lines that are prefixed with the '$' character are
 commands that need to be typed into a Terminal window. Note that the '$'
@@ -69,6 +70,8 @@ constellations of Xcode and osx versions (to be updated once we know more):
 4. XCode 6.3.0 against OSX SDK 10.10 (Y)
 5. Xcode 6.4.0 against OSX SDK 10.10 (Y)
 6. Xcode 7.x against OSX SDK 10.11 (EC)
+7. Xcode 8.0 against OSX SDK 10.12 (EC)
+8. Xcode 8.0 against OSX SDK 10.12 (S)
 
 -----------------------------------------------------------------------------
 3.2 Install Kodi build depends

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -250,6 +250,7 @@ case $host in
           10.9);;
           10.10);;
           10.11);;
+          10.12);;
           *)
             AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
         esac

--- a/tools/depends/native/config.site.native.in
+++ b/tools/depends/native/config.site.native.in
@@ -24,3 +24,12 @@ fi
 
 LD_LIBRARY_PATH=@prefix@/@tool_dir@/lib:$LD_LIBRARY_PATH
 NASM=@prefix@/@tool_dir@/bin/yasm
+
+if test "@platform_os@" = "osx" ; then
+  # Xcode 8 + 10.11, clock_gettime and getentropy is present
+  # in 10.12 but will get wrongly detected if building on 10.11
+  ac_cv_search_clock_gettime=no
+  ac_cv_func_clock_gettime=no
+  ac_cv_func_getentropy=no
+fi
+

--- a/tools/depends/target/config-binaddons.site.in
+++ b/tools/depends/target/config-binaddons.site.in
@@ -118,6 +118,15 @@ if test "@platform_os@" = "android"; then
 
 fi
 
+if test "@platform_os@" = "osx" ; then
+  # Xcode 8 + 10.11, clock_gettime getentropy is present
+  # in 10.12 but will get wrongly detected if building on 10.11
+  ac_cv_search_clock_gettime=no
+  ac_cv_func_clock_gettime=no
+  ac_cv_func_getentropy=no
+fi
+
+
 if test "@platform_os@" = "ios"; then
   # tweaks for libffi (ios must use llvm-gcc-4.2)
   if test "${PACKAGE_NAME}" = "libffi" ; then

--- a/tools/depends/target/config.site.in
+++ b/tools/depends/target/config.site.in
@@ -140,6 +140,15 @@ if test "@platform_os@" = "android"; then
 
 fi
 
+if test "@platform_os@" = "osx" ; then
+  # Xcode 8 + 10.11, clock_gettime and getentropy is present
+  # in 10.12 but will get wrongly detected if building on 10.11
+  ac_cv_search_clock_gettime=no
+  ac_cv_func_clock_gettime=no
+  ac_cv_func_getentropy=no
+fi
+
+
 if test "@platform_os@" = "ios"; then
   # tweaks for libffi (ios must use llvm-gcc-4.2)
   if test "${PACKAGE_NAME}" = "libffi" ; then

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -33,6 +33,9 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 < ../size-max.patch
 	cd $(PLATFORM); $(CONFIGURE)
+ifeq ($(OS),osx)
+	cd $(PLATFORM); sed -ie "s/HAVE_GETENTROPY/HAVE_GETENTROPY_NOPE/" config.h
+endif
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)

--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -52,6 +52,9 @@ endif
 ifeq ($(TARGET_PLATFORM),appletvos)
 	cd $(PLATFORM); patch -p0 < ../no_fork_and_exec.patch
 endif
+ifeq ($(OS),osx)
+	sed -ie "s|ifndef HAVE_CLOCK_GETTIME|if !defined(HAVE_CLOCK_GETTIME) \&\& !defined(CLOCK_REALTIME)|" "$(PLATFORM)/lib/replace/system/time.h"
+endif
 	cd $(PLATFORM)/source3; $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
This allows compiling with Xcode8 on either OSX 10.11 (El Capitan) or macOS 10.12 (Sierra).

thx @davilla for giving a hand.

@ksooo if you are still on el capitan - might want to test this out?
