### PR TITLE
[addons] Fix restart needed to enable/disable peripheral add-ons

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -345,7 +345,8 @@ void OnEnabled(const std::string& id)
   // If the addon is a special, call enabled handler
   AddonPtr addon;
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_PVRDLL) ||
-      CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_ADSPDLL))
+      CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_ADSPDLL) ||
+      CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_PERIPHERALDLL))
     return addon->OnEnabled();
 
   if (CAddonMgr::GetInstance().ServicesHasStarted())
@@ -363,7 +364,8 @@ void OnDisabled(const std::string& id)
 
   AddonPtr addon;
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_PVRDLL, false) ||
-      CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_ADSPDLL, false))
+      CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_ADSPDLL, false) ||
+      CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_PERIPHERALDLL, false))
     return addon->OnDisabled();
 
   if (CAddonMgr::GetInstance().ServicesHasStarted())

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -109,6 +109,22 @@ void CPeripheralAddon::ResetProperties(void)
   m_apiVersion = ADDON::AddonVersion("0.0.0");
 }
 
+void CPeripheralAddon::OnDisabled()
+{
+  CAddon::OnDisabled();
+  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
+  if (addonBus)
+    addonBus->UpdateAddons();
+}
+
+void CPeripheralAddon::OnEnabled()
+{
+  CAddon::OnEnabled();
+  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
+  if (addonBus)
+    addonBus->UpdateAddons();
+}
+
 ADDON::AddonPtr CPeripheralAddon::GetRunningInstance(void) const
 {
   PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
@@ -119,6 +135,22 @@ ADDON::AddonPtr CPeripheralAddon::GetRunningInstance(void) const
       return peripheralAddon;
   }
   return CAddon::GetRunningInstance();
+}
+
+void CPeripheralAddon::OnPostInstall(bool update, bool modal)
+{
+  CAddon::OnPostInstall(update, modal);
+  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
+  if (addonBus)
+    addonBus->UpdateAddons();
+}
+
+void CPeripheralAddon::OnPostUnInstall()
+{
+  CAddon::OnPostUnInstall();
+  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
+  if (addonBus)
+    addonBus->UpdateAddons();
 }
 
 ADDON_STATUS CPeripheralAddon::CreateAddon(void)

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -53,7 +53,11 @@ namespace PERIPHERALS
     virtual ~CPeripheralAddon(void);
 
     // implementation of IAddon
+    virtual void OnDisabled() override;
+    virtual void OnEnabled() override;
     virtual ADDON::AddonPtr GetRunningInstance(void) const override;
+    virtual void OnPostInstall(bool update, bool modal) override;
+    virtual void OnPostUnInstall() override;
 
     /*!
      * @brief Initialise the instance of this add-on

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -40,6 +40,8 @@ namespace PERIPHERALS
     CPeripheralBusAddon(CPeripherals *manager);
     virtual ~CPeripheralBusAddon(void);
 
+    void UpdateAddons(void);
+
     /*!
      * \brief Get peripheral add-on by ID
      */
@@ -93,7 +95,6 @@ namespace PERIPHERALS
     virtual void UnregisterRemovedDevices(const PeripheralScanResults &results) override;
 
   private:
-    void UpdateAddons(void);
     void OnEvent(const ADDON::AddonEvent& event);
 
     PeripheralAddonVector m_addons;


### PR DESCRIPTION
Previously, if the joystick add-on was disabled, it would continue to run in the background. This fixes that.

Should we warn the user about disabling this add-on if controllers are connected, and then reenable the add-on if they decline? We do this with unknown sources, but the settings system makes this easy. The addon manager doesn't have a clean way to prevent a disable operation from happening, so this might require some heavier modifications.

Broken out from #10630
