### PR TITLE
[PVR] Do not restart pvr manager on async client reconnect.

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1572,7 +1572,10 @@ void CPVRClients::ConnectionStateChange(int clientId, std::string &strConnection
     {
       CLog::Log(LOGERROR, "PVR - %s - error reading properties", __FUNCTION__);
     }
-    g_PVRManager.Start();
+
+    if (client->GetPreviousConnectionState() == PVR_CONNECTION_STATE_UNKNOWN ||
+        client->GetPreviousConnectionState() == PVR_CONNECTION_STATE_CONNECTING)
+      g_PVRManager.Start();
   }
 }
 


### PR DESCRIPTION
Although PVR manager must be started on first async client connect, do not restart pvr manager on subsequent async client reconnect. This is not necessary and a waste of machine time. 

@FernetMenta your opinion?
