### PR TITLE
[PVR] Guide info dialog: fix record/add timer button visibility.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -29,6 +29,7 @@
 #include "utils/Variant.h"
 
 #include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/windows/GUIWindowPVRBase.h"
@@ -258,6 +259,8 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
   }
 
   bool bHideRecord(true);
+  bool bHideAddTimer(true);
+
   if (m_progItem->HasTimer())
   {
     if (m_progItem->Timer()->IsRecording())
@@ -270,16 +273,17 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
       SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 19060); /* Delete timer */
       bHideRecord = false;
     }
-
-    /* already has a timer. hide the add timer button */
-    SET_CONTROL_HIDDEN(CONTROL_BTN_ADD_TIMER);
   }
-  else if (m_progItem->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
+  else if (g_PVRClients->SupportsTimers() && m_progItem->EndAsLocalTime() > CDateTime::GetCurrentDateTime())
   {
     SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264);     /* Record */
     bHideRecord = false;
+    bHideAddTimer = false;
   }
 
   if (bHideRecord)
     SET_CONTROL_HIDDEN(CONTROL_BTN_RECORD);
+
+  if (bHideAddTimer)
+    SET_CONTROL_HIDDEN(CONTROL_BTN_ADD_TIMER);
 }


### PR DESCRIPTION
Before this PR, in the PVR guide info dialog, the timer-related buttons like "Record" and "Add timer" were visible even if not PVR backend with timer support was available. This PR fixes this misbehavior that the buttons in question are only visible if at least one pvr backend with timer support is available.

This fix was tested on Linux on latest Kodi master with pvr.octonet (which does not support timers).

@Jalle19 for review?