### PR TITLE
[listproviders] directory list provider: fix updates for favourites folders not processed.

### DIFF
--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -22,6 +22,7 @@
 #include "File.h"
 #include "Directory.h"
 #include "Util.h"
+#include "interfaces/AnnouncementManager.h"
 #include "profiles/ProfilesManager.h"
 #include "FileItem.h"
 #include "utils/XBMCTinyXML.h"
@@ -54,7 +55,7 @@ bool CFavouritesDirectory::Exists(const CURL& url)
     return XFILE::CFile::Exists("special://xbmc/system/favourites.xml") 
         || XFILE::CFile::Exists(URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetProfileUserDataFolder(), "favourites.xml"));
   }
-  return XFILE::CDirectory::Exists(url); //directly load the given file
+  return XFILE::CDirectory::Exists(url);
 }
 
 bool CFavouritesDirectory::Load(CFileItemList &items)
@@ -136,7 +137,12 @@ bool CFavouritesDirectory::Save(const CFileItemList &items)
   }
 
   favourites = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetProfileUserDataFolder(), "favourites.xml");
-  return doc.SaveFile(favourites);
+
+  bool bRet = doc.SaveFile(favourites);
+  if (bRet)
+    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::GUI, "xbmc", "OnFavouritesUpdated");
+
+  return bRet;
 }
 
 bool CFavouritesDirectory::AddOrRemove(CFileItem *item, int contextWindow)

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -227,8 +227,8 @@ bool CDirectoryProvider::Update(bool forceRefresh)
 
 void CDirectoryProvider::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
 {
-  // we are only interested in library and player changes
-  if ((flag & (VideoLibrary | AudioLibrary | Player)) == 0)
+  // we are only interested in library, player and GUI changes
+  if ((flag & (VideoLibrary | AudioLibrary | Player | GUI)) == 0)
     return;
 
   {
@@ -249,6 +249,14 @@ void CDirectoryProvider::Announce(AnnouncementFlag flag, const char *sender, con
         if (m_currentSort.sortBy == SortByLastPlayed ||
             m_currentSort.sortBy == SortByPlaycount ||
             m_currentSort.sortBy == SortByLastUsed)
+          m_updateState = INVALIDATED;
+      }
+    }
+    else if (flag & GUI)
+    {
+      if (strcmp(message, "OnFavouritesUpdated") == 0)
+      {
+        if (URIUtils::IsProtocol(m_currentUrl, "favourites"))
           m_updateState = INVALIDATED;
       }
     }


### PR DESCRIPTION
Some skins use a widget for "favourites://" (the favourites folder). This works quite well, but adding, removing and renaming of favourites using the context menu of media items or using the favourites dialog or other ways i don't know will only reflected by the widget after a restart of kodi. This PR fixes this misbehavior by adding a new announcement "OnFavouritesUpdated" and <code>CDirectoryProvider</code> reacting on this announcement.   

The code change has been tested on macOS and Linux on latest Krypton master.

@Jalle19 for review?
