### PR TITLE
[xbmc][win][fix] Update prepare-binary-addons-dev.bat

### DIFF
--- a/tools/windows/prepare-binary-addons-dev.bat
+++ b/tools/windows/prepare-binary-addons-dev.bat
@@ -18,7 +18,7 @@ FOR %%b IN (%*) DO (
 SETLOCAL DisableDelayedExpansion
 
 rem set Visual C++ build environment
-call "%VS120COMNTOOLS%..\..\VC\bin\vcvars32.bat"
+call "%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
 
 SET WORKDIR=%WORKSPACE%
 
@@ -76,7 +76,7 @@ IF "%addon%" NEQ "" (
 )
 
 rem execute cmake to generate Visual Studio 12 project files
-cmake "%ADDONS_PATH%" -G "Visual Studio 12" ^
+cmake "%ADDONS_PATH%" -G "Visual Studio 14" ^
       -DCMAKE_BUILD_TYPE=Debug ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^


### PR DESCRIPTION
This file had apparently been forgotten about and was still
trying to use Visual Studio 2013 toolset.
