### PR TITLE
[gui] change rule type selection from spinner to selectdialog	

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12419,7 +12419,9 @@ msgctxt "#20426"
 msgid "Export to a single file or separate files per entry?"
 msgstr ""
 
-#empty string with id 20427
+msgctxt "#20427"
+msgid "Choose rule type"
+msgstr ""
 
 msgctxt "#20428"
 msgid "Single file"

--- a/addons/skin.estuary/1080i/SmartPlaylistRule.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistRule.xml
@@ -27,7 +27,7 @@
 			<orientation>vertical</orientation>
 			<onup>9000</onup>
 			<ondown>9000</ondown>
-			<control type="spincontrolex" id="15">
+			<control type="button" id="15">
 				<description>Rule Field</description>
 				<include>SettingsItemCommon</include>
 				<width>900</width>


### PR DESCRIPTION
We sometimes have approx 30 different rule types. Doing that via spinners is quite a PITA, so lets use dialogselect instead.
