### PR TITLE
[PVR] Guide window: fix ruler date might taking to much space (result ing in ugly overlap).

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1327,12 +1327,12 @@ std::string CDateTime::GetAsLocalizedTime(const std::string &format, bool withSe
   return strOut;
 }
 
-std::string CDateTime::GetAsLocalizedDate(bool longDate/*=false*/) const
+std::string CDateTime::GetAsLocalizedDate(bool longDate/*=false*/, bool withYear /* = true */) const
 {
-  return GetAsLocalizedDate(g_langInfo.GetDateFormat(longDate));
+  return GetAsLocalizedDate(g_langInfo.GetDateFormat(longDate), withYear);
 }
 
-std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
+std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat, bool withYear /* = true */) const
 {
   std::string strOut;
 
@@ -1449,12 +1449,18 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
         i=length;
       }
 
-      // Format string with the length of the mask
-      std::string str = StringUtils::Format("%d", dateTime.wYear); // four-digit number
-      if (partLength <= 2)
-        str.erase(0, 2); // two-digit number
+      if (withYear)
+      {
+        // Format string with the length of the mask
+        std::string str = StringUtils::Format("%d", dateTime.wYear); // four-digit number
+        if (partLength <= 2)
+          str.erase(0, 2); // two-digit number
 
-      strOut+=str;
+        strOut+=str;
+
+      }
+      else
+        strOut.erase(strOut.size() - 1, 1);
     }
     else // everything else pass to output
       strOut+=c;

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -203,8 +203,8 @@ public:
   std::string GetAsSaveString() const;
   std::string GetAsDBDateTime() const;
   std::string GetAsDBDate() const;
-  std::string GetAsLocalizedDate(bool longDate=false) const;
-  std::string GetAsLocalizedDate(const std::string &strFormat) const;
+  std::string GetAsLocalizedDate(bool longDate=false, bool withYear = true) const;
+  std::string GetAsLocalizedDate(const std::string &strFormat, bool withYear = true) const;
   std::string GetAsLocalizedTime(const std::string &format, bool withSeconds=true) const;
   std::string GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
   std::string GetAsRFC1123DateTime() const;

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -142,7 +142,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
   for (; ruler < rulerEnd; ruler += unit)
   {
     rulerItem.reset(new CFileItem(ruler.GetAsLocalizedTime("", false)));
-    rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true));
+    rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true /* long format */, false /* without year */));
     m_rulerItems.emplace_back(rulerItem);
   }
 


### PR DESCRIPTION
Before:

![screenshot002](https://cloud.githubusercontent.com/assets/3226626/18929440/c3b26e20-85c4-11e6-9fa1-8be744824651.png)

After:

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/18929454/cd4e7744-85c4-11e6-800f-08c86e1a38f5.png)

@phil65 fyi
@Jalle19 mind taking a look at the code changes
