### PR TITLE
[android] don't strip binaries in debug builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -719,6 +719,7 @@ fi
 
 # platform debug flags
 if test "$use_debug" = "yes"; then
+  CMAKE_BUILD_TYPE="Debug"
   final_message="$final_message\n  Debugging:\tYes"
   if test "$use_profiling" = "yes"; then
     final_message="$final_message\n  Profiling:\tYes"
@@ -728,6 +729,7 @@ if test "$use_debug" = "yes"; then
     DEBUG_FLAGS="-g -D_DEBUG -Wall"
   fi
 else
+  CMAKE_BUILD_TYPE="Release"
   final_message="$final_message\n  Debugging:\tNo"
   if test "$use_profiling" = "yes"; then
     final_message="$final_message\n  Profiling:\tYes"
@@ -2268,6 +2270,8 @@ OUTPUT_FILES="$OUTPUT_FILES \
   .dummy"
 AC_SUBST(CORE_SYSTEM_NAME)
 AC_SUBST(CORE_SYSTEM_VARIANT)
+AC_SUBST(CROSS_COMPILING)
+AC_SUBST(CMAKE_BUILD_TYPE)
 AC_SUBST(CFLAGS)
 AC_SUBST(CXXFLAGS)
 AC_SUBST(INCLUDES)
@@ -2321,7 +2325,6 @@ AC_SUBST(HAVE_SSE4)
 AC_SUBST(USE_MMAL)
 AC_SUBST(USE_X11)
 AC_SUBST(USE_OPTICAL_DRIVE)
-AC_SUBST(CROSS_COMPILING)
 
 # pushd and popd are not available in other shells besides bash, so implement
 # our own pushd/popd functions

--- a/project/cmake/scripts/common/ArchSetup.cmake
+++ b/project/cmake/scripts/common/ArchSetup.cmake
@@ -133,3 +133,8 @@ if(NOT DEFINED NEON OR NEON)
     add_options(CXX ALL_BUILDS "-mfpu=neon -mvectorize-with-neon-quad")
   endif()
 endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_options (ALL_LANGUAGES DEBUG "-g" "-D_DEBUG" "-Wall")
+endif()
+

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -135,7 +135,9 @@ libs: $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so
 	find $(PREFIX)/lib/@APP_NAME_LC@/system -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;
 	cd xbmc/obj/local/$(CPU)/; find . -name "*.so" -not -name "lib*.so" | sed "s/\.\///" | xargs -I@ mv @ lib@
 	cp -fp xbmc/obj/local/$(CPU)/*.so xbmc/lib/$(CPU)/
+ifeq (@CMAKE_BUILD_TYPE@,Release)
 	$(STRIP) --strip-unneeded xbmc/lib/$(CPU)/*.so
+endif
 	install -p $(GDBPATH) ./xbmc/libs/$(CPU)/gdbserver
 	echo "set solib-search-path ./obj/local/$(CPU)" > ./xbmc/libs/$(CPU)/gdb.setup
 	echo "directory $(TOOLCHAIN)/sysroot/usr/include $(NDKROOT)/sources/android/native_app_glue" \


### PR DESCRIPTION
allows us to package debug builds for testing
