### PR TITLE
[cmake] 2 small fixes related to binary-addon build

### DIFF
--- a/project/cmake/README.md
+++ b/project/cmake/README.md
@@ -250,7 +250,7 @@ so that the addon can be tested with self-compiled specific versions of Kodi.
 
 ```
 mkdir pvr.demo-build && cd pvr.demo-build
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=<KODI_BUILD_DIR>/build -DCORE_BUILD_DIR=<KODI_BUILD_DIR> <pvr.demo-SRC>
+cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=<KODI_BUILD_DIR>/build -DKODI_BUILD_DIR=<KODI_BUILD_DIR> <pvr.demo-SRC>
 make
 ```
 

--- a/project/cmake/scripts/common/HandleDepends.cmake
+++ b/project/cmake/scripts/common/HandleDepends.cmake
@@ -76,8 +76,13 @@ function(add_addon_depends addon searchpath)
           message(${BUILD_ARGS})
         endif()
 
-        # if there's a CMakeLists.txt use it to prepare the build
+        # prepare patchfile. ensure we have a clean file after reconfiguring
         set(PATCH_FILE ${BUILD_DIR}/${id}/tmp/patch.cmake)
+        if(EXISTS ${PATCH_FILE})
+          file(REMOVE ${PATCH_FILE})
+        endif()
+
+        # if there's a CMakeLists.txt use it to prepare the build
         if(EXISTS ${dir}/CMakeLists.txt)
           set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${dir}/CMakeLists.txt)
           file(APPEND ${PATCH_FILE}


### PR DESCRIPTION
## Description

Typo in readme, patch file for binary-addons build is not cleaned up. If one runs make multiple times, cmake might try to apply the same patch twice because the patchfile was not cleanly generated.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here -->

small improvement for binary-addons
## How Has This Been Tested?

<!--- Please describe in detail how you tested your change -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc -->

local builds
## Screenshots (if appropriate):
## Types of change

<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
