### PR TITLE
[cmake] Allow building add-ons by regex match without bootstrapping f…

### DIFF
--- a/project/cmake/addons/bootstrap/Bootstrap.cmake
+++ b/project/cmake/addons/bootstrap/Bootstrap.cmake
@@ -27,8 +27,7 @@ foreach(ADDON_DEFINITION_FILE ${ADDON_DEFINITIONS})
     list(GET ADDON_DEFINITION 0 ADDON_ID)
 
     # check if the addon definition should be built
-    list(FIND ADDONS_TO_BUILD ${ADDON_ID} ADDONS_TO_BUILD_IDX)
-    if(ADDONS_TO_BUILD_IDX GREATER -1 OR "${ADDONS_TO_BUILD}" STREQUAL "all")
+    if(ADDON_ID MATCHES "^${ADDONS_TO_BUILD}" OR ADDONS_TO_BUILD STREQUAL all)
       # get the path to the addon definition directory
       get_filename_component(ADDON_DEFINITION_DIR ${ADDON_DEFINITION_FILE} DIRECTORY)
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
If we now try to build add-ons using a regex match (`cmake -DADDONS_TO_BUILD="pvr.*" ... ...`) without bootstrapping first, it presents us with a nice message:

>[100%] Completed 'binary-addons'
[100%] Built target binary-addons
CMake Error at CMakeLists.txt:220 (message):
  No addons available to be built

This change allows to build with regex match without bootstrapping first.

## Motivation and Context
I keep forgetting to bootstrap before executing `cmake -DADDONS_TO_BUILD="pvr.*" ... ...` add-on builds.

## How Has This Been Tested?
Build tested.
Bootstrap first: https://travis-ci.org/hudokkow/xbmc/builds/174487228
No bootstrap first: https://travis-ci.org/hudokkow/xbmc/builds/174487491

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

**Note:** `string(REPLACE ...` changes are unrelated and will disappear after https://github.com/xbmc/xbmc/pull/10900 goes in.