### PR TITLE
[PVR] Fix: PVR windows never must list removable media.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -69,6 +69,9 @@ CGUIWindowPVRBase::CGUIWindowPVRBase(bool bRadio, int id, const std::string &xml
   m_bRadio(bRadio),
   m_progressHandle(nullptr)
 {
+  // prevent removable drives to appear in directory listing (base class default behavior).
+  m_rootDir.AllowNonLocalSources(false);
+
   m_selectedItemPaths[false] = "";
   m_selectedItemPaths[true] = "";
 


### PR DESCRIPTION
PVR windows are derived from CGUIMediaWindow. Default behavior of this class is to include removable media (if present) in directory listing in case the listing is empty otherwise.

=> https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/VirtualDirectory.cpp#L168

Example:

![screenshot032-phil65](https://cloud.githubusercontent.com/assets/3226626/19131154/95f89de4-8b4e-11e6-86cb-c97b9c97bd96.png)

This makes no sense for PVR windows. Thus, this PR disables this nonsense base class functionality for all PVR windows. 

@xhaggi for code review?
@phil65 fyi
