### PR TITLE
[Depends] Force link generation (ln -s) to package config files to allow subsequent make binary-addons calls

### DIFF
--- a/tools/depends/xbmc-addons.include
+++ b/tools/depends/xbmc-addons.include
@@ -77,23 +77,23 @@ $(TOOLCHAIN_FILE): $(abs_top_srcdir)/target/Toolchain_binaddons.cmake
 
 linux-system-libs:
 	mkdir -p $(ADDON_DEPS_DIR)/lib/pkgconfig $(ADDON_DEPS_DIR)/include
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/x11.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
-	[ -f $(ADDON_DEPS_DIR)/lib/libX11.so ] || ln -s /usr/lib/$(HOST)/libX11.so* $(ADDON_DEPS_DIR)/lib/
-	[ -L $(ADDON_DEPS_DIR)/include/X11 ] || ln -s /usr/include/X11 $(ADDON_DEPS_DIR)/include/X11
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/xproto.pc ] || ln -s /usr/share/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/kbproto.pc ] || ln -s /usr/share/pkgconfig/kbproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/kbproto.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/damageproto.pc ] || ln -s /usr/share/pkgconfig/damageproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/damageproto.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/fixesproto.pc ] || ln -s /usr/share/pkgconfig/fixesproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/fixesproto.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/pthread-stubs.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/ice.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/sm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/libdrm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/gl.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/glu.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc
-	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glew.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/glew.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glew.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/x11.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
+	[ -f $(ADDON_DEPS_DIR)/lib/libX11.so ] || ln -sf /usr/lib/$(HOST)/libX11.so* $(ADDON_DEPS_DIR)/lib/
+	[ -L $(ADDON_DEPS_DIR)/include/X11 ] || ln -sf /usr/include/X11 $(ADDON_DEPS_DIR)/include/X11
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/xproto.pc ] || ln -sf /usr/share/pkgconfig/x*.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/kbproto.pc ] || ln -sf /usr/share/pkgconfig/kbproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/kbproto.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/damageproto.pc ] || ln -sf /usr/share/pkgconfig/damageproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/damageproto.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/fixesproto.pc ] || ln -sf /usr/share/pkgconfig/fixesproto.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/fixesproto.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/pthread-stubs.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/pthread-stubs.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/ice.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/ice.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/sm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/sm.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/libdrm.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/libdrm.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/gl.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/gl.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/glu.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glu.pc
+	[ -f $(ADDON_DEPS_DIR)/lib/pkgconfig/glew.pc ] || ln -sf /usr/lib/$(HOST)/pkgconfig/glew.pc $(ADDON_DEPS_DIR)/lib/pkgconfig/glew.pc
 	[ -f $(ADDON_DEPS_DIR)/lib/libGL.so ] || \
-          (ln -s /usr/lib/$(HOST)/mesa $(ADDON_DEPS_DIR)/lib/mesa && ln -s $(ADDON_DEPS_DIR)/lib/mesa/libGL.so $(ADDON_DEPS_DIR)/lib/libGL.so)
-	[ -f $(ADDON_DEPS_DIR)/lib/libGLEW.so ] || ln -s /usr/lib/$(HOST)/libGLEW.so* $(ADDON_DEPS_DIR)/lib/
-	[ -L $(ADDON_DEPS_DIR)/include/GL ] || ln -s /usr/include/GL $(ADDON_DEPS_DIR)/include/GL
-	[ -f $(ADDON_DEPS_DIR)/lib/libm.so ] || ln -s /usr/lib/$(HOST)/libm.so $(ADDON_DEPS_DIR)/lib/
+          (ln -sf /usr/lib/$(HOST)/mesa $(ADDON_DEPS_DIR)/lib/mesa && ln -sf $(ADDON_DEPS_DIR)/lib/mesa/libGL.so $(ADDON_DEPS_DIR)/lib/libGL.so)
+	[ -f $(ADDON_DEPS_DIR)/lib/libGLEW.so ] || ln -sf /usr/lib/$(HOST)/libGLEW.so* $(ADDON_DEPS_DIR)/lib/
+	[ -L $(ADDON_DEPS_DIR)/include/GL ] || ln -sf /usr/include/GL $(ADDON_DEPS_DIR)/include/GL
+	[ -f $(ADDON_DEPS_DIR)/lib/libm.so ] || ln -sf /usr/lib/$(HOST)/libm.so $(ADDON_DEPS_DIR)/lib/
 


### PR DESCRIPTION
Force static link for package config files
## Description

see title
## Motivation and Context

Developing of binary addons needs sometimes to do multiple times make binary-addons.
This fails (at least on linux build host) because of existing static links.
This PR forces the links to be updated regardless if they are existing.
## How Has This Been Tested?
- make binary-addons ADDONS="inputstream.mpd"
- make binary-addons ADDONS="inputstream.smoothstream"
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
