### PR TITLE
[cmake] Fix build_addon() macro

### DIFF
--- a/project/cmake/scripts/common/AddonHelpers.cmake
+++ b/project/cmake/scripts/common/AddonHelpers.cmake
@@ -37,7 +37,7 @@ macro (build_addon target prefix libs)
   addon_version(${target} ${prefix})
   if(${prefix}_SOURCES)
     add_library(${target} ${${prefix}_SOURCES})
-    TARGET_link_libraries(${target} ${${libs}})
+    target_link_libraries(${target} ${${libs}})
     set_target_properties(${target} PROPERTIES VERSION ${${prefix}_VERSION}
                                                SOVERSION ${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}
                                                PREFIX "")
@@ -46,8 +46,6 @@ macro (build_addon target prefix libs)
     endif()
   elseif(${prefix}_CUSTOM_BINARY)
     add_custom_target(${target} ALL)
-    list(GET ${prefix}_CUSTOM_BINARY 2 dependency)
-    add_dependencies(${target} ${dependency})
   endif()
 
   # get the library's location


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

Fix build_addon() in AddonHelpers.cmake
## Description

<!--- Describe your change in detail -->

While [cleaning up / modernizing](https://github.com/hudokkow/game.libretro.2048/commit/5920ca3ed2fb93bde7e600efef38b72ac6fbf06f) CMake stuff on game add-ons, I hit an weird error.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

It didn't work the way it's supposed to?
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

Hardly.
Add-ons still build with whatever minimum version they require (usually 2.6 or 2.8) - > http://jenkins.kodi.tv/view/Helpers/job/BuildMulti-All/1662/ and with version 3.1 -> http://jenkins.kodi.tv/job/LINUX-64/9093/
## Screenshots (if appropriate):

Want pretty pics? Press [this](http://lmgtfy.com/?q=beautiful+landscapes)
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

As soon as I bumped `cmake_minimum_required()` from 2.6 to 3.1 (for reference, the problem manifests if CMake version >= 3.0), I was greeted with a nice error: 

> CMake Error at /home/hudo/dev/gamews/build_2048/build/depends/lib/kodi/AddonHelpers.cmake:50 (add_dependencies):
>   The dependency target "2048" of target "game.libretro.2048" does not exist.
- This affects only game.\* add-ons. They are the only ones using `elseif(${prefix}_CUSTOM_BINARY)`code path.
- I still can't understand how `add_dependencies()` worked with lower CMake versions and it doesn't with >= 3.0. Perhaps it was ignored and some CMake policy change from 2.9 to 3.0 caused the call to `add_dependencies()` to get noticed.

Thoughts?
ping @fetzerch, @wsnipex, @Montellese, @notspiff 
