### PR TITLE
Hide controller profiles in the add-on browser

### DIFF
--- a/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Peripheral/AddonCallbacksPeripheral.cpp
@@ -87,7 +87,7 @@ unsigned int CAddonCallbacksPeripheral::FeatureCount(void* addonData, const char
   unsigned int count = 0;
 
   AddonPtr addon;
-  if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER))
+  if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER, false))
   {
     ControllerPtr controller = std::static_pointer_cast<CController>(addon);
     if (controller->LoadLayout())

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -50,7 +50,6 @@ CAddonsDirectory::~CAddonsDirectory(void) {}
 
 const auto CATEGORY_INFO_PROVIDERS = "category.infoproviders";
 const auto CATEGORY_LOOK_AND_FEEL = "category.lookandfeel";
-const auto CATEGORY_GAME_ADDONS = "category.gameaddons";
 
 const std::set<TYPE> dependencyTypes = {
     ADDON_SCRAPER_LIBRARY,
@@ -75,10 +74,6 @@ const std::set<TYPE> lookAndFeelTypes = {
   ADDON_VIZ,
 };
 
-const std::set<TYPE> gameTypes = {
-  ADDON_GAME_CONTROLLER,
-};
-
 static bool IsInfoProviderType(TYPE type)
 {
   return infoProviderTypes.find(type) != infoProviderTypes.end();
@@ -97,16 +92,6 @@ static bool IsLookAndFeelType(TYPE type)
 static bool IsLookAndFeelTypeAddon(const AddonPtr& addon)
 {
   return IsLookAndFeelType(addon->Type());
-}
-
-static bool IsGameType(TYPE type)
-{
-  return gameTypes.find(type) != gameTypes.end();
-}
-
-static bool IsGameAddon(const AddonPtr& addon)
-{
-  return IsGameType(addon->Type());
 }
 
 static bool IsDependecyType(TYPE type)
@@ -185,16 +170,6 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
       item->SetArt("thumb", thumb);
     items.Add(item);
   }
-  if (std::any_of(addons.begin(), addons.end(), IsGameAddon))
-  {
-    CFileItemPtr item(new CFileItem(g_localizeStrings.Get(35049))); // Game add-ons
-    item->SetPath(URIUtils::AddFileToFolder(path.Get(), CATEGORY_GAME_ADDONS));
-    item->m_bIsFolder = true;
-    const std::string thumb = "DefaultGameAddons.png";
-    if (g_TextureManager.HasTexture(thumb))
-      item->SetArt("thumb", thumb);
-    items.Add(item);
-  }
 
   std::set<TYPE> uncategorized;
   for (unsigned int i = ADDON_UNKNOWN + 1; i < ADDON_MAX - 1; ++i)
@@ -222,12 +197,6 @@ static void GenerateCategoryListing(const CURL& path, VECADDONS& addons,
     items.SetProperty("addoncategory", g_localizeStrings.Get(24997));
     items.SetLabel(g_localizeStrings.Get(24997));
     GenerateTypeListing(path, lookAndFeelTypes, addons, items);
-  }
-  else if (category == CATEGORY_GAME_ADDONS)
-  {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(35049)); // Game add-ons
-    items.SetLabel(g_localizeStrings.Get(35049)); // Game add-ons
-    GenerateTypeListing(path, gameTypes, addons, items);
   }
   else
   { // fallback to addon type

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -208,7 +208,7 @@ std::set<std::string> CGUIControllerList::GetNewControllerIDs(ADDON::VECADDONS& 
 {
   std::set<std::string> controllerIds;
 
-  CAddonMgr::GetInstance().GetAddons(addonCache, ADDON_GAME_CONTROLLER);
+  CAddonMgr::GetInstance().GetInstalledAddons(addonCache, ADDON_GAME_CONTROLLER);
 
   std::transform(addonCache.begin(), addonCache.end(), std::inserter(controllerIds, controllerIds.end()),
     [](const AddonPtr& addon)

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -112,7 +112,7 @@ std::vector<std::string> CRumbleGenerator::GetMotors(const std::string& controll
   std::vector<std::string> motors;
 
   AddonPtr addon;
-  if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER))
+  if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER, false))
   {
     ControllerPtr controller = std::static_pointer_cast<CController>(addon);
     if (controller->LoadLayout())


### PR DESCRIPTION
## Motivation and Context

The original reason I used the add-on system for controller profiles was so that installing an emulator would automatically install the required controllers.

However, controller profiles are really internal to the system and, without games, don't need to be shown outside of the controller dialog. We especially don't need to show them as a single node inside another node called "Game add-ons". Talk about confusing.

This PR hides the "Game add-ons" node for the v17 release. As a result, if the user deletes their addon DB, all controllers disappear from the GUI and the user has no way to bring them back. There are two possible solutions:
- Don't disable them in the first place
- Show disabled controller profiles in the controller dialog

I submitted a PR for the first option (#9700) and it was rejected. So this PR includes the second solution.
