### PR TITLE
Album Record Label and Type from music files tags 

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -174,6 +174,7 @@ CAlbum::CAlbum(const CFileItem& item)
 
   iYear = stTime.wYear;
   strLabel = tag.GetRecordLabel();
+  strType = tag.GetMusicBrainzReleaseType();
   bCompilation = tag.GetCompilation();
   iTimesPlayed = 0;
   dateAdded.Reset();

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -173,6 +173,7 @@ CAlbum::CAlbum(const CFileItem& item)
   }
 
   iYear = stTime.wYear;
+  strLabel = tag.GetRecordLabel();
   bCompilation = tag.GetCompilation();
   iTimesPlayed = 0;
   dateAdded.Reset();

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -489,6 +489,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album)
                            album.GetAlbumArtistString(),
                            album.GetGenreString(),
                            album.iYear,
+                           album.strLabel,
                            album.bCompilation, album.releaseType);
 
   // Add the album artists
@@ -853,7 +854,7 @@ int CMusicDatabase::UpdateSong(int idSong,
 
 int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
                              const std::string& strArtist, const std::string& strGenre, int year,
-                             bool bCompilation, CAlbum::ReleaseType releaseType)
+                             const std::string& strRecordLabel, bool bCompilation, CAlbum::ReleaseType releaseType)
 {
   std::string strSQL;
   try
@@ -875,20 +876,22 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       m_pDS->close();
       // doesnt exists, add it
       if (strMusicBrainzAlbumID.empty())
-        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, bCompilation, strReleaseType) values( NULL, '%s', NULL, '%s', '%s', %i, %i, '%s')",
+        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, strLabel, bCompilation, strReleaseType) values( NULL, '%s', NULL, '%s', '%s', %i, '%s', %i, '%s')",
                           strAlbum.c_str(),
                           strArtist.c_str(),
                           strGenre.c_str(),
                           year,
+                          strRecordLabel.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str());
       else
-        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, bCompilation, strReleaseType) values( NULL, '%s', '%s', '%s', '%s', %i, %i, '%s')",
+        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, strLabel, bCompilation, strReleaseType) values( NULL, '%s', '%s', '%s', '%s', %i, '%s', %i, '%s')",
                           strAlbum.c_str(),
                           strMusicBrainzAlbumID.c_str(),
                           strArtist.c_str(),
                           strGenre.c_str(),
                           year,
+                          strRecordLabel.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str());
       m_pDS->exec(strSQL);
@@ -909,18 +912,20 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       int idAlbum = m_pDS->fv("idAlbum").get_asInt();
       m_pDS->close();
       if (strMusicBrainzAlbumID.empty())
-        strSQL=PrepareSQL("UPDATE album SET strGenres = '%s', iYear=%i, bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
+        strSQL=PrepareSQL("UPDATE album SET strGenres = '%s', iYear=%i, strLabel = '%s', bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
                           strGenre.c_str(),
                           year,
+                          strRecordLabel.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str(),
                           idAlbum);
       else
-        strSQL=PrepareSQL("UPDATE album SET strAlbum = '%s', strArtists = '%s', strGenres = '%s', iYear=%i, bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
+        strSQL=PrepareSQL("UPDATE album SET strAlbum = '%s', strArtists = '%s', strGenres = '%s', iYear=%i, strLabel = '%s', bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
                           strAlbum.c_str(),
                           strArtist.c_str(),
                           strGenre.c_str(),
                           year,
+                          strRecordLabel.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str(),
                           idAlbum);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -489,7 +489,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album)
                            album.GetAlbumArtistString(),
                            album.GetGenreString(),
                            album.iYear,
-                           album.strLabel,
+                           album.strLabel, album.strType,
                            album.bCompilation, album.releaseType);
 
   // Add the album artists
@@ -854,7 +854,8 @@ int CMusicDatabase::UpdateSong(int idSong,
 
 int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
                              const std::string& strArtist, const std::string& strGenre, int year,
-                             const std::string& strRecordLabel, bool bCompilation, CAlbum::ReleaseType releaseType)
+                             const std::string& strRecordLabel, const std::string& strType,
+                             bool bCompilation, CAlbum::ReleaseType releaseType)
 {
   std::string strSQL;
   try
@@ -876,22 +877,24 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       m_pDS->close();
       // doesnt exists, add it
       if (strMusicBrainzAlbumID.empty())
-        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, strLabel, bCompilation, strReleaseType) values( NULL, '%s', NULL, '%s', '%s', %i, '%s', %i, '%s')",
+        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, strLabel, strType, bCompilation, strReleaseType) values( NULL, '%s', NULL, '%s', '%s', %i, '%s', '%s', %i, '%s')",
                           strAlbum.c_str(),
                           strArtist.c_str(),
                           strGenre.c_str(),
                           year,
                           strRecordLabel.c_str(),
+                          strType.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str());
       else
-        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, strLabel, bCompilation, strReleaseType) values( NULL, '%s', '%s', '%s', '%s', %i, '%s', %i, '%s')",
+        strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strMusicBrainzAlbumID, strArtists, strGenres, iYear, strLabel, strType, bCompilation, strReleaseType) values( NULL, '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, '%s')",
                           strAlbum.c_str(),
                           strMusicBrainzAlbumID.c_str(),
                           strArtist.c_str(),
                           strGenre.c_str(),
                           year,
                           strRecordLabel.c_str(),
+                          strType.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str());
       m_pDS->exec(strSQL);
@@ -912,20 +915,22 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       int idAlbum = m_pDS->fv("idAlbum").get_asInt();
       m_pDS->close();
       if (strMusicBrainzAlbumID.empty())
-        strSQL=PrepareSQL("UPDATE album SET strGenres = '%s', iYear=%i, strLabel = '%s', bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
+        strSQL=PrepareSQL("UPDATE album SET strGenres = '%s', iYear=%i, strLabel = '%s', strType = '%s', bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
                           strGenre.c_str(),
                           year,
                           strRecordLabel.c_str(),
+                          strType.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str(),
                           idAlbum);
       else
-        strSQL=PrepareSQL("UPDATE album SET strAlbum = '%s', strArtists = '%s', strGenres = '%s', iYear=%i, strLabel = '%s', bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
+        strSQL=PrepareSQL("UPDATE album SET strAlbum = '%s', strArtists = '%s', strGenres = '%s', iYear=%i, strLabel = '%s', strType = '%s', bCompilation=%i, strReleaseType = '%s', lastScraped = NULL WHERE idAlbum=%i",
                           strAlbum.c_str(),
                           strArtist.c_str(),
                           strGenre.c_str(),
                           year,
                           strRecordLabel.c_str(),
+                          strType.c_str(),
                           bCompilation,
                           CAlbum::ReleaseTypeToString(releaseType).c_str(),
                           idAlbum);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -222,13 +222,15 @@ public:
    \param strGenre the album genre(s)
    \param year the year
    \param strRecordLabel the recording lable
+   \param strType album type (Musicbrainz release type e.g. "Broadcast, Soundtrack, live"), 
    \param bCompilation if the album is a compilation
    \param releaseType "album" or "single"
    \return the id of the album
    */
   int  AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
                 const std::string& strArtist, const std::string& strGenre, int year, 
-                const std::string& strRecordLabel, bool bCompilation, CAlbum::ReleaseType releaseType);
+                const std::string& strRecordLabel, const std::string& strType,
+                bool bCompilation, CAlbum::ReleaseType releaseType);
   /*! \brief retrieve an album, optionally with all songs.
    \param idAlbum the database id of the album.
    \param album [out] the album to fill.

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -202,7 +202,12 @@ public:
   /////////////////////////////////////////////////
   // Album
   /////////////////////////////////////////////////
+  /*! \brief Add an album and all its songs to the database
+  \param album the album to add
+  \return the id of the album
+  */
   bool AddAlbum(CAlbum& album);
+
   /*! \brief Update an album and all its nested entities (artists, songs, infoSongs, etc)
    \param album the album to update
    \param OverrideTagData whether or not to replace the artist and song data, defaults to true.
@@ -210,14 +215,20 @@ public:
    */
   bool UpdateAlbum(CAlbum& album, bool OverrideTagData = true);
 
-  /*! \brief Add an album and all its songs to the database
-   \param album the album to add
-   \param songIDs [out] the ids of the added songs
+  /*! \brief Add an album to the database
+   \param strAlbum the album title
+   \param strMusicBrainzAlbumID the Musicbrainz Id
+   \param strArtist the album artist name(s)
+   \param strGenre the album genre(s)
+   \param year the year
+   \param strRecordLabel the recording lable
+   \param bCompilation if the album is a compilation
+   \param releaseType "album" or "single"
    \return the id of the album
    */
   int  AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
-                const std::string& strArtist, const std::string& strGenre,
-                int year, bool bCompilation, CAlbum::ReleaseType releaseType);
+                const std::string& strArtist, const std::string& strGenre, int year, 
+                const std::string& strRecordLabel, bool bCompilation, CAlbum::ReleaseType releaseType);
   /*! \brief retrieve an album, optionally with all songs.
    \param idAlbum the database id of the album.
    \param album [out] the album to fill.

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -149,6 +149,7 @@ CSong::CSong(CFileItem& item)
   iTrack = tag.GetTrackAndDiscNumber();
   iDuration = tag.GetDuration();
   strRecordLabel = tag.GetRecordLabel();
+  strAlbumType = tag.GetMusicBrainzReleaseType();
   bCompilation = tag.GetCompilation();
   embeddedArt = tag.GetCoverArtInfo();
   strFileName = tag.GetURL().empty() ? item.GetPath() : tag.GetURL();

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -148,6 +148,7 @@ CSong::CSong(CFileItem& item)
   iYear = stTime.wYear;
   iTrack = tag.GetTrackAndDiscNumber();
   iDuration = tag.GetDuration();
+  strRecordLabel = tag.GetRecordLabel();
   bCompilation = tag.GetCompilation();
   embeddedArt = tag.GetCoverArtInfo();
   strFileName = tag.GetURL().empty() ? item.GetPath() : tag.GetURL();

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -164,6 +164,7 @@ public:
   int iEndOffset;
   bool bCompilation;
   std::string strRecordLabel; // Record label from tag for album processing by CMusicInfoScanner::FileItemsToAlbums
+  std::string strAlbumType; // (Musicbrainz) album release type from tag for album processing by CMusicInfoScanner::FileItemsToAlbums
 
   ReplayGain replayGain;
 private:

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -163,6 +163,7 @@ public:
   int iStartOffset;
   int iEndOffset;
   bool bCompilation;
+  std::string strRecordLabel; // Record label from tag for album processing by CMusicInfoScanner::FileItemsToAlbums
 
   ReplayGain replayGain;
 private:

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -745,6 +745,7 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
         album.genre = (*k)->genre;
         //       in addition, we may want to use year as discriminating for albums
         album.iYear = (*k)->iYear;
+        album.strLabel = (*k)->strRecordLabel;
         album.songs.push_back(**k);
       }
       albums.push_back(album);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -746,6 +746,7 @@ void CMusicInfoScanner::FileItemsToAlbums(CFileItemList& items, VECALBUMS& album
         //       in addition, we may want to use year as discriminating for albums
         album.iYear = (*k)->iYear;
         album.strLabel = (*k)->strRecordLabel;
+        album.strType = (*k)->strAlbumType;
         album.songs.push_back(**k);
       }
       albums.push_back(album);

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -587,6 +587,11 @@ const std::vector<std::string>& CMusicInfoTag::GetMusicBrainzAlbumArtistHints() 
     return m_musicBrainzAlbumArtistHints;
 }
 
+const std::string &CMusicInfoTag::GetMusicBrainzReleaseType() const
+{
+  return m_strMusicBrainzReleaseType;
+}
+
 void CMusicInfoTag::SetMusicBrainzTrackID(const std::string& strTrackID)
 {
   m_strMusicBrainzTrackID = strTrackID;
@@ -615,6 +620,11 @@ void CMusicInfoTag::SetMusicBrainzAlbumArtistID(const std::vector<std::string>& 
 void CMusicInfoTag::SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints)
 {
     m_musicBrainzAlbumArtistHints = musicBrainzAlbumArtistHints;
+}
+
+void CMusicInfoTag::SetMusicBrainzReleaseType(const std::string& ReleaseType)
+{
+  m_strMusicBrainzReleaseType = ReleaseType;
 }
 
 void CMusicInfoTag::SetCoverArtInfo(size_t size, const std::string &mimeType)
@@ -665,6 +675,7 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetAlbum(album.strAlbum);
   SetTitle(album.strAlbum);
   SetMusicBrainzAlbumID(album.strMusicBrainzAlbumID);
+  SetMusicBrainzReleaseType(album.strType);
   SetGenre(album.genre);
   SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
   SetRecordLabel(album.strLabel);
@@ -851,6 +862,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar << m_musicBrainzArtistID;
     ar << m_strMusicBrainzAlbumID;
     ar << m_musicBrainzAlbumArtistID;
+    ar << m_strMusicBrainzReleaseType;
     ar << m_lastPlayed;
     ar << m_dateAdded;
     ar << m_strComment;
@@ -896,6 +908,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar >> m_musicBrainzArtistID;
     ar >> m_strMusicBrainzAlbumID;
     ar >> m_musicBrainzAlbumArtistID;
+    ar >> m_strMusicBrainzReleaseType;
     ar >> m_lastPlayed;
     ar >> m_dateAdded;
     ar >> m_strComment;
@@ -947,6 +960,7 @@ void CMusicInfoTag::Clear()
   m_musicBrainzArtistID.clear();
   m_strMusicBrainzAlbumID.clear();
   m_musicBrainzAlbumArtistID.clear();
+  m_strMusicBrainzReleaseType.clear();
   m_musicRoles.clear();
   m_iDuration = 0;
   m_iTrack = 0;

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -119,6 +119,7 @@ const CMusicInfoTag& CMusicInfoTag::operator =(const CMusicInfoTag& tag)
   m_musicRoles = tag.m_musicRoles;
   m_strComment = tag.m_strComment;
   m_strMood = tag.m_strMood;
+  m_strMood = tag.m_strMood;
   m_strLyrics = tag.m_strLyrics;
   m_cuesheet = tag.m_cuesheet;
   m_lastPlayed = tag.m_lastPlayed;
@@ -267,6 +268,11 @@ const std::string &CMusicInfoTag::GetComment() const
 const std::string &CMusicInfoTag::GetMood() const
 {
   return m_strMood;
+}
+
+const std::string &CMusicInfoTag::GetRecordLabel() const
+{
+  return m_strRecordLabel;
 }
 
 const std::string &CMusicInfoTag::GetLyrics() const
@@ -468,6 +474,11 @@ void CMusicInfoTag::SetMood(const std::string& mood)
   m_strMood = mood;
 }
 
+void CMusicInfoTag::SetRecordLabel(const std::string& publisher)
+{
+  m_strRecordLabel = publisher;
+}
+
 void CMusicInfoTag::SetCueSheet(const std::string& cueSheet)
 {
   m_cuesheet = cueSheet;
@@ -656,6 +667,7 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetMusicBrainzAlbumID(album.strMusicBrainzAlbumID);
   SetGenre(album.genre);
   SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
+  SetRecordLabel(album.strLabel);
   SetRating(album.fRating);
   SetUserrating(album.iUserrating);
   SetVotes(album.iVotes);
@@ -769,6 +781,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["displayorchestra"] = GetArtistStringForRole("orchestra");
   value["displaylyricist"] = GetArtistStringForRole("lyricist");   //TEXT
   value["mood"] = StringUtils::Split(m_strMood, g_advancedSettings.m_musicItemSeparator);
+  value["recordlabel"] = m_strRecordLabel;
   value["rating"] = m_Rating;
   value["userrating"] = m_Userrating;
   value["votes"] = m_Votes;
@@ -850,6 +863,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
       ar << credit->GetArtistId();
     }
     ar << m_strMood;
+    ar << m_strRecordLabel;
     ar << m_Rating;
     ar << m_Userrating;
     ar << m_Votes;
@@ -901,6 +915,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
       m_musicRoles.emplace_back(idRole, strRole, strArtist, idArtist);
     }
     ar >> m_strMood;
+    ar >> m_strRecordLabel;
     ar >> m_Rating;
     ar >> m_Userrating;
     ar >> m_Votes;
@@ -941,6 +956,7 @@ void CMusicInfoTag::Clear()
   m_bCompilation = false;
   m_strComment.clear();
   m_strMood.clear();
+  m_strRecordLabel.clear();
   m_cuesheet.clear();
   m_iDbId = -1;
   m_type.clear();

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -73,6 +73,7 @@ public:
   const std::string& GetMusicBrainzAlbumID() const;
   const std::vector<std::string>& GetMusicBrainzAlbumArtistID() const;
   const std::vector<std::string>& GetMusicBrainzAlbumArtistHints() const;
+  const std::string& GetMusicBrainzReleaseType() const;
   const std::string& GetComment() const;
   const std::string& GetMood() const;
   const std::string& GetRecordLabel() const;
@@ -119,6 +120,7 @@ public:
   void SetMusicBrainzAlbumID(const std::string& strAlbumID);
   void SetMusicBrainzAlbumArtistID(const std::vector<std::string>& musicBrainzAlbumArtistId);
   void SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints);
+  void SetMusicBrainzReleaseType(const std::string& ReleaseType);
   void SetComment(const std::string& comment);
   void SetMood(const std::string& mood);
   void SetRecordLabel(const std::string& publisher);
@@ -194,6 +196,7 @@ protected:
   std::string m_strMusicBrainzAlbumID;
   std::vector<std::string> m_musicBrainzAlbumArtistID;
   std::vector<std::string> m_musicBrainzAlbumArtistHints;
+  std::string m_strMusicBrainzReleaseType;
   VECMUSICROLES m_musicRoles; //Artists contributing to the recording and role (from tags other than ARTIST or ALBUMARTIST)
   std::string m_strComment;
   std::string m_strMood;

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -75,6 +75,7 @@ public:
   const std::vector<std::string>& GetMusicBrainzAlbumArtistHints() const;
   const std::string& GetComment() const;
   const std::string& GetMood() const;
+  const std::string& GetRecordLabel() const;
   const std::string& GetLyrics() const;
   const std::string& GetCueSheet() const;
   const CDateTime& GetLastPlayed() const;
@@ -120,6 +121,7 @@ public:
   void SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints);
   void SetComment(const std::string& comment);
   void SetMood(const std::string& mood);
+  void SetRecordLabel(const std::string& publisher);
   void SetLyrics(const std::string& lyrics);
   void SetCueSheet(const std::string& cueSheet);
   void SetRating(float rating);
@@ -195,6 +197,7 @@ protected:
   VECMUSICROLES m_musicRoles; //Artists contributing to the recording and role (from tags other than ARTIST or ALBUMARTIST)
   std::string m_strComment;
   std::string m_strMood;
+  std::string m_strRecordLabel;
   std::string m_strLyrics;
   std::string m_cuesheet;
   CDateTime m_lastPlayed;

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -181,7 +181,7 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
     else if (it->first == "WM/Mixer")
       AddArtistRole(tag, "mixer", GetASFStringList(it->second));
     else if (it->first == "WM/Publisher")
-    {} // Known unsupported, supress warnings
+      tag.SetRecordLabel(it->second.front().toString().to8Bit(true));
     else if (it->first == "WM/AlbumArtistSortOrder")
     {} // Known unsupported, supress warnings
     else if (it->first == "WM/ArtistSortOrder")
@@ -303,7 +303,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art,
     else if (it->first == "TPE3")   AddArtistRole(tag, "Conductor", GetID3v2StringList(it->second));
     else if (it->first == "TEXT")   AddArtistRole(tag, "Lyricist", GetID3v2StringList(it->second));
     else if (it->first == "TPE4")   AddArtistRole(tag, "Remixer", GetID3v2StringList(it->second));
-    else if (it->first == "TPUB")   {} // Publisher. Known unsupported, supress warnings
+    else if (it->first == "TPUB")   tag.SetRecordLabel(it->second.front()->toString().to8Bit(true));
     else if (it->first == "TCOP")   {} // Copyright message
     else if (it->first == "TDRC")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), nullptr, 10));
     else if (it->first == "TDRL")   tag.SetYear(strtol(it->second.front()->toString().toCString(true), nullptr, 10));
@@ -520,7 +520,7 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
       // Picard uses PERFORMER tag as musician credits list formatted "name (instrument)"
       AddArtistInstrument(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "LABEL")   
-    {} // Publisher. Known unsupported, supress warnings
+      tag.SetRecordLabel(it->second.toString().to8Bit(true));
     else if (it->first == "COMPILATION")
       tag.SetCompilation(it->second.toString().toInt() == 1);
     else if (it->first == "LYRICS")
@@ -617,7 +617,7 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
       // Picard uses PERFORMER tag as musician credits list formatted "name (instrument)"
       AddArtistInstrument(tag, StringListToVectorString(it->second));
     else if (it->first == "LABEL")
-    {} // Publisher. Known unsupported, supress warnings
+      tag.SetRecordLabel(it->second.front().to8Bit(true));
     else if (it->first == "COMPILATION")
       tag.SetCompilation(it->second.front().toInt() == 1);
     else if (it->first == "LYRICS")
@@ -776,7 +776,7 @@ bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& 
       AddArtistRole(tag, "Mixer", StringListToVectorString(it->second.toStringList()));
     //No MP4 standard tag for musician credits
     else if (it->first == "----:com.apple.iTunes:LABEL")
-    {} // Publisher. Known unsupported, supress warnings
+      tag.SetRecordLabel(it->second.toStringList().front().to8Bit(true));
     else if (it->first == "cpil")
       tag.SetCompilation(it->second.toBool());
     else if (it->first == "trkn")

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -203,7 +203,7 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
     else if (it->first == "MusicBrainz/Album Status")
     {}
     else if (it->first == "MusicBrainz/Album Type")
-    {}
+      SetReleaseType(tag, GetASFStringList(it->second));
     else if (it->first == "MusicIP/PUID")
     {}
     else if (it->first == "replaygain_track_gain")
@@ -346,6 +346,8 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art,
           tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(stringList)));
         else if (desc == "MUSICBRAINZ ALBUM ARTIST")
           SetAlbumArtist(tag, StringListToVectorString(stringList));
+        else if (desc == "MUSICBRAINZ ALBUM TYPE")
+          SetReleaseType(tag, StringListToVectorString(stringList));
         else if (desc == "REPLAYGAIN_TRACK_GAIN")
           replayGainInfo.ParseGain(ReplayGain::TRACK, stringList.front().toCString(true));
         else if (desc == "REPLAYGAIN_ALBUM_GAIN")
@@ -543,6 +545,8 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
       tag.SetMusicBrainzAlbumID(it->second.toString().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_TRACKID")
       tag.SetMusicBrainzTrackID(it->second.toString().to8Bit(true));
+    else if (it->first == "MUSICBRAINZ_ALBUMTYPE")
+      SetReleaseType(tag, StringListToVectorString(it->second.toStringList()));
     else if (g_advancedSettings.m_logLevel == LOG_LEVEL_MAX)
       CLog::Log(LOGDEBUG, "unrecognized APE tag: %s", it->first.toCString(true));
   }
@@ -640,6 +644,8 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
       tag.SetMusicBrainzAlbumID(it->second.front().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_TRACKID")
       tag.SetMusicBrainzTrackID(it->second.front().to8Bit(true));
+    else if (it->first == "RELEASETYPE")
+      SetReleaseType(tag, StringListToVectorString(it->second));
     else if (it->first == "RATING")
     {
       // Vorbis ratings are a mess because the standard forgot to mention anything about them.
@@ -803,6 +809,8 @@ bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& 
       tag.SetMusicBrainzAlbumID(it->second.toStringList().front().to8Bit(true));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Track Id")
       tag.SetMusicBrainzTrackID(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Type")
+      SetReleaseType(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "covr")
     {
       MP4::CoverArtList coverArtList = it->second.toCoverArtList();
@@ -946,6 +954,14 @@ void CTagLoaderTagLib::SetGenre(CMusicInfoTag &tag, const std::vector<std::strin
     tag.SetGenre(genres[0]);
   else
     tag.SetGenre(genres);
+}
+
+void CTagLoaderTagLib::SetReleaseType(CMusicInfoTag &tag, const std::vector<std::string> &values)
+{
+  if (values.size() == 1)
+    tag.SetMusicBrainzReleaseType(values[0]);
+  else
+    tag.SetMusicBrainzReleaseType(StringUtils::Join(values, g_advancedSettings.m_musicItemSeparator));
 }
 
 void CTagLoaderTagLib::AddArtistRole(CMusicInfoTag &tag, const std::string& strRole, const std::vector<std::string> &values)

--- a/xbmc/music/tags/TagLoaderTagLib.h
+++ b/xbmc/music/tags/TagLoaderTagLib.h
@@ -45,6 +45,7 @@ protected:
   static void SetAlbumArtist(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
   static void SetAlbumArtistHints(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
   static void SetGenre(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
+  static void SetReleaseType(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
   static void AddArtistRole(MUSIC_INFO::CMusicInfoTag &tag, const std::string& strRole, const std::vector<std::string> &values);
   static void AddArtistRole(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);
   static void AddArtistInstrument(MUSIC_INFO::CMusicInfoTag &tag, const std::vector<std::string> &values);


### PR DESCRIPTION
Albums have label and type fields that can currently only be filled by scraping from NFO files and maybe from online sources (?). Yet music files can be tagged with record label and release type information that could be used to populate these fields.

This adds processing of the LABEL (TPUB)  and RELEASETYPE (MUSICBRAINZ ALBUM TYPE) tags and uses them to poplate the album library data. Both label and type fields are avaliable in smart playlist rules, so this extends the way that users can explore their music  collection.

Note the album table also has a "releasetype" field, this is used internally to flag if the entry in the album table is a real "album" or a "single" e.g. a fake album created to cover all the singles by that artist. We must take care not to confuse the two. 
