### PR TITLE
[Estury] Add Season/Episode to PVR Recordings

### DIFF
--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -49,7 +49,7 @@
 								<right>30</right>
 								<aligny>center</aligny>
 								<scroll>true</scroll>
-								<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+								<label>$INFO[ListItem.Label,, ]$INFO[ListItem.EpisodeName,(,) ]$INFO[Listitem.Season,,.]$INFO[Listitem.Episode]</label>
 							</control>
 							<control type="label">
 								<left>15</left>
@@ -79,7 +79,7 @@
 								<height>80</height>
 								<right>30</right>
 								<aligny>center</aligny>
-								<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+								<label>$INFO[ListItem.Label,, ]$INFO[ListItem.EpisodeName,(,) ]$INFO[Listitem.Season,,.]$INFO[Listitem.Episode]</label>
 							</control>
 							<control type="label">
 								<left>15</left>
@@ -193,7 +193,7 @@
 									<height>90</height>
 									<width>780</width>
 									<aligny>center</aligny>
-									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label,, ]$INFO[ListItem.EpisodeName,(,) ]$INFO[Listitem.Season,,.]$INFO[Listitem.Episode]</label>
 									<shadowcolor>text_shadow</shadowcolor>
 								</control>
 							</focusedlayout>
@@ -203,7 +203,7 @@
 									<height>90</height>
 									<width>$PARAM[width]</width>
 									<aligny>center</aligny>
-									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label,, ]$INFO[ListItem.EpisodeName,(,) ]$INFO[Listitem.Season,,.]$INFO[Listitem.Episode]</label>
 									<shadowcolor>text_shadow</shadowcolor>
 								</control>
 							</itemlayout>


### PR DESCRIPTION
Adds Season.Episode to PVR recordings in Estuary Skin

## Description
If a PVR client provides Season/Episode information, display it in the PVR recordings list.
Format = Standard kodi Season/Episode format as used in Videos section: 
- 1.2 = Season 1, Episode 2
- S1 = Special 1

## Motivation and Context
If you record a whole series, you may miss one, or they may be recorded out of order. This allows you to see which episode comes next. 
Couple this with sort by 'File' (https://github.com/xbmc/xbmc/pull/10999) and you can sort in season/episode order.

## How Has This Been Tested?
Used for several months (>12) on a confluence based skin with uk-rt, then uk-atlas and now schedules-direct as a listings source.
Tested in this form using pvr.mythtv with a 0.27 backend on x86 linux

## Screenshots (if appropriate):
![screenshot053](https://cloud.githubusercontent.com/assets/12870817/20650070/c3abe3a4-b4c5-11e6-816a-e76b6e0b2c8d.png)
![screenshot051](https://cloud.githubusercontent.com/assets/12870817/20650100/f0575a0a-b4c5-11e6-8ae0-627b6de2ada4.png)
![screenshot055](https://cloud.githubusercontent.com/assets/12870817/20650445/70993f1c-b4c6-11e6-8eb2-74a535b31e86.png)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@ksooo @phil65 something for L??? I guess as I seem to have missed the boat for Krypton