### PR TITLE
AMC(surface) is not a BYPASS

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -209,6 +209,11 @@ void CDVDMediaCodecInfo::Validate(bool state)
   m_valid = state;
 }
 
+bool CDVDMediaCodecInfo::WaitForFrame(int millis)
+{
+  return m_frameready->WaitMSec(millis);
+}
+
 void CDVDMediaCodecInfo::ReleaseOutputBuffer(bool render)
 {
   CSingleLock lock(m_section);
@@ -277,7 +282,7 @@ void CDVDMediaCodecInfo::UpdateTexImage()
   // we hook the SurfaceTexture OnFrameAvailable callback
   // using CJNISurfaceTextureOnFrameAvailableListener and wait
   // on a CEvent to fire. 50ms seems to be a good max fallback.
-  m_frameready->WaitMSec(50);
+  WaitForFrame(50);
 
   m_surfacetexture->updateTexImage();
   if (xbmc_jnienv()->ExceptionCheck())

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -63,6 +63,7 @@ public:
 
   // meat and potatos
   void                Validate(bool state);
+  bool                WaitForFrame(int millis);
   // MediaCodec related
   void                ReleaseOutputBuffer(bool render);
   // SurfaceTexture released

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -66,6 +66,7 @@ public:
   bool                WaitForFrame(int millis);
   // MediaCodec related
   void                ReleaseOutputBuffer(bool render);
+  bool                IsReleased() { return m_isReleased; }
   // SurfaceTexture released
   ssize_t             GetIndex() const;
   int                 GetTextureID() const;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -63,6 +63,11 @@ void CRendererMediaCodecSurface::AddVideoPictureHW(DVDVideoPicture &picture, int
 #endif
 }
 
+bool CRendererMediaCodecSurface::RenderUpdateCheckForEmptyField()
+{
+  return false;
+}
+
 void CRendererMediaCodecSurface::ReleaseBuffer(int idx)
 {
   YUVBUFFER &buf = m_buffers[idx];
@@ -77,11 +82,6 @@ void CRendererMediaCodecSurface::ReleaseBuffer(int idx)
 int CRendererMediaCodecSurface::GetImageHook(YV12Image *image, int source, bool readonly)
 {
   return source;
-}
-
-bool CRendererMediaCodecSurface::IsGuiLayer()
-{
-  return false;
 }
 
 bool CRendererMediaCodecSurface::Supports(EINTERLACEMETHOD method)
@@ -113,12 +113,7 @@ bool CRendererMediaCodecSurface::LoadShadersHook()
 
 bool CRendererMediaCodecSurface::RenderHook(int index)
 {
-  return true; // nothing to be done
-}
-
-bool CRendererMediaCodecSurface::RenderUpdateVideoHook(bool clear, DWORD flags, DWORD alpha)
-{
-  CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[m_iYV12RenderBuffer].hwDec);
+  CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[index].hwDec);
   if (mci)
   {
     // this hack is needed to get the 2D mode of a 3D movie going
@@ -151,8 +146,6 @@ bool CRendererMediaCodecSurface::RenderUpdateVideoHook(bool clear, DWORD flags, 
 
     mci->RenderUpdate(srcRect, dstRect);
   }
-
-  CXBMCApp::WaitVSync(1000.0 / g_graphicsContext.GetFPS());
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -114,7 +114,7 @@ bool CRendererMediaCodecSurface::LoadShadersHook()
 bool CRendererMediaCodecSurface::RenderHook(int index)
 {
   CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[index].hwDec);
-  if (mci)
+  if (mci && !mci->IsReleased())
   {
     // this hack is needed to get the 2D mode of a 3D movie going
     RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -36,8 +36,8 @@ public:
 
   // Player functions
   virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index);
+  virtual bool RenderUpdateCheckForEmptyField();
   virtual void ReleaseBuffer(int idx);
-  virtual bool IsGuiLayer();
 
   // Feature support
   virtual bool Supports(EINTERLACEMETHOD method);
@@ -56,7 +56,6 @@ protected:
   virtual bool LoadShadersHook();
   virtual bool RenderHook(int index);  
   virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
-  virtual bool RenderUpdateVideoHook(bool clear, DWORD flags = 0, DWORD alpha = 255);
 };
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

Cut the crap about amcs being a bypass.
Also cut the crap about having to wait for vsync
## Description

<!--- Describe your change in detail -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

Cut the crap ;)
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
