### PR TITLE
[PVR] Fix CPVRDirectory::GetDirectory not to return false in case PVR is not yet (compeletely started).

### DIFF
--- a/xbmc/filesystem/PVRDirectory.cpp
+++ b/xbmc/filesystem/PVRDirectory.cpp
@@ -62,54 +62,56 @@ bool CPVRDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   if (fileName == "")
   {
-    if (!g_PVRManager.IsStarted())
-      return false;
+    if (g_PVRManager.IsStarted())
+    {
+      CFileItemPtr item;
 
-    CFileItemPtr item;
+      item.reset(new CFileItem(base + "channels/", true));
+      item->SetLabel(g_localizeStrings.Get(19019));
+      item->SetLabelPreformated(true);
+      items.Add(item);
 
-    item.reset(new CFileItem(base + "channels/", true));
-    item->SetLabel(g_localizeStrings.Get(19019));
-    item->SetLabelPreformated(true);
-    items.Add(item);
+      item.reset(new CFileItem(base + "recordings/active/", true));
+      item->SetLabel(g_localizeStrings.Get(19017)); // TV Recordings
+      item->SetLabelPreformated(true);
+      items.Add(item);
 
-    item.reset(new CFileItem(base + "recordings/active/", true));
-    item->SetLabel(g_localizeStrings.Get(19017)); // TV Recordings
-    item->SetLabelPreformated(true);
-    items.Add(item);
+      item.reset(new CFileItem(base + "recordings/deleted/", true));
+      item->SetLabel(g_localizeStrings.Get(19108)); // Deleted TV Recordings
+      item->SetLabelPreformated(true);
+      items.Add(item);
 
-    item.reset(new CFileItem(base + "recordings/deleted/", true));
-    item->SetLabel(g_localizeStrings.Get(19108)); // Deleted TV Recordings
-    item->SetLabelPreformated(true);
-    items.Add(item);
-
-    // Sort by name only. Labels are preformated.
-    items.AddSortMethod(SortByLabel, 551 /* Name */, LABEL_MASKS("%L", "", "%L", ""));
-
+      // Sort by name only. Labels are preformated.
+      items.AddSortMethod(SortByLabel, 551 /* Name */, LABEL_MASKS("%L", "", "%L", ""));
+    }
     return true;
   }
   else if (StringUtils::StartsWith(fileName, "recordings"))
   {
-    if (!g_PVRManager.IsStarted())
-      return false;
-
-    const std::string pathToUrl(url.Get());
-    return g_PVRRecordings->GetDirectory(pathToUrl, items);
+    if (g_PVRManager.IsStarted())
+    {
+      const std::string pathToUrl(url.Get());
+      return g_PVRRecordings->GetDirectory(pathToUrl, items);
+    }
+    return true;
   }
   else if (StringUtils::StartsWith(fileName, "channels"))
   {
-    if (!g_PVRChannelGroups || !g_PVRChannelGroups->Loaded())
-      return false;
-
-    const std::string pathToUrl(url.Get());
-    return g_PVRChannelGroups->GetDirectory(pathToUrl, items);
+    if (g_PVRChannelGroups && g_PVRChannelGroups->Loaded())
+    {
+      const std::string pathToUrl(url.Get());
+      return g_PVRChannelGroups->GetDirectory(pathToUrl, items);
+    }
+    return true;
   }
   else if (StringUtils::StartsWith(fileName, "timers"))
   {
-    if (!g_PVRManager.IsStarted())
-      return false;
-
-    const std::string pathToUrl(url.Get());
-    return g_PVRTimers->GetDirectory(pathToUrl, items);
+    if (g_PVRManager.IsStarted())
+    {
+      const std::string pathToUrl(url.Get());
+      return g_PVRTimers->GetDirectory(pathToUrl, items);
+    }
+    return true;
   }
 
   return false;


### PR DESCRIPTION
Fixes log spam on Kodi startup:

<pre>
21:49:43 T:2984   ERROR: XFILE::CDirectory::GetDirectory - Error getting pvr://channels/tv/*?view=lastplayed
21:49:43 T:2984   ERROR: XFILE::CDirectory::GetDirectory - Error getting pvr://recordings/tv/active?view=flat
21:49:43 T:2984   ERROR: XFILE::CDirectory::GetDirectory - Error getting pvr://channels/radio/*?view=lastplayed
21:49:43 T:2984   ERROR: XFILE::CDirectory::GetDirectory - Error getting pvr://recordings/radio/active?view=flat
</pre>


GetDirectory return value semantics is "successfully handed" which can be different from "successfully read directory content". ;-)

This is actually a regression I introduced while working on the new pvr home screen widgets.

@Jalle19 mind taking  a look at the code change.
