### PR TITLE
[epg] fix mouse focus

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -838,8 +838,8 @@ bool CGUIEPGGridContainer::SelectItemFromPoint(const CPoint &point, bool justGri
   if (!m_focusedProgrammeLayout || !m_programmeLayout || (justGrid && point.x < 0))
     return false;
 
-  int channel = MathUtils::round_int(point.y / m_channelHeight);
-  int block   = MathUtils::round_int(point.x / m_blockSize);
+  int channel = point.y / m_channelHeight;
+  int block   = point.x / m_blockSize;
 
   if (channel > m_channelsPerPage)
     channel = m_channelsPerPage - 1;


### PR DESCRIPTION
mouse focus on the epggrid was a bit off.

before:
![before](https://cloud.githubusercontent.com/assets/687265/18811463/464e49fc-82b0-11e6-844b-bc3b52be0562.jpg)

after:
![after](https://cloud.githubusercontent.com/assets/687265/18811466/4beb1444-82b0-11e6-9d81-13cb02898205.jpg)

@ksooo @xhaggi 
