### PR TITLE
add privacy policy

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -522,7 +522,9 @@ install-scripts:
 install-datas: install-scripts
 	@echo "Copying support and legal files..."
 	@install -d $(DESTDIR)$(docdir)
-	@install -m 0644 docs/README.linux LICENSE.GPL *.txt $(DESTDIR)$(docdir)
+	@install -m 0644 docs/README.linux LICENSE.GPL copying.txt version.txt $(DESTDIR)$(docdir)
+	@install -d $(DESTDIR)/$(datarootdir)/@APP_NAME_LC@
+	@install -m 0644 privacy-policy.txt $(DESTDIR)$(datarootdir)/@APP_NAME_LC@
 	@echo "Done!"
 	@echo "Copying system files to $(DESTDIR)$(datarootdir)/@APP_NAME_LC@"
 	@install -d $(DESTDIR)$(datarootdir)/@APP_NAME_LC@

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5495,7 +5495,12 @@ msgctxt "#12386"
 msgid "Month / Day"
 msgstr ""
 
-#empty strings from id 12387 to 12389
+#empty strings from id 12387 to 12388
+
+#: xbmc/windows/GUIWindowSystemInfo.cpp
+msgctxt "#12389"
+msgid "Privacy policy"
+msgstr ""
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#12390"

--- a/addons/skin.estouchy/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estouchy/xml/SettingsSystemInfo.xml
@@ -46,6 +46,7 @@
 				<height>598</height>
 				<itemgap>-1</itemgap>
 				<onleft>5</onleft>
+				<onright>60</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
 				<control type="button" id="95">
@@ -119,6 +120,18 @@
 					<texturenofocus border="40,0,40,5">list_nofocus.png</texturenofocus>
 					<pulseonselect>false</pulseonselect>
 					<label>31556</label>
+					<textoffsetx>20</textoffsetx>
+				</control>
+				<control type="button" id="100">
+					<width>290</width>
+					<height>80</height>
+					<aligny>center</aligny>
+					<font>font24_title</font>
+					<textcolor>white</textcolor>
+					<texturefocus>list_focus.png</texturefocus>
+					<texturenofocus border="40,0,40,5">list_nofocus.png</texturenofocus>
+					<pulseonselect>false</pulseonselect>
+					<label>12389</label>
 					<textoffsetx>20</textoffsetx>
 				</control>
 			</control>
@@ -324,6 +337,31 @@
 					<label></label>
 					<font>font22</font>
 				</control>
+			</control>
+			<control type="textbox" id="30">
+				<posx>340</posx>
+				<posy>25</posy>
+				<width>800</width>
+				<height>550</height>
+				<pagecontrol>60</pagecontrol>
+				<autoscroll delay="5000" repeat="7500" time="5000">true</autoscroll>
+			</control>
+			<control type="scrollbar" id="60">
+				<posx>1200</posx>
+				<posy>0</posy>
+				<width>26</width>
+				<height>602</height>
+				<texturesliderbackground colordiffuse="30FFFFFF">white.png</texturesliderbackground>
+				<texturesliderbar colordiffuse="grey">white.png</texturesliderbar>
+				<texturesliderbarfocus colordiffuse="blue">white.png</texturesliderbarfocus>
+				<textureslidernib>blank.png</textureslidernib>
+				<textureslidernibfocus>blank.png</textureslidernibfocus>
+				<onleft>9000</onleft>
+				<showonepage>false</showonepage>
+				<orientation>vertical</orientation>
+				<animation effect="fade" time="150">Visible</animation>
+				<animation effect="fade" time="150">Hidden</animation>
+				<visible>Control.IsVisible(30)</visible>
 			</control>
 			<control type="group">
 				<posx>60</posx>

--- a/addons/skin.estuary/1080i/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/1080i/SettingsSystemInfo.xml
@@ -21,10 +21,11 @@
 				<height>540</height>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
+				<onright>60</onright>
 				<control type="button" id="95">
 					<description>Button Summary Values</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="75" />
 					</include>
 					<width>400</width>
 					<label>$LOCALIZE[20037]</label>
@@ -32,7 +33,7 @@
 				<control type="button" id="94">
 					<description>Button Storage</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="75" />
 					</include>
 					<width>400</width>
 					<label>$LOCALIZE[13277]</label>
@@ -40,7 +41,7 @@
 				<control type="button" id="96">
 					<description>Button Network</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="75" />
 					</include>
 					<width>400</width>
 					<label>$LOCALIZE[13279]</label>
@@ -48,7 +49,7 @@
 				<control type="button" id="97">
 					<description>Button Video</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="75" />
 					</include>
 					<width>400</width>
 					<label>$LOCALIZE[13280]</label>
@@ -56,7 +57,7 @@
 				<control type="button" id="98">
 					<description>Button Hardware</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="75" />
 					</include>
 					<width>400</width>
 					<label>$LOCALIZE[13281]</label>
@@ -64,10 +65,18 @@
 				<control type="button" id="99">
 					<description>Button PVR</description>
 					<include content="DefaultSettingButton">
-						<param name="height" value="88" />
+						<param name="height" value="75" />
 					</include>
 					<width>400</width>
 					<label>$LOCALIZE[19191]</label>
+				</control>
+				<control type="button" id="100">
+					<description>Button Policy</description>
+					<include content="DefaultSettingButton">
+						<param name="height" value="75" />
+					</include>
+					<width>400</width>
+					<label>$LOCALIZE[12389]</label>
 				</control>
 			</control>
 		</control>
@@ -79,7 +88,7 @@
 				<left>420</left>
 				<top>70</top>
 				<width>1300</width>
-				<height>570</height>
+				<height>572</height>
 				<texture border="22">dialogs/dialog-bg.png</texture>
 			</control>
 			<control type="image">
@@ -149,6 +158,23 @@
 					<width>1220</width>
 					<font>Mono28</font>
 				</control>
+			</control>
+			<control type="textbox" id="30">
+				<left>480</left>
+				<top>105</top>
+				<height>500</height>
+				<width>1200</width>
+				<pagecontrol>60</pagecontrol>
+				<autoscroll delay="5000" repeat="7500" time="5000">true</autoscroll>
+			</control>
+			<control type="scrollbar" id="60">
+				<left>1705</left>
+				<top>90</top>
+				<width>12</width>
+				<height>530</height>
+				<onleft>9000</onleft>
+				<orientation>vertical</orientation>
+				<visible>Control.IsVisible(30)</visible>
 			</control>
 			<control type="grouplist">
 				<left>60</left>

--- a/privacy-policy.txt
+++ b/privacy-policy.txt
@@ -1,0 +1,55 @@
+[B]Kodi Privacy Policy[/B]
+[I]2016 Oct 23[/I]
+
+Your privacy is an important factor that the XBMC Foundation and Team Kodi considers in the development of all of our software and services. We are committed to being transparent and open. This Privacy Policy explains generally how we receive information about you, and what we do with that information once we have it.
+
+
+[B]What do we mean by “personal information?”[/B]
+
+For us, “personal information” means information which identifies you, like your name or email address.
+
+Any information that falls outside of this is “non-personal information.”
+
+If we store your personal information with information that is non-personal, we will consider the combination as personal information. If we remove all personal information from a set of data then the remaining is non-personal information.
+
+
+[B]How do we learn information about you?[/B]
+
+We learn information about you when:
+
+    • you give it to us directly (e.g., when you choose to send us logs in the forums);
+    • we collect it automatically through our software and services (e.g., when your Kodi connects with our servers to update add-ons, or in download statistics provided by Google Play);
+    • when we try and understand more about you based on information you’ve given to us (e.g., when we use your platform information provided to the add-on server to figure out which platforms use Kodi the most, to better understand where we should focus our efforts).
+
+
+[B]What do we do with your information once we have it?[/B]
+
+Generally, we use your information to help us provide and improve our software and services for you (e.g., we use a log you send us to figure out why Kodi isn’t playing a video right or why it might have crashed, or we determine how many active users are using each platform in order to determine how to allocate resources per platform).
+
+
+[B]When do we share your information with others?[/B]
+
+    • When we have asked and received your permission to share it.
+    • When we are fulfilling our educational purpose. We sometimes publicly release information to make our software better and foster an open web, but when we do so, we will remove your personal information and try to disclose it in a way that minimizes the risk of you being re-identified. For example, in a blog post we might attempt to analyze from available data how many active users of Kodi existed at the time and share that info with the community.
+    • When the law requires it. To date, this has never happened, and we do not anticipate it happening in the future, as the majority of the information we collect is already almost entirely anonymous and never shows unique user behavior, except in voluntarily submitted logs on our forum.
+    • If our organizational structure or status changes (if we undergo a restructuring, are acquired, or go bankrupt) we may pass your information to a successor or affiliate.
+
+
+[B]How do we store and protect your personal information?[/B]
+
+We are committed to protecting your personal information once we have it. We implement physical, business and technical security measures. Despite our efforts, if we learn of a security breach, we’ll notify you so that you can take appropriate protective steps.
+
+We also don’t want your personal information for any longer than we need it, so we only keep it long enough to do what we collected it for. Once we don’t need it, we take steps to destroy it unless we are required by law to keep it longer. In the case of logs provided to us in the forums, our servers do not store those logs, and we rely on the users submitting those logs to remove the links when they deem appropriate.
+
+
+[B]What else should you know?[/B]
+
+We’re a global organization and our computers are in several different places around the world. We also use service providers whose computers may also be in various countries. This means that your information might end up on one of those computers in another country, and that country may have a different level of data protection regulation than yours. By giving us information, you consent to this kind of transfer of your information. No matter what country your information is in, we comply with applicable law and will also abide by the commitments we make in this privacy policy.
+
+If you are under 13, we don’t want your personal information, and you must not provide it to us. If you are a parent and believe that your child who is under 13 has provided us with personal information, please contact us to have your child’s information removed.
+
+
+[B]What if we change this privacy policy or any of our privacy notices?[/B]
+
+We may need to change this policy and our notices. The updates will be posted online. If the changes are substantive, we will announce the update through Kodi’s usual channels for such announcements such as blog posts and forums. Your continued use of the product or service after the effective date of such changes constitutes your acceptance of such changes. To make your review more convenient, we will post an effective date at the top of the page.
+

--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -161,8 +161,9 @@ set WORKSPACE=%CD%\..\..\kodi-build
   xcopy %EXE% BUILD_WIN32\application > NUL
   xcopy %D3D% BUILD_WIN32\application > NUL
   xcopy %base_dir%\userdata BUILD_WIN32\application\userdata /E /Q /I /Y /EXCLUDE:exclude.txt > NUL
-  copy %base_dir%\copying.txt BUILD_WIN32\application > NUL
   copy %base_dir%\LICENSE.GPL BUILD_WIN32\application > NUL
+  copy %base_dir%\copying.txt BUILD_WIN32\application > NUL
+  copy %base_dir%\privacy-policy.txt BUILD_WIN32\application > NUL
   copy %base_dir%\known_issues.txt BUILD_WIN32\application > NUL
   xcopy dependencies\*.* BUILD_WIN32\application /Q /I /Y /EXCLUDE:exclude.txt  > NUL
 

--- a/project/cmake/installdata/ios/packaging.txt
+++ b/project/cmake/installdata/ios/packaging.txt
@@ -1,2 +1,3 @@
 LICENSE.gpl
+privacy-policy.txt
 xbmc/platform/darwin/Credits.html

--- a/project/cmake/installdata/osx/packaging.txt
+++ b/project/cmake/installdata/osx/packaging.txt
@@ -1,3 +1,4 @@
 LICENSE.gpl
+privacy-policy.txt
 xbmc/platform/darwin/Credits.html
 tools/darwin/packaging/media/osx/icon.iconset/*

--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -132,6 +132,10 @@ install(FILES ${CORE_SOURCE_DIR}/copying.txt
         DESTINATION ${datarootdir}/doc/${APP_NAME_LC}
         COMPONENT kodi)
 
+install(FILES ${CORE_SOURCE_DIR}/privacy-policy.txt
+        DESTINATION ${datarootdir}/${APP_NAME_LC}
+        COMPONENT kodi)
+
 # Install kodi-tools-texturepacker
 install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/texturepacker/TexturePacker
         DESTINATION ${bindir}

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -94,6 +94,7 @@ shared:
 	cd `pwd`/assets/addons; rm -rf $(EXCLUDED_ADDONS)
 	mkdir -p assets/system/certs
 	cp $(CORE_SOURCE_DIR)/tools/depends/target/openssl/cacert.pem assets/system/certs
+	cp $(CORE_SOURCE_DIR)/privacy-policy.txt assets
 
 sharedapk: shared | xbmc/assets
 	cp -rfp assets/* ./xbmc/assets

--- a/tools/darwin/Support/CopyRootFiles-ios.command
+++ b/tools/darwin/Support/CopyRootFiles-ios.command
@@ -33,6 +33,7 @@ mkdir -p "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/AppHome/media"
 mkdir -p "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/AppHome/tools/darwin/runtime"
 
 ${SYNC} "$SRCROOT/LICENSE.GPL"  "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/"
+${SYNC} "$SRCROOT/privacy-policy.txt"  "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/AppHome"
 ${SYNC} "$SRCROOT/xbmc/platform/darwin/Credits.html"  "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/"
 ${ADDONSYNC} "$SRCROOT/addons"  "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/AppHome"
 ${SYNC} "$SRCROOT/media"    "$TARGET_BUILD_DIR/$TARGET_NAME/AppData/AppHome"

--- a/tools/darwin/Support/CopyRootFiles-osx.command
+++ b/tools/darwin/Support/CopyRootFiles-osx.command
@@ -29,6 +29,7 @@ mkdir -p "$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/$APP_NAME/tools/darw
 mkdir -p "$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/$APP_NAME/extras/user"
 
 ${SYNC} "$SRCROOT/LICENSE.GPL" 	"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/"
+${SYNC} "$SRCROOT/privacy-policy.txt" 	"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/$APP_NAME"
 ${SYNC} "$SRCROOT/xbmc/platform/darwin/Credits.html" 	"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/"
 ${SYNC} "$SRCROOT/tools/darwin/runtime"	"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/$APP_NAME/tools/darwin"
 ${ADDONSYNC} "$SRCROOT/addons"		"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/$APP_NAME"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1130,6 +1130,11 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///                  _string_,
 ///     Returns the version of the addon with the given id
 ///   }
+///   \table_row3{   <b>`System.PrivacyPolicy`</b>,
+///                  \anchor System_PrivacyPolicy
+///                  _string_,
+///     Returns the official Kodi privacy policy
+///   }
 /// \table_end
 /// @}
 const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACTIVE },
@@ -1197,6 +1202,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "stereoscopicmode", SYSTEM_STEREOSCOPIC_MODE },
                                   { "hasadsp",          SYSTEM_HAS_ADSP },
                                   { "hascms",           SYSTEM_HAS_CMS },
+                                  { "privacypolicy",    SYSTEM_PRIVACY_POLICY },
                                   { "haspvraddon",      SYSTEM_HAS_PVR_ADDON }};
 
 /// \page modules__General__List_of_gui_access
@@ -6312,6 +6318,11 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case SYSTEM_TOTALUPTIME:
   case SYSTEM_BATTERY_LEVEL:
     return g_sysinfo.GetInfo(info);
+    break;
+
+
+  case SYSTEM_PRIVACY_POLICY:
+    return g_sysinfo.GetPrivacyPolicy();
     break;
 
   case SYSTEM_SCREEN_RESOLUTION:

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -365,6 +365,7 @@
 #define SKIN_HAS_THEME              606
 #define SKIN_ASPECT_RATIO           607
 
+#define SYSTEM_PRIVACY_POLICY       643
 #define SYSTEM_TOTAL_MEMORY         644
 #define SYSTEM_CPU_USAGE            645
 #define SYSTEM_USED_MEMORY_PERCENT  646

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -31,6 +31,7 @@
 #endif
 #include "guiinfo/GUIInfoLabels.h"
 #include "filesystem/CurlFile.h"
+#include "filesystem/File.h"
 #include "network/Network.h"
 #include "Application.h"
 #include "windowing/WindowingFactory.h"
@@ -79,6 +80,8 @@
 /* Expand macro before stringify */
 #define STR_MACRO(x) #x
 #define XSTR_MACRO(x) STR_MACRO(x)
+
+using namespace XFILE;
 
 #ifdef TARGET_WINDOWS
 static bool sysGetVersionExWByRef(OSVERSIONINFOEXW& osVerInfo)
@@ -1407,6 +1410,22 @@ std::string CSysInfo::GetUsedCompilerNameAndVer(void)
 #endif
 }
 
+std::string CSysInfo::GetPrivacyPolicy()
+{
+  if (m_privacyPolicy.empty())
+  {
+    CFile file;
+    XFILE::auto_buffer buf;
+    if (file.LoadFile("special://xbmc/privacy-policy.txt", buf) > 0)
+    {
+      std::string strBuf(buf.get(), buf.length());
+      m_privacyPolicy = strBuf;
+    }
+    else
+      m_privacyPolicy = g_localizeStrings.Get(19055);
+  }
+  return m_privacyPolicy;
+}
 
 CJob *CSysInfo::GetJob() const
 {

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -144,6 +144,7 @@ public:
   static std::string GetBuildTargetCpuFamily(void);
 
   static std::string GetUsedCompilerNameAndVer(void);
+  std::string GetPrivacyPolicy();
 
 protected:
   virtual CJob *GetJob() const override;
@@ -152,6 +153,7 @@ protected:
 
 private:
   CSysData m_info;
+  std::string m_privacyPolicy;
   static WindowsVersion m_WinVer;
   int m_iSystemTimeTotalUp; // Uptime in minutes!
   void Reset();

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -29,15 +29,17 @@
 #include "storage/MediaManager.h"
 #include "guiinfo/GUIInfoLabels.h"
 
+#define CONTROL_TB_POLICY   30
 #define CONTROL_BT_STORAGE  94
 #define CONTROL_BT_DEFAULT  95
 #define CONTROL_BT_NETWORK  96
 #define CONTROL_BT_VIDEO    97
 #define CONTROL_BT_HARDWARE 98
 #define CONTROL_BT_PVR      99
+#define CONTROL_BT_POLICY   100
 
 #define CONTROL_START       CONTROL_BT_STORAGE
-#define CONTROL_END         CONTROL_BT_PVR
+#define CONTROL_END         CONTROL_BT_POLICY
 
 CGUIWindowSystemInfo::CGUIWindowSystemInfo(void) :
     CGUIWindow(WINDOW_SYSTEM_INFORMATION, "SettingsSystemInfo.xml")
@@ -80,6 +82,13 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
       {
         ResetLabels();
         m_section = focusedControl;
+      }
+      if (m_section >= CONTROL_BT_STORAGE && m_section <= CONTROL_BT_PVR)
+        SET_CONTROL_HIDDEN(CONTROL_TB_POLICY);
+      else if (m_section == CONTROL_BT_POLICY)
+      {
+        SET_CONTROL_LABEL(CONTROL_TB_POLICY, g_infoManager.GetLabel(SYSTEM_PRIVACY_POLICY));
+        SET_CONTROL_VISIBLE(CONTROL_TB_POLICY);
       }
       return true;
     }
@@ -182,6 +191,11 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s: %s", 19168, PVR_BACKEND_DELETED_RECORDINGS);  // Deleted and recoverable recordings
     SetControlLabel(i++, "%s: %s", 19025, PVR_BACKEND_TIMERS);
   }
+
+  else if (m_section == CONTROL_BT_POLICY)
+  {
+    SET_CONTROL_LABEL(40, g_localizeStrings.Get(12389));
+  }
   CGUIWindow::FrameMove();
 }
 
@@ -191,6 +205,7 @@ void CGUIWindowSystemInfo::ResetLabels()
   {
     SET_CONTROL_LABEL(i, "");
   }
+  SET_CONTROL_LABEL(CONTROL_TB_POLICY, "");
 }
 
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)


### PR DESCRIPTION
as reported by @MartijnKaijser on trac (http://trac.kodi.tv/ticket/17016) it's mandatory to provide a way for users to read our privacy policy within kodi.

this pr adds this functionality to the systeminfo window.

please check if i got the install path on each platform correct, the file should be available in special://xbmc/
(assuming we want to save it there...)

![privacypolicy](https://cloud.githubusercontent.com/assets/687265/19743048/f361b5e0-9bc7-11e6-9bb3-d5a1863fed67.jpg)
