### PR TITLE
Follow HTTP redirect to UDP stream

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -177,7 +177,7 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
       return new CDVDInputStreamFFmpeg(finalFileitem);
 
     if (URIUtils::IsProtocol(finalFileitem.GetPath(), "udp"))
-      return CreateInputStream(pPlayer, finalFileitem, scanforextaudio);
+      return new CDVDInputStreamFFmpeg(finalFileitem);
   }
 
   // our file interface handles all these types of streams

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -175,6 +175,9 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
 
     if (finalFileitem.GetMimeType() == "application/vnd.apple.mpegurl")
       return new CDVDInputStreamFFmpeg(finalFileitem);
+
+    if (URIUtils::IsProtocol(finalFileitem.GetPath(), "udp"))
+      return CreateInputStream(pPlayer, finalFileitem, scanforextaudio);
   }
 
   // our file interface handles all these types of streams


### PR DESCRIPTION
Modify the CDVDFactoryInputStream to follow an HTTP redirect to a UDP stream (eg: UDP://:5000).

## Description
Modify the CDVDFactoryInputStream to follow an HTTP redirect to a UDP stream (eg: UDP://:5000). This is useful for services that allow the client to initiate video transfer via http, but deliver it over UDP.

## Motivation and Context
Would allow better frontend development of devices such as the classic HDHomeRun.

## How Has This Been Tested?
Setup a simple IPTV provider (available at https://github.com/micahg/hdhrlive) and test.

Tested in ubuntu linux.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed