### PR TITLE
fixed: use correct type for time parameter in UPnPPlayer

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -466,7 +466,7 @@ failed:
   return;
 }
 
-void CUPnPPlayer::SeekTime(__int64 ms)
+void CUPnPPlayer::SeekTime(int64_t ms)
 {
   NPT_CHECK_LABEL(m_control->Seek(m_delegate->m_device
                                 , m_delegate->m_instance

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -62,7 +62,7 @@ public:
   virtual void GetChapterName(std::string& strChapterName)     { return; }
   virtual int  SeekChapter(int iChapter)                       { return -1; }
 
-  virtual void SeekTime(__int64 iTime = 0);
+  virtual void SeekTime(int64_t iTime = 0);
   virtual int64_t GetTime();
   virtual int64_t GetTotalTime();
   virtual void SetSpeed(float speed = 0) override;


### PR DESCRIPTION
__int64 and int64_t is not necessarily the same.