### PR TITLE
[cmake] Platform specific overrides

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -56,6 +56,53 @@ function(source_group_by_folder target)
   endif()
 endfunction()
 
+# Marks header file as being overridden on a certain list of platforms.
+#
+# Explicitly marking a file as overridden on specific platforms avoids issues with globbing where
+# CMake would have to be called manually when overriding for a new platform.
+#
+# Usage: add_platform_override(${PROJECT_NAME} settings.h PLATFORMS android linux osx)
+function(add_platform_override target filename)
+  cmake_parse_arguments(ARG "" "" "PLATFORMS" ${ARGN})
+  if(NOT ARG_PLATFORMS)
+    message(FATAL_ERROR "Missing parameter PLATFORMS")
+  endif()
+
+  # Generate an _override.h header that is either empty (platform doesn't define overrides)
+  # or includes the corresponding platform override header.
+  # This _override.h has to be included by the generic header.
+
+  # Determine filename of override header.
+  string(REPLACE ".h" "_override.h" override_file ${filename})
+
+  # Check if we have an override defined for this platform.
+  # TODO: Replace by if(IN_LIST) once we bump to CMake 3.3
+  if(";${ARG_PLATFORMS};" MATCHES ";${CORE_SYSTEM_NAME};")
+    message(STATUS "Override active for ${filename} on ${CORE_SYSTEM_NAME}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${override_file} "#include \"overrides/${CORE_SYSTEM_NAME}/${filename}\"")
+
+    # Add platform specific header to target sources (for IDEs)
+    target_sources(${target} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/overrides/${CORE_SYSTEM_NAME}/${filename})
+  else()
+    # Issue an error if a file exists but it's not listed in add_platform_override.
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/overrides/${CORE_SYSTEM_NAME}/${filename})
+      message(FATAL_ERROR "Disabled platform override file detected, add it to the 'add_platform_override' call.")
+    endif()
+
+    message(STATUS "Override disabled for ${filename}, using generic implementation")
+    string(CONCAT COMMENT "// No platform override defined for ${CORE_SYSTEM_NAME}. To add overrides:\n"
+                          "// Create '${CMAKE_CURRENT_SOURCE_DIR}/overrides/${CORE_SYSTEM_NAME}/${filename}' and redefine symbols from '${filename}'.\n"
+                          "// Then adapt '${CMAKE_CURRENT_LIST_FILE}' and add '${CORE_SYSTEM_NAME}' to the 'add_platform_override' call.")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${override_file} ${COMMENT})
+  endif()
+
+  # Add generated file to target sources (for IDEs)
+  target_sources(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${override_file})
+
+  # TODO: If we want to allow the usage of the header in others headers, change to PUBLIC
+  target_include_directories(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+endfunction()
+
 # Add sources to main application
 # Arguments:
 #   name name of the library to add

--- a/xbmc/cores/AudioEngine/AEDefines.h
+++ b/xbmc/cores/AudioEngine/AEDefines.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (C) 2010-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#define AE_AC3_ENCODE_BITRATE 640000
+#define AE_DTS_ENCODE_BITRATE 1411200
+
+// Enable platform specific overrides
+#include "AEDefines_override.h"

--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -133,6 +133,7 @@ if(CORE_SYSTEM_NAME STREQUAL freebsd)
 endif()
 
 core_add_library(audioengine)
+add_platform_override(${CORE_LIBRARY} AEDefines.h PLATFORMS android)
 target_include_directories(${CORE_LIBRARY} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)
   if(HAVE_SSE)

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -6,10 +6,9 @@
  *  See LICENSES/README.md for more information.
  */
 
-#define AC3_ENCODE_BITRATE 640000
-#define DTS_ENCODE_BITRATE 1411200
-
 #include "cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
+
+#include "cores/AudioEngine/AEDefines.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "ServiceBroker.h"
 #include "utils/log.h"
@@ -89,7 +88,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format, bool allow_planar_input
   {
     m_CodecName = "AC3";
     m_CodecID = AV_CODEC_ID_AC3;
-    m_BitRate = AC3_ENCODE_BITRATE;
+    m_BitRate = AE_AC3_ENCODE_BITRATE;
     codec = avcodec_find_encoder(m_CodecID);
   }
 

--- a/xbmc/cores/AudioEngine/overrides/android/AEDefines.h
+++ b/xbmc/cores/AudioEngine/overrides/android/AEDefines.h
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (C) 2010-2017 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+// Several Android TV devices only support 384 kbit/s as maximum
+#undef  AE_AC3_ENCODE_BITRATE
+#define AE_AC3_ENCODE_BITRATE 384000


### PR DESCRIPTION
This is a follow-up on the platform override discussions we had on slack and in the 2 predecessor PRs https://github.com/xbmc/xbmc/pull/10912 and https://github.com/xbmc/xbmc/pull/10909.

I've worked on a couple of minimal examples for different options in a local branch: https://github.com/xbmc/xbmc/compare/master...fetzerch:platform_settings, then discussed with @FernetMenta and implemented to most promising one (option5) for the concrete AE usecase.

Nothing set in stone yet, comments on both, this - or any of the 4 other options in my branch are still highly appreciated.

The last commit is just for easier testing on linux, you can revert the changes to locally switch between override and no override.

My notes might be useful for easier understanding what happens:
![unbenannt](https://cloud.githubusercontent.com/assets/1133994/20237745/1a0c3600-a8db-11e6-94ea-3fbf56bb815a.PNG)

Some more notes and the requirements for this are accessible at: https://drive.google.com/open?id=1E1P2SWELCtUpJxHFeDf0TGi_H6xge-Co2rhCdJN-c4M