### PR TITLE
Fix joysticks not being detected on android startup

### DIFF
--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
@@ -108,6 +108,12 @@ bool CPeripheralBusAndroid::InitializeProperties(CPeripheral* peripheral)
   return true;
 }
 
+void CPeripheralBusAndroid::Initialise(void)
+{
+  CPeripheralBus::Initialise();
+  TriggerDeviceScan();
+}
+
 void CPeripheralBusAndroid::ProcessEvents()
 {
   std::vector<ADDON::PeripheralEvent> events;

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
@@ -43,6 +43,7 @@ namespace PERIPHERALS
 
     // specialisation of CPeripheralBus
     bool InitializeProperties(CPeripheral* peripheral) override;
+    void Initialise(void) override;
     void ProcessEvents() override;
 
     // implementations of IInputDeviceCallbacks


### PR DESCRIPTION
Proper fix for #9823

This fixes an error I had when testing on android. The error in the log was

```
WARNING: CPeripheralBusAndroid: ignoring input event for unknown input device with ID 1
```

This occurred because even though the joystick was discovered, Kodi wasn't doing an initial scan on the android bus (an initial scan only occurs if the bus requires Kodi to poll it). This fixes the bug by doing a scan when the bus is initialized.

Broken out from #10630
