### PR TITLE
[xbmc][Fix] Guard against double free by setting our deleted values to nullptr

### DIFF
--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -130,7 +130,7 @@ double str2double(const std::wstring &str, double fallback /* = 0.0 */)
 }
 
 CVariant::CVariant()
-  : m_type{VariantTypeNull}
+  : CVariant(VariantTypeNull)
 {
 }
 
@@ -307,14 +307,28 @@ CVariant::~CVariant()
 
 void CVariant::cleanup()
 {
-  if (m_type == VariantTypeString)
+  switch (m_type)
+  {
+  case VariantTypeString:
     delete m_data.string;
-  else if (m_type == VariantTypeWideString)
+    m_data.string = nullptr;
+    break;
+
+  case VariantTypeWideString:
     delete m_data.wstring;
-  else if (m_type == VariantTypeArray)
+    m_data.wstring = nullptr;
+    break;
+
+  case VariantTypeArray:
     delete m_data.array;
-  else if (m_type == VariantTypeObject)
+    m_data.array = nullptr;
+    break;
+
+  case VariantTypeObject:
     delete m_data.map;
+    m_data.map = nullptr;
+    break;
+  }
   m_type = VariantTypeNull;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

Issue found through crash reports
HEAP_CORRUPTION_ACTIONABLE_LFHSegmentDoubleFree_DOUBLE_FREE_DETOURS_c0000374_kodi.exe!CVariant::cleanup
## Description

<!--- Describe your change in detail -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

Crashes reported through Windows Store and Google Play, reasonable to assume it's on all platforms
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

Not at all, don't know how to reproduce crash
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
