### PR TITLE
[gui] smartplaylisteditor: convert spinners etc to regular buttons

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8453,7 +8453,10 @@ msgctxt "#16022"
 msgid "Bob - Inverted"
 msgstr ""
 
-#empty string with id 16023
+#: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+msgctxt "#16023"
+msgid "Choose operator"
+msgstr ""
 
 #: xbmc/dialogs/GUIDialogProgress.cpp
 msgctxt "#16024"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12419,7 +12419,9 @@ msgctxt "#20426"
 msgid "Export to a single file or separate files per entry?"
 msgstr ""
 
-#empty string with id 20427
+msgctxt "#20427"
+msgid "Choose rule type"
+msgstr ""
 
 msgctxt "#20428"
 msgid "Single file"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12422,6 +12422,7 @@ msgctxt "#20426"
 msgid "Export to a single file or separate files per entry?"
 msgstr ""
 
+#: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 msgctxt "#20427"
 msgid "Choose rule type"
 msgstr ""
@@ -13045,7 +13046,7 @@ msgstr ""
 
 #: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
 msgctxt "#21433"
-msgid "Name of the playlist"
+msgid "Playlist name"
 msgstr ""
 
 msgctxt "#21434"

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -29,14 +29,9 @@
 					<include>SettingsItemCommon</include>
 					<label>$LOCALIZE[467]</label>
 				</control>
-				<control type="label" id="1100">
-					<description>Name Label</description>
-					<width>660</width>
-					<label>$LOCALIZE[21433]</label>
-					<include>SettingsLabelCommon</include>
-				</control>
-				<control type="edit" id="12">
+				<control type="button" id="12">
 					<description>Name Button</description>
+					<label>$LOCALIZE[21433]</label>
 					<width>660</width>
 					<include>SettingsItemCommon</include>
 				</control>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -56,7 +56,7 @@
 					<label>$LOCALIZE[21427]</label>
 					<include>SettingsItemCommon</include>
 				</control>
-				<control type="spincontrolex" id="18">
+				<control type="button" id="18">
 					<label>$LOCALIZE[21429]</label>
 					<width>660</width>
 					<include>SettingsItemCommon</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -109,32 +109,18 @@
 				<height>435</height>
 				<onleft>500</onleft>
 				<onright>500</onright>
-				<ondown>13</ondown>
+				<ondown>9001</ondown>
 				<onup>9001</onup>
 				<include content="DefaultSimpleListLayout">
 					<param name="width" value="600" />
 					<param name="list_id" value="10" />
 				</include>
 			</control>
-			<control type="button" id="13">
-				<description>Add rule Button</description>
-				<left>650</left>
-				<top>555</top>
-				<width>300</width>
-				<height>90</height>
-				<include>SettingsItemCommon</include>
-				<align>center</align>
-				<label>$LOCALIZE[15019]</label>
-				<onleft>500</onleft>
-				<onright>500</onright>
-				<ondown>9001</ondown>
-				<onup>10</onup>
-			</control>
 			<control type="textbox">
 				<left>680</left>
-				<top>640</top>
+				<top>570</top>
 				<width>540</width>
-				<height>188</height>
+				<height>248</height>
 				<aligny>top</aligny>
 				<label>$LOCALIZE[31043]</label>
 				<textcolor>grey</textcolor>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -23,7 +23,7 @@
 				<ondown>9001</ondown>
 				<onup>9001</onup>
 				<itemgap>-20</itemgap>
-				<control type="spincontrolex" id="22">
+				<control type="button" id="22">
 					<description>Set Playlist type</description>
 					<width>660</width>
 					<include>SettingsItemCommon</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -46,7 +46,7 @@
 					<label>$LOCALIZE[31042]</label>
 					<include>SettingsLabelCommon</include>
 				</control>
-				<control type="spincontrolex" id="16">
+				<control type="button" id="16">
 					<width>660</width>
 					<label>$LOCALIZE[21424]</label>
 					<include>SettingsItemCommon</include>
@@ -61,11 +61,10 @@
 					<width>660</width>
 					<include>SettingsItemCommon</include>
 				</control>
-				<control type="togglebutton" id="19">
+				<control type="button" id="19">
 					<width>660</width>
 					<include>SettingsItemCommon</include>
-					<label>$LOCALIZE[31032]: $LOCALIZE[21431]</label>
-					<altlabel>$LOCALIZE[31032]: $LOCALIZE[21430]</altlabel>
+					<label>$LOCALIZE[31032]</label>
 				</control>
 				<control type="spincontrolex" id="23">
 					<width>660</width>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -51,7 +51,7 @@
 					<label>$LOCALIZE[21424]</label>
 					<include>SettingsItemCommon</include>
 				</control>
-				<control type="spincontrolex" id="17">
+				<control type="button" id="17">
 					<width>660</width>
 					<label>$LOCALIZE[21427]</label>
 					<include>SettingsItemCommon</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -2,15 +2,15 @@
 <window>
 	<defaultcontrol always="true">22</defaultcontrol>
 	<coordinates>
-		<left>310</left>
-		<top>80</top>
+		<left>110</left>
+		<top>150</top>
 	</coordinates>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">
 			<include content="DialogBackgroundCommons">
-				<param name="DialogBackgroundWidth" value="1300" />
-				<param name="DialogBackgroundHeight" value="920" />
+				<param name="DialogBackgroundWidth" value="1700" />
+				<param name="DialogBackgroundHeight" value="790" />
 				<param name="DialogHeaderLabel" value="" />
 				<param name="DialogHeaderId" value="2" />
 			</include>
@@ -19,67 +19,96 @@
 				<left>10</left>
 				<top>95</top>
 				<onright>10</onright>
-				<onleft>10</onleft>
-				<ondown>9001</ondown>
-				<onup>9001</onup>
+				<onleft>9001</onleft>
 				<itemgap>-20</itemgap>
 				<control type="button" id="22">
 					<description>Set Playlist type</description>
-					<width>660</width>
+					<width>700</width>
 					<include>SettingsItemCommon</include>
 					<label>$LOCALIZE[467]</label>
 				</control>
 				<control type="button" id="12">
 					<description>Name Button</description>
 					<label>$LOCALIZE[21433]</label>
-					<width>660</width>
+					<width>700</width>
 					<include>SettingsItemCommon</include>
 				</control>
 				<control type="label" id="1101">
 					<description>Name Label</description>
-					<width>660</width>
+					<width>700</width>
 					<label>$LOCALIZE[31042]</label>
 					<include>SettingsLabelCommon</include>
 				</control>
 				<control type="button" id="16">
-					<width>660</width>
+					<width>700</width>
 					<label>$LOCALIZE[21424]</label>
 					<include>SettingsItemCommon</include>
 				</control>
 				<control type="button" id="17">
-					<width>660</width>
+					<width>700</width>
 					<label>$LOCALIZE[21427]</label>
 					<include>SettingsItemCommon</include>
 				</control>
 				<control type="button" id="18">
 					<label>$LOCALIZE[21429]</label>
-					<width>660</width>
+					<width>700</width>
 					<include>SettingsItemCommon</include>
 				</control>
 				<control type="button" id="19">
-					<width>660</width>
+					<width>700</width>
 					<include>SettingsItemCommon</include>
 					<label>$LOCALIZE[31032]</label>
 				</control>
 				<control type="button" id="23">
-					<width>660</width>
+					<width>700</width>
 					<label>$LOCALIZE[21458]</label>
 					<include>SettingsItemCommon</include>
 				</control>
 				<control type="radiobutton" id="24">
-					<width>660</width>
+					<width>700</width>
 					<include>SettingsItemCommon</include>
 					<label>$LOCALIZE[467]: $LOCALIZE[21459]</label>
 				</control>
 			</control>
-			<control type="grouplist" id="9001">
+			<control type="image">
+				<left>720</left>
+				<top>95</top>
+				<width>640</width>
+				<height>530</height>
+				<texture border="40">buttons/dialogbutton-nofo.png</texture>
+			</control>
+			<control type="panel" id="10">
+				<description>Rules List Control</description>
+				<left>740</left>
+				<top>115</top>
+				<width>600</width>
+				<height>480</height>
+				<onleft>500</onleft>
+				<onright>9001</onright>
 				<orientation>horizontal</orientation>
-				<left>0</left>
+				<include content="DefaultSimpleListLayout">
+					<param name="width" value="600" />
+					<param name="list_id" value="10" />
+				</include>
+			</control>
+			<control type="textbox">
+				<left>740</left>
+				<top>620</top>
+				<width>610</width>
+				<height>348</height>
+				<aligny>top</aligny>
+				<label>$LOCALIZE[31043]</label>
+				<textcolor>grey</textcolor>
+				<font>font12</font>
+			</control>
+			<control type="grouplist" id="9001">
+				<orientation>vertical</orientation>
+				<left>1380</left>
 				<width>1300</width>
-				<align>center</align>
-				<top>820</top>
-				<onup>24</onup>
-				<ondown>22</ondown>
+				<align>left</align>
+				<top>100</top>
+				<onleft>10</onleft>
+				<onright>500</onright>
 				<include content="DefaultDialogButton">
 					<param name="id" value="20" />
 					<param name="label" value="$LOCALIZE[186]" />
@@ -88,38 +117,6 @@
 					<param name="id" value="21" />
 					<param name="label" value="$LOCALIZE[222]" />
 				</include>
-			</control>
-			<control type="image">
-				<left>650</left>
-				<top>95</top>
-				<width>640</width>
-				<height>485</height>
-				<texture border="40">buttons/dialogbutton-nofo.png</texture>
-			</control>
-			<control type="list" id="10">
-				<description>Rules List Control</description>
-				<left>670</left>
-				<top>115</top>
-				<width>600</width>
-				<height>435</height>
-				<onleft>500</onleft>
-				<onright>500</onright>
-				<ondown>9001</ondown>
-				<onup>9001</onup>
-				<include content="DefaultSimpleListLayout">
-					<param name="width" value="600" />
-					<param name="list_id" value="10" />
-				</include>
-			</control>
-			<control type="textbox">
-				<left>680</left>
-				<top>570</top>
-				<width>540</width>
-				<height>248</height>
-				<aligny>top</aligny>
-				<label>$LOCALIZE[31043]</label>
-				<textcolor>grey</textcolor>
-				<font>font12</font>
 			</control>
 		</control>
 	</controls>

--- a/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistEditor.xml
@@ -66,7 +66,7 @@
 					<include>SettingsItemCommon</include>
 					<label>$LOCALIZE[31032]</label>
 				</control>
-				<control type="spincontrolex" id="23">
+				<control type="button" id="23">
 					<width>660</width>
 					<label>$LOCALIZE[21458]</label>
 					<include>SettingsItemCommon</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistRule.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistRule.xml
@@ -32,7 +32,7 @@
 				<include>SettingsItemCommon</include>
 				<width>900</width>
 			</control>
-			<control type="spincontrolex" id="16">
+			<control type="button" id="16">
 				<description>Rule operator</description>
 				<width>900</width>
 				<include>SettingsItemCommon</include>

--- a/addons/skin.estuary/1080i/SmartPlaylistRule.xml
+++ b/addons/skin.estuary/1080i/SmartPlaylistRule.xml
@@ -27,7 +27,7 @@
 			<orientation>vertical</orientation>
 			<onup>9000</onup>
 			<ondown>9000</ondown>
-			<control type="spincontrolex" id="15">
+			<control type="button" id="15">
 				<description>Rule Field</description>
 				<include>SettingsItemCommon</include>
 				<width>900</width>

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -324,11 +324,22 @@ void CGUIDialogSmartPlaylistEditor::OnOrderDirection()
 
 void CGUIDialogSmartPlaylistEditor::OnGroupBy()
 {
-  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_GROUP_BY);
-  OnMessage(msg);
-  m_playlist.SetGroup(CSmartPlaylistRule::TranslateGroup((Field)msg.GetParam1()));
+  std::vector<Field> groups = CSmartPlaylistRule::GetGroups(m_playlist.GetType());
+  Field currentGroup = CSmartPlaylistRule::TranslateGroup(m_playlist.GetGroup().c_str());
+  CGUIDialogSelect* dialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
+  dialog->Reset();
+  for (auto group : groups)
+    dialog->Add(CSmartPlaylistRule::GetLocalizedGroup(group));
+  dialog->SetHeading(CVariant{ 21458 });
+  dialog->SetSelected(CSmartPlaylistRule::GetLocalizedGroup(currentGroup));
+  dialog->Open();
+  int newSelected = dialog->GetSelectedItem();
+   // check if selection has changed
+  if (!dialog->IsConfirmed() || newSelected < 0 || groups[newSelected] == currentGroup)
+    return;
+  m_playlist.SetGroup(CSmartPlaylistRule::TranslateGroup(groups[newSelected]));
 
-  if (m_playlist.IsGroupMixed() && !CSmartPlaylistRule::CanGroupMix((Field)msg.GetParam1()))
+  if (m_playlist.IsGroupMixed() && !CSmartPlaylistRule::CanGroupMix(currentGroup))
     m_playlist.SetGroupMixed(false);
 
   UpdateButtons();
@@ -390,13 +401,9 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   SET_CONTROL_LABEL2(CONTROL_ORDER_FIELD, g_localizeStrings.Get(SortUtils::GetSortLabel(m_playlist.m_orderField)));
 
   // setup groups
-  std::vector< std::pair<std::string, int> > labels;
   std::vector<Field> groups = CSmartPlaylistRule::GetGroups(m_playlist.GetType());
   Field currentGroup = CSmartPlaylistRule::TranslateGroup(m_playlist.GetGroup().c_str());
-  for (unsigned int i = 0; i < groups.size(); i++)
-    labels.push_back(make_pair(CSmartPlaylistRule::GetLocalizedGroup(groups[i]), groups[i]));
-  SET_CONTROL_LABELS(CONTROL_GROUP_BY, currentGroup, &labels);
-
+  SET_CONTROL_LABEL2(CONTROL_GROUP_BY, CSmartPlaylistRule::GetLocalizedGroup(currentGroup));
   if (m_playlist.IsGroupMixed())
     CONTROL_SELECT(CONTROL_GROUP_MIXED);
   else

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -271,9 +271,11 @@ void CGUIDialogSmartPlaylistEditor::OnCancel()
 
 void CGUIDialogSmartPlaylistEditor::OnMatch()
 {
-  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_MATCH);
-  OnMessage(msg);
-  m_playlist.m_ruleCombination.SetType(msg.GetParam1() == 0 ? CSmartPlaylistRuleCombination::CombinationAnd : CSmartPlaylistRuleCombination::CombinationOr);
+  // toggle between AND and OR setting
+  if (m_playlist.m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationOr)
+    m_playlist.m_ruleCombination.SetType(CSmartPlaylistRuleCombination::CombinationAnd);
+  else
+    m_playlist.m_ruleCombination.SetType(CSmartPlaylistRuleCombination::CombinationOr);
   UpdateButtons();
 }
 
@@ -355,7 +357,12 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
     SET_CONTROL_LABEL2(CONTROL_NAME, m_playlist.m_playlistName);
   
   UpdateRuleControlButtons();
+  
 
+  if (m_playlist.m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationOr)
+    SET_CONTROL_LABEL2(CONTROL_MATCH, g_localizeStrings.Get(21426));
+  else
+    SET_CONTROL_LABEL2(CONTROL_MATCH, g_localizeStrings.Get(21425));
   CONTROL_ENABLE_ON_CONDITION(CONTROL_MATCH, m_playlist.m_ruleCombination.m_rules.size() > 1);
 
   int currentItem = GetSelectedItem();
@@ -377,11 +384,11 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
 
   if (m_playlist.m_orderDirection != SortOrderDescending)
   {
-    CONTROL_SELECT(CONTROL_ORDER_DIRECTION);
+    SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION, g_localizeStrings.Get(21430));
   }
   else
   {
-    CONTROL_DESELECT(CONTROL_ORDER_DIRECTION);
+    SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION, g_localizeStrings.Get(21431));
   }
 
   SET_CONTROL_LABEL2(CONTROL_ORDER_FIELD, g_localizeStrings.Get(SortUtils::GetSortLabel(m_playlist.m_orderField)));
@@ -430,14 +437,9 @@ void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
   CGUIDialog::OnWindowLoaded();
 
   SendMessage(GUI_MSG_SET_TYPE, CONTROL_NAME, 0, 16012);
-  // setup the match spinner
-  std::vector< std::pair<std::string, int> > labels;
-  labels.push_back(make_pair(g_localizeStrings.Get(21425), 0));
-  labels.push_back(make_pair(g_localizeStrings.Get(21426), 1));
-  SET_CONTROL_LABELS(CONTROL_MATCH, m_playlist.m_ruleCombination.GetType() == CSmartPlaylistRuleCombination::CombinationAnd ? 0 : 1, &labels);
 
-  // and now the limit spinner
-  labels.clear();
+  // set up the limit spinner
+  std::vector< std::pair<std::string, int> > labels;
   labels.push_back(make_pair(g_localizeStrings.Get(21428), 0));
   const int limits[] = { 10, 25, 50, 100, 250, 500, 1000 };
   for (unsigned int i = 0; i < sizeof(limits) / sizeof(int); i++)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -111,7 +111,7 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_RULE_REMOVE)
         OnRuleRemove(GetSelectedItem());
       else if (iControl == CONTROL_NAME)
-        OnEditChanged(iControl, m_playlist.m_playlistName);
+        OnName();
       else if (iControl == CONTROL_OK)
         OnOK();
       else if (iControl == CONTROL_CANCEL)
@@ -278,6 +278,16 @@ void CGUIDialogSmartPlaylistEditor::OnMatch()
   else
     m_playlist.m_ruleCombination.SetType(CSmartPlaylistRuleCombination::CombinationOr);
   UpdateButtons();
+}
+
+void CGUIDialogSmartPlaylistEditor::OnName()
+{
+  std::string name = m_playlist.m_playlistName;
+  if (CGUIKeyboardFactory::ShowAndGetInput(name, CVariant{g_localizeStrings.Get(16012)}, false))
+  {
+    m_playlist.m_playlistName = name;
+    UpdateButtons();
+  }
 }
 
 void CGUIDialogSmartPlaylistEditor::OnLimit()
@@ -463,13 +473,6 @@ void CGUIDialogSmartPlaylistEditor::UpdateRuleControlButtons()
                               iSize > 0 && // there is at least one item
                               iItem >= 0 && iItem < iSize && // and a valid item is selected
                               m_playlist.m_ruleCombination.m_rules[iItem]->m_field != FieldNone); // and it is not be empty
-}
-
-void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
-{
-  CGUIDialog::OnWindowLoaded();
-
-  SendMessage(GUI_MSG_SET_TYPE, CONTROL_NAME, 0, 16012);
 }
 
 void CGUIDialogSmartPlaylistEditor::OnInitWindow()

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -60,6 +60,7 @@ protected:
   void UpdateRuleControlButtons();
   int GetSelectedItem();
   void HighlightItem(int item);
+  std::vector<PLAYLIST_TYPE> GetAllowedTypes(std::string mode);
   PLAYLIST_TYPE ConvertType(const std::string &type);
   std::string ConvertType(PLAYLIST_TYPE type);
   std::string GetLocalizedType(PLAYLIST_TYPE type);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -60,7 +60,7 @@ protected:
   void UpdateRuleControlButtons();
   int GetSelectedItem();
   void HighlightItem(int item);
-  std::vector<PLAYLIST_TYPE> GetAllowedTypes(std::string mode);
+  std::vector<PLAYLIST_TYPE> GetAllowedTypes(const std::string& mode);
   PLAYLIST_TYPE ConvertType(const std::string &type);
   std::string ConvertType(PLAYLIST_TYPE type);
   std::string GetLocalizedType(PLAYLIST_TYPE type);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -35,7 +35,6 @@ public:
   virtual ~CGUIDialogSmartPlaylistEditor(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
-  virtual void OnWindowLoaded();
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
 
@@ -48,6 +47,7 @@ protected:
   void OnRuleRemove(int item);
   void OnMatch();
   void OnLimit();
+  void OnName();
   void OnType();
   void OnOrder();
   void OnOrderDirection();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -43,7 +43,7 @@ protected:
   void OnCancel();
   void UpdateButtons();
   void OnBrowse();
-
+  std::vector< std::pair<std::string, int> > GetValidOperators(const CSmartPlaylistRule& rule);
   CSmartPlaylistRule m_rule;
   bool m_cancelled;
   std::string m_type;


### PR DESCRIPTION
Next one...this time the order-by button in Smartplaylisteditor.
this PR adds the same header file to GUIDialogSmartPlaylistEditor.cpp as https://github.com/xbmc/xbmc/pull/10593, so remind me to update the PR which gets pulled last. :)
Could have put all commits into one big PR, so sorry for the additional pinging. 

EDIT: all PRs merged into this one.

EDIT: FInished!
![screenshot031](https://cloud.githubusercontent.com/assets/110931/18980048/afa36dbe-86d0-11e6-8c11-174fc483830d.png)
