### PR TITLE
[PVR] Recordings window: fix recordings sub folders after #10930.

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -145,13 +145,12 @@ std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string &
     return strReturn;
 
   strUsePath.erase(0, m_directoryPath.size());
+  strUsePath = TrimSlashes(strUsePath);
 
   /* check for more occurences */
   size_t iDelimiter = strUsePath.find('/');
   if (iDelimiter == std::string::npos)
     strReturn = strUsePath;
-  else if (iDelimiter == 0)
-    strReturn = strUsePath.substr(1);
   else
     strReturn = strUsePath.substr(0, iDelimiter);
 


### PR DESCRIPTION
Recordings sub-subfolders did not work anymore after #10930. That PR revealed an ancient bug with recordings url/path parsing which is fixed by the PR.

Bug was reported here: http://forum.kodi.tv/showthread.php?tid=269814&pid=2459718#pid2459718

This fix was tested with latest krypton master on macOS.

@MilhouseVH fyi
@Jalle19 for a quick check? Want to have this in beta 6, since it is a regression.