### PR TITLE
[AE/OsxSink] fix 16bit ne passthrough when there is no dedicated encoded stream

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -251,8 +251,9 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
     }
     else
     {
-      CLog::Log(LOGERROR, "%s, Unable to find suitable stream", __FUNCTION__);
-      return false;
+      CLog::Log(LOGERROR, "%s, Unable to find suitable virtual stream", __FUNCTION__);
+      //return false;
+      numOutputChannelsVirt = 0;
     }
   }
 
@@ -277,7 +278,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   CLog::Log(LOGDEBUG, "%s: Previous Physical Format: %s", __FUNCTION__, StreamDescriptionToString(previousPhysicalFormat, formatString));
 
   m_outputStream.SetPhysicalFormat(&outputFormat); // Set the active format (the old one will be reverted when we close)
-  if (passthrough)
+  if (passthrough && numOutputChannelsVirt > 0)
     m_outputStream.SetVirtualFormat(&outputFormatVirt);
 
   m_outputStream.GetVirtualFormat(&virtualFormat);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -137,6 +137,7 @@ OSStatus deviceChangedCB(AudioObjectID                       inObjectID,
 CAESinkDARWINOSX::CAESinkDARWINOSX()
 : m_latentFrames(0),
   m_outputBufferIndex(0),
+  m_outputBitstream(false),
   m_planes(1),
   m_frameSizePerPlane(0),
   m_framesPerSecond(0),
@@ -261,6 +262,15 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   format.m_sampleRate    = outputFormat.mSampleRate;
   
   m_outputBufferIndex = requestedStreamIndex;
+  
+  // if we are in passthrough but didn't have a matching
+  // virtual format - enable bitstream which deals with
+  // backconverting from float to 16bit
+  if (passthrough && numOutputChannelsVirt == 0)
+  {
+    m_outputBitstream = true;
+    CLog::Log(LOGDEBUG, "%s: Bitstream passthrough with float -> int16 conversion enabled", __FUNCTION__);
+  }
 
   std::string formatString;
   CLog::Log(LOGDEBUG, "%s: Selected stream[%u] - id: 0x%04X, Physical Format: %s %s", __FUNCTION__, (unsigned int)m_outputBufferIndex, (unsigned int)outputStream, StreamDescriptionToString(outputFormat, formatString), passthrough ? "passthrough" : "");
@@ -352,6 +362,7 @@ void CAESinkDARWINOSX::Deinitialize()
     m_buffer = NULL;
   }
   m_outputBufferIndex = 0;
+  m_outputBitstream = false;
   m_planes = 1;
 
   m_started = false;
@@ -472,18 +483,45 @@ OSStatus CAESinkDARWINOSX::renderCallback(AudioDeviceID inDevice, const AudioTim
     //planar always starts at outputbuffer/streamidx 0
     unsigned int startIdx = sink->m_buffer->NumPlanes() == 1 ? sink->m_outputBufferIndex : 0;
     unsigned int endIdx = startIdx + sink->m_buffer->NumPlanes();
-
-    /* buffers appear to come from CA already zero'd, so just copy what is wanted */
-    unsigned int wanted = outOutputData->mBuffers[0].mDataByteSize;
-    unsigned int bytes = std::min(sink->m_buffer->GetReadSize(), wanted);
-    for (unsigned int i = startIdx; i < endIdx; i++)
+    
+    /* NOTE: We assume that the buffers are all the same size... */
+    if (sink->m_outputBitstream)
     {
-      if (i < outOutputData->mNumberBuffers && outOutputData->mBuffers[i].mData)
-        sink->m_buffer->Read((unsigned char *)outOutputData->mBuffers[i].mData, bytes, i);
-      else
-        sink->m_buffer->Read(NULL, bytes, i);
+      /* HACK for bitstreaming AC3/DTS via PCM.
+       We reverse the float->S16LE conversion done in the stream or device */
+      static const float mul = 1.0f / (INT16_MAX + 1);
+
+      size_t wanted = outOutputData->mBuffers[0].mDataByteSize / sizeof(float) * sizeof(int16_t);
+      size_t bytes = std::min((size_t)sink->m_buffer->GetReadSize(), wanted);
+      for (unsigned int j = 0; j < bytes / sizeof(int16_t); j++)
+      {
+        for (unsigned int i = startIdx; i < endIdx; i++)
+        {
+          int16_t src;
+          sink->m_buffer->Read((unsigned char *)&src, sizeof(int16_t), i);
+          if (i < outOutputData->mNumberBuffers && outOutputData->mBuffers[i].mData)
+          {
+            float *dest = (float *)outOutputData->mBuffers[i].mData;
+            dest[j] = src * mul;
+          }
+        }
+      }
+      LogLevel(bytes, wanted);
     }
-    LogLevel(bytes, wanted);
+    else
+    {
+      /* buffers appear to come from CA already zero'd, so just copy what is wanted */
+      unsigned int wanted = outOutputData->mBuffers[0].mDataByteSize;
+      unsigned int bytes = std::min(sink->m_buffer->GetReadSize(), wanted);
+      for (unsigned int i = startIdx; i < endIdx; i++)
+      {
+        if (i < outOutputData->mNumberBuffers && outOutputData->mBuffers[i].mData)
+          sink->m_buffer->Read((unsigned char *)outOutputData->mBuffers[i].mData, bytes, i);
+        else
+          sink->m_buffer->Read(NULL, bytes, i);
+      }
+      LogLevel(bytes, wanted);
+    }
 
     // tell the sink we're good for more data
     condVar.notifyAll();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -54,6 +54,7 @@ private:
   unsigned int       m_latentFrames;
   unsigned int       m_outputBufferIndex;
 
+  bool               m_outputBitstream;   ///< true if we're bistreaming into a LinearPCM stream rather than AC3 stream.
   unsigned int       m_planes;            ///< number of audio planes (1 if non-planar)
   unsigned int       m_frameSizePerPlane; ///< frame size (per plane) in bytes
   unsigned int       m_framesPerSecond;   ///< sample rate

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -355,27 +355,42 @@ AEDataFormatList AEDeviceEnumerationOSX::caFormatToAE(const AudioStreamBasicDesc
     {
       case 16:
         if (formatDesc.mFormatFlags & kAudioFormatFlagIsBigEndian)
+        {
           formatList.push_back(AE_FMT_S16BE);
+        }
         else
         {
           formatList.push_back(AE_FMT_S16LE);
         }
+        formatList.push_back(AE_FMT_S16NE); // if we support either LE or BE - we always support NE too...
         break;
       case 24:
         if (formatDesc.mFormatFlags & kAudioFormatFlagIsBigEndian)
+        {
           formatList.push_back(AE_FMT_S24BE3);
+        }
         else
+        {
           formatList.push_back(AE_FMT_S24LE3);
+        }
+        formatList.push_back(AE_FMT_S24NE3); // if we support either LE or BE - we always support NE too...
         break;
       case 32:
         if (formatDesc.mFormatFlags & kAudioFormatFlagIsFloat)
+        {
           formatList.push_back(AE_FMT_FLOAT);
+        }
         else
         {
           if (formatDesc.mFormatFlags & kAudioFormatFlagIsBigEndian)
+          {
             formatList.push_back(AE_FMT_S32BE);
+          }
           else
+          {
             formatList.push_back(AE_FMT_S32LE);
+          }
+          formatList.push_back(AE_FMT_S32NE); // if we support either LE or BE - we always support NE too...
         }
         break;
     }


### PR DESCRIPTION
This restores the pcm passthrough mode for the osx sink when only 32bit float virtual formats are available.

We have multiple ways of passing through on osx
1. Use dedicated passthrough streams - this is the prefered way but not all audio devices have those streams
2. If we have a 16 bit integer stream with 48000 Hz sample rate we try to use this.
   a. We open the physical stream and try to open a virtual stream with the same format so that no conversion is taking place and we get a raw passthrough situation
   b. If we fail to open a virtual stream with 16bit integer 48000 Hz (which is the case if there simply is no suche virtual stream like on my mac mini for example), we use the bitstream option we had before (developed by jmarshall) which reverses the conversion from virtual to physical format which is done in the device/CoreAudio layer to achieve raw passthrough.

This PR adds the 2.b. use case again which was removed in 

https://github.com/xbmc/xbmc/commit/ddc3d29e50105180f4cfeddf462dfa6f934f923f#diff-3dd678432bba9d51a39816409d376717

@FernetMenta you can try this with this patch http://pastebin.com/6MM375AX which basically disables the dedicated encoded streams and leaves you with only integer streams. On my macmini i get the same behavior as the user in the forum - it fails to find a virtual stream which matches the physical format and opens the nullsink ... (because my macmini also only has 32bit float virtual formats).

Jenkins bakes a testbuild i want to provide to the user too.
