### PR TITLE
Correction issue on Android TV when intent usage

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -858,10 +858,8 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
   std::string action = intent.getAction();
   if (action == "android.intent.action.VIEW")
   {
-    CFileItem* fileitem = new CFileItem(GetFilenameFromIntent(intent));
-    fileitem->SetPath(GetFilenameFromIntent(intent));
-
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PLAY, 1, 0, static_cast<void*>(fileitem));
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PLAY, 1, 0, static_cast<void*>(
+                                                 new CFileItem(GetFilenameFromIntent(intent), false)));
   }
 }
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -858,8 +858,10 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
   std::string action = intent.getAction();
   if (action == "android.intent.action.VIEW")
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PLAY, 1, 0, static_cast<void*>(
-                                         new CFileItem(GetFilenameFromIntent(intent))));
+    CFileItem* fileitem = new CFileItem(GetFilenameFromIntent(intent));
+    fileitem->SetPath(GetFilenameFromIntent(intent));
+
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_PLAY, 1, 0, static_cast<void*>(fileitem));
   }
 }
 


### PR DESCRIPTION
Correct issue when two intents are run one after the other

## Description
The function onNewIntent don't set the path of fileitem. So, When the second intent is run, kodi try to play video but it have not the path.

## Motivation and Context
I'm writting an android Tv plugin to provide recommendation. 
To run kodi, i use intent. 
For the first played video, it's work fine. But the second video just open kodi.

## How Has This Been Tested?
My change is test on android TV (shield TV). 
Now, when I play my second video, kodi start fine.

## Screenshots (if appropriate):

## Types of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed