### PR TITLE
[xbmc][win]Build addons with debug info on Windows

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -58,7 +58,7 @@ FOR %%b in (%1, %2, %3, %4, %5, %6) DO (
   IF %%b==sh SET useshell=sh
 )
 
-SET buildconfig=Release
+SET buildconfig=RelWithDebInfo
 set WORKSPACE=%CD%\..\..\kodi-build
 
 
@@ -218,6 +218,7 @@ set WORKSPACE=%CD%\..\..\kodi-build
   CALL extract_git_rev.bat > NUL
   SET APP_SETUPFILE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%.exe
   SET APP_PDBFILE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%.pdb
+  SET APP_PDB_BUNDLE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%-PDB.7z
   ECHO Creating installer %APP_SETUPFILE%...
   IF EXIST %APP_SETUPFILE% del %APP_SETUPFILE% > NUL
   rem get path to makensis.exe from registry, first try tab delim
@@ -261,7 +262,12 @@ set WORKSPACE=%CD%\..\..\kodi-build
     set DIETEXT=Failed to create %APP_SETUPFILE%. NSIS installed?
     goto DIE
   )
-  copy %PDB% %APP_PDBFILE% > nul
+  REM copy %PDB% %APP_PDBFILE% > nul
+
+  rmdir /S /Q PDB > nul
+  md PDB > nul
+  powershell -ExecutionPolicy Unrestricted -File .\copy-pdb.ps1
+  tools\7z\7za.exe a -bd -r %APP_PDB_BUNDLE% PDB
   ECHO ------------------------------------------------------------
   ECHO Done!
   ECHO Setup is located at %CD%\%APP_SETUPFILE%

--- a/project/Win32BuildSetup/copy-pdb.ps1
+++ b/project/Win32BuildSetup/copy-pdb.ps1
@@ -1,0 +1,6 @@
+Get-ChildItem -Recurse -Include *.pdb -Exclude vc140.pdb,'kodi-test.pdb',gtest.pdb,CMakeCCompilerId.pdb,CMakeCXXCompilerId.pdb,example.pdb ..\.. |
+foreach {
+  if (-not $_.DirectoryName.EndsWith('PDB')) {
+    Copy-Item $_.FullName (join-path PDB $_.Name)
+  }
+}

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -104,7 +104,7 @@ IF "%addon%" NEQ "" (
 
 rem execute cmake to generate makefiles processable by nmake
 cmake "%ADDONS_PATH%" -G "NMake Makefiles" ^
-      -DCMAKE_BUILD_TYPE=Release ^
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^
       -DCMAKE_INSTALL_PREFIX=%ADDONS_INSTALL_PATH% ^


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

<!--- Describe your change in detail -->

Change buildsetup to bundle all our PDB files into an
archive, should hopefully make it easier to look at addon
crashes
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

Get better crash logs and make investigation of crashes easier.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
