### PR TITLE
[addons] improve safety of installing/uninstalling addon files

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -840,6 +840,8 @@
 		DF1D2DF11B6E85EE002BB9DB /* XbtFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1D2DE91B6E85EE002BB9DB /* XbtFile.cpp */; };
 		DF1D2DF31B6E85EE002BB9DB /* XbtManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1D2DEB1B6E85EE002BB9DB /* XbtManager.cpp */; };
 		DF1D2DF41B6E85EE002BB9DB /* XbtManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF1D2DEB1B6E85EE002BB9DB /* XbtManager.cpp */; };
+		DF209C121DB2A0C300515D1F /* FilesystemInstaller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF209C101DB2A0C200515D1F /* FilesystemInstaller.cpp */; };
+		DF209C131DB2A0D400515D1F /* FilesystemInstaller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF209C101DB2A0C200515D1F /* FilesystemInstaller.cpp */; };
 		DF2345E115FA639500A934F6 /* UPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF2345D915FA639500A934F6 /* UPnP.cpp */; settings = {COMPILER_FLAGS = "-I$SRCROOT/lib/libUPnP -I$SRCROOT/lib/libUPnP/Neptune/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Platinum  -I$SRCROOT/lib/libUPnP/Platinum/Source/Extras -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaServer -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaConnect -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaRenderer"; }; };
 		DF2345E215FA639500A934F6 /* UPnPInternal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF2345DB15FA639500A934F6 /* UPnPInternal.cpp */; settings = {COMPILER_FLAGS = "-I$SRCROOT/lib/libUPnP -I$SRCROOT/lib/libUPnP/Neptune/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Platinum  -I$SRCROOT/lib/libUPnP/Platinum/Source/Extras -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaServer -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaConnect -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaRenderer"; }; };
 		DF2345E315FA639500A934F6 /* UPnPRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF2345DD15FA639500A934F6 /* UPnPRenderer.cpp */; settings = {COMPILER_FLAGS = "-I$SRCROOT/lib/libUPnP -I$SRCROOT/lib/libUPnP/Neptune/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Core -I$SRCROOT/lib/libUPnP/Platinum/Source/Platinum  -I$SRCROOT/lib/libUPnP/Platinum/Source/Extras -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaServer -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaConnect -I$SRCROOT/lib/libUPnP/Platinum/Source/Devices/MediaRenderer"; }; };
@@ -3723,6 +3725,8 @@
 		DF1D2DEA1B6E85EE002BB9DB /* XbtFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XbtFile.h; sourceTree = "<group>"; };
 		DF1D2DEB1B6E85EE002BB9DB /* XbtManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XbtManager.cpp; sourceTree = "<group>"; };
 		DF1D2DEC1B6E85EE002BB9DB /* XbtManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XbtManager.h; sourceTree = "<group>"; };
+		DF209C101DB2A0C200515D1F /* FilesystemInstaller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FilesystemInstaller.cpp; sourceTree = "<group>"; };
+		DF209C111DB2A0C300515D1F /* FilesystemInstaller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FilesystemInstaller.h; sourceTree = "<group>"; };
 		DF2345D915FA639500A934F6 /* UPnP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UPnP.cpp; sourceTree = "<group>"; };
 		DF2345DA15FA639500A934F6 /* UPnP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UPnP.h; sourceTree = "<group>"; };
 		DF2345DB15FA639500A934F6 /* UPnPInternal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UPnPInternal.cpp; sourceTree = "<group>"; };
@@ -5184,6 +5188,8 @@
 				9A2FAD681C972BE10049652A /* ContextMenus.cpp */,
 				9A2FAD691C972BE10049652A /* ContextMenus.h */,
 				18B49FF61152BFA5001AF8A6 /* DllAddon.h */,
+				DF209C101DB2A0C200515D1F /* FilesystemInstaller.cpp */,
+				DF209C111DB2A0C300515D1F /* FilesystemInstaller.h */,
 				18B7C38612942090009E7A26 /* GUIDialogAddonInfo.cpp */,
 				18B7C38712942090009E7A26 /* GUIDialogAddonInfo.h */,
 				18B7C8F912942718009E7A26 /* GUIDialogAddonSettings.cpp */,
@@ -10270,6 +10276,7 @@
 				18B7C7C11294222E009E7A26 /* GUIFontManager.cpp in Sources */,
 				18B7C7C21294222E009E7A26 /* GUIFontTTF.cpp in Sources */,
 				18B7C7C31294222E009E7A26 /* GUIFontTTFDX.cpp in Sources */,
+				DF209C121DB2A0C300515D1F /* FilesystemInstaller.cpp in Sources */,
 				18B7C7C41294222E009E7A26 /* GUIFontTTFGL.cpp in Sources */,
 				18B7C7C51294222E009E7A26 /* GUIImage.cpp in Sources */,
 				18B7C7C61294222E009E7A26 /* GUIIncludes.cpp in Sources */,
@@ -11308,6 +11315,7 @@
 				395897161AAD94F00033D27C /* KeyboardLayoutManager.cpp in Sources */,
 				395C2A251AA4C32100EBC7AD /* AudioDecoder.cpp in Sources */,
 				E499130C174E5DAD00741B6D /* GUIRSSControl.cpp in Sources */,
+				DF209C131DB2A0D400515D1F /* FilesystemInstaller.cpp in Sources */,
 				E499130D174E5DAD00741B6D /* GUIScrollBarControl.cpp in Sources */,
 				E499130F174E5DAD00741B6D /* GUISettingsSliderControl.cpp in Sources */,
 				E4991310174E5DAD00741B6D /* GUIShader.cpp in Sources */,

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -178,11 +178,6 @@ private:
   bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 
-  /*! \brief Delete an addon following install failure
-   \param addonFolder - the folder to delete
-   */
-  bool DeleteAddon(const std::string &addonFolder);
-
   bool DoFileOperation(FileAction action, CFileItemList &items, const std::string &file, bool useSameJob = true);
 
   /*! \brief Queue a notification for addon installation/update failure
@@ -206,11 +201,6 @@ public:
   virtual bool DoWork();
 
 private:
-  /*! \brief Delete an addon following install failure
-   \param addonFolder - the folder to delete
-   */
-  bool DeleteAddon(const std::string &addonFolder);
-
   void ClearFavourites();
 
   ADDON::AddonPtr m_addon;

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES Addon.cpp
             AudioEncoder.cpp
             ContextMenuAddon.cpp
             ContextMenus.cpp
+            FilesystemInstaller.cpp
             GUIDialogAddonInfo.cpp
             GUIDialogAddonSettings.cpp
             GUIViewStateAddonBrowser.cpp
@@ -49,6 +50,7 @@ set(HEADERS Addon.h
             DllAudioDSP.h
             DllLibCPluff.h
             DllPVRClient.h
+            FilesystemInstaller.h
             GUIDialogAddonInfo.h
             GUIDialogAddonSettings.h
             GUIViewStateAddonBrowser.h

--- a/xbmc/addons/FilesystemInstaller.cpp
+++ b/xbmc/addons/FilesystemInstaller.cpp
@@ -1,0 +1,114 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "FilesystemInstaller.h"
+#include "FileItem.h"
+#include "filesystem/Directory.h"
+#include "filesystem/SpecialProtocol.h"
+#include "utils/log.h"
+#include "utils/FileOperationJob.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+using namespace XFILE;
+
+CFilesystemInstaller::CFilesystemInstaller()
+{
+  m_addonFolder = CSpecialProtocol::TranslatePath("special://home/addons/");
+  m_tempFolder = CSpecialProtocol::TranslatePath("special://home/temp/");
+}
+
+bool CFilesystemInstaller::InstallToFilesystem(const std::string& archive, const std::string& addonId)
+{
+  auto addonFolder = URIUtils::AddFileToFolder(m_addonFolder, addonId);
+  auto newAddonData = URIUtils::AddFileToFolder(m_tempFolder, StringUtils::CreateUUID());
+  auto oldAddonData = URIUtils::AddFileToFolder(m_tempFolder, StringUtils::CreateUUID());
+
+  if (!UnpackArchive(archive, newAddonData))
+  {
+    CLog::Log(LOGERROR, "Failed to unpack archive '%s' to '%s'", archive.c_str(), newAddonData.c_str());
+    return false;
+  }
+
+  bool hasOldData = CDirectory::Exists(addonFolder);
+  if (hasOldData)
+  {
+    if (!CFile::Rename(addonFolder, oldAddonData))
+    {
+      CLog::Log(LOGERROR, "Failed to move old addon files from '%s' to '%s'", addonFolder.c_str(), oldAddonData.c_str());
+      return false;
+    }
+  }
+
+  if (!CFile::Rename(newAddonData, addonFolder))
+  {
+    CLog::Log(LOGERROR, "Failed to move new addon files from '%s' to '%s'", newAddonData.c_str(), addonFolder.c_str());
+    return false;
+  }
+
+  if (hasOldData)
+  {
+    if (!CDirectory::RemoveRecursive(oldAddonData))
+    {
+      CLog::Log(LOGWARNING, "Failed to delete old addon files in '%s'", oldAddonData.c_str());
+    }
+  }
+  return true;
+}
+
+bool CFilesystemInstaller::UnInstallFromFilesystem(const std::string& addonFolder)
+{
+  auto tempFolder = URIUtils::AddFileToFolder(m_tempFolder, StringUtils::CreateUUID());
+  if (!CFile::Rename(addonFolder, tempFolder))
+  {
+    CLog::Log(LOGERROR, "Failed to move old addon files from '%s' to '%s'", addonFolder.c_str(), tempFolder.c_str());
+    return false;
+  }
+
+  if (!CDirectory::RemoveRecursive(tempFolder))
+  {
+    CLog::Log(LOGWARNING, "Failed to delete old addon files in '%s'", tempFolder.c_str());
+  }
+  return true;
+}
+
+bool CFilesystemInstaller::UnpackArchive(std::string path, const std::string& dest)
+{
+  if (!URIUtils::IsProtocol(path, "zip"))
+    path = URIUtils::CreateArchivePath("zip", CURL(path), "").Get();
+
+  CFileItemList files;
+  if (!CDirectory::GetDirectory(path, files))
+    return false;
+
+  if (files.Size() == 1 && files[0]->m_bIsFolder)
+  {
+    path = files[0]->GetPath();
+    files.Clear();
+    if (!CDirectory::GetDirectory(path, files))
+      return false;
+  }
+  CLog::Log(LOGDEBUG, "Unpacking %s to %s", path.c_str(), dest.c_str());
+
+  for (auto i = 0; i < files.Size(); ++i)
+    files[i]->Select(true);
+
+  CFileOperationJob job(CFileOperationJob::ActionCopy, files, dest);
+  return job.DoWork();
+}

--- a/xbmc/addons/FilesystemInstaller.h
+++ b/xbmc/addons/FilesystemInstaller.h
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+
+/*!
+ * Responsible for safely unpacking/copying/removing addon files from/to the addon folder.
+ */
+class CFilesystemInstaller
+{
+public:
+
+  CFilesystemInstaller();
+
+  /*!
+   * @param archive Absolute path to zip file to install.
+   * @param addonId
+   * @return true on success, otherwise false.
+   */
+  bool InstallToFilesystem(const std::string& archive, const std::string& addonId);
+
+  bool UnInstallFromFilesystem(const std::string& addonPath);
+
+private:
+  static bool UnpackArchive(std::string path, const std::string& dest);
+
+  std::string m_addonFolder;
+  std::string m_tempFolder;
+};

--- a/xbmc/addons/Makefile
+++ b/xbmc/addons/Makefile
@@ -11,6 +11,7 @@ SRCS=Addon.cpp \
      ContextMenuAddon.cpp \
      ContextMenus.cpp \
      AudioDecoder.cpp \
+     FilesystemInstaller.cpp \
      GUIDialogAddonInfo.cpp \
      GUIDialogAddonSettings.cpp \
      GUIViewStateAddonBrowser.cpp \

--- a/xbmc/filesystem/posix/PosixDirectory.cpp
+++ b/xbmc/filesystem/posix/PosixDirectory.cpp
@@ -128,8 +128,9 @@ bool CPosixDirectory::Remove(const CURL& url)
 
   return !Exists(url);
 }
- bool CPosixDirectory::RemoveRecursive(const CURL& url)
- {
+
+bool CPosixDirectory::RemoveRecursive(const CURL& url)
+{
   std::string root = url.Get();
 
   if (IsAliasShortcut(root, true))
@@ -166,8 +167,6 @@ bool CPosixDirectory::Remove(const CURL& url)
     {
       if (!RemoveRecursive(CURL{ itemPath }))
         return false;
-      if (rmdir(itemPath.c_str()) != 0)
-        return false;
     }
     else
     {
@@ -175,9 +174,14 @@ bool CPosixDirectory::Remove(const CURL& url)
         return false;
     }
   }
+
   closedir(dir);
+
+  if (rmdir(root.c_str()) != 0)
+   return false;
+
   return true;
- }
+}
 
 bool CPosixDirectory::Exists(const CURL& url)
 {

--- a/xbmc/filesystem/win32/Win32Directory.cpp
+++ b/xbmc/filesystem/win32/Win32Directory.cpp
@@ -223,12 +223,6 @@ bool CWin32Directory::RemoveRecursive(const CURL& url)
         success = false;
         break;
       }
-
-      if (FALSE == RemoveDirectoryW(pathW.c_str()))
-      {
-        success = false;
-        break;
-      }
     }
     else
     {
@@ -241,6 +235,12 @@ bool CWin32Directory::RemoveRecursive(const CURL& url)
   } while (FindNextFileW(hSearch, &findData));
 
   FindClose(hSearch);
+
+  if (success)
+  {
+    if (FALSE == RemoveDirectoryW(basePath.c_str()))
+      success = false;
+  }
 
   return success;
 }


### PR DESCRIPTION
This change should ensure that addons are either completely installed to the file system, or not installed if something fails, not leaving any partially installed/removed files.

Unlike the current procedure which just copies files one-by-one over the existing folder _praying_ everything goes ok.

Also includes some fixes to RemoveRecursive.

cc @Paxxi 
