### PR TITLE
[cmake] Fix always outdated targets

### DIFF
--- a/project/cmake/scripts/common/Macros.cmake
+++ b/project/cmake/scripts/common/Macros.cmake
@@ -211,6 +211,14 @@ function(copy_file_to_buildtree file)
     file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake "# Export files to build tree\n")
   endif()
 
+  # Exclude autotools build artefacts and other blacklisted files in source tree.
+  if(file MATCHES "(Makefile|\.in|\.xbt|\.so|\.dylib|\.gitignore)$")
+    if(VERBOSE)
+      message(STATUS "copy_file_to_buildtree - ignoring file: ${file}")
+    endif()
+    return()
+  endif()
+
   if(NOT file STREQUAL ${CMAKE_BINARY_DIR}/${outfile})
     if(VERBOSE)
       message(STATUS "copy_file_to_buildtree - copying file: ${file} -> ${CMAKE_BINARY_DIR}/${outfile}")

--- a/project/cmake/scripts/linux/Macros.cmake
+++ b/project/cmake/scripts/linux/Macros.cmake
@@ -32,7 +32,7 @@ function(core_link_library lib wraplib)
   endif()
 
   get_filename_component(dir ${wraplib} PATH)
-  add_custom_command(OUTPUT ${wraplib}-${ARCH}${CMAKE_SHARED_MODULE_SUFFIX}
+  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${wraplib}-${ARCH}${CMAKE_SHARED_MODULE_SUFFIX}
                      COMMAND cmake -E make_directory ${dir}
                      COMMAND ${CMAKE_C_COMPILER}
                      ARGS    -Wl,--whole-archive
@@ -43,7 +43,7 @@ function(core_link_library lib wraplib)
                      DEPENDS ${target} wrapper.def wrapper)
 
   get_filename_component(libname ${wraplib} NAME_WE)
-  add_custom_target(wrap_${libname} ALL DEPENDS ${wraplib}-${ARCH}${CMAKE_SHARED_MODULE_SUFFIX})
+  add_custom_target(wrap_${libname} ALL DEPENDS ${CMAKE_BINARY_DIR}/${wraplib}-${ARCH}${CMAKE_SHARED_MODULE_SUFFIX})
   set_target_properties(wrap_${libname} PROPERTIES FOLDER lib/wrapped)
   add_dependencies(${APP_NAME_LC}-libraries wrap_${libname})
 


### PR DESCRIPTION
CMake detects some targets (pack-skin, addon libraries) as always outdated when autotools leftovers are present in the source directory.

The issue is caused by xbt and so files that are present in the kodi source tree from an previous autotools build. The export-files target would override correctly generated libraries or skin packs by the old ones in the source tree. I've blacklisted the problematic file endings, because we never want to mirror them, as they are built by the project.

ping: let's see if mention-bot figures it out ;) --> also reported by @Memphiz for osx
