### PR TITLE
[jenkins] allow override of cpu build threads on locally used systems

### DIFF
--- a/tools/buildsteps/win32/buildhelpers.sh
+++ b/tools/buildsteps/win32/buildhelpers.sh
@@ -4,17 +4,23 @@ MAKEFLAGS="$1"
 BGPROCESSFILE="$2"
 tools="$3"
 
-cpuCount=1
-if [ $NUMBER_OF_PROCESSORS > 1 ]; then
-  if [ $NUMBER_OF_PROCESSORS > 4 ]; then
-    cpuCount=6
-  else
-    cpuCount=`expr $NUMBER_OF_PROCESSORS + $NUMBER_OF_PROCESSORS / 2`
+if [[ -z $BUILDTHREADS ]]; then
+  cpuCount=1
+  if [ $NUMBER_OF_PROCESSORS > 1 ]; then
+    if [ $NUMBER_OF_PROCESSORS > 4 ]; then
+      cpuCount=6
+    else
+      cpuCount=`expr $NUMBER_OF_PROCESSORS + $NUMBER_OF_PROCESSORS / 2`
+    fi
   fi
+  if [[ ! $cpuCount =~ ^[0-9]+$ ]]; then
+    cpuCount="$(($(nproc)/2))"
+  fi
+else
+  cpuCount=$BUILDTHREADS
 fi
-if [[ ! $cpuCount =~ ^[0-9]+$ ]]; then
-  cpuCount="$(($(nproc)/2))"
-fi
+
+echo "Amount of cpu build jobs $([[ -z $BUILDTHREADS ]] && echo "calculated by system check" || echo "defined by global variable"): '$cpuCount'"
 
 if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)


### PR DESCRIPTION
Hack fix for ffmpeg build problems

## Description
This is to fix jenkins build failures on local systems with override the on script generated cpu jobs count.

## Motivation and Context
On ffmpeg itself is a failure to build with multi threads. It want to generate the libraries but still are parts missing to compile.

Here the error:
```
STRIP   libavcodec/x86/vp9itxfm.o
STRIP   libswresample/x86/audio_convert.o
LD      libavutil/avutil-55.dll
.sed -e "s/ @[^ ]*//" libavutil/avutil-55.orig.def > libavutil/avutil-55.def; lib.exe /machine:i386 /def:libavutil/avutil-55.def /out:libavutil/avutil.lib
Microsoft (R) Library Manager Version 14.00.24215.1
Copyright (C) Microsoft Corporation.  All rights reserved.

   Bibliothek "libavutil/avutil.lib" und Objekt "libavutil/avutil.exp" werden erstellt.
LD      libswscale/swscale-4.dll
LD      libpostproc/postproc-54.dll
LD      libswresample/swresample-2.dll
sed -e "s/ @[^ ]*//" libpostproc/postproc-54.orig.def > libpostproc/postproc-54.def; lib.exe /machine:i386 /def:libpostproc/postproc-54.def /out:libpostproc/postproc.lib
sed -e "s/ @[^ ]*//" libswresample/swresample-2.orig.def > libswresample/swresample-2.def; lib.exe /machine:i386 /def:libswresample/swresample-2.def /out:libswresample/swresample.lib
sed -e "s/ @[^ ]*//" libswscale/swscale-4.orig.def > libswscale/swscale-4.def; lib.exe /machine:i386 /def:libswscale/swscale-4.def /out:libswscale/swscale.lib
Microsoft (R) Library Manager Version 14.00.24215.1
Copyright (C) Microsoft Corporation.  All rights reserved.

   Bibliothek "libpostproc/postproc.lib" und Objekt "libpostproc/postproc.exp" werden erstellt.
Microsoft (R) Library Manager Version 14.00.24215.1
Copyright (C) Microsoft Corporation.  All rights reserved.

Microsoft (R) Library Manager Version 14.00.24215.1
Copyright (C) Microsoft Corporation.  All rights reserved.

   Bibliothek "libswresample/swresample.lib" und Objekt "libswresample/swresample.exp" werden erstellt.
   Bibliothek "libswscale/swscale.lib" und Objekt "libswscale/swscale.exp" werden erstellt.
LD      libavcodec/avcodec-57.dll
gcc.exe: error: libavcodec/x86/lossless_audiodsp.o: No such file or directory
gcc.exe: error: libavcodec/x86/videodsp.o: No such file or directory
library.mak:99: recipe for target 'libavcodec/avcodec-57.dll' failed
make: *** [libavcodec/avcodec-57.dll] Error 1
...YASM libavcodec/x86/lossless_audiodsp.o
STRIP   libavcodec/x86/lossless_audiodsp.o
YASM    libavcodec/x86/videodsp.o
STRIP   libavcodec/x86/videodsp.o
LD      libavcodec/avcodec-57.dll
libavcodec/x86/lossless_audiodsp.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x0): multiple definition of `ff_scalarproduct_and_madd_int16_mmxext'
libavcodec/x86/imdct36.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x0): first defined here
libavcodec/x86/lossless_audiodsp.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x80): multiple definition of `ff_scalarproduct_and_madd_int16_sse2'
libavcodec/x86/imdct36.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x80): first defined here
libavcodec/x86/lossless_audiodsp.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x120): multiple definition of `ff_scalarproduct_and_madd_int32_sse4'
libavcodec/x86/imdct36.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x120): first defined here
libavcodec/x86/lossless_audiodsp.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x1b0): multiple definition of `ff_scalarproduct_and_madd_int16_ssse3'
libavcodec/x86/imdct36.o:libavcodec/x86/lossless_audiodsp.asm:(.text+0x1b0): first defined here
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0xad): undefined reference to `ff_four_imdct36_float_avx'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x14c): undefined reference to `ff_imdct36_float_avx'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x23d): undefined reference to `ff_four_imdct36_float_sse'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x2dc): undefined reference to `ff_imdct36_float_ssse3'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x3cd): undefined reference to `ff_four_imdct36_float_sse'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x46c): undefined reference to `ff_imdct36_float_sse3'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x55d): undefined reference to `ff_four_imdct36_float_sse'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x5fc): undefined reference to `ff_imdct36_float_sse2'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x6ed): undefined reference to `ff_four_imdct36_float_sse'
libavcodec/x86/mpegaudiodsp.o:mpegaudiodsp.c:(.text+0x78c): undefined reference to `ff_imdct36_float_sse'
collect2.exe: error: ld returned 1 exit status
library.mak:99: recipe for target 'libavcodec/avcodec-57.dll' failed
make: *** [libavcodec/avcodec-57.dll] Error 1
ffmpeg-3.1.5-Krypton-Beta5-1 (32bit) ................................ [Done]
cp: cannot stat ‘/xbmc/lib/win32/ffmpeg/bin/*.dll’: No such file or directory
failed to compile /xbmc/system/avcodec-57.dll

exiting msys environment
failed to build mingw libs
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

