### PR TITLE
Fix Music Standard Roles Nodes

### DIFF
--- a/system/library/music/musicroles/Arrangers.xml
+++ b/system/library/music/musicroles/Arrangers.xml
@@ -2,5 +2,5 @@
 <node order="5" type="folder" visible="Library.HasContent(Role, Arranger)">
 	<label>29988</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Arranger</path>
+	<path>musicdb://artists/?role=Arranger&albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Composers.xml
+++ b/system/library/music/musicroles/Composers.xml
@@ -2,5 +2,5 @@
 <node order="1" type="folder" visible="Library.HasContent(Role, Composer)">
 	<label>29989</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Composer</path>
+	<path>musicdb://artists/?role=Composer&albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Conductors.xml
+++ b/system/library/music/musicroles/Conductors.xml
@@ -2,5 +2,5 @@
 <node order="2" type="folder" visible="Library.HasContent(Role, Conductor)">
 	<label>29990</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Conductor</path>
+	<path>musicdb://artists/?role=Conductor&albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/DJMixers.xml
+++ b/system/library/music/musicroles/DJMixers.xml
@@ -2,5 +2,5 @@
 <node order="6" type="folder" visible="Library.HasContent(Role, DJMixer)">
 	<label>29991</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=DJMixer</path>
+	<path>musicdb://artists/?role=DJMixer&albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Lyricists.xml
+++ b/system/library/music/musicroles/Lyricists.xml
@@ -2,5 +2,5 @@
 <node order="4" type="folder" visible="Library.HasContent(Role, Lyricist)">
 	<label>29992</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Lyricist</path>
+	<path>musicdb://artists/?role=Lyricist&albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Orchestras.xml
+++ b/system/library/music/musicroles/Orchestras.xml
@@ -2,5 +2,5 @@
 <node order="3" type="folder" visible="Library.HasContent(Role, Orchestra)">
 	<label>29993</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Orchestra</path>
+	<path>musicdb://artists/?role=Orchestra&albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Remixers.xml
+++ b/system/library/music/musicroles/Remixers.xml
@@ -2,5 +2,5 @@
 <node order="7" type="folder" visible="Library.HasContent(Role, Remixer)">
 	<label>29987</label>
         <icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Remixer</path>
+	<path>musicdb://artists/?role=Remixer&albumartistsonly=false</path>
 </node>


### PR DESCRIPTION
For the standard roles nodes (for composers, conductors, arrangers, DJ mixers, lyricists, orchestras and remixers) set option albumartistsonly=false, so that all artists with the role are shown not just those that are also album artists.

It was pointed out that if users have the "show song and album artists" setting disabled then the standard roles nodes for  composers, conductors, arrangers, DJ mixers, lyricists, orchestras and remixers will often display blank because they are limited to artists that are also album artists.  Better default behavior is for these to be independant of the album artist only setting, although users can easily create nodes to show only album artists with that role.
