### PR TITLE
[guilib] modify container.refresh to reset any container

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -473,6 +473,12 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
       }
       return true;
     }
+    else if (message.GetMessage() == GUI_MSG_REFRESH_CONTAINER)
+    {
+      Reset();
+      m_listProvider->Reset(true);
+      UpdateListProvider(true);
+    }
   }
   return CGUIControl::OnMessage(message);
 }

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -161,6 +161,11 @@
  */
 #define GUI_MSG_UI_READY       49
 
+/*!
+ \brief A request to refresh a container's list content
+ */
+#define GUI_MSG_REFRESH_CONTAINER 50
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
@@ -59,10 +59,8 @@ static int ChangeViewMode(const std::vector<std::string>& params)
  *  \details params[0] = The URL to refresh window at.
  */
 static int Refresh(const std::vector<std::string>& params)
-{ // NOTE: These messages require a media window, thus they're sent to the current activewindow.
-  //       This shouldn't stop a dialog intercepting it though.
-  CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE, 1); // 1 to reset the history
-  message.SetStringParam(!params.empty() ? params[0] : "");
+{
+  CGUIMessage message(GUI_MSG_REFRESH_CONTAINER, g_windowManager.GetActiveWindow(), atoi(params[0].c_str()), NULL, 10);
   g_windowManager.SendMessage(message);
 
   return 0;
@@ -111,8 +109,9 @@ static int ToggleSortDirection(const std::vector<std::string>& params)
 static int Update(const std::vector<std::string>& params)
 {
   CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE, 0);
-  message.SetStringParam(params[0]);
-  if (params.size() > 1 && StringUtils::EqualsNoCase(params[1], "replace"))
+  message.SetStringParam(!params.empty() ? params[0] : "");
+  if ((params.size() > 1 && StringUtils::EqualsNoCase(params[1], "replace"))
+      || params.empty())
     message.SetParam2(1); // reset the history
   g_windowManager.SendMessage(message);
 
@@ -190,7 +189,7 @@ CBuiltins::CommandMap CGUIContainerBuiltins::GetOperations() const
            {"container.nextviewmode",       {"Move to the next view type (and refresh the listing)", 0, ChangeViewMode<1>}},
            {"container.previoussortmethod", {"Change to the previous sort method", 0, ChangeSortMethod<-1>}},
            {"container.previousviewmode",   {"Move to the previous view type (and refresh the listing)", 0, ChangeViewMode<-1>}},
-           {"container.refresh",            {"Refresh current listing", 0, Refresh}},
+           {"container.refresh",            {"Refresh current listing of given container", 1, Refresh}},
            {"container.setsortdirection",   {"Toggle the sort direction", 0, ToggleSortDirection}},
            {"container.setsortmethod",      {"Change to the specified sort method", 1, SetSortMethod}},
            {"container.setviewmode",        {"Move to the view with the given id", 1, SetViewMode}},


### PR DESCRIPTION
## Description
```Container.Refresh```  and ```Container.Update``` are basically the same. They send the same message, only ```Container.Refresh``` resets the history by default. This merges those two message, so that if you send ```Container.Update``` without parameters it does the same as previously ```Container.Refresh```. Add the ```replace``` parameter to get the same results as previously ```Container.Refresh(path)```.
That only works in media windows and for the main container.
This PR adds a new message that resets the dynamic content container so it will be refreshed.
```Container.Refresh(ID)```
## Motivation and Context
EDIT:
See #10931 for solution for stalled dynamic content lists.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Code is based on https://github.com/Black09/xbmc/commit/3e31795addaaa3bc37e184ba68db887f7db6c013

@phil65 @ronie @HitcherUK 