### PR TITLE
instance id

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -820,7 +820,7 @@
 		DF033D381946612400BFC82E /* AEDeviceEnumerationOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF033D361946612400BFC82E /* AEDeviceEnumerationOSX.cpp */; };
 		DF0ABB73183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
 		DF0ABB74183A94A30018445D /* Utf8Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0ABB71183A94A30018445D /* Utf8Utils.cpp */; };
-		DF0D9F4D1D63931F006A7DBB /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
+		DF0D9F4D1D63931F006A7DBB /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE_CLASSPLATFORM"; }; };
 		DF0D9F511D63961B006A7DBB /* PlatformDarwinOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F501D63961B006A7DBB /* PlatformDarwinOSX.cpp */; };
 		DF0D9F551D639898006A7DBB /* PlatformDarwinIOS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F531D639893006A7DBB /* PlatformDarwinIOS.cpp */; };
 		DF0DF15C13A3ADA7008ED511 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF15913A3ADA7008ED511 /* NFSDirectory.cpp */; };
@@ -979,7 +979,7 @@
 		DFA8157E16713B1200E4E597 /* WakeOnAccess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFA8157C16713B1200E4E597 /* WakeOnAccess.cpp */; };
 		DFAB049813F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
 		DFACDB891D6CAC33003BBB92 /* PlatformDarwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF8E55951D5F1D7000FD2BA3 /* PlatformDarwin.cpp */; };
-		DFACDB8E1D6CAD06003BBB92 /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
+		DFACDB8E1D6CAD06003BBB92 /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0D9F4B1D63931F006A7DBB /* Platform.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE_CLASSPLATFORM"; }; };
 		DFAF6A4F16EBAE3800D6AE12 /* RssManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAF6A4D16EBAE3800D6AE12 /* RssManager.cpp */; };
 		DFB02DEA16629DBA00F37752 /* PyContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB02DE816629DBA00F37752 /* PyContext.cpp */; };
 		DFB0F472161B747500D744F4 /* AddonsOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB0F470161B747500D744F4 /* AddonsOperations.cpp */; };

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5528,7 +5528,12 @@ msgctxt "#12395"
 msgid "Battery level"
 msgstr ""
 
-#empty strings from id 12396 to 12599
+#: xbmc/windows/GUIWindowSystemInfo.cpp
+msgctxt "#12396"
+msgid "Instance ID"
+msgstr ""
+
+#empty strings from id 12397 to 12599
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12600"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1188,6 +1188,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "profileautologin", SYSTEM_PROFILEAUTOLOGIN },
                                   { "progressbar",      SYSTEM_PROGRESS_BAR },
                                   { "batterylevel",     SYSTEM_BATTERY_LEVEL },
+                                  { "instanceid",       SYSTEM_INSTANCE_ID },
                                   { "friendlyname",     SYSTEM_FRIENDLY_NAME },
                                   { "alarmpos",         SYSTEM_ALARM_POS },
                                   { "isinhibit",        SYSTEM_ISINHIBIT },
@@ -6311,6 +6312,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case SYSTEM_UPTIME:
   case SYSTEM_TOTALUPTIME:
   case SYSTEM_BATTERY_LEVEL:
+  case SYSTEM_INSTANCE_ID:
     return g_sysinfo.GetInfo(info);
     break;
 

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -65,3 +65,8 @@ PLAYLIST::CPlayListPlayer &CServiceBroker::GetPlaylistPlayer()
 {
   return g_application.m_ServiceManager->GetPlaylistPlayer();
 }
+
+CPlatform& CServiceBroker::GetPlatform()
+{
+  return g_application.m_ServiceManager->GetPlatform();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -47,6 +47,7 @@ namespace PLAYLIST
 class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
+class CPlatform;
 
 class CServiceBroker
 {
@@ -60,4 +61,5 @@ public:
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
   static PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
+  static CPlatform& GetPlatform();
 };

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -426,6 +426,8 @@
 #define SYSTEM_CAN_HIBERNATE        752
 #define SYSTEM_CAN_REBOOT           753
 
+#define SYSTEM_INSTANCE_ID          754
+
 #define SLIDESHOW_ISPAUSED          800
 #define SLIDESHOW_ISRANDOM          801
 #define SLIDESHOW_ISACTIVE          802

--- a/xbmc/platform/CMakeLists.txt
+++ b/xbmc/platform/CMakeLists.txt
@@ -15,5 +15,5 @@ set(HEADERS MessagePrinter.h
 core_add_library(platform_common)
 
 if(OVERRIDES_CPP)
-  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE)
+  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE_CLASSPLATFORM)
 endif()

--- a/xbmc/platform/Makefile.in
+++ b/xbmc/platform/Makefile.in
@@ -2,7 +2,7 @@
 
 OVERRIDES = $(wildcard overrides/@CORE_SYSTEM_NAME@/*.cpp) $(wildcard overrides/@CORE_SYSTEM_VARIANT@/*.cpp)
 ifneq ($(strip $(OVERRIDES)),)
-  CXXFLAGS += -DPLATFORM_OVERRIDE
+  CXXFLAGS += -DPLATFORM_OVERRIDE_CLASSPLATFORM
 endif
   
 SRCS = posix/MessagePrinter.cpp

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -21,7 +21,7 @@
 #include "Platform.h"
 
 // Override for platform ports
-#if !defined(PLATFORM_OVERRIDE)
+#if !defined(PLATFORM_OVERRIDE_CLASSPLATFORM)
 
 CPlatform* CPlatform::CreateInstance()
 {

--- a/xbmc/platform/Platform.cpp
+++ b/xbmc/platform/Platform.cpp
@@ -18,7 +18,15 @@
  *
  */
 
+#include "system.h"
 #include "Platform.h"
+#include "Application.h"
+#include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+const std::string CPlatform::NoValidUUID = "NOUUID";
 
 // Override for platform ports
 #if !defined(PLATFORM_OVERRIDE_CLASSPLATFORM)
@@ -34,16 +42,38 @@ CPlatform* CPlatform::CreateInstance()
 
 CPlatform::CPlatform()
 {
-  
-}
-
-CPlatform::~CPlatform()
-{
-  
+  m_uuid = NoValidUUID;
 }
 
 void CPlatform::Init()
 {
-  // nothing for now
+  InitInstanceIdentifier();
 }
 
+void CPlatform::InitInstanceIdentifier()
+{
+  using namespace XFILE;
+
+  const auto path = CSpecialProtocol::TranslatePath("special://home/instance_id");
+  if (CFile::Exists(path))
+  {
+    CFile file;
+    if (file.Open(path))
+    {
+      char temp[36];
+      if (file.Read(temp, 36) == 36)
+      {
+        m_uuid = temp;
+        return;
+      }
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "instance id not found. creating..");
+  auto uuid = StringUtils::CreateUUID();
+  CFile file;
+  if (file.OpenForWrite(path, true) && file.Write(uuid.c_str(), 36) == 36)
+    m_uuid = std::move(uuid);
+  else
+    CLog::Log(LOGERROR, "failed to write instance id");
+}

--- a/xbmc/platform/Platform.h
+++ b/xbmc/platform/Platform.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <string>
 
 /**\brief Class for the Platform object
  *
@@ -39,7 +40,7 @@ public:
   CPlatform();
   
   /**\brief D'tor */
-  virtual ~CPlatform();
+  virtual ~CPlatform() = default;
   
   /**\brief Called at an early stage of application startup
    *
@@ -47,5 +48,14 @@ public:
    * or initialisation (like setting environment variables for example)
    */
   virtual void Init();
+
+  const std::string& GetInstanceIdentifier() { return m_uuid; };
+
+  // constants
+  static const std::string NoValidUUID;
   
+private:
+  void InitInstanceIdentifier();
+
+  std::string m_uuid;
 };

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -38,6 +38,7 @@
 #include "CPUInfo.h"
 #include "CompileInfo.h"
 #include "settings/Settings.h"
+#include "ServiceBroker.h"
 
 #ifdef TARGET_WINDOWS
 #include "dwmapi.h"
@@ -257,6 +258,7 @@ bool CSysInfoJob::DoWork()
   m_info.osVersionInfo     = CSysInfo::GetOsPrettyNameWithVersion() + " (kernel: " + CSysInfo::GetKernelName() + " " + CSysInfo::GetKernelVersionFull() + ")";
   m_info.macAddress        = GetMACAddress();
   m_info.batteryLevel      = GetBatteryLevel();
+  m_info.instanceId        = CServiceBroker::GetPlatform().GetInstanceIdentifier();
   return true;
 }
 
@@ -385,6 +387,8 @@ std::string CSysInfo::TranslateInfo(int info) const
       return g_localizeStrings.Get(13297);
   case SYSTEM_BATTERY_LEVEL:
     return m_info.batteryLevel;
+  case SYSTEM_INSTANCE_ID:
+    return m_info.instanceId;
   default:
     return "";
   }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -282,11 +282,9 @@ CSysData::INTERNET_STATE CSysInfoJob::GetInternetState()
 
 std::string CSysInfoJob::GetMACAddress()
 {
-#if defined(HAS_LINUX_NETWORK) || defined(HAS_WIN32_NETWORK)
   CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
   if (iface)
     return iface->GetMacAddress();
-#endif
   return "";
 }
 

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -54,6 +54,7 @@ public:
   std::string osVersionInfo;
   std::string macAddress;
   std::string batteryLevel;
+  std::string instanceId;
 };
 
 class CSysInfoJob : public CJob

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -164,6 +164,7 @@ void CGUIWindowSystemInfo::FrameMove()
     i++;  // empty line
     SetControlLabel(i++, "%s: %s", 22012, SYSTEM_TOTAL_MEMORY);
     SetControlLabel(i++, "%s: %s", 158, SYSTEM_FREE_MEMORY);
+    SetControlLabel(i++, "%s: %s", 12396, SYSTEM_INSTANCE_ID);
   }
 
   else if (m_section == CONTROL_BT_PVR)


### PR DESCRIPTION
Alternative to #10543 which uses uuid4. This ensures that the id is not reproducible and trackable by others.

Also, this makes it easier for user to reset the ID by simply deleting it, in contrast to a hardware IDs which are much harder to change.

This should be more than good enough for our purposes.
