### PR TITLE
Display milliseconds in log file

### DIFF
--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -93,7 +93,7 @@ void CLog::LogString(int logLevel, const std::string& logString)
       WriteLogString(s_globals.m_repeatLogLevel, strData2);
       s_globals.m_repeatCount = 0;
     }
-    
+
     s_globals.m_repeatLine = strData;
     s_globals.m_repeatLogLevel = logLevel;
 
@@ -198,19 +198,21 @@ void CLog::PrintDebugString(const std::string& line)
 
 bool CLog::WriteLogString(int logLevel, const std::string& logString)
 {
-  static const char* prefixFormat = "%02.2d:%02.2d:%02.2d T:%" PRIu64" %7s: ";
+  static const char* prefixFormat = "%02d:%02d:%02d.%03d T:%" PRIu64" %7s: ";
 
   std::string strData(logString);
   /* fixup newline alignment, number of spaces should equal prefix length */
   StringUtils::Replace(strData, "\n", "\n                                            ");
 
   int hour, minute, second;
-  s_globals.m_platform.GetCurrentLocalTime(hour, minute, second);
-  
+  double millisecond;
+  s_globals.m_platform.GetCurrentLocalTime(hour, minute, second, millisecond);
+
   strData = StringUtils::Format(prefixFormat,
                                   hour,
                                   minute,
                                   second,
+                                  static_cast<int>(millisecond),
                                   (uint64_t)CThread::GetCurrentThreadId(),
                                   levelNames[logLevel]) + strData;
 

--- a/xbmc/utils/posix/PosixInterfaceForCLog.cpp
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.cpp
@@ -21,6 +21,7 @@
 #include "PosixInterfaceForCLog.h"
 #include <stdio.h>
 #include <time.h>
+#include <sys/time.h>
 
 #if defined(TARGET_DARWIN)
 #include "platform/darwin/DarwinUtils.h"
@@ -94,16 +95,21 @@ void CPosixInterfaceForCLog::PrintDebugString(const std::string &debugString)
 #endif // _DEBUG
 }
 
-void CPosixInterfaceForCLog::GetCurrentLocalTime(int &hour, int &minute, int &second)
+void CPosixInterfaceForCLog::GetCurrentLocalTime(int &hour, int &minute, int &second, double &milliseconds)
 {
-  time_t curTime;
   struct tm localTime;
-  if (time(&curTime) != -1 && localtime_r(&curTime, &localTime) != NULL)
+  struct timeval tv;
+
+  if (gettimeofday(&tv, nullptr) != -1 && localtime_r(&tv.tv_sec, &localTime) != NULL)
   {
     hour   = localTime.tm_hour;
     minute = localTime.tm_min;
     second = localTime.tm_sec;
+    milliseconds = static_cast<double>(tv.tv_usec) / 1000;
   }
   else
+  {
     hour = minute = second = 0;
+    milliseconds = 0.0;
+  }
 }

--- a/xbmc/utils/posix/PosixInterfaceForCLog.h
+++ b/xbmc/utils/posix/PosixInterfaceForCLog.h
@@ -32,7 +32,7 @@ public:
   void CloseLogFile(void);
   bool WriteStringToLog(const std::string& logString);
   void PrintDebugString(const std::string& debugString);
-  static void GetCurrentLocalTime(int& hour, int& minute, int& second);
+  static void GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond);
 private:
   FILEWRAP* m_file;
 };

--- a/xbmc/utils/win32/Win32InterfaceForCLog.cpp
+++ b/xbmc/utils/win32/Win32InterfaceForCLog.cpp
@@ -110,11 +110,12 @@ void CWin32InterfaceForCLog::PrintDebugString(const std::string& debugString)
 #endif // _DEBUG
 }
 
-void CWin32InterfaceForCLog::GetCurrentLocalTime(int& hour, int& minute, int& second)
+void CWin32InterfaceForCLog::GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond)
 {
   SYSTEMTIME time;
   GetLocalTime(&time);
   hour = time.wHour;
   minute = time.wMinute;
   second = time.wSecond;
+  millisecond = static_cast<double>(time.wMilliseconds);
 }

--- a/xbmc/utils/win32/Win32InterfaceForCLog.h
+++ b/xbmc/utils/win32/Win32InterfaceForCLog.h
@@ -32,7 +32,7 @@ public:
   void CloseLogFile(void);
   bool WriteStringToLog(const std::string& logString);
   void PrintDebugString(const std::string& debugString);
-  static void GetCurrentLocalTime(int& hour, int& minute, int& second);
+  static void GetCurrentLocalTime(int& hour, int& minute, int& second, double& millisecond);
 private:
   HANDLE m_hFile;
 };


### PR DESCRIPTION
Display milliseconds in log file

## Description
Display milliseconds in log file

## Motivation and Context
Analysing PTS values and timing is nearly impossible without milliseconds

## How Has This Been Tested?
Runtime test

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

