### PR TITLE
[PVR] Fix recordings url encoding.

### DIFF
--- a/addons/skin.estuary/1080i/MyPVRRecordings.xml
+++ b/addons/skin.estuary/1080i/MyPVRRecordings.xml
@@ -251,7 +251,7 @@
 						<top>60</top>
 						<visible>ListItem.IsFolder + !ListItem.IsParentFolder</visible>
 						<include content="InfoList">
-							<param name="path" value="$INFO[ListItem.Path]/$INFO[ListItem.Label]" />
+							<param name="path" value="$INFO[ListItem.FilenameAndPath]" />
 							<param name="height" value="362" />
 							<param name="width" value="560" />
 							<param name="font" value="font12" />

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -104,7 +104,7 @@ void CPVRRecordings::GetSubDirectories(const CPVRRecordingsPath &recParentPath, 
     if (current->IsRadio() != bRadio)
       continue;
 
-    const std::string strCurrent = recParentPath.GetSubDirectoryPath(current->m_strDirectory);
+    const std::string strCurrent(recParentPath.GetUnescapedSubDirectoryPath(current->m_strDirectory));
     if (strCurrent.empty())
       continue;
 
@@ -296,7 +296,7 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
   {
     // Get the directory structure if in non-flatten mode
     // Deleted view is always flatten. So only for an active view
-    std::string strDirectory(recPath.GetDirectoryPath());
+    std::string strDirectory(recPath.GetUnescapedDirectoryPath());
     if (!recPath.IsDeleted() && bGrouped)
       GetSubDirectories(recPath, &items);
 

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -52,8 +52,8 @@ namespace PVR
     bool IsDeleted() const { return !IsActive(); }
     bool IsRadio() const { return m_bRadio; }
     bool IsTV() const { return !IsRadio(); }
-    std::string GetDirectoryPath() const { return m_directoryPath; }
-    std::string GetSubDirectoryPath(const std::string &strPath) const;
+    std::string GetUnescapedDirectoryPath() const;
+    std::string GetUnescapedSubDirectoryPath(const std::string &strPath) const;
 
     const std::string GetTitle() const;
     void AppendSegment(const std::string &strSegment);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -245,7 +245,7 @@ void CGUIWindowPVRRecordings::UpdateButtons(void)
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowDeletedRecordings ? g_localizeStrings.Get(19179) : ""); /* Deleted recordings trash */
 
   const CPVRRecordingsPath path(m_vecItems->GetPath());
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, bGroupRecordings && path.IsValid() ? path.GetDirectoryPath() : "");
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, bGroupRecordings && path.IsValid() ? path.GetUnescapedDirectoryPath() : "");
 }
 
 bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)


### PR DESCRIPTION
Regression introduced by #10438 => 5ba26b9c21c665310d3ce0424958069f29f26b99

If a recording folder name contained "?", the children of this folder were never displayed.

This PR fixes this bug.

Changes were runtime tested on macOS, latest kodi master.

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/20284206/7caa285c-aabc-11e6-9828-ef1efc979da6.png)
![screenshot001](https://cloud.githubusercontent.com/assets/3226626/20284207/7cac9aba-aabc-11e6-8469-6dcc170cf4a1.png)

@Jalle19 for code review?
@fetzerch fyi, maybe you can runtime test.