### PR TITLE
aml: Support for 4K H264 on S905X

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1499,7 +1499,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   am_private->video_format      = codecid_to_vformat(hints.codec);
   if ((am_private->video_format == VFORMAT_H264)
     && (hints.width > 1920 || hints.height > 1088)
-    && (aml_support_h264_4k2k() == 1))
+    && (aml_support_h264_4k2k() == AML_HAS_H264_4K2K))
   {
     am_private->video_format = VFORMAT_H264_4K2K;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1497,10 +1497,11 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     am_private->video_rotation_degree = 3;
   // handle extradata
   am_private->video_format      = codecid_to_vformat(hints.codec);
-  if (am_private->video_format == VFORMAT_H264) {
-      if (hints.width > 1920 || hints.height > 1088) {
-        am_private->video_format = VFORMAT_H264_4K2K;
-      }
+  if ((am_private->video_format == VFORMAT_H264)
+    && (hints.width > 1920 || hints.height > 1088)
+    && (aml_support_h264_4k2k() == 1))
+  {
+    am_private->video_format = VFORMAT_H264_4K2K;
   }
   switch (am_private->video_format)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -113,7 +113,7 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
         case FF_PROFILE_H264_CAVLC_444:
           return false;
       }
-      if ((!aml_support_h264_4k2k()) && ((m_hints.width > 1920) || (m_hints.height > 1088)))
+      if ((aml_support_h264_4k2k() == AML_NO_H264_4K2K) && ((m_hints.width > 1920) || (m_hints.height > 1088)))
       {
         // 4K is supported only on Amlogic S802/S812 chip
         return false;

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -216,7 +216,7 @@ bool aml_support_hevc_10bit()
   return (has_hevc_10bit == 1);
 }
 
-bool aml_support_h264_4k2k()
+int aml_support_h264_4k2k()
 {
   static int has_h264_4k2k = -1;
 
@@ -224,12 +224,15 @@ bool aml_support_h264_4k2k()
   {
     std::string valstr;
     if (SysfsUtils::GetString("/sys/class/amstream/vcodec_profile", valstr) != 0)
-    {
-      return false;
-    }
-    return (valstr.find("h264_4k2k:") != std::string::npos);
+      has_h264_4k2k = 0;
+    else if (valstr.find("h264:4k") != std::string::npos)
+      has_h264_4k2k = 2;
+    else if (valstr.find("h264_4k2k:") != std::string::npos)
+      has_h264_4k2k = 1;
+    else
+      has_h264_4k2k = 0;
   }
-  return (has_h264_4k2k == 1);
+  return has_h264_4k2k;
 }
 
 void aml_set_audio_passthrough(bool passthrough)

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -216,21 +216,21 @@ bool aml_support_hevc_10bit()
   return (has_hevc_10bit == 1);
 }
 
-int aml_support_h264_4k2k()
+AML_SUPPORT_H264_4K2K aml_support_h264_4k2k()
 {
-  static int has_h264_4k2k = -1;
+  static AML_SUPPORT_H264_4K2K has_h264_4k2k = AML_SUPPORT_H264_4K2K_UNINIT;
 
-  if (has_h264_4k2k == -1)
+  if (has_h264_4k2k == AML_SUPPORT_H264_4K2K_UNINIT)
   {
     std::string valstr;
     if (SysfsUtils::GetString("/sys/class/amstream/vcodec_profile", valstr) != 0)
-      has_h264_4k2k = 0;
+      has_h264_4k2k = AML_NO_H264_4K2K;
     else if (valstr.find("h264:4k") != std::string::npos)
-      has_h264_4k2k = 2;
+      has_h264_4k2k = AML_HAS_H264_4K2K_SAME_PROFILE;
     else if (valstr.find("h264_4k2k:") != std::string::npos)
-      has_h264_4k2k = 1;
+      has_h264_4k2k = AML_HAS_H264_4K2K;
     else
-      has_h264_4k2k = 0;
+      has_h264_4k2k = AML_NO_H264_4K2K;
   }
   return has_h264_4k2k;
 }

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -48,7 +48,7 @@ bool aml_wired_present();
 bool aml_support_hevc();
 bool aml_support_hevc_4k2k();
 bool aml_support_hevc_10bit();
-bool aml_support_h264_4k2k();
+int  aml_support_h264_4k2k();
 void aml_set_audio_passthrough(bool passthrough);
 bool aml_IsHdmiConnected();
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -41,6 +41,14 @@ enum AML_DISPLAY_AXIS_PARAM
   AML_DISPLAY_AXIS_PARAM_HEIGHT
 };
 
+enum AML_SUPPORT_H264_4K2K
+{
+  AML_SUPPORT_H264_4K2K_UNINIT = -1,
+  AML_NO_H264_4K2K,
+  AML_HAS_H264_4K2K,
+  AML_HAS_H264_4K2K_SAME_PROFILE
+};
+
 bool aml_present();
 bool aml_permissions();
 bool aml_hw3d_present();
@@ -48,7 +56,7 @@ bool aml_wired_present();
 bool aml_support_hevc();
 bool aml_support_hevc_4k2k();
 bool aml_support_hevc_10bit();
-int  aml_support_h264_4k2k();
+AML_SUPPORT_H264_4K2K aml_support_h264_4k2k();
 void aml_set_audio_passthrough(bool passthrough);
 bool aml_IsHdmiConnected();
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Patch fixes 4K H264 playback on Amlogic S905X.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
S905X (and possibly newer chips) need to use VFORMAT_H264 for 4K decoding instead of VFORMAT_H264_4K2K. We can determine which one to use by probing vcodec_profile:

S905:
```
h264:;
h264_4k2k:;
```

S905X:
```
h264:4k;
h264_4k2k:;
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested in Kodi Jarvis and Kodi Krypton for S805, S905 and S905X in LibreELEC.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed