### PR TITLE
Allow multiple content elements in a single container

### DIFF
--- a/xbmc/listproviders/CMakeLists.txt
+++ b/xbmc/listproviders/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES DirectoryProvider.cpp
             IListProvider.cpp
+            MultiProvider.cpp
             StaticProvider.cpp)
 
 set(HEADERS DirectoryProvider.h
             IListProvider.h
+            MultiProvider.h
             StaticProvider.h)
 
 core_add_library(listproviders)

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2013-2017 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -278,7 +278,7 @@ void CDirectoryProvider::Announce(AnnouncementFlag flag, const char *sender, con
   }
 }
 
-void CDirectoryProvider::Fetch(std::vector<CGUIListItemPtr> &items) const
+void CDirectoryProvider::Fetch(std::vector<CGUIListItemPtr> &items)
 {
   CSingleLock lock(m_section);
   items.clear();

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2013-2017 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -59,7 +59,7 @@ public:
 
   virtual bool Update(bool forceRefresh) override;
   virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
-  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const override;
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) override;
   virtual void Reset() override;
   virtual bool OnClick(const CGUIListItemPtr &item) override;
   bool OnInfo(const CGUIListItemPtr &item) override;

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2013-2017 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,18 +22,30 @@
 #include "utils/XBMCTinyXML.h"
 #include "StaticProvider.h"
 #include "DirectoryProvider.h"
+#include "MultiProvider.h"
 
 IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
 {
-  const TiXmlElement *root = node->FirstChildElement("content");
+  const TiXmlNode *root = node->FirstChild("content");
   if (root)
   {
-    const TiXmlElement *item = root->FirstChildElement("item");
-    if (item)
-      return new CStaticListProvider(root, parentID);
+    const TiXmlNode *next = root->NextSibling("content");
+    if (next)
+      return new CMultiProvider(root, parentID);
 
-    if (!root->NoChildren())
-      return new CDirectoryProvider(root, parentID);
+    return CreateSingle(root, parentID);
   }
+  return NULL;
+}
+
+IListProvider *IListProvider::CreateSingle(const TiXmlNode *content, int parentID)
+{
+  const TiXmlElement *item = content->FirstChildElement("item");
+  if (item)
+    return new CStaticListProvider(content->ToElement(), parentID);
+
+  if (!content->NoChildren())
+    return new CDirectoryProvider(content->ToElement(), parentID);
+
   return NULL;
 }

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2013-2017 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -38,11 +38,18 @@ public:
   virtual ~IListProvider() {}
 
   /*! \brief Factory to create list providers.
-   \param node a TiXmlNode to create.
+   \param parent a parent TiXmlNode for the container.
    \param parentID id of parent window for context.
    \return the list provider, NULL if none.
    */
-  static IListProvider *Create(const TiXmlNode *node, int parentID);
+  static IListProvider *Create(const TiXmlNode *parent, int parentID);
+
+  /*! \brief Factory to create list providers.  Cannot create a multi-provider.
+   \param content the TiXmlNode for the content to create.
+   \param parentID id of parent window for context.
+   \return the list provider, NULL if none.
+   */
+  static IListProvider *CreateSingle(const TiXmlNode *content, int parentID);
 
   /*! \brief Update the list content
    \return true if the content has changed, false otherwise.
@@ -52,7 +59,7 @@ public:
   /*! \brief Fetch the current list of items.
    \param items [out] the list to be filled.
    */
-  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const=0;
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items)=0;
 
   /*! \brief Check whether the list provider is updating content.
    \return true if in the processing of updating, false otherwise.

--- a/xbmc/listproviders/MultiProvider.cpp
+++ b/xbmc/listproviders/MultiProvider.cpp
@@ -1,0 +1,118 @@
+/*
+ *      Copyright (C) 2013-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MultiProvider.h"
+#include "utils/XBMCTinyXML.h"
+#include "threads/SingleLock.h"
+
+CMultiProvider::CMultiProvider(const TiXmlNode *first, int parentID)
+ : IListProvider(parentID)
+{
+  for (const TiXmlNode *content = first; content; content = content->NextSiblingElement("content"))
+  {
+    IListProviderPtr sub(IListProvider::CreateSingle(content, parentID));
+    if (sub)
+      m_providers.push_back(sub);
+  }
+}
+
+bool CMultiProvider::Update(bool forceRefresh)
+{
+  bool result = false;
+  for (auto& provider : m_providers)
+    result |= provider->Update(forceRefresh);
+  return result;
+}
+
+void CMultiProvider::Fetch(std::vector<CGUIListItemPtr> &items)
+{
+  CSingleLock lock(m_section);
+  std::vector<CGUIListItemPtr> subItems;
+  items.clear();
+  m_itemMap.clear();
+  for (auto const& provider : m_providers)
+  {
+    provider->Fetch(subItems);
+    for (auto& item : subItems)
+    {
+      auto key = GetItemKey(item);
+      m_itemMap[key] = provider;
+      items.push_back(item);
+    }
+    subItems.clear();
+  }
+}
+
+bool CMultiProvider::IsUpdating() const
+{
+  bool result = false;
+  for (auto const& provider : m_providers)
+    result |= provider->IsUpdating();
+  return result;
+}
+
+void CMultiProvider::Reset()
+{
+  {
+    CSingleLock lock(m_section);
+    m_itemMap.clear();
+  }
+
+  for (auto const& provider : m_providers)
+    provider->Reset();
+}
+
+bool CMultiProvider::OnClick(const CGUIListItemPtr &item)
+{
+  CSingleLock lock(m_section);
+  auto key = GetItemKey(item);
+  auto it = m_itemMap.find(key);
+  if (it != m_itemMap.end())
+    return it->second->OnClick(item);
+  else
+    return false;
+}
+
+bool CMultiProvider::OnInfo(const CGUIListItemPtr &item)
+{
+  CSingleLock lock(m_section);
+  auto key = GetItemKey(item);
+  auto it = m_itemMap.find(key);
+  if (it != m_itemMap.end())
+    return it->second->OnInfo(item);
+  else
+    return false;
+}
+
+bool CMultiProvider::OnContextMenu(const CGUIListItemPtr &item)
+{
+  CSingleLock lock(m_section);
+  auto key = GetItemKey(item);
+  auto it = m_itemMap.find(key);
+  if (it != m_itemMap.end())
+    return it->second->OnContextMenu(item);
+  else
+    return false;
+}
+
+CMultiProvider::item_key_type CMultiProvider::GetItemKey(CGUIListItemPtr const &item)
+{
+  return reinterpret_cast<item_key_type>(item.get());
+}

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2013-2017 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -78,7 +78,7 @@ bool CStaticListProvider::Update(bool forceRefresh)
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 
-void CStaticListProvider::Fetch(std::vector<CGUIListItemPtr> &items) const
+void CStaticListProvider::Fetch(std::vector<CGUIListItemPtr> &items)
 {
   items.clear();
   for (std::vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

This change adds a new IListProvider, called CMultiProvider, which aggregates several independent &lt;content&gt; blocks (either DirectoryProviders or StaticProviders or both).
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

DirectoryProviders (dynamically filled &lt;content&gt; blocks) are a powerful feature.  But currently you can only fill a list with a single directory at a time, and you also cannot add other static elements to a dynamic list.  For example, you might like to add some navigational list entries at the top of a list, and have it fill with dynamic content below those static entries.  Or maybe you would like to combine two different directories in one list for some reason.  This was hinted as a potential new feature in 2014, but it seems it never got added: http://forum.kodi.tv/showthread.php?tid=176864
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

I tested this by trying a few different combinations of multiple &lt;content&gt; blocks.
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
