### PR TITLE
[addons] make sure temp dir exists before running CFileOperationJob

### DIFF
--- a/xbmc/addons/FilesystemInstaller.cpp
+++ b/xbmc/addons/FilesystemInstaller.cpp
@@ -40,6 +40,9 @@ bool CFilesystemInstaller::InstallToFilesystem(const std::string& archive, const
   auto newAddonData = URIUtils::AddFileToFolder(m_tempFolder, StringUtils::CreateUUID());
   auto oldAddonData = URIUtils::AddFileToFolder(m_tempFolder, StringUtils::CreateUUID());
 
+  if (!CDirectory::Create(newAddonData))
+    return false;
+
   if (!UnpackArchive(archive, newAddonData))
   {
     CLog::Log(LOGERROR, "Failed to unpack archive '%s' to '%s'", archive.c_str(), newAddonData.c_str());


### PR DESCRIPTION
As a workaround as the whole CFileOperationJob breaks down if it happens to find a directory before a file in the archive..
