### PR TITLE
[gui] field and operator buttons from label2 to label

### DIFF
--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -493,14 +493,14 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
 {
   if (m_rule.m_field == 0)
     m_rule.m_field = CSmartPlaylistRule::GetFields(m_type)[0];
-  SET_CONTROL_LABEL2(CONTROL_FIELD, CSmartPlaylistRule::GetLocalizedField(m_rule.m_field));
+  SET_CONTROL_LABEL(CONTROL_FIELD, CSmartPlaylistRule::GetLocalizedField(m_rule.m_field));
 
   CONTROL_ENABLE(CONTROL_VALUE);
   if (CSmartPlaylistRule::IsFieldBrowseable(m_rule.m_field))
     CONTROL_ENABLE(CONTROL_BROWSE);
   else
     CONTROL_DISABLE(CONTROL_BROWSE);
-  SET_CONTROL_LABEL2(CONTROL_OPERATOR, std::get<0>(OperatorLabel(m_rule.m_operator)));
+  SET_CONTROL_LABEL(CONTROL_OPERATOR, std::get<0>(OperatorLabel(m_rule.m_operator)));
 
   // update label2 appropriately
   SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetParameter());


### PR DESCRIPTION
Change the button labels from right to left.

Before:
<img width="1712" alt="schermafbeelding 2016-10-07 om 15 32 07" src="https://cloud.githubusercontent.com/assets/447067/19191586/6c440398-8ca3-11e6-867e-1d44ac77e9ac.png">

After:
<img width="1712" alt="schermafbeelding 2016-10-07 om 15 29 55" src="https://cloud.githubusercontent.com/assets/447067/19191591/7319a29a-8ca3-11e6-8130-0694f0a36f65.png">
