### PR TITLE
[xbmc][fix] Don't try to index outside our lookup table and crash

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -615,7 +615,7 @@ CGUIFontTTFBase::Character* CGUIFontTTFBase::GetCharacter(character_t chr)
   if (letter < 255)
   {
     character_t ch = (style << 8) | letter;
-    if (m_charquick[ch])
+    if (ch < LOOKUPTABLE_SIZE && m_charquick[ch])
       return m_charquick[ch];
   }
 

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -42,6 +42,7 @@ using namespace DirectX;
 using namespace DirectX::PackedVector;
 #endif
 
+constexpr size_t LOOKUPTABLE_SIZE = 256 * 8;
 // forward definition
 class CBaseTexture;
 
@@ -157,7 +158,7 @@ protected:
   color_t m_color;
 
   Character *m_char;                 // our characters
-  Character *m_charquick[256*7];     // ascii chars (7 styles) here
+  Character *m_charquick[LOOKUPTABLE_SIZE];     // ascii chars (7 styles) here
   int m_maxChars;                    // size of character array (can be incremented)
   int m_numChars;                    // the current number of cached characters
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
The lookup table was miscalculated and one chunk too small causing us to index outside of it and return garbage when using the style font_light + font_bold + font_italic = 7

## Description
<!--- Describe your change in detail -->
Increase the lookup table to be 256\*8 instead of 256\*7 and add a guard against this happening again by actually checking our index against our table size

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Locally

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed