### PR TITLE
[cmake] Crossguid offline url override

### DIFF
--- a/project/cmake/modules/FindCrossGUID.cmake
+++ b/project/cmake/modules/FindCrossGUID.cmake
@@ -7,8 +7,13 @@ if(ENABLE_INTERNAL_CROSSGUID)
 
   # allow user to override the download URL with a local tarball
   # needed for offline build envs
-  if(NOT EXISTS ${CROSSGUID_URL})
+  if(CROSSGUID_URL)
+    get_filename_component(CROSSGUID_URL "${CROSSGUID_URL}" ABSOLUTE)
+  else()
     set(CROSSGUID_URL http://mirrors.kodi.tv/build-deps/sources/crossguid-${CGUID_VER}.tar.gz)
+  endif()
+  if(VERBOSE)
+    message(STATUS "CROSSGUID_URL: ${CROSSGUID_URL}")
   endif()
 
   set(CROSSGUID_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libcrossguid.a)


### PR DESCRIPTION
Crossguid offline url override

## Description
When attempting to build offline crossguid will still attempt to download even when you override the URL. It also does not generate the full path for you. Updated it so it will override the URL the same way as ffmpeg and libdvd.

I could also be assuming something here but trying to use it like ffmpeg/libdvd. If so just reject this PR!

## Motivation and Context
Would like to override the URL for offline building.

## How Has This Been Tested?
Test by -DCROSSGUID_URL=foo.tar.bz2 then make crossguid and see that it still downloads the tar ball. With the change, it wont download anymore! (Though it'll fail unless you have a foo.tar.bz2 as the real crossguild tar ball!)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
