### PR TITLE
[xbmc][win32][fix] Disable minidump handler when running as a store package

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -469,11 +469,6 @@ bool CApplication::Create()
 #ifndef TARGET_POSIX
   //floating point precision to 24 bits (faster performance)
   _controlfp(_PC_24, _MCW_PC);
-
-  /* install win32 exception translator, win32 exceptions
-   * can now be caught using c++ try catch */
-  win32_exception::install_handler();
-
 #endif
 
   //! @todo - move to CPlatformXXX

--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -59,8 +59,11 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
     sprintf_s(ver, "%d.%d Git:%s", CCompileInfo::GetMajor(),
     CCompileInfo::GetMinor(), CCompileInfo::GetSCMID());
 
-  win32_exception::set_version(std::string(ver));
-  SetUnhandledExceptionFilter(CreateMiniDump);
+  if (win32_exception::ShouldHook())
+  {
+    win32_exception::set_version(std::string(ver));
+    SetUnhandledExceptionFilter(CreateMiniDump);
+  }
 
   // check if Kodi is already running
   std::string appName = CCompileInfo::GetAppName();

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -20,7 +20,6 @@
 
 #include <windows.h>
 #include <process.h>
-#include "threads/platform/win/Win32Exception.h"
 #include "platform/win32/WIN32Util.h"
 
 void CThread::SpawnThread(unsigned stacksize)
@@ -75,8 +74,6 @@ void CThread::SetThreadInfo()
   }
 
   CWIN32Util::SetThreadLocalLocale(true); // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122
-
-    win32_exception::install_handler();
 }
 
 ThreadIdentifier CThread::GetCurrentThreadId()
@@ -196,6 +193,4 @@ float CThread::GetRelativeUsage()
 
 void CThread::SetSignalHandlers()
 {
-  // install win32 exception translator
-  win32_exception::install_handler();
 }

--- a/xbmc/threads/platform/win/Win32Exception.h
+++ b/xbmc/threads/platform/win/Win32Exception.h
@@ -20,54 +20,20 @@
  *
  */
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
 #include <windows.h>
-#include <exception>
-#include "commons/Exception.h"
 
-class win32_exception: public XbmcCommons::UncheckedException
+class win32_exception
 {
 public:
     typedef const void* Address; // OK on Win32 platform
 
-    static void install_handler();
     static void set_version(std::string version) { mVersion = version; };
-    virtual const char* what() const { return mWhat; };
-    Address where() const { return mWhere; };
-    unsigned code() const { return mCode; };
-    virtual void LogThrowMessage(const char *prefix) const;
     static bool write_minidump(EXCEPTION_POINTERS* pEp);
     static bool write_stacktrace(EXCEPTION_POINTERS* pEp);
-protected:
-    win32_exception(EXCEPTION_POINTERS*, const char* classname = NULL);
-    static void translate(unsigned code, EXCEPTION_POINTERS* info);
-
-    inline bool write_minidump() const { return write_minidump(mExceptionPointers); };
-    inline bool write_stacktrace() const { return write_stacktrace(mExceptionPointers); };
+    static bool ShouldHook();
 private:
-    const char* mWhat;
-    Address mWhere;
-    unsigned mCode;
-    EXCEPTION_POINTERS *mExceptionPointers;
     static std::string mVersion;
-};
-
-class access_violation: public win32_exception
-{
-  enum access_type
-  {
-    Invalid,
-    Read,
-    Write,
-    DEP
-  };
-
-public:
-    Address address() const { return mBadAddress; };
-    virtual void LogThrowMessage(const char *prefix) const;
-protected:
-    friend void win32_exception::translate(unsigned code, EXCEPTION_POINTERS* info);
-private:
-    access_type mAccessType;
-    Address mBadAddress;
-    access_violation(EXCEPTION_POINTERS* info);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

<!--- Describe your change in detail -->

Remove some win32 exception handling code that wasn't used
or disabled because of compile flags and not really needed.

Stop using CCharsetConverter when handling a crash as
reporting shows we often crash there.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

Get better crash reporting
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
