### PR TITLE
DVDOverlaySSA: Fix Leak with SSA subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -54,7 +54,6 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo &hints)
     if (curEvent)
     {
       CDVDOverlaySSA* overlay = new CDVDOverlaySSA(m_libass);
-      overlay->Acquire(); // increase ref count with one so that we can hold a handle to this overlay
 
       overlay->iPTSStartTime = (double)curEvent->Start * (DVD_TIME_BASE / 1000);
       overlay->iPTSStopTime  = (double)(curEvent->Start + curEvent->Duration) * (DVD_TIME_BASE / 1000);


### PR DESCRIPTION
## Description
CDVDSubtitlesLibass is reference counted and only releases libass
reasources (typically hundreds of MBs) when count gets to zero.

But when replacing a subtitle it is acquiring it a second time
and this is never released.

## Motivation and Context
Fixes: http://trac.kodi.tv/ticket/15820

## How Has This Been Tested?
Tested with subtitle file from trac ticket.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed