### PR TITLE
Revert "Picture: Use av_malloc when using ffmpeg scalers"

### DIFF
--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -42,7 +42,6 @@
 
 extern "C" {
 #include "libswscale/swscale.h"
-#include "libavutil/mem.h"
 }
 
 using namespace XFILE;
@@ -177,7 +176,7 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
   // create a buffer large enough for the resulting image
   GetScale(width, height, dest_width, dest_height);
 
-  uint8_t *buffer = (uint8_t*) av_malloc(dest_width * dest_height * sizeof(uint32_t));
+  uint8_t *buffer = new uint8_t[dest_width * dest_height * sizeof(uint32_t)];
   if (buffer == NULL)
   {
     result = NULL;
@@ -187,14 +186,14 @@ bool CPicture::ResizeTexture(const std::string &image, uint8_t *pixels, uint32_t
 
   if (!ScaleImage(pixels, width, height, pitch, buffer, dest_width, dest_height, dest_width * sizeof(uint32_t), scalingAlgorithm))
   {
-    av_free(&buffer);
+    delete[] buffer;
     result = NULL;
     result_size = 0;
     return false;
   }
 
   bool success = GetThumbnailFromSurface(buffer, dest_width, dest_height, dest_width * sizeof(uint32_t), image, result, result_size);
-  av_free(&buffer);
+  delete[] buffer;
 
   if (!success)
   {
@@ -246,7 +245,7 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
 
     // create a buffer large enough for the resulting image
     GetScale(width, height, dest_width, dest_height);
-    uint32_t *buffer = (uint32_t*) av_malloc(dest_width * dest_height);
+    uint32_t *buffer = new uint32_t[dest_width * dest_height];
     if (buffer)
     {
       if (ScaleImage(pixels, width, height, pitch,
@@ -258,7 +257,7 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
           success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height, dest_width * 4, dest);
         }
       }
-      av_free(&buffer);
+      delete[] buffer;
     }
     return success;
   }
@@ -298,7 +297,7 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
       GetScale(texture->GetWidth(), texture->GetHeight(), width, height);
 
       // scale appropriately
-      uint32_t *scaled = (uint32_t*) av_malloc(width * height);
+      uint32_t *scaled = new uint32_t[width * height];
       if (ScaleImage(texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(),
                      (uint8_t *)scaled, width, height, width * 4))
       {
@@ -318,7 +317,7 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
           }
         }
       }
-      av_free(&scaled);
+      delete[] scaled;
     }
     delete texture;
   }


### PR DESCRIPTION
Currently in a hurry, that broke Pictures. I need to have a look after being back.

Remember: It's not safe to put custom buffers into ffmpeg methods, cause they don't have proper alignment. With the above original code - it happened the other way round :-)