### PR TITLE
Fix remixers node to use string constant

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15268,6 +15268,12 @@ msgid "If traffic advisory is send from RDS, volume is increased"
 msgstr ""
 
 #. Music role category
+#: system/library/music/musicroles/Remixers.xml
+msgctxt "#29987"
+msgid "Remixers"
+msgstr ""
+
+#. Music role category
 #: system/library/music/musicroles/Arrangers.xml
 msgctxt "#29988"
 msgid "Arrangers"

--- a/system/library/music/musicroles/Remixers.xml
+++ b/system/library/music/musicroles/Remixers.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <node order="7" type="folder" visible="Library.HasContent(Role, Remixer)">
-	<label>Remixers</label>
+	<label>29987</label>
         <icon>DefaultMusicGenres.png</icon>
 	<path>musicdb://artists/?role=Remixer</path>
 </node>


### PR DESCRIPTION
String constant ommited for remixer node lable.
