### PR TITLE
MemoryAlignment: Fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1085,7 +1085,7 @@ void CActiveAESink::GenerateNoise()
   nb_floats *= m_sampleOfSilence.pkt->config.channels;
   size_t size = nb_floats*sizeof(float);
 
-  float *noise = (float*)_aligned_malloc(size, 16);
+  float *noise = (float*)_aligned_malloc(size, 32);
   if (!noise)
     throw std::bad_alloc();
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -21,9 +21,10 @@
 #include "DVDVideoPPFFmpeg.h"
 #include "utils/log.h"
 #include "cores/FFmpeg.h"
-#ifdef TARGET_POSIX
-#include "linux/XMemUtils.h"
-#endif
+
+extern "C" {
+#include "libavutil/mem.h"
+}
 
 CDVDVideoPPFFmpeg::CDVDVideoPPFFmpeg():
   m_sType("")
@@ -57,7 +58,7 @@ void CDVDVideoPPFFmpeg::Dispose()
     {
       if( m_FrameBuffer.data[i] )
       {
-        _aligned_free(m_FrameBuffer.data[i]);
+        av_free(&(m_FrameBuffer.data[i]));
         m_FrameBuffer.data[i] = NULL;
         m_FrameBuffer.iLineSize[i] = 0;
       }
@@ -185,9 +186,9 @@ bool CDVDVideoPPFFmpeg::CheckFrameBuffer(const DVDVideoPicture* pSource)
     m_FrameBuffer.iWidth = pSource->iWidth;
     m_FrameBuffer.iHeight = pSource->iHeight;
 
-    m_FrameBuffer.data[0] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[0] * m_FrameBuffer.iHeight  , 16);
-    m_FrameBuffer.data[1] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[1] * m_FrameBuffer.iHeight/2, 16);
-    m_FrameBuffer.data[2] = (uint8_t*)_aligned_malloc(m_FrameBuffer.iLineSize[2] * m_FrameBuffer.iHeight/2, 16);
+    m_FrameBuffer.data[0] = (uint8_t*)av_malloc(m_FrameBuffer.iLineSize[0] * m_FrameBuffer.iHeight);
+    m_FrameBuffer.data[1] = (uint8_t*)av_malloc(m_FrameBuffer.iLineSize[1] * m_FrameBuffer.iHeight/2);
+    m_FrameBuffer.data[2] = (uint8_t*)av_malloc(m_FrameBuffer.iLineSize[2] * m_FrameBuffer.iHeight/2);
 
     if( !m_FrameBuffer.data[0] || !m_FrameBuffer.data[1] || !m_FrameBuffer.data[2])
     {

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -404,7 +404,7 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
 
   bool needsCopy = false;
   int pixelsSize = pitch * height;
-  bool aligned = (((uintptr_t)(const void *)(pixels)) % (16) == 0);
+  bool aligned = (((uintptr_t)(const void *)(pixels)) % (32) == 0);
   if (!aligned)
     CLog::Log(LOGDEBUG, "Alignment of external buffer is not suitable for ffmpeg intrinsics - please fix your malloc");
 

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -108,7 +108,7 @@ void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned in
   if (GetPitch() * GetRows() > 0)
   {
     size_t size = GetPitch() * GetRows();
-    m_pixels = (unsigned char*) _aligned_malloc(size, 16);
+    m_pixels = (unsigned char*) _aligned_malloc(size, 32);
 
     if (m_pixels == nullptr)
     {

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -42,6 +42,7 @@
 
 extern "C" {
 #include "libswscale/swscale.h"
+#include "libavutil/mem.h"
 }
 
 using namespace XFILE;
@@ -176,7 +177,7 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
   // create a buffer large enough for the resulting image
   GetScale(width, height, dest_width, dest_height);
 
-  uint8_t *buffer = new uint8_t[dest_width * dest_height * sizeof(uint32_t)];
+  uint8_t *buffer = (uint8_t*) av_malloc(dest_width * dest_height * sizeof(uint32_t));
   if (buffer == NULL)
   {
     result = NULL;
@@ -186,14 +187,14 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
 
   if (!ScaleImage(pixels, width, height, pitch, buffer, dest_width, dest_height, dest_width * sizeof(uint32_t), scalingAlgorithm))
   {
-    delete[] buffer;
+    av_free(&buffer);
     result = NULL;
     result_size = 0;
     return false;
   }
 
   bool success = GetThumbnailFromSurface(buffer, dest_width, dest_height, dest_width * sizeof(uint32_t), image, result, result_size);
-  delete[] buffer;
+  av_free(&buffer);
 
   if (!success)
   {
@@ -245,7 +246,7 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
 
     // create a buffer large enough for the resulting image
     GetScale(width, height, dest_width, dest_height);
-    uint32_t *buffer = new uint32_t[dest_width * dest_height];
+    uint32_t *buffer = (uint32_t*) av_malloc(dest_width * dest_height);
     if (buffer)
     {
       if (ScaleImage(pixels, width, height, pitch,
@@ -257,7 +258,7 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
           success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height, dest_width * 4, dest);
         }
       }
-      delete[] buffer;
+      av_free(&buffer);
     }
     return success;
   }
@@ -297,7 +298,7 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
       GetScale(texture->GetWidth(), texture->GetHeight(), width, height);
 
       // scale appropriately
-      uint32_t *scaled = new uint32_t[width * height];
+      uint32_t *scaled = (uint32_t*) av_malloc(width * height);
       if (ScaleImage(texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(),
                      (uint8_t *)scaled, width, height, width * 4))
       {
@@ -317,7 +318,7 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
           }
         }
       }
-      delete[] scaled;
+      av_free(&scaled);
     }
     delete texture;
   }


### PR DESCRIPTION
Whenever we provide a user buffer directly into ffmpeg we should take care that its alignment is 32 byte, cause our ffmpeg build with AVX support might do nasty things.

This PR does two things:
a) Use av_malloc when we directly communicate with ffmpeg / sws_scale and so on
b) Use _aligned_malloc(size, 32) whenever we don't want ffmpeg dependencies in that other code, e.g. Texture.cpp and friends.
