### PR TITLE
FFmpegImage: free avpacket side data

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -686,6 +686,8 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
   bufferoutSize = avpkt.size;
   bufferout = m_outputBuffer;
 
+  av_packet_unref(&avpkt);
+
   return true;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Found this memory leak when looking at a memcheck log:
```
840 (240 direct, 600 indirect) bytes in 15 blocks are definitely lost in loss record 13,454 of 15,456
  at 0x4843AB8: malloc (vg_replace_malloc.c:298)
  by 0x4845A3B: realloc (vg_replace_malloc.c:785)
  by 0x5472997: av_packet_add_side_data (avpacket.c:303)
  by 0x5472A33: av_packet_new_side_data (avpacket.c:329)
  by 0x5473A1F: ff_side_data_set_encoder_stats (avpacket.c:654)
  by 0x57017DB: ff_mpv_encode_picture (mpegvideo_enc.c:1968)
  by 0x57EEEF7: avcodec_encode_video2 (utils.c:2023)
  by 0x894863: CFFmpegImage::CreateThumbnailFromSurface(unsigned char*, unsigned int, unsigned int, unsigned int, unsigned int, std::string const&, unsigned char*&, unsigned int&) (FFmpegImage.cpp:673)
  by 0xAFD8DB: CPicture::CreateThumbnailFromSurface(unsigned char const*, int, int, int, std::string const&) (Picture.cpp:88)
  by 0xAFE62F: CPicture::CacheTexture(unsigned char*, unsigned int, unsigned int, unsigned int, int, unsigned int&, unsigned int&, std::string const&, CPictureScalingAlgorithm::Algorithm) (Picture.cpp:268)
  by 0x8D036F: CDVDFileInfo::ExtractThumb(std::string const&, CTextureDetails&, CStreamDetails*, int) (DVDFileInfo.cpp:278)
  by 0x867707: CThumbExtractor::DoWork() (VideoThumbLoader.cpp:117)
```

`av_packet_unref` takes care of this and should leave `m_outputBuffer` alone

## Motivation and Context
Fixes a memory leak in `CFFmpegImage::CreateThumbnailFromSurface`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Running LibreELEC+Kodi on a WeTek Hub

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

