### PR TITLE
[PVR] fix recordings window subfolder listings

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -340,14 +340,6 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
     }
   }
 
-  if (items.IsEmpty())
-  {
-    // Note: Do not change the ".." label. It has very special meaning/logic.
-    //       CFileItem::IsParentFolder() and and other code depends on this.
-    const CFileItemPtr item(new CFileItem(".."));
-    items.Add(item);
-  }
-
   return recPath.IsValid();
 }
 

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -137,14 +137,19 @@ std::string CPVRRecordingsPath::GetUnescapedDirectoryPath() const
 
 std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string &strPath) const
 {
+  // note: strPath must be unescaped.
+
   std::string strReturn;
   std::string strUsePath(TrimSlashes(strPath));
 
+  const std::string strUnescapedDirectoryPath(GetUnescapedDirectoryPath());
+
   /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
-  if (!m_directoryPath.empty() && (strUsePath.size() <= m_directoryPath.size() || !URIUtils::PathHasParent(strUsePath, m_directoryPath)))
+  if (!strUnescapedDirectoryPath.empty() &&
+      (strUsePath.size() <= strUnescapedDirectoryPath.size() || !URIUtils::PathHasParent(strUsePath, strUnescapedDirectoryPath)))
     return strReturn;
 
-  strUsePath.erase(0, m_directoryPath.size());
+  strUsePath.erase(0, strUnescapedDirectoryPath.size());
   strUsePath = TrimSlashes(strUsePath);
 
   /* check for more occurences */
@@ -154,7 +159,7 @@ std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string &
   else
     strReturn = strUsePath.substr(0, iDelimiter);
 
-  return CURL::Decode(strReturn);
+  return strReturn;
 }
 
 const std::string CPVRRecordingsPath::GetTitle() const


### PR DESCRIPTION
This PR fixes problems with recording folders/subfolders with names containing special characters, like blanks.

The problem was reported in the forum: http://forum.kodi.tv/showthread.php?tid=269814&pid=2462329#pid2462329

The second commit fixes recordings listings containing two ".." items. GUI media window has been fixed some time ago, so this hack causes trouble now.

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/20609489/854f4b94-b28d-11e6-9dc5-c270fa8c14b5.png)

@MilhouseVH could you please include this PR in your next build and ask the reporter (grisia) to test and report back?

@Jalle19 mind taking a look at the code.
