### PR TITLE
[AirTunes] - fix the "IsRunning" method.

### DIFF
--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -617,13 +617,23 @@ void CAirTunesServer::StopServer(bool bWait)
   }
 }
 
- bool CAirTunesServer::IsRunning()
- {
-   if (ServerInstance == NULL)
-     return false;
+bool CAirTunesServer::IsRunning()
+{
+  if (ServerInstance == NULL)
+    return false;
 
-   return ((CThread*)ServerInstance)->IsRunning();
- }
+  return ServerInstance->IsRAOPRunningInternal();
+}
+
+bool CAirTunesServer::IsRAOPRunningInternal()
+{
+  if (m_pLibShairplay != nullptr && m_pRaop != nullptr)
+  {
+    return m_pLibShairplay->raop_is_running(m_pRaop);
+  }
+  return false;
+}
+
 
 CAirTunesServer::CAirTunesServer(int port, bool nonlocal)
 : CThread("AirTunesActionThread"),
@@ -718,6 +728,7 @@ void CAirTunesServer::Deinitialize()
     m_pLibShairplay->raop_stop(m_pRaop);
     m_pLibShairplay->raop_destroy(m_pRaop);
     m_pLibShairplay->Unload();
+    m_pRaop = nullptr;
   }
 }
 

--- a/xbmc/network/AirTunesServer.h
+++ b/xbmc/network/AirTunesServer.h
@@ -60,6 +60,7 @@ public:
   static bool StartServer(int port, bool nonlocal, bool usePassword, const std::string &password="");
   static void StopServer(bool bWait);
   static bool IsRunning();
+  bool IsRAOPRunningInternal();
   static void SetMetadataFromBuffer(const char *buffer, unsigned int size);
   static void SetCoverArtFromBuffer(const char *buffer, unsigned int size);
   static void SetupRemoteControl();


### PR DESCRIPTION
The thread only runs during playback so we can't use it as the indicator for the service itself.

This fixes the problem that the airtunes server doesn't stop when you deactivate it in the Settings (because IsRunning always returned false).
