### PR TITLE
OMXPlayer: Fix bug where audio timestamps fail to update

### DIFF
--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -152,6 +152,11 @@ int COMXAudioCodecOMX::Decode(BYTE* pData, int iSize, double dts, double pts)
   if (!m_pCodecContext) return -1;
 
   AVPacket avpkt;
+  if (!m_iBufferOutputUsed)
+  {
+    m_dts = dts;
+    m_pts = pts;
+  }
   if (m_bGotFrame)
     return 0;
   av_init_packet(&avpkt);
@@ -182,11 +187,6 @@ int COMXAudioCodecOMX::Decode(BYTE* pData, int iSize, double dts, double pts)
   }
 
   m_bGotFrame = true;
-  if (!m_iBufferOutputUsed)
-  {
-    m_dts = dts;
-    m_pts = pts;
-  }
   return iBytesUsed;
 }
 


### PR DESCRIPTION
This causes issues with out of sync audio after packet loss with live tv
See: http://forum.kodi.tv/showthread.php?tid=269814&pid=2412025
