### PR TITLE
FFmpeg: Bump to 3.1.5-Krypton-Beta5-1

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.4-Krypton-Beta3
+VERSION=3.1.5-Krypton-Beta5-1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
Rebase on upstream ffmpeg. Nothing too critical for us: https://github.com/xbmc/FFmpeg/commit/2a5c41e3e4a7e763503af59de903d5649dcc071a 
