### PR TITLE
[addon] use another way for__declspec and __cdecl on kodi_inputstream_types.h

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -20,8 +20,15 @@
  *
  */
 
+#ifdef TARGET_WINDOWS
+#include <windows.h>
+#else
 #ifndef __cdecl
 #define __cdecl
+#endif
+#ifndef __declspec
+#define __declspec(X)
+#endif
 #endif
 
 #ifdef BUILD_KODI_ADDON


### PR DESCRIPTION
Small part of my add-on system rework.

## Description
It add windows include to the kodi_inputstream_types.h, like on other headers.

## Motivation and Context
Is to reduce amount of commits on my rework, this is not critical and only to standardize to the other headers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
