### PR TITLE
[Estuary] Changes to allow 3 button BottomMainMenuItem

### DIFF
--- a/addons/skin.estuary/1080i/Custom_1100_AddonLauncher.xml
+++ b/addons/skin.estuary/1080i/Custom_1100_AddonLauncher.xml
@@ -166,72 +166,40 @@
 				<include>OpenClose_Left</include>
 				<onright>400</onright>
 				<usecontrolcoords>true</usecontrolcoords>
-				<control type="radiobutton" id="801">
-					<width>157</width>
-					<height>110</height>
-					<align>right</align>
-					<aligny>center</aligny>
-					<onclick>ActivateWindow(addonbrowser,root)</onclick>
-					<font>font10</font>
-					<label></label>
-					<textoffsetx>40</textoffsetx>
-					<textwidth>230</textwidth>
-					<texturefocus border="40" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
-					<texturenofocus border="40">buttons/button-nofo.png</texturenofocus>
-					<radioposx>55</radioposx>
-					<radioposy>0</radioposy>
-					<radiowidth>40</radiowidth>
-					<radioheight>40</radioheight>
-					<textureradioonfocus>icons/submenu/add-ons.png</textureradioonfocus>
-					<textureradioonnofocus>icons/submenu/add-ons.png</textureradioonnofocus>
-					<textureradioofffocus>icons/submenu/add-ons.png</textureradioofffocus>
-					<textureradiooffnofocus>icons/submenu/add-ons.png</textureradiooffnofocus>
-				</control>
-				<control type="radiobutton" id="802">
-					<width>157</width>
-					<height>110</height>
-					<align>right</align>
-					<aligny>center</aligny>
-					<onclick>ActivateWindow(addonbrowser,addons://outdated/,return)</onclick>
-					<font>font10</font>
-					<label></label>
-					<textoffsetx>40</textoffsetx>
-					<textwidth>230</textwidth>
-					<texturefocus border="40" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
-					<texturenofocus border="40">buttons/button-nofo.png</texturenofocus>
-					<radioposx>35</radioposx>
-					<radioposy>0</radioposy>
-					<radiowidth>40</radiowidth>
-					<radioheight>40</radioheight>
-					<enable>Integer.IsGreater(Container(8000).NumItems,0)</enable>
-					<textureradioonfocus>icons/submenu/updatelibrary.png</textureradioonfocus>
-					<textureradioonnofocus>icons/submenu/updatelibrary.png</textureradioonnofocus>
-					<textureradioofffocus>icons/submenu/updatelibrary.png</textureradioofffocus>
-					<textureradiooffnofocus>icons/submenu/updatelibrary.png</textureradiooffnofocus>
-					<textureradioondisabled colordiffuse="disabled">icons/submenu/updatelibrary.png</textureradioondisabled>
-					<textureradiooffdisabled colordiffuse="disabled">icons/submenu/updatelibrary.png</textureradiooffdisabled>
-				</control>
-				<control type="radiobutton" id="803">
-					<width>157</width>
-					<height>110</height>
-					<align>right</align>
-					<aligny>center</aligny>
-					<onclick>ActivateWindow(systemsettings,addons)</onclick>
-					<font>font10</font>
-					<label></label>
-					<textoffsetx>40</textoffsetx>
-					<textwidth>230</textwidth>
-					<texturefocus border="40" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
-					<texturenofocus border="40">buttons/button-nofo.png</texturenofocus>
-					<radioposx>55</radioposx>
-					<radioposy>0</radioposy>
-					<radiowidth>40</radiowidth>
-					<radioheight>40</radioheight>
-					<textureradioonfocus>icons/settings.png</textureradioonfocus>
-					<textureradioonnofocus>icons/settings.png</textureradioonnofocus>
-					<textureradioofffocus>icons/settings.png</textureradioofffocus>
-					<textureradiooffnofocus>icons/settings.png</textureradiooffnofocus>
-				</control>
+				<include content="BottomMainMenuItem">
+					<param name="control_id" value="801" />
+					<param name="width" value="156" />
+					<param name="height" value="110" />
+					<param name="align" value="center" />
+					<param name="radioposx" value="56" />
+					<param name="onclick" value="ActivateWindow(addonbrowser,root)" />
+					<param name="textoffsetx" value="40" />
+					<param name="textwidth" value="230" />
+					<param name="icon" value="icons/submenu/add-ons.png" />
+				</include>
+				<include content="BottomMainMenuItem">
+					<param name="control_id" value="802" />
+					<param name="enable" value="Integer.IsGreater(Container(8000).NumItems,0)" />
+					<param name="width" value="156" />
+					<param name="height" value="110" />
+					<param name="align" value="left" />
+					<param name="radioposx" value="36" />
+					<param name="onclick" value="ActivateWindow(addonbrowser,addons://outdated/,return)" />
+					<param name="textoffsetx" value="40" />
+					<param name="textwidth" value="230" />
+					<param name="icon" value="icons/submenu/updatelibrary.png" />
+				</include>
+				<include content="BottomMainMenuItem">
+					<param name="control_id" value="803" />
+					<param name="width" value="156" />
+					<param name="height" value="110" />
+					<param name="align" value="center" />
+					<param name="radioposx" value="56" />
+					<param name="onclick" value="ActivateWindow(systemsettings,addons)" />
+					<param name="textoffsetx" value="40" />
+					<param name="textwidth" value="230" />
+					<param name="icon" value="icons/settings.png" />
+				</include>
 				<control type="label" id="804">
 					<left>-217</left>
 					<top>20</top>

--- a/addons/skin.estuary/1080i/Home.xml
+++ b/addons/skin.estuary/1080i/Home.xml
@@ -1199,7 +1199,7 @@
 				</control>
 				<control type="grouplist" id="700">
 					<orientation>horizontal</orientation>
-					<itemgap>-16</itemgap>
+					<itemgap>-22</itemgap>
 					<left>33</left>
 					<top>878</top>
 					<onup>SetFocus(9000,99)</onup>
@@ -1208,27 +1208,33 @@
 					<onright>2000</onright>
 					<include content="BottomMainMenuItem">
 						<param name="control_id" value="804" />
+						<param name="width" value="156" />
+						<param name="height" value="110" />
+						<param name="align" value="center" />
+						<param name="radioposx" value="56" />
 						<param name="onclick" value="ActivateWindow(shutdownmenu)" />
 						<param name="icon" value="icons/power.png" />
 						<param name="label" value="$LOCALIZE[33060]" />
 					</include>
 					<include content="BottomMainMenuItem">
 						<param name="control_id" value="802" />
+						<param name="width" value="156" />
+						<param name="height" value="110" />
+						<param name="align" value="center" />
+						<param name="radioposx" value="56" />
 						<param name="onclick" value="ActivateWindow(settings)" />
 						<param name="icon" value="icons/settings.png" />
 						<param name="label" value="$LOCALIZE[21417]" />
 					</include>
 					<include content="BottomMainMenuItem">
 						<param name="control_id" value="803" />
+						<param name="width" value="156" />
+						<param name="height" value="110" />
+						<param name="align" value="center" />
+						<param name="radioposx" value="56" />
 						<param name="onclick" value="ActivateWindow(favourites)" />
 						<param name="icon" value="icons/favourites.png" />
 						<param name="label" value="$LOCALIZE[10134]" />
-					</include>
-					<include content="BottomMainMenuItem">
-						<param name="control_id" value="801" />
-						<param name="onclick" value="ActivateWindow(filemanager)" />
-						<param name="icon" value="icons/filemanager.png" />
-						<param name="label" value="$LOCALIZE[10003]" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/1080i/Includes_Buttons.xml
+++ b/addons/skin.estuary/1080i/Includes_Buttons.xml
@@ -184,19 +184,21 @@
 		</definition>
 	</include>
 	<include name="BottomMainMenuItem">
-		<param name="height">110</param>
 		<definition>
 			<control type="radiobutton" id="$PARAM[control_id]">
-				<width>118</width>
+				<enable>$PARAM[enable]</enable>
+				<width>$PARAM[width]</width>
 				<height>$PARAM[height]</height>
-				<align>center</align>
+				<align>$PARAM[align]</align>
 				<aligny>center</aligny>
 				<onclick>$PARAM[onclick]</onclick>
 				<font></font>
 				<label>$PARAM[label]</label>
+				<textoffsetx>$PARAM[textoffsetx]</textoffsetx>
+				<textwidth>$PARAM[textwidth]</textwidth>
 				<texturefocus border="40" colordiffuse="button_focus">buttons/button-fo.png</texturefocus>
 				<texturenofocus border="40">buttons/button-nofo.png</texturenofocus>
-				<radioposx>38</radioposx>
+				<radioposx>$PARAM[radioposx]</radioposx>
 				<radioposy>0</radioposy>
 				<radiowidth>40</radiowidth>
 				<radioheight>40</radioheight>
@@ -204,6 +206,8 @@
 				<textureradioonnofocus>$PARAM[icon]</textureradioonnofocus>
 				<textureradioofffocus>$PARAM[icon]</textureradioofffocus>
 				<textureradiooffnofocus>$PARAM[icon]</textureradiooffnofocus>
+				<textureradioondisabled colordiffuse="disabled">$PARAM[icon]</textureradioondisabled>
+				<textureradiooffdisabled colordiffuse="disabled">$PARAM[icon]</textureradiooffdisabled>
 			</control>
 		</definition>
 	</include>

--- a/addons/skin.estuary/1080i/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/1080i/Includes_MediaMenu.xml
@@ -221,19 +221,28 @@
 						</include>
 						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14102" />
+							<param name="width" value="118" />
 							<param name="height" value="95" />
+							<param name="align" value="center" />
+							<param name="radioposx" value="38" />
 							<param name="onclick" value="Stop" />
 							<param name="icon" value="icons/now-playing/stop.png" />
 						</include>
 						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14104" />
+							<param name="width" value="118" />
 							<param name="height" value="95" />
+							<param name="align" value="center" />
+							<param name="radioposx" value="38" />
 							<param name="onclick" value="Next" />
 							<param name="icon" value="icons/now-playing/next.png" />
 						</include>
 						<include content="BottomMainMenuItem">
 							<param name="control_id" value="14105" />
+							<param name="width" value="118" />
 							<param name="height" value="95" />
+							<param name="align" value="center" />
+							<param name="radioposx" value="38" />
 							<param name="onclick" value="Fullscreen" />
 							<param name="icon" value="icons/now-playing/fullscreen.png" />
 						</include>
@@ -298,19 +307,28 @@
 			</include>
 			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14102" />
+				<param name="width" value="118" />
 				<param name="height" value="95" />
+				<param name="align" value="center" />
+				<param name="radioposx" value="38" />
 				<param name="onclick" value="Stop" />
 				<param name="icon" value="icons/now-playing/stop.png" />
 			</include>
 			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14104" />
+				<param name="width" value="118" />
 				<param name="height" value="95" />
+				<param name="align" value="center" />
+				<param name="radioposx" value="38" />
 				<param name="onclick" value="PlayerControl(Next)" />
 				<param name="icon" value="icons/now-playing/next.png" />
 			</include>
 			<include content="BottomMainMenuItem">
 				<param name="control_id" value="14105" />
+				<param name="width" value="118" />
 				<param name="height" value="95" />
+				<param name="align" value="center" />
+				<param name="radioposx" value="38" />
 				<param name="onclick" value="Fullscreen" />
 				<param name="icon" value="icons/now-playing/fullscreen.png" />
 			</include>


### PR DESCRIPTION
## Description

This makes the changes needed to the BottomMainMenuItem to allow a 3 button arrangement and make BottomMainMenuItem more flexible so it can be used in Custom_110_AddonLauncher to replace the 3 button arrangement there.

2nd attempt at this following https://github.com/xbmc/xbmc/pull/10575
## Motivation and Context

Since File Manager is now in the Settings window it's no longer needed on Home, so changes the Home bottom menu bar to be 3 button instead of 4.
## Screenshots (if appropriate):

Home now looks like

![image](https://cloud.githubusercontent.com/assets/5781142/19212907/5d506914-8d55-11e6-8957-b46bae6325dc.png)

This matches the Add-on Launcher 3 button look which now also uses BottomMainMenuItem

![image](https://cloud.githubusercontent.com/assets/5781142/19212917/9ba97fac-8d55-11e6-9d73-1c8c1ce6f8aa.png)
## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
