### PR TITLE
[curl] cleanup multi handle in proper order

### DIFF
--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -152,12 +152,12 @@ void DllLibCurlGlobal::CheckIdle()
     {
       CLog::Log(LOGINFO, "%s - Closing session to %s://%s (easy=%p, multi=%p)\n", __FUNCTION__, it->m_protocol.c_str(), it->m_hostname.c_str(), (void*)it->m_easy, (void*)it->m_multi);
 
-      // It's important to clean up multi *before* cleaning up easy, because the multi cleanup
-      // code accesses stuff in the easy's structure.
-      if(it->m_multi)
-        multi_cleanup(it->m_multi);
+      if(it->m_multi && it->m_easy)
+        multi_remove_handle(it->m_multi, it->m_easy);
       if(it->m_easy)
         easy_cleanup(it->m_easy);
+      if(it->m_multi)
+        multi_cleanup(it->m_multi);
 
       Unload();
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Changes cleaning up order of curl multi/easy handles

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
From https://curl.haxx.se/libcurl/c/curl_multi_cleanup.html
1 - curl_multi_remove_handle before any easy handles are cleaned up
2 - curl_easy_cleanup can now be called independently since the easy handle is no longer connected to the multi handle
3 - curl_multi_cleanup should be called when all easy handles are removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

