### PR TITLE
disable debug in depends in Release builds

### DIFF
--- a/tools/buildsteps/android-arm64-v8a/configure-depends
+++ b/tools/buildsteps/android-arm64-v8a/configure-depends
@@ -17,5 +17,5 @@ then
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
     --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT \
-    --enable-neon
+    --enable-neon $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -17,5 +17,5 @@ then
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
     --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT \
-    --enable-neon
+    --enable-neon $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/androidx86/configure-depends
+++ b/tools/buildsteps/androidx86/configure-depends
@@ -16,5 +16,5 @@ then
     --with-ndk=$NDK_PATH \
     $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
     --with-toolchain=$TOOLCHAIN \
-    --prefix=$XBMC_DEPENDS_ROOT
+    --prefix=$XBMC_DEPENDS_ROOT $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -73,6 +73,11 @@ then
   Configuration=$DEFAULT_CONFIGURATION
 fi
 
+if [ "$Configuration" == "Release" ]
+then
+  DEBUG_SWITCH='--disable-debug'
+fi
+
 #helper functions
 
 #hash a dir based on the git revision, SDK_PATH, NDK_PATH, NDK_VERSION, SDK_VERSION, TOOLCHAIN and XBMC_DEPENDS_ROOT

--- a/tools/buildsteps/ios/configure-depends
+++ b/tools/buildsteps/ios/configure-depends
@@ -9,5 +9,5 @@ then
     --host=arm-apple-darwin \
     --with-sdk=$SDK_VERSION \
     --with-cpu=$DARWIN_ARM_CPU \
-    --prefix=$XBMC_DEPENDS_ROOT
+    --prefix=$XBMC_DEPENDS_ROOT $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/linux64/configure-depends
+++ b/tools/buildsteps/linux64/configure-depends
@@ -5,5 +5,5 @@ XBMC_PLATFORM_DIR=linux64
 if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
 then
   cd $WORKSPACE/tools/depends;./configure \
-    --with-toolchain=/usr --prefix=$XBMC_DEPENDS_ROOT --host=x86_64-linux-gnu --with-tarballs=$TARBALLS
+    --with-toolchain=/usr --prefix=$XBMC_DEPENDS_ROOT --host=x86_64-linux-gnu --with-tarballs=$TARBALLS $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/osx64/configure-depends
+++ b/tools/buildsteps/osx64/configure-depends
@@ -8,5 +8,5 @@ then
     --with-tarballs=/Users/Shared/xbmc-depends/tarballs \
     --host=x86_64-apple-darwin \
     --with-sdk=$SDK_VERSION \
-    --prefix=$XBMC_DEPENDS_ROOT
+    --prefix=$XBMC_DEPENDS_ROOT $DEBUG_SWITCH
 fi

--- a/tools/buildsteps/rbpi/configure-depends
+++ b/tools/buildsteps/rbpi/configure-depends
@@ -8,5 +8,5 @@ then
 
   PATH="$PATH:$JENKINS_RBPI_DEVENV/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin" \
   ./configure --with-platform=raspberry-pi --host=arm-linux-gnueabihf --prefix=$XBMC_DEPENDS_ROOT --with-tarballs=$TARBALLS \
-    --with-firmware=$JENKINS_RBPI_DEVENV/firmware --build=i686-linux
+    --with-firmware=$JENKINS_RBPI_DEVENV/firmware --build=i686-linux $DEBUG_SWITCH
 fi

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -5,9 +5,18 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_FILES([target/config.site native/config.site.native Makefile.include target/Toolchain.cmake
                  target/config-binaddons.site target/Toolchain_binaddons.cmake])
 AC_CANONICAL_HOST
+
+# save flags before autotools checks the compiler, since
+# it will automatically include -g in c/cxxflags
+passed_cflags="$CFLAGS"
+passed_ldflags="$LDFLAGS"
+passed_cxxflags="$CXXFLAGS"
+
 m4_include([../../m4/xbmc_arch.m4])
 m4_include([../../m4/ax_cxx_compile_stdcxx_11.m4])
-AX_CXX_COMPILE_STDCXX_11(,[optional])
+AX_CXX_COMPILE_STDCXX_11(,[mandatory])
+c11_flags="$CFLAGS"
+cxx11_flags="$CXXFLAGS"
 
 # check for not same cpu value
 AC_DEFUN([MC_CHECK_NOT_CPU],
@@ -21,6 +30,12 @@ AC_DEFUN([MC_CHECK_NOT_CPU],
       AC_MSG_RESULT([$1 is not $2])
   esac
 ])
+
+AC_ARG_ENABLE([debug],
+  [AS_HELP_STRING([--enable-debug],
+  [enable debugging information (default is yes)])],
+  [use_debug=$enableval],
+  [use_debug=yes])
 
 AC_ARG_WITH([toolchain],
   [AS_HELP_STRING([--with-toolchain],
@@ -101,9 +116,6 @@ deps_dir=$use_host
 tool_dir=$build_cpu-$build_os-native
 cross_compiling="yes"
 
-passed_cflags="$CFLAGS"
-passed_ldflags="$LDFLAGS"
-passed_cxxflags="$CXXFLAGS"
 platform_cc=gcc
 platform_cxx=g++
 
@@ -567,6 +579,15 @@ if test "$platform_os" == "android"; then
     AC_MSG_ERROR(unable to create $prefix/$deps_dir/lib/$use_sdk. verify that the path and permissions are correct.)
   fi
 fi
+
+if test "$use_debug" = "yes"; then
+  DEBUG_FLAGS="-g -D_DEBUG"
+else
+  DEBUG_FLAGS="-DNDEBUG=1"
+fi
+platform_cflags+="$c11_flags $DEBUG_FLAGS"
+platform_cxxflags+="$cxx11_flags $DEBUG_FLAGS"
+
 
 if test "$platform_os" == "android"; then
 echo -e


### PR DESCRIPTION
as discussed on slack, should fix ugly asserts (e.g. in pil) in Release builds
