### PR TITLE
[gui] Always show "Add rule" item in smartplaylisteditor rule list

### DIFF
--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -110,32 +110,18 @@
 				<height>435</height>
 				<onleft>500</onleft>
 				<onright>500</onright>
-				<ondown>13</ondown>
+				<ondown>9001</ondown>
 				<onup>9001</onup>
 				<include content="DefaultSimpleListLayout">
 					<param name="width" value="600" />
 					<param name="list_id" value="10" />
 				</include>
 			</control>
-			<control type="button" id="13">
-				<description>Add rule Button</description>
-				<left>650</left>
-				<top>555</top>
-				<width>300</width>
-				<height>90</height>
-				<include>SettingsItemCommon</include>
-				<align>center</align>
-				<label>$LOCALIZE[15019]</label>
-				<onleft>500</onleft>
-				<onright>500</onright>
-				<ondown>9001</ondown>
-				<onup>10</onup>
-			</control>
 			<control type="textbox">
 				<left>680</left>
-				<top>640</top>
+				<top>570</top>
 				<width>540</width>
-				<height>188</height>
+				<height>248</height>
 				<aligny>top</aligny>
 				<label>$LOCALIZE[31043]</label>
 				<textcolor>grey</textcolor>

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -188,9 +188,7 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
 
 void CGUIDialogSmartPlaylistEditor::OnPopupMenu(int item)
 {
-  if (item < 0 || item >= m_ruleLabels->Size())
-    return;
-  if (m_playlist.m_ruleCombination.m_rules.size() == 1 && m_playlist.m_ruleCombination.m_rules[0]->m_field == FieldNone)
+  if (item < 0 || static_cast<size_t>(item) >= m_playlist.m_ruleCombination.m_rules.size())
     return;
   // highlight the item
   m_ruleLabels->Get(item)->Select(true);
@@ -208,14 +206,17 @@ void CGUIDialogSmartPlaylistEditor::OnPopupMenu(int item)
 }
 
 void CGUIDialogSmartPlaylistEditor::OnRuleList(int item)
-{
-  if (item < 0 || item >= (int)m_playlist.m_ruleCombination.m_rules.size()) return;
-
-  CSmartPlaylistRule rule = *std::static_pointer_cast<CSmartPlaylistRule>(m_playlist.m_ruleCombination.m_rules[item]);
-
-  if (CGUIDialogSmartPlaylistRule::EditRule(rule,m_playlist.GetType()))
-    *m_playlist.m_ruleCombination.m_rules[item] = rule;
-
+{ 
+  if (item == static_cast<int>(m_playlist.m_ruleCombination.m_rules.size()))
+    OnRuleAdd();
+  else if (item < 0 || item > static_cast<int>(m_playlist.m_ruleCombination.m_rules.size()))
+    return;
+  else
+  {
+    CSmartPlaylistRule rule = *std::static_pointer_cast<CSmartPlaylistRule>(m_playlist.m_ruleCombination.m_rules[item]);
+    if (CGUIDialogSmartPlaylistRule::EditRule(rule,m_playlist.GetType()))
+      *m_playlist.m_ruleCombination.m_rules[item] = rule;
+  }
   UpdateButtons();
 }
 
@@ -331,11 +332,6 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
 {
   CONTROL_ENABLE(CONTROL_OK); // always enabled since we can have no rules -> match everything (as we do with default partymode playlists)
   
-  // if there's no rule available, add a dummy one the user can edit
-  if (m_playlist.m_ruleCombination.m_rules.size() <= 0)
-    m_playlist.m_ruleCombination.AddRule(CSmartPlaylistRule());
-
-  // name
   if (m_mode == "partyvideo" || m_mode == "partymusic")
   {
     SET_CONTROL_LABEL2(CONTROL_NAME, g_localizeStrings.Get(16035));
@@ -352,15 +348,15 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
   OnMessage(msgReset);
   m_ruleLabels->Clear();
-  for (unsigned int i = 0; i < m_playlist.m_ruleCombination.m_rules.size(); i++)
+  for (const auto& rule: m_playlist.m_ruleCombination.m_rules)
   {
     CFileItemPtr item(new CFileItem("", false));
-    if (m_playlist.m_ruleCombination.m_rules[i]->m_field == FieldNone)
-      item->SetLabel(g_localizeStrings.Get(21423));
-    else
-      item->SetLabel(std::static_pointer_cast<CSmartPlaylistRule>(m_playlist.m_ruleCombination.m_rules[i])->GetLocalizedRule());
+    item->SetLabel(std::static_pointer_cast<CSmartPlaylistRule>(rule)->GetLocalizedRule());
     m_ruleLabels->Add(item);
   }
+  CFileItemPtr item(new CFileItem("", false));
+  item->SetLabel(g_localizeStrings.Get(21423));
+  m_ruleLabels->Add(item);
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_RULE_LIST, 0, 0, m_ruleLabels);
   OnMessage(msg);
   SendMessage(GUI_MSG_ITEM_SELECT, GetID(), CONTROL_RULE_LIST, currentItem);
@@ -556,22 +552,13 @@ void CGUIDialogSmartPlaylistEditor::OnRuleRemove(int item)
     HighlightItem(m_ruleLabels->Size() - 1);
   else
     HighlightItem(item);
-  if (m_ruleLabels->Size() <= 1)
-  {
-    SET_CONTROL_FOCUS(CONTROL_RULE_ADD, 0);
-  }
 }
 
 void CGUIDialogSmartPlaylistEditor::OnRuleAdd()
 {
   CSmartPlaylistRule rule;
   if (CGUIDialogSmartPlaylistRule::EditRule(rule,m_playlist.GetType()))
-  {
-    if (m_playlist.m_ruleCombination.m_rules.size() == 1 && m_playlist.m_ruleCombination.m_rules[0]->m_field == FieldNone)
-      *m_playlist.m_ruleCombination.m_rules[0] = rule;
-    else
-      m_playlist.m_ruleCombination.AddRule(rule);
-  }
+    m_playlist.m_ruleCombination.AddRule(rule);
   UpdateButtons();
 }
 


### PR DESCRIPTION
This changes the smartplaylisteditor rule list to always show the "add rule" item, that way the separate button for that action can get removed.
This allows us to revert  https://github.com/xbmc/xbmc/commit/fc87499d3dfd95790be7e2df52b094d98b939d6b

@Montellese or @xhaggi for review perhaps?
@ronie, mind doing some quick testing?
