### PR TITLE
Fix mapping controllers with accelerometers

### DIFF
--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -53,6 +53,7 @@ namespace GAME
     // implementation of IButtonMapper
     virtual std::string ControllerID(void) const override { return m_strControllerId; }
     virtual bool MapPrimitive(JOYSTICK::IButtonMap* buttonMap, const JOYSTICK::CDriverPrimitive& primitive) override;
+    virtual int MappingDurationMs(void) const override;
 
     // implementation of IKeyboardHandler
     virtual bool OnKeyPress(const CKey& key) override;
@@ -79,6 +80,7 @@ namespace GAME
     IFeatureButton*                      m_currentButton;
     JOYSTICK::ANALOG_STICK_DIRECTION     m_currentDirection;
     std::set<JOYSTICK::CDriverPrimitive> m_history; // History to avoid repeated features
+    unsigned int                         m_startTimeMs; // The start time, or 0 if not currently mapping
     CCriticalSection                     m_stateMutex;
 
     // Synchronization event

--- a/xbmc/input/joysticks/IButtonMapper.h
+++ b/xbmc/input/joysticks/IButtonMapper.h
@@ -59,6 +59,14 @@ namespace JOYSTICK
      */
     virtual bool MapPrimitive(IButtonMap* buttonMap, const CDriverPrimitive& primitive) = 0;
 
+    /*!
+     * \brief Get the duration for which this mapper has been accepting input
+     *        for mapping buttons
+     *
+     * \return The duration, in ms, or -1 if this mapper is not mapping buttons
+     */
+    virtual int MappingDurationMs(void) const = 0;
+
     // Button map callback interface
     void SetButtonMapCallback(IButtonMapCallback* callback) { m_callback = callback; }
     void ResetButtonMapCallback(void) { m_callback = nullptr; }

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -68,6 +68,7 @@ namespace JOYSTICK
     void Activate(const CDriverPrimitive& semiAxis);
     void Deactivate(const CDriverPrimitive& semiAxis);
     bool IsActive(const CDriverPrimitive& semiAxis);
+    bool IsStuck(const CDriverPrimitive& semiAxis);
 
     IButtonMapper* const m_buttonMapper;
     IButtonMap* const    m_buttonMap;
@@ -79,6 +80,7 @@ namespace JOYSTICK
     };
 
     std::vector<ActivatedAxis> m_activatedAxes;
+    std::vector<CDriverPrimitive> m_stuckAxes;
     unsigned int               m_lastAction;
   };
 }


### PR DESCRIPTION
If a controller has an accelerometer, when the user goes to map a button, the configuration wizard will immediately skip to the next button. This is because the Z axis is "activated", so Kodi thinks the user is trying to map this axis to the button.

The fix is to wait 50ms when the user starts mapping buttons. If an axis is activated, then it is ignored until deactivated again. This means that as long as the controller stays upright, the accelerometer shouldn't get in the way anymore.

Only tested with a faked accelerometer so far, I'm in the process of getting a controller that has a physical one.

Broken out from #10630