### PR TITLE
[AMLUtils] Update aml_permissions() to check for RW access to more paths

### DIFF
--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -140,6 +140,14 @@ bool aml_permissions()
     {
       CLog::Log(LOGERROR, "AML: no rw on /sys/class/ppmgr/ppmgr_3d_mode");
     }
+    if (!SysfsUtils::HasRW("/sys/class/vfm/map"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/vfm/map");
+    }
+    if (!SysfsUtils::HasRW("/sys/class/tsync/enable"))
+    {
+      CLog::Log(LOGERROR, "AML: no rw on /sys/class/tsync/enable");
+    }
 #ifndef TARGET_ANDROID
     if (!SysfsUtils::HasRW("/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq"))
     {


### PR DESCRIPTION
- /sys/class/vfm/map:

This is normally set in initramfs on OSMC and LibreELEC, but after @codesnake's 59828832455794019c59d46e931b1f96efa312f5, Kodi now needs to be able to write to this file during when setting up playback.
- /sys/class/tsync/enable

RW has been needed for this file for a while, but it was never in aml_permissions() check.
