### PR TITLE
[AirTunes/DACP] - fix remote control

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -825,6 +825,10 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
           m_postdata = Base64::Decode(value);
           m_postdataset = true;
         }
+        else if (name == "active-remote")// needed for DACP!
+        {
+          SetRequestHeader(it->first, value);
+        }
         // other standard headers (see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields)
         else if (name == "accept" || name == "accept-language" || name == "accept-datetime" ||
                  name == "authorization" || name == "cache-control" || name == "connection" ||


### PR DESCRIPTION
This fixes the DACP remote control feature which allows us to control the client when streaming audio/music via airtunes with the Kodi playback controls.

@FernetMenta any idea why i only get an OnSpeedChanged announcement when playback is resumed? Is this expected?

Also who the fuck stripped off the arbitrary request header support in CurlFile. Imo those changes should be communicated. Or at the least have a grep at the code on who is using "SetProtocolOption" before restricting request headers and simply throw away anything else.

Its always the apple features that get broken _grrr_
