### PR TITLE
Fade the current controller while mapping its buttons

### DIFF
--- a/xbmc/games/controllers/windows/GUIControllerList.h
+++ b/xbmc/games/controllers/windows/GUIControllerList.h
@@ -47,6 +47,7 @@ namespace GAME
     virtual bool Refresh(void) override;
     virtual void OnFocus(unsigned int controllerIndex) override;
     virtual void OnSelect(unsigned int controllerIndex) override;
+    virtual int GetFocusedController() const override { return m_focusedController; }
     virtual void ResetController(void) override;
 
   private:

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -26,6 +26,8 @@
 #include "addons/GUIWindowAddonBrowser.h"
 #include "addons/IAddon.h"
 #include "addons/AddonManager.h"
+#include "guilib/GUIButtonControl.h"
+#include "guilib/GUIControl.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/WindowIDs.h"
 
@@ -54,6 +56,39 @@ CGUIControllerWindow::~CGUIControllerWindow(void)
 {
   delete m_controllerList;
   delete m_featureList;
+}
+
+void CGUIControllerWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  /*
+   * Apply the faded focus texture to the current controller when unfocused
+   */
+
+  CGUIControl* control = nullptr; // The controller button
+  bool bAlphaFaded = false; // True if the controller button has been focused and faded this frame
+
+  if (m_controllerList && m_controllerList->GetFocusedController() >= 0)
+  {
+    control = GetFirstFocusableControl(CONTROL_CONTROLLER_BUTTONS_START + m_controllerList->GetFocusedController());
+    if (control && !control->HasFocus())
+    {
+      if (control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
+      {
+        control->SetFocus(true);
+        static_cast<CGUIButtonControl*>(control)->SetAlpha(0x80);
+        bAlphaFaded = true;
+      }
+    }
+  }
+
+  CGUIDialog::DoProcess(currentTime, dirtyregions);
+
+  if (control && bAlphaFaded)
+  {
+    control->SetFocus(false);
+    if (control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
+      static_cast<CGUIButtonControl*>(control)->SetAlpha(0xFF);
+  }
 }
 
 bool CGUIControllerWindow::OnMessage(CGUIMessage& message)

--- a/xbmc/games/controllers/windows/GUIControllerWindow.h
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.h
@@ -35,6 +35,7 @@ namespace GAME
     virtual ~CGUIControllerWindow(void);
 
     // implementation of CGUIControl via CGUIDialog
+    virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
     virtual bool OnMessage(CGUIMessage& message) override;
 
   protected:

--- a/xbmc/games/controllers/windows/IConfigurationWindow.h
+++ b/xbmc/games/controllers/windows/IConfigurationWindow.h
@@ -88,6 +88,12 @@ namespace GAME
     virtual void OnSelect(unsigned int controllerIndex) = 0;
 
     /*!
+     * \brief Get the index of the focused controller
+     * \return The index of the focused controller, or -1 if no controller has been focused yet
+     */
+    virtual int GetFocusedController() const = 0;
+
+    /*!
      * \brief Reset the focused controller
      */
     virtual void ResetController(void) = 0;


### PR DESCRIPTION
This keeps the controller button focused (albeit faded) so that the user can know which controller they're mapping at all times.

<img width="1219" alt="screen shot 2016-10-23 at 2 34 18 pm" src="https://cloud.githubusercontent.com/assets/531482/19629653/26c4b460-992e-11e6-81a4-af2232e329e7.png">

Broken out from #10630
