### PR TITLE
Controller dialog: Fix Kodi actions sent after mapping final analog stick

### DIFF
--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.h
@@ -42,6 +42,7 @@ namespace GAME
     virtual bool MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
                               JOYSTICK::IActionMap* actionMap,
                               const JOYSTICK::CDriverPrimitive& primitive) override;
+    virtual void OnEventFrame(const JOYSTICK::IButtonMap* buttonMap, bool bMotion) override { }
 
     // implementation of Observer
     virtual void Notify(const Observable &obs, const ObservableMessage msg) override;

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -34,6 +34,9 @@ using namespace GAME;
 #define ESC_KEY_CODE  27
 #define SKIPPING_DETECTION_MS  200
 
+// Duration to wait for axes to neutralize after mapping is finished
+#define POST_MAPPING_WAIT_TIME_MS  (5 * 1000)
+
 CGUIConfigurationWizard::CGUIConfigurationWizard() :
   CThread("GUIConfigurationWizard"),
   m_callback(nullptr)
@@ -61,6 +64,11 @@ void CGUIConfigurationWizard::Run(const std::string& strControllerId, const std:
     m_buttons = buttons;
     m_callback = callback;
 
+    // Reset synchronization variables
+    m_inputEvent.Reset();
+    m_motionlessEvent.Reset();
+    m_bInMotion.clear();
+
     // Initialize state variables
     InitializeState();
   }
@@ -83,6 +91,7 @@ bool CGUIConfigurationWizard::Abort(bool bWait /* = true */)
     StopThread(false);
 
     m_inputEvent.Set();
+    m_motionlessEvent.Set();
 
     if (bWait)
       StopThread(true);
@@ -138,6 +147,19 @@ void CGUIConfigurationWizard::Process(void)
 
   for (auto callback : ButtonMapCallbacks())
     callback.second->SaveButtonMap();
+
+  bool bInMotion;
+
+  {
+    CSingleLock lock(m_motionMutex);
+    bInMotion = !m_bInMotion.empty();
+  }
+
+  if (bInMotion)
+  {
+    CLog::Log(LOGDEBUG, "Configuration wizard: waiting %ums for axes to neutralize", POST_MAPPING_WAIT_TIME_MS);
+    m_motionlessEvent.WaitMSec(POST_MAPPING_WAIT_TIME_MS);
+  }
 
   RemoveHooks();
 
@@ -217,12 +239,36 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
         }
         m_lastMappingActionMs = XbmcThreads::SystemClockMillis();
 
+        OnMotion(buttonMap);
         m_inputEvent.Set();
       }
     }
   }
   
   return bHandled;
+}
+
+void CGUIConfigurationWizard::OnEventFrame(const JOYSTICK::IButtonMap* buttonMap, bool bMotion)
+{
+  CSingleLock lock(m_motionMutex);
+
+  if (m_bInMotion.find(buttonMap) != m_bInMotion.end() && !bMotion)
+    OnMotionless(buttonMap);
+}
+
+void CGUIConfigurationWizard::OnMotion(const JOYSTICK::IButtonMap* buttonMap)
+{
+  CSingleLock lock(m_motionMutex);
+
+  m_motionlessEvent.Reset();
+  m_bInMotion.insert(buttonMap);
+}
+
+void CGUIConfigurationWizard::OnMotionless(const JOYSTICK::IButtonMap* buttonMap)
+{
+  m_bInMotion.erase(buttonMap);
+  if (m_bInMotion.empty())
+    m_motionlessEvent.Set();
 }
 
 bool CGUIConfigurationWizard::OnKeyPress(const CKey& key)

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -56,6 +56,7 @@ namespace GAME
     virtual bool MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
                               JOYSTICK::IActionMap* actionMap,
                               const JOYSTICK::CDriverPrimitive& primitive) override;
+    virtual void OnEventFrame(const JOYSTICK::IButtonMap* buttonMap, bool bMotion) override;
 
     // implementation of IKeyboardHandler
     virtual bool OnKeyPress(const CKey& key) override;
@@ -74,6 +75,9 @@ namespace GAME
     void InstallHooks(void);
     void RemoveHooks(void);
 
+    void OnMotion(const JOYSTICK::IButtonMap* buttonMap);
+    void OnMotionless(const JOYSTICK::IButtonMap* buttonMap);
+
     // Run() parameters
     std::string                          m_strControllerId;
     std::vector<IFeatureButton*>         m_buttons;
@@ -86,7 +90,10 @@ namespace GAME
     unsigned int                         m_lastMappingActionMs; // The last mapping action, or 0 if not currently mapping
     CCriticalSection                     m_stateMutex;
 
-    // Synchronization event
+    // Synchronization events
     CEvent                               m_inputEvent;
+    CEvent                               m_motionlessEvent;
+    CCriticalSection                     m_motionMutex;
+    std::set<const JOYSTICK::IButtonMap*> m_bInMotion;
   };
 }

--- a/xbmc/input/joysticks/IButtonMapper.h
+++ b/xbmc/input/joysticks/IButtonMapper.h
@@ -67,9 +67,32 @@ namespace JOYSTICK
      * \param actionMap  An interface capable of translating driver primitives to Kodi actions
      * \param primitive  The driver primitive
      *
+     * Called in the same thread as \ref IButtonMapper::OnFrame.
+     *
      * \return True if driver primitive was mapped to a feature
      */
     virtual bool MapPrimitive(IButtonMap* buttonMap, IActionMap* actionMap, const CDriverPrimitive& primitive) = 0;
+
+    /*!
+     * \brief Called once per event frame to notify the implementation of motion status
+     *
+     * \param buttonMap The button map passed to MapPrimitive() (shall not be modified)
+     * \param bMotion True if a previously-mapped axis is still in motion
+     *
+     * This allows the implementer to wait for an axis to be centered before
+     * allowing it to be used as Kodi input.
+     *
+     * If mapping finishes on an axis, then the axis will still be pressed and
+     * sending input every frame when the mapping ends. For example, when the
+     * right analog stick is the last feature to be mapped, it is still pressed
+     * when mapping ends and immediately sends Volume Down actions.
+     *
+     * The fix is to allow implementers to wait until all axes are motionless
+     * before deattaching themselves.
+     *
+     * Called in the same thread as \ref IButtonMapper::MapPrimitive.
+     */
+    virtual void OnEventFrame(const IButtonMap* buttonMap, bool bMotion) = 0;
 
     // Button map callback interface
     void SetButtonMapCallback(const std::string& deviceName, IButtonMapCallback* callback) { m_callbacks[deviceName] = callback; }

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -75,24 +75,35 @@ bool CButtonMapping::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
 
 bool CButtonMapping::OnAxisMotion(unsigned int axisIndex, float position)
 {
-  SEMIAXIS_DIRECTION dir = CJoystickTranslator::PositionToSemiAxisDirection(position);
+  const bool bInMotion = (position != 0.0f);
+  const bool bIsActive = (std::abs(position) >= AXIS_THRESHOLD);
 
-  CDriverPrimitive axis(axisIndex, dir);
-  CDriverPrimitive oppositeAxis(axisIndex, dir * -1);
-
-  if (position == 0.0f)
+  if (!bInMotion)
   {
+    CDriverPrimitive axis(axisIndex, SEMIAXIS_DIRECTION::POSITIVE);
+    CDriverPrimitive oppositeAxis(axisIndex, SEMIAXIS_DIRECTION::NEGATIVE);
+
+    OnMotionless(axis);
+    OnMotionless(oppositeAxis);
+
     Deactivate(axis);
     Deactivate(oppositeAxis);
   }
   else
   {
-    Deactivate(oppositeAxis);
+    SEMIAXIS_DIRECTION dir = CJoystickTranslator::PositionToSemiAxisDirection(position);
 
-    if (std::abs(position) >= AXIS_THRESHOLD)
+    CDriverPrimitive axis(axisIndex, dir);
+    CDriverPrimitive oppositeAxis(axisIndex, dir * -1);
+
+    // OnMotion() occurs within ProcessAxisMotions()
+    OnMotionless(oppositeAxis);
+
+    if (bIsActive)
       Activate(axis);
     else
       Deactivate(axis);
+    Deactivate(oppositeAxis);
   }
 
   return true;
@@ -100,6 +111,7 @@ bool CButtonMapping::OnAxisMotion(unsigned int axisIndex, float position)
 
 void CButtonMapping::ProcessAxisMotions(void)
 {
+  // Process newly-activated axes
   for (std::vector<ActivatedAxis>::iterator it = m_activatedAxes.begin(); it != m_activatedAxes.end(); ++it)
   {
     ActivatedAxis& semiaxis = *it;
@@ -108,9 +120,12 @@ void CButtonMapping::ProcessAxisMotions(void)
     if (!semiaxis.bEmitted)
     {
       semiaxis.bEmitted = true;
-      MapPrimitive(semiaxis.driverPrimitive);
+      if (MapPrimitive(semiaxis.driverPrimitive))
+        OnMotion(semiaxis.driverPrimitive);
     }
   }
+
+  m_buttonMapper->OnEventFrame(m_buttonMap, IsMoving());
 }
 
 void CButtonMapping::SaveButtonMap()
@@ -162,6 +177,22 @@ bool CButtonMapping::MapPrimitive(const CDriverPrimitive& primitive)
   return bHandled;
 }
 
+void CButtonMapping::OnMotion(const CDriverPrimitive& semiaxis)
+{
+  if (std::find(m_movingAxes.begin(), m_movingAxes.end(), semiaxis) == m_movingAxes.end())
+    m_movingAxes.push_back(semiaxis);
+}
+
+void CButtonMapping::OnMotionless(const CDriverPrimitive& semiaxis)
+{
+  m_movingAxes.erase(std::remove(m_movingAxes.begin(), m_movingAxes.end(), semiaxis), m_movingAxes.end());
+}
+
+bool CButtonMapping::IsMoving() const
+{
+  return !m_movingAxes.empty();
+}
+
 void CButtonMapping::Activate(const CDriverPrimitive& semiaxis)
 {
   if (!IsActive(semiaxis))
@@ -177,7 +208,7 @@ void CButtonMapping::Deactivate(const CDriverPrimitive& semiaxis)
     }), m_activatedAxes.end());
 }
 
-bool CButtonMapping::IsActive(const CDriverPrimitive& semiaxis)
+bool CButtonMapping::IsActive(const CDriverPrimitive& semiaxis) const
 {
   return std::find_if(m_activatedAxes.begin(), m_activatedAxes.end(),
     [&semiaxis](const ActivatedAxis& axis)

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -66,12 +66,30 @@ namespace JOYSTICK
     virtual void RevertButtonMap() override;
 
   private:
+    /*!
+     * \brief Process the primitive mapping command
+     *
+     * First, this function checks if the input should be dropped. This can
+     * happen if the input is ignored or the cooldown period is active. If the
+     * input is dropped, this returns true with no effect, effectively absorbing
+     * the input. Otherwise, the mapping command is sent to m_buttonMapper.
+     *
+     * \param primitive The primitive being mapped
+     * \return True if the mapping command was handled, false otherwise
+     */
     bool MapPrimitive(const CDriverPrimitive& primitive);
 
-    void Activate(const CDriverPrimitive& semiAxis);
-    void Deactivate(const CDriverPrimitive& semiAxis);
-    bool IsActive(const CDriverPrimitive& semiAxis);
+    // Motion functions
+    void OnMotion(const CDriverPrimitive& semiaxis);
+    void OnMotionless(const CDriverPrimitive& semiaxis);
+    bool IsMoving() const;
 
+    // Action functions
+    void Activate(const CDriverPrimitive& semiaxis);
+    void Deactivate(const CDriverPrimitive& semiaxis);
+    bool IsActive(const CDriverPrimitive& semiaxis) const;
+
+    // Construction parameters
     IButtonMapper* const m_buttonMapper;
     IButtonMap* const    m_buttonMap;
     IActionMap* const    m_actionMap;
@@ -82,6 +100,7 @@ namespace JOYSTICK
       bool             bEmitted; // true if this axis has emited a button-mapping command
     };
 
+    std::vector<CDriverPrimitive> m_movingAxes;
     std::vector<ActivatedAxis> m_activatedAxes;
     unsigned int               m_lastAction;
   };


### PR DESCRIPTION
The final step in mapping the Kodi controller profile is "Move right analog stick left...". However, when the stick is moved left and the mapping is successful, the mapping wizard ends and the fully-left stick sends a volume down command.

The solution in this PR is to keep track of which axes have successfully mapped a button, and continue absorbing input from then until the axis is re-centered. The button mapping wizard has been modified to wait until all successfully-mapped axes are centered before unregistering itself.

## Motivation and Context
Better UX

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Broken out from #10630