### PR TITLE
[utils] drop AsyncFileCopy from Makefile, too

### DIFF
--- a/xbmc/utils/test/Makefile
+++ b/xbmc/utils/test/Makefile
@@ -2,7 +2,6 @@ SRCS=	\
 	TestAlarmClock.cpp \
 	TestAliasShortcutUtils.cpp \
 	TestArchive.cpp \
-	TestAsyncFileCopy.cpp \
 	TestBase64.cpp \
 	TestBitstreamStats.cpp \
 	TestCharsetConverter.cpp \


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

drop AsyncFileCopy from Makefile, too
## Motivation and Context

Running make in xbmc/utils/test fails
## How Has This Been Tested?

As a patch to the Debian package
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ x] All new and existing tests passed
