### PR TITLE
Fix missing lock in CAddonButtonMap

### DIFF
--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -25,6 +25,7 @@
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/JoystickTypes.h"
 #include "peripherals/PeripheralTypes.h"
+#include "threads/CriticalSection.h"
 
 namespace PERIPHERALS
 {
@@ -104,5 +105,6 @@ namespace PERIPHERALS
     const std::string   m_strControllerId;
     FeatureMap          m_features;
     DriverMap           m_driverMap;
+    CCriticalSection    m_mutex;
   };
 }


### PR DESCRIPTION
This fixes a race condition I hit while pausing/resuming during debugging. peripheral.joystick was doing an extra refresh of the button map, which was fixed in https://github.com/kodi-game/peripheral.joystick/commit/f902039. This is the corresponding change needed in core to prevent other add-ons from crashing kodi.

Broken out from #10630
