### PR TITLE
[cmake] Debug binary-addon packaging issues on android

### DIFF
--- a/project/cmake/addons/CMakeLists.txt
+++ b/project/cmake/addons/CMakeLists.txt
@@ -165,7 +165,7 @@ if(NOT WIN32)
     set(NEED_SUDO TRUE)
     set(ADDON_INSTALL_DIR ${CMAKE_BINARY_DIR}/.install)
     list(APPEND BUILD_ARGS -DOVERRIDE_PATHS=ON)
-    message(STATUS "NEED_SUDO: ${NEED_SUDO}")
+    message(STATUS "NEED_SUDO: ${NEED_SUDO} (no write permission for ${CMAKE_INSTALL_PREFIX})")
   endif()
 endif()
 

--- a/project/cmake/scripts/common/CheckTargetPlatform.cmake
+++ b/project/cmake/scripts/common/CheckTargetPlatform.cmake
@@ -47,10 +47,14 @@ function(check_install_permissions install_dir have_perms)
   execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${install_dir}/lib/kodi
                   COMMAND ${CMAKE_COMMAND} -E make_directory ${install_dir}/share/kodi
                   COMMAND ${CMAKE_COMMAND} -E touch ${install_dir}/lib/kodi/.cmake-inst-test ${install_dir}/share/kodi/.cmake-inst-test
-                  RESULT_VARIABLE permtest)
+                  RESULT_VARIABLE permtest
+                  OUTPUT_VARIABLE output
+                  ERROR_VARIABLE  output
+                  )
 
   if(${permtest} GREATER 0)
-    message(STATUS "check_install_permissions: ${permtest}")
+    message(STATUS "check_install_permissions failed for ${install_dir}: ${permtest}")
+    message(STATUS "${output}")
     set(${have_perms} FALSE)
   endif()
   set(${have_perms} "${${have_perms}}" PARENT_SCOPE)

--- a/project/cmake/scripts/common/CheckTargetPlatform.cmake
+++ b/project/cmake/scripts/common/CheckTargetPlatform.cmake
@@ -52,9 +52,13 @@ function(check_install_permissions install_dir have_perms)
                   ERROR_VARIABLE  output
                   )
 
+  message(STATUS "============ DEBUG ADDON PACKAGING  ======")
+  message(STATUS "check_install_permissions ${install_dir}: ${permtest}")
+  message(STATUS "${output}")
+  execute_process(COMMAND find ${install_dir})
+  execute_process(COMMAND ls -laR ${install_dir})
+
   if(${permtest} GREATER 0)
-    message(STATUS "check_install_permissions failed for ${install_dir}: ${permtest}")
-    message(STATUS "${output}")
     set(${have_perms} FALSE)
   endif()
   set(${have_perms} "${${have_perms}}" PARENT_SCOPE)


### PR DESCRIPTION
## Description

Adds more log output to debug the current issue that sometimes binary-addons are not packaged on android. The second commit needs to be reverted once the issue is sorted out.
http://trac.kodi.tv/ticket/17033#ticket
## Motivation and Context

Get it included in more builds as it's a heisenbug  and didn't show up in 5 manually triggered builds.
## How Has This Been Tested?

Locally and on Jenkins. Doesn't change behavior, just adds more logging. 
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
