### PR TITLE
[guiinfo][pvr] Fix LISTITEM_RESUMABLE to prefer recording info tag over video info tag, fire recordings updated event on playcount change"

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9741,12 +9741,12 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
     break;
   case LISTITEM_PLAYCOUNT:
     {
-      if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_playCount > 0)
+      if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag()->m_playCount > 0)
+        return StringUtils::Format("%i", item->GetPVRRecordingInfoTag()->m_playCount);
+      else if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_playCount > 0)
         return StringUtils::Format("%i", item->GetVideoInfoTag()->m_playCount);
       else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetPlayCount() > 0)
         return StringUtils::Format("%i", item->GetMusicInfoTag()->GetPlayCount());
-      else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag()->m_playCount > 0)
-        return StringUtils::Format("%i", item->GetPVRRecordingInfoTag()->m_playCount);
       break;
     }
   case LISTITEM_LASTPLAYED:
@@ -10719,7 +10719,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
   {
     if (item->IsFileItem())
     {
-      const CFileItem *pItem = (const CFileItem *)item;
+      const CFileItem *pItem = static_cast<const CFileItem *>(item);
       return pItem->IsParentFolder();
     }
   }
@@ -10727,10 +10727,11 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
   {
     if (item->IsFileItem())
     {
-      if (((const CFileItem *)item)->HasVideoInfoTag())
-        return ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.timeInSeconds > 0;
-      else if (((const CFileItem *)item)->HasPVRRecordingInfoTag())
-        return ((const CFileItem *)item)->GetPVRRecordingInfoTag()->m_resumePoint.timeInSeconds > 0;
+      const CFileItem *pItem = static_cast<const CFileItem *>(item);
+      if (pItem->HasPVRRecordingInfoTag())
+        return pItem->GetPVRRecordingInfoTag()->m_resumePoint.timeInSeconds > 0;
+      else if (pItem->HasVideoInfoTag())
+        return pItem->GetVideoInfoTag()->m_resumePoint.timeInSeconds > 0;
     }
   }
   else if (item->IsFileItem())

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -567,6 +567,8 @@ bool CPVRRecordings::ChangeRecordingsPlayCount(const CFileItemPtr &item, int cou
           m_database.SetPlayCount(*pItem, count);
       }
     }
+
+    g_PVRManager.PublishEvent(RecordingsInvalidated);
   }
 
   return bResult;


### PR DESCRIPTION
Some skins extend the recent recordings pvr widget by displaying the watched state of the recordings. This works quite well, but marking recordings watched / unwatched using the context menu of recordings in te recordings window will only be reflected by the widget after a restart of kodi, or in case of a partly watched recordings, never. This PR fixes this misbehavior.

The code change has been tested on macOS and Linux on latest Krypton master.

@Jalle19 for review?