### PR TITLE
[MediaSettings] - fixed loading interlacemode_none from defaultsettings

### DIFF
--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -86,7 +86,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
   if (pElement != NULL)
   {
     int interlaceMethod;
-    bool interlaceMethodPresent = XMLUtils::GetInt(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_MAX);
+    bool interlaceMethodPresent = XMLUtils::GetInt(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_NONE, VS_INTERLACEMETHOD_MAX);
 
     m_defaultVideoSettings.m_InterlaceMethod = (EINTERLACEMETHOD)interlaceMethod;
     int scalingMethod;


### PR DESCRIPTION
I think this is a leftover from this:

https://github.com/xbmc/xbmc/commit/25718f4ccebd227eaf63f0f8b53f0552f89f01e5

Reproduction:
1. Play an interlaced movie
2. Disable deinterlacing
3. Hit "save for all media"
4. Restart kodi
5. see how deinterlace mode is reset to something != none

The problem was the minvalue of loading interlace mode from defaultsettings was set to interlace_auto (instead of interlace_none)

@FernetMenta i think this wasn't left that way by intention right?
