### PR TITLE
[tests][fix] Fix tests on win32

### DIFF
--- a/xbmc/platform/win32/CMakeLists.txt
+++ b/xbmc/platform/win32/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES MessagePrinter.cpp
+set(SOURCES CharsetConverter.cpp
+            MessagePrinter.cpp
             WinMain.cpp
             crts_caller.cpp
             dxerr.cpp
@@ -9,7 +10,8 @@ set(SOURCES MessagePrinter.cpp
             WIN32Util.cpp
             WindowHelper.cpp)
 
-set(HEADERS crts_caller.h
+set(HEADERS CharsetConverter.h
+            crts_caller.h
             dirent.h
             dxerr.h
             IMMNotificationClient.h

--- a/xbmc/platform/win32/CharsetConverter.cpp
+++ b/xbmc/platform/win32/CharsetConverter.cpp
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2005-2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <memory>
+
+#include "CharsetConverter.h"
+namespace KODI
+{
+namespace PLATFORM
+{
+namespace WINDOWS
+{
+std::string FromW(const wchar_t* str, size_t length)
+{
+  int result = WideCharToMultiByte(CP_UTF8, 0, str, length, nullptr, 0, nullptr, nullptr);
+  if (result == 0)
+    return std::string();
+
+  auto newStr = std::make_unique<char[]>(result);
+  result = WideCharToMultiByte(CP_UTF8, 0, str, length, newStr.get(), result, nullptr, nullptr);
+  if (result == 0)
+    return std::string();
+
+  return std::string(newStr.get());
+}
+
+std::string FromW(const std::wstring& str)
+{
+  return FromW(str.c_str(), str.length());
+}
+
+std::wstring ToW(const char* str, size_t length)
+{
+  int result = MultiByteToWideChar(CP_UTF8, 0, str, length, nullptr, 0);
+  if (result == 0)
+    return std::wstring();
+
+  auto newStr = std::make_unique<wchar_t[]>(result);
+  result = MultiByteToWideChar(CP_UTF8, 0, str, length, newStr.get(), result);
+
+  if (result == 0)
+    return std::wstring();
+
+  return std::wstring(newStr.get());
+}
+
+std::wstring ToW(const std::string& str)
+{
+  return ToW(str.c_str(), str.length());
+}
+
+}
+}
+}

--- a/xbmc/platform/win32/CharsetConverter.h
+++ b/xbmc/platform/win32/CharsetConverter.h
@@ -1,0 +1,74 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+namespace KODI
+{
+namespace PLATFORM
+{
+namespace WINDOWS
+{
+/**
+ * Convert UTF-16 to UTF-8 strings
+ * Windows specific method to avoid initialization issues
+ * and locking issues that are unique to Windows as API calls
+ * expect UTF-16 strings
+ * \param str[in] string to be converted
+ * \param length[in] length in characters of the string
+ * \returns utf8 string, empty string on failure
+ */
+std::string FromW(const wchar_t* str, size_t length);
+
+/**
+ * Convert UTF-16 to UTF-8 strings
+ * Windows specific method to avoid initialization issues
+ * and locking issues that are unique to Windows as API calls
+ * expect UTF-16 strings
+ * \param str[in] string to be converted
+ * \returns utf8 string, empty string on failure
+ */
+std::string FromW(const std::wstring& str);
+
+/**
+ * Convert UTF-8 to UTF-16 strings
+ * Windows specific method to avoid initialization issues
+ * and locking issues that are unique to Windows as API calls
+ * expect UTF-16 strings
+ * \param str[in] string to be converted
+ * \param length[in] length in characters of the string
+ * \returns UTF-16 string, empty string on failure
+ */
+std::wstring ToW(const char* str, size_t length);
+
+/**
+ * Convert UTF-8 to UTF-16 strings
+ * Windows specific method to avoid initialization issues
+ * and locking issues that are unique to Windows as API calls
+ * expect UTF-16 strings
+ * \param str[in] string to be converted
+ * \returns UTF-16 string, empty string on failure
+ */
+std::wstring ToW(const std::string& str);
+}
+}
+}

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -56,7 +56,7 @@
 #endif
 
 #ifdef TARGET_WINDOWS
-#include "utils/CharsetConverter.h"
+#include "platform/win32/CharsetConverter.h"
 #include <algorithm>
 #include <intrin.h>
 #include <Pdh.h>
@@ -154,6 +154,8 @@ CCPUInfo::CCPUInfo(void)
   }
 
 #elif defined(TARGET_WINDOWS)
+  using KODI::PLATFORM::WINDOWS::FromW;
+
   HKEY hKeyCpuRoot;
 
   if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor", 0, KEY_READ, &hKeyCpuRoot) == ERROR_SUCCESS)
@@ -176,7 +178,7 @@ CCPUInfo::CCPUInfo(void)
         if (RegQueryValueExW(hCpuKey, L"ProcessorNameString", nullptr, &valType, LPBYTE(buf), &bufSize) == ERROR_SUCCESS &&
             valType == REG_SZ)
         {
-          g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strModel);
+          cpuCore.m_strModel = FromW(buf, bufSize / sizeof(wchar_t));
           cpuCore.m_strModel = cpuCore.m_strModel.substr(0, cpuCore.m_strModel.find(char(0))); // remove extra null terminations
           StringUtils::RemoveDuplicatedSpacesAndTabs(cpuCore.m_strModel);
           StringUtils::Trim(cpuCore.m_strModel);
@@ -185,7 +187,7 @@ CCPUInfo::CCPUInfo(void)
         if (RegQueryValueExW(hCpuKey, L"VendorIdentifier", nullptr, &valType, LPBYTE(buf), &bufSize) == ERROR_SUCCESS &&
             valType == REG_SZ)
         {
-          g_charsetConverter.wToUTF8(std::wstring(buf, bufSize / sizeof(wchar_t)), cpuCore.m_strVendor);
+          cpuCore.m_strVendor = FromW(buf, bufSize / sizeof(wchar_t));
           cpuCore.m_strVendor = cpuCore.m_strVendor.substr(0, cpuCore.m_strVendor.find(char(0))); // remove extra null terminations
         }
         DWORD mhzVal;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

Fix tests on win32. CPUInfo is initialized before CCharsetConverter causing us to blow up.
## Description

<!--- Describe your change in detail -->

Added Windows specific conversion methods to avoid these kinds of issues as the string conversion is a bit special for Windows as API calls expect UTF-16 strings.

These methods are not meant for general usage, just for Windows specific scenarios.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

with the test suite that now runs :)
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
