### PR TITLE
[python] change signature for ListItem.setRating

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -157,12 +157,12 @@ namespace XBMCAddon
         vtag.SetUniqueID(it->second, it->first);
     }
 
-    void ListItem::setRating(std::string type, float rating, int votes /* = 0 */, bool def /* = false */)
+    void ListItem::setRating(std::string type, float rating, int votes /* = 0 */, bool defaultt /* = false */)
     {
       if (!item) return;
 
       LOCKGUI;
-      item->GetVideoInfoTag()->SetRating(rating, votes, type, def);
+      item->GetVideoInfoTag()->SetRating(rating, votes, type, defaultt);
     }
 
     void ListItem::select(bool selected)

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -291,14 +291,14 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
-      /// @brief \python_func{ setRating(type, rating, votes = 0, default = True) }
+      /// @brief \python_func{ setRating(type, rating, votes = 0, defaultt = False) }
       ///-----------------------------------------------------------------------
       /// Sets a listitem's rating. It needs at least type and rating param
       ///
       /// @param type       string - the type of the rating. Any string.
       /// @param rating     float - the value of the rating.
       /// @param votes      int - the number of votes. Default 0.
-      /// @param default    bool - is the default rating?. Default False.
+      /// @param defaultt   bool - is the default rating?. Default False.
       ///  - Some example type (any string possible):
       ///  | Label         | Type                                              |
       ///  |:-------------:|:--------------------------------------------------|
@@ -314,14 +314,14 @@ namespace XBMCAddon
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
       /// ...
-      /// # setRating(type, rating, votes, default))
+      /// # setRating(type, rating, votes, defaultt))
       /// self.list.getSelectedItem().setRating("imdb", 4.6, 8940, True)
       /// ...
       /// ~~~~~~~~~~~~~
       ///
       setRating(...);
 #else
-      void setRating(std::string type, float rating, int votes = 0, bool def = false);
+      void setRating(std::string type, float rating, int votes = 0, bool defaultt = false);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS


### PR DESCRIPTION
At the moment the signature of ListItem.setRating contains a keyword argument called "def". Since this is a builtin keyword for python we should use something else for this, otherwise it cant be used explicitely. This PR adjusts it to use "defaultt", as we do in other parts of the API, too.
Also fixes some stuff in the docs.

@tamland    
