### PR TITLE
Fixed missing binary addons

### DIFF
--- a/project/cmake/scripts/common/CheckTargetPlatform.cmake
+++ b/project/cmake/scripts/common/CheckTargetPlatform.cmake
@@ -9,7 +9,11 @@ function(check_target_platform dir target_platform build)
   if(EXISTS ${dir} AND EXISTS ${dir}/platforms.txt)
     # get all the specified platforms
     file(STRINGS ${dir}/platforms.txt platforms)
-    string(REPLACE " " ";" platforms ${platforms})
+    
+    list( LENGTH platforms listlen )
+    if(${listlen} EQUAL 1)    
+        string(REPLACE " " ";" platforms ${platforms})
+    endif()
 
     # check if the addon/dependency should be built for the current platform
     foreach(platform ${platforms})


### PR DESCRIPTION
897094feeef8357eaf7ce2a4328a062b1af9d151 <- changed the way platforms.txt files are parsed. It assumes that all platforms are in a space seperated list in that file. In reality those platforms are in multiple lines for some addons.

@hudokkow @fetzerch  for review.

Fixes regression where osx is missing some visualisation addons (because the platform is in the second line of platforms.txt)