### PR TITLE
added: include watched status for movies in actor search dialog

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -458,12 +458,18 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
     pDlgSelect->Reset();
     pDlgSelect->SetHeading(CVariant{283});
 
+    CVideoThumbLoader loader;
     for (int i = 0; i < (int)items.Size(); i++)
     {
-      CFileItemPtr pItem = items[i];
-      pDlgSelect->Add(pItem->GetLabel());
+      if (items[i]->HasVideoInfoTag() &&
+          items[i]->GetVideoInfoTag()->m_playCount > 0)
+        items[i]->SetLabel2(g_localizeStrings.Get(16102));
+
+      loader.LoadItem(items[i].get());
+      pDlgSelect->Add(*items[i]);
     }
 
+    pDlgSelect->SetUseDetails(true);
     pDlgSelect->Open();
 
     int iItem = pDlgSelect->GetSelectedItem();


### PR DESCRIPTION
## Description

It is useful to see watched status for movies when searching from the info dialog. This adds a textual indicator, and changes the dialog to the detailed one (with thumbs).
## Motivation and Context

Easily finding an unwatched movie with a specific actor.
## How Has This Been Tested?

Simple human inspection.
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

ref http://forum.kodi.tv/showthread.php?tid=293624
