### PR TITLE
[gui] - remove fallbacks for pvr next* infolabels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -8826,10 +8826,10 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
       return epgTag ? epgTag->PlotOutline() : "";
     case VIDEOPLAYER_NEXT_STARTTIME:
       epgTag = tag->GetEPGNext();
-      return epgTag ? epgTag->StartAsLocalTime().GetAsLocalizedTime("", false) : CDateTime::GetCurrentDateTime().GetAsLocalizedTime("", false);
+      return epgTag ? epgTag->StartAsLocalTime().GetAsLocalizedTime("", false) : "";
     case VIDEOPLAYER_NEXT_ENDTIME:
       epgTag = tag->GetEPGNext();
-      return epgTag ? epgTag->EndAsLocalTime().GetAsLocalizedTime("", false) : CDateTime::GetCurrentDateTime().GetAsLocalizedTime("", false);
+      return epgTag ? epgTag->EndAsLocalTime().GetAsLocalizedTime("", false) : "";
     case VIDEOPLAYER_NEXT_DURATION:
       {
         std::string duration;
@@ -10405,7 +10405,6 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (tag)
         return tag->StartAsLocalTime().GetAsLocalizedTime("", false);
     }
-    return CDateTime::GetCurrentDateTime().GetAsLocalizedTime("", false);
   case LISTITEM_NEXT_ENDTIME:
     if (item->HasPVRChannelInfoTag())
     {
@@ -10413,7 +10412,6 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (tag)
         return tag->EndAsLocalTime().GetAsLocalizedTime("", false);
     }
-    return CDateTime::GetCurrentDateTime().GetAsLocalizedTime("", false);
   case LISTITEM_NEXT_STARTDATE:
     if (item->HasPVRChannelInfoTag())
     {
@@ -10421,7 +10419,6 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (tag)
         return tag->StartAsLocalTime().GetAsLocalizedDate(true);
     }
-    return CDateTime::GetCurrentDateTime().GetAsLocalizedDate(true);
   case LISTITEM_NEXT_ENDDATE:
     if (item->HasPVRChannelInfoTag())
     {
@@ -10429,7 +10426,6 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (tag)
         return tag->EndAsLocalTime().GetAsLocalizedDate(true);
     }
-    return CDateTime::GetCurrentDateTime().GetAsLocalizedDate(true);
   case LISTITEM_NEXT_PLOT:
     if (item->HasPVRChannelInfoTag())
     {


### PR DESCRIPTION
At the moment the PVR infolabels nextstarttime/date fallback to current time in case the info is not available. Makes much more sense to fallback to an empty label instead, skinners can do fallbacks via $VARs.

@ronie  @xhaggi 
