### PR TITLE
splash text improvements

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1142,9 +1142,10 @@ bool CApplication::Initialize()
 
     g_windowManager.CreateWindows();
 
-    CSplash::GetInstance().Show(g_localizeStrings.Get(24151));
     m_confirmSkinChange = false;
-    m_incompatibleAddons = CAddonSystemSettings::GetInstance().MigrateAddons();
+    m_incompatibleAddons = CAddonSystemSettings::GetInstance().MigrateAddons([](){
+      CSplash::GetInstance().Show(g_localizeStrings.Get(24151));
+    });
     m_confirmSkinChange = true;
     CSplash::GetInstance().Show();
 

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -126,7 +126,7 @@ bool CAddonSystemSettings::UnsetActive(const AddonPtr& addon)
 }
 
 
-std::vector<std::string> CAddonSystemSettings::MigrateAddons()
+std::vector<std::string> CAddonSystemSettings::MigrateAddons(std::function<void(void)> onMigrate)
 {
   auto getIncompatible = [](){
     VECADDONS incompatible;
@@ -141,6 +141,8 @@ std::vector<std::string> CAddonSystemSettings::MigrateAddons()
 
   if (CSettings::GetInstance().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON)
   {
+    onMigrate();
+
     if (CRepositoryUpdater::GetInstance().CheckForUpdates())
       CRepositoryUpdater::GetInstance().Await();
 

--- a/xbmc/addons/AddonSystemSettings.h
+++ b/xbmc/addons/AddonSystemSettings.h
@@ -21,6 +21,7 @@
 
 #include "addons/IAddon.h"
 #include "settings/lib/ISettingCallback.h"
+#include <functional>
 #include <string>
 
 namespace ADDON
@@ -48,9 +49,12 @@ public:
   bool UnsetActive(const AddonPtr& addon);
 
   /*!
-   * Attempt to migrate installed addons. Returns a list of addons that was modified.
+   * Check compatibility of installed addons and attempt to migrate.
+   *
+   * @param onMigrate Called when a long running migration task takes place.
+   * @return list of addons that was modified.
    */
-  std::vector<std::string> MigrateAddons();
+  std::vector<std::string> MigrateAddons(std::function<void(void)> onMigrate);
 
 private:
   CAddonSystemSettings();

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -46,18 +46,18 @@ void CSplash::Show()
 
 void CSplash::Show(const std::string& message)
 {
-  if (g_advancedSettings.m_splashImage)
-  {
-    if (!m_image)
-    {
-      std::string splashImage = "special://home/media/Splash.png";
-      if (!XFILE::CFile::Exists(splashImage))
-        splashImage = "special://xbmc/media/Splash.png";
+  if (!g_advancedSettings.m_splashImage)
+    return;
 
-      m_image = std::unique_ptr<CGUIImage>(new CGUIImage(0, 0, 0, 0, g_graphicsContext.GetWidth(),
-          g_graphicsContext.GetHeight(), CTextureInfo(splashImage)));
-      m_image->SetAspectRatio(CAspectRatio::AR_SCALE);
-    }
+  if (!m_image)
+  {
+    std::string splashImage = "special://home/media/Splash.png";
+    if (!XFILE::CFile::Exists(splashImage))
+      splashImage = "special://xbmc/media/Splash.png";
+
+    m_image = std::unique_ptr<CGUIImage>(new CGUIImage(0, 0, 0, 0, g_graphicsContext.GetWidth(),
+        g_graphicsContext.GetHeight(), CTextureInfo(splashImage)));
+    m_image->SetAspectRatio(CAspectRatio::AR_SCALE);
   }
 
   g_graphicsContext.Lock();
@@ -69,12 +69,9 @@ void CSplash::Show(const std::string& message)
   //render splash image
   g_Windowing.BeginRender();
 
-  if (m_image)
-  {
-    m_image->AllocResources();
-    m_image->Render();
-    m_image->FreeResources();
-  }
+  m_image->AllocResources();
+  m_image->Render();
+  m_image->FreeResources();
 
   if (!message.empty())
   {


### PR DESCRIPTION
This reduces the addon migration splash text to only show when updating addons and we know it will take time. Database migration is still always shown as it's far too many layer to go though.
