### PR TITLE
Bump game.controller.default to v1.0.3

### DIFF
--- a/addons/game.controller.default/addon.xml
+++ b/addons/game.controller.default/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="game.controller.default"
         name="Default Controller"
-        version="1.0.0"
+        version="1.0.3"
         provider-name="Team Kodi">
     <requires>
     </requires>


### PR DESCRIPTION
See conversation at https://github.com/xbmc/repo-resources/pull/12

This is needed so that when game.controller.default is modified again, we know to bump to 1.0.4 so that the version from the repo doesn't override our changes
