### PR TITLE
Changed WinEventsSDL.cpp to better support Mac Native Full Screen

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -355,16 +355,6 @@ bool CWinEventsSDL::MessagePump()
       }
       case SDL_VIDEORESIZE:
       {
-        // Under linux returning from fullscreen, SDL sends an extra event to resize to the desktop
-        // resolution causing the previous window dimensions to be lost. This is needed to rectify
-        // that problem.
-        if(!g_Windowing.IsFullScreen())
-        {
-          int RES_SCREEN = g_Windowing.DesktopResolution(g_Windowing.GetCurrentScreen());
-          if((event.resize.w == CDisplaySettings::GetInstance().GetResolutionInfo(RES_SCREEN).iWidth) &&
-              (event.resize.h == CDisplaySettings::GetInstance().GetResolutionInfo(RES_SCREEN).iHeight))
-            break;
-        }
         XBMC_Event newEvent;
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = event.resize.w;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

A Linux code check should not run on Mac - see below
## Motivation and Context

On Mac, when switching to Full screen using the native Mac method, the content of Kodi does not resize to fill the screen.
## How Has This Been Tested?

Tested on my Mac
## Screenshots (if appropriate):

Windowed:
![screen shot 2016-10-11 at 21 09 58](https://cloud.githubusercontent.com/assets/1786847/19284007/d2cf660a-8ffc-11e6-8b94-d3f521c8fe1a.png)

Mac native full screen with bug:
![screen shot 2016-10-11 at 21 10 26](https://cloud.githubusercontent.com/assets/1786847/19284039/f69cdafe-8ffc-11e6-86ef-b52bfa097013.png)

Mac native full screen after fix:
![screen shot 2016-10-11 at 21 11 55](https://cloud.githubusercontent.com/assets/1786847/19284055/006428b2-8ffd-11e6-9376-950fc27f4360.png)
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
