### PR TITLE
[xbmc][fix] Fix issue where yes/no dialog would show blank buttons

### DIFF
--- a/xbmc/messaging/helpers/DialogHelper.h
+++ b/xbmc/messaging/helpers/DialogHelper.h
@@ -70,7 +70,8 @@ struct DialogYesNoMessage
   \sa CGUIDialogYesNo::ShowAndGetInput
   \sa DialogYesNoMessage
 */
-DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noLabel = "", CVariant yesLabel = "", uint32_t autoCloseTimeout = 0);
+DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noLabel = CVariant(),
+                                   CVariant yesLabel = CVariant(), uint32_t autoCloseTimeout = 0);
 
 /*!
   \brief This is a helper method to send a threadmessage to open a Yes/No dialog box
@@ -90,8 +91,9 @@ DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noL
   \sa CGUIDialogYesNo::ShowAndGetInput
   \sa DialogYesNoMessage
 */
-DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1 = "",
-  CVariant line2 = "", CVariant noLabel = "", CVariant yesLabel = "", uint32_t autoCloseTimeout = 0);
+DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1 = CVariant(),
+                                    CVariant line2 = CVariant(), CVariant noLabel = CVariant(),
+                                    CVariant yesLabel = CVariant(), uint32_t autoCloseTimeout = 0);
 
 }
 }

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -129,6 +129,11 @@ double str2double(const std::wstring &str, double fallback /* = 0.0 */)
   return fallback;
 }
 
+CVariant::CVariant()
+  : m_type{VariantTypeNull}
+{
+}
+
 CVariant CVariant::ConstNullVariant = CVariant::VariantTypeConstNull;
 
 CVariant::CVariant(VariantType type)

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -48,7 +48,8 @@ public:
     VariantTypeConstNull
   };
 
-  CVariant(VariantType type = VariantTypeNull);
+  CVariant();
+  CVariant(VariantType type);
   CVariant(int integer);
   CVariant(int64_t integer);
   CVariant(unsigned int unsignedinteger);


### PR DESCRIPTION
Default values given to ShowYesNoDialog was wrong and caused the null check to think they contained valid values.
## Description

Add a default constructor to CVariant to allow instantiating a null CVariant
## Motivation and Context

Solves a bug seen when downloading Metropolis skin(likely any skin) and being asked to install the Skin Helper Addon
## How Has This Been Tested?

Run time tested
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
  Setting default values to empty strings is not very smart
  when checking for a null variant. It's not null and we
  end up displaying empty strings instead of yes/no
