### PR TITLE
VideoPlayer: change time parameter of SeekTime from int to double

### DIFF
--- a/addons/kodi.inputstream/addon.xml
+++ b/addons/kodi.inputstream/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.inputstream" version="1.0.5" provider-name="Team Kodi">
-  <backwards-compatibility abi="1.0.5"/>
+<addon id="kodi.inputstream" version="1.0.6" provider-name="Team Kodi">
+  <backwards-compatibility abi="1.0.6"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="5.2.0" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.2.0"/>
+<addon id="xbmc.pvr" version="5.2.1" provider-name="Team-Kodi">
+  <backwards-compatibility abi="5.2.1"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -494,7 +494,7 @@ DemuxPacket* CInputStream::ReadDemux()
   return pPacket;
 }
 
-bool CInputStream::SeekTime(int time, bool backward, double* startpts)
+bool CInputStream::SeekTime(double time, bool backward, double* startpts)
 {
   bool ret = false;
   try

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -75,7 +75,7 @@ namespace ADDON
     CDemuxStream* GetStream(int iStreamId);
     std::vector<CDemuxStream*> GetStreams() const;
     DemuxPacket* ReadDemux();
-    bool SeekTime(int time, bool backward, double* startpts);
+    bool SeekTime(double time, bool backward, double* startpts);
     void AbortDemux();
     void FlushDemux();
     void SetSpeed(int iSpeed);

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1383,7 +1383,7 @@ int64_t CPVRClient::SeekStream(int64_t iFilePosition, int iWhence/* = SEEK_SET*/
   return -EINVAL;
 }
 
-bool CPVRClient::SeekTime(int time, bool backwards, double *startpts)
+bool CPVRClient::SeekTime(double time, bool backwards, double *startpts)
 {
   if (IsPlaying())
   {

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -515,7 +515,7 @@ namespace PVR
      * @return True if the seek operation was possible
      * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
      */
-    bool SeekTime(int time, bool backwards, double *startpts);
+    bool SeekTime(double time, bool backwards, double *startpts);
 
     /*!
      * Notify the pvr addon/demuxer that XBMC wishes to change playback speed

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
@@ -122,7 +122,7 @@ extern "C"
    * @return True if the seek operation was possible
    * @remarks Optional, and only used if addon has its own demuxer.
    */
-  bool DemuxSeekTime(int time, bool backwards, double *startpts);
+  bool DemuxSeekTime(double time, bool backwards, double *startpts);
 
   /*!
    * Notify the InputStream addon/demuxer that XBMC wishes to change playback speed

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -31,7 +31,7 @@
 #endif
 
 /* current API version */
-#define INPUTSTREAM_API_VERSION "1.0.5"
+#define INPUTSTREAM_API_VERSION "1.0.6"
 
 extern "C" {
 
@@ -140,7 +140,7 @@ extern "C" {
     void (__cdecl* DemuxAbort)(void);
     void (__cdecl* DemuxFlush)(void);
     DemuxPacket* (__cdecl* DemuxRead)(void);
-    bool (__cdecl* DemuxSeekTime)(int, bool, double*);
+    bool (__cdecl* DemuxSeekTime)(double, bool, double*);
     void (__cdecl* DemuxSetSpeed)(int);
     void (__cdecl* SetVideoResolution)(int, int);
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -589,7 +589,7 @@ extern "C"
    * @return True if the seek operation was possible
    * @remarks Optional, and only used if addon has its own demuxer. Return False if this add-on won't provide this function.
    */
-  bool SeekTime(int time, bool backwards, double *startpts);
+  bool SeekTime(double time, bool backwards, double *startpts);
 
   /*!
    * Notify the pvr addon/demuxer that XBMC wishes to change playback speed

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "5.2.0"
+#define XBMC_PVR_API_VERSION "5.2.1"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "5.2.0"
+#define XBMC_PVR_MIN_API_VERSION "5.2.1"
 
 #ifdef __cplusplus
 extern "C" {
@@ -594,7 +594,7 @@ extern "C" {
     bool         (__cdecl* CanPauseStream)(void);
     void         (__cdecl* PauseStream)(bool);
     bool         (__cdecl* CanSeekStream)(void);
-    bool         (__cdecl* SeekTime)(int, bool, double*);
+    bool         (__cdecl* SeekTime)(double, bool, double*);
     void         (__cdecl* SetSpeed)(int);
     time_t       (__cdecl* GetPlayingTime)(void);
     time_t       (__cdecl* GetBufferTimeStart)(void);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -259,7 +259,7 @@ public:
   /*
    * Seek, time in msec calculated from stream start
    */
-  virtual bool SeekTime(int time, bool backwords = false, double* startpts = NULL) = 0;
+  virtual bool SeekTime(double time, bool backwards = false, double* startpts = NULL) = 0;
 
   /*
    * Seek to a specified chapter.

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h
@@ -64,7 +64,7 @@ public:
   void Abort();
   void Flush();
   DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) { return false; }
+  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override { return false; }
   void SetSpeed(int iSpeed) {};
   int GetStreamLength() { return (int)m_header.durationMs; }
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -35,7 +35,7 @@ public:
   virtual void Abort() {};
   virtual void Flush() {};
   virtual DemuxPacket* Read() { return NULL; };
-  virtual bool SeekTime(int time, bool backwords = false, double* startpts = NULL) {return true;};
+  virtual bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override {return true;};
   virtual void SetSpeed(int iSpeed) {};
   virtual int GetStreamLength() {return 0;};
   virtual CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.cpp
@@ -136,7 +136,7 @@ DemuxPacket* CDVDDemuxCDDA::Read()
   return pPacket;
 }
 
-bool CDVDDemuxCDDA::SeekTime(int time, bool backwords, double* startpts)
+bool CDVDDemuxCDDA::SeekTime(double time, bool backwards, double* startpts)
 {
   int bytes_per_second = m_stream->iBitRate>>3;
   // clamp seeks to bytes per full sample

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCDDA.h
@@ -45,7 +45,7 @@ public:
   void Abort();
   void Flush();
   DemuxPacket* Read();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
   void SetSpeed(int iSpeed) {};
   int GetStreamLength() ;
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -586,7 +586,7 @@ std::string CDVDDemuxClient::GetStreamCodecName(int iStreamId)
   return strName;
 }
 
-bool CDVDDemuxClient::SeekTime(int timems, bool backwards, double *startpts)
+bool CDVDDemuxClient::SeekTime(double timems, bool backwards, double *startpts)
 {
   if (m_IDemux)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -41,7 +41,7 @@ public:
   void Abort() override;
   void Flush() override;
   DemuxPacket* Read() override;
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
+  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
   void SetSpeed(int iSpeed) override;
   int GetStreamLength() override { return 0; }
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1064,7 +1064,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
   return pPacket;
 }
 
-bool CDVDDemuxFFmpeg::SeekTime(int time, bool backwords, double *startpts)
+bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
 {
   bool hitEnd = false;
 
@@ -1109,7 +1109,7 @@ bool CDVDDemuxFFmpeg::SeekTime(int time, bool backwords, double *startpts)
   int ret;
   {
     CSingleLock lock(m_critSection);
-    ret = av_seek_frame(m_pFormatContext, -1, seek_pts, backwords ? AVSEEK_FLAG_BACKWARD : 0);
+    ret = av_seek_frame(m_pFormatContext, -1, seek_pts, backwards ? AVSEEK_FLAG_BACKWARD : 0);
 
     // demuxer can return failure, if seeking behind eof
     if (ret < 0 && m_pFormatContext->duration &&

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -100,7 +100,7 @@ public:
 
   DemuxPacket* Read() override;
 
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL) override;
+  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
   bool SeekByte(int64_t pos);
   int GetStreamLength() override;
   CDemuxStream* GetStream(int iStreamId) const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -141,7 +141,7 @@ void CDVDDemuxVobsub::Flush()
   m_Demuxer->Flush();
 }
 
-bool CDVDDemuxVobsub::SeekTime(int time, bool backwords, double* startpts)
+bool CDVDDemuxVobsub::SeekTime(double time, bool backwards, double* startpts)
 {
   double pts = DVD_MSEC_TO_TIME(time);
   m_Timestamp = m_Timestamps.begin();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -39,7 +39,7 @@ public:
   virtual void          Abort() {};
   virtual void          Flush();
   virtual DemuxPacket*  Read();
-  virtual bool          SeekTime(int time, bool backwords, double* startpts = NULL);
+  virtual bool SeekTime(double time, bool backwards, double* startpts = NULL) override;
   virtual void          SetSpeed(int speed) {}
   virtual CDemuxStream* GetStream(int index) const override { return m_Streams[index]; }
   virtual std::vector<CDemuxStream*> GetStreams() const override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
@@ -203,7 +203,7 @@ DemuxPacket* CDemuxMultiSource::Read()
   return packet;
 }
 
-bool CDemuxMultiSource::SeekTime(int time, bool backwords, double* startpts)
+bool CDemuxMultiSource::SeekTime(double time, bool backwards, double* startpts)
 {
   DemuxQueue demuxerQueue = DemuxQueue();
   bool ret = false;
@@ -212,12 +212,12 @@ bool CDemuxMultiSource::SeekTime(int time, bool backwords, double* startpts)
     if (iter.second->SeekTime(time, false, startpts))
     {
       demuxerQueue.push(std::make_pair(*startpts, iter.second));
-      CLog::Log(LOGDEBUG, "%s - starting demuxer from: %d", __FUNCTION__, time);
+      CLog::Log(LOGDEBUG, "%s - starting demuxer from: %f", __FUNCTION__, time);
       ret = true;
     }
     else
     {
-      CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %d", __FUNCTION__, time);
+      CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %f", __FUNCTION__, time);
     }
   }
   m_demuxerQueue = demuxerQueue;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.h
@@ -59,7 +59,7 @@ public:
   bool Open(CDVDInputStream* pInput);
   DemuxPacket* Read();
   void Reset();
-  bool SeekTime(int time, bool backwords = false, double* startpts = NULL);
+  bool SeekTime(double time, bool backwards = false, double* startpts = NULL) override;
   virtual void SetSpeed(int iSpeed) {};
 
 private:

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -125,7 +125,7 @@ public:
     virtual void EnableStream(int iStreamId, bool enable) = 0;
     virtual int GetNrOfStreams() const = 0;
     virtual void SetSpeed(int iSpeed) = 0;
-    virtual bool SeekTime(int time, bool backward = false, double* startpts = NULL) = 0;
+    virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) = 0;
     virtual void AbortDemux() = 0;
     virtual void FlushDemux() = 0;
     virtual void SetVideoResolution(int width, int height) {};

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -553,7 +553,7 @@ void CDVDInputStreamPVRManager::SetSpeed(int Speed)
   }
 }
 
-bool CDVDInputStreamPVRManager::SeekTime(int timems, bool backwards, double *startpts)
+bool CDVDInputStreamPVRManager::SeekTime(double timems, bool backwards, double *startpts)
 {
   PVR_CLIENT client;
   if (g_PVRClients->GetPlayingClient(client))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -101,7 +101,7 @@ public:
   virtual std::vector<CDemuxStream*> GetStreams() const override;
   virtual int GetNrOfStreams() const override;
   virtual void SetSpeed(int iSpeed) override;
-  virtual bool SeekTime(int time, bool backward = false, double* startpts = NULL) override;
+  virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) override;
   virtual void AbortDemux() override;
   virtual void FlushDemux() override;
   virtual void EnableStream(int iStreamId, bool enable) override {};

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -221,7 +221,7 @@ void CInputStreamAddon::SetSpeed(int iSpeed)
   m_addon->SetSpeed(iSpeed);
 }
 
-bool CInputStreamAddon::SeekTime(int time, bool backward, double* startpts)
+bool CInputStreamAddon::SeekTime(double time, bool backward, double* startpts)
 {
   if (!m_addon)
     return false;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -81,7 +81,7 @@ public:
   virtual void EnableStream(int iStreamId, bool enable) override;
   virtual int GetNrOfStreams() const override;
   virtual void SetSpeed(int iSpeed) override;
-  virtual bool SeekTime(int time, bool backward = false, double* startpts = NULL) override;
+  virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) override;
   virtual void AbortDemux() override;
   virtual void FlushDemux() override;
   virtual void SetVideoResolution(int width, int height) override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2561,7 +2561,7 @@ void CVideoPlayer::HandleMessages()
 
       double start = DVD_NOPTS_VALUE;
 
-      int time = msg.GetTime();
+      double time = msg.GetTime();
       if (msg.GetRelative())
         time = GetTime() + time;
 
@@ -2576,14 +2576,14 @@ void CVideoPlayer::HandleMessages()
       if (m_pInputStream->GetIPosTime() == nullptr)
         time -= DVD_TIME_TO_MSEC(m_State.time_offset);
 
-      CLog::Log(LOGDEBUG, "demuxer seek to: %d", time);
+      CLog::Log(LOGDEBUG, "demuxer seek to: %f", time);
       if (m_pDemuxer && m_pDemuxer->SeekTime(time, msg.GetBackward(), &start))
       {
-        CLog::Log(LOGDEBUG, "demuxer seek to: %d, success", time);
+        CLog::Log(LOGDEBUG, "demuxer seek to: %f, success", time);
         if(m_pSubtitleDemuxer)
         {
           if(!m_pSubtitleDemuxer->SeekTime(time, msg.GetBackward()))
-            CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
+            CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %f, success", time);
         }
         // dts after successful seek
         if (start == DVD_NOPTS_VALUE)


### PR DESCRIPTION
fixes i.e. seeking for PVR for cases where pts is larger than INT_MAX * 1000

pvr and inputstream addons need to be adapted