### PR TITLE
[PVR] Recording home screen widget: Fix info dialog (show recording info, not generic video info).

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -34,6 +34,7 @@
 #include "music/MusicThumbLoader.h"
 #include "pictures/PictureThumbLoader.h"
 #include "pvr/PVRManager.h"
+#include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/JobManager.h"
@@ -386,6 +387,11 @@ bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
 
   if (fileItem->HasAddonInfo())
     return CGUIDialogAddonInfo::ShowForItem(fileItem);
+  else if (fileItem->HasPVRRecordingInfoTag())
+  {
+    CGUIDialogPVRRecordingInfo::ShowFor(fileItem);
+    return true;
+  }
   else if (fileItem->HasVideoInfoTag())
   {
     CGUIDialogVideoInfo::ShowFor(*fileItem.get());

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "FileItem.h"
+#include "guilib/GUIWindowManager.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
 
 #include "GUIDialogPVRRecordingInfo.h"
@@ -90,3 +91,17 @@ CFileItemPtr CGUIDialogPVRRecordingInfo::GetCurrentListItem(int offset)
 {
   return m_recordItem;
 }
+
+void CGUIDialogPVRRecordingInfo::ShowFor(const CFileItemPtr& item)
+{
+  if (item && item->IsPVRRecording())
+  {
+    CGUIDialogPVRRecordingInfo* pDlgInfo = dynamic_cast<CGUIDialogPVRRecordingInfo*>(g_windowManager.GetWindow(WINDOW_DIALOG_PVR_RECORDING_INFO));
+    if (pDlgInfo)
+    {
+      pDlgInfo->SetRecording(item.get());
+      pDlgInfo->Open();
+    }
+  }
+}
+

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -35,6 +35,8 @@ namespace PVR
 
     void SetRecording(const CFileItem *item);
 
+    static void ShowFor(const CFileItemPtr& item);
+
   protected:
     bool OnClickButtonOK(CGUIMessage &message);
     bool OnClickButtonPlay(CGUIMessage &message);


### PR DESCRIPTION
Problem reported internally by @da-anda: "I use "show info" as default select action, and from home screen there is a different "info" view than from PVR -> recordings window. From the default "info" view, there is no "resume point" handling when clicking the play button while form the PVR info view it's working."

Cause of the bug is that directory provider did display the info dialog for videos instead of the special one for pvr recordings. This PR fixes that misbehavior.

@xhaggi okay to go in?
