### PR TITLE
Song Info Dialog contributors in control list

### DIFF
--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -157,6 +157,40 @@
 					<ondown>130</ondown>
 					<onup>9000</onup>
 					<orientation>horizontal</orientation>
+					<itemlayout height="72.5" width="595" condition="Container.Content(songs)">
+						<control type="image">
+							<top>-10</top>
+							<width>595</width>
+							<height>100</height>
+							<texture border="40">buttons/button-nofo.png</texture>
+						</control>
+						<control type="label">
+							<left>40</left>
+							<top>10</top>
+							<width>546</width>
+							<height>60</height>
+							<font>font12</font>
+							<aligny>center</aligny>
+							<label>$INFO[ListItem.Label,[COLOR grey], - [/COLOR]]$INFO[ListItem.Label2]</label>
+						</control>
+					</itemlayout>
+					<focusedlayout height="72.5" width="595" condition="Container.Content(songs)">
+						<control type="image">
+							<top>-10</top>
+							<width>595</width>
+							<height>100</height>
+							<texture border="40" colordiffuse="button_focus">buttons/button-fo.png</texture>
+						</control>
+						<control type="label">
+							<left>40</left>
+							<top>10</top>
+							<width>546</width>
+							<height>60</height>
+							<font>font12</font>
+							<aligny>center</aligny>
+							<label>$INFO[ListItem.Label,[COLOR white], - [/COLOR]]$INFO[ListItem.Label2]</label>
+						</control>
+					</focusedlayout>
 					<itemlayout height="72.5" width="595" condition="Container.Content(albums)">
 						<control type="image">
 							<top>-10</top>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -31,7 +31,7 @@
 		<value>$INFO[ListItem.Label2]</value>
 	</variable>
 	<variable name="MusicInfoTextboxVar">
-		<value condition="String.IsEqual(ListItem.DbType,song)">$INFO[ListItem.ContributorAndRole,[B]$LOCALIZE[31128][/B][CR][COLOR=white],[/COLOR]]</value>
+		<value condition="String.IsEqual(ListItem.DbType,song)">$INFO[ListItem.Comment,[B]$LOCALIZE[569][/B][CR][COLOR=white],[/COLOR]]</value>
 		<value condition="String.IsEqual(ListItem.DbType,album)">$INFO[ListItem.Property(Album_Description),[COLOR=white],[/COLOR]]</value>
 		<value condition="String.IsEqual(ListItem.DbType,artist)">$INFO[ListItem.Property(Artist_Description),[COLOR=white],[/COLOR]]</value>
 	</variable>

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -80,9 +80,13 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
           db.Close();
         }
       }
+      CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_LIST);
+      OnMessage(msg);
       break;
     }
   case GUI_MSG_WINDOW_INIT:
+    CGUIDialog::OnMessage(message);    
+    Update();
     m_cancelled = false;
     break;
 
@@ -110,6 +114,32 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
       {
         OnGetThumb();
         return true;
+      }
+      else if (iControl == CONTROL_LIST)
+      {
+        int iAction = message.GetParam1();
+        if ((ACTION_SELECT_ITEM == iAction || ACTION_MOUSE_LEFT_CLICK == iAction))
+        {
+          CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
+          g_windowManager.SendMessage(msg);
+          int iItem = msg.GetParam1();
+          if (iItem < 0 || iItem >= static_cast<int>(m_song->GetMusicInfoTag()->GetContributors().size()))
+            break;
+          int idArtist = m_song->GetMusicInfoTag()->GetContributors()[iItem].GetArtistId();
+          if (idArtist > 0)
+          {
+              CGUIWindowMusicBase *window = (CGUIWindowMusicBase *)g_windowManager.GetWindow(WINDOW_MUSIC_NAV);
+              if (window)
+              {
+                CFileItem item(*m_song);
+                std::string path = StringUtils::Format("musicdb://artists/%li", idArtist);
+                item.SetPath(path);
+                item.m_bIsFolder = true;
+                window->OnItemInfo(&item, true);
+              }
+          }
+          return true;
+        }
       }
     }
     break;
@@ -147,20 +177,25 @@ bool CGUIDialogSongInfo::OnBack(int actionID)
 
 void CGUIDialogSongInfo::OnInitWindow()
 {
-  CMusicDatabase db;
-  db.Open();
+  // Normally have album id from song
+  m_albumId = m_song->GetMusicInfoTag()->GetAlbumId();
+  if (m_albumId < 0)
+  {
+    CMusicDatabase db;
+    db.Open();
 
-  // no known db info - check if parent dir is an album
-  if (m_song->GetMusicInfoTag()->GetDatabaseId() == -1)
-  {
-    std::string path = URIUtils::GetDirectory(m_song->GetPath());
-    m_albumId = db.GetAlbumIdByPath(path);
-  }
-  else
-  {
-    CAlbum album;
-    db.GetAlbumFromSong(m_song->GetMusicInfoTag()->GetDatabaseId(),album);
-    m_albumId = album.idAlbum;
+    // no known db info - check if parent dir is an album
+    if (m_song->GetMusicInfoTag()->GetDatabaseId() == -1)
+    {
+      std::string path = URIUtils::GetDirectory(m_song->GetPath());
+      m_albumId = db.GetAlbumIdByPath(path);
+    }
+    else
+    {
+      CAlbum album;
+      db.GetAlbumFromSong(m_song->GetMusicInfoTag()->GetDatabaseId(), album);
+      m_albumId = album.idAlbum;
+    }
   }
   CONTROL_ENABLE_ON_CONDITION(CONTROL_ALBUMINFO, m_albumId > -1);
 
@@ -171,12 +206,25 @@ void CGUIDialogSongInfo::OnInitWindow()
     CONTROL_ENABLE(CONTROL_USERRATING);
 
   SET_CONTROL_HIDDEN(CONTROL_BTN_REFRESH);
-  SET_CONTROL_HIDDEN(CONTROL_LIST);
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);
   SET_CONTROL_LABEL(CONTROL_BTN_GET_THUMB, 13405);
   SET_CONTROL_LABEL(CONTROL_ALBUMINFO, 10523);
 
   CGUIDialog::OnInitWindow();
+}
+
+void CGUIDialogSongInfo::Update()
+{
+  CFileItemList items;
+  for (const auto& contributor : m_song->GetMusicInfoTag()->GetContributors())
+  {
+    auto item = std::make_shared<CFileItem>(contributor.GetRoleDesc());
+    item->SetLabel2(contributor.GetArtist());
+    item->GetMusicInfoTag()->SetDatabaseId(contributor.GetArtistId(), "artist");
+    items.Add(std::move(item));
+  }
+  CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, &items);
+  OnMessage(message);
 }
 
 void CGUIDialogSongInfo::SetUserrating(int userrating)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -40,6 +40,7 @@ public:
   virtual CFileItemPtr GetCurrentListItem(int offset = 0);
 protected:
   virtual void OnInitWindow();
+  void Update();
   bool DownloadThumbnail(const std::string &thumbFile);
   void OnGetThumb();
   void SetUserrating(int userrating);


### PR DESCRIPTION
Enable a control list to show the various contributors to a song e.g. composer, conductor, musicians and other people involved in the recording. Clicking on the artist displays the artist info dialog for that artist.  

This is particularly nice when you have artists covering songs composed by other artists in your library, or doing background vocals, or playing instruments etc. It also lets the user look at conductor or orchestra details for classical music, including the discography of other albums by that orchstra or conductor. Of course this needs the music to be fully tagged, and artist info to be scraped.

This also gives the skin the option to format how the artist name and role are displayed.

@phil65 if you could look at what tweek is needed for Estuary that would be great.
@HitcherUK I got this working myself in Confluence, but probably needs checking.

@tamland not sure I am opeing the artist dialog correctly. I could not see how to set the artist and use `CGUIDialogMusicInfo.showfor`

In Confluence it could look like this
![image](http://i.imgur.com/oYksU4J.png)