### PR TITLE
[python] add xbmcgui.Dialog().videoinfo() and .musicinfo()

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -27,6 +27,8 @@
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogNumeric.h"
+#include "video/dialogs/GUIDialogVideoInfo.h"
+#include "music/dialogs/GUIDialogMusicInfo.h"
 #include "settings/MediaSourceSettings.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "ModuleXbmcgui.h"
@@ -36,6 +38,7 @@
 #include "WindowException.h"
 #include "messaging/ApplicationMessenger.h"
 #include "Dialog.h"
+#include "ListItem.h"
 #ifdef TARGET_POSIX
 #include "linux/XTimeUtils.h"
 #endif
@@ -83,6 +86,22 @@ namespace XBMCAddon
       pDialog->Open();
 
       return pDialog->IsConfirmed();
+    }
+
+    bool Dialog::info(const ListItem* item)
+    {
+      const AddonClass::Ref<xbmcgui::ListItem> listitem(item);
+      if (listitem->item->HasVideoInfoTag())
+      {
+        CGUIDialogVideoInfo::ShowFor(*listitem->item);
+        return true;
+      }
+      else if (listitem->item->HasMusicInfoTag())
+      {
+        CGUIDialogMusicInfo::ShowFor(*listitem->item);
+        return true;
+      }
+      return false;
     }
 
     int Dialog::contextmenu(const std::vector<String>& list)

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -108,7 +108,37 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
-      /// \python_func{ xbmcgui.Dialog().select(heading, list[, autoclose, preselect, useDetails]) }
+      /// \python_func{ xbmcgui.Dialog().info(listitem) }
+      ///------------------------------------------------------------------------
+      ///
+      /// **Info dialog**
+      ///
+      /// Show the corresponding info dialog for a given listitem
+      ///
+      /// @param listitem       xbmcgui.ListItem - ListItem to show info for.
+      /// @return Returns whether the dialog opened successfully.
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v17 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// dialog = xbmcgui.Dialog()
+      /// ret = dialog.info(listitem)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      info(...);
+#else
+      bool info(const ListItem* item);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Dialog
+      /// \python_func{ xbmcgui.Dialog().select(heading, list[, autoclose,preselect]) }
       ///------------------------------------------------------------------------
       ///
       /// **Select dialog**


### PR DESCRIPTION
Allows to open musicinfo and videoinfo dialog via python, which will allow several script add-ons to drop their custom infowindow implementations.
@tamland @xhaggi @ronie 
