### PR TITLE
Fix potential SQL constraint integrity violation in the PVR database

### DIFF
--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -27,6 +27,7 @@
  **********************************************************************/
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "sqlitedataset.h"
@@ -196,10 +197,15 @@ int SqliteDatabase::setErr(int err_code, const char * qry){
     break;
   default : error = "Undefined SQLite error";
   }
-  error = "[" + db + "] " + error;
-  error += "\nQuery: ";
-  error += qry;
-  error += "\n";
+
+  // Append some more details to the error
+  std::stringstream ss;
+  ss << "[" << db << "[" << error;
+  ss << "\nQuery: ";
+  ss << qry;
+  ss << "\n";
+  error = ss.str();
+
   return err_code;
 }
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -490,17 +490,14 @@ int CPVRDatabase::Get(CPVRChannelGroup &group)
 
 bool CPVRDatabase::PersistChannels(CPVRChannelGroup &group)
 {
-  bool bReturn(true);
-
-  for (PVR_CHANNEL_GROUP_MEMBERS::iterator it = group.m_members.begin(); it != group.m_members.end(); ++it)
+  for (auto &member : group.m_members)
   {
-    if (it->second.channel->IsChanged() || it->second.channel->IsNew())
+    CPVRChannelPtr channel = member.second.channel;
+
+    if (channel->IsChanged() || channel->IsNew())
     {
-      if (Persist(*it->second.channel))
-      {
-        it->second.channel->Persisted();
-        bReturn = true;
-      }
+      if (Persist(*channel))
+        channel->Persisted();
     }
   }
 

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -183,6 +183,14 @@ namespace PVR
     bool PersistChannels(CPVRChannelGroup &group);
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup &group);
+
+    /*!
+     * Returns the channel ID of the channel with the specified unique combination for a channel, or -1 if not found
+     * @param iClientId
+     * @param iUniqueId
+     * @return the ID of the existing channel, or -1 if not found
+     */
+    int GetChannelId(int iClientId, int iUniqueId);
   };
 
   /*!

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -220,7 +220,7 @@ bool CPVRChannel::Persist()
 
   if (CPVRDatabase *database = GetPVRDatabase())
   {
-    bool bReturn = database->Persist(*this) && database->CommitInsertQueries();
+    bool bReturn = database->Persist(*this);
     CSingleLock lock(m_critSection);
     m_bChanged = !bReturn;
     return bReturn;


### PR DESCRIPTION
Supersedes #8953
Fixes trac #16031
Closes kodi-pvr/pvr.hts#172

This fixes the problem without bumping the database version so it should be more possibly to get it merged for V17.

Basically the code that persists channels has been made smarter. Instead of just blindly looking at the primary key stored in the object we query the database to check if a channel with the unique ID and client ID already exists. If it does, we update that channel, if not we create a new channel. There is more background information in the referenced PRs.

This fix also has the added side-effect that it increases database performance. While a new SELECT statement has been added, we now do an UPDATE instead of a REPLACE INTO which prevents indexes from having to be re-calculated (REPLACE INTO basically does a DELETE followed by an INSERT). This also means we don't need to worry about the channel ID changing after the channel has been updated (which was a side effect of using REPLACE INTO).
