### PR TITLE
GUIFontTTFGL: Fix texture leak in subtitles

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -53,6 +53,7 @@ CGUIFontTTFGL::~CGUIFontTTFGL(void)
   // destructed before the CGUIFontTTFGL goes out of scope, because
   // our virtual methods won't be accessible after this point
   m_dynamicCache.Flush();
+  DeleteHardwareTexture();
 }
 
 bool CGUIFontTTFGL::FirstBegin()


### PR DESCRIPTION
## Description
With mkv file with S_TEXT/UTF8, we leak one texture of
1024x64x32bpp (256K) for every file that is played.

## Motivation and Context
Fixes large texture memory leak with mkv file with S_TEXT/UTF8 subtitles.

## How Has This Been Tested?
In last couple of Milhouse nightly builds.
Allows looped playback of a file that previously would crash with texture OOM.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed