### PR TITLE
Cache controller layouts

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -45,7 +45,9 @@ bool CServiceManager::Init1()
 bool CServiceManager::Init2()
 {
   m_Platform->Init();
-  
+
+  m_binaryAddonCache.reset(new ADDON::CBinaryAddonCache());
+
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
@@ -57,7 +59,6 @@ bool CServiceManager::Init2()
   m_PVRManager.reset(new PVR::CPVRManager());
   m_dataCacheCore.reset(new CDataCacheCore());
 
-  m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
 
   m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -32,7 +32,12 @@ CBinaryAddonCache::~CBinaryAddonCache()
 
 void CBinaryAddonCache::Init()
 {
-  m_addonsToCache = {ADDON_AUDIODECODER, ADDON_INPUTSTREAM, ADDON_PVRDLL};
+  m_addonsToCache = {
+    ADDON_AUDIODECODER,
+    ADDON_INPUTSTREAM,
+    ADDON_PVRDLL,
+    ADDON_GAME_CONTROLLER,
+  };
   CAddonMgr::GetInstance().Events().Subscribe(this, &CBinaryAddonCache::OnEvent);
   Update();
 }

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -23,6 +23,7 @@
 #include "ControllerTypes.h"
 #include "addons/Addon.h"
 
+#include <atomic>
 #include <string>
 
 namespace GAME
@@ -39,16 +40,20 @@ public:
 
   static const ControllerPtr EmptyPtr;
 
+  // implementation of IAddon via CAddon
+  virtual ADDON::AddonPtr GetRunningInstance() const override;
+  virtual void OnPostInstall(bool update, bool modal) override;
+
   std::string Label(void);
   std::string ImagePath(void) const;
 
   bool LoadLayout(void);
 
-  const CControllerLayout& Layout(void) const { return m_layout; }
+  const CControllerLayout& Layout(void);
 
 private:
   CControllerLayout m_layout;
-  bool              m_bLoaded;
+  std::atomic<bool> m_bLoaded;
 };
 
 }


### PR DESCRIPTION
AddonMgr used to create a new uninitialised controller add-on every time GetAddon() was called. This means that CController::LoadLayout() was called a whole bunch. In some extreme cases, like every time a button is mapped in the controller dialog, the layout would be reloaded from disk three times.

This change caches controller add-ons so that the layout is only loaded once (and reloaded if the add-on version is updated).

The strategy for caching controllers is identical to binary add-ons, so I reused the binary add-on mgr, even though controllers are just XML files.

This change exposes a pre-existing bug with cyclical dependencies in the service manager. Kodi crashes on startup if a system add-on in addonmanifest.xml has a type that is cached by the binary add-on manager. I fixed this by creating the binary add-on cache, then initializing the add-on manager (which uses the empty binary add-on cache), then initializing the binary add-on cache. Not sure if there's a better approach.
