### PR TITLE
libdvd/Makefile: cross-compile, allow to specify the ar command

### DIFF
--- a/lib/libdvd/Makefile.in
+++ b/lib/libdvd/Makefile.in
@@ -1,4 +1,5 @@
 
+AR=@AR@
 ARCH=@ARCH@
 CC=@CC@
 CXX=@CXX@
@@ -54,7 +55,7 @@ ifeq ($(findstring osx,$(ARCH)), osx)
 
 $(SYSDIR)/libdvdcss-$(ARCH).so:  $(WRAPPER) $(DVDREAD_DEPS)
 	[ -d libdvdcss ] || mkdir libdvdcss
-	cd libdvdcss; ar x $(DVDCSS_A)
+	cd libdvdcss; $(AR) x $(DVDCSS_A)
 	$(CC) $(SO_LDFLAGS) -Wl,-alias_list,$(WRAPPER_MACH_ALIAS) -o $@ \
                 $(WRAPPER) $(DVDCSS_OBJS) $(BUNDLE1_O)
 
@@ -62,16 +63,16 @@ $(SYSDIR)/libdvdnav-$(ARCH).so: $(WRAPPER) $(DVDNAV_A) $(DVDREAD_A) $(DVDREAD_DE
 	[ -d libdvdread ] || mkdir libdvdread
 	[ -d libdvdnav ] || mkdir libdvdnav
 	[ $(BUILD_DVDCSS) -eq 1 ] && { [ -d libdvdcss ] || mkdir libdvdcss; } || :
-	[ $(BUILD_DVDCSS) -eq 1 ] && { cd libdvdcss && ar x $(DVDCSS_A); } || :
-	cd libdvdnav; ar x $(DVDNAV_A)
-	cd libdvdread; ar x $(DVDREAD_A)
+	[ $(BUILD_DVDCSS) -eq 1 ] && { cd libdvdcss && $(AR) x $(DVDCSS_A); } || :
+	cd libdvdnav; $(AR) x $(DVDNAV_A)
+	cd libdvdread; $(AR) x $(DVDREAD_A)
 	$(CC) $(SO_LDFLAGS) -Wl,-alias_list,$(WRAPPER_MACH_ALIAS) -o $@ \
                 $(WRAPPER) libdvdread/*.o libdvdnav/*.o $(DVDCSS_OBJS) $(BUNDLE1_O)
 
 else
 $(SYSDIR)/libdvdcss-$(ARCH).so: $(WRAPPER) $(WRAPPER_DEF) $(DVDCSS_A)
 	[ -d libdvdcss ] || mkdir libdvdcss
-	cd libdvdcss; ar x $(DVDCSS_A)
+	cd libdvdcss; $(AR) x $(DVDCSS_A)
 	$(CC) -o $@ $(SO_LDFLAGS) -Wl,--soname,$@ $(DVDCSS_OBJS) -Wl,--unresolved-symbols=ignore-all -lm \
         `cat $(WRAPPER_DEF)` $(WRAPPER)
 
@@ -79,9 +80,9 @@ $(SYSDIR)/libdvdnav-$(ARCH).so: $(WRAPPER) $(WRAPPER_DEF) $(DVDNAV_A) $(DVDREAD_
 	[ -d libdvdread ] || mkdir libdvdread
 	[ -d libdvdnav ] || mkdir libdvdnav
 	[ $(BUILD_DVDCSS) -eq 1 ] && { [ -d libdvdcss ] || mkdir libdvdcss; } || :
-	[ $(BUILD_DVDCSS) -eq 1 ] && { cd libdvdcss && ar x $(DVDCSS_A); } || :
-	cd libdvdnav; ar x $(DVDNAV_A)
-	cd libdvdread; ar x $(DVDREAD_A)
+	[ $(BUILD_DVDCSS) -eq 1 ] && { cd libdvdcss && $(AR) x $(DVDCSS_A); } || :
+	cd libdvdnav; $(AR) x $(DVDNAV_A)
+	cd libdvdread; $(AR) x $(DVDREAD_A)
 	$(CC) -o $@ $(SO_LDFLAGS) -Wl,--soname,$@ libdvdread/*.o libdvdnav/*.o $(DVDCSS_OBJS) -lm -Wl,--unresolved-symbols=ignore-all \
                 `cat  $(WRAPPER_DEF)` $(WRAPPER)
 endif


### PR DESCRIPTION
This commit fixes a build issue on cross environments where the ar command may be prefixed with e.g. the host triplet, like x86_64-pc-linux-gnu-ar and results in a build failure not finding the ar command.
## How Has This Been Tested?

Building kodi-17.0_beta4 locally with the changes applied.
## Types of change
- [ x] Bug fix (non-breaking change which fixes an issue)
