### PR TITLE
FFmpeg: Bump to 3.1.4-Krypton-Beta3

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.3-Krypton-Beta3-2
+VERSION=3.1.4-Krypton-Beta3
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
FFmpeg rebase on 3.1.4

The backported HLS patch was merged upstream together with several other fixes.
