### PR TITLE
[estuary] fix lost focus in mediasource dialog

### DIFF
--- a/addons/skin.estuary/1080i/DialogMediaSource.xml
+++ b/addons/skin.estuary/1080i/DialogMediaSource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol>10</defaultcontrol>
+	<defaultcontrol always="true">10</defaultcontrol>
 	<coordinates>
 		<left>360</left>
 		<top>150</top>


### PR DESCRIPTION
fixes: http://forum.kodi.tv/showthread.php?tid=262373&pid=2442043#pid2442043

without this kodi remembers the last focused position in this dialog, which would usually be the 'ok button'
but this button is disabled (and can't be focused) if you open the dialog again to add another source.

@phil65 