### PR TITLE
[paplayer] fix codec deinit for audio decoder add-on (was never called)

### DIFF
--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -46,6 +46,11 @@ CAudioDecoder::CAudioDecoder(AddonProps props, std::string extension, std::strin
   m_strExt = std::move(strExt);
 }
 
+CAudioDecoder::~CAudioDecoder()
+{
+  DeInit();
+}
+
 bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)
 {
   if (!Initialized())

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -56,7 +56,7 @@ namespace ADDON
     CAudioDecoder(AddonProps props, std::string extension, std::string mimetype, bool tags,
         bool tracks, std::string codecName, std::string strExt);
 
-    virtual ~CAudioDecoder() {}
+    virtual ~CAudioDecoder();
 
     // Things that MUST be supplied by the child classes
     bool Init(const CFileItem& file, unsigned int filecache) override;

--- a/xbmc/cores/paplayer/ICodec.h
+++ b/xbmc/cores/paplayer/ICodec.h
@@ -56,11 +56,6 @@ public:
   // 3.  Fill in the m_TotalTime, m_SampleRate, m_BitsPerSample and m_Channels parameters.
   virtual bool Init(const CFileItem &file, unsigned int filecache)=0;
 
-  // DeInit()
-  // Should just cleanup anything as necessary.  No need to free buffers here if they
-  // are allocated and destroyed in the destructor.
-  virtual void DeInit()=0;
-
   virtual bool CanSeek() {return true;}
 
   // Seek()

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -39,13 +39,13 @@ public:
   virtual ~VideoPlayerCodec();
 
   virtual bool Init(const CFileItem &file, unsigned int filecache) override;
-  virtual void DeInit();
   virtual bool Seek(int64_t iSeekTime);
   virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
   virtual int ReadRaw(uint8_t **pBuffer, int *bufferSize);
   virtual bool CanInit();
   virtual bool CanSeek();
 
+  void DeInit();
   AEAudioFormat GetFormat();
   void SetContentType(const std::string &strContent);
 


### PR DESCRIPTION
## Description

Fix of never called decoder deinit
## Motivation and Context

Has found during my add-on system rework that on audio decoder add-on the `DeInit` was never called and a mem leak with this come.

This add the use of `ICodec::DeInit` call to the `CAudioDecoder::Destroy()` function.

On the other class (`VideoPlayerCodec`) who use also the `ICodec` is it done from his destructor.
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
