### PR TITLE
[gui] fix slider focus handling

### DIFF
--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -81,8 +81,6 @@ void CGUIDialogSlider::SetSlider(const std::string &label, float value, float mi
   m_callbackData = callbackData;
   if (slider)
   {
-    slider->SetActive();
-    slider->KeepActive();
     slider->SetType(SLIDER_CONTROL_TYPE_FLOAT);
     slider->SetFloatRange(min, max);
     slider->SetFloatInterval(delta);

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUISettingsSliderControl.h"
+#include "input/Key.h"
 
 CGUISettingsSliderControl::CGUISettingsSliderControl(int parentID, int controlID, float posX, float posY, float width, float height, float sliderWidth, float sliderHeight, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& backGroundTexture, const CTextureInfo& nibTexture, const CTextureInfo& nibTextureFocus, const CLabelInfo &labelInfo, int iType)
     : CGUISliderControl(parentID, controlID, posX, posY, sliderWidth, sliderHeight, backGroundTexture, nibTexture,nibTextureFocus, iType, HORIZONTAL)
@@ -27,6 +28,7 @@ CGUISettingsSliderControl::CGUISettingsSliderControl(int parentID, int controlID
 {
   m_label.SetAlign((labelInfo.align & XBFONT_CENTER_Y) | XBFONT_RIGHT);  
   ControlType = GUICONTROL_SETTINGS_SLIDER;
+  m_active = false;
 }
 
 CGUISettingsSliderControl::~CGUISettingsSliderControl(void)
@@ -75,7 +77,39 @@ void CGUISettingsSliderControl::ProcessText()
 
 bool CGUISettingsSliderControl::OnAction(const CAction &action)
 {
+  // intercept ACTION_SELECT_ITEM because onclick functionality is different from base class
+  if (action.GetID() == ACTION_SELECT_ITEM)
+  { 
+    if (!IsActive())
+      m_active = true;
+     // switch between the two sliders
+    else if (m_rangeSelection && m_currentSelector == RangeSelectorLower)
+      SwitchRangeSelector();
+    else
+    {
+      m_active = false;
+      if (m_rangeSelection)
+        SwitchRangeSelector();
+    }
+    return true;
+  }
   return CGUISliderControl::OnAction(action);
+}
+
+void CGUISettingsSliderControl::OnUnFocus()
+{
+  m_active = false;
+}
+
+EVENT_RESULT CGUISettingsSliderControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
+{
+  SetActive();
+  return CGUISliderControl::OnMouseEvent(point, event);
+}
+
+void CGUISettingsSliderControl::SetActive()
+{
+  m_active = true;
 }
 
 void CGUISettingsSliderControl::FreeResources(bool immediately)

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -46,6 +46,10 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
+  void OnUnFocus() override;
+  EVENT_RESULT OnMouseEvent(const CPoint& point, const CMouseEvent& event) override;
+  void SetActive();
+  bool IsActive() const override { return m_active; };
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void DynamicResourceAlloc(bool bOnOff);
@@ -70,5 +74,6 @@ protected:
 private:
   CGUIButtonControl m_buttonControl;
   CGUILabel m_label;
+  bool m_active; ///< Whether the slider has been activated by a click.
 };
 #endif

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -59,8 +59,6 @@ CGUISliderControl::CGUISliderControl(int parentID, int controlID, float posX, fl
   m_iInfoCode = 0;
   m_dragging = false;
   m_action = NULL;
-  m_active = false;
-  m_keepactive = false;
 }
 
 CGUISliderControl::~CGUISliderControl(void)
@@ -87,7 +85,7 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
   dirty |= m_guiBackground.SetWidth(m_width);
   dirty |= m_guiBackground.Process(currentTime);
 
-  CGUITexture &nibLower = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
+  CGUITexture &nibLower = (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
   float fScale;
   if (m_orientation == HORIZONTAL)
     fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
@@ -97,7 +95,7 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
   dirty |= ProcessSelector(nibLower, currentTime, fScale, RangeSelectorLower);
   if (m_rangeSelection)
   {
-    CGUITexture &nibUpper = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
+    CGUITexture &nibUpper = (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
     if (m_orientation == HORIZONTAL)
       fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
     else
@@ -159,11 +157,11 @@ bool CGUISliderControl::ProcessSelector(CGUITexture &nib, unsigned int currentTi
 void CGUISliderControl::Render()
 {
   m_guiBackground.Render();
-  CGUITexture &nibLower = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
+  CGUITexture &nibLower = (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
   nibLower.Render();
   if (m_rangeSelection)
   {
-    CGUITexture &nibUpper = (m_active && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
+    CGUITexture &nibUpper = (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
     nibUpper.Render();
   }
   CGUIControl::Render();
@@ -198,7 +196,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
   switch ( action.GetID() )
   {
   case ACTION_MOVE_LEFT:
-    if (m_active && m_orientation == HORIZONTAL)
+    if (IsActive() && m_orientation == HORIZONTAL)
     {
       Move(-1);
       return true;
@@ -206,7 +204,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_RIGHT:
-    if (m_active && m_orientation == HORIZONTAL)
+    if (IsActive() && m_orientation == HORIZONTAL)
     {
       Move(1);
       return true;
@@ -214,7 +212,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_UP:
-    if (m_active && m_orientation == VERTICAL)
+    if (IsActive() && m_orientation == VERTICAL)
     {
       Move(1);
       return true;
@@ -222,7 +220,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_DOWN:
-    if (m_active && m_orientation == VERTICAL)
+    if (IsActive() && m_orientation == VERTICAL)
     {
       Move(-1);
       return true;
@@ -230,29 +228,14 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_SELECT_ITEM:
-    if (!m_active)
-      m_active = true;
-    // switch between the two sliders
-    else if (m_rangeSelection && m_currentSelector == RangeSelectorLower)
+    if (m_rangeSelection)
       SwitchRangeSelector();
-    else
-    {
-      m_active = false;
-      if (m_rangeSelection)
-        SwitchRangeSelector();
-    }
-    return true;
+      return true;
 
   default:
     break;
   }
   return CGUIControl::OnAction(action);
-}
-
-void CGUISliderControl::OnUnFocus()
-{
-  if (!m_keepactive)
-    m_active = false;
 }
 
 void CGUISliderControl::Move(int iNumSteps)
@@ -505,17 +488,6 @@ void CGUISliderControl::SetFloatRange(float fStart, float fEnd)
   }
 }
 
-void CGUISliderControl::SetActive()
-{
-  m_active = true;
-}
-
-
-void CGUISliderControl::KeepActive()
-{
-  m_keepactive = true;
-}
-
 void CGUISliderControl::FreeResources(bool immediately)
 {
   CGUIControl::FreeResources(immediately);
@@ -613,7 +585,6 @@ void CGUISliderControl::SetFromPosition(const CPoint &point, bool guessSelector 
 
 EVENT_RESULT CGUISliderControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
-  m_active = true;
   m_dragging = false;
   if (event.m_id == ACTION_MOUSE_DRAG)
   {

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -63,15 +63,13 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
-  virtual void OnUnFocus() override;
+  virtual bool IsActive() const { return true; };
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void DynamicResourceAlloc(bool bOnOff);
   virtual void SetInvalid();
   virtual void SetRange(int iStart, int iEnd);
   virtual void SetFloatRange(float fStart, float fEnd);
-  virtual void SetActive();
-  virtual void KeepActive();
   virtual bool OnMessage(CGUIMessage& message);
   bool ProcessSelector(CGUITexture &nib, unsigned int currentTime, float fScale, RangeSelector selector);
   void SetRangeSelection(bool rangeSelection);
@@ -132,8 +130,6 @@ protected:
   std::string m_textValue; ///< Allows overriding of the text value to be displayed (parent must update when the slider updates)
   const SliderAction *m_action; ///< Allows the skin to configure the action of a click on the slider \sa SendClick
   bool m_dragging; ///< Whether we're in a (mouse/touch) drag operation or not - some actions are sent only on release.
-  bool m_active; ///< Whether the slider has been activated by a click.
-  bool m_keepactive; ///< Whether the slider should be deactivated when losing focus.
   ORIENTATION m_orientation;
 };
 #endif


### PR DESCRIPTION
PR https://github.com/xbmc/xbmc/pull/10445 intended to change the handling of sliderex controls ("SettingsSlider"), but adjusted the base slidercontrol class instead and therefore also the behaviour of "normal" slider controls. That way we also had to introduce unneeded complexity by adding a keepActive member bool to CGUISliderControl, which basically was a workaround to not break normal slider controls.

This PR changes that so that original behaviour for normal slider controls is restored and only behaviour for sliderex controls gets changed. That way we can also drop the keepActive bool again.
The base slider control is now always "active" (like it always was), while the derived settingsslider control becomes active after havin clicked on it.

This needs proper testing, some parts of guilib can be a minefield :)
@Montellese perhaps for review? or @xhaggi ?
Some testing from @ronie would also be cool.
Should fix an issue reported by @romanvm.           
