### PR TITLE
FFmpeg: Bump to version 3.1.3-Krypton-Beta3-2

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.3-Krypton-Beta3
+VERSION=3.1.3-Krypton-Beta3-2
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
This bumps ffmpeg to a newer prelease:
- Changes: Adjust to av_version_info changes we did some days ago
- As we don't ship vanilla ffmpeg, make that sure in a patch (hard coded: major_release-kodi)
- Fix kodi trac http://trac.kodi.tv/ticket/16926
