### PR TITLE
[dxva] fix hw decoding on some mpeg2 files and DVDs

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -195,8 +195,7 @@ enum AVPixelFormat CDVDVideoCodecFFmpeg::GetFormat(struct AVCodecContext * avctx
     }
 #endif
 #ifdef HAS_DX
-  if(DXVA::CDecoder::Supports(*cur) && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDXVA2) &&
-     !ctx->m_hints.dvd && !ctx->m_hints.stills)
+  if(DXVA::CDecoder::Supports(*cur) && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEDXVA2))
   {
     CLog::Log(LOGNOTICE, "CDVDVideoCodecFFmpeg::GetFormat - Creating DXVA(%ix%i)", avctx->width, avctx->height);
     DXVA::CDecoder* dec = new DXVA::CDecoder(ctx->m_processInfo);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -790,8 +790,25 @@ static bool HasVP3WidthBug(AVCodecContext *avctx)
   return false;
 }
 
+static bool HasATIMP2Bug(AVCodecContext *avctx)
+{
+  DXGI_ADAPTER_DESC AIdentifier = g_Windowing.GetAIdentifier();
+  if (AIdentifier.VendorId != PCIV_ATI)
+    return false;
+
+  // AMD/ATI card doesn't like some SD MPEG2 content
+  // here are params of these videos
+  return avctx->height <= 576
+      && avctx->colorspace == AVCOL_SPC_BT470BG
+      && avctx->color_primaries == AVCOL_PRI_BT470BG 
+      && avctx->color_trc == AVCOL_TRC_GAMMA28;
+}
+
 static bool CheckCompatibility(AVCodecContext *avctx)
 {
+  if (avctx->codec_id == AV_CODEC_ID_MPEG2VIDEO && HasATIMP2Bug(avctx))
+    return false;
+
   // The incompatibilities are all for H264
   if(avctx->codec_id != AV_CODEC_ID_H264)
     return true;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -939,12 +939,11 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
   if(result)
     return result;
 
-  SAFE_RELEASE(m_presentPicture);
-
   if(frame)
   {
     if (m_surface_context->IsValid(reinterpret_cast<ID3D11View*>(frame->data[3])))
     {
+      SAFE_RELEASE(m_presentPicture);
       m_presentPicture = new CRenderPicture(m_surface_context);
       m_presentPicture->view = reinterpret_cast<ID3D11View*>(frame->data[3]);
       m_surface_context->MarkRender(m_presentPicture->view);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -897,9 +897,11 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
 
   avctx->get_buffer2 = GetBufferS;
   avctx->hwaccel_context = m_context;
+  avctx->slice_flags = SLICE_FLAG_ALLOW_FIELD | SLICE_FLAG_CODED_ORDER;
 
   mainctx->get_buffer2 = GetBufferS;
   mainctx->hwaccel_context = m_context;
+  mainctx->slice_flags = SLICE_FLAG_ALLOW_FIELD | SLICE_FLAG_CODED_ORDER;
 
   m_avctx = mainctx;
   DXGI_ADAPTER_DESC AIdentifier = g_Windowing.GetAIdentifier();


### PR DESCRIPTION
see title

@Voyager1 iirc you had the issue on some DVDs. could you check them on this? I've checked on WILLEM only.
@FernetMenta ping
