### PR TITLE
Fix deadlock introduced by #10690

### DIFF
--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -375,16 +375,16 @@ void CPeripheralBusAddon::UpdateAddons(void)
   std::set<std::string> added;
   std::set<std::string> removed;
 
+  // Get new add-ons
+  VECADDONS newAddons;
+  CAddonMgr::GetInstance().GetAddons(newAddons, ADDON_PERIPHERALDLL);
+  std::transform(newAddons.begin(), newAddons.end(), std::inserter(newIds, newIds.end()), GetAddonID);
+
   CSingleLock lock(m_critSection);
 
   // Get current add-ons
   std::transform(m_addons.begin(), m_addons.end(), std::inserter(currentIds, currentIds.end()), GetPeripheralAddonID);
   std::transform(m_failedAddons.begin(), m_failedAddons.end(), std::inserter(currentIds, currentIds.end()), GetPeripheralAddonID);
-
-  // Get new add-ons
-  VECADDONS newAddons;
-  CAddonMgr::GetInstance().GetAddons(newAddons, ADDON_PERIPHERALDLL);
-  std::transform(newAddons.begin(), newAddons.end(), std::inserter(newIds, newIds.end()), GetAddonID);
 
   // Differences
   std::set_difference(newIds.begin(), newIds.end(), currentIds.begin(), currentIds.end(), std::inserter(added, added.end()));


### PR DESCRIPTION
This fixes a possible deadlock by querying the add-on database before acquiring the lock.
