### PR TITLE
Allocate and free AVFrames with the proper FFmpeg API

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1909,16 +1909,11 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
     st->codec->skip_loop_filter = AVDISCARD_ALL;
 
     // We are looking for an IDR frame
-    AVFrame picture;
-    memset(&picture, 0, sizeof(AVFrame));
-    picture.pts = picture.pkt_dts = picture.pkt_pts = picture.best_effort_timestamp = AV_NOPTS_VALUE;
-    picture.pkt_pos = -1;
-    picture.key_frame = 1;
-    picture.format = -1;
+    AVFrame *picture = av_frame_alloc();
 
     int got_picture = 0;
-    avcodec_decode_video2(st->codec, &picture, &got_picture, pkt);
-    av_frame_unref(&picture);
+    avcodec_decode_video2(st->codec, picture, &got_picture, pkt);
+    av_frame_free(&picture);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -167,7 +167,7 @@ void CMMALPool::AlignedSize(AVCodecContext *avctx, uint32_t &width, uint32_t &he
   if (!avctx)
     return;
   int w = width, h = height;
-  AVFrame picture;
+  AVFrame *picture = av_frame_alloc();
   int unaligned;
   int stride_align[AV_NUM_DATA_POINTERS];
 
@@ -179,16 +179,17 @@ void CMMALPool::AlignedSize(AVCodecContext *avctx, uint32_t &width, uint32_t &he
   do {
     // NOTE: do not align linesizes individually, this breaks e.g. assumptions
     // that linesize[0] == 2*linesize[1] in the MPEG-encoder for 4:2:2
-    av_image_fill_linesizes(picture.linesize, avctx->pix_fmt, w);
+    av_image_fill_linesizes(picture->linesize, avctx->pix_fmt, w);
     // increase alignment of w for next try (rhs gives the lowest bit set in w)
     w += w & ~(w - 1);
 
     unaligned = 0;
     for (int i = 0; i < 4; i++)
-      unaligned |= picture.linesize[i] % stride_align[i];
+      unaligned |= picture->linesize[i] % stride_align[i];
   } while (unaligned);
   width = w;
   height = h;
+  av_frame_free(&picture);
 }
 
 CMMALBuffer *CMMALPool::GetBuffer(uint32_t timeout)


### PR DESCRIPTION
Kodi allocated AVFrames using sizeof() which is not part of FFmpeg's official public API

## Description
Now it uses allocator and deallocator functions for that type. The patch itself was written by me following Andreas' description of the needed change.

## Motivation and Context
This fixes crashes when updating FFmpeg under Kodi

## How Has This Been Tested?
Build-tested on Debian, also asked for verification in original Debian bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=831591

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x ] All new and existing tests passed

