### PR TITLE
[videoplayer] reset VideoCodecInfo in CProcessInfo constructor

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -37,7 +37,7 @@ CProcessInfo* CProcessInfo::CreateInstance()
 // base class definitions
 CProcessInfo::CProcessInfo()
 {
-
+  ResetVideoCodecInfo();
 }
 
 CProcessInfo::~CProcessInfo()


### PR DESCRIPTION
@FernetMenta 

Should (hopefully) fix DialogSeekBar issues.	