### PR TITLE
[audioengine] fix oss related compile fault

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -479,17 +479,12 @@ void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
     ||  info.m_displayName.find("DisplayPort") != std::string::npos)
     {
       info.m_deviceType = AE_DEVTYPE_HDMI;
-      info.m_dataFormats.push_back(AE_FMT_AC3);
-      info.m_dataFormats.push_back(AE_FMT_DTS);
-      info.m_dataFormats.push_back(AE_FMT_EAC3);
-      info.m_dataFormats.push_back(AE_FMT_TRUEHD);
-      info.m_dataFormats.push_back(AE_FMT_DTSHD);
+      info.m_dataFormats.push_back(AE_FMT_RAW);
     }
     else if (info.m_displayName.find("Digital") != std::string::npos)
     {
       info.m_deviceType = AE_DEVTYPE_IEC958;
-      info.m_dataFormats.push_back(AE_FMT_AC3);
-      info.m_dataFormats.push_back(AE_FMT_DTS);
+      info.m_dataFormats.push_back(AE_FMT_RAW);
     }
     else
     {


### PR DESCRIPTION
Fix on oss who comes with https://github.com/xbmc/xbmc/commit/4d17aaa6ed3e6361a6404963a30ce07c8202c9fe#diff-2eff2ae722752c73b4f4d3f5a760bc06.

## Description
This changes fix the following compile fault on Linux with OSS found from CMake.

```
[ 14%] Building CXX object build/cores/audioengine/CMakeFiles/audioengine.dir/Sinks/AESinkOSS.cpp.o
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp: In static member function ‘static void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList&, bool)’:
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:482:36: error: ‘AE_FMT_AC3’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_AC3);
                                    ^
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:483:36: error: ‘AE_FMT_DTS’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_DTS);
                                    ^
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:484:36: error: ‘AE_FMT_EAC3’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_EAC3);
                                    ^
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:485:36: error: ‘AE_FMT_TRUEHD’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_TRUEHD);
                                    ^
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:486:36: error: ‘AE_FMT_DTSHD’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_DTSHD);
                                    ^
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:491:36: error: ‘AE_FMT_AC3’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_AC3);
                                    ^
/home/alwin/Development/kodi/kodi-agile/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp:492:36: error: ‘AE_FMT_DTS’ was not declared in this scope
       info.m_dataFormats.push_back(AE_FMT_DTS);
                                    ^
build/cores/audioengine/CMakeFiles/audioengine.dir/build.make:686: die Regel für Ziel „build/cores/audioengine/CMakeFiles/audioengine.dir/Sinks/AESinkOSS.cpp.o“ scheiterte
make[2]: *** [build/cores/audioengine/CMakeFiles/audioengine.dir/Sinks/AESinkOSS.cpp.o] Fehler 1
CMakeFiles/Makefile2:2856: die Regel für Ziel „build/cores/audioengine/CMakeFiles/audioengine.dir/all“ scheiterte
make[1]: *** [build/cores/audioengine/CMakeFiles/audioengine.dir/all] Fehler 2
Makefile:138: die Regel für Ziel „all“ scheiterte
make: *** [all] Fehler 2
```

## Motivation and Context
Needed to fix ;)

## How Has This Been Tested?
Not sure how it can be tested, OSS is no more selectable on settings, but I think the changes are related to other codes correct.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

