### PR TITLE
[depends] alsa-lib: fix typo in configure.in

### DIFF
--- a/tools/depends/target/alsa-lib/Makefile
+++ b/tools/depends/target/alsa-lib/Makefile
@@ -39,6 +39,7 @@ ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p0 < ../removeshm-3.patch
 	cd $(PLATFORM); patch -p0 < ../timeval.patch
 endif
+	cd $(PLATFORM); patch -p0 < ../host-os.patch
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)

--- a/tools/depends/target/alsa-lib/host-os.patch
+++ b/tools/depends/target/alsa-lib/host-os.patch
@@ -1,0 +1,11 @@
+--- configure.in	2010-04-16 12:11:05.000000000 +0100
++++ configure.in	2016-11-01 15:15:21.645908396 +0000
+@@ -31,7 +31,7 @@
+ 
+   which ${program_prefix}gcc >/dev/null 2>&1 && CC=${program_prefix}gcc
+   which ${host_cpu}-${host_os}-gcc >/dev/null 2>&1 \
+-  && CC=${host_cpu}-${host-os}-gcc
++  && CC=${host_cpu}-${host_os}-gcc
+   which ${host_cpu}-${host_vendor}-${host_os}-gcc >/dev/null 2>&1 \
+   && CC=${host_cpu}-${host_vendor}-${host_os}-gcc
+ 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Change `${host-os}` to `${host_os}` in `tools/depends/target/alsa-lib`'s `configure.in`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Currently, if alsa-lib's configure finds `${host_cpu}-${host_os}-gcc`, it will set `$CC` to `${host_cpu}-${host-os}-gcc`. Since the variables are not the same (on the raspberry pi `${host-os}` is set to `arm-unknown`, resulting in `$CC` being a non-existent `arm-arm-unknown-..`), `configure` fails when testing the compiler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
On a raspberry pi:
```
cd tools/depends
./configure --with-platform=raspberry-pi --prefix=${HOME}/opt/kodi
make
```
Without the patch, configure claims the C compiler is not able to produce binaries. With the patch, the build completes.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

