### PR TITLE
[gui] fix header on sort dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19625,3 +19625,8 @@ msgstr ""
 msgctxt "#39009"
 msgid "Zoom - 110% width"
 msgstr ""
+
+#: view/GUIViewState.cpp
+msgctxt "#39010"
+msgid "Select sort method"
+msgstr ""

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -346,7 +346,7 @@ bool CGUIViewState::ChooseSortMethod()
   if (!dialog)
     return false;
   dialog->Reset();
-  dialog->SetHeading(CVariant{ 32104 }); // Label "Sort by"
+  dialog->SetHeading(CVariant{ 39010 }); // Label "Sort by"
   for (auto &sortMethod : m_sortMethods)
     dialog->Add(g_localizeStrings.Get(sortMethod.m_buttonLabel));
   dialog->SetSelected(m_currentSortMethod);


### PR DESCRIPTION
This fixes the empty header on the select dialog when selecting a sort method.
This was added in #9647 but I can't seem to find label 32104 anywhere in history. That number should also be reserved for scripts.

Before:
![schermafbeelding 2016-09-28 om 10 47 23](https://cloud.githubusercontent.com/assets/447067/18906891/ba84031e-8569-11e6-848f-1a19c4a70681.png)

After:
![schermafbeelding 2016-09-28 om 10 48 01](https://cloud.githubusercontent.com/assets/447067/18906896/c0557782-8569-11e6-9198-0f00abe9dd89.png)

@phil65 since you added the string id in #9647 
