### PR TITLE
[PVR]Small fixes and optimizations

### DIFF
--- a/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/binary/interfaces/api1/PVR/AddonCallbacksPVR.cpp
@@ -345,7 +345,7 @@ void CAddonCallbacksPVR::PVRConnectionStateChange(void* addonData, const char* s
   if (strMessage != nullptr)
     msg = strMessage;
 
-  g_PVRManager.ConnectionStateChange(client->GetID(), std::string(strConnectionString), newState, msg);
+  g_PVRManager.ConnectionStateChange(client, std::string(strConnectionString), newState, msg);
 }
 
 typedef struct EpgEventStateChange

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -155,6 +155,8 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
   m_blocks = (gridDuration.GetDays() * 24 * 60 + gridDuration.GetHours() * 60 + gridDuration.GetMinutes()) / MINSPERBLOCK;
   if (m_blocks >= MAXBLOCKS)
     m_blocks = MAXBLOCKS;
+  else if (m_blocks < iBlocksPerPage)
+    m_blocks = iBlocksPerPage;
 
   m_gridIndex.reserve(m_channelItems.size());
   const std::vector<GridItem> blocks(m_blocks);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1817,9 +1817,9 @@ void CPVRManager::TriggerSearchMissingChannelIcons(void)
   CJobManager::GetInstance().AddJob(new CPVRSearchMissingChannelIconsJob(), NULL);
 }
 
-void CPVRManager::ConnectionStateChange(int clientId, std::string connectString, PVR_CONNECTION_STATE state, std::string message)
+void CPVRManager::ConnectionStateChange(CPVRClient *client, std::string connectString, PVR_CONNECTION_STATE state, std::string message)
 {
-  CJobManager::GetInstance().AddJob(new CPVRClientConnectionJob(clientId, connectString, state, message), NULL);
+  CJobManager::GetInstance().AddJob(new CPVRClientConnectionJob(client, connectString, state, message), NULL);
 }
 
 void CPVRManager::ExecutePendingJobs(void)
@@ -1871,7 +1871,7 @@ bool CPVRSearchMissingChannelIconsJob::DoWork(void)
 
 bool CPVRClientConnectionJob::DoWork(void)
 {
-  g_PVRClients->ConnectionStateChange(m_clientId, m_connectString, m_state, m_message);
+  g_PVRClients->ConnectionStateChange(m_client, m_connectString, m_state, m_message);
   return true;
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -49,6 +49,7 @@ namespace EPG
 
 namespace PVR
 {
+  class CPVRClient;
   class CPVRClients;
   class CPVRChannel;
   typedef std::shared_ptr<CPVRChannel> CPVRChannelPtr;
@@ -554,7 +555,7 @@ private:
     /*!
      * @brief Signal a connection change of a client
      */
-    void ConnectionStateChange(int clientId, std::string connectString, PVR_CONNECTION_STATE state, std::string message);
+    void ConnectionStateChange(CPVRClient *client, std::string connectString, PVR_CONNECTION_STATE state, std::string message);
 
     /*!
      * @brief Explicitly set the state of channel preview. This is when channel is displayed on OSD without actually switching
@@ -773,14 +774,14 @@ private:
   class CPVRClientConnectionJob : public CJob
   {
   public:
-    CPVRClientConnectionJob(int clientId, std::string connectString, PVR_CONNECTION_STATE state, std::string message) :
-    m_clientId(clientId), m_connectString(connectString), m_state(state), m_message(message) {}
+    CPVRClientConnectionJob(CPVRClient *client, std::string connectString, PVR_CONNECTION_STATE state, std::string message)
+    : m_client(client), m_connectString(connectString), m_state(state), m_message(message) {}
     virtual ~CPVRClientConnectionJob() {}
     virtual const char *GetType() const { return "pvr-client-connection"; }
 
     virtual bool DoWork();
   private:
-    int m_clientId;
+    CPVRClient *m_client;
     std::string m_connectString;
     PVR_CONNECTION_STATE m_state;
     std::string m_message;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1495,11 +1495,10 @@ bool CPVRClients::IsRealTimeStream(void) const
   return false;
 }
 
-void CPVRClients::ConnectionStateChange(int clientId, std::string &strConnectionString, PVR_CONNECTION_STATE newState,
+void CPVRClients::ConnectionStateChange(CPVRClient *client, std::string &strConnectionString, PVR_CONNECTION_STATE newState,
                                         std::string &strMessage)
 {
-  PVR_CLIENT client;
-  if (!GetClient(clientId, client))
+  if (!client)
   {
     CLog::Log(LOGDEBUG, "PVR - %s - invalid client id", __FUNCTION__);
     return;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -659,7 +659,7 @@ namespace PVR
 
     bool IsRealTimeStream() const;
 
-    void ConnectionStateChange(int clientId, std::string &strConnectionString, PVR_CONNECTION_STATE newState,
+    void ConnectionStateChange(CPVRClient *client, std::string &strConnectionString, PVR_CONNECTION_STATE newState,
                                std::string &strMessage);
 
     /*!


### PR DESCRIPTION
I stumbled over some random stuff while testing Krypton nightlies. This PR contains:

1. Fixed an edge case I spotted while using the guide window as Kodi startup window where the grid was not fully painted. (see screenshot)

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/20628595/249089ae-b327-11e6-8d6d-6f8fd2ba0439.png)

2. A small optimization for PVR client addon connection handling. Instead of getting the id of a given client object, then transferring the id to other methods to retrieve the client object from that id at the and is not really optimal. No big deal, but still...

@phil65 is the skin change okay?
@Jalle19 for code review?
