### PR TITLE
[listprovider] whitelist mediatypes which may get opened in VideoInfo…

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -402,8 +402,16 @@ bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
   }
   else if (fileItem->HasVideoInfoTag())
   {
-    CGUIDialogVideoInfo::ShowFor(*fileItem.get());
-    return true;
+    auto mediaType = fileItem->GetVideoInfoTag()->m_type;
+    if (mediaType == MediaTypeMovie ||
+        mediaType == MediaTypeTvShow ||
+        mediaType == MediaTypeEpisode ||
+        mediaType == MediaTypeVideo ||
+        mediaType == MediaTypeMusicVideo)
+    {
+      CGUIDialogVideoInfo::ShowFor(*fileItem.get());
+      return true;
+    }
   }
   else if (fileItem->HasMusicInfoTag())
   {


### PR DESCRIPTION
only allow the videoinfodialog for specific mediatypes (via whitelisting)
Fixes issues when using genres /tags VFS path etc on home screen, esp. when "Default select action" is set to "Show Information".
@Montellese @tamland 