### PR TITLE
[python] add getTrailer() function to the xbmc.InfoTagVideo() class

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -171,5 +171,10 @@ namespace XBMCAddon
     {
       return infoTag->m_firstAired.GetAsLocalizedDate();
     }
+
+    String InfoTagVideo::getTrailer()
+    {
+      return infoTag->m_strTrailer;
+    }
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -546,6 +546,24 @@ namespace XBMCAddon
 #else
       String getFirstAired();
 #endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagVideo
+      /// @brief \python_func{ getTrailer() }
+      ///-----------------------------------------------------------------------
+      /// To get the path where the trailer is stored.
+      ///
+      /// @return [string] Trailer path
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v17 New function added.
+      ///
+      getTrailer();
+#else
+      String getTrailer();
+#endif
     };
   }
 }


### PR DESCRIPTION
allow addons to retrieve the trailer from the selected listitem.