### PR TITLE
[cmake/android] Attempt to fix binary-addon packaging

### DIFF
--- a/project/cmake/scripts/common/CheckTargetPlatform.cmake
+++ b/project/cmake/scripts/common/CheckTargetPlatform.cmake
@@ -46,7 +46,8 @@ function(check_install_permissions install_dir have_perms)
   set(${have_perms} TRUE)
   execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${install_dir}/lib/kodi
                   COMMAND ${CMAKE_COMMAND} -E make_directory ${install_dir}/share/kodi
-                  COMMAND ${CMAKE_COMMAND} -E touch ${install_dir}/lib/kodi/.cmake-inst-test ${install_dir}/share/kodi/.cmake-inst-test
+                  COMMAND ${CMAKE_COMMAND} -E touch ${install_dir}/lib/kodi/.cmake-inst-test
+                  COMMAND ${CMAKE_COMMAND} -E touch ${install_dir}/share/kodi/.cmake-inst-test
                   RESULT_VARIABLE permtest
                   OUTPUT_VARIABLE output
                   ERROR_VARIABLE  output


### PR DESCRIPTION
## Description
Try to fix binary addon packaging on android.

[This log](http://jenkins.kodi.tv/job/Android-ARM/9748/consoleFull) shows that the second file didn't get created even though the permissions are correct. Maybe it's caused by this.

## Motivation and Context
Would be good if addons were packaged reliably ;)

## How Has This Been Tested?
Needs to be tested on jenkins as the problems doesn't appear locally.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed