### PR TITLE
[listprovider] Make sure content is always loaded. Fixes #16635

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -322,6 +322,8 @@ void CDirectoryProvider::Reset(bool immediately /* = false */)
   if (m_jobID)
     CJobManager::GetInstance().CancelJob(m_jobID);
   m_jobID = 0;
+  // Make sure job is always fired on start
+  m_updateState = INVALIDATED;
   // reset only if this is going to be destructed
   if (immediately)
   {


### PR DESCRIPTION
## Description
Set begin state to ```INVALIDATED``` so that dynamic content always gets fetched when the list is loaded, even if content attributes haven't changed. 

## Motivation and Context
See http://trac.kodi.tv/ticket/16635 for full details.
One side effect of previous behaviour was that a list that had not changed it seemed to load very fast on window load. But in fact that was old content, so could potentially be out of date. Behaviour in this PR is the correct way imo.
## How Has This Been Tested?
Runtime tested

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@phil65 @ronie @HitcherUK 