### PR TITLE
Fix unable to open controller dialog if all controllers are unplugged

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16056,7 +16056,19 @@ msgctxt "#35016"
 msgid "Axis %d"
 msgstr ""
 
-#empty strings from id 35017 to 35048
+#. Error dialog title when the controller dialog is opened but peripheral add-ons are disabled
+#: xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+msgctxt "#35017"
+msgid "Unable to configure controllers"
+msgstr ""
+
+#. Error dialog text when the controller dialog is opened but peripheral add-ons are disabled
+#: xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+msgctxt "#35018"
+msgid "Controller configuration depends on a disabled add-on. Would you like to enable it?"
+msgstr ""
+
+#empty strings from id 35019 to 35048
 
 #. Name of game add-ons category
 #: xbmc/filesystem/AddonsDirectory.cpp
@@ -16092,17 +16104,7 @@ msgctxt "#35055"
 msgid "Use the keyboard or remote to select a controller profile. When prompted, press the button on your game controller that best matches what you see on the screen. If you make a mistake you can repeat the process."
 msgstr ""
 
-#. Title of error dialog shown when no joystick add-ons provide button mapping
-#: xbmc/games/controllers/windows/GUIControllerWindow.cpp
-msgctxt "#35056"
-msgid "Joystick support not found"
-msgstr ""
-
-#. Text of error dialog shown when no joystick add-ons provide button mapping
-#: xbmc/games/controllers/windows/GUIControllerWindow.cpp
-msgctxt "#35057"
-msgid "Controller configuration is disabled. Install the proper joystick support add-on."
-msgstr ""
+#empty strings from id 35056 to 35057
 
 #. Title of controller configuration window
 #: addons/skin.estuary/1080i/DialogGameControllers.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2622,9 +2622,6 @@
         </setting>
         <setting id="input.controllerconfig" type="action" label="35063" help="35064">
           <level>0</level>
-          <dependencies>
-            <dependency type="enable" on="property" name="SupportsPeripheralControllers" />
-          </dependencies>
           <control type="button" format="action" />
         </setting>
         <setting id="input.testrumble" type="action" label="35051" help="35052">
@@ -2637,9 +2634,6 @@
         <setting id="input.controllerpoweroff" type="boolean" label="35088" help="35089">
           <level>0</level>
           <default>false</default>
-          <dependencies>
-            <dependency type="enable" on="property" name="SupportsPeripheralControllers" />
-          </dependencies>
           <control type="toggle" />
         </setting>
       </group>

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -225,23 +225,9 @@ void CGUIControllerWindow::OnInitWindow(void)
   CGUIMessage msgFocus(GUI_MSG_SETFOCUS, GetID(), CONTROL_CONTROLLER_BUTTONS_START);
   OnMessage(msgFocus);
 
-  // Check for button mapping support
-  //! @todo remove this
-  PeripheralBusAddonPtr bus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  if (bus && !bus->HasFeature(FEATURE_JOYSTICK))
-  {
-    //! @todo Move the XML implementation of button map storage from add-on to
-    //! Kodi while keeping support for add-on button-mapping
-
-    CLog::Log(LOGERROR, "Joystick support not found");
-
-    // "Joystick support not found"
-    // "Controller configuration is disabled. Install the proper joystick support add-on."
-    CGUIDialogOK::ShowAndGetInput(CVariant{35056}, CVariant{35057});
-
-    // close the window as there's nothing that can be done
-    Close();
-  }
+  // Enable button mapping support
+  if (!g_peripherals.GetInstance().EnableButtonMapping())
+    CLog::Log(LOGDEBUG, "Joystick support not found");
 
   // FIXME: not thread safe
 //  ADDON::CRepositoryUpdater::GetInstance().Events().Subscribe(this, &CGUIControllerWindow::OnEvent);

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -767,6 +767,22 @@ void CPeripherals::ProcessEvents(void)
     bus->ProcessEvents();
 }
 
+bool CPeripherals::EnableButtonMapping()
+{
+  bool bEnabled = false;
+
+  std::vector<PeripheralBusPtr> busses;
+  {
+    CSingleLock lock(m_critSectionBusses);
+    busses = m_busses;
+  }
+
+  for (PeripheralBusPtr& bus : busses)
+    bEnabled |= bus->EnableButtonMapping();
+
+  return bEnabled;
+}
+
 PeripheralAddonPtr CPeripherals::GetAddonWithButtonMap(const CPeripheral* device)
 {
   PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(GetBusByType(PERIPHERAL_BUS_ADDON));

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -238,6 +238,19 @@ namespace PERIPHERALS
     // implementation of IEventScannerCallback
     virtual void ProcessEvents(void) override;
 
+    /*!
+     * \brief Initialize button mapping
+     *
+     * This command enables button mapping on all busses. Button maps allow
+     * connect events from the driver to the higher-level features used by
+     * controller profiles.
+     *
+     * If user input is required, a blocking dialog may be shown.
+     *
+     * \return True if button mapping is enabled for at least one bus
+     */
+    bool EnableButtonMapping();
+
     PeripheralAddonPtr GetAddonWithButtonMap(const CPeripheral* device);
 
     void ResetButtonMaps(const std::string& controllerId);

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -251,11 +251,37 @@ namespace PERIPHERALS
      */
     bool EnableButtonMapping();
 
+    /*!
+     * \brief Get an add-on that can provide button maps for a device
+     * \return An add-on that provides button maps, or empty if no add-on is found
+     */
     PeripheralAddonPtr GetAddonWithButtonMap(const CPeripheral* device);
 
+    /*!
+     * \brief Reset all button maps to the defaults for all devices and the given controller
+     * \param controllerId The controller profile to reset
+     * @todo Add a device parameter to allow resetting button maps per-device
+     */
     void ResetButtonMaps(const std::string& controllerId);
 
+    /*!
+     * \brief Register a button mapper interface
+     * \param mapper The button mapper
+     *
+     * Clients implementing the IButtonMapper interface call
+     * \ref CPeripherals::RegisterJoystickButtonMapper to register themselves
+     * as eligible for button mapping commands.
+     *
+     * When registering the mapper is forwarded to all peripherals. See
+     * \ref CPeripheral::RegisterJoystickButtonMapper for what is done to the
+     * mapper after being given to the peripheral.
+     */
     void RegisterJoystickButtonMapper(JOYSTICK::IButtonMapper* mapper);
+
+    /*!
+     * \brief Unregister a button mapper interface
+     * \param mapper The button mapper
+     */
     void UnregisterJoystickButtonMapper(JOYSTICK::IButtonMapper* mapper);
 
     virtual void OnSettingChanged(const CSetting *setting) override;

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -161,6 +161,12 @@ namespace PERIPHERALS
      */
     virtual void ProcessEvents(void) { }
 
+    /*!
+    * \brief Initialize button mapping
+    * \return True if button mapping is enabled for this bus
+    */
+    virtual bool EnableButtonMapping() { return false; }
+
   protected:
     virtual void Process(void);
     virtual bool ScanForDevices(void);
@@ -185,4 +191,5 @@ namespace PERIPHERALS
     CEvent                     m_triggerEvent;
   };
   using PeripheralBusPtr = std::shared_ptr<CPeripheralBus>;
+  using PeripheralBusVector = std::vector<PeripheralBusPtr>;
 }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -48,6 +48,11 @@ namespace PERIPHERALS
     bool GetAddon(const std::string &strId, ADDON::AddonPtr &addon) const;
 
     /*!
+    * \brief Get peripheral add-on that can provide button maps
+    */
+    bool GetAddonWithButtonMap(PeripheralAddonPtr &addon) const;
+
+    /*!
      * \brief Get peripheral add-on that can provide button maps for the given device
      */
     bool GetAddonWithButtonMap(const CPeripheral* device, PeripheralAddonPtr &addon) const;
@@ -82,6 +87,7 @@ namespace PERIPHERALS
     virtual size_t       GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const override;
     virtual void         GetDirectory(const std::string &strPath, CFileItemList &items) const override;
     virtual void         ProcessEvents(void) override;
+    virtual bool         EnableButtonMapping() override;
 
     // implementation of IAddonMgrCallback
     bool RequestRestart(ADDON::AddonPtr addon, bool datachanged) override;
@@ -96,6 +102,8 @@ namespace PERIPHERALS
 
   private:
     void OnEvent(const ADDON::AddonEvent& event);
+
+    bool PromptEnableAddons(const ADDON::VECADDONS& disabledAddons);
 
     PeripheralAddonVector m_addons;
     PeripheralAddonVector m_failedAddons;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -80,14 +80,6 @@ bool HasPeripherals(const std::string &condition, const std::string &value, cons
   return PERIPHERALS::g_peripherals.GetNumberOfPeripherals() > 0;
 }
 
-bool SupportsPeripheralControllers(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
-{
-  using namespace PERIPHERALS;
-
-  PeripheralBusAddonPtr bus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
-  return bus && bus->HasFeature(FEATURE_JOYSTICK);
-}
-
 bool HasRumbleFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
   using namespace PERIPHERALS;
@@ -354,7 +346,6 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("checkmasterlock",               CheckMasterLock));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("checkpvrparentalpin",           CheckPVRParentalPin));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasperipherals",                HasPeripherals));
-  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("supportsperipheralcontrollers", SupportsPeripheralControllers));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblefeature",              HasRumbleFeature));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isfullscreen",                  IsFullscreen));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ismasteruser",                  IsMasterUser));


### PR DESCRIPTION
While testing, I've become aware of something: there are endless quirks in real life hardware, which means that inevitably the button mapper will get messed up.

Sometimes, things can get so bad that simply connecting the controller causes erratic behavior. In this case, the user's only hope is to unplug the controller, open the controller dialog, start the mapping (or ignoring) process, and then plug in the controller to capture the erratic input. However, if all controllers are disconnected, the user can't open the configuration dialog.

This change removes the constraint that controllers must be connected to open the controller dialog. Also, as there's no check done for add-ons anymore, we ensure that add-ons are enabled so that button mapping is possible when the dialog opens.

## Motivation and Context
Better UX

## Screenshots (if appropriate):
![unable to configure controllers](https://cloud.githubusercontent.com/assets/531482/20243299/c9b00c78-a906-11e6-8473-72103df6674a.png)


## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Broken out from #10630