### PR TITLE
[cmake] Fix issue with PLATFORM_OVERRIDE (on linux)

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -377,8 +377,8 @@
 		7C2612711825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
 		7C2612721825B6340086E04D /* DatabaseQuery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C26126F1825B6340086E04D /* DatabaseQuery.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
-		7C2ED53D1C7F7A9800C04032 /* ProcessInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2ED53B1C7F7A9800C04032 /* ProcessInfo.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
-		7C2ED53E1C7F7A9800C04032 /* ProcessInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2ED53B1C7F7A9800C04032 /* ProcessInfo.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE"; }; };
+		7C2ED53D1C7F7A9800C04032 /* ProcessInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2ED53B1C7F7A9800C04032 /* ProcessInfo.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE_VP_PROCESSINFO"; }; };
+		7C2ED53E1C7F7A9800C04032 /* ProcessInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2ED53B1C7F7A9800C04032 /* ProcessInfo.cpp */; settings = {COMPILER_FLAGS = "-DPLATFORM_OVERRIDE_VP_PROCESSINFO"; }; };
 		7C4458BD161E203800A905F6 /* Screenshot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C4458BB161E203800A905F6 /* Screenshot.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
 		7C4705AE12EF584C00369E51 /* AddonInstaller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C4705AC12EF584C00369E51 /* AddonInstaller.cpp */; };

--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -71,12 +71,10 @@ endif()
 
 # Build static libraries per directory
 if(NOT CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT CMAKE_GENERATOR STREQUAL Xcode)
-  set(STATIC_LIBS_DEFAULT ON)
+  set(ENABLE_STATIC_LIBS TRUE)
 else()
-  set(STATIC_LIBS_DEFAULT OFF)
+  set(ENABLE_STATIC_LIBS FALSE)
 endif()
-option(ENABLE_STATIC_LIBS "Build static libraries per directory" ${STATIC_LIBS_DEFAULT})
-unset(STATIC_LIBS_DEFAULT)
 
 core_find_git_rev(APP_SCMID FULL)
 core_find_versions()

--- a/xbmc/cores/VideoPlayer/Process/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Process/CMakeLists.txt
@@ -6,5 +6,5 @@ set(HEADERS ProcessInfo.h ${OVERRIDES_H})
 
 core_add_library(process)
 if(OVERRIDES_CPP)
-  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE)
+  target_compile_definitions(${CORE_LIBRARY} PRIVATE -DPLATFORM_OVERRIDE_VP_PROCESSINFO)
 endif()

--- a/xbmc/cores/VideoPlayer/Process/Makefile.in
+++ b/xbmc/cores/VideoPlayer/Process/Makefile.in
@@ -8,7 +8,7 @@ INCLUDES += -I@abs_top_srcdir@/xbmc/cores/VideoPlayer
 
 OVERRIDES = $(wildcard overrides/@CORE_SYSTEM_NAME@/*.cpp) $(wildcard overrides/@CORE_SYSTEM_VARIANT@/*.cpp)
 ifneq ($(strip $(OVERRIDES)),)
-  CXXFLAGS += -DPLATFORM_OVERRIDE
+  CXXFLAGS += -DPLATFORM_OVERRIDE_VP_PROCESSINFO
 endif
 
 SRCS  = ProcessInfo.cpp $(OVERRIDES)

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -24,7 +24,7 @@
 #include "threads/SingleLock.h"
 
 // Override for platform ports
-#if !defined(PLATFORM_OVERRIDE)
+#if !defined(PLATFORM_OVERRIDE_VP_PROCESSINFO)
 
 CProcessInfo* CProcessInfo::CreateInstance()
 {


### PR DESCRIPTION
## Description
An issue reported in the forum revieled a subtle issue in the platform overrides. 

The way our CMake build system works, we cannot specify defines on a per file level. Mainly because of the ENABLE_STATIC_LIBS option that is necessary to create nice Xcode/VS projects.
Therefore the PLATFORM_OVERRIDE define in `cores/VideoPlayer/ProcessInfo` overrides the one in `platform`. While this was not causing harm on OSX/iOS/Android where we have platform overrides for both, it causes an issue on Linux where `platform` uses the default implementation.

As agreed with @wsnipex, we remove the option to change ENABLE_STATIC_LIBS for users.

Reported in: http://forum.kodi.tv/showthread.php?tid=295948

## Motivation and Context
Fix.

## How Has This Been Tested?
Compile tested on linux.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed