### PR TITLE
[iOS] Fix IsIosSandboxed

### DIFF
--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -504,6 +504,13 @@ bool CDarwinUtils::IsIosSandboxed(void)
       {
         ret = 1;
       }
+      
+      // Some time after ios8, Apple decided to change this yet again
+      if (strlen("/var/containers/Bundle/") < path_size &&
+        strncmp(given_path, "/var/containers/Bundle/", strlen("/var/containers/Bundle/")) == 0)
+      {
+        ret = 1;
+      }
     }
   }
   return ret == 1;


### PR DESCRIPTION
## Description
Some time after iOS 8 the executable path has changed and this breaks the IsIosSandboxed function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This not working causes the Kodi home folder to be placed in the Library folder on non-jailbroken devices which is inaccessible to iTunes file sharing.

## How Has This Been Tested?
This has not been tested since I am not in front of a Mac to compile it

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

