### PR TITLE
[PVR] Fullscreen video: On up/down and no channel info is currently s…

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1438,9 +1438,15 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannelPtr &channel, bool bPrev
       return false;
     }
 
-    // no need to do anything except switching m_currentFile
     if (bPreview)
     {
+      if (!g_infoManager.GetShowInfo())
+      {
+        // no need to do anything
+        return true;
+      }
+
+      // no need to do anything except switching m_currentFile
       delete m_currentFile;
       m_currentFile = new CFileItem(channel);
 


### PR DESCRIPTION
Fullscreen video: On up/down and no channel info is currently shown, display channel info for playing channel, not info for next/prev channel.

This is, how other PVRs behave and was requested in the forum: http://forum.kodi.tv/showthread.php?tid=297623

This change was tested on latest krypton master on macOS.

@Jalle19  objections?