### PR TITLE
Fix conversion of POPM tag values to the new 0 to 10 user rating for songs

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -238,26 +238,26 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
 int CTagLoaderTagLib::POPMtoXBMC(int popm)
 {
   // Ratings:
-  // FROM: http://thiagoarrais.com/repos/banshee/src/Core/Banshee.Core/Banshee.Streaming/StreamRatingTagger.cs
+  // FROM: http://www.mediamonkey.com/forum/viewtopic.php?f=7&t=40532&start=30#p391067
   // The following schemes are used by the other POPM-compatible players:
   // WMP/Vista: "Windows Media Player 9 Series" ratings:
   //   1 = 1, 2 = 64, 3=128, 4=196 (not 192), 5=255
-  // MediaMonkey: "no@email" ratings:
-  //   0.5=26, 1=51, 1.5=76, 2=102, 2.5=128,
-  //   3=153, 3.5=178, 4=204, 4.5=230, 5=255
-  // Quod Libet: "quodlibet@lists.sacredchao.net" ratings
-  //   (but that email can be changed):
-  //   arbitrary scale from 0-255
+  // MediaMonkey (v4.2.1): "no@email" ratings:
+  //   0.5=13, 1=1, 1.5=54, 2=64, 2.5=118,
+  //   3=128, 3.5=186, 4=196, 4.5=242, 5=255
+  //   Note 1 star written as 1 while half a star is 13, a higher value
+  // Accommodate these mapped values in a scale from 0-255
   if (popm == 0) return 0;
-  if (popm < 0x19) return 1;
-  if (popm < 0x32) return 2;
-  if (popm < 0x4b) return 3;
-  if (popm < 0x64) return 4;
-  if (popm < 0x7d) return 5;
-  if (popm < 0x96) return 6;
-  if (popm < 0xaf) return 7;
-  if (popm < 0xc8) return 8;
-  if (popm < 0xe1) return 9;
+  if (popm == 1) return 2;
+  if (popm < 23) return 1;
+  if (popm < 32) return 2;
+  if (popm < 64) return 3;
+  if (popm < 96) return 4;
+  if (popm < 128) return 5;
+  if (popm < 160) return 6;
+  if (popm < 196) return 7;
+  if (popm < 224) return 8;
+  if (popm < 255) return 9;
   else return 10;
 }
 


### PR DESCRIPTION
Fix conversion of POPM tag value, as written by Media Monkey,  WMP or other POPM-compatible players, to the 0 to 10 user rating value stored in the library.

This is another follow up to #8405 that reworked song and album ratings. The arbitrary scale conversion of POPM values to user rating was not correctly capturing the 10 step rating (0 to 5 with half stars) written by Media Monkey, and not mapping the 1 to 5 score evenly to 1 to 10.

This can be seen here
````
       WMP                  Current   Values
       Etc.*   MediaMonkey  Kodi      After
Stars  Writes  writes       rating    PR
------ --------------------------------------
0         ---       0        0         0
0.5       ---      13        1         1
1           1       1        1         2
1.5       ---      54        3         3
2          64      64        3         4
2.5       ---     118        5         5
3         128     128        6         6
3.5       ---     186        8         7
4         196     196        8         8
4.5       ---     242       10         9
5         255     255       10        10
````

Instead I propose the following mapping
````
Stars  POPM      Kodi 
       Values    Rating
-----------------------
0             0   0    
0.5        2-22   1
1      1, 23-31   2
1.5       32-63   3
2         64-95   4
2.5      96-127   5
3       128-159   6
3.5     160-195   7
4       196-223   8
4.5     224-254   9
5           255  10
````
@Razzeee  since you did the original ratings changes. @zag2me if you are still around
@MartijnKaijser would like to get this into v17 to make the ratings rework go as smoothly as possible.