### PR TITLE
[paplayer] remove no more needed virtual CAEChannelInfo GetChannelInfo()

### DIFF
--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -132,11 +132,6 @@ int CAudioDecoder::GetTrackCount(const std::string& strPath)
   return result;
 }
 
-CAEChannelInfo CAudioDecoder::GetChannelInfo()
-{
-  return m_format.m_channelLayout;
-}
-
 void CAudioDecoder::Destroy()
 {
   AudioDecoderDll::Destroy();

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -69,7 +69,6 @@ namespace ADDON
               MUSIC_INFO::CMusicInfoTag& tag,
               MUSIC_INFO::EmbeddedArt *art = NULL);
     int GetTrackCount(const std::string& strPath);
-    virtual CAEChannelInfo GetChannelInfo();
 
     const std::string& GetExtensions() const { return m_extension; }
     const std::string& GetMimetypes() const { return m_mimetype; }

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -45,7 +45,6 @@ public:
   virtual int ReadRaw(uint8_t **pBuffer, int *bufferSize);
   virtual bool CanInit();
   virtual bool CanSeek();
-  virtual CAEChannelInfo GetChannelInfo() {return m_srcFormat.m_channelLayout;}
 
   AEAudioFormat GetFormat();
   void SetContentType(const std::string &strContent);


### PR DESCRIPTION
Remove no more needed function
## Description

With the old commit 071d9423d5dc0632f3505627f5adc73cea0d528e is the `GetChannelInfo` no more needed. @fritsch @FernetMenta is this OK?
## Motivation and Context

Cleanup
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
  The use of them was removed with commit 071d9423d5dc0632f3505627f5adc73cea0d528e
  (AE: move iec packing for passthrough into AE, contains squashed code...)
