### PR TITLE
Export max value in ratings by default

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -543,8 +543,14 @@ bool CAlbum::Save(TiXmlNode *node, const std::string &tag, const std::string& st
   }
   XMLUtils::SetString(album,        "path", strPath);
 
-  XMLUtils::SetFloat(album,         "rating", fRating);
-  XMLUtils::SetInt(album,           "userrating", iUserrating);
+  auto* rating = XMLUtils::SetFloat(album, "rating", fRating);
+  if (rating)
+    rating->ToElement()->SetAttribute("max", 10);
+
+  auto* userrating = XMLUtils::SetInt(album, "userrating", iUserrating);
+  if (userrating)
+    userrating->ToElement()->SetAttribute("max", 10);
+
   XMLUtils::SetInt(album,           "votes", iVotes);
   XMLUtils::SetInt(album,           "year", iYear);
 

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -288,7 +288,7 @@ void XMLUtils::SetStringArray(TiXmlNode* pRootNode, const char *strTag, const st
     SetString(pRootNode, strTag, arrayValue.at(i));
 }
 
-void XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue)
+TiXmlNode* XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue)
 {
   TiXmlElement newElement(strTag);
   TiXmlNode *pNewNode = pRootNode->InsertEndChild(newElement);
@@ -297,12 +297,13 @@ void XMLUtils::SetString(TiXmlNode* pRootNode, const char *strTag, const std::st
     TiXmlText value(strValue);
     pNewNode->InsertEndChild(value);
   }
+  return pNewNode;
 }
 
-void XMLUtils::SetInt(TiXmlNode* pRootNode, const char *strTag, int value)
+TiXmlNode* XMLUtils::SetInt(TiXmlNode* pRootNode, const char *strTag, int value)
 {
   std::string strValue = StringUtils::Format("%i", value);
-  SetString(pRootNode, strTag, strValue);
+  return SetString(pRootNode, strTag, strValue);
 }
 
 void XMLUtils::SetLong(TiXmlNode* pRootNode, const char *strTag, long value)
@@ -311,10 +312,10 @@ void XMLUtils::SetLong(TiXmlNode* pRootNode, const char *strTag, long value)
   SetString(pRootNode, strTag, strValue);
 }
 
-void XMLUtils::SetFloat(TiXmlNode* pRootNode, const char *strTag, float value)
+TiXmlNode* XMLUtils::SetFloat(TiXmlNode* pRootNode, const char *strTag, float value)
 {
   std::string strValue = StringUtils::Format("%f", value);
-  SetString(pRootNode, strTag, strValue);
+  return SetString(pRootNode, strTag, strValue);
 }
 
 void XMLUtils::SetBoolean(TiXmlNode* pRootNode, const char *strTag, bool value)

--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -88,11 +88,11 @@ public:
    */
   static std::string GetAttribute(const TiXmlElement *element, const char *tag);
 
-  static void SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);
+  static TiXmlNode* SetString(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);
   static void SetAdditiveString(TiXmlNode* pRootNode, const char *strTag, const std::string& strSeparator, const std::string& strValue);
   static void SetStringArray(TiXmlNode* pRootNode, const char *strTag, const std::vector<std::string>& arrayValue);
-  static void SetInt(TiXmlNode* pRootNode, const char *strTag, int value);
-  static void SetFloat(TiXmlNode* pRootNode, const char *strTag, float value);
+  static TiXmlNode* SetInt(TiXmlNode* pRootNode, const char *strTag, int value);
+  static TiXmlNode* SetFloat(TiXmlNode* pRootNode, const char *strTag, float value);
   static void SetBoolean(TiXmlNode* pRootNode, const char *strTag, bool value);
   static void SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value);
   static void SetPath(TiXmlNode* pRootNode, const char *strTag, const std::string& strValue);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -126,6 +126,7 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
       rating.SetAttribute("name", it.first.c_str());
       XMLUtils::SetFloat(&rating, "value", it.second.rating);
       XMLUtils::SetInt(&rating, "votes", it.second.votes);
+      rating.SetAttribute("max", 10);
       if (it.first == m_strDefaultRating)
         rating.SetAttribute("default", "true");
       ratings.InsertEndChild(rating);


### PR DESCRIPTION
We support a max value to calc the true rating but we never exported it or documented it. This could have solved some problem we have now with switched music ratings from 5 to 10..
