### PR TITLE
Use DRM as a fallback if not on X11 for VAAPI

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -125,7 +125,6 @@ struct CVaapiConfig
   VADisplay dpy;
   VAProfile profile;
   VAConfigAttrib attrib;
-  Display *x11dsp;
   CProcessInfo *processInfo;
 };
 
@@ -378,7 +377,6 @@ public:
   static bool EnsureContext(CVAAPIContext **ctx, CDecoder *decoder);
   void Release(CDecoder *decoder);
   VADisplay GetDisplay();
-  Display* GetX11Display();
   bool SupportsProfile(VAProfile profile);
   VAConfigAttrib GetAttrib(VAProfile profile);
   VAConfigID CreateConfig(VAProfile profile, VAConfigAttrib attrib);
@@ -386,14 +384,15 @@ public:
 private:
   CVAAPIContext();
   void Close();
+  void SetVaDisplayForSystem();
   bool CreateContext();
   void DestroyContext();
   void QueryCaps();
   bool CheckSuccess(VAStatus status);
   bool IsValidDecoder(CDecoder *decoder);
+  void SetValidDRMVaDisplayFromRenderNode();
   static CVAAPIContext *m_context;
   static CCriticalSection m_section;
-  static Display *m_X11dpy;
   VADisplay m_display;
   int m_refCount;
   int m_attributeCount;
@@ -401,6 +400,10 @@ private:
   int m_profileCount;
   VAProfile *m_profiles;
   std::vector<CDecoder*> m_decoders;
+  int m_renderNodeFD{-1};
+#ifdef HAVE_X11
+  static Display *m_X11dpy;
+#endif
 };
 
 /**


### PR DESCRIPTION
Use DRM in VAAPI as a fallback if X11 is not present.

## Description
If we are not on the X11 windowing system lets fall back to using DRM for VAAPI. Which will use vaGetDisplayDRM using render nodes. This requires opening any device in /dev/dri/renderD<num>.

## Motivation and Context
This will allow hardware acceleration in other display servers that use DRM/EGL such as mir (and most likely wayland, untested).

## How Has This Been Tested?
This has been tested on X11 and my Mir branch here: https://github.com/xbmc/xbmc/pull/10898 on ubuntu 16.10 (yakkety)

This change does require at lease a kernel >= 3.15.

## Screenshots (if appropriate):
http://i.imgur.com/OGtB2W7.jpg (x11)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

