### PR TITLE
[gui] allow implicit container referencing for non-media windows

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7934,18 +7934,23 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   if (info.m_info >= LISTITEM_START && info.m_info <= LISTITEM_END)
   {
     CFileItemPtr item;
-    CGUIWindow *window = NULL;
+    CGUIWindow *window = GetWindowWithCondition(contextWindow, 0);
 
     int data1 = info.GetData1();
     if (!data1) // No container specified, so we lookup the current view container
     {
-      window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_HAS_LIST_ITEMS);
-      if (window && window->IsMediaWindow())
-        data1 = ((CGUIMediaWindow*)(window))->GetViewContainerID();
+      if (window)
+      {
+        if (window->IsMediaWindow())
+          data1 = static_cast<CGUIMediaWindow*>(window)->GetViewContainerID();
+        else
+        {
+          auto control = window->GetFocusedControl();
+          if (control && control->IsContainer())
+            data1 = control->GetID();
+        }
+      }
     }
-
-    if (!window) // If we don't have a window already (from lookup above), get one
-      window = GetWindowWithCondition(contextWindow, 0);
 
     if (window)
     {


### PR DESCRIPTION
At the moment implicit referencing of containers only works in MediaWindows. This PR also allows implicit referencing for non-media windows by choosing the actual focused container. That way common constructs like 
```
<value condition="!String.IsEmpty(Container(5400).ListItem.Art(fanart)) + Control.HasFocus(5400)">$INFO[Container(5400).ListItem.Art(fanart)]</value>
<value condition="!String.IsEmpty(Container(6100).ListItem.Art(fanart)) + Control.HasFocus(6100)">$INFO[Container(6100).ListItem.Art(fanart)]</value>
<value condition="!String.IsEmpty(Container(6200).ListItem.Art(fanart)) + Control.HasFocus(6200)">$INFO[Container(6200).ListItem.Art(fanart)]</value>
...
```
can get reduced to
```
<value condition="!String.IsEmpty(Container.ListItem.Art(fanart))">$INFO[Container.ListItem.Art(fanart)]</value>
```

@ronie @BigNoid @HitcherUK for opinions.
@xhaggi for review			