### PR TITLE
FFmpeg: Bump to 3.1.6-Krypton-Beta6

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.5-Krypton-Beta5-1
+VERSION=3.1.6-Krypton-Beta6
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
Fixes a possible memleak when reallocating.

FFmpeg 3.1 series got pretty calm. Version 3.2.1 is already out. I think the next ffmpeg release we do we should use for final.

This links to another prerelease I tagged some minutes ago.