### PR TITLE
Remove duplicate saving of album type to xml

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -531,7 +531,6 @@ bool CAlbum::Save(TiXmlNode *node, const std::string &tag, const std::string& st
   XMLUtils::SetString(album,        "type", strType);
   XMLUtils::SetString(album, "releasedate", m_strDateOfRelease);
   XMLUtils::SetString(album,       "label", strLabel);
-  XMLUtils::SetString(album,        "type", strType);
   if (!thumbURL.m_xml.empty())
   {
     CXBMCTinyXML doc;


### PR DESCRIPTION
Album type is saved to xml twice - probably a merging error sometime. Remove the duplicate line.