### PR TITLE
[PVR] Fix local art lookup log spam. pvr recordings never have local art.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2888,6 +2888,7 @@ bool CFileItem::SkipLocalArt() const
        || IsLibraryFolder()
        || IsParentFolder()
        || IsLiveTV()
+       || IsPVRRecording()
        || IsDVD());
 }
 


### PR DESCRIPTION
Estuary's new "recently recordings" widget my cause serious kodi.log spamming due to attempts to obtain local (fan)art for PVR recordings - which never is possible.

For every recording, (at least?) 3 log warnings are written:
<pre>
2016-10-31 19:56:15.202542 Kodi[32146:857701] Debug Print: CreateLoader - unsupported protocol(pvr) in pvr://recordings/tv/active/Kauniit ja rohkeat/Kauniit ja rohkeat (S) Steffy kakkosveljen kainalossa. Steffy on pettynyt sulhaseensa, mutta yrittää silti vastustella Wyattin hempeitä lemmenkutsuja. Nicole ei pidä siitä, että Zende inspiroituu muista naisista. Amerikkalainen saippuasarja., TV (MTV3 HD), 20161031_152500, 1894834710-poster.jpg
2016-10-31 19:56:31.563713 Kodi[32146:857701] Debug Print: CreateLoader - unsupported protocol(pvr) in pvr://recordings/tv/active/Kauniit ja rohkeat/Kauniit ja rohkeat (S) Steffy kakkosveljen kainalossa. Steffy on pettynyt sulhaseensa, mutta yrittää silti vastustella Wyattin hempeitä lemmenkutsuja. Nicole ei pidä siitä, että Zende inspiroituu muista naisista. Amerikkalainen saippuasarja., TV (MTV3 HD), 20161031_152500, 1894834710-poster.png
2016-10-31 19:56:35.824451 Kodi[32146:857701] Debug Print: CreateLoader - unsupported protocol(pvr) in pvr://recordings/tv/active/Kauniit ja rohkeat/Kauniit ja rohkeat (S) Steffy kakkosveljen kainalossa. Steffy on pettynyt sulhaseensa, mutta yrittää silti vastustella Wyattin hempeitä lemmenkutsuja. Nicole ei pidä siitä, että Zende inspiroituu muista naisista. Amerikkalainen saippuasarja., TV (MTV3 HD), 20161031_152500, 1894834710-banner.jpg
</pre>

Note to @Jalle19 : look what i have taken for testing. ;-)

Fix is straight forward: skip local art lookup for pvr recordings, like it is done already for Live TV and many other type of content.

@Jalle19 mind taking a look at the code change?