### PR TITLE
Controller fixes

### DIFF
--- a/doxygen_resources/pages/mainpage.dox
+++ b/doxygen_resources/pages/mainpage.dox
@@ -130,10 +130,29 @@
 	Everything around input
 */
 
+/*! \defgroup keyboard Keyboard
+    \ingroup input
+
+    Keyboard input is processed by \ref CInputManager and forwarded to
+    registered keyboard handlers (e.g. game clients) or as actions to the UI:
+
+    - If no keyboard handlers are registered or if they don't consume events,
+      the keyboard events are forwarded to the UI via \ref CInputManager::OnKey.
+    - Clients (e.g. game clients implementing \ref KEYBOARD::IKeyboardHandler) call
+      \ref CInputManager::RegisterKeyboardHandler to register themselves as eligible
+      for keyboard input events.
+*/
+
 /*!
 	\defgroup mouse Mouse
 	\ingroup input
 	Everything around mouse
+*/
+
+/*!
+	\defgroup joystick Joystick
+	\ingroup input
+	Everything around joystick
 */
 
 /*!

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -780,7 +780,7 @@ void CInputManager::OnSettingChanged(const CSetting *setting)
 void CInputManager::RegisterKeyboardHandler(KEYBOARD::IKeyboardHandler* handler)
 {
   if (std::find(m_keyboardHandlers.begin(), m_keyboardHandlers.end(), handler) == m_keyboardHandlers.end())
-    m_keyboardHandlers.push_back(handler);
+    m_keyboardHandlers.insert(m_keyboardHandlers.begin(), handler);
 }
 
 void CInputManager::UnregisterKeyboardHandler(KEYBOARD::IKeyboardHandler* handler)

--- a/xbmc/input/joysticks/DeadzoneFilter.h
+++ b/xbmc/input/joysticks/DeadzoneFilter.h
@@ -45,7 +45,7 @@ namespace JOYSTICK
    *
    *   - Negative in the interval [-1.0, -deadzone)
    *   - Zero in the interval [-deadzone, deadzone]
-   *   - Positive in the interval (deadzone, 1.0)
+   *   - Positive in the interval (deadzone, 1.0]
    */
   class CDeadzoneFilter
   {
@@ -55,7 +55,7 @@ namespace JOYSTICK
     /*!
      * \brief Apply deadzone filtering to an axis
      * \param axisIndex The axis index
-     * \param axisValud The axis value\
+     * \param axisValud The axis value
      * \return The value after applying deadzone filtering
      */
     float FilterAxis(unsigned int axisIndex, float axisValue);

--- a/xbmc/input/joysticks/DeadzoneFilter.h
+++ b/xbmc/input/joysticks/DeadzoneFilter.h
@@ -29,6 +29,7 @@ namespace JOYSTICK
   class IButtonMap;
 
   /*!
+   * \ingroup joystick
    * \brief Analog axis deadzone filtering
    *
    * Axis is scaled appropriately, so position is continuous

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -202,6 +202,7 @@ void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, ANALOG_ST
       m_handler->OnAnalogKey(keyId, 0.0f);
     }
 
+    m_holdStartTimes.erase(keyId);
     m_currentDirections[feature] = ANALOG_STICK_DIRECTION::UNKNOWN;
   }
 }

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -123,7 +123,8 @@ bool CDefaultJoystick::OnAnalogStickMotion(const FeatureName& feature, float x, 
   }
 
   // Now activate direction the analog stick is pointing
-  bHandled = ActivateDirection(feature, magnitude, analogStickDir, motionTimeMs);
+  if (magnitude != 0.0f)
+    bHandled = ActivateDirection(feature, magnitude, analogStickDir, motionTimeMs);
 
   return bHandled;
 }
@@ -178,22 +179,30 @@ bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magni
     bHandled = true;
   }
 
+  if (bHandled)
+    m_currentDirections[feature] = dir;
+
   return bHandled;
 }
 
 void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, ANALOG_STICK_DIRECTION dir)
 {
-  // Calculate the button key ID and input type for this direction
-  const unsigned int  keyId     = GetKeyID(feature, dir);
-  const INPUT_TYPE    inputType = m_handler->GetInputType(keyId);
+  if (m_currentDirections[feature] == dir)
+  {
+    // Calculate the button key ID and input type for this direction
+    const unsigned int  keyId     = GetKeyID(feature, dir);
+    const INPUT_TYPE    inputType = m_handler->GetInputType(keyId);
 
-  if (inputType == INPUT_TYPE::DIGITAL)
-  {
-    m_handler->OnDigitalKey(keyId, false);
-  }
-  else if (inputType == INPUT_TYPE::ANALOG)
-  {
-    m_handler->OnAnalogKey(keyId, 0.0f);
+    if (inputType == INPUT_TYPE::DIGITAL)
+    {
+      m_handler->OnDigitalKey(keyId, false);
+    }
+    else if (inputType == INPUT_TYPE::ANALOG)
+    {
+      m_handler->OnAnalogKey(keyId, 0.0f);
+    }
+
+    m_currentDirections[feature] = ANALOG_STICK_DIRECTION::UNKNOWN;
   }
 }
 

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -147,8 +147,23 @@ bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magni
 
   if (inputType == INPUT_TYPE::DIGITAL)
   {
+    unsigned int holdTimeMs = 0;
+
     const bool bIsPressed = (magnitude >= ANALOG_DIGITAL_THRESHOLD);
-    m_handler->OnDigitalKey(keyId, bIsPressed, motionTimeMs);
+    if (bIsPressed)
+    {
+      const bool bIsHeld = (m_holdStartTimes.find(keyId) != m_holdStartTimes.end());
+      if (bIsHeld)
+        holdTimeMs = motionTimeMs - m_holdStartTimes[keyId];
+      else
+        m_holdStartTimes[keyId] = motionTimeMs;
+    }
+    else
+    {
+      m_holdStartTimes.erase(keyId);
+    }
+
+    m_handler->OnDigitalKey(keyId, bIsPressed, holdTimeMs);
     return true;
   }
   else if (inputType == INPUT_TYPE::ANALOG)

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -95,6 +95,7 @@ namespace JOYSTICK
 
     // State variables used to process joystick input
     std::map<unsigned int, unsigned int> m_holdStartTimes; // Key ID -> hold start time (ms)
+    std::map<FeatureName, ANALOG_STICK_DIRECTION> m_currentDirections; // Analog stick name -> direction
 
     // Rumble functionality
     CRumbleGenerator m_rumbleGenerator;

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -24,6 +24,7 @@
 #include "JoystickTypes.h"
 #include "RumbleGenerator.h"
 
+#include <map>
 #include <vector>
 
 #define DEFAULT_CONTROLLER_ID    "game.controller.default"
@@ -89,6 +90,8 @@ namespace JOYSTICK
     static const std::vector<ANALOG_STICK_DIRECTION>& GetDirections(void);
 
     IKeymapHandler* const  m_handler;
+
+    std::map<unsigned int, unsigned int> m_holdStartTimes; // Key ID -> hold start time (ms)
 
     CRumbleGenerator m_rumbleGenerator;
   };

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -90,10 +90,13 @@ namespace JOYSTICK
      */
     static const std::vector<ANALOG_STICK_DIRECTION>& GetDirections(void);
 
-    IKeymapHandler* const  m_handler;
+    // Handler to process joystick input to Kodi actions
+    IKeymapHandler* const m_handler;
 
+    // State variables used to process joystick input
     std::map<unsigned int, unsigned int> m_holdStartTimes; // Key ID -> hold start time (ms)
 
+    // Rumble functionality
     CRumbleGenerator m_rumbleGenerator;
   };
 }

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -38,6 +38,7 @@ namespace JOYSTICK
   class IKeymapHandler;
 
   /*!
+   * \ingroup joystick
    * \brief Implementation of IInputHandler for Kodi input
    *
    * \sa IInputHandler

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -42,7 +42,7 @@ namespace JOYSTICK
    *
    * \sa IInputHandler
    */
-  class CDefaultJoystick : public JOYSTICK::IInputHandler,
+  class CDefaultJoystick : public IInputHandler,
                            public IActionMap
   {
   public:

--- a/xbmc/input/joysticks/DriverPrimitive.h
+++ b/xbmc/input/joysticks/DriverPrimitive.h
@@ -26,6 +26,7 @@
 namespace JOYSTICK
 {
   /*!
+   * \ingroup joystick
    * \brief Basic driver element associated with input events
    *
    * Driver input (bools, floats and enums) is split into primitives that better

--- a/xbmc/input/joysticks/IButtonMap.h
+++ b/xbmc/input/joysticks/IButtonMap.h
@@ -28,6 +28,7 @@
 namespace JOYSTICK
 {
   /*!
+   * \ingroup joystick
    * \brief Button map interface to translate between the driver's raw
    *        button/hat/axis elements and physical joystick features.
    *

--- a/xbmc/input/joysticks/IButtonMapper.h
+++ b/xbmc/input/joysticks/IButtonMapper.h
@@ -29,8 +29,7 @@ namespace JOYSTICK
   class IButtonMapCallback;
 
   /*!
-   * \ingroup joysticks
-   *
+   * \ingroup joystick
    * \brief Button mapper interface to assign the driver's raw button/hat/axis
    *        elements to physical joystick features using a provided button map.
    *

--- a/xbmc/input/joysticks/IDriverReceiver.h
+++ b/xbmc/input/joysticks/IDriverReceiver.h
@@ -22,6 +22,7 @@
 namespace JOYSTICK
 {
   /*!
+   * \ingroup joystick
    * \brief Interface for sending input events to joystick drivers
    */
   class IDriverReceiver

--- a/xbmc/input/joysticks/IInputHandler.h
+++ b/xbmc/input/joysticks/IInputHandler.h
@@ -28,6 +28,7 @@ namespace JOYSTICK
   class IInputReceiver;
 
   /*!
+   * \ingroup joystick
    * \brief Interface for handling input events for game controllers
    */
   class IInputHandler

--- a/xbmc/input/joysticks/IInputReceiver.h
+++ b/xbmc/input/joysticks/IInputReceiver.h
@@ -24,6 +24,7 @@
 namespace JOYSTICK
 {
   /*!
+   * \ingroup joystick
    * \brief Interface for sending input events to game controllers
    */
   class IInputReceiver

--- a/xbmc/input/joysticks/IKeymapHandler.h
+++ b/xbmc/input/joysticks/IKeymapHandler.h
@@ -24,6 +24,7 @@
 namespace JOYSTICK
 {
   /*!
+   * \ingroup joystick
    * \brief Interface for handling keymap keys
    *
    * Keys can be mapped to analog actions (e.g. "AnalogSeekForward") or digital

--- a/xbmc/input/joysticks/JoystickMonitor.h
+++ b/xbmc/input/joysticks/JoystickMonitor.h
@@ -24,6 +24,7 @@
 namespace JOYSTICK
 {
   /*!
+   * \ingroup joystick
    * \brief Monitors joystick input and resets screensaver/shutdown timers
    *        whenever motion occurs.
    */

--- a/xbmc/input/joysticks/JoystickTranslator.h
+++ b/xbmc/input/joysticks/JoystickTranslator.h
@@ -23,6 +23,9 @@
 
 namespace JOYSTICK
 {
+  /*!
+   * \brief Joystick translation utilities
+   */
   class CJoystickTranslator
   {
   public:

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -19,6 +19,11 @@
  */
 #pragma once
 
+/*!
+ \file
+ \ingroup joystick
+ */
+
 #include <string>
 
 namespace JOYSTICK

--- a/xbmc/input/joysticks/JoystickUtils.h
+++ b/xbmc/input/joysticks/JoystickUtils.h
@@ -21,6 +21,9 @@
 
 #include "JoystickTypes.h"
 
+/// \ingroup joystick
+/// \{
+
 inline JOYSTICK::HAT_DIRECTION& operator|=(JOYSTICK::HAT_DIRECTION& lhs, JOYSTICK::HAT_DIRECTION rhs)
 {
   return lhs = static_cast<JOYSTICK::HAT_DIRECTION>(static_cast<int>(lhs) | static_cast<int>(rhs));
@@ -45,3 +48,5 @@ inline float operator*(float lhs, JOYSTICK::SEMIAXIS_DIRECTION rhs)
 {
   return lhs * static_cast<int>(rhs);
 }
+
+/// \}

--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -48,16 +48,17 @@ CKeymapHandler::~CKeymapHandler(void)
 
 INPUT_TYPE CKeymapHandler::GetInputType(unsigned int keyId) const
 {
+  CAction action(ACTION_NONE);
+
   if (keyId != 0)
+    action = CButtonTranslator::GetInstance().GetAction(g_windowManager.GetActiveWindowID(), CKey(keyId));
+
+  if (action.GetID() > ACTION_NONE)
   {
-    CAction action(CButtonTranslator::GetInstance().GetAction(g_windowManager.GetActiveWindowID(), CKey(keyId)));
-    if (action.GetID() > 0)
-    {
-      if (action.IsAnalog())
-        return INPUT_TYPE::ANALOG;
-      else
-        return INPUT_TYPE::DIGITAL;
-    }
+    if (action.IsAnalog())
+      return INPUT_TYPE::ANALOG;
+    else
+      return INPUT_TYPE::DIGITAL;
   }
 
   return INPUT_TYPE::UNKNOWN;

--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -96,7 +96,8 @@ void CKeymapHandler::ProcessButtonPress(unsigned int keyId, unsigned int holdTim
   {
     m_pressedButtons.push_back(keyId);
 
-    if (SendDigitalAction(keyId))
+    // Only dispatch action if button was pressed this frame
+    if (holdTimeMs == 0 && SendDigitalAction(keyId))
     {
       m_lastButtonPress = keyId;
       m_lastDigitalActionMs = holdTimeMs;

--- a/xbmc/input/joysticks/KeymapHandler.h
+++ b/xbmc/input/joysticks/KeymapHandler.h
@@ -25,6 +25,9 @@
 
 namespace JOYSTICK
 {
+  /*!
+   * Handles keymaps
+   */
   class CKeymapHandler : public IKeymapHandler
   {
   public:

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -31,7 +31,8 @@ namespace JOYSTICK
   class IButtonMap;
   class IButtonMapper;
 
-  /*
+  /*!
+   * \ingroup joystick
    * \brief Generic implementation of a class that provides button mapping by
    *        translating driver events to button mapping commands
    *
@@ -44,7 +45,7 @@ namespace JOYSTICK
                          public IButtonMapCallback
   {
   public:
-    /*
+    /*!
      * \brief Constructor for CButtonMapping
      *
      * \param buttonMapper Carries out button-mapping commands using <buttonMap>

--- a/xbmc/input/joysticks/generic/DriverReceiving.h
+++ b/xbmc/input/joysticks/generic/DriverReceiving.h
@@ -30,6 +30,7 @@ namespace JOYSTICK
   class IButtonMap;
 
   /*!
+   * \ingroup joystick
    * \brief Class to translate input events from higher-level features to driver primitives
    *
    * A button map is used to translate controller features to driver primitives.

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -33,6 +33,7 @@ namespace JOYSTICK
   typedef std::shared_ptr<CJoystickFeature> FeaturePtr;
 
   /*!
+   * \ingroup joystick
    * \brief Base class for joystick features
    *
    * See list of feature types in JoystickTypes.h.
@@ -116,6 +117,7 @@ namespace JOYSTICK
   };
 
   /*!
+   * \ingroup joystick
    * \brief Axis of a feature (analog stick, accelerometer, etc)
    *
    * Axes are composed of two driver primitives, one for the positive semiaxis

--- a/xbmc/input/joysticks/generic/InputHandling.h
+++ b/xbmc/input/joysticks/generic/InputHandling.h
@@ -33,6 +33,7 @@ namespace JOYSTICK
   class IButtonMap;
 
   /*!
+   * \ingroup joystick
    * \brief Class to translate input from the driver into higher-level features
    *
    * Raw driver input arrives for three elements: buttons, hats and axes. When

--- a/xbmc/input/keyboard/IKeyboardHandler.h
+++ b/xbmc/input/keyboard/IKeyboardHandler.h
@@ -24,7 +24,7 @@ class CKey;
 namespace KEYBOARD
 {
   /*!
-   * \ingroup input
+   * \ingroup keyboard
    * \brief Interface for handling keyboard events
    */
   class IKeyboardHandler

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -25,6 +25,7 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_utils.hpp"
 #include "input/joysticks/JoystickTypes.h"
 #include "peripherals/PeripheralTypes.h"
+#include "threads/CriticalSection.h"
 
 #include <map>
 #include <memory>
@@ -106,6 +107,8 @@ namespace PERIPHERALS
     virtual bool CheckAPIVersion(void) override;
 
   private:
+    void UnregisterButtonMap(CPeripheral* device);
+
     /*!
      * @brief Helper functions
      */
@@ -149,6 +152,7 @@ namespace PERIPHERALS
 
     /* @brief Button map observers */
     std::vector<std::pair<CPeripheral*, JOYSTICK::IButtonMap*> > m_buttonMaps;
+    CCriticalSection m_buttonMapMutex;
 
     /* @brief Thread synchronization */
     CCriticalSection    m_critSection;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -133,12 +133,6 @@ bool CPeripheralBusAddon::GetAddonWithButtonMap(const CPeripheral* device, Perip
   return addon.get() != nullptr;
 }
 
-unsigned int CPeripheralBusAddon::GetAddonCount(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_addons.size();
-}
-
 bool CPeripheralBusAddon::PerformDeviceScan(PeripheralScanResults &results)
 {
   PeripheralAddonVector addons;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -515,7 +515,10 @@ bool CPeripheralBusAddon::PromptEnableAddons(const ADDON::VECADDONS& disabledAdd
   if (bAccepted)
   {
     for (const AddonPtr& addon : disabledAddons)
-      CAddonMgr::GetInstance().EnableAddon(addon->ID());
+    {
+      if (std::static_pointer_cast<CPeripheralAddon>(addon)->HasButtonMaps())
+        CAddonMgr::GetInstance().EnableAddon(addon->ID());
+    }
   }
 
   PeripheralAddonPtr dummy;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -58,11 +58,6 @@ namespace PERIPHERALS
     bool GetAddonWithButtonMap(const CPeripheral* device, PeripheralAddonPtr &addon) const;
 
     /*!
-     * \brief Get the number of peripheral add-on libraries
-     */
-    unsigned int GetAddonCount(void) const;
-
-    /*!
      * \brief Set the rumble state of a rumble motor
      *
      * \param strLocation The location of the peripheral with the motor


### PR DESCRIPTION
This PR manages the remaining bugs in the input system from #8807. I'll break out fixes in this PR to another PR as they're ready.

The remaining bugs are:
### Input
- [x] Joysticks not being detected on android startup (#10689)
- [x] Restart needed to enable/disable peripheral add-ons (#10690, #10734)
- [x] Missing lock in CAddonButtonMap (#10691)
- [x] Broken Shield controller if add-on isn't present (#10695)
- [x] Problems with accelerometers ([report and linux solution](http://forum.kodi.tv/showthread.php?tid=211138&pid=2207458#pid2207458)) (#10725, #10910)
- [x] PS4 controllers skip because button presses are sent when trigger is partially pressed (#10910)
- [x] Deadlock when updating peripheral add-ons (#10726)
- [x] Button map doesn't refresh when the user hits reset (#10735)
- [x] Possible crash when controllers are unplugged (#10740)
- [x] Incompatible with Unified Remote server ([report](http://forum.kodi.tv/showthread.php?tid=164725&pid=2119476#pid2119476), [support thread](http://forum.kodi.tv/showthread.php?tid=295961))
- [x] Constant joystick discovery on Windows ([report](http://forum.kodi.tv/showthread.php?tid=295548&pid=2449281#pid2449281), [peripheral.joystick#62](https://github.com/xbmc/peripheral.joystick/pull/62))
- [x] 100% cpu when scanning for joystick events after 6 days (#10921)
- [x] User should be able to open controller dialog with controllers unplugged (#10923)
- [x] Use 300ms rumble on weak motor for notifications (#10929)
- [ ] Incompatible with xpadder ([report](http://forum.kodi.tv/showthread.php?tid=173361&pid=2393609#pid2393609))
- [ ] All controllers vibrate whenever a new one is plugged in ([report](http://forum.kodi.tv/showthread.php?tid=173361&pid=2423447#pid2423447))
- [ ] Launching a game by holding A causes all hell to break loose ([report](http://forum.kodi.tv/showthread.php?tid=173361&pid=2413498#pid2413498))
- [ ] Missing a `mod="longpress"`  parameter for [joystick.xml](https://github.com/xbmc/xbmc/blob/master/system/keymaps/joystick.xml) keymap (should fix above bug)
- [ ] If Kodi crashes, the controller could vibrate without stopping ([report](http://forum.kodi.tv/showthread.php?tid=173361&pid=2430664#pid2430664))
- [ ] No navigation sounds for controllers ([report](http://forum.kodi.tv/showthread.php?tid=173361&pid=2442755#pid2442755))
- [ ] Mapping axis to Select sends one command per frame, locking the GUI ([sample buttonmap](https://gist.github.com/garbear/b1a8ce9eedc8bdcb462edab14a11c596))

### UX
- [x] Controller button should stay focused while mapping (#10761)
- [x] Open the controller dialog if a button press comes from an unmapped controller (#10882)
- [x] Volume is lowered when final analog stick is mapped ([report](http://forum.kodi.tv/showthread.php?tid=173361&pid=2430774#pid2430774), #10966)
- [x] Fix loss of control if A becomes unmapped (https://github.com/xbmc/peripheral.joystick/pull/65)
- [ ] Button list focus should stay centered:

<img width="1416" alt="screen shot 2016-10-09" src="https://cloud.githubusercontent.com/assets/531482/19223097/eab3cff0-8e1b-11e6-9898-376c7c5053ab.png">

In the image, you can see that the wizard focus travels down the page as the user maps buttons. The focus should stay in the center for as long as possible because this lets the user see which buttons are coming up.
