### PR TITLE
[DirectoryNodes] override GetChildType() for Episode DirectoryNodes

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -49,3 +49,8 @@ bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items) const
 
   return bSuccess;
 }
+
+NODE_TYPE CDirectoryNodeEpisodes::GetChildType() const
+{
+  return NODE_TYPE_EPISODES;
+}

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
@@ -31,6 +31,7 @@ namespace XFILE
       CDirectoryNodeEpisodes(const std::string& strEntryName, CDirectoryNode* pParent);
     protected:
       virtual bool GetContent(CFileItemList& items) const;
+      NODE_TYPE GetChildType() const override;
     };
   }
 }


### PR DESCRIPTION
Content type (and perhaps some other things?)  for episode directory nodes is broken atm (NODE_TYPE_NONE). This should fix it.
@Montellese 