### PR TITLE
[python] add dbid to musicinfotag

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -42,6 +42,11 @@ namespace XBMCAddon
       delete infoTag;
     }
 
+    int InfoTagMusic::getDbId()
+    {
+      return infoTag->GetDatabaseId();
+    }
+
     String InfoTagMusic::getURL()
     {
       return infoTag->GetURL();

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -67,6 +67,24 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ getDbId() }
+      ///-----------------------------------------------------------------------
+      /// Get identification number of tag in database.
+      ///
+      /// @return [integer] database id.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v17 New function added.
+      ///
+      getDbId();
+#else
+      int getDbId();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
       /// @brief \python_func{ getURL() }
       ///-----------------------------------------------------------------------
       /// Returns url of source as string from music info tag.

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -479,6 +479,8 @@ namespace XBMCAddon
             else
               CLog::Log(LOGWARNING, "Invalid media type \"%s\"", value.c_str());
           }
+          else
+            CLog::Log(LOGERROR,"NEWADDON Unknown Video Info Key \"%s\"", key.c_str());
         }
       }
       else if (strcmpi(type, "music") == 0)

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -483,6 +483,25 @@ namespace XBMCAddon
       }
       else if (strcmpi(type, "music") == 0)
       {
+        std::string type;
+        for (auto it = infoLabels.begin(); it != infoLabels.end(); ++it)
+        {
+          String key = it->first;
+          StringUtils::ToLower(key);
+          const InfoLabelValue& alt = it->second;
+          const String value(alt.which() == first ? alt.former() : emptyString);
+
+          if (key == "mediatype")
+          {
+            if (CMediaTypes::IsValidMediaType(value))
+            {
+              type = value;
+              item->GetMusicInfoTag()->SetType(value);
+            }
+            else
+              CLog::Log(LOGWARNING, "Invalid media type \"%s\"", value.c_str());
+          }
+        }
         for (InfoLabelDict::const_iterator it = infoLabels.begin(); it != infoLabels.end(); ++it)
         {
           String key = it->first;
@@ -492,7 +511,9 @@ namespace XBMCAddon
           const String value(alt.which() == first ? alt.former() : emptyString);
 
           //! @todo add the rest of the infolabels
-          if (key == "tracknumber")
+          if (key == "dbid" && !type.empty())
+            item->GetMusicInfoTag()->SetDatabaseId(strtol(value.c_str(), NULL, 10), type);
+          else if (key == "tracknumber")
             item->GetMusicInfoTag()->SetTrackNumber(strtol(value.c_str(), NULL, 10));
           else if (key == "discnumber")
             item->GetMusicInfoTag()->SetDiscNumber(strtol(value.c_str(), NULL, 10));
@@ -534,13 +555,6 @@ namespace XBMCAddon
             item->GetMusicInfoTag()->SetMusicBrainzAlbumArtistID(StringUtils::Split(value, g_advancedSettings.m_musicItemSeparator));
           else if (key == "comment")
             item->GetMusicInfoTag()->SetComment(value);
-          else if (key == "mediatype")
-          {
-            if (CMediaTypes::IsValidMediaType(value))
-              item->GetMusicInfoTag()->SetType(value);
-            else
-              CLog::Log(LOGWARNING, "Invalid media type \"%s\"", value.c_str());
-          }
           else if (key == "date")
           {
             if (strlen(value.c_str()) == 10)
@@ -551,7 +565,7 @@ namespace XBMCAddon
               item->m_dateTime.SetDate(year, month, day);
             }
           }
-          else
+          else if (key != "mediatype")
             CLog::Log(LOGERROR,"NEWADDON Unknown Music Info Key \"%s\"", key.c_str());
 
           // This should probably be set outside of the loop but since the original

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -616,6 +616,7 @@ namespace XBMCAddon
       /// | playcount                | integer (2) - number of times this item has been played
       /// | lastplayed               | string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)
       /// | mediatype                | string - "music", "song", "album", "artist"
+      /// | dbid                     | integer (23) - Only add this for items which are part of the local db. You also need to set the correct 'mediatype'!
       /// | listeners                | integer (25614)
       /// | musicbrainztrackid       | string (cd1de9af-0b71-4503-9f96-9f5efe27923c)
       /// | musicbrainzartistid      | string (d87e52c5-bb8d-4da8-b941-9f4928627dc8)


### PR DESCRIPTION
allow python addons to get/set the dbid of a (music) listitem.

added logging for invalid videoinfo tags (we already do this for musicinfo).