### PR TITLE
[python] Add xbmcgui.DialogBusy()

### DIFF
--- a/addons/skin.estuary/1080i/DialogBusy.xml
+++ b/addons/skin.estuary/1080i/DialogBusy.xml
@@ -50,6 +50,13 @@
 				<texture flipx="true" colordiffuse="button_focus">spinner.png</texture>
 				<animation effect="fade" end="100" time="300" delay="200">WindowOpen</animation>
 			</control>
+			<control type="progress" id="10">
+				<left>920</left>
+				<top>620</top>
+				<width>80</width>
+				<height>24</height>
+				<animation effect="fade" end="100" time="300" delay="200">WindowOpen</animation>
+			</control>
 		</control>
 	</controls>
 </window>

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -91,7 +91,7 @@ CGUIDialogBusy::CGUIDialogBusy(void)
 {
   m_loadType = LOAD_ON_GUI_INIT;
   m_bCanceled = false;
-  m_progress = 0;
+  m_progress = -1;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void)
@@ -102,7 +102,7 @@ void CGUIDialogBusy::Open_Internal(const std::string &param /* = "" */)
 {
   m_bCanceled = false;
   m_bLastVisible = true;
-  m_progress = 0;
+  m_progress = -1;
 
   CGUIDialog::Open_Internal(false, param);
 }
@@ -121,7 +121,7 @@ void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirty
   {
     CGUIProgressControl *progress = (CGUIProgressControl *)control;
     progress->SetPercentage(m_progress);
-    progress->SetVisible(m_progress > 0);
+    progress->SetVisible(m_progress > -1);
   }
 
   CGUIDialog::DoProcess(currentTime, dirtyregions);

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -46,7 +46,7 @@ void CGUIDialogProgress::Reset()
   m_iCurrent = 0;
   m_iMax = 0;
   m_percentage = 0;
-  m_showProgress = false;
+  m_showProgress = true;
   m_bCanCancel = true;
   SetInvalid();
 }
@@ -64,7 +64,7 @@ void CGUIDialogProgress::Open(const std::string &param /* = "" */)
 
   {
     CSingleLock lock(g_graphicsContext);
-    ShowProgressBar(false);
+    ShowProgressBar(true);
   }
   
   CGUIDialog::Open_Internal(false, param);

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -512,6 +512,61 @@ namespace XBMCAddon
       return dlg->IsCanceled();
     }
 
+    DialogBusy::~DialogBusy() { XBMC_TRACE; deallocating(); }
+
+    void DialogBusy::deallocating()
+    {
+      XBMC_TRACE;
+
+      if (dlg && open)
+      {
+        DelayedCallGuard dg;
+        dlg->Close();
+      }
+    }
+
+    void DialogBusy::create()
+    {
+      DelayedCallGuard dcguard(languageHook);
+      CGUIDialogBusy* pDialog = static_cast<CGUIDialogBusy*>(g_windowManager.GetWindow(WINDOW_DIALOG_BUSY));
+
+      if (pDialog == nullptr)
+        throw WindowException("Error: Window is NULL, this is not possible :-)");
+
+      dlg = pDialog;
+      open = true;
+
+      pDialog->Open();
+    }
+
+    void DialogBusy::update(int percent) const
+    {
+      DelayedCallGuard dcguard(languageHook);
+
+      if (dlg == nullptr)
+        throw WindowException("Dialog not created.");
+
+      if (percent >= -1 && percent <= 100)
+        dlg->SetProgress(percent);
+
+    }
+
+    void DialogBusy::close()
+    {
+      DelayedCallGuard dcguard(languageHook);
+      if (dlg == nullptr)
+        throw WindowException("Dialog not created.");
+      dlg->Close();
+      open = false;
+    }
+
+    bool DialogBusy::iscanceled() const
+    {
+      if (dlg == nullptr)
+        throw WindowException("Dialog not created.");
+      return dlg->IsCanceled();
+    }
+
     DialogProgressBG::~DialogProgressBG() { XBMC_TRACE; deallocating(); }
 
     void DialogProgressBG::deallocating()

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -29,6 +29,7 @@
 #include "ListItem.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
+#include "dialogs/GUIDialogBusy.h"
 
 #define INPUT_ALPHANUM        0
 #define INPUT_NUMERIC         1
@@ -654,7 +655,6 @@ namespace XBMCAddon
       /// @param line3          [opt] string or unicode - line #3 text.
       ///
       /// @note It is preferred to only use line1 as it is actually a multi-line text. In this case line2 and line3 must be omitted.
-      /// @note If percent == 0, the progressbar will be hidden.
       ///
       ///
       ///------------------------------------------------------------------------
@@ -721,6 +721,116 @@ namespace XBMCAddon
       bool iscanceled();
 #endif
     };
+
+    //@}
+
+    ///
+    /// \defgroup python_DialogBusy DialogBusy
+    /// \ingroup python_xbmcgui
+    /// @{
+    /// @brief <b>Kodi's busy dialog class</b>
+    ///
+    ///-----------------------------------------------------------------------
+    /// @python_v17 New class added.
+    ///
+    class DialogBusy : public AddonClass
+    {
+      CGUIDialogBusy* dlg;
+      bool open;
+
+    protected:
+      virtual void deallocating();
+
+    public:
+
+      DialogBusy() : dlg(NULL), open(false) {}
+      virtual ~DialogBusy();
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_DialogBusy
+      /// \python_func{ xbmcgui.DialogBusy().create() }
+      ///------------------------------------------------------------------------
+      ///
+      /// Create and show a busy dialog.
+      ///
+      /// @note Use update() to update the progressbar.
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v17 New method added
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// dialog = xbmcgui.DialogBusy()
+      /// dialog.create()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      create(...);
+#else
+      void create();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_DialogBusy
+      /// \python_func{ xbmcgui.DialogBusy().update(percent) }
+      ///------------------------------------------------------------------------
+      ///
+      /// Updates the busy dialog.
+      ///
+      /// @param percent        integer - percent complete. (-1:100)
+      ///
+      /// @note If percent == -1 (default), the progressbar will be hidden.
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v17 New method added
+      ///
+      update(...);
+#else
+      void update(int percent) const;
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_DialogBusy
+      /// \python_func{ xbmcgui.DialogBusy().close() }
+      ///------------------------------------------------------------------------
+      ///
+      /// Close the progress dialog.
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v17 New method added
+      ///
+      close(...);
+#else
+      void close();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_DialogBusy
+      /// \python_func{ xbmcgui.DialogBusy().iscanceled() }
+      ///------------------------------------------------------------------------
+      ///
+      /// Checks if busy dialog is canceled.
+      ///
+      /// @return True if the user pressed cancel.
+      ///
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v17 New method added
+      ///
+      iscanceled(...);
+#else
+      bool iscanceled() const;
+#endif
+    };
+
     //@}
 
     ///


### PR DESCRIPTION
## Description

Adds a new dialog class to the python interface.
## Motivation and Context

Lot of python scripters are making use of our busy dialog although there is no proper interface to do that. So their solution is to use executebuiltin("ActivateWindow(busydialog)") and executebuiltin("Dialog.Close(busydialog)") in order to open / close it, which feels very workaround-ish.
Because of that, I added busydialog handling to our xbmcgui class, with a similar interface as our progress dialog.
When doin this I also found out that our busydialog core code supports a progress bar. That one can be used via python as well now, and I also added one to estuary in a separate commit.
## How Has This Been Tested?

With some simple test scripts
## Screenshots (if appropriate):

![screenshot041](https://cloud.githubusercontent.com/assets/110931/19356998/fad906d2-916f-11e6-8b36-ee979095be74.png)
## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
