### PR TITLE
workaround for addon installer deadlocks

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1159,11 +1159,11 @@ bool CApplication::Initialize()
     event.Reset();
     std::atomic<bool> isMigratingAddons(false);
     CJobManager::GetInstance().Submit([&event, &incompatibleAddons, &isMigratingAddons]() {
-      incompatibleAddons = CAddonSystemSettings::GetInstance().MigrateAddons([&isMigratingAddons]() {
-        isMigratingAddons = true;
-      });
-      event.Set();
-    });
+        incompatibleAddons = CAddonSystemSettings::GetInstance().MigrateAddons([&isMigratingAddons]() {
+          isMigratingAddons = true;
+        });
+        event.Set();
+      }, CJob::PRIORITY_DEDICATED);
     localizedStr = g_localizeStrings.Get(24151);
     iDots = 1;
     while (!event.WaitMSec(1000))

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -243,7 +243,9 @@ bool CAddonInstaller::DoInstall(const AddonPtr &addon, const RepositoryPtr& repo
   CAddonInstallJob* installJob = new CAddonInstallJob(addon, repo, hash);
   if (background)
   {
-    unsigned int jobID = CJobManager::GetInstance().AddJob(installJob, this);
+    // Workaround: because CAddonInstallJob is blocking waiting for other jobs, it needs to be run
+    // with priority dedicated.
+    unsigned int jobID = CJobManager::GetInstance().AddJob(installJob, this, CJob::PRIORITY_DEDICATED);
     m_downloadJobs.insert(make_pair(addon->ID(), CDownloadJob(jobID)));
     m_idle.Reset();
     return true;

--- a/xbmc/utils/Job.h
+++ b/xbmc/utils/Job.h
@@ -109,7 +109,8 @@ public:
     PRIORITY_LOW_PAUSABLE = 0,
     PRIORITY_LOW,
     PRIORITY_NORMAL,
-    PRIORITY_HIGH
+    PRIORITY_HIGH,
+    PRIORITY_DEDICATED, // will create a new worker if no worker is available at queue time
   };
   CJob() { m_callback = NULL; };
 

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -201,7 +201,7 @@ void CJobManager::CancelJobs()
   m_running = false;
 
   // clear any pending jobs
-  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_HIGH; ++priority)
+  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_DEDICATED; ++priority)
   {
     for_each(m_jobQueue[priority].begin(), m_jobQueue[priority].end(), std::mem_fun_ref(&CWorkItem::FreeJob));
     m_jobQueue[priority].clear();
@@ -249,7 +249,7 @@ void CJobManager::CancelJob(unsigned int jobID)
   CSingleLock lock(m_section);
 
   // check whether we have this job in the queue
-  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_HIGH; ++priority)
+  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_DEDICATED; ++priority)
   {
     JobQueue::iterator i = find(m_jobQueue[priority].begin(), m_jobQueue[priority].end(), jobID);
     if (i != m_jobQueue[priority].end())
@@ -287,7 +287,7 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
 CJob *CJobManager::PopJob()
 {
   CSingleLock lock(m_section);
-  for (int priority = CJob::PRIORITY_HIGH; priority >= CJob::PRIORITY_LOW_PAUSABLE; --priority)
+  for (int priority = CJob::PRIORITY_DEDICATED; priority >= CJob::PRIORITY_LOW_PAUSABLE; --priority)
   {
     // Check whether we're pausing pausable jobs
     if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
@@ -435,5 +435,7 @@ void CJobManager::RemoveWorker(const CJobWorker *worker)
 unsigned int CJobManager::GetMaxWorkers(CJob::PRIORITY priority)
 {
   static const unsigned int max_workers = 5;
+  if (priority == CJob::PRIORITY_DEDICATED)
+    return 10000; // A large number..
   return max_workers - (CJob::PRIORITY_HIGH - priority);
 }

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -350,7 +350,7 @@ private:
   typedef std::vector<CWorkItem>   Processing;
   typedef std::vector<CJobWorker*> Workers;
 
-  JobQueue   m_jobQueue[CJob::PRIORITY_HIGH+1];
+  JobQueue   m_jobQueue[CJob::PRIORITY_DEDICATED + 1];
   bool       m_pauseJobs;
   Processing m_processing;
   Workers    m_workers;

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -242,9 +242,9 @@ public:
    \brief Add a function f to this job manager for asynchronously execution.
    */
   template<typename F>
-  void Submit(F&& f)
+  void Submit(F&& f, CJob::PRIORITY priority = CJob::PRIORITY_LOW)
   {
-    AddJob(new CLambdaJob<F>(std::forward<F>(f)), nullptr);
+    AddJob(new CLambdaJob<F>(std::forward<F>(f)), nullptr, priority);
   }
 
   /*!


### PR DESCRIPTION
This fixes deadlocks caused by the addon installer giving jobs to the job manager which depends on waiting on other jobs to finish (see https://github.com/xbmc/xbmc/blob/49cf9e6a5cb2e393cd1769c0b2ae34e2689e4931/xbmc/addons/AddonInstaller.cpp#L729). If the job manager is out of workers, it deadlocks.

Since this is the addon installer being broken at its core,  I see no other way (other than a rewrite) than to give it as many threads as required.
