### PR TITLE
[PVR] Fix search window update

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -33,6 +33,7 @@
 #include "epg/Epg.h"
 #include "epg/GUIEPGGridContainer.h"
 #include "filesystem/StackDirectory.h"
+#include "GUIUserMessages.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
@@ -227,6 +228,21 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
         UpdateSelectedItemPath();
       }
       bReturn = true;
+    }
+    break;
+
+    case GUI_MSG_NOTIFY_ALL:
+    {
+      switch (message.GetParam1())
+      {
+        case GUI_MSG_UPDATE_SOURCES:
+        {
+          // removable drive connected/disconnected. base class triggers a window
+          // content refresh, which makes no sense for pvr windows.
+          bReturn = true;
+          break;
+        }
+      }
     }
     break;
   }

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -169,8 +169,6 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
 
   if (m_bSearchConfirmed)
   {
-    m_bSearchConfirmed = false;
-
     bAddSpecialSearchItem = true;
 
     items.Clear();


### PR DESCRIPTION
The problem:
- open pvr search window, click "Search...", enter some search string, search
  => search dialog closes, progress dialog appears, progress dialog closes, search window fills with search results
- now, plug in a usb stick (yeah, no kidding)
  => Bug: all search results disappear from search window

Background/cause: plugging in a usb stick triggers an update of the pvr search window. where first update works fine, any subsequent update erases search results due to wrong reset of <code>m_bSearchConfirmed</code> during search window content update in <code>OnPrepareFileItems</code>.

The second commit introduces to ignore the window message sent upon plugging/unplugging removable media as it makes no sense to update pvr search window content in this case. Nevertheless, the first commit is still needed to ensure proper updates (not erasing the search results) triggered by other window messages/actions.

@xhaggi for review?
