### PR TITLE
Hide passwords from advancedsettings log

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -451,11 +451,46 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   // succeeded - tell the user it worked
   CLog::Log(LOGNOTICE, "Loaded settings file from %s", file.c_str());
 
-  // Dump contents of AS.xml to debug log
+  //Make a copy of the AS.xml and hide advancedsettings passwords
+  CXBMCTinyXML advancedXMLCopy(advancedXML);
+  TiXmlNode *pRootElementCopy = advancedXMLCopy.RootElement();
+  for (const auto& dbname : { "videodatabase", "musicdatabase", "tvdatabase", "adspdatabase", "epgdatabase" })
+  {
+    TiXmlNode *db = pRootElementCopy->FirstChild(dbname);
+    if (db)
+    {
+      TiXmlNode *passTag = db->FirstChild("pass");
+      if (passTag)
+      {
+        TiXmlNode *pass = passTag->FirstChild();
+        if (pass)
+        {
+          passTag->RemoveChild(pass);
+          passTag->LinkEndChild(new TiXmlText("*****"));
+        }
+      }
+    }
+  }
+  TiXmlNode *network = pRootElementCopy->FirstChild("network");
+  if (network)
+  {
+    TiXmlNode *passTag = network->FirstChild("httpproxypassword");
+    if (passTag)
+    {
+      TiXmlNode *pass = passTag->FirstChild();
+      if (pass)
+      {
+        passTag->RemoveChild(pass);
+        passTag->LinkEndChild(new TiXmlText("*****"));
+      }
+    }
+  }
+
+  // Dump contents of copied AS.xml to debug log
   TiXmlPrinter printer;
   printer.SetLineBreak("\n");
   printer.SetIndent("  ");
-  advancedXML.Accept(&printer);
+  advancedXMLCopy.Accept(&printer);
   CLog::Log(LOGNOTICE, "Contents of %s are...\n%s", file.c_str(), printer.CStr());
 
   TiXmlElement *pElement = pRootElement->FirstChildElement("audio");


### PR DESCRIPTION
Hide passwords when we dump advancedsettings in the log.
## Motivation and Context

Right now we dump passwords from advancedsettings in our log
## How Has This Been Tested?

I tested it with my advancedsettings file
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
