### PR TITLE
Move eject drive and eject disk to new contextmenu system

### DIFF
--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES Application.cpp
             BackgroundInfoLoader.cpp
             ContextMenuItem.cpp
             ContextMenuManager.cpp
+            ContextMenus.cpp
             CueDocument.cpp
             DatabaseManager.cpp
             DbUrl.cpp
@@ -45,6 +46,7 @@ set(HEADERS AppParamParser.h
             CompileInfo.h
             ContextMenuItem.h
             ContextMenuManager.h
+            ContextMenus.h
             CueDocument.h
             DatabaseManager.h
             DbUrl.h

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -30,6 +30,7 @@
 #include "ServiceBroker.h"
 
 #include <iterator>
+#include "ContextMenus.h"
 
 using namespace ADDON;
 
@@ -71,6 +72,8 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CSongInfo>(),
       std::make_shared<CONTEXTMENU::CMarkWatched>(),
       std::make_shared<CONTEXTMENU::CMarkUnWatched>(),
+      std::make_shared<CONTEXTMENU::CEjectDisk>(),
+      std::make_shared<CONTEXTMENU::CEjectDrive>(),
   };
   ReloadAddonItems();
 }

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ContextMenus.h"
+#include "guilib/GUIWindowManager.h"
+#include "storage/MediaManager.h"
+
+
+namespace CONTEXTMENU
+{
+
+  bool CEjectDisk::IsVisible(const CFileItem& item) const
+  {
+    return item.IsRemovable() && (item.IsDVD() || item.IsCDDA());
+  }
+
+  bool CEjectDisk::Execute(const CFileItemPtr& item) const
+  {
+#ifdef HAS_DVD_DRIVE
+    g_mediaManager.ToggleTray(g_mediaManager.TranslateDevicePath(item->GetPath())[0]);
+#endif
+    return true;
+  }
+
+  bool CEjectDrive::IsVisible(const CFileItem& item) const
+  {
+    // Must be HDD
+    return item.IsRemovable() && !item.IsDVD() && !item.IsCDDA();
+  }
+
+  bool CEjectDrive::Execute(const CFileItemPtr& item) const
+  {
+    return g_mediaManager.Eject(item->GetPath());
+  }
+
+}

--- a/xbmc/ContextMenus.h
+++ b/xbmc/ContextMenus.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ContextMenuItem.h"
+
+
+namespace CONTEXTMENU
+{
+
+struct CEjectDisk : CStaticContextMenuAction
+{
+  CEjectDisk() : CStaticContextMenuAction(13391) {} // Eject/Load CD/DVD!
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+};
+
+struct CEjectDrive : CStaticContextMenuAction
+{
+  CEjectDrive() : CStaticContextMenuAction(13420) {} // Eject Removable HDD!
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+};
+
+}

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -24,7 +24,6 @@
 #include "guilib/GUIControlGroupList.h"
 #include "GUIDialogFileBrowser.h"
 #include "GUIUserMessages.h"
-#include "Autorun.h"
 #include "GUIPassword.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
@@ -37,7 +36,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "GUIDialogYesNo.h"
-#include "addons/AddonManager.h"
 #include "FileItem.h"
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
@@ -224,20 +222,6 @@ bool CGUIDialogContextMenu::SourcesMenu(const std::string &strType, const CFileI
 
 void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFileItemPtr& item, CContextButtons &buttons)
 {
-  // Add buttons to the ContextMenu that should be visible for both sources and autosourced items
-  if (item && item->IsRemovable())
-  {
-    if (item->IsDVD() || item->IsCDDA())
-    {
-      buttons.Add(CONTEXT_BUTTON_EJECT_DISC, 13391);  // Eject/Load CD/DVD!
-    }
-    else // Must be HDD
-    {
-      buttons.Add(CONTEXT_BUTTON_EJECT_DRIVE, 13420);  // Eject Removable HDD!
-    }
-  }
-
-
   // Next, Add buttons to the ContextMenu that should ONLY be visible for sources and not autosourced items
   CMediaSource *share = GetShare(type, item.get());
 
@@ -291,21 +275,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 {
   // buttons that are available on both sources and autosourced items
   if (!item) return false;
-
-  switch (button)
-  {
-  case CONTEXT_BUTTON_EJECT_DRIVE:
-    return g_mediaManager.Eject(item->GetPath());
-
-#ifdef HAS_DVD_DRIVE
-  case CONTEXT_BUTTON_EJECT_DISC:
-    g_mediaManager.ToggleTray(g_mediaManager.TranslateDevicePath(item->GetPath())[0]);
-#endif
-    return true;
-  default:
-    break;
-  }
-
+  
   // the rest of the operations require a valid share
   CMediaSource *share = GetShare(type, item.get());
   if (!share) return false;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Marvel your eyes, as your now able to eject your disks and drives right from your homescreen 🚀 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
No ejection from the homescreen ☮️ 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Only tested eject disk, as I have no drive to eject in my reach.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

