### PR TITLE
Use new add-on hooks to enable/disable peripheral add-ons

### DIFF
--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -109,22 +109,6 @@ void CPeripheralAddon::ResetProperties(void)
   m_apiVersion = ADDON::AddonVersion("0.0.0");
 }
 
-void CPeripheralAddon::OnDisabled()
-{
-  CAddon::OnDisabled();
-  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  if (addonBus)
-    addonBus->UpdateAddons();
-}
-
-void CPeripheralAddon::OnEnabled()
-{
-  CAddon::OnEnabled();
-  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  if (addonBus)
-    addonBus->UpdateAddons();
-}
-
 ADDON::AddonPtr CPeripheralAddon::GetRunningInstance(void) const
 {
   PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
@@ -135,22 +119,6 @@ ADDON::AddonPtr CPeripheralAddon::GetRunningInstance(void) const
       return peripheralAddon;
   }
   return CAddon::GetRunningInstance();
-}
-
-void CPeripheralAddon::OnPostInstall(bool update, bool modal)
-{
-  CAddon::OnPostInstall(update, modal);
-  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  if (addonBus)
-    addonBus->UpdateAddons();
-}
-
-void CPeripheralAddon::OnPostUnInstall()
-{
-  CAddon::OnPostUnInstall();
-  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  if (addonBus)
-    addonBus->UpdateAddons();
 }
 
 ADDON_STATUS CPeripheralAddon::CreateAddon(void)

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -53,11 +53,7 @@ namespace PERIPHERALS
     virtual ~CPeripheralAddon(void);
 
     // implementation of IAddon
-    virtual void OnDisabled() override;
-    virtual void OnEnabled() override;
     virtual ADDON::AddonPtr GetRunningInstance(void) const override;
-    virtual void OnPostInstall(bool update, bool modal) override;
-    virtual void OnPostUnInstall() override;
 
     /*!
      * @brief Initialise the instance of this add-on

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -329,7 +329,9 @@ bool CPeripheralBusAddon::RequestRemoval(ADDON::AddonPtr addon)
 
 void CPeripheralBusAddon::OnEvent(const ADDON::AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::InstalledChanged))
+  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
+      typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+      typeid(event) == typeid(ADDON::AddonEvents::InstalledChanged))
     UpdateAddons();
 }
 


### PR DESCRIPTION
This improves on #10690 by avoiding the old hooks and using the new ones that @tamland added
