### PR TITLE
X11, osx: yield to main loop after input action has been handled

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -220,7 +220,7 @@ bool CWinEventsSDL::MessagePump()
   SDL_Event event;
   bool ret = false;
 
-  while (SDL_PollEvent(&event))
+  while (!ret && SDL_PollEvent(&event))
   {
     switch(event.type)
     {

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -316,7 +316,7 @@ bool CWinEventsX11Imp::MessagePump()
   XEvent xevent;
   unsigned long serial = 0;
 
-  while (WinEvents && XPending(WinEvents->m_display))
+  while (!ret && XPending(WinEvents->m_display))
   {
     memset(&xevent, 0, sizeof (XEvent));
     XNextEvent(WinEvents->m_display, &xevent);


### PR DESCRIPTION
see title

I noticed on OSX where holding down a key was blocking all other processing including rendering video.
