### PR TITLE
minor keymap change for tempo up/down

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -354,8 +354,8 @@
       <down>ChapterOrBigStepBack</down>
       <up mod="longpress">AudioNextLanguage</up>
       <down mod="longpress">NextSubtitle</down>
-      <left mod="ctrl">PlayerControl(tempodown)</left>
-      <right mod="ctrl">PlayerControl(tempoup)</right>
+      <left mod="alt">PlayerControl(tempodown)</left>
+      <right mod="alt">PlayerControl(tempoup)</right>
       <a>AudioDelay</a>
       <a mod="ctrl">AudioNextLanguage</a>
       <escape>Fullscreen</escape>


### PR DESCRIPTION
As requested here: https://github.com/xbmc/xbmc/commit/9719da3ea8046d363f3ebf650368ce7ef0838ed3#commitcomment-19212541

change control + arrow to alt + arrow, to avoid conflict on Mac OS X.
