### PR TITLE
VideoPlayer: fix CDVDMessageQueue::WaitUntilEmpty

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -114,6 +114,7 @@ private:
 
   std::atomic<bool> m_bAbortRequest;
   bool m_bInitialized;
+  bool m_drain;
 
   int m_iDataSize;
   double m_TimeFront;


### PR DESCRIPTION
see title, this has been broken since ever but did not show because the entire sync did not work
