### PR TITLE
rbp: Don't close the display here it should be closed by the opener

### DIFF
--- a/xbmc/linux/RBP.cpp
+++ b/xbmc/linux/RBP.cpp
@@ -245,9 +245,6 @@ void CRBP::Deinitialize()
   if(m_omx_initialized)
     m_OMX->Deinitialize();
 
-  if (m_display)
-    CloseDisplay(m_display);
-
   m_DllBcmHost->bcm_host_deinit();
 
   if(m_initialized)


### PR DESCRIPTION
## Description
Don't close the display here it should be closed by the opener

## Motivation and Context
During a normal shutdown, either way is fine as the EGL context has already been shut down and the display will already be closed.
However while debugging the exception in https://github.com/xbmc/xbmc/pull/10971 I found that the cleanup code causes the display to be closed with the EGL context still active.
The firmware doesn't like that and can result in garbage on the display.

## How Has This Been Tested?
In last week of Milhouse builds.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

