### PR TITLE
Fix album rating to 0 to 10 range when loaded

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -376,12 +376,12 @@ bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
   if (rElement)
   {
     float rating = 0;
-    float max_rating = 5;
+    float max_rating = 10;
     XMLUtils::GetFloat(album, "rating", rating);
     if (rElement->QueryFloatAttribute("max", &max_rating) == TIXML_SUCCESS && max_rating>=1)
-      rating *= (5.f / max_rating); // Normalise the Rating to between 0 and 5 
-    if (rating > 5.f)
-      rating = 5.f;
+      rating *= (10.f / max_rating); // Normalise the Rating to between 0 and 10 
+    if (rating > 10.f)
+      rating = 10.f;
     fRating = rating;
   }
   const TiXmlElement* userrating = album->FirstChildElement("userrating");


### PR DESCRIPTION
Left out by #8405 when album rating was changed from 0 to 5 range.

@Razzeee @zag2me @MartijnKaijser 
