### PR TITLE
[WIP] AudioDSP V2 dialog changes

### DIFF
--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -114,16 +114,6 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTN_ENABLE)
       {
-        //FIXME: should be moved to somewhere appropriate (e.g CAddonMgs::CanAddonBeDisabled or IsInUse) and button should be disabled
-        if (m_localAddon)
-        {
-          if (m_localAddon->Type() == ADDON_ADSPDLL && CServiceBroker::GetADSP().IsProcessing())
-          {
-            CGUIDialogOK::ShowAndGetInput(24137, 0, 24138, 0);
-            return true;
-          }
-        }
-
         OnEnableDisable();
         return true;
       }

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -21,12 +21,12 @@
 #include "GUIDialogAudioDSPSettings.h"
 #include "Application.h"
 #include "addons/Skin.h"
-#include "cores/IPlayer.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPDatabase.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPMode.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -80,7 +80,7 @@ using namespace ActiveAE;
 CGUIDialogAudioDSPSettings::CGUIDialogAudioDSPSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_DSP_OSD_SETTINGS, "DialogSettings.xml")
 {
-  m_ActiveStreamId                                = 0;
+  m_ActiveStreamId                                = -1;
   m_GetCPUUsage                                   = false;
   m_MenuPositions[SETTING_AUDIO_CAT_MAIN]         = CONTROL_SETTINGS_START_CONTROL;
   m_MenuPositions[SETTING_AUDIO_CAT_MASTER]       = CONTROL_SETTINGS_START_CONTROL;
@@ -122,7 +122,7 @@ void CGUIDialogAudioDSPSettings::OpenMenu(const std::string &id)
   else if (id == SETTING_AUDIO_CAT_RESAMPLING)
     m_MenuName = 15035;
   else if (id == SETTING_AUDIO_CAT_PRE_PROCESS)
-    m_MenuName = 15037;
+    m_MenuName = 15039;
   else if (id == SETTING_AUDIO_CAT_MISC)
     m_MenuName = 15038;
   else if (id == SETTING_AUDIO_CAT_PROC_INFO)
@@ -155,6 +155,32 @@ bool CGUIDialogAudioDSPSettings::OnMessage(CGUIMessage &message)
             OpenMenu(SETTING_AUDIO_CAT_PRE_PROCESS);
           else if (setting->GetId() == SETTING_AUDIO_MAIN_BUTTON_MISC)
             OpenMenu(SETTING_AUDIO_CAT_MISC);
+          else if (setting->GetId() == SETTING_AUDIO_MAIN_MODETYPE)
+          {
+            CGUIDialogSelect* pDlgSelect = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
+            pDlgSelect->Reset();
+            pDlgSelect->SetHeading(CVariant{15022});
+
+            int selectedItem=0;
+            CSettingString *masterModeSelectionButton = dynamic_cast<CSettingString*>(GetSetting(SETTING_AUDIO_MAIN_MODETYPE));
+            for (int ii = 0; ii < m_MasterModeList.size(); ii++)
+            {
+              pDlgSelect->Add(m_MasterModeList[ii].first);
+              if(m_MasterModeList[ii].first == masterModeSelectionButton->GetValue())
+              {
+                selectedItem = ii;
+              }
+            }
+
+            pDlgSelect->SetSelected(selectedItem);
+            pDlgSelect->Open();
+
+            int iItem = pDlgSelect->GetSelectedItem();
+            if (iItem >= 0)
+            {
+              masterModeSelectionButton->SetValue(m_MasterModeList[iItem].first);
+            }
+          }
           else if (setting->GetId() == SETTING_AUDIO_MAIN_BUTTON_INFO)
           {
             SetupView();
@@ -216,12 +242,12 @@ void CGUIDialogAudioDSPSettings::FrameMove()
     const CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
 
     bool forceReload = false;
-    unsigned int  streamId = CServiceBroker::GetADSP().GetActiveStreamId();
+    int  streamId = CServiceBroker::GetADSP().GetActiveStreamId();
     if (m_ActiveStreamId != streamId)
     {
       m_ActiveStreamId      = streamId;
       m_ActiveStreamProcess = CServiceBroker::GetADSP().GetDSPProcess(m_ActiveStreamId);
-      if (m_ActiveStreamId == (unsigned int)-1 || !m_ActiveStreamProcess)
+      if (m_ActiveStreamId < 0 || !m_ActiveStreamProcess)
       {
         Close(true);
         return;
@@ -274,38 +300,20 @@ void CGUIDialogAudioDSPSettings::OnSettingChanged(const CSetting *setting)
 
   CGUIDialogSettingsManualBase::OnSettingChanged(setting);
 
-  CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
   const std::string &settingId = setting->GetId();
-  if (settingId == SETTING_AUDIO_MAIN_STREAMTYPE)
+  if (settingId == SETTING_AUDIO_MAIN_MODETYPE)
   {
-    int type = (AE_DSP_STREAMTYPE)static_cast<const CSettingInt*>(setting)->GetValue();
-    CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterStreamTypeSel = type;
-    if (type == AE_DSP_ASTREAM_AUTO)
-      type = m_ActiveStreamProcess->GetDetectedStreamType();
+    std::string newMode = static_cast<const CSettingString*>(setting)->GetValue();
 
-    CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterStreamType = type;
-
-    /* Set the input stream type if any modes are available for this type */
-    if (type >= AE_DSP_ASTREAM_BASIC && type < AE_DSP_ASTREAM_AUTO && !m_MasterModes[type].empty())
+    for(int ii = 0; ii < m_MasterModeList.size(); ii++)
     {
-      /* Find the master mode id for the selected stream type if it was not known before */
-      if (CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterModes[type][m_baseTypeUsed] < 0)
-        CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterModes[type][m_baseTypeUsed] = m_MasterModes[type][0]->ModeID();
+      if(newMode == m_MasterModeList[ii].first)
+      {
+        m_modeTypeUsed = ii;
+      }
+    }
 
-      /* Switch now the master mode and stream type for audio dsp processing */
-      m_ActiveStreamProcess->SetMasterMode((AE_DSP_STREAMTYPE)type,
-                                           CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterModes[type][m_baseTypeUsed],
-                                           true);
-    }
-    else
-    {
-      CLog::Log(LOGERROR, "ActiveAE DSP Settings - %s - Change of audio stream type failed (type = %i)", __FUNCTION__, type);
-    }
-  }
-  else if (settingId == SETTING_AUDIO_MAIN_MODETYPE)
-  {
-    m_modeTypeUsed = static_cast<const CSettingInt*>(setting)->GetValue();
-    if (m_ActiveStreamProcess->SetMasterMode(m_streamTypeUsed, m_modeTypeUsed))
+    if (m_ActiveStreamProcess->SetMasterMode(m_streamTypeUsed, m_MasterModeList[m_modeTypeUsed].second))
       CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterModes[m_streamTypeUsed][m_baseTypeUsed] = m_modeTypeUsed;
   }
 }
@@ -393,7 +401,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
 
   m_ActiveStreamId      = CServiceBroker::GetADSP().GetActiveStreamId();
   m_ActiveStreamProcess = CServiceBroker::GetADSP().GetDSPProcess(m_ActiveStreamId);
-  if (m_ActiveStreamId == (unsigned int)-1 || !m_ActiveStreamProcess)
+  if (m_ActiveStreamId < 0 || !m_ActiveStreamProcess)
   {
     m_iCategory = FindCategoryIndex(SETTING_AUDIO_CAT_MAIN);
     Close(true);
@@ -431,15 +439,10 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       modeEntries.push_back(std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_PHONE),   AE_DSP_ASTREAM_PHONE));
     if (modesAvailable > 1 && m_MasterModes[m_streamTypeUsed].size() > 1)
       modeEntries.insert(modeEntries.begin(), std::pair<int, int>(CServiceBroker::GetADSP().GetStreamTypeName(AE_DSP_ASTREAM_AUTO), AE_DSP_ASTREAM_AUTO));
-
-    AddSpinner(groupAudioModeSel,
-                SETTING_AUDIO_MAIN_STREAMTYPE, 15021, 0,
-                (AE_DSP_STREAMTYPE)CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterStreamTypeSel,
-                modeEntries);
   }
 
   bool AddonMasterModeSetupPresent = false;
-  m_ModeList.clear();
+  m_MasterModeList.clear();
   for (unsigned int i = 0; i < m_MasterModes[m_streamTypeUsed].size(); i++)
   {
     if (m_MasterModes[m_streamTypeUsed][i])
@@ -448,11 +451,11 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       int modeId = m_MasterModes[m_streamTypeUsed][i]->ModeID();
       if (modeId == AE_DSP_MASTER_MODE_ID_PASSOVER || modeId >= AE_DSP_MASTER_MODE_ID_INTERNAL_TYPES)
       {
-        m_ModeList.push_back(make_pair(g_localizeStrings.Get(m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
+        m_MasterModeList.push_back(make_pair(g_localizeStrings.Get(m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
       }
       else if (CServiceBroker::GetADSP().GetAudioDSPAddon(m_MasterModes[m_streamTypeUsed][i]->AddonID(), addon))
       {
-        m_ModeList.push_back(make_pair(g_localizeStrings.GetAddonString(addon->ID(), m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
+        m_MasterModeList.push_back(make_pair(g_localizeStrings.GetAddonString(addon->ID(), m_MasterModes[m_streamTypeUsed][i]->ModeName()), modeId));
         if (!AddonMasterModeSetupPresent)
           AddonMasterModeSetupPresent = m_MasterModes[m_streamTypeUsed][i]->HasSettingsDialog();
       }
@@ -460,28 +463,21 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
   }
 
   m_modeTypeUsed = CMediaSettings::GetInstance().GetCurrentAudioSettings().m_MasterModes[m_streamTypeUsed][m_baseTypeUsed];
-  CSettingInt *spinner = AddSpinner(groupAudioModeSel, SETTING_AUDIO_MAIN_MODETYPE, 15022, 0, m_modeTypeUsed, AudioModeOptionFiller);
-  spinner->SetOptionsFiller(AudioModeOptionFiller, this);
-
-  ///-----------------------
-
-  // audio settings
-  // audio volume setting
-  m_volume = g_application.GetVolume(false);
-  if (!g_windowManager.IsWindowActive(WINDOW_DIALOG_AUDIO_OSD_SETTINGS))
+  std::string masterModeName = m_MasterModes[m_streamTypeUsed][m_modeTypeUsed]->AddonModeName();
+  if (masterModeName == "Passover")
   {
-    CSettingNumber *settingAudioVolume = AddSlider(groupAudioVolumeSel, SETTING_AUDIO_MAIN_VOLUME, 13376, 0, m_volume, 14054, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM);
-    static_cast<CSettingControlSlider*>(settingAudioVolume->GetControl())->SetFormatter(SettingFormatterPercentAsDecibel);
+    masterModeName = g_localizeStrings.Get(13551);
   }
+  AddInfoLabelButton(groupAudioModeSel, SETTING_AUDIO_MAIN_MODETYPE, 15023, 0, masterModeName, true);
 
   ///-----------------------
 
-  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_MASTER,   15025, 0, false, AddonMasterModeSetupPresent, -1);
-  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_OUTPUT,   15026, 0, false, HaveActiveMenuHooks(AE_DSP_MENUHOOK_POST_PROCESS) || SupportsAudioFeature(IPC_AUD_OFFSET), -1);
-  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_RESAMPLE, 15033, 0, false, HaveActiveMenuHooks(AE_DSP_MENUHOOK_RESAMPLE), -1);
+  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_MASTER,   15029, 0, false, AddonMasterModeSetupPresent, -1);
+  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_OUTPUT,   15030, 0, false, HaveActiveMenuHooks(AE_DSP_MENUHOOK_POST_PROCESS), -1);
+  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_RESAMPLE, 15035, 0, false, HaveActiveMenuHooks(AE_DSP_MENUHOOK_RESAMPLE), -1);
   AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_PRE_PROC, 15039, 0, false, HaveActiveMenuHooks(AE_DSP_MENUHOOK_PRE_PROCESS), -1);
   AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_MISC,     15034, 0, false, HaveActiveMenuHooks(AE_DSP_MENUHOOK_MISCELLANEOUS), -1);
-  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_INFO,     15027, 0, false, true, -1);
+  AddButton(groupAudioSubmenuSel, SETTING_AUDIO_MAIN_BUTTON_INFO,     15031, 0, false, true, -1);
 
   ///-----------------------
 
@@ -647,11 +643,11 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       CLog::Log(LOGERROR, "CGUIDialogAudioDSPSettings: unable to setup settings group for '%s'", g_localizeStrings.Get(15089).c_str());
       return;
     }
-    m_InputChannels = StringUtils::Format("%i", m_ActiveStreamProcess->GetInputChannels());
+    AEAudioFormat inputFormat = m_ActiveStreamProcess->GetInputFormat();
+    m_InputChannels = StringUtils::Format("%i", inputFormat.m_channelLayout.Count());
     AddInfoLabelButton(group, SETTING_STREAM_INFO_INPUT_CHANNELS, 21444, 0, m_InputChannels);
-    m_InputChannelNames = m_ActiveStreamProcess->GetInputChannelNames();
-    AddInfoLabelButton(group, SETTING_STREAM_INFO_INPUT_CHANNEL_NAMES, 15091, 0, m_InputChannelNames);
-    m_InputSamplerate = StringUtils::Format("%i Hz", (int)m_ActiveStreamProcess->GetInputSamplerate());
+    AddInfoLabelButton(group, SETTING_STREAM_INFO_INPUT_CHANNEL_NAMES, 15091, 0, inputFormat.m_channelLayout);
+    m_InputSamplerate = StringUtils::Format("%i Hz", (int)inputFormat.m_sampleRate);
     AddInfoLabelButton(group, SETTING_STREAM_INFO_INPUT_SAMPLERATE, 613, 0, m_InputSamplerate);
 
     group = AddGroup(category, 15090);
@@ -660,11 +656,12 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
       CLog::Log(LOGERROR, "CGUIDialogAudioDSPSettings: unable to setup settings group for '%s'", g_localizeStrings.Get(15090).c_str());
       return;
     }
-    m_OutputChannels = StringUtils::Format("%i", m_ActiveStreamProcess->GetOutputChannels());
+
+    AEAudioFormat outputFormat = m_ActiveStreamProcess->GetInputFormat();
+    m_OutputChannels = StringUtils::Format("%i", outputFormat.m_channelLayout.Count());
     AddInfoLabelButton(group, SETTING_STREAM_INFO_OUTPUT_CHANNELS, 21444, 0, m_OutputChannels);
-    m_OutputChannelNames = m_ActiveStreamProcess->GetOutputChannelNames();
-    AddInfoLabelButton(group, SETTING_STREAM_INFO_OUTPUT_CHANNEL_NAMES, 15091, 0, m_OutputChannelNames);
-    m_OutputSamplerate = StringUtils::Format("%i Hz", (int)m_ActiveStreamProcess->GetOutputSamplerate());
+    AddInfoLabelButton(group, SETTING_STREAM_INFO_OUTPUT_CHANNEL_NAMES, 15091, 0, outputFormat.m_channelLayout);
+    m_OutputSamplerate = StringUtils::Format("%i Hz", (int)outputFormat.m_sampleRate);
     AddInfoLabelButton(group, SETTING_STREAM_INFO_OUTPUT_SAMPLERATE, 613, 0, m_OutputSamplerate);
 
     group = AddGroup(category, 15081);
@@ -691,7 +688,7 @@ void CGUIDialogAudioDSPSettings::InitializeSettings()
             break;
           case AE_DSP_MODE_TYPE_OUTPUT_RESAMPLE:
             group = AddGroup(category, 15088, -1, true, true);
-            label = StringUtils::Format(g_localizeStrings.Get(15083).c_str(), m_ActiveStreamProcess->GetOutputSamplerate());
+            label = StringUtils::Format(g_localizeStrings.Get(15083).c_str(), outputFormat.m_sampleRate);
             break;
           case AE_DSP_MODE_TYPE_MASTER_PROCESS:
             group = AddGroup(category, 15084, -1, true, true);
@@ -855,7 +852,7 @@ void CGUIDialogAudioDSPSettings::GetAudioDSPMenus(CSettingGroup *group, AE_DSP_M
 
 bool CGUIDialogAudioDSPSettings::OpenAudioDSPMenu(unsigned int setupEntry)
 {
-  if (setupEntry >= m_Menus.size())
+  if (setupEntry >= m_Menus.size() || m_ActiveStreamId < 0)
     return false;
 
   AE_DSP_ADDON addon;
@@ -876,7 +873,7 @@ bool CGUIDialogAudioDSPSettings::OpenAudioDSPMenu(unsigned int setupEntry)
     case AE_DSP_MENUHOOK_MASTER_PROCESS:
     case AE_DSP_MENUHOOK_RESAMPLE:
     case AE_DSP_MENUHOOK_POST_PROCESS:
-      hookData.data.iStreamId = m_ActiveStreamId;
+      hookData.data.iStreamId = (AE_DSP_STREAM_ID)m_ActiveStreamId;
       break;
     default:
       break;

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.h
@@ -53,8 +53,6 @@ namespace ActiveAE
     // specialization of CGUIDialogSettingsManualBase
     virtual void InitializeSettings();
 
-    bool SupportsAudioFeature(int feature);
-
     static void AudioModeOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
     std::string GetSettingsLabel(CSetting *pSetting);
@@ -79,7 +77,7 @@ namespace ActiveAE
     bool OpenAudioDSPMenu(unsigned int setupEntry);
     int FindCategoryIndex(const std::string &catId);
 
-    AE_DSP_STREAM_ID                            m_ActiveStreamId;                         /*!< The on dialog selectable stream identifier */
+    int                                         m_ActiveStreamId;                         /*!< The on dialog selectable stream identifier */
     ActiveAE::CActiveAEDSPProcessPtr            m_ActiveStreamProcess;                    /*!< On dialog adjustable dsp processing class */
     AE_DSP_STREAMTYPE                           m_streamTypeUsed;                         /*!< The currently available stream type */
     AE_DSP_BASETYPE                             m_baseTypeUsed;                           /*!< The currently detected and used base type */
@@ -90,19 +88,16 @@ namespace ActiveAE
     std::map<std::string, int>                  m_MenuPositions;                          /*!< The differnet menu selection positions */
     std::vector<int>                            m_MenuHierarchy;                          /*!< Menu selection flow hierachy */
     std::vector<MenuHookMember>                 m_Menus;                                  /*!< storage about present addon menus on currently selected submenu */
-    std::vector< std::pair<std::string, int> >  m_ModeList;                               /*!< currently present modes */
+    std::vector< std::pair<std::string, int> >  m_MasterModeList;                         /*!< currently present master modes */
     bool                                        m_GetCPUUsage;                            /*!< if true cpu usage detection is active */
     Features                                    m_audioCaps;                              /*!< the on current playback on KODI supported audio features */
     int                                         m_MenuName;                               /*!< current menu name, needed to get after the dialog was closed for addon */
 
     /*! Settings control selection and information data */
     std::string                                 m_InputChannels;
-    std::string                                 m_InputChannelNames;
     std::string                                 m_InputSamplerate;
     std::string                                 m_OutputChannels;
-    std::string                                 m_OutputChannelNames;
     std::string                                 m_OutputSamplerate;
     std::string                                 m_CPUUsage;
-    float                                       m_volume;
   };
 }

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.h
@@ -40,10 +40,6 @@ namespace ActiveAE
     // specialization of CGUIWindow
     virtual void FrameMove();
 
-    static std::string FormatDelay(float value, float interval);
-    static std::string FormatDecibel(float value);
-    static std::string FormatPercentAsDecibel(float value);
-
   protected:
     // implementations of ISettingCallback
     virtual void OnSettingChanged(const CSetting *setting);
@@ -60,9 +56,6 @@ namespace ActiveAE
     bool SupportsAudioFeature(int feature);
 
     static void AudioModeOptionFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
-
-    static std::string SettingFormatterDelay(const CSettingControlSlider *control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum);
-    static std::string SettingFormatterPercentAsDecibel(const CSettingControlSlider *control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum);
 
     std::string GetSettingsLabel(CSetting *pSetting);
 


### PR DESCRIPTION
This PR tries to improve the AudioDSP dialogs.

I did the following changes:
- It replaces the spincontrolex for master mode selection with an dialog box
- Use the int data type for streamId
- Remove the volume and delay settings

After this PR gets merged I like to integrate the remaining settings from AudioDSP into OSD audio settings.
