### PR TITLE
[PVR] Reintroduce filename sort for PVR recordings

### DIFF
--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -54,6 +54,7 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
                   : SortAttributeNone);
   AddSortMethod(SortByDate,  552, LABEL_MASKS("%L", "%d", "%L", "%d")); // "Date"     : Filename, DateTime | Foldername, DateTime
   AddSortMethod(SortByTime,  180, LABEL_MASKS("%L", "%D", "%L", ""));   // "Duration" : Filename, Duration | Foldername, empty
+  AddSortMethod(SortByFile,  561, LABEL_MASKS("%L", "%d", "%L", ""));   // "File"     : Filename, DateTime | Foldername, empty
 
   // Default sorting
   SetSortMethod(SortByDate);


### PR DESCRIPTION
Re-introduce filename sorting for PVR recordings which was removed by https://github.com/xbmc/xbmc/pull/10907 as requested by @ksooo 

## Description
Allows recordings to be sorted by filename again - which is by season/episode when that information is provided by the PVR client.

## How Has This Been Tested?
Tested on x86 using default estuary skin and modified version of confluence.

## Types of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)