### PR TITLE
[cmake] allow using an existing Texturepacker binary

### DIFF
--- a/project/cmake/modules/FindTexturePacker.cmake
+++ b/project/cmake/modules/FindTexturePacker.cmake
@@ -3,6 +3,10 @@
 # -----------------
 # Finds the TexturePacker
 #
+# If WITH_TEXTUREPACKER is defined and points to a directory,
+# this path will be used to search for the Texturepacker binary
+#
+#
 # This will define the following (imported) targets::
 #
 #   TexturePacker::TexturePacker   - The TexturePacker executable
@@ -17,7 +21,21 @@ if(NOT TARGET TexturePacker::TexturePacker)
     set_target_properties(TexturePacker::TexturePacker PROPERTIES
                                                        IMPORTED_LOCATION "${CORE_SOURCE_DIR}/tools/TexturePacker/TexturePacker.exe")
   else()
-    add_subdirectory(${CORE_SOURCE_DIR}/tools/depends/native/TexturePacker build/texturepacker)
-    add_executable(TexturePacker::TexturePacker ALIAS TexturePacker)
+    if(WITH_TEXTUREPACKER)
+      get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
+      find_program(TEXTUREPACKER_EXECUTABLE TexturePacker PATHS ${_tppath})
+
+      include(FindPackageHandleStandardArgs)
+      find_package_handle_standard_args(TexturePacker DEFAULT_MSG TEXTUREPACKER_EXECUTABLE)
+      if(TEXTUREPACKER_FOUND)
+        add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
+        set_target_properties(TexturePacker::TexturePacker PROPERTIES
+                                                           IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
+      endif()
+      mark_as_advanced(TEXTUREPACKER)
+    else()
+      add_subdirectory(${CORE_SOURCE_DIR}/tools/depends/native/TexturePacker build/texturepacker)
+      add_executable(TexturePacker::TexturePacker ALIAS TexturePacker)
+    endif()
   endif()
 endif()

--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -137,9 +137,11 @@ install(FILES ${CORE_SOURCE_DIR}/privacy-policy.txt
         COMPONENT kodi)
 
 # Install kodi-tools-texturepacker
-install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/texturepacker/TexturePacker
-        DESTINATION ${bindir}
-        COMPONENT kodi-tools-texturepacker)
+if(NOT WITH_TEXTUREPACKER)
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/texturepacker/TexturePacker
+          DESTINATION ${bindir}
+          COMPONENT kodi-tools-texturepacker)
+endif()
 
 # Install kodi-addon-dev headers
 install(FILES ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_vfs_types.h


### PR DESCRIPTION
allows passing the PATH to an external Texturepacker binary. Restores the same functionality as in autotools.
If the path is invalid, we still search in default cmake paths.

usage: -DWITH_TEXTUREPACKER=/path/to