### PR TITLE
Move peripherals to shared_ptr

### DIFF
--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -60,13 +60,13 @@ void CKeyboardStat::Initialize()
 
 bool CKeyboardStat::LookupSymAndUnicodePeripherals(XBMC_keysym &keysym, uint8_t *key, char *unicode)
 {
-  std::vector<CPeripheral *> hidDevices;
+  PeripheralVector hidDevices;
   if (g_peripherals.GetPeripheralsWithFeature(hidDevices, FEATURE_HID))
   {
-    for (unsigned int iDevicePtr = 0; iDevicePtr < hidDevices.size(); iDevicePtr++)
+    for (auto& peripheral : hidDevices)
     {
-      CPeripheralHID *hidDevice = (CPeripheralHID *) hidDevices.at(iDevicePtr);
-      if (hidDevice && hidDevice->LookupSymAndUnicode(keysym, key, unicode))
+      std::shared_ptr<CPeripheralHID> hidDevice = std::static_pointer_cast<CPeripheralHID>(peripheral);
+      if (hidDevice->LookupSymAndUnicode(keysym, key, unicode))
         return true;
     }
   }

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -76,6 +76,10 @@ namespace PERIPHERALS
     PERIPHERAL_JOYSTICK,
   };
 
+  class CPeripheral;
+  typedef std::shared_ptr<CPeripheral> PeripheralPtr;
+  typedef std::vector<PeripheralPtr>   PeripheralVector;
+
   class CPeripheralAddon;
   typedef std::shared_ptr<CPeripheralAddon> PeripheralAddonPtr;
   typedef std::vector<PeripheralAddonPtr>   PeripheralAddonVector;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -72,7 +72,7 @@ namespace PERIPHERALS
      * @param busType The bus to query. Default (PERIPHERAL_BUS_UNKNOWN) searches all busses.
      * @return The peripheral or NULL if it wasn't found.
      */
-    CPeripheral *GetPeripheralAtLocation(const std::string &strLocation, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
+    PeripheralPtr GetPeripheralAtLocation(const std::string &strLocation, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
     /*!
      * @brief Check whether a peripheral is present at the given location.
@@ -96,7 +96,7 @@ namespace PERIPHERALS
      * @param busType The bus to query. Default (PERIPHERAL_BUS_UNKNOWN) searches all busses.
      * @return The number of devices that have been found.
      */
-    int GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
+    int GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
     size_t GetNumberOfPeripherals() const;
 
@@ -128,7 +128,7 @@ namespace PERIPHERALS
      * @param result The scan result from the device scanning code.
      * @return The new peripheral or NULL if it could not be created.
      */
-    CPeripheral *CreatePeripheral(CPeripheralBus &bus, const PeripheralScanResult& result);
+    void CreatePeripheral(CPeripheralBus &bus, const PeripheralScanResult& result);
 
     /*!
      * @brief Add the settings that are defined in the mappings file to the peripheral (if there is anything defined).
@@ -160,7 +160,7 @@ namespace PERIPHERALS
      * @param strPath The path to the peripheral.
      * @return The peripheral or NULL if it wasn't found.
      */
-    CPeripheral *GetByPath(const std::string &strPath) const;
+    PeripheralPtr GetByPath(const std::string &strPath) const;
 
     /*!
      * @brief Try to let one of the peripherals handle an action.
@@ -184,10 +184,9 @@ namespace PERIPHERALS
     /*!
      * @brief Try to toggle the playing device state via a peripheral.
      * @param mode Whether to activate, put on standby or toggle the source.
-     * @param iPeripheral Optional CPeripheralCecAdapter pointer to a specific device, instead of iterating through all of them.
      * @return True when the playing device has been switched on, false otherwise.
      */
-    bool ToggleDeviceState(const CecStateChange mode = STATE_SWITCH_TOGGLE, const unsigned int iPeripheral = 0);
+    bool ToggleDeviceState(const CecStateChange mode = STATE_SWITCH_TOGGLE);
 
     /*!
      * @brief Try to mute the audio via a peripheral.

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -59,12 +59,12 @@ namespace PERIPHERALS
     /*!
      * @brief Initialise the peripherals manager.
      */
-    virtual void Initialise();
+    void Initialise();
 
     /*!
      * @brief Clear all data known by the peripherals manager.
      */
-    virtual void Clear();
+    void Clear();
 
     /*!
      * @brief Get the instance of the peripheral at the given location.
@@ -72,7 +72,7 @@ namespace PERIPHERALS
      * @param busType The bus to query. Default (PERIPHERAL_BUS_UNKNOWN) searches all busses.
      * @return The peripheral or NULL if it wasn't found.
      */
-    virtual CPeripheral *GetPeripheralAtLocation(const std::string &strLocation, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
+    CPeripheral *GetPeripheralAtLocation(const std::string &strLocation, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
     /*!
      * @brief Check whether a peripheral is present at the given location.
@@ -80,14 +80,14 @@ namespace PERIPHERALS
      * @param busType The bus to query. Default (PERIPHERAL_BUS_UNKNOWN) searches all busses.
      * @return True when a peripheral was found, false otherwise.
      */
-    virtual bool HasPeripheralAtLocation(const std::string &strLocation, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
+    bool HasPeripheralAtLocation(const std::string &strLocation, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
     /*!
      * @brief Get the bus that holds the device with the given location.
      * @param strLocation The location.
      * @return The bus or NULL if no device was found.
      */
-    virtual PeripheralBusPtr GetBusWithDevice(const std::string &strLocation) const;
+    PeripheralBusPtr GetBusWithDevice(const std::string &strLocation) const;
 
     /*!
      * @brief Get all peripheral instances that have the given feature.
@@ -96,7 +96,7 @@ namespace PERIPHERALS
      * @param busType The bus to query. Default (PERIPHERAL_BUS_UNKNOWN) searches all busses.
      * @return The number of devices that have been found.
      */
-    virtual int GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
+    int GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
     size_t GetNumberOfPeripherals() const;
 
@@ -106,21 +106,21 @@ namespace PERIPHERALS
      * @param busType The bus to query. Default (PERIPHERAL_BUS_UNKNOWN) searches all busses.
      * @return True when at least one device was found with this feature, false otherwise.
      */
-    virtual bool HasPeripheralWithFeature(const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
+    bool HasPeripheralWithFeature(const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
     /*!
      * @brief Called when a device has been added to a bus.
      * @param bus The bus the device was added to.
      * @param peripheral The peripheral that has been added.
      */
-    virtual void OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &peripheral);
+    void OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &peripheral);
 
     /*!
      * @brief Called when a device has been deleted from a bus.
      * @param bus The bus from which the device removed.
      * @param peripheral The peripheral that has been removed.
      */
-    virtual void OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral);
+    void OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral);
 
     /*!
      * @brief Creates a new instance of a peripheral.
@@ -139,47 +139,47 @@ namespace PERIPHERALS
     /*!
      * @brief Trigger a device scan on all known busses
      */
-    virtual void TriggerDeviceScan(const PeripheralBusType type = PERIPHERAL_BUS_UNKNOWN);
+    void TriggerDeviceScan(const PeripheralBusType type = PERIPHERAL_BUS_UNKNOWN);
 
     /*!
      * @brief Get the instance of a bus given it's type.
      * @param type The bus type.
      * @return The bus or NULL if it wasn't found.
      */
-    virtual PeripheralBusPtr GetBusByType(const PeripheralBusType type) const;
+    PeripheralBusPtr GetBusByType(const PeripheralBusType type) const;
 
     /*!
      * @brief Get all fileitems for a path.
      * @param strPath The path to the directory to get the items from.
      * @param items The item list.
      */
-    virtual void GetDirectory(const std::string &strPath, CFileItemList &items) const;
+    void GetDirectory(const std::string &strPath, CFileItemList &items) const;
 
     /*!
      * @brief Get the instance of a peripheral given it's path.
      * @param strPath The path to the peripheral.
      * @return The peripheral or NULL if it wasn't found.
      */
-    virtual CPeripheral *GetByPath(const std::string &strPath) const;
+    CPeripheral *GetByPath(const std::string &strPath) const;
 
     /*!
      * @brief Try to let one of the peripherals handle an action.
      * @param action The change to handle.
      * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
      */
-    virtual bool OnAction(const CAction &action);
+    bool OnAction(const CAction &action);
 
     /*!
      * @brief Check whether there's a peripheral that reports to be muted.
      * @return True when at least one peripheral reports to be muted, false otherwise.
      */
-    virtual bool IsMuted();
+    bool IsMuted();
 
     /*!
      * @brief Try to toggle the mute status via a peripheral.
      * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
      */
-    virtual bool ToggleMute();
+    bool ToggleMute();
 
     /*!
      * @brief Try to toggle the playing device state via a peripheral.
@@ -187,19 +187,19 @@ namespace PERIPHERALS
      * @param iPeripheral Optional CPeripheralCecAdapter pointer to a specific device, instead of iterating through all of them.
      * @return True when the playing device has been switched on, false otherwise.
      */
-    virtual bool ToggleDeviceState(const CecStateChange mode = STATE_SWITCH_TOGGLE, const unsigned int iPeripheral = 0);
+    bool ToggleDeviceState(const CecStateChange mode = STATE_SWITCH_TOGGLE, const unsigned int iPeripheral = 0);
 
     /*!
      * @brief Try to mute the audio via a peripheral.
      * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
      */
-    virtual bool Mute() { return ToggleMute(); } //! @todo CEC only supports toggling the mute status at this time
+    bool Mute() { return ToggleMute(); } //! @todo CEC only supports toggling the mute status at this time
 
     /*!
      * @brief Try to unmute the audio via a peripheral.
      * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
      */
-    virtual bool UnMute() { return ToggleMute(); } //! @todo CEC only supports toggling the mute status at this time
+    bool UnMute() { return ToggleMute(); } //! @todo CEC only supports toggling the mute status at this time
 
     /*!
      * @brief Try to get a keypress from a peripheral.
@@ -207,7 +207,7 @@ namespace PERIPHERALS
      * @param key The fetched key.
      * @return True when a keypress was fetched, false otherwise.
      */
-    virtual bool GetNextKeypress(float frameTime, CKey &key);
+    bool GetNextKeypress(float frameTime, CKey &key);
 
     /*!
      * @brief Request event scan rate
@@ -239,9 +239,9 @@ namespace PERIPHERALS
     // implementation of IEventScannerCallback
     virtual void ProcessEvents(void) override;
 
-    virtual PeripheralAddonPtr GetAddonWithButtonMap(const CPeripheral* device);
+    PeripheralAddonPtr GetAddonWithButtonMap(const CPeripheral* device);
 
-    virtual void ResetButtonMaps(const std::string& controllerId);
+    void ResetButtonMaps(const std::string& controllerId);
 
     void RegisterJoystickButtonMapper(JOYSTICK::IButtonMapper* mapper);
     void UnregisterJoystickButtonMapper(JOYSTICK::IButtonMapper* mapper);

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -60,13 +60,13 @@ namespace PERIPHERALS
      */
     ADDON_STATUS CreateAddon(void);
 
-    bool         Register(unsigned int peripheralIndex, CPeripheral* peripheral);
-    void         UnregisterRemovedDevices(const PeripheralScanResults &results, std::vector<CPeripheral*>& removedPeripherals);
+    bool         Register(unsigned int peripheralIndex, const PeripheralPtr& peripheral);
+    void         UnregisterRemovedDevices(const PeripheralScanResults &results, PeripheralVector& removedPeripherals);
     void         GetFeatures(std::vector<PeripheralFeature> &features) const;
     bool         HasFeature(const PeripheralFeature feature) const;
-    CPeripheral* GetPeripheral(unsigned int index) const;
-    CPeripheral* GetByPath(const std::string &strPath) const;
-    int          GetPeripheralsWithFeature(std::vector<CPeripheral*> &results, const PeripheralFeature feature) const;
+    PeripheralPtr GetPeripheral(unsigned int index) const;
+    PeripheralPtr GetByPath(const std::string &strPath) const;
+    int          GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const;
     size_t       GetNumberOfPeripherals(void) const;
     size_t       GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const;
     void         GetDirectory(const std::string &strPath, CFileItemList &items) const;
@@ -141,7 +141,7 @@ namespace PERIPHERALS
     bool                m_bProvidesButtonMaps;
 
     /* @brief Map of peripherals belonging to the add-on */
-    std::map<unsigned int, CPeripheral*>  m_peripherals;
+    std::map<unsigned int, PeripheralPtr>  m_peripherals;
 
     /* @brief Button map observers */
     std::vector<std::pair<CPeripheral*, JOYSTICK::IButtonMap*> > m_buttonMaps;

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -50,7 +50,7 @@ bool CPeripheralBus::InitializeProperties(CPeripheral& peripheral)
     // Ensure an add-on is present to translate input
     if (!g_peripherals.GetInstance().GetAddonWithButtonMap(&peripheral))
     {
-      CLog::Log(LOGWARNING, "Button mapping add-on not present for %s (%s), skipping", peripheral.Location().c_str(), peripheral.DeviceName().c_str(), peripheral.VendorIdAsString(), peripheral.ProductIdAsString());
+      CLog::Log(LOGWARNING, "Button mapping add-on not present for %s (%s), skipping", peripheral.Location().c_str(), peripheral.DeviceName().c_str());
       return false;
     }
   }

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -43,17 +43,14 @@ CPeripheralBus::CPeripheralBus(const std::string &threadname, CPeripherals *mana
 {
 }
 
-bool CPeripheralBus::InitializeProperties(CPeripheral* peripheral)
+bool CPeripheralBus::InitializeProperties(CPeripheral& peripheral)
 {
-  if (peripheral == nullptr)
-    return false;
-
-  if (peripheral->Type() == PERIPHERAL_JOYSTICK)
+  if (peripheral.Type() == PERIPHERAL_JOYSTICK)
   {
     // Ensure an add-on is present to translate input
-    if (!g_peripherals.GetInstance().GetAddonWithButtonMap(peripheral))
+    if (!g_peripherals.GetInstance().GetAddonWithButtonMap(&peripheral))
     {
-      CLog::Log(LOGWARNING, "Button mapping add-on not present for %s (%s), skipping", peripheral->Location().c_str(), peripheral->DeviceName().c_str(), peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
+      CLog::Log(LOGWARNING, "Button mapping add-on not present for %s (%s), skipping", peripheral.Location().c_str(), peripheral.DeviceName().c_str(), peripheral.VendorIdAsString(), peripheral.ProductIdAsString());
       return false;
     }
   }
@@ -90,18 +87,16 @@ void CPeripheralBus::Clear(void)
   }
 
   CSingleLock lock(m_critSection);
-  for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
-    delete m_peripherals.at(iPeripheralPtr);
   m_peripherals.clear();
 }
 
 void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults &results)
 {
   CSingleLock lock(m_critSection);
-  std::vector<CPeripheral *> removedPeripherals;
+  PeripheralVector removedPeripherals;
   for (int iDevicePtr = (int) m_peripherals.size() - 1; iDevicePtr >= 0; iDevicePtr--)
   {
-    CPeripheral *peripheral = m_peripherals.at(iDevicePtr);
+    const PeripheralPtr& peripheral = m_peripherals.at(iDevicePtr);
     PeripheralScanResult updatedDevice(m_type);
     if (!results.GetDeviceOnLocation(peripheral->Location(), &updatedDevice) ||
         *peripheral != updatedDevice)
@@ -113,9 +108,8 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults &resul
   }
   lock.Leave();
 
-  for (unsigned int iDevicePtr = 0; iDevicePtr < removedPeripherals.size(); iDevicePtr++)
+  for (auto& peripheral : removedPeripherals)
   {
-    CPeripheral *peripheral = removedPeripherals.at(iDevicePtr);
     std::vector<PeripheralFeature> features;
     peripheral->GetFeatures(features);
     bool peripheralHasFeatures = features.size() > 1 || (features.size() == 1 && features.at(0) != FEATURE_UNKNOWN);
@@ -126,7 +120,6 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults &resul
     }
 
     m_manager->OnDeviceDeleted(*this, *peripheral);
-    delete peripheral;
   }
 }
 
@@ -182,30 +175,30 @@ void CPeripheralBus::GetFeatures(std::vector<PeripheralFeature> &features) const
     m_peripherals.at(iPeripheralPtr)->GetFeatures(features);
 }
 
-CPeripheral *CPeripheralBus::GetPeripheral(const std::string &strLocation) const
+PeripheralPtr CPeripheralBus::GetPeripheral(const std::string &strLocation) const
 {
-  CPeripheral *peripheral(NULL);
+  PeripheralPtr result;
   CSingleLock lock(m_critSection);
-  for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
+  for (auto& peripheral : m_peripherals)
   {
-    if (m_peripherals.at(iPeripheralPtr)->Location() == strLocation)
+    if (peripheral->Location() == strLocation)
     {
-      peripheral = m_peripherals.at(iPeripheralPtr);
+      result = peripheral;
       break;
     }
   }
-  return peripheral;
+  return result;
 }
 
-int CPeripheralBus::GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature) const
+int CPeripheralBus::GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const
 {
   int iReturn(0);
   CSingleLock lock(m_critSection);
-  for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < m_peripherals.size(); iPeripheralPtr++)
+  for (auto& peripheral : m_peripherals)
   {
-    if (m_peripherals.at(iPeripheralPtr)->HasFeature(feature))
+    if (peripheral->HasFeature(feature))
     {
-      results.push_back(m_peripherals.at(iPeripheralPtr));
+      results.push_back(peripheral);
       ++iReturn;
     }
   }
@@ -268,7 +261,7 @@ void CPeripheralBus::Initialise(void)
   }
 }
 
-void CPeripheralBus::Register(CPeripheral *peripheral)
+void CPeripheralBus::Register(const PeripheralPtr& peripheral)
 {
   if (!peripheral)
     return;
@@ -308,9 +301,8 @@ void CPeripheralBus::GetDirectory(const std::string &strPath, CFileItemList &ite
 {
   std::string strDevPath;
   CSingleLock lock(m_critSection);
-  for (unsigned int iDevicePtr = 0; iDevicePtr < m_peripherals.size(); iDevicePtr++)
+  for (const auto& peripheral : m_peripherals)
   {
-    const CPeripheral *peripheral = m_peripherals.at(iDevicePtr);
     if (peripheral->IsHidden())
       continue;
 
@@ -337,17 +329,22 @@ void CPeripheralBus::GetDirectory(const std::string &strPath, CFileItemList &ite
   }
 }
 
-CPeripheral *CPeripheralBus::GetByPath(const std::string &strPath) const
+PeripheralPtr CPeripheralBus::GetByPath(const std::string &strPath) const
 {
+  PeripheralPtr result;
+
   std::string strDevPath;
   CSingleLock lock(m_critSection);
-  for (unsigned int iDevicePtr = 0; iDevicePtr < m_peripherals.size(); iDevicePtr++)
+  for (auto& peripheral : m_peripherals)
   {
-    if (StringUtils::EqualsNoCase(strPath, m_peripherals.at(iDevicePtr)->FileLocation()))
-      return m_peripherals.at(iDevicePtr);
+    if (StringUtils::EqualsNoCase(strPath, peripheral->FileLocation()))
+    {
+      result = peripheral;
+      break;
+    }
   }
 
-  return NULL;
+  return result;
 }
 
 size_t CPeripheralBus::GetNumberOfPeripherals() const

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -59,14 +59,14 @@ namespace PERIPHERALS
     /*!
     * \brief Initialize the properties of a peripheral with a known location
     */
-    virtual bool InitializeProperties(CPeripheral* peripheral);
+    virtual bool InitializeProperties(CPeripheral& peripheral);
 
     /*!
      * @brief Get the instance of the peripheral at the given location.
      * @param strLocation The location.
      * @return The peripheral or NULL if it wasn't found.
      */
-    virtual CPeripheral *GetPeripheral(const std::string &strLocation) const;
+    virtual PeripheralPtr GetPeripheral(const std::string &strLocation) const;
 
     /*!
      * @brief Check whether a peripheral is present at the given location.
@@ -81,7 +81,7 @@ namespace PERIPHERALS
      * @param feature The feature to search for.
      * @return The number of devices that have been found.
      */
-    virtual int GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature) const;
+    virtual int GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const;
 
     virtual size_t GetNumberOfPeripherals() const;
     virtual size_t GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const;
@@ -144,13 +144,13 @@ namespace PERIPHERALS
      * @param strPath The path to the peripheral.
      * @return The peripheral or NULL if it wasn't found.
      */
-    virtual CPeripheral *GetByPath(const std::string &strPath) const;
+    virtual PeripheralPtr GetByPath(const std::string &strPath) const;
 
     /*!
      * @brief Register a new peripheral on this bus.
      * @param peripheral The peripheral to register.
      */
-    virtual void Register(CPeripheral *peripheral);
+    virtual void Register(const PeripheralPtr& peripheral);
 
     virtual bool FindComPort(std::string &strLocation) { return false; }
 
@@ -174,7 +174,7 @@ namespace PERIPHERALS
      */
     virtual bool PerformDeviceScan(PeripheralScanResults &results) = 0;
 
-    std::vector<CPeripheral *> m_peripherals;
+    PeripheralVector           m_peripherals;
     int                        m_iRescanTime;
     bool                       m_bInitialised;
     bool                       m_bIsStarted;

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
@@ -42,7 +42,7 @@ namespace PERIPHERALS
     virtual ~CPeripheralBusAndroid();
 
     // specialisation of CPeripheralBus
-    bool InitializeProperties(CPeripheral* peripheral) override;
+    bool InitializeProperties(CPeripheral& peripheral) override;
     void Initialise(void) override;
     void ProcessEvents() override;
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -71,13 +71,13 @@ namespace PERIPHERALS
     bool SendRumbleEvent(const std::string& strLocation, unsigned int motorIndex, float magnitude);
 
     // Inherited from CPeripheralBus
-    virtual bool         InitializeProperties(CPeripheral* peripheral) override;
-    virtual void         Register(CPeripheral *peripheral) override;
+    virtual bool         InitializeProperties(CPeripheral& peripheral) override;
+    virtual void         Register(const PeripheralPtr& peripheral) override;
     virtual void         GetFeatures(std::vector<PeripheralFeature> &features) const override;
     virtual bool         HasFeature(const PeripheralFeature feature) const override;
-    virtual CPeripheral* GetPeripheral(const std::string &strLocation) const override;
-    virtual CPeripheral* GetByPath(const std::string &strPath) const override;
-    virtual int          GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature) const override;
+    virtual PeripheralPtr GetPeripheral(const std::string &strLocation) const override;
+    virtual PeripheralPtr GetByPath(const std::string &strPath) const override;
+    virtual int          GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const override;
     virtual size_t       GetNumberOfPeripherals(void) const override;
     virtual size_t       GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const override;
     virtual void         GetDirectory(const std::string &strPath, CFileItemList &items) const override;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -84,8 +84,6 @@ CPeripheral::~CPeripheral(void)
 {
   PersistSettings(true);
 
-  for (unsigned int iSubdevicePtr = 0; iSubdevicePtr < m_subDevices.size(); iSubdevicePtr++)
-    delete m_subDevices.at(iSubdevicePtr);
   m_subDevices.clear();
 
   ClearSettings();
@@ -200,10 +198,9 @@ bool CPeripheral::Initialise(void)
   return bReturn;
 }
 
-void CPeripheral::GetSubdevices(std::vector<CPeripheral *> &subDevices) const
+void CPeripheral::GetSubdevices(PeripheralVector &subDevices) const
 {
-  for (unsigned int iSubdevicePtr = 0; iSubdevicePtr < m_subDevices.size(); iSubdevicePtr++)
-    subDevices.push_back(m_subDevices.at(iSubdevicePtr));
+  subDevices = m_subDevices;
 }
 
 bool CPeripheral::IsMultiFunctional(void) const

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -133,7 +133,7 @@ namespace PERIPHERALS
      * @brief Get all subdevices if this device is multifunctional.
      * @param subDevices The subdevices.
      */
-    virtual void GetSubdevices(std::vector<CPeripheral *> &subDevices) const;
+    virtual void GetSubdevices(PeripheralVector &subDevices) const;
 
     /*!
      * @return True when this device is multifunctional, false otherwise.
@@ -221,7 +221,7 @@ namespace PERIPHERALS
     bool                             m_bHidden;
     bool                             m_bError;
     std::vector<PeripheralFeature>   m_features;
-    std::vector<CPeripheral *>       m_subDevices;
+    PeripheralVector                 m_subDevices;
     std::map<std::string, PeripheralDeviceSetting> m_settings;
     std::set<std::string>             m_changedSettings;
     CPeripheralBus*                  m_bus;

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -62,7 +62,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
   {
     if (feature == FEATURE_JOYSTICK)
     {
-      if (m_bus->InitializeProperties(this))
+      if (m_bus->InitializeProperties(*this))
         bSuccess = true;
       else
         CLog::Log(LOGERROR, "CPeripheralJoystick: Invalid location (%s)", m_strLocation.c_str());

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -91,8 +91,8 @@ void CGUIDialogPeripheralSettings::Save()
   if (m_item == NULL || m_initialising)
     return;
 
-  CPeripheral *peripheral = g_peripherals.GetByPath(m_item->GetPath());
-  if (peripheral == NULL)
+  PeripheralPtr peripheral = g_peripherals.GetByPath(m_item->GetPath());
+  if (!peripheral)
     return;
 
   peripheral->PersistSettings();
@@ -103,8 +103,8 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   if (m_item == NULL)
     return;
 
-  CPeripheral *peripheral = g_peripherals.GetByPath(m_item->GetPath());
-  if (peripheral == NULL)
+  PeripheralPtr peripheral = g_peripherals.GetByPath(m_item->GetPath());
+  if (!peripheral)
     return;
 
   if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
@@ -138,8 +138,8 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
   m_initialising = true;
   bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
 
-  CPeripheral *peripheral = g_peripherals.GetByPath(m_item->GetPath());
-  if (peripheral == NULL)
+  PeripheralPtr peripheral = g_peripherals.GetByPath(m_item->GetPath());
+  if (!peripheral)
   {
     CLog::Log(LOGDEBUG, "%s - no peripheral", __FUNCTION__);
     m_initialising = false;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -85,14 +85,14 @@ bool SupportsPeripheralControllers(const std::string &condition, const std::stri
   using namespace PERIPHERALS;
 
   PeripheralBusAddonPtr bus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  return bus != nullptr && bus->HasFeature(FEATURE_JOYSTICK);
+  return bus && bus->HasFeature(FEATURE_JOYSTICK);
 }
 
 bool HasRumbleFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
   using namespace PERIPHERALS;
 
-  std::vector<CPeripheral*> results;
+  PeripheralVector results;
   g_peripherals.GetPeripheralsWithFeature(results, FEATURE_RUMBLE);
   return !results.empty();
 }


### PR DESCRIPTION
This stores peripherals as shared_ptrs instead of raw pointers.

The danger of raw pointers is that peripherals are exposed to outside classes. For example, whenever a key is pressed, InputManager will ask g_peripherals for all HID peripherals, and then ask each HID peripheral for a translated key. This is dangerous if a CEC adapter is unplugged while the key is being translated, because the peripheral will be destroyed before InputManager asks it for the translated key.

As a second example, the settings system enables/disables the rumble setting by asking for all joysticks, and then checking each joystick for rumble. If the joystick is unplugged at the exact instance of these checks, then things blow up.

That's all the examples in the current code. Everything else I've added in the past, including the controller dialog, is safe because the reasoning occurs inside the peripherals subsystem. Still, better safe then sorry, especially when RetroPlayer is merged and we allocate ports to controllers in the games code instead of the peripherals code.

The third commit removes the ability to have sub devices. I'm not sure what the intended purpose of this was, but it's not used currently, and the ownership of sub devices should be reevaluated after the change in this PR.

Broken out from #10630
