### PR TITLE
[addon] remove not needed header comment in CScreenSaver

### DIFF
--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -36,7 +36,6 @@ public:
   virtual ~CScreenSaver() {}
   virtual bool IsInUse() const;
 
-  // Things that MUST be supplied by the child classes
   bool CreateScreenSaver();
   void Start();
   void Render();


### PR DESCRIPTION
The comment says 'Things that MUST be supplied by the child classes', but there
are no childs, is everything inside him.