### PR TITLE
[VTB/GLES] - release CVBuffer after it actually has been rendered

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.cpp
@@ -48,6 +48,7 @@ CRendererVTB::CRendererVTB()
     buf.m_textureY = nullptr;
     buf.m_textureUV = nullptr;
     buf.m_videoBuffer = nullptr;
+    buf.m_fence = nullptr;
   }
 }
 
@@ -55,6 +56,11 @@ CRendererVTB::~CRendererVTB()
 {
   if (m_textureCache)
     CFRelease(m_textureCache);
+
+  for (int i = 0; i < NUM_BUFFERS; ++i)
+  {
+    DeleteTexture(i);
+  }
 }
 
 void CRendererVTB::AddVideoPictureHW(DVDVideoPicture &picture, int index)
@@ -73,6 +79,12 @@ void CRendererVTB::ReleaseBuffer(int idx)
   if (buf.m_videoBuffer)
     CVBufferRelease(buf.m_videoBuffer);
   buf.m_videoBuffer = nullptr;
+  
+  if (buf.m_fence && glIsSyncAPPLE(buf.m_fence))
+  {
+    glDeleteSyncAPPLE(buf.m_fence);
+    buf.m_fence = nullptr;
+  }
 }
 
 int CRendererVTB::GetImageHook(YV12Image *image, int source, bool readonly)
@@ -154,10 +166,6 @@ void CRendererVTB::DeleteTexture(int index)
 {
   CRenderBuffer &buf = m_vtbBuffers[index];
   
-  if (buf.m_videoBuffer)
-    CVBufferRelease(buf.m_videoBuffer);
-  buf.m_videoBuffer = nullptr;
-
   if (buf.m_textureY)
     CFRelease(buf.m_textureY);
   buf.m_textureY = nullptr;
@@ -165,6 +173,8 @@ void CRendererVTB::DeleteTexture(int index)
   if (buf.m_textureUV)
     CFRelease(buf.m_textureUV);
   buf.m_textureUV = nullptr;
+
+  ReleaseBuffer(index);
 
   YUVFIELDS &fields = m_buffers[index].fields;
   fields[FIELD_FULL][0].id = 0;
@@ -243,4 +253,27 @@ bool CRendererVTB::UploadTexture(int index)
   return true;
 }
 
+void CRendererVTB::AfterRenderHook(int idx)
+{
+  CRenderBuffer &buf = m_vtbBuffers[idx];
+  if (buf.m_fence && glIsSyncAPPLE(buf.m_fence))
+  {
+    glDeleteSyncAPPLE(buf.m_fence);
+  }
+  buf.m_fence = glFenceSyncAPPLE(GL_SYNC_GPU_COMMANDS_COMPLETE_APPLE, 0);
+}
+
+bool CRendererVTB::NeedBuffer(int idx)
+{
+  CRenderBuffer &buf = m_vtbBuffers[idx];
+  if (buf.m_fence && glIsSyncAPPLE(buf.m_fence))
+  {
+    int syncState = GL_UNSIGNALED_APPLE;
+    glGetSyncivAPPLE(buf.m_fence, GL_SYNC_STATUS_APPLE, 1, nullptr, &syncState);
+    if (syncState == GL_SIGNALED_APPLE)
+      return false;
+  }
+  
+  return true;
+}
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.h
@@ -33,17 +33,17 @@ public:
   CRendererVTB();
   virtual ~CRendererVTB();
 
-  // Player functions
+  // Feature support
   virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index) override;
   virtual void ReleaseBuffer(int idx) override;
-
-  // Feature support
+  virtual bool NeedBuffer(int idx) override;
   virtual CRenderInfo GetRenderInfo() override;
 
 protected:
   // hooks for hw dec renderer
   virtual bool LoadShadersHook() override;
   virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false) override;
+  virtual void AfterRenderHook(int idx) override;
 
   // textures
   virtual bool UploadTexture(int index) override;
@@ -56,6 +56,7 @@ protected:
     CVOpenGLESTextureRef m_textureY;
     CVOpenGLESTextureRef m_textureUV;
     CVBufferRef m_videoBuffer;
+    GLsync m_fence;
   };
   CRenderBuffer m_vtbBuffers[NUM_BUFFERS];
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -811,6 +811,8 @@ void CLinuxRendererGLES::Render(DWORD flags, int index)
       break;
     }
   }
+  
+  AfterRenderHook(index);
 }
 
 void CLinuxRendererGLES::RenderSinglePass(int index, int field)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -187,6 +187,7 @@ protected:
   // hooks for HwDec Renderered
   virtual bool LoadShadersHook() { return false; }
   virtual bool RenderHook(int idx) { return false; }
+  virtual void AfterRenderHook(int idx) {};
   virtual bool RenderUpdateVideoHook(bool clear, DWORD flags, DWORD alpha) { return false; }
   virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false) { return NOSOURCE; }
   virtual bool RenderUpdateCheckForEmptyField() { return true; }


### PR DESCRIPTION
This is the (hopefully) same as #10615 just for gles/ios vtb rendering.

@FernetMenta could you have a look if i did it right? Not sure about m_textureY and m_textureUV handling here. I basically copied your VTB/GL approach 1:1.
