### PR TITLE
FileFactory: handle library protocol

### DIFF
--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -115,7 +115,8 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   }
   else if (url.IsProtocol("xbt")) return new CXbtFile();
   else if (url.IsProtocol("musicdb")) return new CMusicDatabaseFile();
-  else if (url.IsProtocol("videodb")) return NULL;
+  else if (url.IsProtocol("videodb")) return nullptr;
+  else if (url.IsProtocol("library")) return nullptr;
   else if (url.IsProtocol("special")) return new CSpecialProtocolFile();
   else if (url.IsProtocol("multipath")) return new CMultiPathFile();
   else if (url.IsProtocol("image")) return new CImageFile();


### PR DESCRIPTION
when using a path like library://video/movies/ on home screen, the log gets polluted with some error messages:

WARNING: XFILE::CFileFactory::CreateLoader - unsupported protocol(library) in library://video/movies/f.xml/folder.jpg
...

This should fix it. 
@Montellese 		