### PR TITLE
Fix autoconf-based build after #10491.

### DIFF
--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -1,7 +1,6 @@
 SRCS += AlarmClock.cpp
 SRCS += AliasShortcutUtils.cpp
 SRCS += Archive.cpp
-SRCS += AsyncFileCopy.cpp
 SRCS += auto_buffer.cpp
 SRCS += Base64.cpp
 SRCS += BitstreamConverter.cpp


### PR DESCRIPTION
Fix Makefile after #10491 (removal of AsyncFileCopy.(cpp|h)

Reported by https://github.com/xbmc/xbmc/pull/10491#issuecomment-248974387 & https://github.com/xbmc/xbmc/pull/10534#issuecomment-248986438
