### PR TITLE
[osx] - Fix build on case-sensitive filesystems.

### DIFF
--- a/xbmc/platform/darwin/osx/XBMCHelper.cpp
+++ b/xbmc/platform/darwin/osx/XBMCHelper.cpp
@@ -39,7 +39,7 @@
 #include "utils/TimeUtils.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "url.h"
+#include "URL.h"
 
 #include "threads/Atomics.h"
 


### PR DESCRIPTION
Fix build on OSX when underlying filesystem is case-sensitive.  XBMCHelper.cpp includes "url.h" when it should be "URL.h".
