### PR TITLE
CUtil::MakeShortenPath() should return true if the given path is already short enough (fixes #16783)

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1433,7 +1433,10 @@ bool CUtil::MakeShortenPath(std::string StrInput, std::string& StrOutput, size_t
 {
   size_t iStrInputSize = StrInput.size();
   if(iStrInputSize <= 0 || iTextMaxLength >= iStrInputSize)
-    return false;
+  {
+    StrOutput = StrInput;
+    return true;
+  }
 
   char cDelim = '\0';
   size_t nGreaterDelim, nPos;


### PR DESCRIPTION
This fixes the behaviour of `CUtil::MakeShortenPath()` which in turn fixes the fact that right now any setting pointing at a path which is 30 characters or shorter does not show up in the GUI at all. If the path is longer than 30 characters it is shortened and properly shown. This has been reported in http://trac.kodi.tv/ticket/16783.
