### PR TITLE
Dont load inputstream addons on startup if they are disabled

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -38,7 +38,8 @@ std::unique_ptr<CInputStream> CInputStream::FromExtension(AddonProps props, cons
   std::string name(ext->plugin->identifier);
   std::unique_ptr<CInputStream> istr(new CInputStream(props, name, listitemprops,
                                                       extensions, protocols));
-  istr->CheckConfig();
+  if (!CAddonMgr::GetInstance().IsAddonDisabled(props.id))
+    istr->CheckConfig();
   return istr;
 }
 


### PR DESCRIPTION
Dont load inputstream addons on startup if they are disabled
## Description

see title
## Motivation and Context

Faster startup if one or more inputstream addons are dsabled
## How Has This Been Tested?

runtime test, start with disabled inputstream.mpd / enable it / read log
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [?] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
