### PR TITLE
Amlogic: fixes to hardware decoding blacklist

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -104,7 +104,11 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       {
         case FF_PROFILE_H264_HIGH_10:
         case FF_PROFILE_H264_HIGH_10_INTRA:
-          // Amlogic decodes Hi10P with lots of artifacts
+        case FF_PROFILE_H264_HIGH_422:
+        case FF_PROFILE_H264_HIGH_422_INTRA:
+        case FF_PROFILE_H264_HIGH_444_PREDICTIVE:
+        case FF_PROFILE_H264_HIGH_444_INTRA:
+        case FF_PROFILE_H264_CAVLC_444:
           return false;
       }
       if ((!aml_support_h264_4k2k()) && ((m_hints.width > 1920) || (m_hints.height > 1088)))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -177,6 +177,10 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
         // HEVC supported only on S805 and S812.
         return false;
       }
+      if ((hints.profile == FF_PROFILE_HEVC_MAIN_10) && !aml_support_hevc_10bit())
+      {
+        return false;
+      }
       m_pFormatName = "am-h265";
       m_bitstream = new CBitstreamConverter();
       m_bitstream->Open(m_hints.codec, (uint8_t*)m_hints.extradata, m_hints.extrasize, true);

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -191,6 +191,23 @@ bool aml_support_hevc_4k2k()
   return (has_hevc_4k2k == 1);
 }
 
+bool aml_support_hevc_10bit()
+{
+  static int has_hevc_10bit = -1;
+
+  if (has_hevc_10bit == -1)
+  {
+    CRegExp regexp;
+    regexp.RegComp("hevc:.*10bit");
+    std::string valstr;
+    if (SysfsUtils::GetString("/sys/class/amstream/vcodec_profile", valstr) != 0)
+      has_hevc_10bit = 0;
+    else
+      has_hevc_10bit = (regexp.RegFind(valstr) >= 0) ? 1 : 0;
+  }
+  return (has_hevc_10bit == 1);
+}
+
 bool aml_support_h264_4k2k()
 {
   static int has_h264_4k2k = -1;

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -47,6 +47,7 @@ bool aml_hw3d_present();
 bool aml_wired_present();
 bool aml_support_hevc();
 bool aml_support_hevc_4k2k();
+bool aml_support_hevc_10bit();
 bool aml_support_h264_4k2k();
 void aml_set_audio_passthrough(bool passthrough);
 bool aml_IsHdmiConnected();


### PR DESCRIPTION
These two commits extend a list of formats when Amlogic hardware decoder should not be used.
## Description

Adds 2 more cases to fall back to software decoding:
- High 4:2:2 and 4:4:4 profiles for all Amlogic devices, as these are not supported by H/W decoder
- HEVC 10bit decoding for SoCs that don't support it (S8xx)
## Motivation and Context

Fix black screen/artifacts when hardware decoder is used for unsupported formats.
## How Has This Been Tested?

Compiled and tested for LibreELEC, Kodi 17.0b2, S805 and S905 devices.
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
