### PR TITLE
Setting album user rating using album ID not GetAlbumIdByPath

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -194,9 +194,7 @@ public:
   bool Search(const std::string& search, CFileItemList &items);
   bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songs, bool exact=true);
   bool SetSongUserrating(const std::string &filePath, int userrating);
-  bool SetAlbumUserrating(const std::string &filePath, int userrating);
   bool SetSongVotes(const std::string &filePath, int votes);
-  bool SetAlbumVotes(const std::string &filePath, int votes);
   int  GetSongByArtistAndAlbumAndTitle(const std::string& strArtist, const std::string& strAlbum, const std::string& strTitle);
 
   /////////////////////////////////////////////////
@@ -250,6 +248,7 @@ public:
   int  GetAlbumByName(const std::string& strAlbum, const std::string& strArtist="");
   int  GetAlbumByName(const std::string& strAlbum, const std::vector<std::string>& artist);
   std::string GetAlbumById(int id);
+  bool SetAlbumUserrating(const int idAlbum, int userrating);
 
   /////////////////////////////////////////////////
   // Artist CRUD

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -80,7 +80,7 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
         if (db.Open())
         {
           m_needsUpdate = true;
-          db.SetAlbumUserrating(m_albumItem->GetPath(), m_albumItem->GetMusicInfoTag()->GetUserrating());
+          db.SetAlbumUserrating(m_albumItem->GetMusicInfoTag()->GetAlbumId(), m_albumItem->GetMusicInfoTag()->GetUserrating());
           db.Close();
         }
       }


### PR DESCRIPTION
Fixes a bug when setting album user rating when the user has songs from more than one album in the same folder.

There is nothing to say that all albums must have a unique folder that does not contain songs from any other album, even if this is the common way to organise your music files.  Path may not be sufficient to identify an album uniquely. Hence `GetAlbumIdByPath` needs to allow for more than one album being found for a path, just as `GetAlbumByName` and `GetArtistByName` do, rather than return the ID of the first in the results set.

Setting album user rating was using path to attempt to identify the album when the unique album ID is readily available. Switch to use ID not path.

Also `SetAlbumVotes` was removed as it was unused. The idea seems to be that "rating" and "votes" are values loaded from scraping NFO or online sources, and are never set via the GUI, hence this routine was unnecessary as  votes are never set in isolation ( and there is no routine to set rating).  Rating and votes are loaded by `CAlbum::Load`.

@Razzeee perhaps you would like to comment as you did the original work on this in  #8405
@zag2me most likely to have data to test this out.
