### PR TITLE
Fix digital buttons with analog actions only sending one action

### DIFF
--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -111,8 +111,10 @@ namespace JOYSTICK
     const INPUT_TYPE m_inputType;
     bool             m_bDigitalState;
     bool             m_bDigitalHandled;
-    unsigned int     m_holdStartTimeMs;
+    unsigned int     m_motionStartTimeMs;
     float            m_analogState;
+    bool             m_analogEvent;
+    bool             m_bDiscrete;
   };
 
   /*!


### PR DESCRIPTION
Sometime in the past, a bug was introduced where a digital button mapped to an analog action only sent 1 action, when it used to send 1 action every frame (as a true analog button/trigger/stick would). This fixes the bug by sending an analog action each frame for as long as the button is pressed.

Furthermore, a ramp-up function has been applied to the analog value. This is because with analog buttons/triggers/sticks, you can control the amount of the action, so scrolling slowly is possible. However, with digital buttons, the amount is always 1.0, which can be unpleasant when you're trying to scroll slowly through a long list.

Now, when the button is pressed, it has an initial analog value of 0.3, which ramps up to 1.0 after 1.5 seconds.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Broken out from #10630