### PR TITLE
ActiveAESink: Allow sending of plain zeros

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15804,8 +15804,20 @@ msgctxt "#34111"
 msgid "Select the behaviour when no sound is required for either playback or GUI sounds.[CR][Always] Continuous inaudible signal is output, this keeps the receiving audio device alive for any new sounds, however this might also block sound from other applications.[CR][1-10 Minutes] Same as [Always] except that after the selected period of time audio enters a suspended state.[CR][Off] Audio output enters a suspended state. Note: Sounds can be missed if audio enters suspended state."
 msgstr ""
 
-#empty strings from id 34112 to 34119
-#34112-34119 reserved for future use
+#. Indicates if Audio Engine should transmit noise or real silence
+#: system/settings/settings.xml
+msgctxt "#34112"
+msgid "Send low volume noise"
+msgstr ""
+
+#. Description of setting with label #34112 "Send low volume noise"
+#: system/settings/settings.xml
+msgctxt "#34113"
+msgid "To keep certain AVRs powered we send an inaudible random noise signal. You can disable this setting if you are using headphone or analog output."
+msgstr ""
+
+#empty strings from id 34114 to 34119
+#34114-34119 reserved for future use
 
 #: system/settings/settings.xml
 msgctxt "#34120"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2410,6 +2410,11 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="audiooutput.streamnoise" type="boolean" label="34112" help="34113">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2" label="15108">
         <setting id="audiooutput.guisoundmode" type="integer" label="34120" help="36373">

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -72,6 +72,8 @@ struct AudioSettings
   unsigned int samplerate;
   AEQuality resampleQuality;
   double atempoThreshold;
+  bool streamNoise;
+  int silenceTimeout;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -63,6 +63,8 @@ public:
     VOLUME,
     FLUSH,
     TIMEOUT,
+    SETSILENCETIMEOUT,
+    SETNOISETYPE,
   };
   enum InSignal
   {
@@ -123,6 +125,7 @@ protected:
   int m_state;
   bool m_bStateMachineSelfTrigger;
   int m_extTimeout;
+  int m_silenceTimeOut;
   bool m_extError;
   unsigned int m_extSilenceTimeout;
   bool m_extAppFocused;
@@ -148,6 +151,7 @@ protected:
   int m_sinkLatency;
   CAEBitstreamPacker *m_packer;
   bool m_needIecPack;
+  bool m_streamNoise;
 };
 
 }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -357,6 +357,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME = "audio
 const std::string CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY = "audiooutput.processquality";
 const std::string CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD = "audiooutput.atempothreshold";
 const std::string CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE = "audiooutput.streamsilence";
+const std::string CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE = "audiooutput.streamnoise";
 const std::string CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED = "audiooutput.dspaddonsenabled";
 const std::string CSettings::SETTING_AUDIOOUTPUT_DSPSETTINGS = "audiooutput.dspsettings";
 const std::string CSettings::SETTING_AUDIOOUTPUT_DSPRESETDB = "audiooutput.dspresetdb";
@@ -1077,6 +1078,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
+  settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_MAINTAINORIGINALVOLUME);
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_DSPADDONSENABLED);
   settingSet.insert(CSettings::SETTING_LOOKANDFEEL_SKIN);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -314,6 +314,7 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_PROCESSQUALITY;
   static const std::string SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD;
   static const std::string SETTING_AUDIOOUTPUT_STREAMSILENCE;
+  static const std::string SETTING_AUDIOOUTPUT_STREAMNOISE;
   static const std::string SETTING_AUDIOOUTPUT_DSPADDONSENABLED;
   static const std::string SETTING_AUDIOOUTPUT_DSPSETTINGS;
   static const std::string SETTING_AUDIOOUTPUT_DSPRESETDB;


### PR DESCRIPTION
This gives the advanced possibility to stream zeros instead of noise. That won't keep AVRs alive anymore, but on Analog / Heaphones there is no need to hammer random noise on the sink.

Background: The noise was just made fool AVRs to not go off while we are idleing.
