### PR TITLE
[python] add xbmcgui.ListItem.setCast()

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -588,6 +588,30 @@ namespace XBMCAddon
       }
     } // end ListItem::setInfo
 
+    void ListItem::setCast(const std::vector<Properties>& actors)
+    {
+      LOCKGUI;
+      item->GetVideoInfoTag()->m_cast.clear();
+      for (const auto& dictionary: actors)
+      {
+        SActorInfo info;
+        for (auto it = dictionary.begin(); it != dictionary.end(); ++it)
+        {
+          const String& key = it->first;
+          const String& value = it->second;
+          if (key == "name")
+            info.strName = value;
+          else if (key == "role")
+            info.strRole = value;
+          else if (key == "thumbnail")
+            info.thumbUrl = value;
+          else if (key == "order")
+            info.order = strtol(value.c_str(), NULL, 10);
+        }
+        item->GetVideoInfoTag()->m_cast.push_back(std::move(info));
+      }
+    }
+
     void ListItem::addStreamInfo(const char* cType, const Properties& dictionary)
     {
       LOCKGUI;

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -629,6 +629,40 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setCast(actors) }
+      ///-----------------------------------------------------------------------
+      /// @brief Set cast including thumbnails
+      ///
+      /// @param actors            list of dictionaries (see below for relevant keys)
+      ///
+      /// - Keys:
+      /// | Label         | Description                                     |
+      /// |--------------:|:------------------------------------------------|
+      /// | name          | string (Michael C. Hall)
+      /// | role          | string (Dexter)
+      /// | thumbnail     | string (http://www.someurl.com/someimage.png)
+      /// | order         | integer (1)
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v17 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// actors = [{"name": "Actor 1", "role": "role 1"}, {"name": "Actor 2", "role": "role 2"}]
+      /// listitem.setCast(actors)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      setCast(...);
+#else
+      void setCast(const std::vector<Properties>& actors);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ addStreamInfo(type, values) }
       ///-----------------------------------------------------------------------
       /// @brief Add a stream with details.


### PR DESCRIPTION
A separate setter for cast.
With current means it is not possible to set actor thumbnails since setInfo() only takes a name-role tuple for cast.
This PR adds a separate new setter to keep bw compatibility. I adjusted the dict keys in a way that it can directly take a cast dict received via JSON getMovie(s) method.

@tamland, as usual. :)

Should I mark the setinfo-cast as deprecated?

EDIT: also recently requested in http://forum.kodi.tv/showthread.php?tid=293913
