### PR TITLE
VideoPlayer: add user name and password back to url after testing for…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -154,6 +154,8 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
         {
           CURL finalUrl(curlFile.GetURL());
           finalUrl.SetProtocolOptions(origUrl.GetProtocolOptions());
+          finalUrl.SetUserName(origUrl.GetUserName());
+          finalUrl.SetPassword(origUrl.GetPassWord());
           finalFileitem.SetPath(finalUrl.Get());
         }
         curlFile.Close();


### PR DESCRIPTION
fix http://trac.kodi.tv/ticket/17005

This is not the only issue. Scraped item lose the property "IsHTTPDirectory" and are treated as internet streams.
