### PR TITLE
Extend "Would you like to keep this change?" to 15 seconds

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -293,7 +293,7 @@ bool CDisplaySettings::OnSettingChanging(const CSetting *setting)
     {
       if (!m_resolutionChangeAborted)
       {
-        if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""}, 10000) !=
+        if (HELPERS::ShowYesNoDialogText(CVariant{13110}, CVariant{13111}, CVariant{""}, CVariant{""}, 15000) !=
           DialogResponse::YES)
         {
           m_resolutionChangeAborted = true;


### PR DESCRIPTION
## Motivation and Context

Certain TVs and AVR take quite a time to adjust to resolution and refreshrate changes for GUI and you would have to guess if it would actually work or not.

On average my setup takes about 5 to 8 seconds to switch and that leaves only two seconds to hit the OK button else it would revert. Doing 15 seconds should give enough time for users to check and navigate to the OK button.
