### PR TITLE
[python] fix pydocs after a2f675e04b8e4c8dab2cf1398bcd2be2e3d8e98f

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -138,7 +138,7 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
-      /// \python_func{ xbmcgui.Dialog().select(heading, list[, autoclose,preselect]) }
+      /// \python_func{ xbmcgui.Dialog().select(heading, list[, autoclose, preselect, useDetails]) }
       ///------------------------------------------------------------------------
       ///
       /// **Select dialog**


### PR DESCRIPTION
Fix lost pydocs line in https://github.com/xbmc/xbmc/pull/10616