### PR TITLE
AML clock timing adjustments

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1553,7 +1553,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   am_private->dumpdemux = false;
   dumpfile_open(am_private);
 
-  m_dll->codec_resume(&am_private->vcodec);
+  m_dll->codec_pause(&am_private->vcodec);
 
   m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
   m_dll->codec_set_video_delay_limited_ms(&am_private->vcodec, 1000);
@@ -1688,9 +1688,10 @@ void CAMLCodec::Reset()
   // restore the speed (some amcodec versions require this)
   if (m_speed != DVD_PLAYSPEED_NORMAL)
   {
-    m_dll->codec_resume(&am_private->vcodec);
     m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
   }
+  m_dll->codec_pause(&am_private->vcodec);
+
   // reset the decoder
   m_dll->codec_reset(&am_private->vcodec);
   m_dll->codec_set_video_delay_limited_ms(&am_private->vcodec, 1000);
@@ -1786,7 +1787,10 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
       Reset();
     }
     if ((m_state & STATE_PREFILLED) == 0 && timesize >= 1.0)
+    {
+      m_dll->codec_resume(&am_private->vcodec);
       m_state |= STATE_PREFILLED;
+    }
   }
 
   int rtn(0);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1326,6 +1326,8 @@ CAMLCodec::CAMLCodec()
   am_private->vcodec.cntl_handle        = -1;
   am_private->vcodec.sub_handle         = -1;
   am_private->vcodec.audio_utils_handle = -1;
+  am_private->vcodec.has_audio = 0;
+  am_private->vcodec.has_sub = 0;
 }
 
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1817,8 +1817,6 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
     }
     if (m_prefill_state == PREFILL_STATE_FILLING && timesize >= 1.0)
       m_prefill_state = PREFILL_STATE_FILLED;
-    else if (m_prefill_state == PREFILL_STATE_FILLING)
-      usleep(1000);
   }
 
   int rtn(0);
@@ -1829,6 +1827,9 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
     m_last_pts = m_cur_pts;
     m_cur_pts = decode_pts;
   }
+  else //Timesize actualizes each 10ms, throttle decode calls to avoid reading too much
+    usleep(2500);
+
   if (((rtn & VC_PICTURE) == 0 && timesize < 2.0) || timesize < 1.0)
    rtn |= VC_BUFFER;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1827,7 +1827,7 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
     m_last_pts = m_cur_pts;
     m_cur_pts = decode_pts;
   }
-  if ((rtn & VC_PICTURE)==0 || timesize < 1.0)
+  if (((rtn & VC_PICTURE)==0 && timesize < 2.0) || timesize < 1.0)
    rtn |= VC_BUFFER;
 
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -571,46 +571,15 @@ void am_packet_release(am_packet_t *pkt)
 
 int check_in_pts(am_private_t *para, am_packet_t *pkt)
 {
-    int last_duration = 0;
-    static int last_v_duration = 0;
-    int64_t pts = 0;
-
-    last_duration = last_v_duration;
-
-    if (para->stream_type == AM_STREAM_ES) {
-        if ((int64_t)INT64_0 != pkt->avpts) {
-            pts = pkt->avpts;
-
-            if (para->m_dll->codec_checkin_pts(pkt->codec, pts) != 0) {
-                CLog::Log(LOGDEBUG, "ERROR check in pts error!");
-                return PLAYER_PTS_ERROR;
-            }
-
-        } else if ((int64_t)INT64_0 != pkt->avdts) {
-            pts = pkt->avdts * last_duration;
-
-            if (para->m_dll->codec_checkin_pts(pkt->codec, pts) != 0) {
-                CLog::Log(LOGDEBUG, "ERROR check in dts error!");
-                return PLAYER_PTS_ERROR;
-            }
-
-            last_v_duration = pkt->avduration ? pkt->avduration : 1;
-        } else {
-            if (!para->check_first_pts) {
-                if (para->m_dll->codec_checkin_pts(pkt->codec, 0) != 0) {
-                    CLog::Log(LOGDEBUG, "ERROR check in 0 to video pts error!");
-                    return PLAYER_PTS_ERROR;
-                }
-            }
-        }
-        if (!para->check_first_pts) {
-            para->check_first_pts = 1;
-        }
+  if (para->stream_type == AM_STREAM_ES && (int64_t)INT64_0 != pkt->avpts)
+  {
+    if (para->m_dll->codec_checkin_pts(pkt->codec, pkt->avpts) != 0)
+    {
+      CLog::Log(LOGDEBUG, "ERROR check in pts error!");
+      return PLAYER_PTS_ERROR;
     }
-    if (pts > 0)
-      pkt->lastpts = pts;
-
-    return PLAYER_SUCCESS;
+  }
+  return PLAYER_SUCCESS;
 }
 
 static int write_header(am_private_t *para, am_packet_t *pkt)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -224,7 +224,7 @@ public:
 
 #define PTS_FREQ        90000
 #define UNIT_FREQ       96000
-#define AV_SYNC_THRESH  PTS_FREQ*0
+#define AV_SYNC_THRESH  PTS_FREQ*30
 
 #define TRICKMODE_NONE  0x00
 #define TRICKMODE_I     0x01

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1711,6 +1711,7 @@ void CAMLCodec::Reset()
   // reset some interal vars
   m_cur_pts = INT64_0;
   m_state = 0;
+  m_start_adj = 0;
   SetSpeed(m_speed);
 }
 
@@ -1820,10 +1821,12 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
     else
       memset(&vfs, 0, sizeof(vfs));
 
-    CLog::Log(LOGDEBUG, "CAMLCodec::Decode: ret: %d dts_in: %0.6f, pts_in: %0.6f, ptsOut:%0.6f, amlpts:%d vfs:[%d-%d-%d-%d] timesize:%0.2f",
+    CLog::Log(LOGDEBUG, "CAMLCodec::Decode: ret: %d, sz: %llu, dts_in: %0.6f[%llX], pts_in: %0.6f[%llX], adj:%llu, ptsOut:%0.6f, amlpts:%d vfs:[%d-%d-%d-%d] timesize:%0.2f",
       rtn,
-      static_cast<float>(dts)/DVD_TIME_BASE,
-      static_cast<float>(pts)/DVD_TIME_BASE,
+      iSize,
+      static_cast<float>(dts)/DVD_TIME_BASE, am_private->am_pkt.avdts,
+      static_cast<float>(pts)/DVD_TIME_BASE, am_private->am_pkt.avpts,
+      m_start_adj,
       static_cast<float>(m_cur_pts)/PTS_FREQ,
       static_cast<int>(m_cur_pts),
       vfs.vf_pool_size, vfs.buf_free_num,vfs.buf_recycle_num,vfs.buf_avail_num,

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -24,8 +24,6 @@
 #include "cores/IPlayer.h"
 #include "guilib/Geometry.h"
 #include "rendering/RenderSystem.h"
-#include "threads/Thread.h"
-#include <deque>
 
 typedef struct am_private_t am_private_t;
 
@@ -34,7 +32,7 @@ class DllLibAmCodec;
 class PosixFile;
 typedef std::shared_ptr<PosixFile> PosixFilePtr;
 
-class CAMLCodec : public CThread
+class CAMLCodec
 {
 public:
   CAMLCodec();
@@ -51,11 +49,13 @@ public:
   int           GetDataSize();
   double        GetTimeSize();
   void          SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
+  void          SetVideoRate(int videoRate);
   int64_t       GetCurPts() const { return m_cur_pts; }
   int       	GetOMXPts() const { return static_cast<int>(m_cur_pts - m_start_pts); }
-
-protected:
-  virtual void  Process();
+  static float  OMXPtsToSeconds(int omxpts);
+  static int    OMXDurationToNs(int duration);
+  int           GetAmlDuration() const;
+  int           PollFrame();
 
 private:
   void          ShowMainVideo(const bool show);
@@ -73,16 +73,15 @@ private:
 
   DllLibAmCodec   *m_dll;
   bool             m_opened;
+  bool             m_ptsIs64us;
   am_private_t    *am_private;
   CDVDStreamInfo   m_hints;
   volatile int     m_speed;
-  volatile int64_t m_1st_pts;
   volatile int64_t m_cur_pts;
-  volatile double  m_timesize;
   volatile int64_t m_vbufsize;
   int64_t          m_start_dts;
   int64_t          m_start_pts;
-  CEvent           m_ready_event;
+  int64_t          m_last_pts;
 
   CRect            m_dst_rect;
   CRect            m_display_rect;
@@ -94,8 +93,15 @@ private:
   int              m_contrast;
   int              m_brightness;
 
+  enum PREFILLSTATE
+  {
+    PREFILL_STATE_FILLING,
+    PREFILL_STATE_FILLED
+  };
+  PREFILLSTATE     m_prefill_state;
+
+
   PosixFilePtr     m_amlVideoFile;
   std::string      m_defaultVfmMap;
-  std::deque<int64_t>  m_ptsQueue;
   CCriticalSection m_ptsQueueMutex;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -76,8 +76,8 @@ private:
   bool             m_ptsIs64us;
   am_private_t    *am_private;
   CDVDStreamInfo   m_hints;
-  volatile int     m_speed;
-  volatile int64_t m_cur_pts;
+  int              m_speed;
+  int64_t          m_cur_pts;
   volatile int64_t m_vbufsize;
   int64_t          m_start_adj;
   int64_t          m_last_pts;
@@ -93,6 +93,7 @@ private:
   int              m_brightness;
 
   static const unsigned int STATE_PREFILLED  = 1;
+  static const unsigned int STATE_HASPTS     = 2;
 
   unsigned int m_state;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -51,7 +51,7 @@ public:
   void          SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
   void          SetVideoRate(int videoRate);
   int64_t       GetCurPts() const { return m_cur_pts; }
-  int       	GetOMXPts() const { return static_cast<int>(m_cur_pts - m_start_pts); }
+  int       	GetOMXPts() const { return static_cast<int>(m_cur_pts - m_start_adj); }
   static float  OMXPtsToSeconds(int omxpts);
   static int    OMXDurationToNs(int duration);
   int           GetAmlDuration() const;
@@ -79,8 +79,7 @@ private:
   volatile int     m_speed;
   volatile int64_t m_cur_pts;
   volatile int64_t m_vbufsize;
-  int64_t          m_start_dts;
-  int64_t          m_start_pts;
+  int64_t          m_start_adj;
   int64_t          m_last_pts;
 
   CRect            m_dst_rect;
@@ -94,7 +93,6 @@ private:
   int              m_brightness;
 
   static const unsigned int STATE_PREFILLED  = 1;
-  static const unsigned int STATE_HASPTS     = 2;
 
   unsigned int m_state;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -50,8 +50,8 @@ public:
   double        GetTimeSize();
   void          SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
   void          SetVideoRate(int videoRate);
-  int64_t       GetCurPts() const { return m_cur_pts; }
-  int       	GetOMXPts() const { return static_cast<int>(m_cur_pts - m_start_adj); }
+  int64_t       GetCurPts() const { return m_cur_pts + m_start_adj; }
+  int       	GetOMXPts() const { return static_cast<int>(m_cur_pts); }
   static float  OMXPtsToSeconds(int omxpts);
   static int    OMXDurationToNs(int duration);
   int           GetAmlDuration() const;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -93,13 +93,10 @@ private:
   int              m_contrast;
   int              m_brightness;
 
-  enum PREFILLSTATE
-  {
-    PREFILL_STATE_FILLING,
-    PREFILL_STATE_FILLED
-  };
-  PREFILLSTATE     m_prefill_state;
+  static const unsigned int STATE_PREFILLED  = 1;
+  static const unsigned int STATE_HASPTS     = 2;
 
+  unsigned int m_state;
 
   PosixFilePtr     m_amlVideoFile;
   std::string      m_defaultVfmMap;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -99,6 +99,7 @@ protected:
   mpeg2_sequence *m_mpeg2_sequence;
   double          m_mpeg2_sequence_pts;
   bool            m_drop;
+  bool            m_has_idr;
 
   CBitstreamParser *m_bitparser;
   CBitstreamConverter *m_bitstream;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -99,7 +99,7 @@ protected:
   mpeg2_sequence *m_mpeg2_sequence;
   double          m_mpeg2_sequence_pts;
   bool            m_drop;
-  bool            m_has_idr;
+  bool            m_has_keyframe;
 
   CBitstreamParser *m_bitparser;
   CBitstreamConverter *m_bitstream;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -36,7 +36,7 @@ class CDVDVideoCodecAmlogic;
 class CDVDAmlogicInfo
 {
 public:
-  CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts);
+  CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts, int amlDuration);
 
   // reference counting
   CDVDAmlogicInfo* Retain();
@@ -44,6 +44,7 @@ public:
 
   CAMLCodec *getAmlCodec() const;
   int GetOmxPts() const { return m_omxPts; }
+  int GetAmlDuration() const { return m_amlDuration; }
   void invalidate();
 
 protected:
@@ -52,7 +53,7 @@ protected:
 
   CDVDVideoCodecAmlogic* m_codec;
   CAMLCodec* m_amlCodec;
-  int m_omxPts;
+  int m_omxPts, m_amlDuration;
 };
 
 class CDVDVideoCodecAmlogic : public CDVDVideoCodec

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -233,7 +233,8 @@ void CRendererAML::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
     SysfsUtils::SetInt("/sys/module/amvideo/parameters/omx_pts", pcrscr);
 
-    amlcodec->SetVideoRect(m_sourceRect, m_destRect);
+    if(amlcodec)
+      amlcodec->SetVideoRect(m_sourceRect, m_destRect);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -21,24 +21,82 @@
 #include "RendererAML.h"
 
 #if defined(HAS_LIBAMCODEC)
-#include "cores/IPlayer.h"
-#include "windowing/egl/EGLWrapper.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h"
 #include "utils/log.h"
-#include "utils/GLUtils.h"
 #include "utils/SysfsUtils.h"
 #include "settings/MediaSettings.h"
 #include "windowing/WindowingFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
+#include "settings/AdvancedSettings.h"
+
+static int get_pts(const char *strPath)
+{
+  int fd = open(strPath, O_RDONLY);
+  if (fd >= 0)
+  {
+    char pts_str[64];
+    int size = read(fd, pts_str, sizeof(pts_str));
+    close(fd);
+    return strtol(pts_str, NULL, 16);
+  }
+  return 0;
+}
+
+static void set_pts(const char *strPath, int pts)
+{
+  int fd = open(strPath, O_WRONLY);
+  if (fd >= 0)
+  {
+    char pts_str[64];
+    sprintf(pts_str, "0x%x", pts);
+    write(fd, pts_str, strlen(pts_str));
+    close(fd);
+  }
+}
 
 CRendererAML::CRendererAML()
+ : m_prevPts(-1)
+ , m_bConfigured(false)
+ , m_iRenderBuffer(0)
+ , m_diff_counter(0)
 {
-  m_prevPts = -1;
 }
 
 CRendererAML::~CRendererAML()
 {
+}
+
+bool CRendererAML::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_formatl, unsigned int orientation)
+{
+  m_sourceWidth = width;
+  m_sourceHeight = height;
+  m_renderOrientation = orientation;
+
+  // Save the flags.
+  m_iFlags = flags;
+  m_format = format;
+
+  // Calculate the input frame aspect ratio.
+  CalculateFrameAspectRatio(d_width, d_height);
+  SetViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
+  ManageRenderArea();
+
+  m_bConfigured = true;
+
+  for (int i = 0 ; i < m_numRenderBuffers ; ++i)
+    m_buffers[i].hwDec = 0;
+
+  return true;
+}
+
+CRenderInfo CRendererAML::GetRenderInfo()
+{
+  CRenderInfo info;
+  info.formats.push_back(RENDER_FMT_BYPASS);
+  info.max_buffer_size = m_numRenderBuffers;
+  info.optimal_buffer_size = m_numRenderBuffers;
+  return info;
 }
 
 bool CRendererAML::RenderCapture(CRenderCapture* capture)
@@ -48,16 +106,28 @@ bool CRendererAML::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
+int CRendererAML::GetImage(YV12Image *image, int source, bool readonly)
+{
+  if (image == nullptr)
+    return -1;
+
+  /* take next available buffer */
+  if (source == -1)
+   source = (m_iRenderBuffer + 1) % m_numRenderBuffers;
+
+  return source;
+}
+
 void CRendererAML::AddVideoPictureHW(DVDVideoPicture &picture, int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  BUFFER &buf = m_buffers[index];
   if (picture.amlcodec)
     buf.hwDec = picture.amlcodec->Retain();
 }
 
 void CRendererAML::ReleaseBuffer(int idx)
 {
-  YUVBUFFER &buf = m_buffers[idx];
+  BUFFER &buf = m_buffers[idx];
   if (buf.hwDec)
   {
     CDVDAmlogicInfo *amli = static_cast<CDVDAmlogicInfo *>(buf.hwDec);
@@ -66,9 +136,14 @@ void CRendererAML::ReleaseBuffer(int idx)
   }
 }
 
-int CRendererAML::GetImageHook(YV12Image *image, int source, bool readonly)
+void CRendererAML::FlipPage(int source)
 {
-  return source;
+  if( source >= 0 && source < m_numRenderBuffers )
+    m_iRenderBuffer = source;
+  else
+    m_iRenderBuffer = (m_iRenderBuffer + 1) % m_numRenderBuffers;
+
+  return;
 }
 
 bool CRendererAML::IsGuiLayer()
@@ -104,37 +179,47 @@ EINTERLACEMETHOD CRendererAML::AutoInterlaceMethod()
   return VS_INTERLACEMETHOD_NONE;
 }
 
-bool CRendererAML::LoadShadersHook()
+void CRendererAML::Reset()
 {
-  CLog::Log(LOGNOTICE, "GL: Using AML render method");
-  m_textureTarget = GL_TEXTURE_2D;
-  m_renderMethod = RENDER_BYPASS;
-  return false;
+  m_prevPts = 0;
+  m_diff_counter = 0;
 }
 
-bool CRendererAML::RenderHook(int index)
-{
-  return true;// nothing to be done for aml
-}
-
-bool CRendererAML::RenderUpdateVideoHook(bool clear, DWORD flags, DWORD alpha)
+void CRendererAML::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 {
   ManageRenderArea();
 
-  CDVDAmlogicInfo *amli = static_cast<CDVDAmlogicInfo *>(m_buffers[m_iYV12RenderBuffer].hwDec);
+  CDVDAmlogicInfo *amli = static_cast<CDVDAmlogicInfo *>(m_buffers[m_iRenderBuffer].hwDec);
+  CAMLCodec *amlcodec = amli ? amli->getAmlCodec() : 0;
+
+  if(amlcodec)
+    amlcodec->PollFrame();
+
   if (amli && amli->GetOmxPts() != m_prevPts)
   {
     m_prevPts = amli->GetOmxPts();
-    SysfsUtils::SetInt("/sys/module/amvideo/parameters/omx_pts", amli->GetOmxPts());
 
-    CAMLCodec *amlcodec = amli->getAmlCodec();
+    int pcrscr(get_pts("/sys/class/tsync/pts_pcrscr"));
+    m_diff_counter += static_cast<int>((pcrscr - m_prevPts)*1.1 / amli->GetAmlDuration()); 
+
+    if (abs(m_diff_counter) > 2)
+    {
+      int videopts(get_pts("/sys/class/tsync/pts_video"));
+      set_pts("/sys/class/tsync/pts_pcrscr", m_prevPts);
+      CLog::Log(LOGDEBUG, "RenderUpdate: Adjusting: ptsclock:%d ptsscr:%d vpts:%d diff:%d", m_prevPts, pcrscr, videopts, m_diff_counter);
+      pcrscr = m_prevPts;
+      m_diff_counter = 0;
+    }
+    else if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    {
+      int videopts(get_pts("/sys/class/tsync/pts_video"));
+      CLog::Log(LOGDEBUG, "RenderUpdate: ptsclock:%d ptsscr:%d vpts:%d diff:%d", m_prevPts, pcrscr, videopts, m_diff_counter);
+    }
+    SysfsUtils::SetInt("/sys/module/amvideo/parameters/omx_pts", pcrscr);
+
     if (amlcodec)
       amlcodec->SetVideoRect(m_sourceRect, m_destRect);
   }
-
-  usleep(10000);
-
-  return true;
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -219,7 +219,7 @@ void CRendererAML::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
         ++m_diff_counter;
     }
 
-    if (abs(m_diff_counter) > 10)
+    if (abs(m_diff_counter) > 5)
     {
       set_pts("/sys/class/tsync/pts_pcrscr", pts);
       CLog::Log(LOGDEBUG, "RenderUpdate: Adjusting: ptsclock:%d ptsscr:%d vpts:%d dur:%d diff:%d diffsum:%d", pts, pcrscr, videopts,amli->GetAmlDuration(), diff, m_diff_counter);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -24,17 +24,29 @@
 
 #if defined(HAS_LIBAMCODEC)
 
-#include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+#include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 
-class CRendererAML : public CLinuxRendererGLES
+class CRendererAML : public CBaseRenderer
 {
 public:
   CRendererAML();
   virtual ~CRendererAML();
-  
+
   virtual bool RenderCapture(CRenderCapture* capture);
   virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index);
   virtual void ReleaseBuffer(int idx);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_formatl, unsigned int orientation);
+  virtual bool IsConfigured(){ return m_bConfigured; };
+  virtual CRenderInfo GetRenderInfo();
+  virtual int GetImage(YV12Image *image, int source = -1, bool readonly = false);
+  virtual void ReleaseImage(int source, bool preserve = false){};
+  virtual void FlipPage(int source);
+  virtual void PreInit(){};
+  virtual void UnInit(){};
+  virtual void Reset();
+  virtual void Update(){};
+  virtual void RenderUpdate(bool clear, unsigned int flags = 0, unsigned int alpha = 255);
+  virtual bool SupportsMultiPassRendering(){ return false; };
 
   // Player functions
   virtual bool IsGuiLayer();
@@ -47,16 +59,20 @@ public:
 
   virtual EINTERLACEMETHOD AutoInterlaceMethod();
 
-protected:
-
-  // hooks for hw dec renderer
-  virtual bool LoadShadersHook();
-  virtual bool RenderHook(int index);  
-  virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
-  virtual bool RenderUpdateVideoHook(bool clear, DWORD flags = 0, DWORD alpha = 255);
-
 private:
+
+  int m_iRenderBuffer;
+  static const int m_numRenderBuffers = 3;
+
+  struct BUFFER
+  {
+    void *hwDec;
+    int duration;
+  } m_buffers[m_numRenderBuffers];
+
   int m_prevPts;
+  bool m_bConfigured;
+  int m_diff_counter;
 };
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -70,7 +70,7 @@ private:
     int duration;
   } m_buffers[m_numRenderBuffers];
 
-  int m_prevPts;
+  int m_prevVPts;
   bool m_bConfigured;
   int m_diff_counter;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -62,7 +62,7 @@ public:
 private:
 
   int m_iRenderBuffer;
-  static const int m_numRenderBuffers = 3;
+  static const int m_numRenderBuffers = 4;
 
   struct BUFFER
   {

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -336,7 +336,7 @@ bool CBitstreamParser::HasKeyframe(const uint8_t *buf, int buf_size)
         rtn = true;
         break;
       case AVC_NAL_SEI:
-        buf_begin = buf;
+        buf_begin = buf - 1;
         buf = find_start_code(buf, buf_end, &state) - 4;
         if (has_sei_recovery_point(buf_begin, buf))
           rtn = true;

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -72,6 +72,34 @@ enum {
     HEVC_NAL_SEI_SUFFIX = 40
 };
 
+enum {
+  SEI_BUFFERING_PERIOD = 0,
+  SEI_PIC_TIMING,
+  SEI_PAN_SCAN_RECT,
+  SEI_FILLER_PAYLOAD,
+  SEI_USER_DATA_REGISTERED_ITU_T_T35,
+  SEI_USER_DATA_UNREGISTERED,
+  SEI_RECOVERY_POINT,
+  SEI_DEC_REF_PIC_MARKING_REPETITION,
+  SEI_SPARE_PIC,
+  SEI_SCENE_INFO,
+  SEI_SUB_SEQ_INFO,
+  SEI_SUB_SEQ_LAYER_CHARACTERISTICS,
+  SEI_SUB_SEQ_CHARACTERISTICS,
+  SEI_FULL_FRAME_FREEZE,
+  SEI_FULL_FRAME_FREEZE_RELEASE,
+  SEI_FULL_FRAME_SNAPSHOT,
+  SEI_PROGRESSIVE_REFINEMENT_SEGMENT_START,
+  SEI_PROGRESSIVE_REFINEMENT_SEGMENT_END,
+  SEI_MOTION_CONSTRAINED_SLICE_GROUP_SET,
+  SEI_FILM_GRAIN_CHARACTERISTICS,
+  SEI_DEBLOCKING_FILTER_DISPLAY_PREFERENCE,
+  SEI_STEREO_VIDEO_INFO,
+  SEI_POST_FILTER_HINTS,
+  SEI_TONE_MAPPING
+};
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
 // GStreamer h264 parser
@@ -205,6 +233,34 @@ static const uint8_t* avc_find_startcode(const uint8_t *p, const uint8_t *end)
   return out;
 }
 
+static bool has_sei_recovery_point(const uint8_t *p, const uint8_t *end)
+{
+  int pt(0), ps(0), offset(1);
+
+  do
+  {
+    pt = 0;
+    do {
+      pt += p[offset];
+    } while (p[offset++] == 0xFF);
+
+    ps = 0;
+    do {
+      ps += p[offset];
+    } while (p[offset++] == 0xFF);
+
+    if (pt == SEI_RECOVERY_POINT)
+    {
+      nal_bitstream bs;
+      nal_bs_init(&bs, p + offset, ps);
+      return nal_bs_read_ue(&bs) >= 0;
+    }
+    offset += ps;
+  } while(p + offset < end && p[offset] != 0x80);
+
+  return false;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
 CBitstreamParser::CBitstreamParser()
@@ -255,16 +311,16 @@ const uint8_t* CBitstreamParser::find_start_code(const uint8_t *p,
   return p + 4;
 }
 
-bool CBitstreamParser::FindIdrSlice(const uint8_t *buf, int buf_size)
+bool CBitstreamParser::HasKeyframe(const uint8_t *buf, int buf_size)
 {
   if (!buf)
     return false;
 
   bool rtn = false;
   uint32_t state = -1;
-  const uint8_t *buf_end = buf + buf_size;
+  const uint8_t *buf_begin, *buf_end = buf + buf_size;
 
-  for(;;)
+  for(;rtn == false;)
   {
     buf = find_start_code(buf, buf_end, &state);
     if (buf >= buf_end)
@@ -280,6 +336,10 @@ bool CBitstreamParser::FindIdrSlice(const uint8_t *buf, int buf_size)
         rtn = true;
         break;
       case AVC_NAL_SEI:
+        buf_begin = buf;
+        buf = find_start_code(buf, buf_end, &state) - 4;
+        if (has_sei_recovery_point(buf_begin, buf))
+          rtn = true;
         break;
       case AVC_NAL_SPS:
         break;
@@ -308,6 +368,7 @@ CBitstreamConverter::CBitstreamConverter()
   m_convert_3byteTo4byteNALSize = false;
   m_convert_bytestream = false;
   m_sps_pps_context.sps_pps_data = NULL;
+  m_has_keyframe = true;
 }
 
 CBitstreamConverter::~CBitstreamConverter()
@@ -387,7 +448,7 @@ bool CBitstreamConverter::Open(enum AVCodecID codec, uint8_t *in_extradata, int 
             // are valid, setup to convert 3 byte NAL sizes to 4 byte.
             in_extradata[4] = 0xFF;
             m_convert_3byteTo4byteNALSize = true;
-           
+
             m_extradata = (uint8_t *)av_malloc(in_extrasize);
             memcpy(m_extradata, in_extradata, in_extrasize);
             m_extrasize = in_extrasize;
@@ -498,7 +559,7 @@ void CBitstreamConverter::Close(void)
 bool CBitstreamConverter::Convert(uint8_t *pData, int iSize)
 {
   if (m_convertBuffer)
-  {  
+  {
     av_free(m_convertBuffer);
     m_convertBuffer = NULL;
   }
@@ -548,7 +609,7 @@ bool CBitstreamConverter::Convert(uint8_t *pData, int iSize)
       {
         m_inputSize = iSize;
         m_inputBuffer = pData;
-  
+
         if (m_convert_bytestream)
         {
           if(m_convertBuffer)
@@ -636,9 +697,14 @@ int CBitstreamConverter::GetExtraSize() const
     return m_extrasize;
 }
 
-bool CBitstreamConverter::IdrFramePassed() const
+void CBitstreamConverter::ResetKeyframe(void)
 {
-  return m_sps_pps_context.first_idr == 0;
+  m_has_keyframe = false;
+}
+
+bool CBitstreamConverter::HasKeyframe() const
+{
+  return m_has_keyframe;
 }
 
 bool CBitstreamConverter::BitstreamConvertInitAVC(void *in_extradata, int in_extrasize)
@@ -855,7 +921,7 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
   int i;
   uint8_t *buf = pData;
   uint32_t buf_size = iSize;
-  uint8_t  unit_type, nal_sps, nal_pps;
+  uint8_t  unit_type, nal_sps, nal_pps, nal_sei;
   int32_t  nal_size;
   uint32_t cumul_size = 0;
   const uint8_t *buf_end = buf + buf_size;
@@ -865,10 +931,12 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
     case AV_CODEC_ID_H264:
       nal_sps = AVC_NAL_SPS;
       nal_pps = AVC_NAL_PPS;
+      nal_sei = AVC_NAL_SEI;
       break;
     case AV_CODEC_ID_HEVC:
       nal_sps = HEVC_NAL_SPS;
       nal_pps = HEVC_NAL_PPS;
+      nal_sei = HEVC_NAL_SEI_PREFIX;
       break;
     default:
       return false;
@@ -899,7 +967,10 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
     if (m_sps_pps_context.first_idr && (unit_type == nal_sps || unit_type == nal_pps))
       m_sps_pps_context.idr_sps_pps_seen = 1;
 
-      // prepend only to the first access unit of an IDR picture, if no sps/pps already present
+    if (!m_has_keyframe && (IsIDR(unit_type) || (unit_type == nal_sei && has_sei_recovery_point(buf, buf + nal_size))))
+      m_has_keyframe = true;
+
+    // prepend only to the first access unit of an IDR picture, if no sps/pps already present
     if (m_sps_pps_context.first_idr && IsIDR(unit_type) && !m_sps_pps_context.idr_sps_pps_seen)
     {
       BitstreamAllocAndCopy(poutbuf, poutbuf_size,

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -269,35 +269,25 @@ bool CBitstreamParser::FindIdrSlice(const uint8_t *buf, int buf_size)
     buf = find_start_code(buf, buf_end, &state);
     if (buf >= buf_end)
     {
-      //CLog::Log(LOGDEBUG, "FindIdrSlice: buf(%p), buf_end(%p)", buf, buf_end);
       break;
     }
 
-    --buf;
-    int src_length = buf_end - buf;
     switch (state & 0x1f)
     {
-      default:
-        CLog::Log(LOGDEBUG, "FindIdrSlice: found nal_type(%d)", state & 0x1f);
-        break;
       case AVC_NAL_SLICE:
-        CLog::Log(LOGDEBUG, "FindIdrSlice: found NAL_SLICE");
         break;
       case AVC_NAL_IDR_SLICE:
-        CLog::Log(LOGDEBUG, "FindIdrSlice: found NAL_IDR_SLICE");
         rtn = true;
         break;
       case AVC_NAL_SEI:
-        CLog::Log(LOGDEBUG, "FindIdrSlice: found NAL_SEI");
         break;
       case AVC_NAL_SPS:
-        CLog::Log(LOGDEBUG, "FindIdrSlice: found NAL_SPS");
         break;
       case AVC_NAL_PPS:
-        CLog::Log(LOGDEBUG, "FindIdrSlice: found NAL_PPS");
+        break;
+      default:
         break;
     }
-    buf += src_length;
   }
 
   return rtn;
@@ -644,6 +634,11 @@ int CBitstreamConverter::GetExtraSize() const
     return m_sps_pps_context.size;
   else
     return m_extrasize;
+}
+
+bool CBitstreamConverter::IdrFramePassed() const
+{
+  return m_sps_pps_context.first_idr == 0;
 }
 
 bool CBitstreamConverter::BitstreamConvertInitAVC(void *in_extradata, int in_extrasize)

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -137,7 +137,7 @@ public:
 
   static bool Open();
   static void Close();
-  static bool FindIdrSlice(const uint8_t *buf, int buf_size);
+  static bool HasKeyframe(const uint8_t *buf, int buf_size);
 
 protected:
   static const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);
@@ -157,7 +157,8 @@ public:
   int               GetConvertSize() const;
   uint8_t*          GetExtraData(void) const;
   int               GetExtraSize() const;
-  bool              IdrFramePassed() const;
+  void              ResetKeyframe(void);
+  bool              HasKeyframe() const;
 
   static void       bits_reader_set( bits_reader_t *br, uint8_t *buf, int len );
   static uint32_t   read_bits( bits_reader_t *br, int nbits );
@@ -208,5 +209,6 @@ protected:
   bool              m_convert_3byteTo4byteNALSize;
   bool              m_convert_bytestream;
   AVCodecID         m_codec;
+  bool              m_has_keyframe;
 };
 

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -157,6 +157,7 @@ public:
   int               GetConvertSize() const;
   uint8_t*          GetExtraData(void) const;
   int               GetExtraSize() const;
+  bool              IdrFramePassed() const;
 
   static void       bits_reader_set( bits_reader_t *br, uint8_t *buf, int len );
   static uint32_t   read_bits( bits_reader_t *br, int nbits );


### PR DESCRIPTION
Timing adjustments to get AML clock better synced to kodi DVDClock

## Description
This PR does mainly 2 things:
- wait for AML decoder start until enough packets are feeded
- adjust AML clock to be never behind kodi clock (can lead to stutter) and not to much behind kodi clock(can lead to stutter as well)

## Motivation and Context
MPEG2 videos delivered from TVHeadend do not play without stutter.

## How Has This Been Tested?
Runtime tests 23.97fps, 25 fps , 50fps live-tv and streams on local drive.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

