### PR TITLE
[Util/darwin] - fix GetHomePath again - fixes osx unit tests

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -232,7 +232,7 @@ std::string GetHomePath(const std::string& strTarget, std::string strPath)
       // see if this assumption is valid
       if (!CDirectory::Exists(given_path))
       {
-        std::string given_path_stdstr = given_path;
+        std::string given_path_stdstr = CUtil::ResolveExecutablePath();
         // try to find the correct folder by going back
         // in the executable path until settings.xml was found
         bool validRoot = false;


### PR DESCRIPTION
what a bitch to track down ... i think this might be broken since the change of GetHomePath or since the switch to cmake build ... (maybe the latter).
