### PR TITLE
Resolution: Don't let code assumption from before 2k break behaviour

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -317,7 +317,7 @@ float CResolutionUtils::RefreshWeight(float refresh, float fps)
   // punish when refreshrate > 60 hz to not have to switch
   // twice for 30i content
   if (refresh > 60 && round > 1)
-    weight += round / 1000.0;
+    weight += round / 10000.0;
 
   return weight;
 }


### PR DESCRIPTION
I was biten by some non documented code in Resolution.cpp, that defined a threshold, above that it would introduce a 2:3 cadence, here: https://github.com/fritsch/xbmc/blob/f3b0fe3fbcb96bd2822120093bc1a8633b61e34b/xbmc/guilib/Resolution.cpp#L132

As I don't want to open yet another can of worms, I move the punish term one digit to the right. This still fulfills what I had in mind, see:

```
Input Refreshrate: 23.976000
Available Refreshrates:  23.976: 0.000000 24: 0.001001 50: 0.042709 59.94: 0.166138 60: 0.165833 80: 0.112523 100: 0.043109 120: 0.001501 144: 0.001601
Input Refreshrate: 30.000000
Available Refreshrates:  23.976: 0.200800 24: 0.200000 50: 0.166667 59.94: 0.000367 60: 0.000000 80: 0.111411 100: 0.111411 120: 0.000400 144: 0.040500
Input Refreshrate: 50.000000
Available Refreshrates:  23.976: 0.520480 24: 0.520000 50: 0.000000 59.94: 0.199560 60: 0.200000 80: 0.200200 100: 0.000200 120: 0.200200 144: 0.040300
Input Refreshrate: 59.939999
Available Refreshrates:  23.976: 0.600000 24: 0.599600 50: 0.165832 59.94: 0.000634 60: 0.001001 80: 0.334668 100: 0.166032 120: 0.001201 144: 0.201401
Input Refreshrate: 60.000000
Available Refreshrates:  23.976: 0.600400 24: 0.600000 50: 0.166667 59.94: 0.000367 60: 0.000000 80: 0.333333 100: 0.166867 120: 0.000200 144: 0.200200
```

What one sees above: 30.0 fps will be played at 60 hz and not 120.0
But 23.976 won't be 2:3 cadenced but played at 120 hz
Forum thread: http://forum.kodi.tv/showthread.php?tid=292865
