### PR TITLE
Revert "[xbmc][win]Build addons with debug info on Windows"

### DIFF
--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -58,7 +58,7 @@ FOR %%b in (%1, %2, %3, %4, %5, %6) DO (
   IF %%b==sh SET useshell=sh
 )
 
-SET buildconfig=RelWithDebInfo
+SET buildconfig=Release
 set WORKSPACE=%CD%\..\..\kodi-build
 
 
@@ -218,7 +218,6 @@ set WORKSPACE=%CD%\..\..\kodi-build
   CALL extract_git_rev.bat > NUL
   SET APP_SETUPFILE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%.exe
   SET APP_PDBFILE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%.pdb
-  SET APP_PDB_BUNDLE=%APP_NAME%Setup-%GIT_REV%-%BRANCH%-PDB.7z
   ECHO Creating installer %APP_SETUPFILE%...
   IF EXIST %APP_SETUPFILE% del %APP_SETUPFILE% > NUL
   rem get path to makensis.exe from registry, first try tab delim
@@ -262,12 +261,7 @@ set WORKSPACE=%CD%\..\..\kodi-build
     set DIETEXT=Failed to create %APP_SETUPFILE%. NSIS installed?
     goto DIE
   )
-  REM copy %PDB% %APP_PDBFILE% > nul
-
-  rmdir /S /Q PDB > nul
-  md PDB > nul
-  powershell -ExecutionPolicy Unrestricted -File .\copy-pdb.ps1
-  tools\7z\7za.exe a -bd -r %APP_PDB_BUNDLE% PDB
+  copy %PDB% %APP_PDBFILE% > nul
   ECHO ------------------------------------------------------------
   ECHO Done!
   ECHO Setup is located at %CD%\%APP_SETUPFILE%

--- a/project/Win32BuildSetup/copy-pdb.ps1
+++ b/project/Win32BuildSetup/copy-pdb.ps1
@@ -1,6 +1,0 @@
-Get-ChildItem -Recurse -Include *.pdb -Exclude vc140.pdb,'kodi-test.pdb',gtest.pdb,CMakeCCompilerId.pdb,CMakeCXXCompilerId.pdb,example.pdb ..\.. |
-foreach {
-  if (-not $_.DirectoryName.EndsWith('PDB')) {
-    Copy-Item $_.FullName (join-path PDB $_.Name)
-  }
-}

--- a/tools/buildsteps/win32/make-addons.bat
+++ b/tools/buildsteps/win32/make-addons.bat
@@ -104,7 +104,7 @@ IF "%addon%" NEQ "" (
 
 rem execute cmake to generate makefiles processable by nmake
 cmake "%ADDONS_PATH%" -G "NMake Makefiles" ^
-      -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+      -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^
       -DCMAKE_INSTALL_PREFIX=%ADDONS_INSTALL_PATH% ^


### PR DESCRIPTION
Reverts xbmc/xbmc#10760

Causes binary add-on to not load. Will investigate later why and do proper fix.
