### PR TITLE
[PVR][Estuary] Recordings window: show status for recordings in progress

### DIFF
--- a/addons/skin.estuary/1080i/Variables.xml
+++ b/addons/skin.estuary/1080i/Variables.xml
@@ -314,6 +314,7 @@
 		<value condition="!String.IsEmpty(Skin.String(HomeFanart.path))">$INFO[Skin.String(HomeFanart.path)]weather$INFO[Skin.String(HomeFanart.ext)]</value>
 	</variable>
 	<variable name="ListWatchedIconVar">
+		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
 		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10758,6 +10758,10 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
         if (timer)
           return timer->IsRecording();
       }
+      else if (pItem->HasPVRRecordingInfoTag())
+      {
+        return pItem->GetPVRRecordingInfoTag()->IsInProgress();
+      }
     }
     else if (condition == LISTITEM_INPROGRESS)
     {

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -237,6 +237,12 @@ namespace PVR
      */
     std::string EpisodeName(void) const { return m_strShowTitle; };
 
+    /*!
+     * @brief check whether this recording is currently in progress (according to its start time and duration)
+     * @return true if the recording is in progress, false otherwise
+     */
+    bool IsInProgress() const;
+
   private:
     CDateTime    m_recordingTime; /*!< start time of the recording */
     bool         m_bGotMetaData;


### PR DESCRIPTION
PVR recordings window list items are missing an indicator for "in progress" recordings. This was reported in the forum.

This PR adds the missing functionality.

![screenshot003](https://cloud.githubusercontent.com/assets/3226626/20441112/6260a5e8-adc3-11e6-8605-99fb30762b53.png)

The change was tested with latest Krypton master on macOS.

@Jalle19 for review?
@phil65 we discussed this internally
