### PR TITLE
Fix crash in PVR input streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -317,7 +317,7 @@ bool CDVDInputStreamPVRManager::NextChannel(bool preview/* = false*/)
     CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
     CFileItemPtr item(g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelUp(channel));
     if (item)
-      return CloseAndOpen(item->GetPath().c_str());
+      return CloseAndOpen(item->GetPath());
   }
   else if (!m_isRecording)
     return g_PVRManager.ChannelUp(&newchannel, preview);
@@ -333,7 +333,7 @@ bool CDVDInputStreamPVRManager::PrevChannel(bool preview/* = false*/)
     CPVRChannelPtr channel(g_PVRManager.GetCurrentChannel());
     CFileItemPtr item(g_PVRChannelGroups->Get(channel->IsRadio())->GetSelectedGroup()->GetByChannelDown(channel));
     if (item)
-      return CloseAndOpen(item->GetPath().c_str());
+      return CloseAndOpen(item->GetPath());
   }
   else if (!m_isRecording)
     return g_PVRManager.ChannelDown(&newchannel, preview);
@@ -350,7 +350,7 @@ bool CDVDInputStreamPVRManager::SelectChannelByNumber(unsigned int iChannelNumbe
 
   if (IsOtherStreamHack())
   {
-    return CloseAndOpen(item->GetPath().c_str());
+    return CloseAndOpen(item->GetPath());
   }
   else if (!m_isRecording)
   {
@@ -369,7 +369,7 @@ bool CDVDInputStreamPVRManager::SelectChannel(const CPVRChannelPtr &channel)
   if (IsOtherStreamHack())
   {
     CFileItem item(channel);
-    return CloseAndOpen(item.GetPath().c_str());
+    return CloseAndOpen(item.GetPath());
   }
   else if (!m_isRecording)
   {
@@ -445,7 +445,7 @@ std::string CDVDInputStreamPVRManager::GetInputFormat()
   return "";
 }
 
-bool CDVDInputStreamPVRManager::CloseAndOpen(const char* strFile)
+bool CDVDInputStreamPVRManager::CloseAndOpen(const std::string& strFile)
 {
   Close();
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -234,7 +234,6 @@ void CDVDInputStreamPVRManager::Close()
 
   CDVDInputStream::Close();
 
-  m_pPlayer         = NULL;
   m_pOtherStream    = NULL;
   m_eof             = true;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -107,7 +107,7 @@ public:
   virtual void EnableStream(int iStreamId, bool enable) override {};
 
 protected:
-  bool CloseAndOpen(const char* strFile);
+  bool CloseAndOpen(const std::string& strFile);
   void UpdateStreamMap();
   std::string ThisIsAHack(const std::string& pathFile);
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);


### PR DESCRIPTION
Ref http://forum.kodi.tv/showthread.php?tid=269814&pid=2458794#pid2458794

Also drops a seemingly unmotivated pass by const char* for a string.