### PR TITLE
Align play button in context menu to behavior in library

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -21,6 +21,7 @@
 #include "ContextMenus.h"
 #include "Application.h"
 #include "Autorun.h"
+#include "playlists/PlayList.h"
 #include "Util.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoBase.h"
@@ -119,7 +120,17 @@ static void SetPathAndPlay(CFileItem& item)
     item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
   }
   item.SetProperty("check_resume", false);
-  g_application.PlayMedia(item, "", PLAYLIST_NONE);
+
+  CFileItemPtr movieItem((std::make_shared<CFileItem>(item)));
+
+  g_playlistPlayer.Reset();
+  g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
+  PLAYLIST::CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO);
+  playlist.Clear();
+  playlist.Add(movieItem);
+
+  // play movie...
+  g_playlistPlayer.Play(0, "");
 }
 
 bool CResume::Execute(const CFileItemPtr& itemIn) const


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Use the global way to play files not the one from GUIWindowVideoNav, which creates a playlist for some reason. Before this PR, if you go into the library and open the info for a movie, then choose play from there, you will end up with a playlist running. After this PR you won't have anything in your playlist when you do that. Same as when you start playback from anywhere else.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
http://trac.kodi.tv/ticket/16982

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on win10 from various parts of the places where the info window is available from.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Closes #16982