### PR TITLE
Fix controller input on the Shield if peripheral.joystick is not present

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -43,6 +43,24 @@ CPeripheralBus::CPeripheralBus(const std::string &threadname, CPeripherals *mana
 {
 }
 
+bool CPeripheralBus::InitializeProperties(CPeripheral* peripheral)
+{
+  if (peripheral == nullptr)
+    return false;
+
+  if (peripheral->Type() == PERIPHERAL_JOYSTICK)
+  {
+    // Ensure an add-on is present to translate input
+    if (!g_peripherals.GetInstance().GetAddonWithButtonMap(peripheral))
+    {
+      CLog::Log(LOGWARNING, "Button mapping add-on not present for %s (%s), skipping", peripheral->Location().c_str(), peripheral->DeviceName().c_str(), peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
+      return false;
+    }
+  }
+
+  return true;
+}
+
 void CPeripheralBus::OnDeviceAdded(const std::string &strLocation)
 {
   ScanForDevices();

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -59,7 +59,7 @@ namespace PERIPHERALS
     /*!
     * \brief Initialize the properties of a peripheral with a known location
     */
-    virtual bool InitializeProperties(CPeripheral* peripheral) { return true; }
+    virtual bool InitializeProperties(CPeripheral* peripheral);
 
     /*!
      * @brief Get the instance of the peripheral at the given location.

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
@@ -62,6 +62,9 @@ CPeripheralBusAndroid::~CPeripheralBusAndroid()
 
 bool CPeripheralBusAndroid::InitializeProperties(CPeripheral* peripheral)
 {
+  if (!CPeripheralBus::InitializeProperties(peripheral))
+    return false;
+
   if (peripheral == nullptr || peripheral->Type() != PERIPHERAL_JOYSTICK)
   {
     CLog::Log(LOGWARNING, "CPeripheralBusAndroid: unknown peripheral");

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -133,6 +133,9 @@ bool CPeripheralBusAddon::PerformDeviceScan(PeripheralScanResults &results)
 
 bool CPeripheralBusAddon::InitializeProperties(CPeripheral* peripheral)
 {
+  if (!CPeripheralBus::InitializeProperties(peripheral))
+    return false;
+
   bool bSuccess = false;
 
   PeripheralAddonPtr addon;


### PR DESCRIPTION
The shield controller sends keypresses when it hasn't been scanned by Kodi, so if no add-on is present to translate joystick input, skip the controller so that it continues sending somewhat-functional keypresses.

Broken out from #10630
