### PR TITLE
use debug logging for missing textures

### DIFF
--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -646,7 +646,7 @@ std::string CGUITextureManager::GetTexturePath(const std::string &textureName, b
     }
   }
 
-  CLog::Log(LOGERROR, "CGUITextureManager::GetTexturePath: could not find texture '%s'", textureName.c_str());
+  CLog::Log(LOGDEBUG, "[Warning] CGUITextureManager::GetTexturePath: could not find texture '%s'", textureName.c_str());
   return "";
 }
 


### PR DESCRIPTION
logging missing textures as error can get a bit spammy:

`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultYear.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultGenre.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultTags.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultMovieTitle.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultSets.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultStudios.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultCountry.png'`
`01:47:27 T:140711760611072   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'DefaultDirector.png'`

none of these are real errors as it's not mandatory for skins to include these images.
kodi will check if they exist, but will fallback to DefaultFolder.png if they don't.

@tamland 
