### PR TITLE
Change splash db upgrade logic

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14654,13 +14654,13 @@ msgstr ""
 #. Progress text on splash screen
 #: xbmc/Application.cpp
 msgctxt "#24150"
-msgid "Database migration in progress - please wait..."
+msgid "Database migration in progress - please wait"
 msgstr ""
 
 #. Progress text on splash screen
 #: xbmc/Application.cpp
 msgctxt "#24151"
-msgid "Add-on migration in progress - please wait..."
+msgid "Add-on migration in progress - please wait"
 msgstr ""
 
 #empty strings from id 24152 to 24990

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <string>
 #include "threads/CriticalSection.h"
@@ -63,6 +64,7 @@ public:
    \return true if the database can be opened, false otherwise.
    */ 
   bool CanOpen(const std::string &name);
+  std::atomic<bool> m_bIsUpgrading;
 
 private:
   // private construction, and no assignements; use the provided singleton methods
@@ -74,6 +76,8 @@ private:
   enum DB_STATUS { DB_CLOSED, DB_UPDATING, DB_READY, DB_FAILED };
   void UpdateStatus(const std::string &name, DB_STATUS status);
   void UpdateDatabase(CDatabase &db, DatabaseSettings *settings = NULL);
+  bool Update(CDatabase &db, const DatabaseSettings &settings);
+  bool UpdateVersion(CDatabase &db, const std::string &dbName);
 
   CCriticalSection            m_section;     ///< Critical section protecting m_dbStatus.
   std::map<std::string, DB_STATUS> m_dbStatus;    ///< Our database status map.

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -70,6 +70,8 @@ public:
   virtual bool CommitTransaction();
   void RollbackTransaction();
   bool InTransaction();
+  void CopyDB(const std::string& latestDb);
+  void DropAnalytics();
 
   std::string PrepareSQL(std::string strStmt, ...) const;
 
@@ -157,7 +159,6 @@ public:
 
 protected:
   friend class CDatabaseManager;
-  bool Update(const DatabaseSettings &db);
 
   void Split(const std::string& strFileNameAndPath, std::string& strPath, std::string& strFileName);
 
@@ -194,7 +195,6 @@ protected:
   virtual const char *GetBaseDBName() const=0;
 
   int GetDBVersion();
-  bool UpdateVersion(const std::string &dbName);
 
   bool BuildSQL(const std::string &strQuery, const Filter &filter, std::string &strSQL);
 

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -39,14 +39,9 @@ CSplash& CSplash::GetInstance()
   return instance;
 }
 
-void CSplash::Show()
+void CSplash::Show(const std::string& message /* = "" */)
 {
-  Show("");
-}
-
-void CSplash::Show(const std::string& message)
-{
-  if (!g_advancedSettings.m_splashImage)
+  if (!g_advancedSettings.m_splashImage && !(m_image || !message.empty()))
     return;
 
   if (!m_image)
@@ -90,7 +85,7 @@ void CSplash::Show(const std::string& message)
 
       int width = g_graphicsContext.GetWidth();
       int height = g_graphicsContext.GetHeight();
-      float y = height - textHeight - 30; // -30 for safe viewing area
+      float y = height - textHeight - 100;
       m_messageLayout->RenderOutline(width/2, y, 0, 0xFF000000, XBFONT_CENTER_X, width);
     }
   }

--- a/xbmc/utils/Splash.h
+++ b/xbmc/utils/Splash.h
@@ -31,8 +31,7 @@ class CSplash
 public:
   static CSplash& GetInstance();
 
-  void Show();
-  void Show(const std::string& message);
+  void Show(const std::string& message = "");
 
 protected:
   CSplash();


### PR DESCRIPTION
Change the splash screen to show the message of upgrading database only when we're actually upgrading a database.
## Description

<!--- Describe your change in detail -->
## Motivation and Context

The old method wassn't aware if there was some upgrade and what db was doing the upgrade
## How Has This Been Tested?

Tested upgrading my old mysql databases
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
