### PR TITLE
[WIP][addons] Fix broken libKODI_audioengine

### DIFF
--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -176,6 +176,8 @@ install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME}Config.cm
 
 # Install kodi-audio-dev
 install(FILES ${CORE_SOURCE_DIR}/xbmc/cores/AudioEngine/Utils/AEChannelData.h
+              ${CORE_SOURCE_DIR}/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
+              ${CORE_SOURCE_DIR}/xbmc/cores/AudioEngine/Utils/AEStreamData.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audiodec_dll.h

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -37,4 +37,6 @@ BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h
 BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_codec.h
 BINDINGS+=xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
 BINDINGS+=xbmc/cores/AudioEngine/Utils/AEChannelData.h
+BINDINGS+=xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
+BINDINGS+=xbmc/cores/AudioEngine/Utils/AEStreamData.h
 BINDINGS+=xbmc/filesystem/IFileTypes.h

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audioengine_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audioengine_types.h
@@ -25,7 +25,7 @@
  */
 
 #ifdef BUILD_KODI_ADDON
-  #include "kodi/AudioEngine/AEChannelInfo.h"
+  #include "AEChannelInfo.h"
 #else
   #include "cores/AudioEngine/Utils/AEChannelInfo.h"
 #endif

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_audioengine.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_audioengine.h
@@ -27,9 +27,9 @@
 
 #include "kodi_audioengine_types.h"
 #ifdef BUILD_KODI_ADDON
-  #include "kodi/AudioEngine/AEChannelData.h"
-  #include "kodi/AudioEngine/AEChannelInfo.h"
-  #include "kodi/AudioEngine/AEStreamData.h"
+  #include "AEChannelData.h"
+  #include "AEChannelInfo.h"
+  #include "AEStreamData.h"
 #else
   #include "cores/AudioEngine/Utils/AEChannelData.h"
   #include "cores/AudioEngine/Utils/AEChannelInfo.h"


### PR DESCRIPTION
Some header files for this library where missing. 

Currently I can't get information from the sink, which I will try to fix in the next days.
