### PR TITLE
Fix button maps not refreshing after a reset

### DIFF
--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -650,6 +650,9 @@ void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::stri
 
   try { m_pStruct->ResetButtonMap(&joystickStruct, strControllerId.c_str()); }
   catch (std::exception &e) { LogException(e, "ResetButtonMap()"); return; }
+
+  // Notify observing button maps
+  RefreshButtonMaps(device->DeviceName());
 }
 
 void CPeripheralAddon::PowerOffJoystick(unsigned int index)


### PR DESCRIPTION
If the user resets the controller in the controller dialog, the effect doesn't take effect immediately.

![controller reset](https://cloud.githubusercontent.com/assets/531482/19541689/0206516a-961d-11e6-9316-28adb48f1f80.png)

This fix causes the button map to be refreshed when the user hits reset.

Broken out from #10630
