### PR TITLE
Use applicationmessenger to show CGUIDialogOK with an helper

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -66,6 +66,7 @@
 #include "messaging/ThreadMessage.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "SectionLoader.h"
 #include "cores/DllLoader/DllLoaderContainer.h"
 #include "GUIUserMessages.h"
@@ -139,7 +140,6 @@
 
 // Dialog includes
 #include "video/dialogs/GUIDialogVideoBookmarks.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSubMenu.h"
 #include "dialogs/GUIDialogButtonMenu.h"
@@ -3201,7 +3201,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
     }
     else
 #endif
-      CGUIDialogOK::ShowAndGetInput(CVariant{435}, CVariant{436});
+      HELPERS::ShowOKDialogText(CVariant{435}, CVariant{436});
 
     return PLAYBACK_OK;
   }
@@ -4165,7 +4165,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         {
           auto addonList = StringUtils::Join(m_incompatibleAddons, ", ");
           auto msg = StringUtils::Format(g_localizeStrings.Get(24149).c_str(), addonList.c_str());
-          CGUIDialogOK::ShowAndGetInput(CVariant{24148}, CVariant{std::move(msg)});
+          HELPERS::ShowOKDialogText(CVariant{24148}, CVariant{std::move(msg)});
           m_incompatibleAddons.clear();
         }
 
@@ -4428,7 +4428,7 @@ void CApplication::ShowAppMigrationMessage()
   if (CFile::Exists("special://home/.kodi_data_was_migrated") &&
       !CFile::Exists("special://home/.kodi_migration_info_shown"))
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{24128}, CVariant{24129});
+    HELPERS::ShowOKDialogText(CVariant{24128}, CVariant{24129});
     CFile tmpFile;
     // create the file which will prevent this dialog from appearing in the future
     tmpFile.OpenForWrite("special://home/.kodi_migration_info_shown");

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -25,7 +25,6 @@
 #include "dialogs/GUIDialogGamepad.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogNumeric.h"
-#include "dialogs/GUIDialogOK.h"
 #include "profiles/ProfilesManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
@@ -35,6 +34,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "view/ViewStateSettings.h"
 #include "utils/Variant.h"
@@ -73,7 +73,7 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
     {
       if (0 != CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES) && pItem->m_iBadPwdCount >= CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES))
       { // user previously exhausted all retries, show access denied error
-        CGUIDialogOK::ShowAndGetInput(CVariant{12345}, CVariant{12346});
+        HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
         return false;
       }
       // show the appropriate lock dialog
@@ -148,7 +148,7 @@ bool CGUIPassword::CheckStartUpLock()
         std::string strLabel = StringUtils::Format("%i %s", iLeft, strLabel1.c_str());
 
         // PopUp OK and Display: MasterLock mode has changed but no new Mastercode has been set!
-        CGUIDialogOK::ShowAndGetInput(CVariant{12360}, CVariant{12367}, CVariant{strLabel}, CVariant{""});
+        HELPERS::ShowOKDialogLines(CVariant{12360}, CVariant{12367}, CVariant{strLabel}, CVariant{""});
       }
       else
         i=g_passwordManager.iMasterLockRetriesLeft;
@@ -285,7 +285,7 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
         // user has run out of retry attempts
         g_passwordManager.iMasterLockRetriesLeft = 0;
         // Tell the user they ran out of retry attempts
-        CGUIDialogOK::ShowAndGetInput(CVariant{12345}, CVariant{12346});
+        HELPERS::ShowOKDialogText(CVariant{12345}, CVariant{12346});
         return ;
       }
     }
@@ -294,7 +294,7 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
       dlgLine1 = StringUtils::Format("%d %s",
                                      g_passwordManager.iMasterLockRetriesLeft,
                                      g_localizeStrings.Get(12343).c_str());
-    CGUIDialogOK::ShowAndGetInput(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
+    HELPERS::ShowOKDialogLines(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
   }
   else
     g_passwordManager.iMasterLockRetriesLeft = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES); // user entered correct mastercode, reset retries to max allowed

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -23,11 +23,11 @@
 #include <algorithm>
 
 #include "Application.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
 #include "music/windows/GUIWindowMusicPlaylist.h"
 #include "PlayListPlayer.h"
@@ -41,6 +41,7 @@
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 
+using namespace KODI::MESSAGING;
 using namespace PLAYLIST;
 
 #define QUEUE_DEPTH       10
@@ -514,7 +515,7 @@ void CPartyModeManager::Play(int iPos)
 void CPartyModeManager::OnError(int iError, const std::string&  strLogMessage)
 {
   // open error dialog
-  CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{16030}, CVariant{iError}, CVariant{0});
+  HELPERS::ShowOKDialogLines(CVariant{257}, CVariant{16030}, CVariant{iError}, CVariant{0});
   CLog::Log(LOGERROR, "PARTY MODE MANAGER: %s", strLogMessage.c_str());
   m_bEnabled = false;
   SendUpdateMessage();

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -25,7 +25,6 @@
 #include "settings/AdvancedSettings.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogOK.h"
 #include "playlists/PlayList.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -38,6 +37,7 @@
 #include "URL.h"
 #include "messaging/ApplicationMessenger.h"
 #include "filesystem/VideoDatabaseFile.h"
+#include "messaging/helpers/DialogOKHelper.h"
 
 using namespace PLAYLIST;
 using namespace KODI::MESSAGING;
@@ -327,7 +327,7 @@ bool CPlayListPlayer::Play(int iSong, std::string player, bool bAutoPlay /* = fa
       CLog::Log(LOGDEBUG,"Playlist Player: one or more items failed to play... aborting playback");
 
       // open error dialog
-      CGUIDialogOK::ShowAndGetInput(CVariant{16026}, CVariant{16027});
+      HELPERS::ShowOKDialogText(CVariant{16026}, CVariant{16027});
 
       CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, m_iCurrentPlayList, m_iCurrentSong);
       g_windowManager.SendThreadMessage(msg);

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -34,6 +34,7 @@
 #include "settings/Settings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "favourites/FavouritesService.h"
 #include "FilesystemInstaller.h"
 #include "utils/JobManager.h"
@@ -42,7 +43,6 @@
 #include "guilib/GUIWindowManager.h"      // for callback
 #include "GUIUserMessages.h"              // for callback
 #include "utils/StringUtils.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "URL.h"
 #ifdef TARGET_POSIX
@@ -809,7 +809,7 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
 
     activity = EventPtr(new CAddonManagementEvent(addon, EventLevel::Error, msg));
     if (IsModal())
-      CGUIDialogOK::ShowAndGetInput(CVariant{m_addon->Name()}, CVariant{msg});
+      HELPERS::ShowOKDialogText(CVariant{m_addon->Name()}, CVariant{msg});
   }
   else
   {
@@ -818,7 +818,7 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
         EventLevel::Error));
 
     if (IsModal())
-      CGUIDialogOK::ShowAndGetInput(CVariant{fileName}, CVariant{msg});
+      HELPERS::ShowOKDialogText(CVariant{fileName}, CVariant{msg});
   }
 
   CEventLog::GetInstance().Add(activity, !IsModal(), false);

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -24,8 +24,8 @@
 #include "messaging/ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogYesNo.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -93,13 +93,7 @@ void CAddonStatusHandler::Process()
   /* Request to restart the AddOn and data structures need updated */
   if (m_status == ADDON_STATUS_NEED_RESTART)
   {
-    CGUIDialogOK* pDialog = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-    if (!pDialog) return;
-
-    pDialog->SetHeading(CVariant{heading});
-    pDialog->SetLine(1, CVariant{24074});
-    pDialog->Open();
-
+    HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{24074});
     CAddonMgr::GetInstance().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
   }
   /* Some required settings are missing/invalid */

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -31,7 +31,6 @@
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogTextViewer.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "games/GameUtils.h"
@@ -40,6 +39,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "settings/Settings.h"
 #include "utils/JobManager.h"
@@ -294,7 +294,7 @@ void CGUIDialogAddonInfo::OnUpdate()
   }
 
   if (versions.empty())
-    CGUIDialogOK::ShowAndGetInput(CVariant{21341}, CVariant{21342});
+    HELPERS::ShowOKDialogText(CVariant{21341}, CVariant{21342});
   else
   {
     int i = AskForVersion(versions);
@@ -421,7 +421,7 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
   {
     std::string line0 = StringUtils::Format(g_localizeStrings.Get(24046).c_str(), m_localAddon->Name().c_str());
     std::string line1 = StringUtils::Join(deps, ", ");
-    CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{std::move(line0)}, CVariant{std::move(line1)}, CVariant{line2});
+    HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{std::move(line0)}, CVariant{std::move(line1)}, CVariant{line2});
     return true;
   }
   return false;

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -28,11 +28,11 @@
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogOK.h"
 #include "utils/URIUtils.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/Directory.h"
+#include "messaging/helpers/DialogOKHelper.h" 
 #include "settings/lib/SettingSection.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -46,6 +46,7 @@
 #include "addons/interfaces/Network.h"
 #include "addons/interfaces/GUI/General.h"
 
+using namespace KODI::MESSAGING;
 
 namespace ADDON
 {
@@ -135,16 +136,8 @@ bool CAddonDll::LoadDll()
     delete m_pDll;
     m_pDll = NULL;
 
-    CGUIDialogOK* pDialog = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-    if (pDialog)
-    {
-      std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
-      pDialog->SetHeading(CVariant{heading});
-      pDialog->SetLine(1, CVariant{24070});
-      pDialog->SetLine(2, CVariant{24071});
-      pDialog->SetLine(2, CVariant{"Can't load shared library"});
-      pDialog->Open();
-    }
+    std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{24070}, CVariant{24071});
 
     return false;
   }
@@ -202,16 +195,9 @@ ADDON_STATUS CAddonDll::Create(ADDON_TYPE type, void* funcTable, void* info)
   else
   { // Addon failed initialization
     CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
-    
-    CGUIDialogOK* pDialog = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-    if (pDialog)
-    {
-      std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
-      pDialog->SetHeading(CVariant{heading});
-      pDialog->SetLine(1, CVariant{24070});
-      pDialog->SetLine(2, CVariant{24071});
-      pDialog->Open();
-    }
+
+    std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    HELPERS::ShowOKDialogLines(CVariant{ heading }, CVariant{ 24070 }, CVariant{ 24071 });
   }
 
   return status;
@@ -258,15 +244,8 @@ ADDON_STATUS CAddonDll::Create(KODI_HANDLE firstKodiInstance)
     CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
 
     // @todo currently a copy and paste from other function and becomes improved.
-    CGUIDialogOK* pDialog = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-    if (pDialog)
-    {
-      std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
-      pDialog->SetHeading(CVariant{heading});
-      pDialog->SetLine(1, CVariant{24070});
-      pDialog->SetLine(2, CVariant{24071});
-      pDialog->Open();
-    }
+    std::string heading = StringUtils::Format("%s: %s", CAddonInfo::TranslateType(Type(), true).c_str(), Name().c_str());
+    HELPERS::ShowOKDialogLines(CVariant{ heading }, CVariant{ 24070 }, CVariant{ 24071 });
   }
 
   return status;

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -28,7 +28,6 @@
 #include "addons/Addon.h"
 #include "addons/Skin.h"
 #include "dialogs/GUIDialogNumeric.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogTextViewer.h"
 #include "dialogs/GUIDialogSelect.h"
@@ -43,6 +42,7 @@
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -1854,12 +1854,12 @@ bool CAddonCallbacksGUI::Dialog_FileBrowser_ShowAndGetFile(const char *directory
 //@{
 void CAddonCallbacksGUI::Dialog_OK_ShowAndGetInputSingleText(const char *heading, const char *text)
 {
-  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{text});
+  HELPERS::ShowOKDialogText(CVariant{heading}, CVariant{text});
 }
 
 void CAddonCallbacksGUI::Dialog_OK_ShowAndGetInputLineText(const char *heading, const char *line0, const char *line1, const char *line2)
 {
-  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});
+  HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});
 }
 //@}
 

--- a/xbmc/addons/interfaces/GUI/dialogs/OK.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/OK.cpp
@@ -22,9 +22,10 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/OK.h"
 
 #include "addons/binary-addons/AddonDll.h"
-#include "dialogs/GUIDialogOK.h"
+#include "messaging/helpers/DialogOKHelper.h" 
 #include "utils/log.h"
 #include "utils/Variant.h"
+using namespace KODI::MESSAGING;
 
 extern "C"
 {
@@ -54,7 +55,7 @@ void Interface_GUIDialogOK::show_and_get_input_single_text(void* kodiBase, const
     return;
   }
 
-  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{text});
+  HELPERS::ShowOKDialogText(CVariant{heading}, CVariant{text});
 }
 
 void Interface_GUIDialogOK::show_and_get_input_line_text(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2)
@@ -66,8 +67,7 @@ void Interface_GUIDialogOK::show_and_get_input_line_text(void* kodiBase, const c
                                         __FUNCTION__, addon, heading, line0, line1, line2);
     return;
   }
-
-  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});
+  HELPERS::ShowOKDialogLines(CVariant{ heading }, CVariant{ line0 }, CVariant{ line1 }, CVariant{ line2 });
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/settings/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.cpp
@@ -22,13 +22,15 @@
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
 #include "addons/settings/AddonSettings.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h" 
 #include "settings/lib/SettingsManager.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+
+using namespace KODI::MESSAGING;
 
 CGUIDialogAddonSettings::CGUIDialogAddonSettings()
   : CGUIDialogSettingsManagerBase(WINDOW_DIALOG_ADDON_SETTINGS, "DialogAddonSettings.xml")
@@ -80,7 +82,7 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr &addon, bool sa
   if (!addon->HasSettings())
   {
     // addon does not support settings, inform user
-    CGUIDialogOK::ShowAndGetInput(CVariant{ 24000 }, CVariant{ 24030 });
+    HELPERS::ShowOKDialogText(CVariant{ 24000 }, CVariant{ 24030 });
     return false;
   }
 

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -33,7 +33,6 @@
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
-#include "dialogs/GUIDialogOK.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingPath.h"
 #include "settings/Settings.h"
@@ -48,10 +47,12 @@
 #include "music/MusicDatabase.h"
 #include "addons/AudioEncoder.h"
 #include "addons/binary-addons/BinaryAddonBase.h"
+#include "messaging/helpers/DialogOKHelper.h"
 
 using namespace ADDON;
 using namespace XFILE;
 using namespace MUSIC_INFO;
+using namespace KODI::MESSAGING;
 
 CCDDARipper& CCDDARipper::GetInstance()
 {
@@ -168,7 +169,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag, std::
     // no rip path has been set, show error
     CLog::Log(LOGERROR, "Error: CDDARipPath has not been set");
     g_graphicsContext.Lock();
-    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{608});
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{608});
     g_graphicsContext.Unlock();
     return false;
   }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.cpp
@@ -37,7 +37,6 @@ extern "C" {
 #include "cores/AudioEngine/Interfaces/AEResample.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -31,7 +31,6 @@
 #include "GUIPassword.h"
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
-#include "GUIDialogOK.h"
 #include "GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "GUIUserMessages.h"
@@ -47,7 +46,9 @@
 #include "URL.h"
 #include "utils/Variant.h"
 #include "settings/AdvancedSettings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 
+using namespace KODI::MESSAGING;
 using namespace XFILE;
 
 #define CONTROL_LIST          450
@@ -223,7 +224,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
             Close();
           }
           else
-            CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{20072});
+            HELPERS::ShowOKDialogText(CVariant{257}, CVariant{20072});
         }
         else
         {
@@ -255,7 +256,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
           if (CDirectory::Create(strPath))
             Update(m_vecItems->GetPath());
           else
-            CGUIDialogOK::ShowAndGetInput(CVariant{20069}, CVariant{20072});
+            HELPERS::ShowOKDialogText(CVariant{20069}, CVariant{20072});
         }
       }
       else if (message.GetSenderId() == CONTROL_FLIP)
@@ -568,7 +569,7 @@ bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
   {
     if ( !g_mediaManager.IsDiscInDrive() )
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{218}, CVariant{219});
+      HELPERS::ShowOKDialogText(CVariant{218}, CVariant{219});
       return false;
     }
   }
@@ -577,7 +578,7 @@ bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
     //! @todo Handle not connected to a remote share
     if ( !g_application.getNetwork().IsConnected() )
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{221});
+      HELPERS::ShowOKDialogText(CVariant{220}, CVariant{221});
       return false;
     }
   }

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -23,12 +23,14 @@
 #include "utils/StringUtils.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "GUIDialogOK.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/Variant.h"
 
 #include <utility>
+
+using namespace KODI::MESSAGING;
 
 CGUIDialogGamepad::CGUIDialogGamepad(void)
     : CGUIDialogBoxBase(WINDOW_DIALOG_GAMEPAD, "DialogConfirm.xml")
@@ -208,7 +210,7 @@ bool CGUIDialogGamepad::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (ShowAndVerifyInput(strUserInput, "12340", "12330", "12331", "", true, true))
   {
     //! @todo Show error to user saying the password entry was blank
-    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12358}); // Password is empty/blank
+    HELPERS::ShowOKDialogText(CVariant{12357}, CVariant{12358}); // Password is empty/blank
     return false;
   }
 
@@ -220,7 +222,7 @@ bool CGUIDialogGamepad::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (!ShowAndVerifyInput(strUserInput, "12341", "12330", "12331", "", false, true))
   {
     //! @todo Show error to user saying the password re-entry failed
-    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12344}); // Password do not match
+    HELPERS::ShowOKDialogText(CVariant{12357}, CVariant{12344}); // Password do not match
     return false;
   }
 

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -29,7 +29,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "GUIUserMessages.h"
 #include "GUIDialogNumeric.h"
-#include "GUIDialogOK.h"
 #include "GUIDialogKeyboardGeneric.h"
 #include "ServiceBroker.h"
 #include "settings/Settings.h"

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -25,13 +25,13 @@
 #include "guilib/GUILabelControl.h"
 #include "utils/md5.h"
 #include "guilib/GUIWindowManager.h"
-#include "GUIDialogOK.h"
 #include "input/XBMC_vkeys.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/helpers/DialogOKHelper.h"
 
 #define CONTROL_HEADING_LABEL  1
 #define CONTROL_INPUT_LABEL    4
@@ -42,6 +42,7 @@
 #define CONTROL_NEXT          22
 #define CONTROL_BACKSPACE     23
 
+using namespace KODI::MESSAGING;
 
 CGUIDialogNumeric::CGUIDialogNumeric(void)
   : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml")
@@ -565,7 +566,7 @@ bool CGUIDialogNumeric::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (!ShowAndVerifyInput(strUserInput, g_localizeStrings.Get(12340), false))
   {
     // Show error to user saying the password entry was blank
-    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12358}); // Password is empty/blank
+    HELPERS::ShowOKDialogText(CVariant{12357}, CVariant{12358}); // Password is empty/blank
     return false;
   }
 
@@ -577,7 +578,7 @@ bool CGUIDialogNumeric::ShowAndVerifyNewPassword(std::string& strNewPassword)
   if (!ShowAndVerifyInput(strUserInput, g_localizeStrings.Get(12341), true))
   {
     // Show error to user saying the password re-entry failed
-    CGUIDialogOK::ShowAndGetInput(CVariant{12357}, CVariant{12344}); // Password do not match
+    HELPERS::ShowOKDialogText(CVariant{12357}, CVariant{12344}); // Password do not match
     return false;
   }
 

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -71,6 +71,22 @@ bool CGUIDialogOK::ShowAndGetInput(CVariant heading, CVariant line0, CVariant li
   return dialog->IsConfirmed();
 }
 
+bool CGUIDialogOK::ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogOKMessage & options)
+{
+  if (!options.heading.isNull())
+    SetHeading(options.heading);
+  if (!options.text.isNull())
+    SetText(options.text);
+
+  for (size_t i = 0; i < 3; ++i)
+  {
+    if (!options.lines[i].isNull())
+      SetLine(i, options.lines[i]);
+  }
+  Open();
+  return IsConfirmed();
+}
+
 void CGUIDialogOK::OnInitWindow()
 {
   SET_CONTROL_HIDDEN(CONTROL_NO_BUTTON);

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -71,7 +71,7 @@ bool CGUIDialogOK::ShowAndGetInput(CVariant heading, CVariant line0, CVariant li
   return dialog->IsConfirmed();
 }
 
-bool CGUIDialogOK::ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogOKMessage & options)
+bool CGUIDialogOK::ShowAndGetInput(const HELPERS::DialogOKMessage & options)
 {
   if (!options.heading.isNull())
     SetHeading(options.heading);

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -26,6 +26,8 @@
 class CGUIMessage;
 class CVariant;
 
+using namespace KODI::MESSAGING;
+
 class CGUIDialogOK :
       public CGUIDialogBoxBase
 {
@@ -43,7 +45,7 @@ public:
 
   \sa KODI::MESSAGING::HELPERS::DialogOKMessage
   */
-  bool ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogOKMessage& options);
+  bool ShowAndGetInput(const HELPERS::DialogOKMessage& options);
 protected:
   void OnInitWindow() override;
   int GetDefaultLabelID(int controlId) const override;

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -21,6 +21,7 @@
  */
 
 #include "GUIDialogBoxBase.h"
+#include "messaging/helpers/DialogOKHelper.h"
 
 class CGUIMessage;
 class CVariant;
@@ -34,6 +35,15 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   static bool ShowAndGetInput(CVariant heading, CVariant text);
   static bool ShowAndGetInput(CVariant heading, CVariant line0, CVariant line1, CVariant line2);
+  /*!
+  \brief Open a OK dialog and wait for input
+
+  \param[in] options  a struct of type DialogOKMessage containing
+  the options to set for this dialog.
+
+  \sa KODI::MESSAGING::HELPERS::DialogOKMessage
+  */
+  bool ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogOKMessage& options);
 protected:
   void OnInitWindow() override;
   int GetDefaultLabelID(int controlId) const override;

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -33,11 +33,11 @@
 #include "addons/BinaryAddonCache.h"
 #include "addons/PluginSource.h"
 #include "addons/RepositoryUpdater.h"
-#include "dialogs/GUIDialogOK.h"
 #include "games/addons/GameClient.h"
 #include "games/GameUtils.h"
 #include "guilib/TextureManager.h"
 #include "File.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/Settings.h"
 #include "SpecialProtocol.h"
 #include "utils/URIUtils.h"
@@ -46,6 +46,7 @@
 
 using namespace KODI;
 using namespace ADDON;
+using namespace KODI::MESSAGING;
 
 namespace XFILE
 {
@@ -558,7 +559,7 @@ static bool Browse(const CURL& path, CFileItemList &items)
 
       if (!database.GetRepositoryContent(addon->ID(), addons))
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{addon->Name()}, CVariant{24991});
+        HELPERS::ShowOKDialogText(CVariant{addon->Name()}, CVariant{24991});
         return false;
       }
     }

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -19,13 +19,14 @@
  */
 
 #include "IDirectory.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "URL.h"
 #include "PasswordManager.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 
+using namespace KODI::MESSAGING;
 using namespace XFILE;
 
 IDirectory::IDirectory(void)
@@ -141,7 +142,7 @@ bool IDirectory::ProcessRequirements()
   }
   else if (type == "error")
   {
-    CGUIDialogOK::ShowAndGetInput(m_requirements["heading"], m_requirements["line1"], m_requirements["line2"], m_requirements["line3"]);
+    HELPERS::ShowOKDialogLines(CVariant{m_requirements["heading"]}, CVariant{m_requirements["line1"]}, CVariant{m_requirements["line2"]}, CVariant{m_requirements["line3"]});
   }
   m_requirements.clear();
   return false;

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -22,11 +22,11 @@
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
 #include "addons/BinaryAddonCache.h"
-#include "dialogs/GUIDialogOK.h"
 #include "games/addons/GameClient.h"
 #include "games/dialogs/GUIDialogSelectGameClient.h"
 #include "games/tags/GameInfoTag.h"
 #include "filesystem/SpecialProtocol.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "FileItem.h"
@@ -64,7 +64,7 @@ bool CGameUtils::FillInGameClient(CFileItem &item, bool bPrompt)
             35212;  // "This game isn't compatible with any available emulators."
 
         // "Failed to play game"
-        CGUIDialogOK::ShowAndGetInput(CVariant{ 35210 }, CVariant{ errorTextId });
+        KODI::MESSAGING::HELPERS::ShowOKDialogText(CVariant{ 35210 }, CVariant{ errorTextId });
       }
       else if (candidates.size() == 1 && installable.empty())
       {

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -29,7 +29,6 @@
 #include "addons/AddonManager.h"
 #include "addons/BinaryAddonCache.h"
 #include "cores/AudioEngine/Utils/AEChannelInfo.h"
-#include "dialogs/GUIDialogOK.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "games/addons/playback/GameClientRealtimePlayback.h"
@@ -43,6 +42,7 @@
 #include "input/joysticks/JoystickTypes.h"
 #include "input/InputManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "peripherals/Peripherals.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
@@ -61,6 +61,7 @@
 
 using namespace KODI;
 using namespace GAME;
+using namespace KODI::MESSAGING;
 
 #define EXTENSION_SEPARATOR          "|"
 #define EXTENSION_WILDCARD           "*"
@@ -428,13 +429,13 @@ void CGameClient::NotifyError(GAME_ERROR error)
   {
     // Failed to play game
     // This game requires the following add-on: %s
-    CGUIDialogOK::ShowAndGetInput(CVariant{ 35210 }, StringUtils::Format(g_localizeStrings.Get(35211).c_str(), missingResource.c_str()));
+    HELPERS::ShowOKDialogText(CVariant{ 35210 }, CVariant{ StringUtils::Format(g_localizeStrings.Get(35211).c_str(), missingResource.c_str()) });
   }
   else
   {
     // Failed to play game
     // The emulator "%s" had an internal error.
-    CGUIDialogOK::ShowAndGetInput(CVariant{ 35210 }, StringUtils::Format(g_localizeStrings.Get(35213).c_str(), Name().c_str()));
+    HELPERS::ShowOKDialogText(CVariant{ 35210 }, CVariant{ StringUtils::Format(g_localizeStrings.Get(35213).c_str(), Name().c_str()) });
   }
 }
 

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -28,6 +28,7 @@
 #include "input/joysticks/JoystickUtils.h"
 #include "input/IKeymap.h"
 #include "input/ActionIDs.h"
+#include "messaging/helpers/DialogOKHelper.h" 
 #include "peripherals/Peripherals.h"
 #include "utils/Variant.h"
 #include "ServiceBroker.h"
@@ -37,6 +38,7 @@
 
 using namespace KODI;
 using namespace GAME;
+using namespace KODI::MESSAGING;
 
 CGUIDialogButtonCapture::CGUIDialogButtonCapture() :
   CThread("ButtonCaptureDlg")
@@ -56,7 +58,7 @@ void CGUIDialogButtonCapture::Show()
 
     Create();
 
-    bool bAccepted = CGUIDialogOK::ShowAndGetInput(CVariant{ GetDialogHeader() }, CVariant{ GetDialogText() });
+    bool bAccepted = HELPERS::ShowOKDialogText(CVariant{ GetDialogHeader() }, CVariant{ GetDialogText() });
 
     StopThread(false);
 

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "GUIDialogButtonCapture.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/JoystickIDs.h"
@@ -80,9 +79,7 @@ void CGUIDialogButtonCapture::Process()
       break;
 
     //! @todo Move to rendering thread when there is a rendering thread
-    auto dialog = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-    if (dialog)
-      dialog->SetText(GetDialogText());
+    HELPERS::UpdateOKDialogText(CVariant{ 35013 }, CVariant{ GetDialogText() });
   }
 }
 

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -34,7 +34,7 @@
 #include "ServiceBroker.h"
 
 // To check for button mapping support
-#include "dialogs/GUIDialogOK.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "peripherals/bus/virtual/PeripheralBusAddon.h"
 #include "peripherals/Peripherals.h"
 #include "utils/log.h"
@@ -44,6 +44,7 @@
 
 using namespace KODI;
 using namespace GAME;
+using namespace KODI::MESSAGING;
 
 CGUIControllerWindow::CGUIControllerWindow(void) :
   CGUIDialog(WINDOW_DIALOG_GAME_CONTROLLERS, "DialogGameControllers.xml"),
@@ -295,7 +296,7 @@ void CGUIControllerWindow::GetMoreControllers(void)
   {
     // "Controller profiles"
     // "All available controller profiles are installed."
-    CGUIDialogOK::ShowAndGetInput(CVariant{ 35050 }, CVariant{ 35062 });
+    HELPERS::ShowOKDialogText(CVariant{ 35050 }, CVariant{ 35062 });
     return;
   }
 }
@@ -310,7 +311,7 @@ void CGUIControllerWindow::ShowHelp(void)
 {
   // "Help"
   // <help text>
-  CGUIDialogOK::ShowAndGetInput(CVariant{10043}, CVariant{35055});
+  HELPERS::ShowOKDialogText(CVariant{10043}, CVariant{35055});
 }
 
 void CGUIControllerWindow::ShowButtonCaptureDialog(void)

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -23,13 +23,14 @@
 #include "addons/AddonManager.h"
 #include "addons/GUIWindowAddonBrowser.h"
 #include "dialogs/GUIDialogContextMenu.h"
-#include "dialogs/GUIDialogOK.h"
 #include "games/addons/GameClient.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/helpers/DialogOKHelper.h" 
 #include "utils/log.h"
 
 using namespace KODI;
+using namespace KODI::MESSAGING;
 using namespace GAME;
 
 std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const GameClientVector& candidates, const GameClientVector& installable)
@@ -144,7 +145,7 @@ std::string CGUIDialogSelectGameClient::InstallGameClient(const GameClientVector
       CLog::Log(LOGERROR, "Select game client dialog: Failed to install %s", gameClientId.c_str());
       // "Error"
       // "Failed to install add-on."
-      CGUIDialogOK::ShowAndGetInput(257, 35256);
+      HELPERS::ShowOKDialogText(257, 35256);
     }
   }
   else if (result == iAddonBrowser)

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -23,9 +23,9 @@
 #include "messaging/ApplicationMessenger.h"
 #include "LocalizeStrings.h"
 #include "GUIKeyboardFactory.h"
-#include "dialogs/GUIDialogOK.h"
 #include "GUIUserMessages.h"
 #include "GUIWindowManager.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/Settings.h"
 #include "utils/md5.h"
 #include "utils/StringUtils.h"
@@ -169,7 +169,7 @@ bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, CVa
     StringUtils::ToLower(newPassword);
     return true;
   }
-  CGUIDialogOK::ShowAndGetInput(CVariant{12341}, CVariant{12344});
+  HELPERS::ShowOKDialogText(CVariant{12341}, CVariant{12344});
   return false;
 }
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -956,6 +956,8 @@ void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)
     break;
 
   case TMSG_GUI_DIALOG_YESNO:
+  {
+
     if (!pMsg->lpVoid && pMsg->param1 < 0 && pMsg->param2 < 0)
       return;
 
@@ -973,7 +975,31 @@ void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)
       pMsg->SetResult(dialog->ShowAndGetInput(options));
     }
 
-    break;
+  }
+  break;
+
+  case TMSG_GUI_DIALOG_OK:
+  {
+
+    if (!pMsg->lpVoid && pMsg->param1 < 0 && pMsg->param2 < 0)
+      return;
+
+    auto dialogOK = static_cast<CGUIDialogOK*>(GetWindow(WINDOW_DIALOG_OK));
+    if (!dialogOK)
+      return;
+
+    if (pMsg->lpVoid)
+      dialogOK->ShowAndGetInput(*static_cast<HELPERS::DialogOKMessage*>(pMsg->lpVoid));
+    else
+    {
+      HELPERS::DialogOKMessage options;
+      options.heading = pMsg->param1;
+      options.text = pMsg->param2;
+      dialogOK->ShowAndGetInput(options);
+    }
+    pMsg->SetResult(static_cast<int>(dialogOK->IsConfirmed()));
+  }
+  break;
   }
 }
 

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -19,7 +19,6 @@
  */
 #include "LanguageHook.h"
 
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogContextMenu.h"
@@ -37,6 +36,7 @@
 #include "utils/Variant.h"
 #include "WindowException.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "Dialog.h"
 #include "ListItem.h"
 #ifdef TARGET_POSIX
@@ -182,22 +182,7 @@ namespace XBMCAddon
                     const String& line3)
     {
       DelayedCallGuard dcguard(languageHook);
-      CGUIDialogOK* pDialog = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-      if (pDialog == NULL)
-        throw WindowException("Error: Window is NULL, this is not possible :-)");
-
-      if (!heading.empty())
-        pDialog->SetHeading(CVariant{heading});
-      if (!line1.empty())
-        pDialog->SetLine(0, CVariant{line1});
-      if (!line2.empty())
-        pDialog->SetLine(1, CVariant{line2});
-      if (!line3.empty())
-        pDialog->SetLine(2, CVariant{line3});
-
-      pDialog->Open();
-
-      return pDialog->IsConfirmed();
+      return HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{line1}, CVariant{line2}, CVariant{line3});
     }
 
     void Dialog::textviewer(const String& heading, const String& text)

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -133,6 +133,7 @@
   \sa HELPERS::DialogYesNoMessage
 */
 #define TMSG_GUI_DIALOG_YESNO             TMSG_MASK_WINDOWMANAGER + 8
+#define TMSG_GUI_DIALOG_OK                TMSG_MASK_WINDOWMANAGER + 9
 
 /*!
   \def TMSG_GUI_PREVIOUS_WINDOW
@@ -141,7 +142,7 @@
   This is an alternative to TMSG_GUI_ACTIVATE_WINDOW, but it keeps
   all configured parameters, like startup directory.
 */
-#define TMSG_GUI_PREVIOUS_WINDOW          TMSG_MASK_WINDOWMANAGER + 9
+#define TMSG_GUI_PREVIOUS_WINDOW          TMSG_MASK_WINDOWMANAGER + 10
 
 
 #define TMSG_CALLBACK                     800

--- a/xbmc/messaging/helpers/CMakeLists.txt
+++ b/xbmc/messaging/helpers/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES DialogHelper.cpp)
+set(SOURCES DialogHelper.cpp
+            DialogOKHelper.cpp)
 
-set(HEADERS DialogHelper.h)
+set(HEADERS DialogHelper.h
+            DialogOKHelper.h)
 
 core_add_library(messagingHelpers)

--- a/xbmc/messaging/helpers/DialogOKHelper.cpp
+++ b/xbmc/messaging/helpers/DialogOKHelper.cpp
@@ -1,0 +1,56 @@
+/*
+*      Copyright (C) 2005-2015 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "DialogOKHelper.h"
+#include "messaging/ApplicationMessenger.h"
+
+namespace KODI
+{
+namespace MESSAGING
+{
+namespace HELPERS
+{
+bool ShowOKDialogText(CVariant heading, CVariant text)
+{
+  DialogOKMessage options;
+  options.heading = std::move(heading);
+  options.text = std::move(text);
+  
+  if (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OK, -1, -1, static_cast<void*>(&options)) > 0)
+    return true;
+  return false;
+}
+
+bool ShowOKDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2)
+{
+  DialogOKMessage options;
+  options.heading = std::move(heading);
+  options.lines[0] = std::move(line0);
+  options.lines[1] = std::move(line1);
+  options.lines[2] = std::move(line2);
+
+  if (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OK, -1, -1, static_cast<void*>(&options)) > 0)
+    return true;
+  return false;
+}
+
+}
+}
+}

--- a/xbmc/messaging/helpers/DialogOKHelper.cpp
+++ b/xbmc/messaging/helpers/DialogOKHelper.cpp
@@ -38,6 +38,16 @@ bool ShowOKDialogText(CVariant heading, CVariant text)
   return false;
 }
 
+void UpdateOKDialogText(CVariant heading, CVariant text)
+{
+  DialogOKMessage options;
+  options.heading = std::move(heading);
+  options.text = std::move(text);
+  options.show = false;
+
+  CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_OK, -1, -1, static_cast<void*>(&options));
+}
+
 bool ShowOKDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2)
 {
   DialogOKMessage options;

--- a/xbmc/messaging/helpers/DialogOKHelper.h
+++ b/xbmc/messaging/helpers/DialogOKHelper.h
@@ -1,0 +1,76 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2015 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "utils/Variant.h"
+
+#include <array>
+#include <string>
+
+namespace KODI
+{
+namespace MESSAGING
+{
+namespace HELPERS
+{
+
+/*! \struct DialogOkMessage DialogHelper.h "messaging/helpers/DialogHelper.h"
+    \brief Payload sent for message TMSG_GUI_DIALOG_OK
+
+    \sa ShowOKDialogText
+    \sa ShowOKDialogLines
+*/
+struct DialogOKMessage
+{
+  CVariant heading; //!< Heading to be displayed in the dialog box
+  CVariant text;  //!< Body text to be displayed, this is mutually exclusive with lines below
+  std::array<CVariant, 3> lines;  //!< Body text to be displayed, specified as three lines. This is mutually exclusive with the text above
+};
+
+/*!
+  \brief This is a helper method to send a threadmessage to open a Ok dialog box
+
+  \param[in]  heading           The text to display as the dialog box header
+  \param[in]  text              The text to display in the dialog body
+  \return if it's confirmed
+  \sa ShowOKDialogLines
+  \sa CGUIDialogOK::ShowAndGetInput
+  \sa DialogOKMessage
+*/
+bool ShowOKDialogText(CVariant heading, CVariant text);
+
+/*!
+  \brief This is a helper method to send a threadmessage to open a OK dialog box
+  
+  \param[in]  heading           The text to display as the dialog box header
+  \param[in]  line0             The text to display on the first line
+  \param[in]  line1             The text to display on the second line
+  \param[in]  line2             The text to display on the third line
+  \return if it's confirmed
+  \sa ShowOKDialogText
+  \sa CGUIDialogOK::ShowAndGetInput
+  \sa DialogOKMessage
+*/
+bool ShowOKDialogLines(CVariant heading, CVariant line0, CVariant line1 = CVariant(),
+                                    CVariant line2 = CVariant());
+
+}
+}
+}

--- a/xbmc/messaging/helpers/DialogOKHelper.h
+++ b/xbmc/messaging/helpers/DialogOKHelper.h
@@ -42,6 +42,7 @@ struct DialogOKMessage
   CVariant heading; //!< Heading to be displayed in the dialog box
   CVariant text;  //!< Body text to be displayed, this is mutually exclusive with lines below
   std::array<CVariant, 3> lines;  //!< Body text to be displayed, specified as three lines. This is mutually exclusive with the text above
+  bool show = true; //!< bool to see if the dialog needs to be shown 
 };
 
 /*!
@@ -53,6 +54,16 @@ struct DialogOKMessage
   \sa ShowOKDialogLines
   \sa CGUIDialogOK::ShowAndGetInput
   \sa DialogOKMessage
+*/
+void UpdateOKDialogText(CVariant heading, CVariant text);
+
+/*!
+\brief This is a helper method to send a threadmessage to update a Ok dialog text
+\param[in]  heading           The text to display as the dialog box header
+\param[in]  text              The text to display in the dialog body
+\sa UpdateOKDialogLines
+\sa CGUIDialogOK::ShowAndGetInput
+\sa DialogOKMessage
 */
 bool ShowOKDialogText(CVariant heading, CVariant text);
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -30,7 +30,6 @@
 #include "Artist.h"
 #include "dbwrappers/dataset.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "FileItem.h"
@@ -44,6 +43,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/cddb.h"
 #include "network/Network.h"
@@ -3402,7 +3402,7 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
         pCdInfo->SetNoCDDBInfo();
         // ..no, an error occured, display it to the user
         std::string strErrorText = StringUtils::Format("[%d] %s", cddb.getLastError(), cddb.getLastErrorText());
-        CGUIDialogOK::ShowAndGetInput(CVariant{255}, CVariant{257}, CVariant{std::move(strErrorText)}, CVariant{0});
+        HELPERS::ShowOKDialogLines(CVariant{255}, CVariant{257}, CVariant{std::move(strErrorText)}, CVariant{0});
       }
     } // if ( !cddb.queryCDinfo( pCdInfo ) )
     else
@@ -3423,7 +3423,7 @@ void CMusicDatabase::DeleteCDDBInfo()
   CFileItemList items;
   if (!CDirectory::GetDirectory(CProfilesManager::GetInstance().GetCDDBFolder(), items, ".cddb", DIR_FLAG_NO_FILE_DIRS))
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{313}, CVariant{426});
+    HELPERS::ShowOKDialogText(CVariant{313}, CVariant{426});
     return ;
   }
   // Show a selectdialog that the user can select the album to delete
@@ -3494,7 +3494,7 @@ void CMusicDatabase::Clean()
   // other writing access to the database is prohibited.
   if (g_application.IsMusicScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
+    HELPERS::ShowOKDialogText(CVariant{189}, CVariant{14057});
     return;
   }
   
@@ -3508,7 +3508,7 @@ void CMusicDatabase::Clean()
 
       if (iReturnString != ERROR_OK)
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{313}, CVariant{iReturnString});
+        HELPERS::ShowOKDialogText(CVariant{313}, CVariant{iReturnString});
       }
     }
   }
@@ -6432,7 +6432,7 @@ void CMusicDatabase::ExportToXML(const std::string &xmlFile, bool singleFile, bo
     progress->Close();
 
   if (iFailCount > 0)
-    CGUIDialogOK::ShowAndGetInput(CVariant{20196}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
+    HELPERS::ShowOKDialogLines(CVariant{20196}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
 }
 
 void CMusicDatabase::ImportFromXML(const std::string &xmlFile)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -45,11 +45,11 @@
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "FileItem.h"
 #include "filesystem/File.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "storage/MediaManager.h"
 #include "settings/AdvancedSettings.h"
@@ -78,6 +78,7 @@ using namespace MUSICDATABASEDIRECTORY;
 using namespace PLAYLIST;
 using namespace MUSIC_GRABBER;
 using namespace MUSIC_INFO;
+using namespace KODI::MESSAGING;
 
 #define CONTROL_BTNVIEWASICONS  2
 #define CONTROL_BTNSORTBY       3
@@ -380,7 +381,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
 
       if (g_application.IsMusicScanning())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
+        HELPERS::ShowOKDialogText(CVariant{189}, CVariant{14057});
         break;
       }
 
@@ -397,7 +398,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
       CMusicInfoScanner scanner;
       if (scanner.UpdateDatabaseArtistInfo(artist, scraper, bShowInfo, m_dlgProgress) != INFO_ADDED)
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{21889}, CVariant{20199});
+        HELPERS::ShowOKDialogText(CVariant{21889}, CVariant{20199});
         break;
       }
     }
@@ -457,7 +458,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
 
       if (g_application.IsMusicScanning())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{189}, CVariant{14057});
+        HELPERS::ShowOKDialogText(CVariant{189}, CVariant{14057});
         if (m_dlgProgress)
           m_dlgProgress->Close();
         return false;
@@ -476,7 +477,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
       CMusicInfoScanner scanner;
       if (scanner.UpdateDatabaseAlbumInfo(album, scraper, bShowInfo, m_dlgProgress) != INFO_ADDED)
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{185}, CVariant{500});
+        HELPERS::ShowOKDialogText(CVariant{185}, CVariant{500});
         if (m_dlgProgress)
           m_dlgProgress->Close();
         return false;
@@ -688,7 +689,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
         // load it
         if (!pPlayList->Load(pItem->GetPath()))
         {
-          CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+          HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
           return; //hmmm unable to load playlist?
         }
 
@@ -964,7 +965,7 @@ void CGUIWindowMusicBase::OnRipCD()
 #endif
     }
     else
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{20099});
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{20099});
   }
 }
 
@@ -980,7 +981,7 @@ void CGUIWindowMusicBase::OnRipTrack(int iItem)
 #endif
     }
     else
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{20099});
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{20099});
   }
 }
 
@@ -1062,7 +1063,7 @@ void CGUIWindowMusicBase::LoadPlayList(const std::string& strPlayList)
     // load it
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+      HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
       return; //hmmm unable to load playlist?
     }
   }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -38,7 +38,6 @@
 #include "video/windows/GUIWindowVideoNav.h"
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "view/GUIViewState.h"
 #include "input/Key.h"
@@ -47,6 +46,7 @@
 #include "GUIUserMessages.h"
 #include "FileItem.h"
 #include "Application.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
@@ -854,7 +854,7 @@ bool CGUIWindowMusicNav::GetSongsFromPlayList(const std::string& strPlayList, CF
     // load it
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+      HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
       return false; //hmmm unable to load playlist?
     }
     CPlayList playlist = *pPlayList;

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -25,10 +25,10 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "network/Network.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
@@ -188,7 +188,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
     {
       if (!StartWebserver())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{33101}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{33101}, CVariant{33100});
         return false;
       }
     }
@@ -210,7 +210,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
       // cannot disable 
       if (IsAirPlayServerRunning() || IsAirTunesServerRunning())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{1259}, CVariant{34303});
+        HELPERS::ShowOKDialogText(CVariant{1259}, CVariant{34303});
         return false;
       }
 
@@ -230,7 +230,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
       // AirPlay needs zeroconf
       if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_ZEROCONF))
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{1273}, CVariant{34302});
+        HELPERS::ShowOKDialogText(CVariant{1273}, CVariant{34302});
         return false;
       }
 #endif //HAS_ZEROCONF
@@ -239,14 +239,14 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
 #ifdef HAS_AIRTUNES
       if (!StartAirTunesServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{1274}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{1274}, CVariant{33100});
         return false;
       }
 #endif //HAS_AIRTUNES
       
       if (!StartAirPlayServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{1273}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{1273}, CVariant{33100});
         return false;
       }      
     }
@@ -271,7 +271,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
     {
       if (!StartAirPlayServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{1273}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{1273}, CVariant{33100});
         return false;
       }
     }
@@ -353,7 +353,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
 #ifdef HAS_EVENT_SERVER
       if (!StartEventServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{33102}, CVariant{33100});
         result = false;
       }
 #endif // HAS_EVENT_SERVER
@@ -361,7 +361,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
 #ifdef HAS_JSONRPC
       if (!StartJSONRPCServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{33103}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{33103}, CVariant{33100});
         result = false;
       }
 #endif // HAS_JSONRPC
@@ -388,7 +388,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
 
     if (!StartEventServer())
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
+      HELPERS::ShowOKDialogText(CVariant{33102}, CVariant{33100});
       return false;
     }
 
@@ -408,7 +408,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
 
       if (!StartEventServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{33102}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{33102}, CVariant{33100});
         return false;
       }
     }
@@ -422,7 +422,7 @@ bool CNetworkServices::OnSettingChanging(std::shared_ptr<const CSetting> setting
 
       if (!StartJSONRPCServer())
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{33103}, CVariant{33100});
+        HELPERS::ShowOKDialogText(CVariant{33103}, CVariant{33100});
         return false;
       }
     }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -44,7 +44,6 @@
 #include "devices/PeripheralNyxboard.h"
 #include "devices/PeripheralTuner.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogPeripheralSettings.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "FileItem.h"
@@ -58,6 +57,7 @@
 #include "GUIUserMessages.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "messaging/ThreadMessage.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -77,6 +77,7 @@ using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 using namespace XFILE;
+using namespace KODI::MESSAGING;
 
 CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements) :
   m_announcements(announcements),
@@ -959,7 +960,7 @@ void CPeripherals::OnSettingAction(std::shared_ptr<const CSetting> setting)
         PeripheralPtr peripheral = GetByPath(pItem->GetPath());
         if (!peripheral || peripheral->GetSettings().empty())
         {
-          CGUIDialogOK::ShowAndGetInput(CVariant{35000}, CVariant{35004});
+          HELPERS::ShowOKDialogText(CVariant{35000}, CVariant{35004});
           continue;
         }
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -34,8 +34,8 @@
 #include "PictureInfoLoader.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogOK.h"
 #include "view/GUIViewState.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "settings/MediaSourceSettings.h"
@@ -60,6 +60,7 @@
 
 using namespace XFILE;
 using namespace PLAYLIST;
+using namespace KODI::MESSAGING;
 
 #define CONTROL_BTNSLIDESHOW   6
 #define CONTROL_BTNSLIDESHOW_RECURSIVE   7
@@ -548,7 +549,7 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
   {
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+      HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
       return ; //hmmm unable to load playlist?
     }
   }

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -32,7 +32,6 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "addons/Skin.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -26,7 +26,6 @@
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -46,6 +45,7 @@
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRChannelGuide.h"
@@ -309,14 +309,14 @@ namespace PVR
     CPVRTimerInfoTagPtr rule (bCreateRule ? CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer) : nullptr);
     if (timer || rule)
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19034}); // "Information", "There is already a timer set for this event"
+      HELPERS::ShowOKDialogText(CVariant{ 19033 }, CVariant{ 19034 }); // "Information", "There is already a timer set for this event"
       return false;
     }
 
     CPVRTimerInfoTagPtr newTimer(epgTag ? CPVRTimerInfoTag::CreateFromEpg(epgTag, bCreateRule) : CPVRTimerInfoTag::CreateInstantTimerTag(channel));
     if (!newTimer)
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033},
+      HELPERS::ShowOKDialogText(CVariant{19033},
                                     bCreateRule
                                       ? CVariant{19095} // "Information", "Timer rule creation failed. The PVR add-on does not support a suitable timer rule type."
                                       : CVariant{19094}); // "Information", "Timer creation failed. The PVR add-on does not support a suitable timer type."
@@ -337,19 +337,19 @@ namespace PVR
     if (!item->Channel() && item->GetTimerType() && !item->GetTimerType()->IsEpgBasedTimerRule())
     {
       CLog::Log(LOGERROR, "CPVRGUIActions - %s - no channel given", __FUNCTION__);
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19109}); // "Information", "Couldn't save timer. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19109}); // "Information", "Couldn't save timer. Check the log for more information about this message."
       return false;
     }
 
     if (!CServiceBroker::GetPVRManager().Clients()->GetClientCapabilities(item->m_iClientId).SupportsTimers())
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19215}); // "Information", "The PVR backend does not support timers."
+      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19215}); // "Information", "The PVR backend does not support timers."
       return false;
     }
 
     if (!item->IsTimerRule() && item->GetEpgInfoTag() && !item->GetEpgInfoTag()->IsRecordable())
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19189}); // "Information", "The PVR backend does not allow to record this event."
+      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19189}); // "Information", "The PVR backend does not allow to record this event."
       return false;
     }
 
@@ -587,7 +587,7 @@ namespace PVR
           bReturn = CServiceBroker::GetPVRManager().Timers()->AddTimer(newTimer);
 
         if (!bReturn)
-          CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19164}); // "Information", "Can't start recording. Check the log for more information about this message."
+          HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19164}); // "Information", "Can't start recording. Check the log for more information about this message."
       }
       else if (!bOnOff && channel->IsRecording())
       {
@@ -854,7 +854,7 @@ namespace PVR
 
     if (!AsyncRenameRecording(strNewName).Execute(item))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
       return false;
     }
 
@@ -871,7 +871,7 @@ namespace PVR
 
     if (!AsyncDeleteRecording().Execute(item))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
       return false;
     }
 
@@ -914,7 +914,7 @@ namespace PVR
 
     if (!AsyncUndeleteRecording().Execute(item))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{19111}); // "Error", "PVR backend error. Check the log for more information about this message."
       return false;
     }
 
@@ -1286,7 +1286,7 @@ namespace PVR
     /* no clients found */
     else if (!scanClient)
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033},  // "Information"
+      HELPERS::ShowOKDialogText(CVariant{19033},  // "Information"
                                     CVariant{19192}); // "None of the connected PVR backends supports scanning for channels."
       m_bChannelScanRunning = false;
       return false;
@@ -1299,7 +1299,7 @@ namespace PVR
 
     /* do the scan */
     if (scanClient->StartChannelScan() != PVR_ERROR_NO_ERROR)
-      CGUIDialogOK::ShowAndGetInput(CVariant{257},    // "Error"
+      HELPERS::ShowOKDialogText(CVariant{257},    // "Error"
                                     CVariant{19193}); // "The channel scan can't be started. Check the log for more information about this message."
 
     CLog::Log(LOGNOTICE, "CPVRGUIActions - %s - channel scan finished after %li.%li seconds",
@@ -1567,7 +1567,7 @@ namespace PVR
     if (!bValidPIN)
     {
       // display message: The entered PIN number was incorrect
-      CGUIDialogOK::ShowAndGetInput(CVariant{19264}, CVariant{19265}); // "Incorrect PIN", "The entered PIN was incorrect."
+      HELPERS::ShowOKDialogText(CVariant{19264}, CVariant{19265}); // "Incorrect PIN", "The entered PIN was incorrect."
     }
     else
     {

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -23,8 +23,8 @@
 #include <utility>
 
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -37,6 +37,7 @@
 #include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 CPVRChannelGroupInternal::CPVRChannelGroupInternal(bool bRadio) :
   m_iHiddenChannels(0)
@@ -166,7 +167,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const CPVRChannelPtr &channel)
   CPVRChannelPtr currentChannel(CServiceBroker::GetPVRManager().GetCurrentChannel());
   if (currentChannel && currentChannel == channel)
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{19098}, CVariant{19102});
+    HELPERS::ShowOKDialogText(CVariant{19098}, CVariant{19102});
     return false;
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -25,7 +25,6 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -34,6 +33,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
@@ -62,6 +62,7 @@
 #define BUTTON_RADIO_TV           34
 
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 CGUIDialogPVRChannelManager::CGUIDialogPVRChannelManager(void) :
     CGUIDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER, "DialogPVRChannelManager.xml"),
@@ -475,9 +476,9 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
     if (ret == PVR_ERROR_NO_ERROR)
       Update();
     else if (ret == PVR_ERROR_NOT_IMPLEMENTED)
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
+      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
     else
-      CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // "Add-on error", "Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029});  // "Add-on error", "Check the log for more information about this message."
   }
   return true;
 }
@@ -605,9 +606,9 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
   {
     PVR_ERROR ret = CServiceBroker::GetPVRManager().Clients()->OpenDialogChannelSettings(pItem->GetPVRChannelInfoTag());
     if (ret == PVR_ERROR_NOT_IMPLEMENTED)
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
+      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
     else if (ret != PVR_ERROR_NO_ERROR)
-      CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // "Add-on error", "Check the log for more information about this message."
+      HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029});  // "Add-on error", "Check the log for more information about this message."
   }
   else if (button == CONTEXT_BUTTON_DELETE)
   {
@@ -631,9 +632,9 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
         Renumber();
       }
       else if (ret == PVR_ERROR_NOT_IMPLEMENTED)
-        CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
+        HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19038}); // "Information", "Not supported by the PVR backend."
       else
-        CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // "Add-on error", "Check the log for more information about this message."
+        HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029});  // "Add-on error", "Check the log for more information about this message."
     }
   }
   return true;
@@ -735,7 +736,7 @@ void CGUIDialogPVRChannelManager::RenameChannel(const CFileItemPtr &pItem)
     channel->SetChannelName(strChannelName);
 
     if (!CServiceBroker::GetPVRManager().Clients()->RenameChannel(channel))
-      CGUIDialogOK::ShowAndGetInput(CVariant{2103}, CVariant{16029});  // Add-on error;Check the log file for details.
+      HELPERS::ShowOKDialogText(CVariant{2103}, CVariant{16029});  // Add-on error;Check the log file for details.
   }
 }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -22,19 +22,20 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "messaging/helpers//DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 
+using namespace KODI::MESSAGING;
 using namespace PVR;
 
 #define CONTROL_LIST_CHANNELS_LEFT    11
@@ -203,7 +204,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonUngroupedChannels(CGUIMessage &messa
     {
       if (m_channelGroups->GetFolderCount() == 0)
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19137});
+        HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19137});
       }
       else if (m_ungroupedChannels->GetFileCount() > 0)
       {

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -24,11 +24,11 @@
 
 #include "Application.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -82,7 +82,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
     if (!m_progItem || !m_progItem->HasChannel())
     {
       /* invalid channel */
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19067});
+      HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19067});
       Close();
       return bReturn;
     }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -21,8 +21,8 @@
 #include "PVRRecording.h"
 
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -38,6 +38,7 @@
 #include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 CPVRRecordingUid::CPVRRecordingUid(int iClientId, const std::string& strRecordingId) :
   m_iClientId(iClientId),

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -21,10 +21,11 @@
 #include "PVRTimerInfoTag.h"
 
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "guilib/LocalizeStrings.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
@@ -674,13 +675,13 @@ bool CPVRTimerInfoTag::UpdateOnClient()
 void CPVRTimerInfoTag::DisplayError(PVR_ERROR err) const
 {
   if (err == PVR_ERROR_SERVER_ERROR)
-    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19111}); /* print info dialog "Server error!" */
+    HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19111}); /* print info dialog "Server error!" */
   else if (err == PVR_ERROR_REJECTED)
-    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19109}); /* print info dialog "Couldn't save timer!" */
+    HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19109}); /* print info dialog "Couldn't save timer!" */
   else if (err == PVR_ERROR_ALREADY_PRESENT)
-    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19067}); /* print info dialog */
+    HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19067}); /* print info dialog */
   else
-    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19110}); /* print info dialog "Unknown error!" */
+    HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19110}); /* print info dialog "Unknown error!" */
 }
 
 int CPVRTimerInfoTag::ChannelNumber() const

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -24,13 +24,13 @@
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -255,7 +255,7 @@ bool CGUIWindowPVRBase::CanBeActivated() const
   // check if there is at least one enabled PVR add-on
   if (!ADDON::CAddonMgr::GetInstance().HasAddons(ADDON::ADDON_PVRDLL))
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{19296}, CVariant{19272}); // No PVR add-on enabled, You need a tuner, backend software...
+    HELPERS::ShowOKDialogText(CVariant{19296}, CVariant{19272}); // No PVR add-on enabled, You need a tuner, backend software...
     return false;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -21,11 +21,12 @@
 #include "GUIWindowPVRSearch.h"
 
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogBusy.h"
+#include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 
@@ -38,6 +39,7 @@
 #include "pvr/epg/EpgContainer.h"
 
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 namespace
 {
@@ -127,7 +129,7 @@ void CGUIWindowPVRSearchBase::OnPrepareFileItems(CFileItemList &items)
     AsyncSearchAction(&items, &m_searchfilter).Execute();
 
     if (items.IsEmpty())
-      CGUIDialogOK::ShowAndGetInput(CVariant{284}, // "No results found"
+      HELPERS::ShowOKDialogText(CVariant{284}, // "No results found"
                                     m_searchfilter.GetSearchTerm());
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -22,8 +22,8 @@
 
 #include "GUIInfoManager.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogOK.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
@@ -35,6 +35,7 @@
 #include "pvr/timers/PVRTimers.h"
 
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string &xmlFile) :
   CGUIWindowPVRBase(bRadio, id, xmlFile)
@@ -179,7 +180,7 @@ bool CGUIWindowPVRTimersBase::ActionShowTimer(const CFileItemPtr &item)
 {
   if (!CServiceBroker::GetPVRManager().Clients()->SupportsTimers())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19215}); // "Information", "The PVR backend does not support timers."
+    HELPERS::ShowOKDialogText(CVariant{19033}, CVariant{19215}); // "Information", "The PVR backend does not support timers."
     return false;
   }
 

--- a/xbmc/settings/DiscSettings.cpp
+++ b/xbmc/settings/DiscSettings.cpp
@@ -28,10 +28,12 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
-#include "dialogs/GUIDialogOK.h"
+#include "messaging/helpers/DialogOKHelper.h" 
 #include "utils/Variant.h"
 
 #include <libbluray/bluray-version.h>
+
+using namespace KODI::MESSAGING;
 
 CDiscSettings::CDiscSettings(void)
 {
@@ -77,7 +79,7 @@ void CDiscSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
         if (!info->libjvm_detected)
         {
           CLog::Log(LOGDEBUG, "DiscSettings - Could not load the java vm.");
-          CGUIDialogOK::ShowAndGetInput(CVariant{ 29803 }, CVariant{ 29804 });
+          HELPERS::ShowOKDialogText(CVariant{ 29803 }, CVariant{ 29804 });
         }
         CLog::Log(LOGDEBUG, "DiscSettings - Could not load the libbluray.jar.");
       }

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
@@ -24,7 +24,6 @@
 #include "Util.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "dialogs/GUIDialogTextViewer.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
@@ -32,6 +31,7 @@
 #include "guilib/GUIListContainer.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 
@@ -52,6 +52,7 @@
 #define LIST_OUTPUT_RESAMPLE                    4
 
 using namespace ActiveAE;
+using namespace KODI::MESSAGING;
 
 typedef struct
 {
@@ -641,7 +642,7 @@ bool CGUIDialogAudioDSPManager::OnContextButton(int itemNumber, CONTEXT_BUTTON b
   }
   else if (button == CONTEXT_BUTTON_SETTINGS)
   {
-    CGUIDialogOK::ShowAndGetInput(19033, 0, 15040, 0);
+    HELPERS::ShowOKDialogLines(CVariant{19033}, CVariant{0}, CVariant{15040}, CVariant{0});
   }
 
   return true;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -28,7 +28,6 @@
 #include "addons/settings/SettingUrlEncodedString.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogNumeric.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogSlider.h"
 #include "FileItem.h"

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -33,7 +33,6 @@
 #include "dbwrappers/dataset.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
@@ -47,6 +46,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/AdvancedSettings.h"
@@ -9324,7 +9324,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     progress->Close();
 
   if (iFailCount > 0)
-    CGUIDialogOK::ShowAndGetInput(CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
+    HELPERS::ShowOKDialogText(CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011).c_str(), iFailCount)});
 }
 
 void CVideoDatabase::ExportActorThumbs(const std::string &strDir, const CVideoInfoTag &tag, bool singleFiles, bool overwrite /*=false*/)

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -20,9 +20,8 @@
 
 #include "VideoInfoDownloader.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "dialogs/GUIDialogOK.h"
 #include "messaging/ApplicationMessenger.h"
-#include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
 
@@ -64,12 +63,7 @@ int CVideoInfoDownloader::InternalFindMovie(const std::string &strMovie,
 void CVideoInfoDownloader::ShowErrorDialog(const ADDON::CScraperError &sce)
 {
   if (!sce.Title().empty())
-  {
-    CGUIDialogOK *pdlg = g_windowManager.GetWindow<CGUIDialogOK>(WINDOW_DIALOG_OK);
-    pdlg->SetHeading(CVariant{sce.Title()});
-    pdlg->SetLine(0, CVariant{sce.Message()});
-    pdlg->Open();
-  }
+    HELPERS::ShowOKDialogText(CVariant{ sce.Title() }, CVariant{ sce.Message() });
 }
 
 // threaded functions

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -24,7 +24,6 @@
 
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "events/EventLog.h"
 #include "events/MediaLibraryEvent.h"
@@ -40,6 +39,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "NfoFile.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -2078,7 +2078,7 @@ namespace VIDEO
 
     if (pDialog)
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{20448}, CVariant{20449});
+      HELPERS::ShowOKDialogText(CVariant{20448}, CVariant{20449});
       return false;
     }
     return HELPERS::ShowYesNoDialogText(CVariant{20448}, CVariant{20450}) == DialogResponse::YES;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -34,7 +34,6 @@
 #include "video/VideoInfoTag.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogProgress.h"
@@ -57,6 +56,7 @@
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
 #include "utils/FileUtils.h"
 #include "utils/Variant.h"
+#include "messaging/helpers/DialogOKHelper.h"
 
 #include <iterator>
 
@@ -507,7 +507,7 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
   }
   else
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{194}, CVariant{284});
+    HELPERS::ShowOKDialogText(CVariant{194}, CVariant{284});
   }
 }
 
@@ -1150,7 +1150,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const CFileItemPtr &pItem)
   // dont allow update while scanning
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
     return false;
   }
 
@@ -1239,7 +1239,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
   // dont allow update while scanning
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
     return false;
   }
 
@@ -1884,7 +1884,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const CFileItemPtr &pItem)
   // dont allow update while scanning
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
+    HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
     return false;
   }
 

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -23,7 +23,6 @@
 #include "TextureDatabase.h"
 #include "addons/Scraper.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -31,12 +30,15 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "media/MediaType.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoDownloader.h"
 #include "video/VideoInfoScanner.h"
+
+using namespace KODI::MESSAGING;
 
 CVideoLibraryRefreshingJob::CVideoLibraryRefreshingJob(CFileItemPtr item, bool forceRefresh, bool refreshAll, bool ignoreNfo /* = false */, const std::string& searchTitle /* = "" */)
   : CVideoLibraryProgressJob(nullptr),
@@ -302,7 +304,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
       // check if the user cancelled
       if (!IsCancelled() && IsModal())
-        CGUIDialogOK::ShowAndGetInput(195, itemTitle);
+        HELPERS::ShowOKDialogText(CVariant{195}, CVariant{itemTitle});
 
       return false;
     }
@@ -327,7 +329,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
   } while (needsRefresh);
 
   if (failure && IsModal())
-    CGUIDialogOK::ShowAndGetInput(195, itemTitle);
+    HELPERS::ShowOKDialogText(CVariant{195}, CVariant{itemTitle});
 
   return true;
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -41,10 +41,10 @@
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "PartyModeManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "filesystem/Directory.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/PlayList.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
@@ -71,6 +71,7 @@ using namespace VIDEODATABASEDIRECTORY;
 using namespace VIDEO;
 using namespace ADDON;
 using namespace PVR;
+using namespace KODI::MESSAGING;
 
 #define CONTROL_BTNVIEWASICONS     2
 #define CONTROL_BTNSORTBY          3
@@ -242,7 +243,7 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
       // no video file in this folder
       if (!bFoundFile)
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{13346}, CVariant{20349});
+        HELPERS::ShowOKDialogText(CVariant{13346}, CVariant{20349});
         return;
       }
     }
@@ -390,7 +391,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
 
   if (g_application.IsVideoScanning())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{13346}, CVariant{14057});
+    HELPERS::ShowOKDialogText(CVariant{13346}, CVariant{14057});
     return false;
   }
   
@@ -522,7 +523,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
         // load it
         if (!pPlayList->Load(pItem->GetPath()))
         {
-          CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+          HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
           return; //hmmm unable to load playlist?
         }
 
@@ -1164,7 +1165,7 @@ void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList, int iPlay
     // load it
     if (!pPlayList->Load(strPlayList))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+      HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
       return; //hmmm unable to load playlist?
     }
   }
@@ -1400,7 +1401,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   m_database.Close();
 
   // done...
-  CGUIDialogOK::ShowAndGetInput(CVariant{20177}, CVariant{movie.m_strTitle},
+  HELPERS::ShowOKDialogLines(CVariant{20177}, CVariant{movie.m_strTitle},
                                 CVariant{StringUtils::Join(movie.m_genre, g_advancedSettings.m_videoItemSeparator)},
                                 CVariant{movie.GetUniqueID()});
 
@@ -1453,7 +1454,7 @@ void CGUIWindowVideoBase::OnSearch()
   }
   else
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{194}, CVariant{284});
+    HELPERS::ShowOKDialogText(CVariant{194}, CVariant{284});
   }
 }
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -29,7 +29,6 @@
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseFile.h"
 #include "view/GUIViewState.h"
-#include "dialogs/GUIDialogOK.h"
 #include "PartyModeManager.h"
 #include "music/MusicDatabase.h"
 #include "guilib/GUIWindowManager.h"
@@ -39,6 +38,7 @@
 #include "FileItem.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
@@ -1140,7 +1140,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
     }
     else
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{662});
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{662});
       return true;
     }	  
   }
@@ -1149,7 +1149,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
     // dont allow update while scanning
     if (g_application.IsVideoScanning())
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{257}, CVariant{14057});
+      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
       return true;
     }
 
@@ -1172,7 +1172,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
     if (!videodb.GetSingleValue("tag", "tag.tag_id", videodb.PrepareSQL("tag.name = '%s' AND tag.tag_id IN (SELECT tag_link.tag_id FROM tag_link WHERE tag_link.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
     {
       std::string strError = StringUtils::Format(g_localizeStrings.Get(20463).c_str(), strTag.c_str());
-      CGUIDialogOK::ShowAndGetInput(CVariant{20462}, CVariant{std::move(strError)});
+      HELPERS::ShowOKDialogText(CVariant{20462}, CVariant{std::move(strError)});
       return true;
     }
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -37,7 +37,6 @@
 #endif
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogMediaFilter.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "favourites/FavouritesService.h"
@@ -52,6 +51,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "network/Network.h"
 #include "playlists/PlayList.h"
 #include "profiles/ProfilesManager.h"
@@ -1117,7 +1117,7 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriv
   {
     if (!g_mediaManager.IsDiscInDrive(strPath))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{218}, CVariant{219});
+      HELPERS::ShowOKDialogText(CVariant{218}, CVariant{219});
       return false;
     }
   }
@@ -1126,7 +1126,7 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriv
     //! @todo Handle not connected to a remote share
     if ( !g_application.getNetwork().IsConnected() )
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{221});
+      HELPERS::ShowOKDialogText(CVariant{220}, CVariant{221});
       return false;
     }
   }
@@ -1152,7 +1152,7 @@ void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem) const
   else
     idMessageText = 15300; // Path not found or invalid
 
-  CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{idMessageText});
+  HELPERS::ShowOKDialogText(CVariant{220}, CVariant{idMessageText});
 }
 
 /*!

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -37,7 +37,6 @@
 #include "network/Network.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogProgress.h"
@@ -50,6 +49,7 @@
 #include "settings/Settings.h"
 #include "input/InputManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/JobManager.h"
@@ -615,7 +615,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
     {
       if (!pPlayList->Load(strPlayList))
       {
-        CGUIDialogOK::ShowAndGetInput(CVariant{6}, CVariant{477});
+        HELPERS::ShowOKDialogText(CVariant{6}, CVariant{477});
         return;
       }
     }
@@ -661,7 +661,7 @@ bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDri
   {
     if ( !g_mediaManager.IsDiscInDrive(strPath) )
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{218}, CVariant{219});
+      HELPERS::ShowOKDialogText(CVariant{218}, CVariant{219});
       int iList = GetFocusedList();
       int iItem = GetSelectedItem(iList);
       Update(iList, "");
@@ -674,7 +674,7 @@ bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDri
     //! @todo Handle not connected to a remote share
     if ( !g_application.getNetwork().IsConnected() )
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{221});
+      HELPERS::ShowOKDialogText(CVariant{220}, CVariant{221});
       return false;
     }
   }
@@ -1162,7 +1162,7 @@ void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob
   if(!success)
   {
     CFileOperationJob* fileJob = static_cast<CFileOperationJob*>(job);
-    CGUIDialogOK::ShowAndGetInput(CVariant{fileJob->GetHeading()},
+    HELPERS::ShowOKDialogLines(CVariant{fileJob->GetHeading()},
                                   CVariant{fileJob->GetLine()}, CVariant{16200}, CVariant{0});
   }
 
@@ -1187,7 +1187,7 @@ void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
   else
     idMessageText = 15300; // Path not found or invalid
 
-  CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{idMessageText});
+  HELPERS::ShowOKDialogText(CVariant{220}, CVariant{idMessageText});
 }
 
 void CGUIWindowFileManager::OnInitWindow()

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -31,7 +31,6 @@
 #include "addons/Skin.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "dialogs/GUIDialogContextMenu.h"
-#include "dialogs/GUIDialogOK.h"
 #include "favourites/FavouritesService.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
@@ -43,6 +42,7 @@
 #include "interfaces/json-rpc/JSONRPC.h"
 #endif
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogOKHelper.h"
 #include "network/Network.h"
 #include "PlayListPlayer.h"
 #include "profiles/Profile.h"
@@ -121,7 +121,7 @@ bool CGUIWindowLoginScreen::OnMessage(CGUIMessage& message)
           else
           {
             if (!bCanceled && iItem != 0)
-              CGUIDialogOK::ShowAndGetInput(CVariant{20068}, CVariant{20117});
+              HELPERS::ShowOKDialogText(CVariant{20068}, CVariant{20117});
           }
         }
       }

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -22,7 +22,7 @@
 
 #include <utility>
 
-#include "dialogs/GUIDialogOK.h"
+#include "guilib/WindowIDs.h"
 #include "GUIUserMessages.h"
 #include "LangInfo.h"
 #include "utils/StringUtils.h"


### PR DESCRIPTION
To untangle our code we want to get away from calling methods in guilib directly and go through ApplicationMessenger instead.

So we use ApplicationManager (through an helper method) to call CGUIDialogOK

@paxxi for review when you have time
I left the commits separated to separate the method creation from the long list of replaced calls
I left this one
https://github.com/xbmc/xbmc/blob/master/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
because I'm not sure what to do with it. I also don't think i can use this method in CApplication::OnMessage like I did right?

## Motivation and Context
Helps to untangle guilib dependencies

## How Has This Been Tested?
Tried to make appear an ok dialog

## Types of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
