### PR TITLE
Fix episode selection when entering a show from the homescreen

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -130,6 +130,10 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       if (!CGUIWindowVideoBase::OnMessage(message))
         return false;
 
+      // This needs to be done again, because the initialization of CGUIWindow overwrites it with default values
+      // Mostly affects cases where GUIWindowViedeoNav is constructed and we're already in a show, e.g. entering from the homesceen
+      SelectFirstUnwatched();
+
       return true;
     }
     break;
@@ -284,6 +288,12 @@ bool CGUIWindowVideoNav::Update(const std::string &strDirectory, bool updateFilt
   if (!CGUIWindowVideoBase::Update(strDirectory, updateFilterPath))
     return false;
 
+  SelectFirstUnwatched();
+
+  return true;
+}
+
+void CGUIWindowVideoNav::SelectFirstUnwatched() {
   // Check if we should select the first unwatched item
   SelectFirstUnwatchedItem selectFirstUnwatched = GetSettingSelectFirstUnwatchedItem();
   if (selectFirstUnwatched != SelectFirstUnwatchedItem::NEVER)
@@ -302,8 +312,6 @@ bool CGUIWindowVideoNav::Update(const std::string &strDirectory, bool updateFilt
       m_viewControl.SetSelectedItem(iIndex);
     }
   }
-
-  return true;
 }
 
 bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItemList &items)

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -90,4 +90,5 @@ private:
   virtual SelectFirstUnwatchedItem GetSettingSelectFirstUnwatchedItem();
   virtual IncludeAllSeasonsAndSpecials GetSettingIncludeAllSeasonsAndSpecials();
   virtual int GetFirstUnwatchedItemIndex(bool includeAllSeasons, bool includeSpecials);
+  void SelectFirstUnwatched();
 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
So now, that we can access shows from the homescreen, the call order for the item selection got doesn't work for that order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
http://trac.kodi.tv/ticket/16793#comment:5

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Only tested on a few shows on my dev pc. Accessing them from homescreen and library.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

