### PR TITLE
Fix processing of Performer/TMCL/TIPL Tag values

### DIFF
--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -1021,7 +1021,7 @@ void CMusicInfoTag::AppendGenre(const std::string &genre)
 
 void CMusicInfoTag::AddArtistRole(const std::string& Role, const std::string& strArtist)
 {
-  if (!strArtist.empty())
+  if (!strArtist.empty() && !Role.empty())
     AddArtistRole(Role, StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator));
 }
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -756,6 +756,25 @@ std::vector<std::string> StringUtils::Split(const std::string& input, const char
   return results;
 }
 
+std::vector<std::string> StringUtils::Split(const std::string& input, const std::vector<std::string> &delimiters)
+{
+  std::vector<std::string> results;
+  if (input.empty())
+    return results;
+
+  if (delimiters.empty())
+  {
+    results.push_back(input);
+    return results;
+  }
+  std::string str = input;
+  for (size_t di = 1; di < delimiters.size(); di++)
+    StringUtils::Replace(str, delimiters[di], delimiters[0]);
+  results = Split(str, delimiters[0]);
+
+  return results;
+}
+
 std::vector<std::string> StringUtils::SplitMulti(const std::vector<std::string> &input, const std::vector<std::string> &delimiters, unsigned int iMaxStrings /* = 0 */)
 {
   if (input.empty())

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -106,6 +106,7 @@ public:
    */
   static std::vector<std::string> Split(const std::string& input, const std::string& delimiter, unsigned int iMaxStrings = 0);
   static std::vector<std::string> Split(const std::string& input, const char delimiter, size_t iMaxStrings = 0);
+  static std::vector<std::string> Split(const std::string& input, const std::vector<std::string> &delimiters);
   
   /*! \brief Splits the given input strings using the given delimiters into further separate strings.
 


### PR DESCRIPTION
Refine the processing of the PERFORMER (vorbis), Musicians credits listTMCL and Involved people list TIPL (ID3 v2.4) tag values into individual music artist roles.

Music files tagged using Musicbrainz Picard sometimes include PERFORMER tag values that contain more than one role e.g. James May (Drums, xylophone and piano). This results in  a role of "Drums, xylophone and piano", and soon fills the role table with combined values. This also can end up with vaying capilatisation as taken from the tag value.

This change splits any combined tag role values into individual instruments and capiltalise for consistency. So tag values "James May (Drums, xylophone and piano)", "Pierre Marchand(Drums, keyboards and piano), "Sarah McLachlan(keyboards, guitar)" results in roles "Drums", "Xylophone", "Piano, "Keyboards", "Guitar".  

To see this you will need music files tagged with combined Performer or TIPL/TMCL tags, and to have them scanned afresh.