### PR TITLE
[WIP] Estuary settings window changes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7521,67 +7521,45 @@ msgctxt "#14200"
 msgid "Player"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14201"
-msgid "Player settings"
-msgstr ""
+#empty string id 14201
 
 #: system/settings/settings.xml
 msgctxt "#14202"
 msgid "Library"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14203"
-msgid "Library settings"
-msgstr ""
+#empty string id 14203
 
 #: system/settings/settings.xml
 msgctxt "#14204"
 msgid "TV"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14205"
-msgid "TV settings"
-msgstr ""
+#empty string id 14205
 
 #: system/settings/settings.xml
 msgctxt "#14206"
 msgid "Interface"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14207"
-msgid "Interface settings"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#14208"
-msgid "Service settings"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#14209"
-msgid "System settings"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#14210"
-msgid "Profile settings"
-msgstr ""
+#empty strings from id 14207 to id 14210
 
 #: system/settings/settings.xml
 msgctxt "#14211"
 msgid "Media"
 msgstr ""
 
+#empty string id 14212
+
 #: system/settings/settings.xml
-msgctxt "#14212"
-msgid "Media settings"
+msgctxt "#14213"
+msgid "About system"
 msgstr ""
 
-#empty strings from id 14213 to 14214
+#: system/settings/settings.xml
+msgctxt "#14214"
+msgid "Event log"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14215"

--- a/addons/skin.estuary/1080i/Home.xml
+++ b/addons/skin.estuary/1080i/Home.xml
@@ -1179,7 +1179,7 @@
 				</control>
 				<control type="grouplist" id="700">
 					<orientation>horizontal</orientation>
-					<itemgap>-16</itemgap>
+					<itemgap>-22</itemgap>
 					<left>33</left>
 					<top>878</top>
 					<onup>SetFocus(9000,99)</onup>
@@ -1203,12 +1203,6 @@
 						<param name="onclick" value="ActivateWindow(favourites)" />
 						<param name="icon" value="icons/favourites.png" />
 						<param name="label" value="$LOCALIZE[10134]" />
-					</include>
-					<include content="BottomMainMenuItem">
-						<param name="control_id" value="801" />
-						<param name="onclick" value="ActivateWindow(filemanager)" />
-						<param name="icon" value="icons/filemanager.png" />
-						<param name="label" value="$LOCALIZE[10003]" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/1080i/Includes_Buttons.xml
+++ b/addons/skin.estuary/1080i/Includes_Buttons.xml
@@ -197,7 +197,7 @@
 		<param name="height">110</param>
 		<definition>
 			<control type="radiobutton" id="$PARAM[control_id]">
-				<width>118</width>
+				<width>156</width>
 				<height>$PARAM[height]</height>
 				<align>center</align>
 				<aligny>center</aligny>
@@ -206,7 +206,7 @@
 				<label>$PARAM[label]</label>
 				<texturefocus border="40" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
 				<texturenofocus border="40">buttons/button-nofo.png</texturenofocus>
-				<radioposx>38</radioposx>
+				<radioposx>55</radioposx>
 				<radioposy>0</radioposy>
 				<radiowidth>40</radiowidth>
 				<radioheight>40</radioheight>

--- a/addons/skin.estuary/1080i/Settings.xml
+++ b/addons/skin.estuary/1080i/Settings.xml
@@ -106,47 +106,62 @@
 			</focusedlayout>
 			<content>
 				<item>
-					<label>$LOCALIZE[14201]</label>
+					<label>$LOCALIZE[14200]</label>
 					<onclick>ActivateWindow(PlayerSettings)</onclick>
 					<icon>icons/settings/video.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14212]</label>
+					<label>$LOCALIZE[14211]</label>
 					<onclick>ActivateWindow(MediaSettings)</onclick>
 					<icon>icons/settings/library.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14205]</label>
+					<label>$LOCALIZE[14204]</label>
 					<onclick>ActivateWindow(PVRSettings)</onclick>
 					<icon>icons/settings/livetv.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14208]</label>
+					<label>$LOCALIZE[14036]</label>
 					<onclick>ActivateWindow(ServiceSettings)</onclick>
 					<icon>icons/settings/network.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[14207]</label>
-					<onclick>ActivateWindow(InterfaceSettings)</onclick>
-					<icon>icons/settings/appearance.png</icon>
-				</item>
-				<item>
-					<label>$LOCALIZE[20077]</label>
-					<onclick>ActivateWindow(SkinSettings)</onclick>
-					<icon>icons/settings/skin.png</icon>
-				</item>
-				<item>
-					<label>$LOCALIZE[14210]</label>
-					<onclick>ActivateWindow(Profiles)</onclick>
-					<icon>icons/settings/profiles.png</icon>
-				</item>
-				<item>
-					<label>$LOCALIZE[14209]</label>
+					<label>$LOCALIZE[13000]</label>
 					<onclick>ActivateWindow(SystemSettings)</onclick>
 					<icon>icons/settings/system.png</icon>
 				</item>
 				<item>
-					<label>$LOCALIZE[138]</label>
+				<label>$LOCALIZE[14206]</label>
+					<onclick>ActivateWindow(InterfaceSettings)</onclick>
+					<icon>icons/settings/appearance.png</icon>
+				</item>
+				<item>
+					<label>$LOCALIZE[166]</label>
+					<onclick>ActivateWindow(SkinSettings)</onclick>
+					<icon>icons/settings/skin.png</icon>
+				</item>
+				<item>
+					<label>$LOCALIZE[13200]</label>
+					<onclick>ActivateWindow(Profiles)</onclick>
+					<icon>icons/settings/profiles.png</icon>
+				</item>
+				<item>
+					<label>$LOCALIZE[7]</label>
+					<onclick>ActivateWindow(filemanager)</onclick>
+					<icon>icons/settings/filemanager.png</icon>
+				</item>
+				<item>
+					<label>$LOCALIZE[24001]</label>
+					<onclick>ActivateWindow(addonbrowser)</onclick>
+					<icon>icons/settings/addons.png</icon>
+				</item>
+				<item>
+					<label>$LOCALIZE[14214]</label>
+					<onclick>ActivateWindow(eventlog)</onclick>
+					<icon>icons/settings/sysinfo.png</icon>
+				</item>
+				<item>
+					<label>$LOCALIZE[14213]</label>
 					<onclick>ActivateWindow(systeminfo)</onclick>
 					<icon>icons/settings/sysinfo.png</icon>
 				</item>


### PR DESCRIPTION
## Description

As discuss at Devcon, the layout of the Settings window is being adjusted to accomodate File Manager, Add-on Browser, Event Log, and System Info (renamed here to "About system")
## Motivation and Context

Keep Settings and system utilities one one place
## How Has This Been Tested?

As only xml file changes, this was tested by replacing the relevant files from nightly build 27/09/2016
## Screenshots (if appropriate):

![estuary1](https://cloud.githubusercontent.com/assets/5781142/18885299/11104c24-84e3-11e6-8600-c826336b7836.JPG)

![estuary2](https://cloud.githubusercontent.com/assets/5781142/18885300/111de686-84e3-11e6-99da-07b183a9f3b5.JPG)
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
