### PR TITLE
[gitignore] add addon packages, __.SYMDEF* and certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ config.log
 *xcuserdata
 .libs/
 .deps/
+__.SYMDEF*
 
 # CMake project files
 CMakeCache.txt
@@ -121,7 +122,6 @@ cmake_install.cmake
 /addons/skin.estouchy/media/Makefile
 /addons/skin.estouchy/media/Textures.xbt
 /addons/skin.pm3-hd/media/Textures.xbt
-/addons/visualization.itunes/iTunes.mvis
 /addons/script.module.pil/
 /addons/audioencoder.*
 /addons/pvr.*
@@ -131,6 +131,9 @@ cmake_install.cmake
 /addons/xbmc.json/addon.xml
 /addons/kodi.guilib/addon.xml
 /addons/audiodecoder.*
+/addons/visualization.*
+/addons/screensaver.*
+/addons/inputstream.*
 
 # /lib/
 /lib/Makefile
@@ -553,3 +556,6 @@ tools/depends/native/TexturePacker/src/Win32/Debug/
 tools/depends/native/TexturePacker/src/Win32/Release/
 tools/depends/native/TexturePacker/src/Win32/TexturePacker.VC.db
 exclude_dll.txt
+
+#certificates
+/system/certs/


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

Add files that are untracked after building on my system to gitignore.
## Description

<!--- Describe your change in detail -->

Add visualisation, screensaver.pingpong and inputstream addons to gitignore
Add __.SYMDEF\* to gitignore
Add system/certs to gitignore
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

These files keep popping up as untracked in my folder.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

The files no longer are marked as untracked
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
