### PR TITLE
[cmake] Win-Binary-Addon fixes + Handle "select" as setting type for binary addons

### DIFF
--- a/project/cmake/scripts/common/HandleDepends.cmake
+++ b/project/cmake/scripts/common/HandleDepends.cmake
@@ -161,6 +161,10 @@ function(add_addon_depends addon searchpath)
                                   PATCH_COMMAND ${PATCH_COMMAND}
                                   "${INSTALL_COMMAND}")
 
+        if(CMAKE_VERSION VERSION_GREATER 3.5)
+          list(APPEND EXTERNALPROJECT_SETUP GIT_SHALLOW 1)
+        endif()
+
         # if there's an url defined we need to pass that to externalproject_add()
         if(DEFINED url AND NOT "${url}" STREQUAL "")
           # check if there's a third parameter in the file

--- a/project/cmake/scripts/common/HandleDepends.cmake
+++ b/project/cmake/scripts/common/HandleDepends.cmake
@@ -172,6 +172,20 @@ function(add_addon_depends addon searchpath)
                                 GIT_REPOSITORY ${url}
                                 GIT_TAG ${revision}
                                 "${EXTERNALPROJECT_SETUP}")
+
+            # For patchfiles to work, disable (users globally set) autocrlf=true
+            if(CMAKE_MINIMUM_REQUIRED_VERSION VERSION_GREATER 3.7)
+              message(AUTHOR_WARNING "Make use of GIT_CONFIG")
+            endif()
+            if(WIN32 AND patches)
+              externalproject_add_step(${id} gitconfig
+                                       COMMAND git config core.autocrlf false
+                                       COMMAND git rm -rf --cached .
+                                       COMMAND git reset --hard HEAD
+                                       COMMENT "Performing gitconfig step: Disabling autocrlf to enable patching for '${id}'"
+                                       DEPENDERS patch
+                                       WORKING_DIRECTORY <SOURCE_DIR>)
+            endif()
           else()
             set(CONFIGURE_COMMAND "")
             if(NOT WIN32)

--- a/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/binary/interfaces/api1/Addon/AddonCallbacksAddon.cpp
@@ -232,7 +232,8 @@ bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSetti
               type == "folder"   || type == "action"    ||
               type == "music"    || type == "pictures"  ||
               type == "programs" || type == "fileenum"  ||
-              type == "file"     || type == "labelenum")
+              type == "file"     || type == "labelenum" ||
+              type == "select")
           {
             strcpy((char*) settingValue, addonHelper->m_addon->GetSetting(id).c_str());
             return true;


### PR DESCRIPTION
A couple of changes from the retroplayer branch.

## Description
- Two changes related to binary addons. Ping @hudokkow, @wsnipex or @Paxxi.
- One change for an addon callback. Not sure whom to ping here.

## Motivation and Context
Upstreaming them, to reduce rebase work for @garbear.

## How Has This Been Tested?
Locally and on jenkins.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

---
Jenkins build (retroplayer branch): http://jenkins.kodi.tv/job/WIN-32/10573/