### PR TITLE
[jenkins] fix windows depends build if master branch is used

### DIFF
--- a/tools/buildsteps/win32/buildhelpers.sh
+++ b/tools/buildsteps/win32/buildhelpers.sh
@@ -136,11 +136,11 @@ do_loaddeps() {
   VERSION=$(grep "VERSION=" $file | sed 's/VERSION=//g;s/#.*$//g;/^$/d')
   GNUTLS_VER=$(grep "GNUTLS_VER=" $file | sed 's/GNUTLS_VER=//g;s/#.*$//g;/^$/d')
   GITREV=$(git ls-remote $BASE_URL $VERSION | awk '{print $1}')
+  BASE_URL=$BASE_URL/archive
   if [[ -z "$GITREV" ]]; then
     ARCHIVE=$LIBNAME-$(echo "${VERSION}" | sed 's/\//-/g').tar.gz
   else
     ARCHIVE=$LIBNAME-$GITREV.tar.gz
-    BASE_URL=$BASE_URL/archive
   fi
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
This fix a build with the jenkins way if the master branch is used.

## Description
If master branch, becomes the wrong URL used to download the source.

As example becomes this error generated:
```bash
libdvdread-master.tar.gz ..................................... [Downloading]
--2016-11-15 20:56:41--  https://github.com/xbmc/libdvdread/master.tar.gz
Resolving github.com (github.com)... 192.30.253.112, 192.30.253.113
Connecting to github.com (github.com)|192.30.253.112|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2016-11-15 20:56:41 ERROR 404: Not Found.

libdvdread-master.tar.gz ...................................... [Extracting]
.tar: This does not look like a tar archive

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

It must be `https://github.com/xbmc/libdvdread/archive/master.tar.gz`!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

