### PR TITLE
configure: fix aarch64 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -626,9 +626,13 @@ case $host in
      ARCH="aarch64"
      use_arch="aarch64"
      use_neon=yes
-     use_gles=yes
-     use_gl=no
-     use_wayland=no
+     # Check whether --enable-gl was given.
+     if test "${enable_gl+set}" = set; then :
+       enableval=$enable_gl; use_gl=$enableval
+     else
+       use_gl=no
+       use_gles=yes
+     fi
      USE_STATIC_FFMPEG=1
      ;;
   arm*-*linux-android*)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

Just like x86\* aarch64 has platforms that can be full openGL and/or full openGLES. In the case of mesa/freedreno on Qualcomm SoCs, building against GLES will fail, but full GL works.

So stop hardcoding GL/GLES/Wayland and let honour the --enable-gl flags passed to configure.
## Motivation and Context

After running into Keith and @MartijnKaijser last week I wanted to switch from Jarvis to Krypton on my Dragonboard-410c to test the ffmpeg-v4l2 patches. It didn't build, so I tracked the failure down to the point where I replaced the aarch64 patch I wrote with the upstream one.
## How Has This Been Tested?

Configure now does the right thing now:

```
------------------------
  Kodi Configuration:
------------------------
  Kodi Version: 17.0-BETA4
  git Rev.: 20161015-2f143a8
  Debugging:    Yes
  Profiling:    No
  Optimization: Yes
  SWIG Available:   Yes
  JRE Available:    Yes
  Doxygen Available:    No
  Crosscomp.:   Yes
  target ARCH:  aarch64
  target CPU:   
  OpenGL:   Yes
```

Compilation succeeds, and it runs, see screenshot below.
## Screenshots (if appropriate):

![img_7394](https://cloud.githubusercontent.com/assets/259525/19415599/06b851ea-9375-11e6-9360-24be9a0597e9.JPG)
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I'm not 100% sure this is non-breaking change, but Libreelec always sets the appropriate --enable-opengl/gles, so they won't see breakage.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
