### PR TITLE
Improved Mediacodec drain support

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/Splash.java.in
@@ -491,7 +491,7 @@ public class Splash extends Activity {
     sPackagePath = getPackageResourcePath();
     fPackagePath = new File(sPackagePath);
     String obbfn = "";
-    if (fPackagePath.length() < 40 * 1024 * 1024)
+    if (fPackagePath.length() < 50 * 1024 * 1024)
     {
       sPackagePath = System.getProperty("@APP_NAME@.obb", "");
       if (sPackagePath.equals(""))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -129,6 +129,7 @@ protected:
   bool            m_opened;
   bool            m_drop;
   int             m_codecControlFlags;
+  int             m_state;
 
   CJNISurface    *m_surface;
   unsigned int    m_textureId;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

Better support for codec draining in android mediacodec
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
