### PR TITLE
ListItem.Year - prefer to use the year value from the firstaired date

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -718,11 +718,13 @@ const std::string& CVideoInfoTag::GetDefaultRating() const
 
 const bool CVideoInfoTag::HasYear() const
 {
-  return m_premiered.IsValid();
+  return m_firstAired.IsValid() || m_premiered.IsValid();
 }
 
 const int CVideoInfoTag::GetYear() const
 {
+  if (m_firstAired.IsValid())
+    return GetFirstAired().GetYear();
   if (m_premiered.IsValid())
     return GetPremiered().GetYear();
   return 0;
@@ -736,6 +738,11 @@ const bool CVideoInfoTag::HasPremiered() const
 const CDateTime& CVideoInfoTag::GetPremiered() const
 {
   return m_premiered;
+}
+
+const CDateTime& CVideoInfoTag::GetFirstAired() const
+{
+  return m_firstAired;
 }
 
 const std::string CVideoInfoTag::GetUniqueID(std::string type) const

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -93,6 +93,7 @@ public:
   const int GetYear() const;
   const bool HasPremiered() const;
   const CDateTime& GetPremiered() const;
+  const CDateTime& GetFirstAired() const;
   const std::string GetCast(bool bIncludeRole = false) const;
   bool HasStreamDetails() const;
   bool IsEmpty() const;


### PR DESCRIPTION
ListItem.Year currently returns the year taken from the Premiered date.

for episodes it would be more accurate to use the year from the FirstAired date.

http://forum.kodi.tv/showthread.php?tid=294755

before:
![before](https://cloud.githubusercontent.com/assets/687265/19689085/7b7b61d0-9acc-11e6-84d5-da84afa2532c.jpg)

after:
![after](https://cloud.githubusercontent.com/assets/687265/19689092/813dd058-9acc-11e6-93c1-6a8fc7b28269.jpg)
