### PR TITLE
ActiveAEFilter: Add missing include for avcodec_fill_audio_frame

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -25,6 +25,7 @@
 
 extern "C" {
 #include "libavfilter/avfilter.h"
+#include "libavcodec/avcodec.h"
 #include "libavfilter/buffersink.h"
 #include "libavfilter/buffersrc.h"
 #include "libswresample/swresample.h"


### PR DESCRIPTION
This worked by accident. Found it when I had a brief preview of ffmpeg 3.2 in combination with kodi.
