### PR TITLE
Move favorites to the new contextmenu handling

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -83,6 +83,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CMarkWatched>(),
       std::make_shared<CONTEXTMENU::CMarkUnWatched>(),
       std::make_shared<CONTEXTMENU::CRemoveResumePoint>(),
+      std::make_shared<CONTEXTMENU::CFavorite>(),
       std::make_shared<CONTEXTMENU::CEjectDisk>(),
       std::make_shared<CONTEXTMENU::CEjectDrive>(),
       std::make_shared<CONTEXTMENU::CRemoveFavourite>(),

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -21,9 +21,14 @@
 #include "ContextMenus.h"
 #include "Application.h"
 #include "Autorun.h"
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoBase.h"
+#include "favourites/FavouritesService.h"
+#include "filesystem/FavouritesDirectory.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 
 
 namespace CONTEXTMENU
@@ -190,5 +195,27 @@ bool CPlay::Execute(const CFileItemPtr& itemIn) const
   SetPathAndPlay(item);
   return true;
 };
+
+
+std::string CFavorite::GetLabel(const CFileItem& item) const
+{
+  return g_localizeStrings.Get(CServiceBroker::GetFavouritesService().IsFavourited(item,
+    g_windowManager.GetActiveWindowOrDialog()) ? 14077 : 14076); // Add/Remove Favourite
+}
+
+bool CFavorite::IsVisible(const CFileItem& item) const
+{
+  //! @todo FAVOURITES Conditions on masterlock and localisation
+  return !item.IsParentFolder() && !item.IsPath("add") && !item.IsPath("newplaylist://") &&
+    !URIUtils::IsProtocol(item.GetPath(), "newsmartplaylist") && !URIUtils::IsProtocol(item.GetPath(), "newtag") &&
+    !URIUtils::IsProtocol(item.GetPath(), "musicsearch") && !URIUtils::IsProtocol(item.GetPath(), "favourites") &&
+    !StringUtils::StartsWith(item.GetPath(), "pvr://guide/") && !StringUtils::StartsWith(item.GetPath(), "pvr://timers/");
+}
+
+bool CFavorite::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetFavouritesService().AddOrRemove(*item.get(), g_windowManager.GetActiveWindowOrDialog());
+};
+
 
 }

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -90,4 +90,11 @@ struct CPlay : IContextMenuItem
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const CFileItemPtr& _item) const override;
 };
+
+struct CFavorite : IContextMenuItem
+{
+  std::string GetLabel(const CFileItem& item) const override;
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& _item) const override;
+};
 }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1720,18 +1720,6 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
   if (!item || item->IsParentFolder())
     return;
 
-  //! @todo FAVOURITES Conditions on masterlock and localisation
-  if (!item->IsParentFolder() && !item->IsPath("add") && !item->IsPath("newplaylist://") &&
-      !URIUtils::IsProtocol(item->GetPath(), "newsmartplaylist") && !URIUtils::IsProtocol(item->GetPath(), "newtag") &&
-      !URIUtils::IsProtocol(item->GetPath(), "musicsearch") &&
-      !StringUtils::StartsWith(item->GetPath(), "pvr://guide/") && !StringUtils::StartsWith(item->GetPath(), "pvr://timers/"))
-  {
-    if (CServiceBroker::GetFavouritesService().IsFavourited(*item.get(), GetID()))
-      buttons.Add(CONTEXT_BUTTON_ADD_FAVOURITE, 14077);     // Remove Favourite
-    else
-      buttons.Add(CONTEXT_BUTTON_ADD_FAVOURITE, 14076);     // Add To Favourites;
-  }
-
   if (item->IsFileFolder(EFILEFOLDER_MASK_ONBROWSE))
     buttons.Add(CONTEXT_BUTTON_BROWSE_INTO, 37015);
 
@@ -1741,12 +1729,6 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   switch (button)
   {
-  case CONTEXT_BUTTON_ADD_FAVOURITE:
-    {
-      CFileItemPtr item = m_vecItems->Get(itemNumber);
-      CServiceBroker::GetFavouritesService().AddOrRemove(*item.get(), GetID());
-      return true;
-    }
   case CONTEXT_BUTTON_BROWSE_INTO:
     {
       CFileItemPtr item = m_vecItems->Get(itemNumber);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This will enable having "Add to favourites" and "Remove from favourites" on the homescreen. It also changes the handling inside the library. But it should be the same as before.

One "problem" could be the place I've choosen. As this part is library agnostic (not really video) it might make sense to have a new contextmenu class. But I've choosen the video one for now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Needs more testing, I have tested adding/deleting. Which works fine, we need to check all corners, if there are places, that have multiple items for "Add to favourites"

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

