### PR TITLE
Ask user to configure new controllers (once)

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -323,6 +323,8 @@
 		68AE5C341C9243A000C4D527 /* ControllerTranslator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68AE5C2A1C9243A000C4D527 /* ControllerTranslator.cpp */; };
 		68B7E5E81D5FA9B300A5AEC0 /* GUIFeatureControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68B7E5E61D5FA9B300A5AEC0 /* GUIFeatureControls.cpp */; };
 		68B7E5E91D5FA9B300A5AEC0 /* GUIFeatureControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68B7E5E61D5FA9B300A5AEC0 /* GUIFeatureControls.cpp */; };
+		68D9167A1DD0430E00058B06 /* GUIDialogNewJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D916781DD0430E00058B06 /* GUIDialogNewJoystick.cpp */; };
+		68D9167B1DD0430E00058B06 /* GUIDialogNewJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D916781DD0430E00058B06 /* GUIDialogNewJoystick.cpp */; };
 		761170901C8B85F8006C6366 /* AddonGUIRenderingControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7611708C1C8B85F8006C6366 /* AddonGUIRenderingControl.cpp */; };
 		761170911C8B85F8006C6366 /* AddonGUIWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7611708E1C8B85F8006C6366 /* AddonGUIWindow.cpp */; };
 		76AEFB361C8F79BD00EF2EC0 /* AddonInterfaces.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EDED2E991C878F61000F5E80 /* AddonInterfaces.cpp */; };
@@ -2851,6 +2853,8 @@
 		68AE5C2C1C9243A000C4D527 /* ControllerTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ControllerTypes.h; path = games/controllers/ControllerTypes.h; sourceTree = "<group>"; };
 		68B7E5E61D5FA9B300A5AEC0 /* GUIFeatureControls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUIFeatureControls.cpp; path = games/controllers/guicontrols/GUIFeatureControls.cpp; sourceTree = "<group>"; };
 		68B7E5E71D5FA9B300A5AEC0 /* GUIFeatureControls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GUIFeatureControls.h; path = games/controllers/guicontrols/GUIFeatureControls.h; sourceTree = "<group>"; };
+		68D916781DD0430E00058B06 /* GUIDialogNewJoystick.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUIDialogNewJoystick.cpp; path = joysticks/dialogs/GUIDialogNewJoystick.cpp; sourceTree = "<group>"; };
+		68D916791DD0430E00058B06 /* GUIDialogNewJoystick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GUIDialogNewJoystick.h; path = joysticks/dialogs/GUIDialogNewJoystick.h; sourceTree = "<group>"; };
 		6E97BDBF0DA2B620003A2A89 /* EventClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventClient.h; sourceTree = "<group>"; };
 		6E97BDC00DA2B620003A2A89 /* EventPacket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventPacket.h; sourceTree = "<group>"; };
 		6E97BDC10DA2B620003A2A89 /* EventServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventServer.h; sourceTree = "<group>"; };
@@ -6161,6 +6165,7 @@
 		68AE5BAB1C92419500C4D527 /* joysticks */ = {
 			isa = PBXGroup;
 			children = (
+				68D916771DD0430300058B06 /* dialogs */,
 				68AE5BC71C9241E200C4D527 /* generic */,
 				6838CF7F1D6665510057F17B /* DeadzoneFilter.cpp */,
 				6838CF801D6665510057F17B /* DeadzoneFilter.h */,
@@ -6283,6 +6288,15 @@
 				68AE5C061C92437900C4D527 /* IConfigurationWindow.h */,
 			);
 			name = windows;
+			sourceTree = "<group>";
+		};
+		68D916771DD0430300058B06 /* dialogs */ = {
+			isa = PBXGroup;
+			children = (
+				68D916781DD0430E00058B06 /* GUIDialogNewJoystick.cpp */,
+				68D916791DD0430E00058B06 /* GUIDialogNewJoystick.h */,
+			);
+			name = dialogs;
 			sourceTree = "<group>";
 		};
 		76EC19BB1D15510D00D4AF19 /* AudioDSPAddons */ = {
@@ -10294,6 +10308,7 @@
 				2AB491701CDDF1920004C263 /* HTTPRequestHandlerUtils.cpp in Sources */,
 				18B7C7D01294222E009E7A26 /* GUIMoverControl.cpp in Sources */,
 				18B7C7D11294222E009E7A26 /* GUIMultiImage.cpp in Sources */,
+				68D9167A1DD0430E00058B06 /* GUIDialogNewJoystick.cpp in Sources */,
 				18B7C7D31294222E009E7A26 /* GUIPanelContainer.cpp in Sources */,
 				18B7C7D41294222E009E7A26 /* GUIProgressControl.cpp in Sources */,
 				DF1D2DF01B6E85EE002BB9DB /* XbtFile.cpp in Sources */,
@@ -10901,6 +10916,7 @@
 				68AE5BCF1C9241F800C4D527 /* ButtonMapping.cpp in Sources */,
 				E4991159174E5CC300741B6D /* filcreat.cpp in Sources */,
 				E499115A174E5CC300741B6D /* file.cpp in Sources */,
+				68D9167B1DD0430E00058B06 /* GUIDialogNewJoystick.cpp in Sources */,
 				E499115B174E5CC300741B6D /* filefn.cpp in Sources */,
 				E499115C174E5CC300741B6D /* filestr.cpp in Sources */,
 				E499115D174E5CC300741B6D /* find.cpp in Sources */,

--- a/Makefile.in
+++ b/Makefile.in
@@ -148,6 +148,7 @@ endif
 
 ifeq ($(findstring osx,@ARCH@),osx)
 DIRECTORY_ARCHIVES += xbmc/input/joysticks/input_joysticks.a
+DIRECTORY_ARCHIVES += xbmc/input/joysticks/dialogs/input_joystick_dialogs.a
 DIRECTORY_ARCHIVES += xbmc/input/joysticks/generic/input_joysticks_generic.a
 DIRECTORY_ARCHIVES += xbmc/network/osx/network.a
 DIRECTORY_ARCHIVES += xbmc/network/linux/network_linux.a
@@ -163,6 +164,7 @@ INSTALL_FILTER += .*repository\.pvr-win32\.xbmc\.org.*
 INSTALL_FILTER += .*repository\.pvr-osx.*\.xbmc\.org.*
 ifeq (@USE_ANDROID@,1)
 DIRECTORY_ARCHIVES += xbmc/input/joysticks/input_joysticks.a
+DIRECTORY_ARCHIVES += xbmc/input/joysticks/dialogs/input_joystick_dialogs.a
 DIRECTORY_ARCHIVES += xbmc/input/joysticks/generic/input_joysticks_generic.a
 DIRECTORY_ARCHIVES += xbmc/input/linux/input_linux.a
 DIRECTORY_ARCHIVES += xbmc/input/touch/input_touch.a
@@ -173,6 +175,7 @@ DIRECTORY_ARCHIVES += xbmc/storage/android/storage_android.a
 DIRECTORY_ARCHIVES += xbmc/windowing/X11/windowing_X11.a
 else
 DIRECTORY_ARCHIVES += xbmc/input/joysticks/input_joysticks.a
+DIRECTORY_ARCHIVES += xbmc/input/joysticks/dialogs/input_joystick_dialogs.a
 DIRECTORY_ARCHIVES += xbmc/input/joysticks/generic/input_joysticks_generic.a
 DIRECTORY_ARCHIVES += xbmc/input/linux/input_linux.a
 DIRECTORY_ARCHIVES += xbmc/input/touch/input_touch.a

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16016,7 +16016,19 @@ msgctxt "#35010"
 msgid "Peripheral libraries"
 msgstr ""
 
-#empty strings from id 35011 to 35048
+#. Title of dialog to ask users if they would like to configure a new controller
+#: xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
+msgctxt "#35011"
+msgid "New controller detected"
+msgstr ""
+
+#. Text of dialog to ask users if they would like to configure a new controller
+#: xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
+msgctxt "#35012"
+msgid "A new controller has been detected. Configuration can be done at any time in \"Settings -> System Settings -> Input\". Would you like to configure it now?"
+msgstr ""
+
+#empty strings from id 35013 to 35048
 
 #. Name of game add-ons category
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/project/cmake/treedata/common/subdirs.txt
+++ b/project/cmake/treedata/common/subdirs.txt
@@ -16,6 +16,7 @@ xbmc/epg                                        epg
 xbmc/guilib                                     guilib
 xbmc/input                                      input
 xbmc/input/joysticks                            input/joysticks
+xbmc/input/joysticks/dialogs                    input/joysticks/dialogs
 xbmc/input/joysticks/generic                    input/joysticks/generic
 xbmc/listproviders                              listproviders
 xbmc/media                                      media

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2614,6 +2614,12 @@
           <control type="toggle" />
           <default>true</default>
         </setting>
+        <setting id="input.asknewcontrollers" type="boolean">
+          <level>0</level>
+          <control type="toggle" />
+          <default>true</default>
+          <visible>false</visible>
+        </setting>
         <setting id="input.controllerconfig" type="action" label="35063" help="35064">
           <level>0</level>
           <dependencies>

--- a/xbmc/input/joysticks/IButtonMap.h
+++ b/xbmc/input/joysticks/IButtonMap.h
@@ -60,6 +60,13 @@ namespace JOYSTICK
     virtual void Reset(void) = 0;
 
     /*!
+     * \brief Check if the button map is empty
+     *
+     * \return True if the button map is empty, false if it has features
+     */
+    virtual bool IsEmpty(void) const = 0;
+
+    /*!
      * \brief Get the feature associated with a driver primitive
      *
      * Multiple primitives can be mapped to the same feature. For example,

--- a/xbmc/input/joysticks/dialogs/CMakeLists.txt
+++ b/xbmc/input/joysticks/dialogs/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES GUIDialogNewJoystick.cpp)
+
+set(HEADERS GUIDialogNewJoystick.h)
+
+core_add_library(input_joystick_dialogs)

--- a/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
+++ b/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
@@ -1,0 +1,63 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIDialogNewJoystick.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/WindowIDs.h"
+#include "messaging/helpers/DialogHelper.h"
+#include "settings/Settings.h"
+
+using namespace JOYSTICK;
+
+CGUIDialogNewJoystick::CGUIDialogNewJoystick() :
+  CThread("NewJoystickDlg")
+{
+}
+
+void CGUIDialogNewJoystick::ShowAsync()
+{
+  bool bShow = true;
+
+  if (IsRunning())
+    bShow = false;
+  else if (!CSettings::GetInstance().GetBool(CSettings::SETTING_INPUT_ASKNEWCONTROLLERS))
+    bShow = false;
+  else if (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_GAME_CONTROLLERS)
+    bShow = false;
+
+  if (bShow)
+    Create();
+}
+
+void CGUIDialogNewJoystick::Process()
+{
+  using namespace KODI::MESSAGING::HELPERS;
+
+  // "New controller detected"
+  // "A new controller has been detected. Configuration can be done at any time in "Settings -> System Settings -> Input". Would you like to configure it now?"
+  if (ShowYesNoDialogText(CVariant{ 35011 }, CVariant{ 35012 }) == DialogResponse::YES)
+  {
+    g_windowManager.ActivateWindow(WINDOW_DIALOG_GAME_CONTROLLERS);
+  }
+  else
+  {
+    CSettings::GetInstance().SetBool(CSettings::SETTING_INPUT_ASKNEWCONTROLLERS, false);
+  }
+}

--- a/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.h
+++ b/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.h
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "threads/Thread.h"
+
+namespace JOYSTICK
+{
+  class CGUIDialogNewJoystick : protected CThread
+  {
+  public:
+    CGUIDialogNewJoystick();
+    virtual ~CGUIDialogNewJoystick() = default;
+
+    void ShowAsync();
+
+  protected:
+    // implementation of CThread
+    virtual void Process() override;
+  };
+}

--- a/xbmc/input/joysticks/dialogs/Makefile
+++ b/xbmc/input/joysticks/dialogs/Makefile
@@ -1,0 +1,6 @@
+SRCS=GUIDialogNewJoystick.cpp \
+
+LIB=input_joystick_dialogs.a
+
+include ../../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/input/joysticks/generic/InputHandling.cpp
+++ b/xbmc/input/joysticks/generic/InputHandling.cpp
@@ -19,11 +19,15 @@
  */
 
 #include "InputHandling.h"
+#include "input/joysticks/dialogs/GUIDialogNewJoystick.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/JoystickUtils.h"
+#include "utils/log.h"
 
 using namespace JOYSTICK;
+
+CGUIDialogNewJoystick* const CInputHandling::m_dialog = new CGUIDialogNewJoystick;
 
 CInputHandling::CInputHandling(IInputHandler* handler, IButtonMap* buttonMap)
  : m_handler(handler),
@@ -85,6 +89,16 @@ bool CInputHandling::OnDigitalMotion(const CDriverPrimitive& source, bool bPress
 
     if (feature)
       bHandled = feature->OnDigitalMotion(source, bPressed);
+  }
+  else if (bPressed)
+  {
+    // If button didn't resolve to a feature, check if the button map is empty
+    // and ask the user if they would like to start mapping the controller
+    if (m_buttonMap->IsEmpty())
+    {
+      CLog::Log(LOGDEBUG, "Empty button map detected for %s", m_buttonMap->ControllerID().c_str());
+      m_dialog->ShowAsync();
+    }
   }
 
   return bHandled;

--- a/xbmc/input/joysticks/generic/InputHandling.h
+++ b/xbmc/input/joysticks/generic/InputHandling.h
@@ -28,6 +28,7 @@
 namespace JOYSTICK
 {
   class CDriverPrimitive;
+  class CGUIDialogNewJoystick;
   class IInputHandler;
   class IButtonMap;
 
@@ -66,5 +67,7 @@ namespace JOYSTICK
     IButtonMap* const    m_buttonMap;
 
     std::map<FeatureName, FeaturePtr> m_features;
+
+    static CGUIDialogNewJoystick* const m_dialog;
   };
 }

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -82,6 +82,13 @@ void CAddonButtonMap::Reset(void)
     addon->ResetButtonMap(m_device, m_strControllerId);
 }
 
+bool CAddonButtonMap::IsEmpty(void) const
+{
+  CSingleLock lock(m_mutex);
+
+  return m_driverMap.empty();
+}
+
 bool CAddonButtonMap::GetFeature(const CDriverPrimitive& primitive, FeatureName& feature)
 {
   CSingleLock lock(m_mutex);

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -45,6 +45,8 @@ namespace PERIPHERALS
 
     virtual void Reset(void) override;
 
+    virtual bool IsEmpty(void) const override;
+
     virtual bool GetFeature(
       const JOYSTICK::CDriverPrimitive& primitive,
       JOYSTICK::FeatureName& feature

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -373,6 +373,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH = "audiooutput
 const std::string CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS = "audiooutput.volumesteps";
 const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
+const std::string CSettings::SETTING_INPUT_ASKNEWCONTROLLERS = "input.asknewcontrollers";
 const std::string CSettings::SETTING_INPUT_CONTROLLERCONFIG = "input.controllerconfig";
 const std::string CSettings::SETTING_INPUT_TESTRUMBLE = "input.testrumble";
 const std::string CSettings::SETTING_INPUT_CONTROLLERPOWEROFF = "input.controllerpoweroff";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -330,6 +330,7 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_VOLUMESTEPS;
   static const std::string SETTING_INPUT_PERIPHERALS;
   static const std::string SETTING_INPUT_ENABLEMOUSE;
+  static const std::string SETTING_INPUT_ASKNEWCONTROLLERS;
   static const std::string SETTING_INPUT_CONTROLLERCONFIG;
   static const std::string SETTING_INPUT_TESTRUMBLE;
   static const std::string SETTING_INPUT_CONTROLLERPOWEROFF;


### PR DESCRIPTION
If a button is pressed and the controller isn't mapped, this shows a dialog asking if the user wants to go to the controller dialog.

If the user selects yes, the controller dialog is opened. If the user selects no, nothing happens and the prompt is never shown again.

## Motivation and Context
Better UX

## Screenshots (if appropriate):
![new controller detected](https://cloud.githubusercontent.com/assets/531482/20065357/ac8f5772-a4c2-11e6-8c08-e8b5ffab0782.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Broken out from #10630