### PR TITLE
support reusing of CFile::m_pFile

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1189,6 +1189,12 @@ bool CCurlFile::CReadState::ReadString(char *szLine, int iLineLength)
   return (bool)((pLine - szLine) > 0);
 }
 
+bool CCurlFile::ReOpen(const CURL& url)
+{
+  Close();
+  return Open(url);
+}
+
 bool CCurlFile::Exists(const CURL& url)
 {
   // if file is already running, get info from it

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -51,6 +51,7 @@ namespace XFILE
       virtual ~CCurlFile();
       virtual bool Open(const CURL& url);
       virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false);
+      virtual bool ReOpen(const CURL& url);
       virtual bool Exists(const CURL& url);
       virtual int64_t  Seek(int64_t iFilePosition, int iWhence=SEEK_SET);
       virtual int64_t GetPosition();

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -254,6 +254,19 @@ bool CFile::Open(const std::string& strFileName, const unsigned int flags)
 
 bool CFile::Open(const CURL& file, const unsigned int flags)
 {
+  if (m_pFile)
+  {
+    if ((flags & READ_REOPEN) == 0)
+    {
+      CLog::Log(LOGERROR, "File::Open - already open: %s", file.GetRedacted().c_str());
+      return false;      
+    }
+    else
+    {
+      return m_pFile->ReOpen(URIUtils::SubstitutePath(file));
+    }
+  }
+
   m_flags = flags;
   try
   {
@@ -280,6 +293,10 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       {
         // for internet stream, if it contains multiple stream, file cache need handle it specially.
         m_pFile = new CFileCache(m_flags);
+
+        if (!m_pFile)
+          return false;
+
         return m_pFile->Open(url);
       }
     }

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -64,12 +64,25 @@ public:
   bool CURLAddOption(XFILE::CURLOPTIONTYPE type, const char* name, const char * value);
   bool CURLOpen(unsigned int flags);
 
+  /**
+  * Attempt to open an IFile instance.
+  * @param file reference to CCurl file description
+  * @param flags see IFileTypes.h
+  * @return true on success, false otherwise
+  *
+  * Remarks: Open can only be called once. Calling
+  * Open() on an already opened file will fail
+  * exept flag READ_REOPEN is set and the underlying
+  * file has an implementation of ReOpen().
+  */
   bool Open(const CURL& file, const unsigned int flags = 0);
+  bool Open(const std::string& strFileName, const unsigned int flags = 0);
+
   bool OpenForWrite(const CURL& file, bool bOverWrite = false);
+  bool OpenForWrite(const std::string& strFileName, bool bOverWrite = false);
+
   ssize_t LoadFile(const CURL &file, auto_buffer& outputBuffer);
 
-  bool Open(const std::string& strFileName, const unsigned int flags = 0);
-  bool OpenForWrite(const std::string& strFileName, bool bOverWrite = false);
   /**
    * Attempt to read bufSize bytes from currently opened file into buffer bufPtr.
    * @param bufPtr  pointer to buffer

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -61,6 +61,7 @@ public:
 
   virtual bool Open(const CURL& url) = 0;
   virtual bool OpenForWrite(const CURL& url, bool bOverWrite = false) { return false; };
+  virtual bool ReOpen(const CURL& url) { return false; };
   virtual bool Exists(const CURL& url) = 0;
   /**
    * Fills struct __stat64 with information about file specified by url.

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -49,6 +49,9 @@ namespace XFILE
 /* indicate that caller will do write operations before reading  */
   static const unsigned int READ_AFTER_WRITE = 0x80;
 
+/* indicate that caller want to reopen a file if its already open  */
+  static const unsigned int READ_REOPEN = 0x100;
+
 struct SNativeIoControl
 {
   unsigned long int   request;


### PR DESCRIPTION
Dont open CFile on Open again if its already opened
## Description

see title
## Motivation and Context

Calling multiple times open on a filesystem file without calling Close() after each call lead to memory leaks (m_pFile is not closed / freed).

CCurlfile is not able to handle multiple Open calls -> Close it on start of Open
## How Has This Been Tested?

CURLCreate -> CURLOpen -> CURLOpen -> CURLClose
## Types of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
