### PR TITLE
Fix 100% cpu usage after a while while scanning for peripheral events

### DIFF
--- a/xbmc/peripherals/EventScanRate.cpp
+++ b/xbmc/peripherals/EventScanRate.cpp
@@ -24,7 +24,7 @@
 
 using namespace PERIPHERALS;
 
-CEventRateHandle::CEventRateHandle(float RateHz, IEventRateCallback* callback) :
+CEventRateHandle::CEventRateHandle(double RateHz, IEventRateCallback* callback) :
   m_rateHz(RateHz),
   m_callback(callback)
 {

--- a/xbmc/peripherals/EventScanRate.h
+++ b/xbmc/peripherals/EventScanRate.h
@@ -46,14 +46,14 @@ namespace PERIPHERALS
   class CEventRateHandle
   {
   public:
-    CEventRateHandle(float rateHz, IEventRateCallback* callback);
+    CEventRateHandle(double rateHz, IEventRateCallback* callback);
 
     ~CEventRateHandle(void) { }
 
     /*!
      * \brief Get the rate this handle represents
      */
-    float GetRateHz(void) const { return m_rateHz; }
+    double GetRateHz(void) const { return m_rateHz; }
 
     /*!
      * \brief Release the handle
@@ -61,7 +61,7 @@ namespace PERIPHERALS
     void Release(void);
 
   private:
-    const float               m_rateHz;
+    const double              m_rateHz;
     IEventRateCallback* const m_callback;
   };
 }

--- a/xbmc/peripherals/EventScanner.cpp
+++ b/xbmc/peripherals/EventScanner.cpp
@@ -49,16 +49,16 @@ void CEventScanner::Stop(void)
   StopThread(true);
 }
 
-EventRateHandle CEventScanner::SetRate(float rateHz)
+EventRateHandle CEventScanner::SetRate(double rateHz)
 {
   CSingleLock lock(m_mutex);
 
-  const float oldRate = GetRateHz();
+  const double oldRate = GetRateHz();
 
   EventRateHandle handle = EventRateHandle(new CEventRateHandle(rateHz, this));
   m_handles.push_back(handle);
 
-  const float newRate = GetRateHz();
+  const double newRate = GetRateHz();
 
   CLog::Log(LOGDEBUG, "PERIPHERALS: Event sampling rate set from %.2f to %.2f", oldRate, newRate);
 
@@ -69,7 +69,7 @@ void CEventScanner::Release(CEventRateHandle* handle)
 {
   CSingleLock lock(m_mutex);
 
-  const float oldRate = GetRateHz();
+  const double oldRate = GetRateHz();
 
   m_handles.erase(std::remove_if(m_handles.begin(), m_handles.end(),
     [handle](const EventRateHandle& myHandle)
@@ -77,14 +77,14 @@ void CEventScanner::Release(CEventRateHandle* handle)
       return handle == myHandle.get();
     }), m_handles.end());
 
-  const float newRate = GetRateHz();
+  const double newRate = GetRateHz();
 
   CLog::Log(LOGDEBUG, "PERIPHERALS: Event sampling rate set from %.2f to %.2f", oldRate, newRate);
 }
 
 void CEventScanner::Process(void)
 {
-  float nextScanMs = static_cast<float>(SystemClockMillis());
+  double nextScanMs = static_cast<double>(SystemClockMillis());
 
   while (!m_bStop)
   {
@@ -92,8 +92,8 @@ void CEventScanner::Process(void)
 
     m_callback->ProcessEvents();
 
-    const float nowMs = static_cast<float>(SystemClockMillis());
-    const float scanIntervalMs = GetScanIntervalMs();
+    const double nowMs = static_cast<double>(SystemClockMillis());
+    const double scanIntervalMs = GetScanIntervalMs();
 
     while (nextScanMs <= nowMs)
       nextScanMs += scanIntervalMs;
@@ -105,11 +105,11 @@ void CEventScanner::Process(void)
   }
 }
 
-float CEventScanner::GetRateHz(void) const
+double CEventScanner::GetRateHz(void) const
 {
   CSingleLock lock(m_mutex);
 
-  float scanRateHz = 0.0f;
+  double scanRateHz = 0.0;
 
   for (const EventRateHandle& handle : m_handles)
   {
@@ -117,7 +117,7 @@ float CEventScanner::GetRateHz(void) const
       scanRateHz = handle->GetRateHz();
   }
 
-  if (scanRateHz == 0.0f)
+  if (scanRateHz == 0.0)
     scanRateHz = DEFAULT_SCAN_RATE_HZ;
 
   return scanRateHz;

--- a/xbmc/peripherals/EventScanner.cpp
+++ b/xbmc/peripherals/EventScanner.cpp
@@ -95,6 +95,10 @@ void CEventScanner::Process(void)
     const double nowMs = static_cast<double>(SystemClockMillis());
     const double scanIntervalMs = GetScanIntervalMs();
 
+    // Handle wrap-around
+    if (nowMs < nextScanMs)
+      nextScanMs = nowMs;
+
     while (nextScanMs <= nowMs)
       nextScanMs += scanIntervalMs;
 

--- a/xbmc/peripherals/EventScanner.h
+++ b/xbmc/peripherals/EventScanner.h
@@ -57,7 +57,7 @@ namespace PERIPHERALS
     void Start(void);
     void Stop(void);
 
-    EventRateHandle SetRate(float rateHz);
+    EventRateHandle SetRate(double rateHz);
 
     // implementation of IEventRateCallback
     virtual void Release(CEventRateHandle* handle) override;
@@ -67,8 +67,8 @@ namespace PERIPHERALS
     virtual void Process(void) override;
 
   private:
-    float GetRateHz(void) const;
-    float GetScanIntervalMs(void) const { return 1000.0f / GetRateHz(); }
+    double GetRateHz(void) const;
+    double GetScanIntervalMs(void) const { return 1000.0 / GetRateHz(); }
 
     IEventScannerCallback* const m_callback;
     std::vector<EventRateHandle> m_handles;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -213,7 +213,7 @@ namespace PERIPHERALS
      * @brief rateHz The rate in Hz
      * @return A handle that unsets its rate when expired
      */
-    EventRateHandle SetEventScanRate(float rateHz) { return m_eventScanner.SetRate(rateHz); }
+    EventRateHandle SetEventScanRate(double rateHz) { return m_eventScanner.SetRate(rateHz); }
 
     /*!
      * 


### PR DESCRIPTION
When float is large enough, small increments no longer increase it. nextScanMs becomes stuck at a large value and scanIntervalMs will not change it.

After a little over 6 days, nextScanMs becomes  536870912.0f ms, after which adding the scan interval (16.66666f ms) no longer has effect.

Broken out from #10630