### PR TITLE
Remove XMemUtils' alloc when ffmpeg intrinsics might be used

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1085,7 +1085,7 @@ void CActiveAESink::GenerateNoise()
   nb_floats *= m_sampleOfSilence.pkt->config.channels;
   size_t size = nb_floats*sizeof(float);
 
-  float *noise = (float*)_aligned_malloc(size, 16);
+  float *noise = (float*)_aligned_malloc(size, 32);
   if (!noise)
     throw std::bad_alloc();
 

--- a/xbmc/cores/AudioEngine/Utils/AEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBuffer.cpp
@@ -40,7 +40,7 @@ CAEBuffer::~CAEBuffer()
 void CAEBuffer::Alloc(const size_t size)
 {
   DeAlloc();
-  m_buffer     = (uint8_t*)_aligned_malloc(size, 16);
+  m_buffer     = (uint8_t*)_aligned_malloc(size, 32);
   m_bufferSize = size;
   m_bufferPos  = 0;
 }
@@ -48,9 +48,9 @@ void CAEBuffer::Alloc(const size_t size)
 void CAEBuffer::ReAlloc(const size_t size)
 {
 #if defined(TARGET_WINDOWS)
-  m_buffer = (uint8_t*)_aligned_realloc(m_buffer, size, 16);
+  m_buffer = (uint8_t*)_aligned_realloc(m_buffer, size, 32);
 #else
-  uint8_t* tmp = (uint8_t*)_aligned_malloc(size, 16);
+  uint8_t* tmp = (uint8_t*)_aligned_malloc(size, 32);
   if (m_buffer)
   {
     size_t copy = std::min(size, m_bufferSize);

--- a/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
+++ b/xbmc/cores/AudioEngine/Utils/AERingBuffer.h
@@ -84,7 +84,7 @@ public:
     m_Buffer = new unsigned char*[planes];
     for (unsigned int i = 0; i < planes; i++)
     {
-      m_Buffer[i] = (unsigned char*)_aligned_malloc(size,16);
+      m_Buffer[i] = (unsigned char*)_aligned_malloc(size, 32);
       if (!m_Buffer[i])
         return false;
       memset(m_Buffer[i], 0, size);
@@ -216,7 +216,7 @@ public:
    */
   void Dump()
   {
-    unsigned char *bufferContents =  (unsigned char *)_aligned_malloc(m_iSize*m_planes + 1,16);
+    unsigned char *bufferContents =  (unsigned char *)_aligned_malloc(m_iSize*m_planes + 1, 32);
     unsigned char *dest = bufferContents;
     for (unsigned int j = 0; j < m_planes; j++)
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -185,9 +185,9 @@ bool CDVDVideoPPFFmpeg::CheckFrameBuffer(const DVDVideoPicture* pSource)
     m_FrameBuffer.iWidth = pSource->iWidth;
     m_FrameBuffer.iHeight = pSource->iHeight;
 
-    m_FrameBuffer.data[0] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[0] * m_FrameBuffer.iHeight  , 16);
-    m_FrameBuffer.data[1] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[1] * m_FrameBuffer.iHeight/2, 16);
-    m_FrameBuffer.data[2] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[2] * m_FrameBuffer.iHeight/2, 16);
+    m_FrameBuffer.data[0] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[0] * m_FrameBuffer.iHeight  , 32);
+    m_FrameBuffer.data[1] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[1] * m_FrameBuffer.iHeight/2, 32);
+    m_FrameBuffer.data[2] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[2] * m_FrameBuffer.iHeight/2, 32);
 
     if( !m_FrameBuffer.data[0] || !m_FrameBuffer.data[1] || !m_FrameBuffer.data[2])
     {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -68,7 +68,7 @@ DemuxPacket* CDVDDemuxUtils::AllocateDemuxPacket(int iDataSize)
         * Note, if the first 23 bits of the additional bytes are not 0 then damaged
         * MPEG bitstreams could cause overread and segfault
         */
-      pPacket->pData =(uint8_t*)_aligned_malloc(iDataSize + FF_INPUT_BUFFER_PADDING_SIZE, 16);
+      pPacket->pData =(uint8_t*)_aligned_malloc(iDataSize + FF_INPUT_BUFFER_PADDING_SIZE, 32);
       if (!pPacket->pData)
       {
         FreeDemuxPacket(pPacket);

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -404,7 +404,7 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
 
   bool needsCopy = false;
   int pixelsSize = pitch * height;
-  bool aligned = (((uintptr_t)(const void *)(pixels)) % (16) == 0);
+  bool aligned = (((uintptr_t)(const void *)(pixels)) % (32) == 0);
   if (!aligned)
     CLog::Log(LOGDEBUG, "Alignment of external buffer is not suitable for ffmpeg intrinsics - please fix your malloc");
 

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -108,7 +108,7 @@ void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned in
   if (GetPitch() * GetRows() > 0)
   {
     size_t size = GetPitch() * GetRows();
-    m_pixels = (unsigned char*) _aligned_malloc(size, 16);
+    m_pixels = (unsigned char*) _aligned_malloc(size, 32);
 
     if (m_pixels == nullptr)
     {


### PR DESCRIPTION
This replaces our homebaked _aligned_malloc with just ffmpeg's av_malloc as we continue to run into alignment related intrinsic segfaults with ffmpeg, let ffmpeg decide about it's alignment.

The only areas the old code is left is:
VAAPI.cpp where we need a 64 byte aligned memory area (av_malloc provides)
GUIShaderDX.h which uses some "special" alignment, no idea here
