### PR TITLE
FIX: [amcs] get proper VideoView size (fixes #17032)

### DIFF
--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
@@ -4,6 +4,7 @@ import android.app.NativeActivity;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.hardware.input.InputManager;
+import android.graphics.Rect;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.util.Log;
@@ -38,6 +39,17 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   public Surface getVideoViewSurface()
   {
     return mVideoView.getSurface();
+  }
+
+  public Rect getVideoViewSurfaceRect()
+  {
+    Rect ret = new Rect();
+    ret.top = 0;
+    ret.left = 0;
+    ret.right = mVideoView.mWidth;
+    ret.bottom = mVideoView.mHeight;
+
+    return ret;
   }
 
   public void setVideoViewSurfaceRect(final int left, final int top, final int right, final int bottom)

--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCVideoView.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCVideoView.java.in
@@ -16,12 +16,16 @@ import android.view.SurfaceView;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.view.View;
 
 public class XBMCVideoView extends SurfaceView implements
     SurfaceHolder.Callback
 {
   private static final String TAG = "XBMCVideoPlayView";
+
   public boolean mHasHolder = false;
+  public int mWidth = -1;
+  public int mHeight = -1;
 
   public XBMCVideoView(Context context)
   {
@@ -104,6 +108,10 @@ public class XBMCVideoView extends SurfaceView implements
   {
     Log.d(TAG, "Created");
     mHasHolder = true;
+
+    View v = getRootView();
+    mWidth = v.getWidth();
+    mHeight = v.getHeight();
   }
 
   @Override
@@ -112,6 +120,10 @@ public class XBMCVideoView extends SurfaceView implements
   {
     Log.d(TAG, "Changed, format:" + format + ", width:" + width
         + ", height:" + height);
+
+    View v = getRootView();
+    mWidth = v.getWidth();
+    mHeight = v.getHeight();
   }
 
   @Override

--- a/xbmc/platform/android/activity/JNIMainActivity.cpp
+++ b/xbmc/platform/android/activity/JNIMainActivity.cpp
@@ -123,6 +123,12 @@ void CJNIMainActivity::clearVideoView()
                     "clearVideoView", "()V");
 }
 
+CJNIRect CJNIMainActivity::getVideoViewSurfaceRect()
+{
+  return call_method<jhobject>(m_context,
+                               "getVideoViewSurfaceRect", "()Landroid/graphics/Rect;");
+}
+
 void CJNIMainActivity::setVideoViewSurfaceRect(int l, int t, int r, int b)
 {
   call_method<void>(m_context,

--- a/xbmc/platform/android/activity/JNIMainActivity.h
+++ b/xbmc/platform/android/activity/JNIMainActivity.h
@@ -22,6 +22,7 @@
 #include "platform/android/jni/Activity.h"
 #include "platform/android/jni/InputManager.h"
 #include "platform/android/jni/Surface.h"
+#include "platform/android/jni/Rect.h"
 
 class CJNIMainActivity : public CJNIActivity, public CJNIInputManagerInputDeviceListener
 {
@@ -46,6 +47,7 @@ public:
 
   CJNISurface getVideoViewSurface();
   void clearVideoView();
+  CJNIRect getVideoViewSurfaceRect();
   void setVideoViewSurfaceRect(int l, int t, int r, int b);
 
 private:

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -547,21 +547,10 @@ CRect CXBMCApp::MapRenderToDroid(const CRect& srcRect)
   float scaleX = 1.0;
   float scaleY = 1.0;
 
-  CJNIWindow window = CXBMCApp::getWindow();
-  if (window)
-  {
-    CJNIView view(window.getDecorView());
-    if (view)
-    {
-      CJNIDisplay display = view.getDisplay();
-      if (display)
-      {
-        RESOLUTION_INFO renderRes = g_graphicsContext.GetResInfo(g_graphicsContext.GetVideoResolution());
-        scaleX = (double)display.getWidth() / renderRes.iWidth;
-        scaleY = (double)display.getHeight() / renderRes.iHeight;
-      }
-    }
-  }
+  CJNIRect r = m_xbmcappinstance->getVideoViewSurfaceRect();
+  RESOLUTION_INFO renderRes = g_graphicsContext.GetResInfo(g_graphicsContext.GetVideoResolution());
+  scaleX = (double)r.width() / renderRes.iWidth;
+  scaleY = (double)r.height() / renderRes.iHeight;
 
   return CRect(srcRect.x1 * scaleX, srcRect.y1 * scaleY, srcRect.x2 * scaleX, srcRect.y2 * scaleY);
 }
@@ -659,7 +648,7 @@ bool CXBMCApp::StartActivity(const std::string &package, const std::string &inte
     if (!jniURI)
       return false;
 
-    newIntent.setDataAndType(jniURI, dataType); 
+    newIntent.setDataAndType(jniURI, dataType);
   }
 
   newIntent.setPackage(package);
@@ -786,7 +775,7 @@ float CXBMCApp::GetSystemVolume()
   CJNIAudioManager audioManager(getSystemService("audio"));
   if (audioManager)
     return (float)audioManager.getStreamVolume() / GetMaxSystemVolume();
-  else 
+  else
   {
     android_printf("CXBMCApp::GetSystemVolume: Could not get Audio Manager");
     return 0;

--- a/xbmc/platform/android/jni/CMakeLists.txt
+++ b/xbmc/platform/android/jni/CMakeLists.txt
@@ -82,8 +82,8 @@ set(SOURCES Activity.cpp
             RouteInfo.cpp
             InetAddress.cpp
             NetworkInterface.cpp
+            Rect.cpp
             )
-
 
 set(HEADERS Activity.h
             ApplicationInfo.h
@@ -169,6 +169,7 @@ set(HEADERS Activity.h
             RouteInfo.h
             InetAddress.h
             NetworkInterface.h
+            Rect.h
             jutils/jutils.hpp
             jutils/jutils-details.hpp)
 

--- a/xbmc/platform/android/jni/Makefile.in
+++ b/xbmc/platform/android/jni/Makefile.in
@@ -82,6 +82,7 @@ SRCS      += LinkAddress.cpp
 SRCS      += RouteInfo.cpp
 SRCS      += InetAddress.cpp
 SRCS      += NetworkInterface.cpp
+SRCS      += Rect.cpp
 
 LIB        = jni.a
 

--- a/xbmc/platform/android/jni/Rect.cpp
+++ b/xbmc/platform/android/jni/Rect.cpp
@@ -1,0 +1,90 @@
+/*
+ *      Copyright (C) 2016 Christian Browet
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Rect.h"
+
+#include "jutils/jutils-details.hpp"
+
+using namespace jni;
+
+CJNIRect::CJNIRect() : CJNIBase("android/graphics/Rect")
+{
+  m_object = new_object(GetClassName(),
+    "<init>", "()V");
+}
+
+CJNIRect::CJNIRect(int l, int t, int r, int b) : CJNIBase("android/graphics/Rect")
+{
+  m_object = new_object(GetClassName(),
+    "<init>", "(IIII)V",
+                        l, t, r, b);
+}
+
+int CJNIRect::getLeft()
+{
+  return get_field<int>(m_object, "left");
+}
+
+int CJNIRect::getTop()
+{
+  return get_field<int>(m_object, "top");
+}
+
+int CJNIRect::getRight()
+{
+  return get_field<int>(m_object, "right");
+}
+
+int CJNIRect::getBottom()
+{
+  return get_field<int>(m_object, "bottom");
+}
+
+int CJNIRect::width()
+{
+  return call_method<jint>(m_object,
+    "width", "()I");
+}
+
+int CJNIRect::height()
+{
+  return call_method<jint>(m_object,
+    "height", "()I");
+}
+
+bool CJNIRect::equals(const CJNIRect& other)
+{
+  return call_method<jboolean>(m_object,
+    "equals", "(Ljava/lang/Object;)Z", other.get_raw());
+}
+
+std::string CJNIRect::toString() const
+{
+  return jcast<std::string>(call_method<jhstring>(m_object,
+    "toString", "()Ljava/lang/String;"));
+}
+
+int CJNIRect::describeContents() const
+{
+  return call_method<jint>(m_object,
+    "describeContents", "()I");
+}
+
+

--- a/xbmc/platform/android/jni/Rect.h
+++ b/xbmc/platform/android/jni/Rect.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Christian Browet
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "JNIBase.h"
+
+class CJNIRect: public CJNIBase
+{
+public:
+  CJNIRect(const jni::jhobject &object) : CJNIBase(object){}
+  ~CJNIRect(){}
+
+  CJNIRect();
+  CJNIRect(int l, int t, int r, int b);
+
+  // Fields
+  int getLeft();
+  int getTop();
+  int getRight();
+  int getBottom();
+
+  int width();
+  int height();
+
+  bool        equals(const CJNIRect &other);
+  std::string toString()    const;
+  int         describeContents() const;
+
+};


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description

<!--- Describe your change in detail -->

FIX: [amcs] get proper VideoView size (fixes #17032)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

Current code does not take the right window size into account for Surface, leading to not-fullscreen playback on phones with soft-buttons
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
