### PR TITLE
[PVR][EPG] Feature: gridcontainer orientation

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.dox
+++ b/xbmc/epg/GUIEPGGridContainer.dox
@@ -24,6 +24,7 @@ the position, size, and look of the grid and it's contents.
     <timeblocks>40</timeblocks>
     <rulerunit>6</rulerunit>
     <progresstexture border="5">PVR-EpgProgressIndicator.png</progresstexture>
+    <orienttation>vertical</orientation>
     <onleft>31</onleft>
     <onright>31</onright>
     <onup>10</onup>
@@ -222,12 +223,13 @@ important, as `xml` tags are case-sensitive.
 
 | Tag                   | Description                                                   |
 |----------------------:|:--------------------------------------------------------------|
-| timeblocks            | The number of timeframes on the top row.
-| rulerunit             | Timeframe of each unit on the top row. 1 unit equals 5 minutes.
-| rulerlayout           | The layout of the top row.
+| timeblocks            | The number of timeframes on the ruler.
+| rulerunit             | Timeframe of each unit on ruler. 1 unit equals 5 minutes.
+| rulerdatelayout       | The layout of a ruler date item (usually used to display the start date of current epg page).
+| rulerlayout           | The layout of a ruler item.
 | progresstexture       | A texture which indicates the current progress time
-| channellayout         | The layout of the left column.
-| focusedchannellayout  | The focused layout of the left column.
+| channellayout         | The layout of a channel item.
+| focusedchannellayout  | The focused layout of a channel item.
 | itemlayout            | The layout of the grid
 | focusedlayout         | The focused layout of the grid
 

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -37,7 +37,7 @@ namespace EPG
   {
   public:
     CGUIEPGGridContainer(int parentID, int controlID, float posX, float posY, float width, float height,
-                         int scrollTime, int preloadItems, int minutesPerPage,
+                         ORIENTATION orientation, int scrollTime, int preloadItems, int minutesPerPage,
                          int rulerUnit, const CTextureInfo& progressIndicatorTexture);
     CGUIEPGGridContainer(const CGUIEPGGridContainer &other);
 
@@ -120,26 +120,32 @@ namespace EPG
 
     void ProcessChannels(unsigned int currentTime, CDirtyRegionList &dirtyregions);
     void ProcessRuler(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+    void ProcessRulerDate(unsigned int currentTime, CDirtyRegionList &dirtyregions);
     void ProcessProgrammeGrid(unsigned int currentTime, CDirtyRegionList &dirtyregions);
     void ProcessProgressIndicator(unsigned int currentTime, CDirtyRegionList &dirtyregions);
     void RenderChannels();
+    void RenderRulerDate();
     void RenderRuler();
     void RenderProgrammeGrid();
     void RenderProgressIndicator();
 
     CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
 
+    ORIENTATION m_orientation;
+
     std::vector<CGUIListItemLayout> m_channelLayouts;
     std::vector<CGUIListItemLayout> m_focusedChannelLayouts;
     std::vector<CGUIListItemLayout> m_focusedProgrammeLayouts;
     std::vector<CGUIListItemLayout> m_programmeLayouts;
     std::vector<CGUIListItemLayout> m_rulerLayouts;
+    std::vector<CGUIListItemLayout> m_rulerDateLayouts;
 
     CGUIListItemLayout *m_channelLayout;
     CGUIListItemLayout *m_focusedChannelLayout;
     CGUIListItemLayout *m_programmeLayout;
     CGUIListItemLayout *m_focusedProgrammeLayout;
     CGUIListItemLayout *m_rulerLayout;
+    CGUIListItemLayout *m_rulerDateLayout;
 
     int m_pageControl;
 
@@ -149,7 +155,12 @@ namespace EPG
   private:
     void HandleChannels(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
     void HandleRuler(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+    void HandleRulerDate(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
     void HandleProgrammeGrid(bool bRender, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+
+    float GetCurrentTimePositionOnPage() const;
+    float GetProgressIndicatorWidth() const;
+    float GetProgressIndicatorHeight() const;
 
     void UpdateItems();
 
@@ -167,6 +178,8 @@ namespace EPG
     int m_cacheProgrammeItems;
     int m_cacheRulerItems;
 
+    float m_rulerDateHeight; //! height of ruler date item
+    float m_rulerDateWidth; //! width of ruler date item
     float m_rulerPosX;      //! X position of first ruler item
     float m_rulerPosY;      //! Y position of first ruler item
     float m_rulerHeight;    //! height of the scrolling timeline above the ruler items

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1335,7 +1335,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     break;
   case CGUIControl::GUICONTAINER_EPGGRID:
     {
-      CGUIEPGGridContainer *epgGridContainer = new CGUIEPGGridContainer(parentID, id, posX, posY, width, height, scrollTime, preloadItems, timeBlocks, rulerUnit, textureProgressIndicator);
+      CGUIEPGGridContainer *epgGridContainer = new CGUIEPGGridContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems, timeBlocks, rulerUnit, textureProgressIndicator);
       control = epgGridContainer;
       epgGridContainer->LoadLayout(pControlNode);
       epgGridContainer->SetRenderOffset(offset);


### PR DESCRIPTION
A feature that has been requested several times: PVR guide window with grid layout with channels as columns and timeline as rows.

![screenshot004](https://cloud.githubusercontent.com/assets/3226626/19785663/8e62395c-9c9a-11e6-88aa-0f94df42232a.png)

![screenshot003](https://cloud.githubusercontent.com/assets/3226626/19785458/b8dc379c-9c99-11e6-9d17-41e11d11cf11.png)

Please note that the skin changes are not intended to be merged with this PR (unless people say they want it in estuary). It's just a test/reference implementation. The respective commit will be removed from this PR before merge. 

@xhaggi for code review
@ronie heads-up for skinning engine extension
