### PR TITLE
VideoPlayer: aml: Disable pullup correction when using Amlogic decoder

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -800,7 +800,7 @@ int CVideoPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   int result = 0;
 
   //correct any pattern in the timestamps
-  if (picture.format != RENDER_FMT_BYPASS)
+  if (picture.format != RENDER_FMT_BYPASS && picture.format != RENDER_FMT_AML)
   {
     m_pullupCorrection.Add(pts);
     pts += m_pullupCorrection.GetCorrection();


### PR DESCRIPTION
Disable pullup correction in video player when using Amlogic decoder.
## Description

When using Amlogic decoder to play a video, playback may freeze at some point. Disabling pullup correction fixes that issue.
## Motivation and Context

Before switching to VideoPlayer, Amlogic decoder used RENDER_FMT_BYPASS picture format and pullup correction was disabled for it, but after the switch the decoder uses RENDER_FMT_AML picture format and pullup correction became enabled for it.
## How Has This Been Tested?

This was tested on WeTek Play, WeTek Play 2 and WeTek Hub with LibreELEC installed, using different video formats.
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
