### PR TITLE
[cmake] Properly find correct libcec version

### DIFF
--- a/project/cmake/modules/FindCEC.cmake
+++ b/project/cmake/modules/FindCEC.cmake
@@ -15,13 +15,23 @@
 #   CEC::CEC   - The libCEC library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_CEC libcec>=4.0.0 QUIET)
+  pkg_check_modules(PC_CEC libcec QUIET)
 endif()
 
-find_path(CEC_INCLUDE_DIR libcec/cec.h libCEC/CEC.h
+find_path(CEC_INCLUDE_DIR NAMES libcec/cec.h libCEC/CEC.h
                           PATHS ${PC_CEC_INCLUDEDIR})
 
-set(CEC_VERSION ${PC_CEC_VERSION})
+if(PC_CEC_VERSION)
+  set(CEC_VERSION ${PC_CEC_VERSION})
+elseif(CEC_INCLUDE_DIR AND EXISTS "${CEC_INCLUDE_DIR}/libcec/version.h")
+  file(STRINGS "${CEC_INCLUDE_DIR}/libcec/version.h" cec_version_str REGEX "^[\t ]+LIBCEC_VERSION_TO_UINT\\(.*\\)")
+  string(REGEX REPLACE "^[\t ]+LIBCEC_VERSION_TO_UINT\\(([0-9]+), ([0-9]+), ([0-9]+)\\)" "\\1.\\2.\\3" CEC_VERSION "${cec_version_str}")
+  unset(cec_version_str)
+endif()
+
+if(NOT CEC_FIND_VERSION)
+  set(CEC_FIND_VERSION 4.0.0)
+endif()
 
 include(FindPackageHandleStandardArgs)
 if(NOT WIN32)


### PR DESCRIPTION
Fix compile error if libcec 3.1 is installed.

## Description
Just setting a pkgconfig minimum version doesn't work and just causes pkgconfig to not find an older package. But since our CMake modules don't trust package config and validate that the include directory
really exists, it would still just find whatever version is installed.

The proper way is to either call `find_package` with `VERSION` or set
`<Module Name>_FIND_VERSION` inside the module.

Additionally: If we don't have a version from package config, the code now tries to find the version from the header file.

## Motivation and Context
Fix.

## How Has This Been Tested?
Compile tested on xenial (without build-deb ppa). Btw @wsnipex, will there gonna be a build-dep ppa for xenial?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed