### PR TITLE
[PVR][guiinfo] Fix listitem hastimerschedule

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10778,7 +10778,11 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     }
     else if (condition == LISTITEM_HASTIMERSCHEDULE)
     {
-      if (pItem->HasEPGInfoTag())
+      if (pItem->HasPVRTimerInfoTag())
+      {
+        return pItem->GetPVRTimerInfoTag()->GetTimerRuleId() != PVR_TIMER_NO_PARENT;
+      }
+      else if (pItem->HasEPGInfoTag())
       {
         CPVRTimerInfoTagPtr timer = pItem->GetEPGInfoTag()->Timer();
         if (timer)


### PR DESCRIPTION
Without this PR, Estuary's (upcoming) improved timer / timer rule listings do not show episode names / timer types correctly.

@phil65 as discussed on Slack...