### PR TITLE
[cmake] Add doc target that builds the doxygen documentation

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -378,6 +378,16 @@ if(NOT CMAKE_CROSSCOMPILING)
   add_custom_target(check-commits ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/scripts/common/CheckCommits.cmake
                                                    -DCMAKE_BINARY_DIR=${CMAKE_BINARY_DIR})
   set_target_properties(check-commits PROPERTIES FOLDER "Build Utilities")
+
+  # Documentation
+  find_package(Doxygen)
+  if(DOXYGEN_FOUND)
+    add_custom_target(doc
+                      COMMAND ${DOXYGEN_EXECUTABLE} ${CORE_SOURCE_DIR}/doxygen_resources/Doxyfile.doxy
+                      COMMAND ${CMAKE_COMMAND} -E echo "Documentation built to: file://${CORE_SOURCE_DIR}/docs/html/index.html"
+                      WORKING_DIRECTORY ${CORE_SOURCE_DIR}/doxygen_resources
+                      COMMENT "Generating Doxygen documentation" VERBATIM)
+  endif()
 endif()
 
 # code coverage

--- a/project/cmake/README.md
+++ b/project/cmake/README.md
@@ -222,6 +222,7 @@ When using the makefile builds a few extra targets are defined:
 
 - `make check` builds and executes the test suite.
 - `make check-valgrind` builds and executes the test suite with valgrind memcheck.
+- `make doc` builds the Doxygen documentation.
 
 Code coverage (with Gcov, LCOV and Gcovr) can be built on Linux:
 


### PR DESCRIPTION
## Description
Convenience target to build the doxygen documentation with `make doc`.

## Motivation and Context
Easier to remember than calling doxygen manually from within the right dir.

## How Has This Been Tested?
make doc

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed