### PR TITLE
[PVR] Recordings window: Fix show status for recordings in progress

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -486,24 +486,8 @@ int CPVRRecording::ClientID(void) const
 bool CPVRRecording::IsInProgress() const
 {
   // Note: It is not enough to only check recording time and duration against 'now'.
-  //       This can only be a first cheap quick check. Only the state of the related
-  //       timer is a safe indicator that the backend actually is recording this.
+  //       Only the state of the related timer is a safe indicator that the backend
+  //       actually is recording this.
 
-  const CDateTime now(CDateTime::GetUTCDateTime());
-  if (m_recordingTime <= now && m_recordingTime + m_duration >= now)
-  {
-    const std::vector<CFileItemPtr> timers(g_PVRTimers->GetActiveRecordings());
-    for (const auto& timerItem : timers)
-    {
-      const CPVRTimerInfoTagPtr timer(timerItem->GetPVRTimerInfoTag());
-      if (timer->m_iClientId == m_iClientId &&
-          timer->ChannelTag()->UniqueID() == m_iChannelUid &&
-          timer->StartAsUTC() <= m_recordingTime &&
-          timer->EndAsUTC() >= m_recordingTime + m_duration)
-      {
-        return true;
-      }
-    }
-  }
-  return false;
+  return g_PVRTimers->HasRecordingTimerForRecording(*this);
 }

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -830,6 +830,29 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CEpgInfoTagPtr &epgTag) 
   return CPVRTimerInfoTagPtr();
 }
 
+bool CPVRTimers::HasRecordingTimerForRecording(const CPVRRecording &recording) const
+{
+  CSingleLock lock(m_critSection);
+
+  for (const auto &tagsEntry : m_tags)
+  {
+    for (const auto &timersEntry : *tagsEntry.second)
+    {
+      if (timersEntry->IsRecording() &&
+          !timersEntry->IsTimerRule() &&
+          timersEntry->m_iClientId == recording.ClientID() &&
+          timersEntry->ChannelTag()->UniqueID() == recording.ChannelUid() &&
+          timersEntry->StartAsUTC() <= recording.RecordingTimeAsUTC() &&
+          timersEntry->EndAsUTC() >= (recording.RecordingTimeAsUTC() + recording.m_duration))
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 CPVRTimerInfoTagPtr CPVRTimers::GetTimerRule(const CPVRTimerInfoTagPtr &timer) const
 {
   if (timer)

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -39,6 +39,7 @@ namespace EPG
 
 namespace PVR
 {
+  class CPVRRecording;
   class CPVRTimersPath;
 
   class CPVRTimers : public Observer
@@ -211,6 +212,13 @@ namespace PVR
      * @return The requested timer tag, or an empty fileitemptr if none was found.
      */
     CPVRTimerInfoTagPtr GetTimerForEpgTag(const EPG::CEpgInfoTagPtr &epgTag) const;
+
+    /*!
+     * @brief Check whether there is a timer currently recording the given recording.
+     * @param recording The recording to check.
+     * @return true if there is a timer currently recording the given recording, false otherwise.
+     */
+    bool HasRecordingTimerForRecording(const CPVRRecording &recording) const;
 
     /*!
      * Get the timer rule for a given timer tag


### PR DESCRIPTION
This is a followup to #10954 that fixes the first approach. 

The quick check comparing recording's start time and duration against 'now' before doing a check against the currently recording timers is wrong. The start time and duration is kinda static and does not (necessarily) reflect any adjustments in the events schedule (for example it might last some minutes longer than originally scheduled). So, this check must not be done at all. Otherwise the in progress indicator will disappear too early.

This fix was tested on latest Krypton master on macOS and Linux.

@Jalle19 the correct approach is actually the opposite of your first thought on #10954 ;-)