### PR TITLE
Singledecoder

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -311,6 +311,14 @@ public:
    */
   virtual void Reopen() {};
 
+  /**
+   * Requests if the decoder is Open().
+   *
+   */
+   virtual bool IsOpen() { return true; };
+
+
+
 protected:
   CProcessInfo &m_processInfo;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -110,7 +110,8 @@ public:
   virtual double  GetTimeSize(void);
   virtual const char* GetName(void) { return m_formatname.c_str(); }
   virtual unsigned GetAllowedReferences();
-
+  virtual bool IsOpen() { return m_opened; };
+  virtual void Reopen();
 protected:
   void            Dispose();
   void            FlushInternal(void);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -20,6 +20,29 @@
 
 #include "DVDDemux.h"
 
+unsigned int CDemuxStream::AvDispositionToDemuxFlags(unsigned int disposition)
+{
+  static unsigned int translate[][2]={
+    {AV_DISPOSITION_DEFAULT, FLAG_DEFAULT},
+    {AV_DISPOSITION_DUB, FLAG_DUB},
+    {AV_DISPOSITION_ORIGINAL, FLAG_ORIGINAL},
+    {AV_DISPOSITION_COMMENT, FLAG_COMMENT},
+    {AV_DISPOSITION_LYRICS, FLAG_LYRICS},
+    {AV_DISPOSITION_KARAOKE, FLAG_KARAOKE},
+    {AV_DISPOSITION_FORCED, FLAG_FORCED},
+    {AV_DISPOSITION_HEARING_IMPAIRED, FLAG_HEARING_IMPAIRED},
+    {AV_DISPOSITION_VISUAL_IMPAIRED, FLAG_VISUAL_IMPAIRED},
+    {AV_DISPOSITION_ATTACHED_PIC, FLAG_DISP_ATTACHED_PIC}
+  };
+
+  unsigned int ret(0);
+  for (auto avt : translate)
+    if (disposition & avt[0])
+      ret |= ret[1]);
+
+  return ret;
+}
+
 std::string CDemuxStreamAudio::GetStreamType()
 {
   char sInfo[64] = {0};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -127,18 +127,24 @@ public:
 
   int  changes; // increment on change which player may need to know about
 
-  enum EFlags
-  { FLAG_NONE             = 0x0000 
-  , FLAG_DEFAULT          = 0x0001
-  , FLAG_DUB              = 0x0002
-  , FLAG_ORIGINAL         = 0x0004
-  , FLAG_COMMENT          = 0x0008
-  , FLAG_LYRICS           = 0x0010
-  , FLAG_KARAOKE          = 0x0020
-  , FLAG_FORCED           = 0x0040
-  , FLAG_HEARING_IMPAIRED = 0x0080
-  , FLAG_VISUAL_IMPAIRED  = 0x0100
-  } flags;
+  static const unsigned int FLAG_COMPARE_MASK = 0x0000FFFF;
+  static const unsigned int FLAG_NONE = 0x00000000;
+  static const unsigned int FLAG_DEFAULT = 0x00000001;
+  static const unsigned int FLAG_DUB = 0x00000002;
+  static const unsigned int FLAG_ORIGINAL = 0x00000004;
+  static const unsigned int FLAG_COMMENT = 0x00000008;
+  static const unsigned int FLAG_LYRICS = 0x00000010;
+  static const unsigned int FLAG_KARAOKE = 0x00000020;
+  static const unsigned int FLAG_FORCED = 0x00000040;
+  static const unsigned int FLAG_HEARING_IMPAIRED = 0x00000080;
+  static const unsigned int FLAG_VISUAL_IMPAIRED = 0x00000100;
+  static const unsigned int FLAG_DISP_ATTACHED_PIC = 0x00000200;
+  // Temporary flags wich are not compared against each other
+  static const unsigned int FLAG_STREAMCHANGE = 0x00010000;
+
+  unsigned int flags;
+
+  static unsigned int AvDispositionToDemuxFlags(unsigned int disposition);
 };
 
 class CDemuxStreamVideo : public CDemuxStream
@@ -338,7 +344,7 @@ public:
    * adaptive demuxers like DASH can use this to choose best fitting video stream
    */
   virtual void SetVideoResolution(int width, int height) {};
-  
+
   /*
   * return the id of the demuxer
   */

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1484,7 +1484,8 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
 
     stream->source = STREAM_SOURCE_DEMUX;
     stream->pPrivate = pStream;
-    stream->flags = (CDemuxStream::EFlags)pStream->disposition;
+
+    stream->flags = CDemuxStream::AvDispositionToDemuxFlags(pStream->disposition);
 
     AVDictionaryEntry *langTag = av_dict_get(pStream->metadata, "language", NULL, 0);
     if (!langTag)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
@@ -234,7 +234,7 @@ void CDemuxMultiSource::SetMissingStreamDetails(DemuxPtr demuxer)
 
     if (stream->flags == CDemuxStream::FLAG_NONE)
     {
-      stream->flags = static_cast<CDemuxStream::EFlags>(info.flag);
+      stream->flags = info.flag;
     }
     if (stream->language[0] == '\0')
     {

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -180,7 +180,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
     if (pStream)
     {
       // ignore if it's a picture attachment (e.g. jpeg artwork)
-      if (pStream->type == STREAM_VIDEO && !(pStream->flags & AV_DISPOSITION_ATTACHED_PIC))
+      if (pStream->type == STREAM_VIDEO && !(pStream->flags & CDemuxStream::FLAG_DISP_ATTACHED_PIC))
       {
         nVideoStream = pStream->uniqueId;
         demuxerId = pStream->demuxerId;
@@ -382,7 +382,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
   const CURL pathToUrl(path);
   for (CDemuxStream* stream : pDemux->GetStreams())
   {
-    if (stream->type == STREAM_VIDEO && !(stream->flags & AV_DISPOSITION_ATTACHED_PIC))
+    if (stream->type == STREAM_VIDEO && !(stream->flags & CDemuxStream::FLAG_DISP_ATTACHED_PIC))
     {
       CStreamDetailVideo *p = new CStreamDetailVideo();
       p->m_iWidth = ((CDemuxStreamVideo *)stream)->iWidth;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -64,10 +64,10 @@ struct DVDNavAudioStreamInfo : DVDNavStreamInfo
 
 struct DVDNavSubtitleStreamInfo : DVDNavStreamInfo
 {
-  CDemuxStream::EFlags flags;
+  unsigned int flags;
 
   DVDNavSubtitleStreamInfo() : DVDNavStreamInfo(),
-    flags(CDemuxStream::EFlags::FLAG_NONE) {}
+    flags(CDemuxStream::FLAG_NONE) {}
 };
 
 struct DVDNavVideoStreamInfo : DVDNavStreamInfo

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -83,7 +83,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
   ||  uniqueId  != right.uniqueId
   ||  realtime  != right.realtime
   ||  codec_tag != right.codec_tag
-  ||  flags     != right.flags)
+  ||  (flags & CDemuxStream::FLAG_COMPARE_MASK)  != (right.flags & CDemuxStream::FLAG_COMPARE_MASK))
     return false;
 
   if( withextradata )

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -52,7 +52,7 @@ public:
   StreamType type;
   int uniqueId;
   bool realtime;
-  int flags;
+  unsigned int flags; //DVDDemuxStream::flags
   bool software;  //force software decoding
   std::string filename;
   bool dvd;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -918,7 +918,7 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
 
   // open video stream
   valid   = false;
-  
+
   for (const auto &stream : m_SelectionStreams.Get(STREAM_VIDEO, PredicateVideoPriority))
   {
     if(OpenStream(m_CurrentVideo, stream.demuxerId, stream.id, stream.source, reset))
@@ -3696,7 +3696,7 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
     stream = m_pSubtitleDemuxer->GetStream(demuxerId, iStream);
     if(!stream || stream->disabled)
       return false;
-    
+
     m_pSubtitleDemuxer->EnableStream(demuxerId, iStream, true);
 
     hint.Assign(*stream, true);
@@ -3739,6 +3739,9 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
 
     hint.Assign(*stream, false);
   }
+
+  if (!reset)
+    hint.flags |= CDemuxStream::FLAG_STREAMCHANGE;
 
   bool res;
   switch(current.type)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -332,14 +332,14 @@ static bool PredicateVideoPriority(const SelectionStream& lh, const SelectionStr
   return false;
 }
 
-bool CSelectionStreams::Get(StreamType type, CDemuxStream::EFlags flag, SelectionStream& out)
+bool CSelectionStreams::Get(StreamType type, unsigned int flags, SelectionStream& out)
 {
   CSingleLock lock(m_section);
   for(size_t i=0;i<m_Streams.size();i++)
   {
     if(m_Streams[i].type != type)
       continue;
-    if((m_Streams[i].flags & flag) != flag)
+    if((m_Streams[i].flags & flags) != flags)
       continue;
     out = m_Streams[i];
     return true;
@@ -3857,7 +3857,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
 
   SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, 0);
 
-  if(hint.flags & AV_DISPOSITION_ATTACHED_PIC)
+  if ((hint.flags & CDemuxStream::FLAG_DISP_ATTACHED_PIC) != 0)
     return false;
 
   // set desired refresh rate
@@ -4907,8 +4907,8 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
       if (stream.language.empty())
         stream.language = info.language;
 
-      if (static_cast<CDemuxStream::EFlags>(info.flag) != CDemuxStream::FLAG_NONE)
-        stream.flags = static_cast<CDemuxStream::EFlags>(info.flag);
+      if (info.flag != CDemuxStream::FLAG_NONE)
+        stream.flags = info.flag;
     }
 
     return m_SelectionStreams.IndexOf(STREAM_SUBTITLE,
@@ -4929,8 +4929,8 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
   ExternalStreamInfo info = CUtil::GetExternalStreamDetailsFromFilename(m_item.GetPath(), filename);
   s.name = info.name;
   s.language = info.language;
-  if (static_cast<CDemuxStream::EFlags>(info.flag) != CDemuxStream::FLAG_NONE)
-    s.flags = static_cast<CDemuxStream::EFlags>(info.flag);
+  if (info.flag != CDemuxStream::FLAG_NONE)
+    s.flags = info.flag;
 
   m_SelectionStreams.Update(s);
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, s.source, s.demuxerId, s.id);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -234,7 +234,7 @@ typedef struct SelectionStream
   std::string  filename2;  // for vobsub subtitles, 2 files are necessary (idx/sub)
   std::string  language;
   std::string  name;
-  CDemuxStream::EFlags flags = CDemuxStream::FLAG_NONE;
+  unsigned int flags = CDemuxStream::FLAG_NONE;
   int          source = 0;
   int          id = 0;
   int64_t      demuxerId = -1;
@@ -269,7 +269,7 @@ public:
   int              Count   (StreamType type) const { return IndexOf(type, STREAM_SOURCE_NONE, -1, -1) + 1; }
   int              CountSource(StreamType type, StreamSource source) const;
   SelectionStream& Get     (StreamType type, int index);
-  bool             Get     (StreamType type, CDemuxStream::EFlags flag, SelectionStream& out);
+  bool             Get     (StreamType type, unsigned int flags, SelectionStream& out);
 
   SelectionStreams Get(StreamType type);
   template<typename Compare> SelectionStreams Get(StreamType type, Compare compare)

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -192,6 +192,10 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
     m_pVideoCodec->ClearPicture(&m_picture);
     delete m_pVideoCodec;
   }
+
+  if (!codec->IsOpen())
+    codec->Reopen();
+
   m_pVideoCodec = codec;
   m_hints   = hint;
   m_stalled = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -126,7 +126,7 @@ bool CVideoPlayerVideo::OpenStream( CDVDStreamInfo &hint )
   info = m_renderManager.GetRenderInfo();
 
   m_pullupCorrection.ResetVFRDetection();
-  if(hint.flags & AV_DISPOSITION_ATTACHED_PIC)
+  if ((hint.flags & CDemuxStream::FLAG_DISP_ATTACHED_PIC) != 0)
     return false;
 
   CLog::Log(LOGNOTICE, "Creating video codec with codec id: %i", hint.codec);


### PR DESCRIPTION
Support streamchanges on systems with only 1 h/w decoder
## Description

If there is a stream change on systems wich only allow 1 h/w decoder, every stream change leads to toggle between ffmpeg fallback and h/w. This is because a new decoder on streamchange is prepared before it is used. For a short time 2 decoders are up regarding the current implementation.

This PR introduces a hint in DVDStreamInfo::flags wich can tell the decoder, that the Open() call leads from a streamchange and one more decoder is running. If codec information and capabilities are checked, but the decoder fails, we can be quite sure that this is because of resources.

At the time the stream change is applied, it is checked, if the decoder needs to be reopened. 
## Motivation and Context
- Android encrypted media has to play on with mediaCodec, a fallback to ffmpeg is no alternative.
- Adaptive streamchange (inputstream.mpd) would lead to a mix of s/w and h/w decoding.
## How Has This Been Tested?
- create a .strm file with this content:
  #KODIPROP:inputstreamaddon=inputstream.mpd
  https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd
- enable inputstream.mpd
- The first packet from inputstream generates a DMX_GENERAL_STREAMCHANGE.
- Without this PR on machines with limited resources (Odroid-C2 here) the video is played with ffmpeg. Using this PR, its played with mediaCodec.
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
