### PR TITLE
aml: Do not force default output device for passtrough

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -538,7 +538,6 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
   if (aml_present())
   {
     aml_set_audio_passthrough(m_passthrough);
-    device = "default";
   }
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description
<!--- Describe your change in detail -->
Patch removes forcing default ALSA device for audio passthrough on Amlogic. The change affects only Amlogic targets.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
In Krypton a/v sync no longer breaks USB audio on Amlogic. We should allow audio passthrough for these devices as well.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested in LE on S805 and S905 targets.
## Screenshots (if appropriate):
N/A
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

This fixes passthrough using USB sound cards.