### PR TITLE
[estuary] grey text on focused item == unreadable

### DIFF
--- a/addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+++ b/addons/skin.estuary/1080i/DialogPVRChannelManager.xml
@@ -123,7 +123,6 @@
 						<height>30</height>
 						<font>font10</font>
 						<aligny>center</aligny>
-						<textcolor>grey</textcolor>
 						<label>$LOCALIZE[19210]: $INFO[ListItem.Property(ClientName)]</label>
 					</control>
 				</focusedlayout>

--- a/addons/skin.estuary/1080i/SettingsProfile.xml
+++ b/addons/skin.estuary/1080i/SettingsProfile.xml
@@ -170,7 +170,6 @@
 						<top>275</top>
 						<width>305</width>
 						<height>100</height>
-						<textcolor>grey</textcolor>
 						<font>font10</font>
 						<align>center</align>
 						<aligny>top</aligny>
@@ -182,7 +181,6 @@
 						<width>305</width>
 						<height>100</height>
 						<font>font10</font>
-						<textcolor>grey</textcolor>
 						<align>center</align>
 						<aligny>top</aligny>
 						<label fallback="13170">$INFO[ListItem.Label2]</label>


### PR DESCRIPTION
grey text against a blue background is hardly readable, use white instead.

@phil65 
