### PR TITLE
[platform] - add unique hardware identifier as info label

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -820,7 +820,7 @@
 		DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF033D361946612400BFC82E /* AEDeviceEnumerationOSX.cpp */; };
 		DF0ABB73183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
 		DF0ABB74183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
-		DF0D9F4D1D63931F006A7DBB /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
+		DF0D9F4D1D63931F006A7DBB /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE_CLASSPLATFORM"; }; };
 		DF0D9F511D63961B006A7DBB /* PlatformDarwinOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F501D63961B006A7DBB /* PlatformDarwinOSX.cpp */; };
 		DF0D9F551D639898006A7DBB /* PlatformDarwinIOS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F531D639893006A7DBB /* PlatformDarwinIOS.cpp */; };
 		DF0DF15C13A3ADA7008ED511 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF15913A3ADA7008ED511 /* NFSDirectory.cpp */; };
@@ -977,7 +977,7 @@
 		DFA8157E16713B1200E4E597 /* WakeOnAccess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFA8157C16713B1200E4E597 /* WakeOnAccess.cpp */; };
 		DFAB049813F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
 		DFACDB891D6CAC33003BBB92 /* PlatformDarwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8E55951D5F1D7000FD2BA3 /* PlatformDarwin.cpp */; };
-		DFACDB8E1D6CAD06003BBB92 /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
+		DFACDB8E1D6CAD06003BBB92 /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE_CLASSPLATFORM"; }; };
 		DFAF6A4F16EBAE3800D6AE12 /* RssManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAF6A4D16EBAE3800D6AE12 /* RssManager.cpp */; };
 		DFB02DEA16629DBA00F37752 /* PyContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB02DE816629DBA00F37752 /* PyContext.cpp */; };
 		DFB0F472161B747500D744F4 /* AddonsOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB0F470161B747500D744F4 /* AddonsOperations.cpp */; };

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5525,7 +5525,13 @@ msgctxt "#12395"
 msgid "Battery level"
 msgstr ""
 
-#empty strings from id 12396 to 12599
+#. Please don't translate this but simply use the english version!
+#: xbmc/windows/GUIWindowSystemInfo.cpp
+msgctxt "#12396"
+msgid "Hardware UUID"
+msgstr ""
+
+#empty strings from id 12397 to 12599
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12600"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1188,6 +1188,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "profileautologin", SYSTEM_PROFILEAUTOLOGIN },
                                   { "progressbar",      SYSTEM_PROGRESS_BAR },
                                   { "batterylevel",     SYSTEM_BATTERY_LEVEL },
+                                  { "hardwareuuid",     SYSTEM_HARDWARE_UUID },
                                   { "friendlyname",     SYSTEM_FRIENDLY_NAME },
                                   { "alarmpos",         SYSTEM_ALARM_POS },
                                   { "isinhibit",        SYSTEM_ISINHIBIT },
@@ -6306,6 +6307,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case SYSTEM_UPTIME:
   case SYSTEM_TOTALUPTIME:
   case SYSTEM_BATTERY_LEVEL:
+  case SYSTEM_HARDWARE_UUID:
     return g_sysinfo.GetInfo(info);
     break;
 

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -60,3 +60,8 @@ CDataCacheCore &CServiceBroker::GetDataCacheCore()
 {
   return g_application.m_ServiceManager->GetDataCacheCore();
 }
+
+CPlatform& CServiceBroker::GetPlatform()
+{
+  return g_application.m_ServiceManager->GetPlatform();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -42,6 +42,7 @@ namespace PVR
 class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
+class CPlatform;
 
 class CServiceBroker
 {
@@ -54,4 +55,5 @@ public:
   static ActiveAE::CActiveAEDSP& GetADSP();
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
+  static CPlatform& GetPlatform();
 };

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -424,6 +424,8 @@
 #define SYSTEM_CAN_HIBERNATE        752
 #define SYSTEM_CAN_REBOOT           753
 
+#define SYSTEM_HARDWARE_UUID        754
+
 #define SLIDESHOW_ISPAUSED          800
 #define SLIDESHOW_ISRANDOM          801
 #define SLIDESHOW_ISACTIVE          802

--- a/xbmc/platform/CMakeLists.txt
+++ b/xbmc/platform/CMakeLists.txt
@@ -15,5 +15,5 @@ set(HEADERS MessagePrinter.h
 core_add_library(platform_common)
 
 if(OVERRIDES_CPP)
-  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE)
+  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE_CLASSPLATFORM)
 endif()

--- a/xbmc/platform/Makefile.in
+++ b/xbmc/platform/Makefile.in
@@ -2,7 +2,7 @@
 
 OVERRIDES = $(wildcard overrides/@CORE_SYSTEM_NAME@/*.cpp) $(wildcard overrides/@CORE_SYSTEM_VARIANT@/*.cpp)
 ifneq ($(strip $(OVERRIDES)),)
-  CXXFLAGS += -DPLATFORM_OVERRIDE
+  CXXFLAGS += -DPLATFORM_OVERRIDE_CLASSPLATFORM
 endif
   
 SRCS = posix/MessagePrinter.cpp

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -21,7 +21,7 @@
 #include "Platform.h"
 
 // Override for platform ports
-#if !defined(PLATFORM_OVERRIDE)
+#if !defined(PLATFORM_OVERRIDE_CLASSPLATFORM)
 
 CPlatform* CPlatform::CreateInstance()
 {

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -18,7 +18,14 @@
  *
  */
 
+#include "system.h"
 #include "Platform.h"
+#include "Application.h"
+#include "network/Network.h"
+#include "utils/log.h"
+#include "utils/md5.h"
+
+const std::string CPlatform::NoValidUUID = "NOUUID";
 
 // Override for platform ports
 #if !defined(PLATFORM_OVERRIDE_CLASSPLATFORM)
@@ -34,16 +41,30 @@ CPlatform* CPlatform::CreateInstance()
 
 CPlatform::CPlatform()
 {
-  
-}
-
-CPlatform::~CPlatform()
-{
-  
+  m_uuid = NoValidUUID;
 }
 
 void CPlatform::Init()
 {
-  // nothing for now
+  InitUniqueHardwareIdentifier();
+}
+
+void CPlatform::InitUniqueHardwareIdentifier()
+{
+  CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
+  if (iface)
+  {
+    m_uuid = iface->GetMacAddress();
+#if defined(_DEBUG)
+    CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+    m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
+    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
+  }
+}
+
+std::string CPlatform::GetUniqueHardwareIdentifier()
+{
+  return m_uuid;
 }
 

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -55,11 +55,7 @@ void CPlatform::InitUniqueHardwareIdentifier()
   if (iface)
   {
     m_uuid = iface->GetMacAddress();
-#if defined(_DEBUG)
-    CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
     m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
-    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
   }
 }
 

--- a/xbmc/platform/Platform.h
+++ b/xbmc/platform/Platform.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <string>
 
 /**\brief Class for the Platform object
  *
@@ -39,7 +40,7 @@ public:
   CPlatform();
   
   /**\brief D'tor */
-  virtual ~CPlatform();
+  virtual ~CPlatform() = default;
   
   /**\brief Called at an early stage of application startup
    *
@@ -47,5 +48,29 @@ public:
    * or initialisation (like setting environment variables for example)
    */
   virtual void Init();
+  
+
+  /**\brief Geter for the m_uuid member
+   *
+   *\return the m_uuid member
+   */
+  std::string GetUniqueHardwareIdentifier();
+
+  /**\brief Called for initing the m_uuid member.
+   *
+   * This method should set m_uuid to a string which identifies the hardware we
+   * are running on. The underlaying source for this information could
+   * be a network mac address, hw serial number or other uuid that is provided
+   * by the underlaying operating system.
+   * The best identifiers are those that never change (not even during operating system upgrades).
+   * m_uuid should be filled the the MD5 Hash of the unique identifier!
+   */
+  virtual void InitUniqueHardwareIdentifier();
+  
+  // constants
+  static const std::string NoValidUUID;
+  
+  protected:
+    std::string m_uuid;
   
 };

--- a/xbmc/platform/android/jni/CMakeLists.txt
+++ b/xbmc/platform/android/jni/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCES Activity.cpp
             PowerManager.cpp
             Resources.cpp
             ScanResult.cpp
+            SettingsSecure.cpp
             StatFs.cpp
             StorageManager.cpp
             StorageVolume.cpp
@@ -112,6 +113,7 @@ set(HEADERS Activity.h
             PowerManager.h
             Resources.h
             ScanResult.h
+            SettingsSecure.h
             StatFs.h
             Surface.h
             SurfaceTexture.h

--- a/xbmc/platform/android/jni/Context.cpp
+++ b/xbmc/platform/android/jni/Context.cpp
@@ -48,6 +48,7 @@
 #include "DisplayMetrics.h"
 #include "Intent.h"
 #include "KeyEvent.h"
+#include "SettingsSecure.h"
 
 #include <android/native_activity.h>
 
@@ -91,6 +92,7 @@ void CJNIContext::PopulateStaticFields()
   CJNIIntent::PopulateStaticFields();
   CJNIKeyEvent::PopulateStaticFields();
   CJNIViewInputDevice::PopulateStaticFields();
+  CJNISettingsSecure::PopulateStaticFields();
 }
 
 CJNIPackageManager CJNIContext::GetPackageManager()

--- a/xbmc/platform/android/jni/Makefile.in
+++ b/xbmc/platform/android/jni/Makefile.in
@@ -62,6 +62,7 @@ SRCS      += DisplayMetrics.cpp
 SRCS      += KeyEvent.cpp
 SRCS      += InputManager.cpp
 SRCS      += Os.cpp
+SRCS      += SettingsSecure.cpp
 
 LIB        = jni.a
 

--- a/xbmc/platform/android/jni/SettingsSecure.cpp
+++ b/xbmc/platform/android/jni/SettingsSecure.cpp
@@ -1,0 +1,36 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SettingsSecure.h"
+
+using namespace jni;
+
+std::string CJNISettingsSecure::ANDROID_ID;
+
+void CJNISettingsSecure::PopulateStaticFields()
+{
+  jhclass clazz = find_class("android/provider/Settings$Secure");
+  ANDROID_ID = (jcast<std::string>(get_static_field<jhstring>(clazz, "ANDROID_ID")));
+}
+                                  
+std::string CJNISettingsSecure::getString(CJNIContentResolver resolver, std::string name)
+{
+  return jcast<std::string>(call_static_method<jhstring>("android/provider/Settings$Secure", "getString", "(Landroid/content/ContentResolver;Ljava/lang/String;)Ljava/lang/String;", resolver.get_raw(), jcast<jhstring>(name)));
+}

--- a/xbmc/platform/android/jni/SettingsSecure.h
+++ b/xbmc/platform/android/jni/SettingsSecure.h
@@ -1,0 +1,40 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "jutils/jutils-details.hpp"
+#include "ContentResolver.h"
+#include <string>
+
+namespace jni
+{
+    
+    class CJNISettingsSecure
+    {
+    public:
+        static void PopulateStaticFields();
+        static std::string getString(CJNIContentResolver resolver, std::string name);
+      
+        static std::string ANDROID_ID;
+        
+    };
+    
+};
+

--- a/xbmc/platform/darwin/DarwinUtils.h
+++ b/xbmc/platform/darwin/DarwinUtils.h
@@ -58,5 +58,6 @@ public:
   static bool        IsAliasShortcut(const std::string& path, bool isdirectory);
   static void        TranslateAliasShortcut(std::string& path);
   static bool        CreateAliasShortcut(const std::string& fromPath, const std::string& toPath);
+  static std::string GetHardwareUUID();
 };
 

--- a/xbmc/platform/darwin/PlatformDarwin.cpp
+++ b/xbmc/platform/darwin/PlatformDarwin.cpp
@@ -34,9 +34,5 @@ void CPlatformDarwin::Init()
 void CPlatformDarwin::InitUniqueHardwareIdentifier()
 {
   m_uuid = CDarwinUtils::GetHardwareUUID();
-#if defined(_DEBUG)
-  CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
   m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
-  CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
 }

--- a/xbmc/platform/darwin/PlatformDarwin.cpp
+++ b/xbmc/platform/darwin/PlatformDarwin.cpp
@@ -21,18 +21,22 @@
 #include "PlatformDarwin.h"
 #include <stdlib.h>
 #include "filesystem/SpecialProtocol.h"
-
-CPlatformDarwin::CPlatformDarwin()
-{
-  
-}
-
-CPlatformDarwin::~CPlatformDarwin()
-{
-  
-}
+#include "platform/darwin/DarwinUtils.h"
+#include "utils/log.h"
+#include "utils/md5.h"
 
 void CPlatformDarwin::Init()
 {
-    setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
+  CPlatform::Init();
+  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
+}
+
+void CPlatformDarwin::InitUniqueHardwareIdentifier()
+{
+  m_uuid = CDarwinUtils::GetHardwareUUID();
+#if defined(_DEBUG)
+  CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+  m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
+  CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
 }

--- a/xbmc/platform/darwin/PlatformDarwin.h
+++ b/xbmc/platform/darwin/PlatformDarwin.h
@@ -26,10 +26,12 @@ class CPlatformDarwin : public CPlatform
 {
   public:
     /**\brief C'tor */
-    CPlatformDarwin();
+    CPlatformDarwin() = default;
   
     /**\brief D'tor */
-    virtual ~CPlatformDarwin();
+    virtual ~CPlatformDarwin() = default;
   
     void Init() override;
+  
+    void InitUniqueHardwareIdentifier() override;
 };

--- a/xbmc/platform/overrides/android/PlatformAndroid.cpp
+++ b/xbmc/platform/overrides/android/PlatformAndroid.cpp
@@ -41,10 +41,5 @@ void CPlatformAndroid::Init()
 void CPlatformAndroid::InitUniqueHardwareIdentifier()
 {
   m_uuid = jni::CJNISettingsSecure::getString(CJNIContext::getContentResolver(), jni::CJNISettingsSecure::ANDROID_ID);
-#if defined(_DEBUG)
-    CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
-
   m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
-  CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
 }

--- a/xbmc/platform/overrides/android/PlatformAndroid.cpp
+++ b/xbmc/platform/overrides/android/PlatformAndroid.cpp
@@ -21,23 +21,30 @@
 #include "PlatformAndroid.h"
 #include <stdlib.h>
 #include "filesystem/SpecialProtocol.h"
+#include "platform/android/jni/Context.h"
+#include "platform/android/jni/SettingsSecure.h"
+#include "utils/log.h"
+#include "utils/md5.h"
 
 CPlatform* CPlatform::CreateInstance()
 {
   return new CPlatformAndroid();
 }
 
-CPlatformAndroid::CPlatformAndroid()
-{
-  
-}
-
-CPlatformAndroid::~CPlatformAndroid()
-{
-  
-}
-
 void CPlatformAndroid::Init()
 {
-    setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+  // call base init
+  CPlatform::Init();
+  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+}
+
+void CPlatformAndroid::InitUniqueHardwareIdentifier()
+{
+  m_uuid = jni::CJNISettingsSecure::getString(CJNIContext::getContentResolver(), jni::CJNISettingsSecure::ANDROID_ID);
+#if defined(_DEBUG)
+    CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+
+  m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
+  CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
 }

--- a/xbmc/platform/overrides/android/PlatformAndroid.h
+++ b/xbmc/platform/overrides/android/PlatformAndroid.h
@@ -26,10 +26,12 @@ class CPlatformAndroid : public CPlatform
 {
   public:
     /**\brief C'tor */
-    CPlatformAndroid();
+    CPlatformAndroid() = default;
   
     /**\brief D'tor */
-    virtual ~CPlatformAndroid();
+    virtual ~CPlatformAndroid() = default;
   
     void Init() override;
+    
+    void InitUniqueHardwareIdentifier() override;
 };

--- a/xbmc/platform/overrides/linux/PlatformLinux.cpp
+++ b/xbmc/platform/overrides/linux/PlatformLinux.cpp
@@ -47,9 +47,6 @@ void CPlatformLinux::InitUniqueHardwareIdentifier()
       if (fgets(line, sizeof line, f) != nullptr)
       {
           m_uuid = line;
-#if defined(_DEBUG)
-          CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
       }
       fclose(f);
   }
@@ -69,9 +66,6 @@ void CPlatformLinux::InitUniqueHardwareIdentifier()
           if (colon)
           {
             m_uuid = colon + 2;
-#if defined(_DEBUG)
-              CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
           }
         }
       }
@@ -87,6 +81,5 @@ void CPlatformLinux::InitUniqueHardwareIdentifier()
   else
   {
     m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
-    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
   }
 }

--- a/xbmc/platform/overrides/linux/PlatformLinux.cpp
+++ b/xbmc/platform/overrides/linux/PlatformLinux.cpp
@@ -1,0 +1,92 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlatformLinux.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "utils/log.h"
+#include "utils/md5.h"
+
+CPlatform* CPlatform::CreateInstance()
+{
+    return new CPlatformLinux();
+}
+
+void CPlatformLinux::Init()
+{
+  // call base init
+  CPlatform::Init();
+  // add platform specific init stuff here
+}
+
+void CPlatformLinux::InitUniqueHardwareIdentifier()
+{
+  // try to read the machine-id from etc first
+  FILE *f = fopen("/etc/machine-id", "r");
+  if (f)
+  {
+      char line[33]; // 32 + zero byte
+      if (fgets(line, sizeof line, f) != nullptr)
+      {
+          m_uuid = line;
+#if defined(_DEBUG)
+          CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+      }
+      fclose(f);
+  }
+    
+  // if we didn't get an uuid yet - try to get a serialnumber
+  if (m_uuid == NoValidUUID)
+  {
+    f = fopen("/proc/cpuinfo", "r");
+    if (f)
+    {
+      char line[256];
+      while (fgets(line, sizeof line, f))
+      {
+        if (strncmp(line, "Serial", 6) == 0)
+        {
+          char *colon = strchr(line, ':');
+          if (colon)
+          {
+            m_uuid = colon + 2;
+#if defined(_DEBUG)
+              CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+          }
+        }
+      }
+      fclose(f);
+    }
+  }
+
+  // fallback to base implementation if needed
+  if (m_uuid == NoValidUUID)
+  {
+    CPlatform::InitUniqueHardwareIdentifier();
+  }
+  else
+  {
+    m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
+    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
+  }
+}

--- a/xbmc/platform/overrides/linux/PlatformLinux.h
+++ b/xbmc/platform/overrides/linux/PlatformLinux.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Platform.h"
+
+class CPlatformLinux : public CPlatform
+{
+  public:
+    /**\brief C'tor */
+    CPlatformLinux() = default;
+  
+    /**\brief D'tor */
+    virtual ~CPlatformLinux() = default;
+  
+    void Init() override;
+  
+    void InitUniqueHardwareIdentifier() override;
+};

--- a/xbmc/platform/overrides/rbpi/PlatformRbpi.cpp
+++ b/xbmc/platform/overrides/rbpi/PlatformRbpi.cpp
@@ -50,9 +50,7 @@ void CPlatformRbpi::InitUniqueHardwareIdentifier()
         if (colon)
         {
           m_uuid = colon + 2;
-#if defined(_DEBUG)
-          CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
+          m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
         }
       }
     }

--- a/xbmc/platform/overrides/rbpi/PlatformRbpi.cpp
+++ b/xbmc/platform/overrides/rbpi/PlatformRbpi.cpp
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlatformRbpi.h"
+#include <stdlib.h>
+#include <string.h>
+#include "utils/log.h"
+#include "utils/md5.h"
+
+CPlatform* CPlatform::CreateInstance()
+{
+    return new CPlatformRbpi();
+}
+
+void CPlatformRbpi::Init()
+{
+  // call base init
+  CPlatform::Init();
+  // add platform specific init stuff here
+}
+
+void CPlatformRbpi::InitUniqueHardwareIdentifier()
+{
+  FILE *f = fopen("/proc/cpuinfo", "r");
+  if (f)
+  {
+    char line[256];
+    while (fgets(line, sizeof line, f))
+    {
+      if (strncmp(line, "Serial", 6) == 0)
+      {
+        char *colon = strchr(line, ':');
+        if (colon)
+        {
+          m_uuid = colon + 2;
+#if defined(_DEBUG)
+          CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+        }
+      }
+    }
+    fclose(f);
+  }
+
+  // fallback to base implementation if needed - paranoia
+  if (m_uuid == NoValidUUID)
+  {
+    CPlatform::InitUniqueHardwareIdentifier();
+  }
+  else
+  {
+    m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
+    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
+  }
+}

--- a/xbmc/platform/overrides/rbpi/PlatformRbpi.cpp
+++ b/xbmc/platform/overrides/rbpi/PlatformRbpi.cpp
@@ -56,15 +56,4 @@ void CPlatformRbpi::InitUniqueHardwareIdentifier()
     }
     fclose(f);
   }
-
-  // fallback to base implementation if needed - paranoia
-  if (m_uuid == NoValidUUID)
-  {
-    CPlatform::InitUniqueHardwareIdentifier();
-  }
-  else
-  {
-    m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
-    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
-  }
 }

--- a/xbmc/platform/overrides/rbpi/PlatformRbpi.h
+++ b/xbmc/platform/overrides/rbpi/PlatformRbpi.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Platform.h"
+
+class CPlatformRbpi : public CPlatform
+{
+  public:
+    /**\brief C'tor */
+    CPlatformRbpi() = default;
+  
+    /**\brief D'tor */
+    virtual ~CPlatformRbpi() = default;
+  
+    void Init() override;
+  
+    void InitUniqueHardwareIdentifier() override;
+};

--- a/xbmc/platform/overrides/windows/PlatformWindows.cpp
+++ b/xbmc/platform/overrides/windows/PlatformWindows.cpp
@@ -63,9 +63,6 @@ void CPlatformWindows::InitUniqueHardwareIdentifier()
         uuid.erase(zeroPos); // remove any extra zero-terminations
       }
       m_uuid = uuid;
-#if defined(_DEBUG)
-      CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
-#endif
     }
     RegCloseKey(hKey);
   }
@@ -78,6 +75,5 @@ void CPlatformWindows::InitUniqueHardwareIdentifier()
   else
   {
     m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
-    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
   }
 }

--- a/xbmc/platform/overrides/windows/PlatformWindows.cpp
+++ b/xbmc/platform/overrides/windows/PlatformWindows.cpp
@@ -1,0 +1,83 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlatformWindows.h"
+
+#include "dwmapi.h"
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif // WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "utils/CharsetConverter.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include "utils/log.h"
+#include "utils/md5.h"
+
+
+CPlatform* CPlatform::CreateInstance()
+{
+    return new CPlatformWindows();
+}
+
+void CPlatformWindows::Init()
+{
+  // call base init
+  CPlatform::Init();
+  // add platform specific init stuff here
+}
+
+void CPlatformWindows::InitUniqueHardwareIdentifier()
+{
+  HKEY hKey;
+  std::string uuid;
+  if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Cryptography", 0, KEY_READ | KEY_WOW64_64KEY, &hKey) == ERROR_SUCCESS)
+  {
+    wchar_t buf[40]; // f.e. ce39c043-0661-4920-91dc-1210ad294c73
+    DWORD bufSize = sizeof(buf);
+    DWORD valType;
+    if (RegQueryValueExW(hKey, L"MachineGuid", NULL, &valType, (LPBYTE)buf, &bufSize) == ERROR_SUCCESS && valType == REG_SZ)
+    {
+      g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), uuid);
+      size_t zeroPos = uuid.find(char(0));
+      if (zeroPos != std::string::npos)
+      {
+        uuid.erase(zeroPos); // remove any extra zero-terminations
+      }
+      m_uuid = uuid;
+#if defined(_DEBUG)
+      CLog::Log(LOGDEBUG, "HardwareUUID (nomd5): %s", m_uuid.c_str());
+#endif
+    }
+    RegCloseKey(hKey);
+  }
+
+  // fallback to base implementation if needed - paranoia
+  if (m_uuid == NoValidUUID)
+  {
+    CPlatform::InitUniqueHardwareIdentifier();
+  }
+  else
+  {
+    m_uuid = XBMC::XBMC_MD5::GetMD5(m_uuid);
+    CLog::Log(LOGNOTICE, "HardwareUUID: %s", m_uuid.c_str());
+  }
+}

--- a/xbmc/platform/overrides/windows/PlatformWindows.h
+++ b/xbmc/platform/overrides/windows/PlatformWindows.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Platform.h"
+
+class CPlatformWindows : public CPlatform
+{
+  public:
+    /**\brief C'tor */
+    CPlatformWindows() = default;
+  
+    /**\brief D'tor */
+    virtual ~CPlatformWindows() = default;
+  
+    void Init() override;
+  
+    void InitUniqueHardwareIdentifier() override;
+};

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -284,11 +284,9 @@ CSysData::INTERNET_STATE CSysInfoJob::GetInternetState()
 
 std::string CSysInfoJob::GetMACAddress()
 {
-#if defined(HAS_LINUX_NETWORK) || defined(HAS_WIN32_NETWORK)
   CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
   if (iface)
     return iface->GetMacAddress();
-#endif
   return "";
 }
 

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -38,6 +38,7 @@
 #include "CPUInfo.h"
 #include "CompileInfo.h"
 #include "settings/Settings.h"
+#include "ServiceBroker.h"
 
 #ifdef TARGET_WINDOWS
 #include "dwmapi.h"
@@ -257,6 +258,7 @@ bool CSysInfoJob::DoWork()
   m_info.osVersionInfo     = CSysInfo::GetOsPrettyNameWithVersion() + " (kernel: " + CSysInfo::GetKernelName() + " " + CSysInfo::GetKernelVersionFull() + ")";
   m_info.macAddress        = GetMACAddress();
   m_info.batteryLevel      = GetBatteryLevel();
+  m_info.HardwareUUID      = CServiceBroker::GetPlatform().GetUniqueHardwareIdentifier();
   return true;
 }
 
@@ -387,6 +389,8 @@ std::string CSysInfo::TranslateInfo(int info) const
       return g_localizeStrings.Get(13297);
   case SYSTEM_BATTERY_LEVEL:
     return m_info.batteryLevel;
+  case SYSTEM_HARDWARE_UUID:
+    return m_info.HardwareUUID;
   default:
     return "";
   }

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -54,6 +54,7 @@ public:
   std::string osVersionInfo;
   std::string macAddress;
   std::string batteryLevel;
+  std::string HardwareUUID;
 };
 
 class CSysInfoJob : public CJob

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -164,6 +164,7 @@ void CGUIWindowSystemInfo::FrameMove()
     i++;  // empty line
     SetControlLabel(i++, "%s: %s", 22012, SYSTEM_TOTAL_MEMORY);
     SetControlLabel(i++, "%s: %s", 158, SYSTEM_FREE_MEMORY);
+    SetControlLabel(i++, "%s: %s", 12396, SYSTEM_HARDWARE_UUID);
   }
 
   else if (m_section == CONTROL_BT_PVR)


### PR DESCRIPTION
As discussed at DevCon we would benefit from having a possibility to better identifer unique kodi instances.

This is the core work for this. ATM it simply uses the mac address of the first connected network interface and builds the MD5 of it. This value is:
1. visible in the SystemInfo -> Hardware Section
2. Logged to the header of the kodi.log
3. Available as info label with the name "hardwareuuid"

For osx and ios i already implemented overrides that use proper os methods for getting a unique hardware id (which might be better as a mac address).

@FernetMenta @fritsch @Paxxi @popcornmix please have a look and in case there is something better on your platforms - implement an override class in 
https://github.com/xbmc/xbmc/tree/master/xbmc/platform/overrides/*yourplatform*/Platform*Name*.cpp with overridden GetUniqueHardwareIdentifier method.

The better we get this right in the first shot - the more accurate the statistics will be!

@MartijnKaijser can you do anything good with this? (from an addon side i mean)

Beside that - we agreed that we will document the purpose of that identifier. We should do this before anything gets into production.
