### PR TITLE
reset slideshow state on window close

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -266,6 +266,7 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
     m_Image[1].Close();
   }
   g_infoManager.ResetCurrentSlide();
+  m_bSlideShow = false;
 
   CGUIDialog::OnDeinitWindow(nextWindowID);
 }


### PR DESCRIPTION
the Slideshow.IsActive infobool wasn't reset to false after stopping the slideshow.

http://forum.kodi.tv/showthread.php?tid=298004