### PR TITLE
fix streaminfo set by python

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -653,6 +653,7 @@ namespace XBMCAddon
         }
         item->GetVideoInfoTag()->m_streamDetails.AddStream(subtitle);
       }
+      item->GetVideoInfoTag()->m_streamDetails.DetermineBestStreams();
     } // end ListItem::addStreamInfo
 
     void ListItem::addContextMenuItems(const std::vector<Tuple<String,String> >& items, bool replaceItems /* = false */)


### PR DESCRIPTION
we need to call DetermineBestStreams() after adding streamdetails.

this fixes retrieving ListItem.VideoCodec (and the likes...) in skins, for listitems created by python.
