### PR TITLE
[audioengine] use OSS only on FreeBSD

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -36,10 +36,12 @@
   #if defined(HAS_ALSA)
     #include "Sinks/AESinkALSA.h"
   #endif
+  #if defined(TARGET_FREEBSD)
+    #include "Sinks/AESinkOSS.h"
+  #endif
   #if defined(HAS_PULSEAUDIO)
     #include "Sinks/AESinkPULSE.h"
   #endif
-  #include "Sinks/AESinkOSS.h"
 #else
   #pragma message("NOTICE: No audio sink for target platform.  Audio output will not be available.")
 #endif
@@ -75,10 +77,12 @@ void CAESinkFactory::ParseDevice(std::string &device, std::string &driver)
   #if defined(HAS_ALSA)
         driver == "ALSA"        ||
   #endif
+  #if defined(TARGET_FREEBSD)
+        driver == "OSS"         ||
+  #endif
   #if defined(HAS_PULSEAUDIO)
         driver == "PULSE"       ||
   #endif
-        driver == "OSS"         ||
 #endif
         driver == "PROFILER"    ||
         driver == "NULL")
@@ -125,8 +129,10 @@ IAESink *CAESinkFactory::TrySink(std::string &driver, std::string &device, AEAud
     if (driver == "ALSA")
       sink = new CAESinkALSA();
  #endif
+ #if defined(TARGET_FREEBSD)
     if (driver == "OSS")
       sink = new CAESinkOSS();
+ #endif
 #endif
   }
 
@@ -240,8 +246,10 @@ void CAESinkFactory::EnumerateEx(AESinkInfoList &list, bool force)
     if (envSink == "ALSA")
       CAESinkALSA::EnumerateDevicesEx(info.m_deviceInfoList, force);
     #endif
+    #if defined(TARGET_FREEBSD)
     if (envSink == "OSS")
       CAESinkOSS::EnumerateDevicesEx(info.m_deviceInfoList, force);
+    #endif
 
     if(!info.m_deviceInfoList.empty())
     {
@@ -274,12 +282,13 @@ void CAESinkFactory::EnumerateEx(AESinkInfoList &list, bool force)
     return;
   }
   #endif
-
+  #if defined(TARGET_FREEBSD)
   info.m_deviceInfoList.clear();
   info.m_sinkName = "OSS";
   CAESinkOSS::EnumerateDevicesEx(info.m_deviceInfoList, force);
   if(!info.m_deviceInfoList.empty())
     list.push_back(info);
+  #endif
 
 #endif
 

--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -62,12 +62,10 @@ if(ALSA_FOUND)
   list(APPEND SOURCES Sinks/AESinkALSA.cpp
                       Sinks/alsa/ALSADeviceMonitor.cpp
                       Sinks/alsa/ALSAHControlMonitor.cpp
-                      Sinks/AESinkOSS.cpp
                       Utils/AEELDParser.cpp)
   list(APPEND HEADERS Sinks/AESinkALSA.h
                       Sinks/alsa/ALSADeviceMonitor.h
                       Sinks/alsa/ALSAHControlMonitor.h
-                      Sinks/AESinkOSS.h
                       Utils/AEELDParser.h)
 endif()
 


### PR DESCRIPTION
This use OSS audio now only on FreeBSD

## Description
This prevent also the compile fault related to https://github.com/xbmc/xbmc/pull/10670 

## Motivation and Context
Want to have compile working to continue work ;-)

@FernetMenta is this way OK?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

