### PR TITLE
[PVR][Estuary] Folder overlay fixes

### DIFF
--- a/addons/skin.estuary/1080i/Variables.xml
+++ b/addons/skin.estuary/1080i/Variables.xml
@@ -317,9 +317,10 @@
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
 		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
+		<value condition="ListItem.IsParentFolder">DefaultFolderBack.png</value>
 		<value condition="ListItem.IsFolder">overlays/folder.png</value>
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
-		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>
+		<value>OverlayUnwatched.png</value>
 	</variable>
 	<variable name="SettingsSectionIcon">
 		<value condition="Window.IsActive(playersettings)">icons/settings/video.png</value>

--- a/addons/skin.estuary/1080i/Variables.xml
+++ b/addons/skin.estuary/1080i/Variables.xml
@@ -317,8 +317,8 @@
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
 		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
+		<value condition="ListItem.IsFolder">overlays/folder.png</value>
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
-		<value condition="ListItem.IsFolder + Container.Content(files)">overlays/folder.png</value>
 		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>
 	</variable>
 	<variable name="SettingsSectionIcon">

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -139,9 +139,9 @@ void CPVRRecordings::GetSubDirectories(const CPVRRecordingsPath &recParentPath, 
       unwatchedFolders.insert(pFileItem);
   }
 
-  // Remove the watched overlay from folders containing unwatched entries
+  // Change the watched overlay to unwatched for folders containing unwatched entries
   for (auto item : unwatchedFolders)
-    item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED, true);
+    item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, false);
 }
 
 int CPVRRecordings::Load(void)


### PR DESCRIPTION
Problem: When grouping PVR recordings in folders the overlay shows a "HD" symbol. (screenshot 1)

This is caused by a bug in "PVRRecordings.cpp" which will set the overlay to "ICON_OVERLAY_HD".
Fixing this will solve the issue partially. The folders are handled as normal files now...
Two other fixes in estuary are needed to handle folders just the same as with normal videos. 
Screenshot 2 shows the result with this these three fixes.

@ksooo I will rebase once your other PR is in.

@phil65 I noticed that the "OverlayHD.png" image in estuary might be wrong? OverlayHD in Kodi means "Hard disk" not High Definition".

Before:
![schermafdruk van 2016-11-18 21 58 32](https://cloud.githubusercontent.com/assets/2036512/20446933/553ff698-addc-11e6-81cd-1eaa759441cd.png)
After:
![schermafdruk van 2016-11-18 20 44 10](https://cloud.githubusercontent.com/assets/2036512/20446937/5a28ddbe-addc-11e6-86c6-f400c311b446.png)
