### PR TITLE
[PVR] Guide window: Fix responsiveness on first open. 

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -515,6 +515,9 @@ bool CGUIWindowPVRGuide::RefreshTimelineItems()
     if (epgGridContainer)
     {
       const CPVRChannelGroupPtr group(GetChannelGroup());
+      if (!group)
+        return false;
+
       std::unique_ptr<CFileItemList> timeline(new CFileItemList);
 
       // can be very expensive. never call with lock acquired.


### PR DESCRIPTION
Under special circumstances -- for example if guide window is set as kodi startup window or if opened very(!) quickly after kodi startup -- the window can be experienced as kinda "unresponsive", because due to the async update of the window which is per default every 5 seconds (to avoid unnecessary flickering and cpu load) , it can happen that first epg data are displayed after 5 seconds.

This PR fixes this glitch by introducing an initial boost for the window update.

Second commit just adds some more fail safeness (i once experienced a crash there).

note: pvr.demo + guide window as kodi startup window is nice test setup to test the change.

@xhaggi for review? 
