### PR TITLE
Forced rescan of music file tags for v17

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -900,11 +900,13 @@ msgctxt "#203"
 msgid "Plot outline"
 msgstr ""
 
+#. label of a smartplaylist filter option to filter for albums on compilations
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#204"
 msgid "Compilation"
 msgstr ""
 
+#. label of a smartplaylist filter option to filter for songs or albums on votes for rating
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#205"
 msgid "Votes"
@@ -3477,12 +3479,7 @@ msgctxt "#799"
 msgid "Library update"
 msgstr ""
 
-#: xbmc/music/windows/GUIWindowMusicBase.cpp
-msgctxt "#800"
-msgid "Music library needs to rescan tags from files. Would you like to scan now?"
-msgstr ""
-
-#empty string with id 801
+#empty strings from id 800 to 801
 
 #. Label of progess bar which shows the available/total space of pvr backend
 #: xbmc/pvr/PVRGUIInfo.cpp
@@ -14820,6 +14817,7 @@ msgid "Style"
 msgstr ""
 
 #. Concert composer of the music (if present)
+#: Label of ListItem.Property(Role.Composer)
 #: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
 msgctxt "#29903"
 msgid "Composer"
@@ -14832,6 +14830,7 @@ msgid "Artist"
 msgstr ""
 
 #. Conductor of the classic music (if present)
+#: Label of ListItem.Property(Role.Conductor)
 #: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
 msgctxt "#29905"
 msgid "Conductor"
@@ -15274,49 +15273,49 @@ msgctxt "#29985"
 msgid "If traffic advisory is send from RDS, volume is increased"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #38036
 #: system/library/music/musicroles/Remixers.xml
 msgctxt "#29987"
 msgid "Remixers"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #38037
 #: system/library/music/musicroles/Arrangers.xml
 msgctxt "#29988"
 msgid "Arrangers"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #29903
 #: system/library/music/musicroles/Composers.xml
 msgctxt "#29989"
 msgid "Composers"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #29905
 #: system/library/music/musicroles/Conductors.xml
 msgctxt "#29990"
 msgid "Conductors"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #38040
 #: system/library/music/musicroles/DJ.xml
 msgctxt "#29991"
 msgid "DJ Mixers"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #38035
 #: system/library/music/musicroles/Lyricists.xml
 msgctxt "#29992"
 msgid "Lyricists"
 msgstr ""
 
-#. Music role category
+#. Node title for music artist role, plural of #38034
 #: system/library/music/musicroles/Orchestras.xml
 msgctxt "#29993"
 msgid "Orchestras"
 msgstr ""
 
-#. Roles from music contributor
+#. Title for music artist roles node
 #: system/library/music/musicroles/index.xml
 msgctxt "#29994"
 msgid "Roles"
@@ -19451,46 +19450,54 @@ msgid "Role"
 msgstr ""
 
 #. Orchestra playing on the recording (if present)
+#: Label of ListItem.Property(Role.Orchestra)
 msgctxt "#38034"
 msgid "Orchestra"
 msgstr ""
 
 #. Lyricist that wrote the lyrics of the song (if present)
+#: Label of ListItem.Property(Role.Lyricist)
 msgctxt "#38035"
 msgid "Lyricist"
 msgstr ""
 
 #. Remixer of the song (if present)
+#: Label of ListItem.Property(Role.Remixer)
 msgctxt "#38036"
 msgid "Remixer"
 msgstr ""
 
 #. Arranger of the song (if present)
+#: Label of ListItem.Property(Role.Arranger)
 msgctxt "#38037"
 msgid "Arranger"
 msgstr ""
 
 #. Engineer of the song (if present)
+#: Label of ListItem.Property(Role.Engineer)
 msgctxt "#38038"
 msgid "Engineer"
 msgstr ""
 
 #. Producer of the song (if present)
+#: Label of ListItem.Property(Role.Producer)
 msgctxt "#38039"
 msgid "Producer"
 msgstr ""
 
 #. DJMixer of the song (if present)
+#: Label of ListItem.Property(Role.DJMixer)
 msgctxt "#38040"
 msgid "DJMixer"
 msgstr ""
 
 #. Mixer of the song (if present)
+#: Label of ListItem.Property(Role.Mixer)
 msgctxt "#38041"
 msgid "Mixer"
 msgstr ""
 
-#. Missing artist name
+#. Name used when artist name is missing from music file tags
 #: music/MusicDatabase.cpp
 msgctxt "#38042"
 msgid "[Missing]"
@@ -19508,7 +19515,7 @@ msgctxt "#38044"
 msgid "Song & album artists"
 msgstr ""
 
-#. Title all contributors node (any role)
+#. Title all contributors node (any role e.g. composer, piano, producer, engineer)
 #: system/library/music/musicroles/allcontributors.xml
 msgctxt "#38045"
 msgid "All contributors"
@@ -19520,7 +19527,21 @@ msgctxt "#38046"
 msgid "All roles"
 msgstr ""
 
-#empty strings from id 38047 to 38099
+#empty strings from id 38047 to 38059
+
+#. Question when forced rescan of music tags needed after upgrade from previous version of Kodi
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+msgctxt "#38060"
+msgid "Music library needs to rescan tags from files. Would you like to scan now?"
+msgstr ""
+
+#. Extra scraping question on upgrade from previous version 
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+msgctxt "#38061"
+msgid "Fetch additional information for albums and artists? This could take some time so you may prefer to do this later"
+msgstr ""
+
+#empty strings from id 38062 to 38099
 
 #. Description of section #14200 "Player""
 #: system/settings/settings.xml

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4847,9 +4847,6 @@ void CMusicDatabase::UpdateTables(int version)
       "SELECT idArtist, idAlbum, iOrder, strArtist FROM album_artist");
     m_pDS->exec("DROP TABLE album_artist");
     m_pDS->exec("ALTER TABLE album_artist_new RENAME TO album_artist");
-
-    CMediaSettings::GetInstance().SetMusicNeedsUpdate(58);
-    CSettings::GetInstance().Save();
   }
   if (version < 60)
   { 
@@ -4960,6 +4957,11 @@ void CMusicDatabase::UpdateTables(int version)
     //Remove temp indices, full analyics for database created later
     m_pDS->exec("DROP INDEX idxSongArtist1 ON song_artist");
     m_pDS->exec("DROP INDEX idxAlbumArtist1 ON album_artist");
+
+    // Prompt for rescan of library to read tags that were not processed by previous versions
+    // and accomodate changes to the way some tags are processed
+    CMediaSettings::GetInstance().SetMusicNeedsUpdate(60);
+    CSettings::GetInstance().Save();
   }
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1304,16 +1304,21 @@ bool CGUIWindowMusicBase::CanContainFilter(const std::string &strDirectory) cons
 void CGUIWindowMusicBase::OnInitWindow()
 {
   CGUIMediaWindow::OnInitWindow();
-  if (CMediaSettings::GetInstance().GetMusicNeedsUpdate() == 53)
+  // Prompt for rescan of library to read music file tags that were not processed by previous versions
+  // and accomodate any changes to the way some tags are processed
+  if (CMediaSettings::GetInstance().GetMusicNeedsUpdate() != 0)
   {
     if (g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC) && !g_application.IsMusicScanning())
     {
       // rescan of music library required
-      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{800}))
+      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{38060}))
       {
         int flags = CMusicInfoScanner::SCAN_RESCAN;
+        // When set to fetch information on update enquire about scraping that as well
+        // It may take some time, so the user may want to do it later by "Query Info For All"
         if (CSettings::GetInstance().GetBool(CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO))
-          flags |= CMusicInfoScanner::SCAN_ONLINE;
+          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{38061}))
+            flags |= CMusicInfoScanner::SCAN_ONLINE;
         if (CSettings::GetInstance().GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
           flags |= CMusicInfoScanner::SCAN_BACKGROUND;
         g_application.StartMusicScan("", true, flags);


### PR DESCRIPTION
Add a forced rescan of tags to capture the new tag data that is processed when upgrading to v17 from earlier versions.

Users are not going to many of see the improvements to the music library when they upgrade to V17 from earlier versions unless they rescan the additional tags that v17 processes from their music files. However there is no easy way for users to initiate a rescan of exsisting files without either a) dropping that source and losing their playcount etc. data or b) "touching" the music files so that Kodi thinks they have changed. A library update started by the user will only check the hash table, it then only scans the tags of those that have a different name or timestamp. If users retag for the new features then this is fine, many will have the tags already in their music files but fail to benefit when using Kodi. 

The user will be prompted to rescan the tags from all their music files the first time they enter the music library after upgrading from an older version of Kodi. They can opt not to do so at that time, but they will be asked again the next time they enter the music library. This prompting will repeat until scanning is started.  This scan could be interrupted if the user does not want to completely scan all their files, and Kodi will not prompt again.

Rather than automatically fetch additional data for artists and albums (from online sources or NFO files), if the user has "fetch additional information during update" enabled then they will also be asked if they want to fetch ithis information as well. 

This can take some time, and it is something that the user can do at a later date using "Query Information for all" from the context menu of the artist or album nodes. It also may be unnecessary - most of the additional information previously scraped will still be in the libaray, only the album genre(s), year, compilation, label and type will revert to what is determined from the music  file tags. 

To test this install Kodi as an upgrade from an earlier version (the existence of an earlier MyMyusicXX.db than 60), or modiy the guisettings.xml to trick it into rescanning by

```
    <mymusic>
        <needsupdate>60</needsupdate>
    </mymusic>
```

Plenty of scope to discuss the best words to use. An alternative  3 button dialog "scan now", "scan later", "never scan" is also an option. But we really need something in place before release.

@MartijnKaijser and @jjd-uk after our discussion. @phate89 could be combined with testing of  #10731 
