### PR TITLE
Fix 1 error and 5 compiler warnings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -252,60 +252,55 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 //extern IDirectSoundRenderer* m_pAudioDecoder;
 CApplication::CApplication(void)
   : m_pPlayer(new CApplicationPlayer)
+  , m_iScreenSaveLock(0)
+  , m_bPlaybackStarting(false)
+  , m_ePlayState(PLAY_STATE_NONE)
+  , m_confirmSkinChange(true)
+  , m_ignoreSkinSettingChanges(false)
   , m_saveSkinOnUnloading(true)
   , m_autoExecScriptExecuted(false)
+  , m_bScreenSave(false)
+  , m_bInhibitIdleShutdown(false)
+  , m_dpms(nullptr)
+  , m_dpmsIsActive(false)
+  , m_dpmsIsManual(false)
   , m_itemCurrentFile(new CFileItem)
   , m_stackFileItemToUpdate(new CFileItem)
+  , m_threadID(0)
+  , m_bInitializing(true)
+  , m_bPlatformDirectories(true)
   , m_progressTrackingVideoResumeBookmark(*new CBookmark)
   , m_progressTrackingItem(new CFileItem)
+  , m_progressTrackingPlayCountUpdate(false)
+  , m_currentStackPosition(0)
+  , m_nextPlaylistItem(-1)
+  , m_lastRenderTime(0)
+  , m_skipGuiRender(false)
+  , m_bStandalone(false)
+  , m_bEnableLegacyRes(false)
+  , m_bTestMode(false)
+  , m_bSystemScreenSaverEnable(false)
   , m_musicInfoScanner(new CMusicInfoScanner)
+  , m_muted(false)
+  , m_volumeLevel(VOLUME_MAXIMUM)
+  , m_pInertialScrollingHandler(new CInertialScrollingHandler())
+  , m_network(nullptr)
   , m_fallbackLanguageLoaded(false)
   , m_WaitingExternalCalls(0)
   , m_ProcessedExternalCalls(0)
-  , m_ignoreSkinSettingChanges(false)
 {
-  m_network = NULL;
   TiXmlBase::SetCondenseWhiteSpace(false);
-  m_bInhibitIdleShutdown = false;
-  m_bScreenSave = false;
-  m_dpms = NULL;
-  m_dpmsIsActive = false;
-  m_dpmsIsManual = false;
-  m_iScreenSaveLock = 0;
-  m_bInitializing = true;
-  m_strPlayListFile = "";
-  m_nextPlaylistItem = -1;
-  m_bPlaybackStarting = false;
-  m_ePlayState = PLAY_STATE_NONE;
-  m_confirmSkinChange = true;
 
 #ifdef HAS_GLX
   XInitThreads();
 #endif
 
-
   /* for now always keep this around */
   m_currentStack = new CFileItemList;
 
-  m_bPlatformDirectories = true;
-
-  m_bStandalone = false;
-  m_bEnableLegacyRes = false;
-  m_bSystemScreenSaverEnable = false;
-  m_pInertialScrollingHandler = new CInertialScrollingHandler();
 #ifdef HAS_DVD_DRIVE
   m_Autorun = new CAutorun();
 #endif
-
-  m_threadID = 0;
-  m_progressTrackingPlayCountUpdate = false;
-  m_currentStackPosition = 0;
-  m_lastRenderTime = 0;
-  m_skipGuiRender = false;
-  m_bTestMode = false;
-
-  m_muted = false;
-  m_volumeLevel = VOLUME_MAXIMUM;
 }
 
 CApplication::~CApplication(void)

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -144,7 +144,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
           CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
           OnMessage(msg);
           int start = msg.GetParam1();
-          if (start >= 0 && start < m_item->GetAddonInfo()->Screenshots().size())
+          if (start >= 0 && start < static_cast<int>(m_item->GetAddonInfo()->Screenshots().size()))
             CGUIWindowSlideShow::RunSlideShow(m_item->GetAddonInfo()->Screenshots(), start);
         }
       }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -243,7 +243,7 @@ bool CColorManager::Probe3dLut(const std::string filename)
     return false;
   }
 
-  if (lutFile.Read(&header, sizeof(header)) < sizeof(header))
+  if (lutFile.Read(&header, sizeof(header)) < static_cast<ssize_t>(sizeof(header)))
   {
     CLog::Log(LOGERROR, "%s: Could not read 3DLUT header: %s", __FUNCTION__, filename.c_str());
     return false;
@@ -282,7 +282,7 @@ bool CColorManager::Load3dLut(const std::string filename, uint16_t **CLUT, int *
     return false;
   }
 
-  if (lutFile.Read(&header, sizeof(header)) < sizeof(header))
+  if (lutFile.Read(&header, sizeof(header)) < static_cast<ssize_t>(sizeof(header)))
   {
     CLog::Log(LOGERROR, "%s: Could not read 3DLUT header: %s", __FUNCTION__, filename.c_str());
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -427,7 +427,7 @@ void CRenderManager::PreInit()
 {
   if (!g_application.IsCurrentThread())
   {
-    CLog::Log(LOGERROR, "CRenderManager::UnInit - not called from render thread");
+    CLog::Log(LOGERROR, "CRenderManager::PreInit - not called from render thread");
     return;
   }
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -340,13 +340,13 @@ void CGUIWindowSlideShow::Select(const std::string& strPicture)
 
 void CGUIWindowSlideShow::GetSlideShowContents(CFileItemList &list)
 {
-  for (int index = 0; index < m_slides.size(); index++)
+  for (size_t index = 0; index < m_slides.size(); index++)
     list.Add(CFileItemPtr(new CFileItem(*m_slides.at(index))));
 }
 
 std::shared_ptr<const CFileItem> CGUIWindowSlideShow::GetCurrentSlide()
 {
-  if (m_iCurrentSlide >= 0 && m_iCurrentSlide < m_slides.size())
+  if (m_iCurrentSlide >= 0 && m_iCurrentSlide < static_cast<int>(m_slides.size()))
     return m_slides.at(m_iCurrentSlide);
   return CFileItemPtr();
 }
@@ -389,9 +389,9 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   if (!HasProcessed())
     regions.push_back(CRect(0.0f, 0.0f, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight()));
 
-  if (m_iCurrentSlide < 0 || m_iCurrentSlide >= m_slides.size())
+  if (m_iCurrentSlide < 0 || m_iCurrentSlide >= static_cast<int>(m_slides.size()))
     m_iCurrentSlide = 0;
-  if (m_iNextSlide < 0 || m_iNextSlide >= m_slides.size())
+  if (m_iNextSlide < 0 || m_iNextSlide >= static_cast<int>(m_slides.size()))
     m_iNextSlide = GetNextSlide();
 
   // Create our background loader if necessary
@@ -1110,7 +1110,7 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const std::strin
   if (pTexture)
   {
     // set the pic's texture + size etc.
-    if (iSlideNumber >= m_slides.size() || GetPicturePath(m_slides.at(iSlideNumber).get()) != strFileName)
+    if (iSlideNumber >= static_cast<int>(m_slides.size()) || GetPicturePath(m_slides.at(iSlideNumber).get()) != strFileName)
     { // throw this away - we must have cleared the slideshow while we were still loading
       delete pTexture;
       return;
@@ -1131,9 +1131,12 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, const std::strin
       }
     }
   }
-  else if (iSlideNumber >= m_slides.size() || GetPicturePath(m_slides.at(iSlideNumber).get()) != strFileName)
+  else if (iSlideNumber >= static_cast<int>(m_slides.size()) || GetPicturePath(m_slides.at(iSlideNumber).get()) != strFileName)
   { // Failed to load image. and not match values calling LoadPic, then something is changed, ignore.
-    CLog::Log(LOGDEBUG, "CGUIWindowSlideShow::OnLoadPic(%d, %d, %s) on failure not match current state (cur %d, next %d, curpic %d, pic[0, 1].slidenumber=%d, %d, %s)", iPic, iSlideNumber, strFileName.c_str(), m_iCurrentSlide, m_iNextSlide, m_iCurrentPic, m_Image[0].SlideNumber(), m_Image[1].SlideNumber(), iSlideNumber >= m_slides.size() ? "" : m_slides.at(iSlideNumber)->GetPath().c_str());
+    CLog::Log(LOGDEBUG, "CGUIWindowSlideShow::OnLoadPic(%d, %d, %s) on failure not match current state (cur %d, next %d, curpic %d, pic[0, 1].slidenumber=%d, %d, %s)",
+              iPic, iSlideNumber, strFileName.c_str(), m_iCurrentSlide,
+              m_iNextSlide, m_iCurrentPic, m_Image[0].SlideNumber(), m_Image[1].SlideNumber(),
+              iSlideNumber >= static_cast<int>(m_slides.size()) ? "" : m_slides.at(iSlideNumber)->GetPath().c_str());
   }
   else
   { // Failed to load image.  What should be done??

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1301,7 +1301,7 @@ std::string StringUtils::FormatFileSize(uint64_t bytes)
 
   int i = 0;
   double value = static_cast<double>(bytes);
-  while (i < units.size() - 1 && value >= 999.5)
+  while (i < static_cast<int>(units.size()) - 1 && value >= 999.5)
   {
     ++i;
     value /= 1024.0;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -458,7 +458,7 @@ namespace VIDEO
       if (ret == INFO_CANCELLED || ret == INFO_ERROR)
       {
         CLog::Log(LOGWARNING,
-                  "VideoInfoScanner: Error %s occurred while retrieving"
+                  "VideoInfoScanner: Error %u occurred while retrieving"
                   "information for %s.", ret,
                   CURL::GetRedacted(pItem->GetPath()).c_str());
         FoundSomeInfo = false;


### PR DESCRIPTION
This PR silences some compiler warnings, and also fixes an error in CVideoInfoScanner where an int parameter was used as a string.
