### PR TITLE
[cmake] Make sure we strip when CMAKE_BUILD_TYPE=Release

### DIFF
--- a/project/cmake/scripts/linux/ArchSetup.cmake
+++ b/project/cmake/scripts/linux/ArchSetup.cmake
@@ -24,6 +24,11 @@ else()
   endif()
 endif()
 
+# Make sure we strip binaries in Release build
+if(CMAKE_BUILD_TYPE STREQUAL Release AND CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+endif()
+
 find_package(CXX11 REQUIRED)
 include(LDGOLD)
 


### PR DESCRIPTION
@fritsch, ^^

@wsnipex, @fetzerch I couldn't find a magical CMAKE_STRIP_FILES_IF_BUILD_IS_RELEASE=ON or similar. Apparently one is expected to pass the flag.
