### PR TITLE
[guilib] make onclick override conditional. Fallback to default actio…

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -762,7 +762,7 @@ bool CGUIBaseContainer::OnClick(int actionID)
       int selected = GetSelectedItem();
       if (selected >= 0 && selected < (int)m_items.size())
       {
-        if (m_clickActions.HasAnyActions())
+        if (m_clickActions.HasActionsMeetingCondition())
           m_clickActions.ExecuteActions(0, GetParentID(), m_items[selected]);
         else
           m_listProvider->OnClick(m_items[selected]);


### PR DESCRIPTION
…n if no condition is met.

In #8178 override on clicks were introduced for dynamic content lists. Problem is that once you add an onclick tag to a container it will always try to execute that onclick even if you put a condition to it. This fixes that problem.
Thx to @phil65 for the hint.

Imo this is a fix as previous behaviour was wrong but no problem to lift it to v18 too if anyone objects.
