### PR TITLE
[PVR] Fix: activate/deactivate read-only timer

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -622,7 +622,7 @@ bool CGUIWindowPVRBase::EditTimer(CFileItem *item)
   const CPVRTimerInfoTagPtr newTimer(new CPVRTimerInfoTag);
   newTimer->UpdateEntry(timer);
 
-  if (ShowTimerSettings(newTimer) && !timer->GetTimerType()->IsReadOnly())
+  if (ShowTimerSettings(newTimer) && (!timer->GetTimerType()->IsReadOnly() || timer->GetTimerType()->SupportsEnableDisable()))
   {
     if (newTimer->GetTimerType() == timer->GetTimerType())
     {


### PR DESCRIPTION
Activate/deactivate buttons are not working for read-only timers.

Reproducible with rule based timers and tvheadend 4.2.

@ksooo 
