### PR TITLE
Fixed OnPlayBackResumed not getting fired anymore.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3104,12 +3104,10 @@ void CVideoPlayer::Pause()
   if (GetSpeed() == 0)
   {
     SetSpeed(1);
-    m_callback.OnPlayBackResumed();
   }
   else
   {
     SetSpeed(0);
-    m_callback.OnPlayBackPaused();
   }
 }
 
@@ -3646,6 +3644,13 @@ void CVideoPlayer::SetSpeed(float speed)
     return;
   
   m_newPlaySpeed = speed * DVD_PLAYSPEED_NORMAL;
+  if (m_newPlaySpeed != m_playSpeed)
+  {
+    if (m_newPlaySpeed == DVD_PLAYSPEED_NORMAL)
+      m_callback.OnPlayBackResumed();
+    else if (m_newPlaySpeed == DVD_PLAYSPEED_PAUSE)
+      m_callback.OnPlayBackPaused();
+  }
   SetPlaySpeed(speed * DVD_PLAYSPEED_NORMAL);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

<!--- Describe your change in detail -->

Make sure OnPlayBackResumed get's fired when we resume.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

http://trac.kodi.tv/ticket/16976#ticket
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

Tested on windows 10 in the vs debugger
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
