### PR TITLE
[GUIWindowSystemInfo] - allow one more label/row to be displayed

### DIFF
--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -187,7 +187,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
 void CGUIWindowSystemInfo::ResetLabels()
 {
-  for (int i = 2; i < 12; i++)
+  for (int i = 2; i < 13; i++)
   {
     SET_CONTROL_LABEL(i, "");
   }


### PR DESCRIPTION
What the topic says @phil65 just merge this once the estuary change is in.

Background - after the uuid PR there is one more label and on rbpi we already have all labels used. The estuary skin still has room for one more line without cluttering the UI - so lets add one :)
