### PR TITLE
[PVR] Settings: change label and description to reflect that 'TV' is actually 'PVR & Live TV.'

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7541,12 +7541,12 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14204"
-msgid "TV"
+msgid "PVR & Live TV"
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14205"
-msgid "TV settings"
+msgid "PVR & Live TV settings"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -17117,12 +17117,12 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36201"
-msgid "Settings for PVR / Live TV."
+msgid "Settings for PVR & Live TV."
 msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36202"
-msgid "This category contains the general settings for the PVR / Live TV."
+msgid "This category contains the general settings for the PVR & Live TV."
 msgstr ""
 
 #: system/settings/settings.xml


### PR DESCRIPTION
We discussed this on slack some time ago, but somehow it got (partly) lost.

![screenshot002](https://cloud.githubusercontent.com/assets/3226626/20208164/908df4ca-a7ec-11e6-975f-624381d98118.png)
![screenshot003](https://cloud.githubusercontent.com/assets/3226626/20208163/908d4caa-a7ec-11e6-8872-0bde21e861f6.png)

@jjd-uk is this okay?