### PR TITLE
[cmake] Fix building main executable

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -336,7 +336,7 @@ else()
   add_dependencies(${APP_NAME_LC} export-files pack-skins)
 endif()
 whole_archive(_MAIN_LIBRARIES ${core_DEPENDS})
-target_link_libraries(${APP_NAME_LC} ${_MAIN_LIBRARIES} lib${APP_NAME_LC} ${SYSTEM_LDFLAGS} ${DEPLIBS} ${CMAKE_DL_LIBS})
+target_link_libraries(${APP_NAME_LC} ${_MAIN_LIBRARIES} lib${APP_NAME_LC})
 unset(_MAIN_LIBRARIES)
 
 if(WIN32)

--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -327,14 +327,11 @@ endif()
 # main binary
 if(NOT CORE_SYSTEM_NAME STREQUAL android)
   add_executable(${APP_NAME_LC} ${CORE_MAIN_SOURCE} "${RESOURCES}" ${OTHER_FILES})
-  add_dependencies(${APP_NAME_LC} ${APP_NAME_LC}-libraries export-files pack-skins)
 else()
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
   add_library(${APP_NAME_LC} SHARED ${CORE_MAIN_SOURCE} "${RESOURCES}" ${OTHER_FILES})
-  # The libraries depend on the main shared library for wrapping. Because of this we cannot build
-  # the libraries as a dependency. This requires to build the all target on android (and not only kodi).
-  add_dependencies(${APP_NAME_LC} export-files pack-skins)
 endif()
+add_dependencies(${APP_NAME_LC} ${APP_NAME_LC}-libraries export-files pack-skins)
 whole_archive(_MAIN_LIBRARIES ${core_DEPENDS})
 target_link_libraries(${APP_NAME_LC} ${_MAIN_LIBRARIES} lib${APP_NAME_LC})
 unset(_MAIN_LIBRARIES)

--- a/xbmc/cores/DllLoader/exports/CMakeLists.txt
+++ b/xbmc/cores/DllLoader/exports/CMakeLists.txt
@@ -22,7 +22,6 @@ elseif(NOT CORE_SYSTEM_NAME STREQUAL windows)
 
   if(CORE_SYSTEM_NAME STREQUAL android)
     add_custom_command(TARGET wrapper.def COMMAND echo \"-L${DEPENDS_PATH}/lib/dummy-lib${APP_NAME_LC} -l${APP_NAME_LC}\" >> wrapper.def)
-    add_dependencies(wrapper.def ${APP_NAME_LC})
   endif()
 
   set_target_properties(wrapper PROPERTIES FOLDER "Build Utilities")


### PR DESCRIPTION
- `make kodi` on android will be enough to compile libkodi.so and all shared libraries.
- Libs and dependencies are not added twice to the linker command.

build: http://jenkins.kodi.tv/view/Helpers/job/BuildMulti-All/1659/

pings: @wsnipex, @hudokkow 
