### PR TITLE
[estuary] fix missing texture log error

### DIFF
--- a/addons/skin.estuary/1080i/DialogExtendedProgressBar.xml
+++ b/addons/skin.estuary/1080i/DialogExtendedProgressBar.xml
@@ -25,7 +25,7 @@
 					<top>-11</top>
 					<width>100</width>
 					<height>100</height>
-					<texture>dialogs/volume/progress/p$INFO[Control.GetLabel(32)].png</texture>
+					<texture>$INFO[Control.GetLabel(32),dialogs/volume/progress/p,.png]</texture>
 					<animation effect="fade" end="50" time="0" condition="true">Conditional</animation>
 				</control>
 				<control type="image">

--- a/addons/skin.estuary/1080i/DialogSubtitles.xml
+++ b/addons/skin.estuary/1080i/DialogSubtitles.xml
@@ -107,7 +107,7 @@
 						<top>5</top>
 						<width>50</width>
 						<height>50</height>
-						<texture>windows/subtitles/flags/$INFO[ListItem.Thumb].png</texture>
+						<texture>$INFO[ListItem.Thumb,windows/subtitles/flags/,.png]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -151,7 +151,7 @@
 						<top>10</top>
 						<width>100</width>
 						<height>45</height>
-						<texture fallback="flags/starrating/rating0.png">flags/starrating/rating$INFO[ListItem.ActualIcon].png</texture>
+						<texture fallback="flags/starrating/rating0.png">$INFO[ListItem.ActualIcon,flags/starrating/rating,.png]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 				</itemlayout>
@@ -177,7 +177,7 @@
 						<top>5</top>
 						<width>50</width>
 						<height>50</height>
-						<texture>windows/subtitles/flags/$INFO[ListItem.Thumb].png</texture>
+						<texture>$INFO[ListItem.Thumb,windows/subtitles/flags/,.png]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -221,7 +221,7 @@
 						<top>10</top>
 						<width>100</width>
 						<height>45</height>
-						<texture fallback="flags/starrating/rating0.png">flags/starrating/rating$INFO[ListItem.ActualIcon].png</texture>
+						<texture fallback="flags/starrating/rating0.png">$INFO[ListItem.ActualIcon,flags/starrating/rating,.png]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 				</focusedlayout>

--- a/addons/skin.estuary/1080i/DialogVolumeBar.xml
+++ b/addons/skin.estuary/1080i/DialogVolumeBar.xml
@@ -33,7 +33,7 @@
 				<top>-11</top>
 				<width>100</width>
 				<height>100</height>
-				<texture>dialogs/volume/progress/p$INFO[Control.GetLabel(20)].png</texture>
+				<texture>$INFO[Control.GetLabel(20),dialogs/volume/progress/p,.png]</texture>
 				<animation effect="fade" start="100" end="0" delay="300" time="500" tween="sine" condition="Player.Muted">Conditional</animation>
 			</control>
 			<control type="image">

--- a/addons/skin.estuary/1080i/Includes.xml
+++ b/addons/skin.estuary/1080i/Includes.xml
@@ -973,7 +973,7 @@
 			<height>50</height>
 			<fadetime>300</fadetime>
 			<aspectratio align="left">keep</aspectratio>
-			<texture colordiffuse="button_focus">weather/small/$INFO[Weather.FanartCode].png</texture>
+			<texture colordiffuse="button_focus">$INFO[Weather.FanartCode,weather/small/,.png]</texture>
 			<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEqual(Weather.FanartCode,na) + String.Contains(Weather.Conditions,/)]</visible>
 		</control>
 	</include>

--- a/addons/skin.estuary/1080i/MusicVisualisation.xml
+++ b/addons/skin.estuary/1080i/MusicVisualisation.xml
@@ -131,7 +131,7 @@
 					<top>1022</top>
 					<width>256</width>
 					<height>65</height>
-					<texture>flags/starrating/$INFO[MusicPlayer.UserRating].png</texture>
+					<texture>$INFO[MusicPlayer.UserRating,flags/starrating/,.png]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 			</control>

--- a/addons/skin.estuary/1080i/Variables.xml
+++ b/addons/skin.estuary/1080i/Variables.xml
@@ -50,7 +50,7 @@
 	</variable>
 	<variable name="GlobalFanartVar">
 		<value condition="Skin.HasSetting(use_custom_bg) + !String.IsEmpty(Skin.String(custom_background))">$INFO[Skin.String(custom_background)]</value>
-		<value>special://skin/extras/backgrounds/$INFO[Skin.CurrentColourTheme].jpg</value>
+		<value>$INFO[Skin.CurrentColourTheme,special://skin/extras/backgrounds/,.jpg]</value>
 	</variable>
 	<variable name="FullScreenInfoTextBoxVar">
 		<value condition="Control.HasFocus(5552)">$INFO[VideoPlayer.Duration,$LOCALIZE[180]: [B],[/B][CR]]</value>

--- a/addons/skin.estuary/1080i/VideoFullScreen.xml
+++ b/addons/skin.estuary/1080i/VideoFullScreen.xml
@@ -57,7 +57,7 @@
 				<top>440</top>
 				<width>200</width>
 				<height>200</height>
-				<texture colordiffuse="button_focus">dialogs/volume/progress/p$INFO[Player.CacheLevel].png</texture>
+				<texture colordiffuse="button_focus">$INFO[Player.CacheLevel,dialogs/volume/progress/p,.png]</texture>
 			</control>
 			<control type="label" id="1">
 				<description>buffering value</description>


### PR DESCRIPTION
use info,prefix,postfix formatting for images to get rid of missing texture errors in the log when info returns empty.

```11:21:02.549 T:139697911798080   ERROR: CGUITextureManager::GetTexturePath: could not find texture 'flags/starrating/.png'```

@phil65 