### PR TITLE
Fixed: RTMP swfvfy also accepts 1 instead of just true

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -817,7 +817,7 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
           {
             if (value[0] == "swfurl" || value[0] == "SWFPlayer")
               swfurl = value[1];
-            if (value[0] == "swfvfy" && value[1] == "true")
+            if (value[0] == "swfvfy" && (value[1] == "true" || value[1]=="1"))
               swfvfy = true;
             else
               av_dict_set(&options, it->second.c_str(), value[1].c_str(), 0);


### PR DESCRIPTION
## Description

It turns out that SWFVFY=1 will break RTMP playback on Kodi 17.x. The documentation at http://rtmpdump.mplayerhq.hu/librtmp.3.html does show it as a valid option. 
## Motivation and Context

Currently it breaks backward compatibility and if a user goes to the RTMP documentation, they will find a value for swfvfy that will not work with Kodi.
## How Has This Been Tested?

I compiled and tested with my add-on (Retrospect http://www.rieter.net/content/xot/downloads/) by playing a stream from the "Nickelodeon (Sverige)" channel (from the 'Big Time Rush' show).
## Types of change

Just single new or statement added.
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
