### PR TITLE
[gui] cosmetics: fix indent in GUISliderControl.cpp

### DIFF
--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -230,7 +230,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
   case ACTION_SELECT_ITEM:
     if (m_rangeSelection)
       SwitchRangeSelector();
-      return true;
+    return true;
 
   default:
     break;


### PR DESCRIPTION
Fixes a cosmetic discovered by some static analysis tool (cant remember which), and reported by @MartijnKaijser     
