### PR TITLE
[video] fix NFO parsing of <namedseason>'s

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -985,11 +985,14 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   const TiXmlElement* namedSeason = movie->FirstChildElement("namedseason");
   while (namedSeason != nullptr)
   {
-    int seasonNumber;
-    std::string seasonName = namedSeason->ValueStr();
-    if (!seasonName.empty() &&
-        namedSeason->Attribute("number", &seasonNumber) != nullptr)
-      m_namedSeasons.insert(std::make_pair(seasonNumber, seasonName));
+    if (namedSeason->FirstChild() != nullptr)
+    {
+      int seasonNumber;
+      std::string seasonName = namedSeason->FirstChild()->ValueStr();
+      if (!seasonName.empty() &&
+          namedSeason->Attribute("number", &seasonNumber) != nullptr)
+        m_namedSeasons.insert(std::make_pair(seasonNumber, seasonName));
+    }
 
     namedSeason = namedSeason->NextSiblingElement("namedseason");
   }


### PR DESCRIPTION
This fixes the parsing of `<namedseason>` XML tags in `tvshow.nfo` NFOs which is currently broken as reported by @DanCooper (see https://github.com/xbmc/xbmc/pull/6041#issuecomment-252086294) because it reads the name of the tag instead of its value...
