### PR TITLE
[xbmc][fix] Make CDirectory::Create create all the needed folders

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -104,19 +104,27 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
 #else
         pathsep = "/";
 #endif
-        StringUtils::Tokenize(url.GetFileName(),tokens,pathsep.c_str());
-        std::string strCurrPath;
-        // Handle special
-        if (!url.GetProtocol().empty()) {
-          pathsep = "/";
-          strCurrPath += url.GetProtocol() + "://";
-        } // If the directory has a / at the beginning, don't forget it
-        else if (strDirectory[0] == pathsep[0])
-          strCurrPath += pathsep;
-        for (std::vector<std::string>::iterator iter=tokens.begin();iter!=tokens.end();++iter)
+        // Try to use the recursive creation first, if it fails
+        // it might not be implemented for that subsystem so let's
+        // fall back to the old method in that case
+        if (!CDirectory::Create(url))
         {
-          strCurrPath += *iter+pathsep;
-          CDirectory::Create(strCurrPath);
+          StringUtils::Tokenize(url.GetFileName(), tokens, pathsep.c_str());
+          std::string strCurrPath;
+          // Handle special
+          if (!url.GetProtocol().empty())
+          {
+            pathsep = "/";
+            strCurrPath += url.GetProtocol() + "://";
+          } // If the directory has a / at the beginning, don't forget it
+          else if (strDirectory[0] == pathsep[0])
+            strCurrPath += pathsep;
+
+          for (std::vector<std::string>::iterator iter = tokens.begin(); iter != tokens.end(); ++iter)
+          {
+            strCurrPath += *iter + pathsep;
+            CDirectory::Create(strCurrPath);
+          }
         }
       }
     }

--- a/xbmc/filesystem/posix/PosixDirectory.cpp
+++ b/xbmc/filesystem/posix/PosixDirectory.cpp
@@ -111,12 +111,27 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
 bool CPosixDirectory::Create(const CURL& url)
 {
-  if (mkdir(url.Get().c_str(), 0755) != 0)
+  if (!Create(url.Get()))
+    return Exists(url);
+  
+  return true;
+}
+
+bool CPosixDirectory::Create(std::string path)
+{
+  if (mkdir(path.c_str(), 0755) != 0)
   {
-    if (errno == EEXIST)
-      return Exists(url);
-    else
-      return false;
+    if (errno == ENOENT)
+    {
+      auto sep = path.rfind('/');
+      if (sep == std::string::npos)
+        return false;
+
+      if (Create(path.substr(0, sep)))
+        return Create(path);
+    }
+
+    return false;
   }
   return true;
 }

--- a/xbmc/filesystem/posix/PosixDirectory.h
+++ b/xbmc/filesystem/posix/PosixDirectory.h
@@ -34,5 +34,7 @@ public:
   virtual bool Exists(const CURL& url);
   virtual bool Remove(const CURL& url);
   virtual bool RemoveRecursive(const CURL& url);
+private:
+  bool Create(std::string path);
 };
 }

--- a/xbmc/filesystem/test/TestDirectory.cpp
+++ b/xbmc/filesystem/test/TestDirectory.cpp
@@ -52,3 +52,16 @@ TEST(TestDirectory, General)
   EXPECT_TRUE(XFILE::CDirectory::Remove(tmppath1));
   EXPECT_FALSE(XFILE::CDirectory::Exists(tmppath1));
 }
+
+TEST(TestDirectory, CreateRecursive)
+{
+  auto path1 = URIUtils::AddFileToFolder(
+    CSpecialProtocol::TranslatePath("special://temp/"),
+    "level1");
+  auto path2 = URIUtils::AddFileToFolder(path1,
+    "level2",
+    "level3");
+
+  EXPECT_TRUE(XFILE::CDirectory::Create(path2));
+  EXPECT_TRUE(XFILE::CDirectory::RemoveRecursive(path1));
+}

--- a/xbmc/filesystem/win32/Win32Directory.cpp
+++ b/xbmc/filesystem/win32/Win32Directory.cpp
@@ -129,26 +129,12 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
 
 bool CWin32Directory::Create(const CURL& url)
 {
-  std::wstring nameW(prepareWin32DirectoryName(url.Get()));
+  auto nameW(prepareWin32DirectoryName(url.Get()));
   if (nameW.empty())
     return false;
 
-  if (!CreateDirectoryW(nameW.c_str(), NULL))
-  {
-    if (GetLastError() == ERROR_ALREADY_EXISTS)
-      return Exists(url); // is it file or directory?
-    else
-      return false;
-  }
-
-  // if directory name starts from dot, make it hidden
-  const size_t lastSlashPos = nameW.rfind(L'\\');
-  if (lastSlashPos < nameW.length() - 1 && nameW[lastSlashPos + 1] == L'.')
-  {
-    DWORD dirAttrs = GetFileAttributesW(nameW.c_str());
-    if (dirAttrs != INVALID_FILE_ATTRIBUTES && SetFileAttributesW(nameW.c_str(), dirAttrs | FILE_ATTRIBUTE_HIDDEN))
-      return true;
-  }
+  if (!Create(nameW))
+    return Exists(url);
 
   return true;
 }
@@ -243,5 +229,37 @@ bool CWin32Directory::RemoveRecursive(const CURL& url)
   }
 
   return success;
+}
+
+bool CWin32Directory::Create(std::wstring path) const
+{
+  if (!CreateDirectoryW(path.c_str(), nullptr))
+  {
+    if (GetLastError() == ERROR_ALREADY_EXISTS)
+      return true;
+
+    if (GetLastError() != ERROR_PATH_NOT_FOUND)
+      return false;
+
+    auto sep = path.rfind(L'\\');
+    if (sep == std::wstring::npos)
+      return false;
+
+    if (Create(path.substr(0, sep)))
+      return Create(path);
+
+    return false;
+  }
+
+  // if directory name starts from dot, make it hidden
+  const auto lastSlashPos = path.rfind(L'\\');
+  if (lastSlashPos < path.length() - 1 && path[lastSlashPos + 1] == L'.')
+  {
+    DWORD dirAttrs = GetFileAttributesW(path.c_str());
+    if (dirAttrs != INVALID_FILE_ATTRIBUTES && SetFileAttributesW(path.c_str(), dirAttrs | FILE_ATTRIBUTE_HIDDEN))
+      return true;
+  }
+
+  return true;
 }
 #endif // TARGET_WINDOWS

--- a/xbmc/filesystem/win32/Win32Directory.h
+++ b/xbmc/filesystem/win32/Win32Directory.h
@@ -34,5 +34,8 @@ namespace XFILE
     bool Exists(const CURL& url) override;
     bool Remove(const CURL& url) override;
     bool RemoveRecursive(const CURL& url) override;
+
+  private:
+    bool Create(std::wstring path) const;
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

<!--- Describe your change in detail -->

This is mainly to simplify addon management so it's
currently only implemented for posix and win32 directories

Make use of it for file copy operation to avoid spamming
the logs with useless errors about not being able to create
c:\
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

locally on windows and new test method
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
