### PR TITLE
[listprovider] Refresh list when job was not finished

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -862,9 +862,10 @@ void CGUIBaseContainer::FreeResources(bool immediately)
   if (m_listProvider)
   {
     if (immediately)
+    {
       Reset();
-
-    m_listProvider->Reset(immediately);
+      m_listProvider->Reset();
+    }
   }
   m_scroller.Stop();
 }

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -187,7 +187,7 @@ CDirectoryProvider::CDirectoryProvider(const TiXmlElement *element, int parentID
 
 CDirectoryProvider::~CDirectoryProvider()
 {
-  Reset(true);
+  Reset();
 }
 
 bool CDirectoryProvider::Update(bool forceRefresh)
@@ -315,34 +315,27 @@ void CDirectoryProvider::OnPVRManagerEvent(const PVR::PVREvent& event)
   }
 }
 
-void CDirectoryProvider::Reset(bool immediately /* = false */)
+void CDirectoryProvider::Reset()
 {
-  // cancel any pending jobs
   CSingleLock lock(m_section);
   if (m_jobID)
     CJobManager::GetInstance().CancelJob(m_jobID);
   m_jobID = 0;
-  // Make sure job is always fired on start
-  m_updateState = INVALIDATED;
-  // reset only if this is going to be destructed
-  if (immediately)
-  {
-    m_items.clear();
-    m_currentTarget.clear();
-    m_currentUrl.clear();
-    m_itemTypes.clear();
-    m_currentSort.sortBy = SortByNone;
-    m_currentSort.sortOrder = SortOrderAscending;
-    m_currentLimit = 0;
-    m_updateState = OK;
+  m_items.clear();
+  m_currentTarget.clear();
+  m_currentUrl.clear();
+  m_itemTypes.clear();
+  m_currentSort.sortBy = SortByNone;
+  m_currentSort.sortOrder = SortOrderAscending;
+  m_currentLimit = 0;
+  m_updateState = OK;
 
-    if (m_isAnnounced)
-    {
-      m_isAnnounced = false;
-      CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
-      ADDON::CAddonMgr::GetInstance().Events().Unsubscribe(this);
-      g_PVRManager.Events().Unsubscribe(this);
-    }
+  if (m_isAnnounced)
+  {
+    m_isAnnounced = false;
+    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    ADDON::CAddonMgr::GetInstance().Events().Unsubscribe(this);
+    g_PVRManager.Events().Unsubscribe(this);
   }
 }
 

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -60,7 +60,7 @@ public:
   virtual bool Update(bool forceRefresh) override;
   virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
   virtual void Fetch(std::vector<CGUIListItemPtr> &items) const override;
-  virtual void Reset(bool immediately = false) override;
+  virtual void Reset() override;
   virtual bool OnClick(const CGUIListItemPtr &item) override;
   bool OnInfo(const CGUIListItemPtr &item) override;
   bool OnContextMenu(const CGUIListItemPtr &item) override;

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -61,9 +61,8 @@ public:
 
   /*! \brief Reset the current list of items.
    Derived classes may choose to ignore this.
-   \param immediately whether the content of the provider should be cleared.
    */
-  virtual void Reset(bool immediately = false) {};
+  virtual void Reset() {};
 
   /*! \brief Click event on an item.
    \param item the item that was clicked.


### PR DESCRIPTION
## Description
Follow up of #10931. Instead of always invalidating, only invalidate if ```OnJobComplete``` wasn't reached with success. 
## Motivation and Context
The job manager isn't aware of jobs that are busy but get interrupted because the window is closed.
At this point ```Reset()``` is called. By marking the job there as invalidated if ```OnJobComplete``` wasn't called, the job will fire again the next time the list is visible and otherwise it will only fire again through external events.
@tamland I don't think I can fix this in any other way. The way the jobmanager is setup, is to get results from ```OnJobComplete```. It doesn't handle the cases where ```OnJobComplete``` isn't reached for whatever reason. There's ```OnJobProgress``` but afaict that is only useful for showing the progress. 
## How Has This Been Tested?
Runtime tested

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed