### PR TITLE
Adding a setting to enable or disable prompting for Auto-Skip

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15538,7 +15538,12 @@ msgctxt "#25013"
 msgid "Auto-skip on"
 msgstr ""
 
-#empty strings from id 25014 to 29800
+#: system/settings/settings.xml
+msgctxt "#25014"
+msgid "Notify about commercial auto-skip"
+msgstr ""
+
+#empty strings from id 25015 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -45,6 +45,11 @@
             <formatlabel>14046</formatlabel>
           </control>
         </setting>
+        <setting id="videoplayer.notifycommercialskip" type="boolean" label="25014">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2" label="19177">
         <setting id="videoplayer.adjustrefreshrate" type="integer" label="170" help="36164">

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -77,6 +77,8 @@
 
 using namespace KODI::MESSAGING;
 
+static const std::string SETTING_VIDEOPLAYER_NOTIFYCOMMERCIALSKIP = "videoplayer.notifycommercialskip";
+
 //------------------------------------------------------------------------------
 // selection streams
 //------------------------------------------------------------------------------
@@ -1322,8 +1324,11 @@ void CVideoPlayer::Prepare()
         CLog::Log(LOGDEBUG, "%s - Start position set to end of first commercial break: %d", __FUNCTION__, starttime);
       }
 
-      std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
-      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      if (CServiceBroker::GetSettings()->GetBool(SETTING_VIDEOPLAYER_NOTIFYCOMMERCIALSKIP))
+      {
+        std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      }
     }
   }
 
@@ -2416,8 +2421,11 @@ void CVideoPlayer::CheckAutoSceneSkip()
     // marker for commbrak may be inaccurate. allow user to skip into break from the back
     if (m_playSpeed >= 0 && m_Edl.GetLastCutTime() != cut.start && clock < cut.end - 1000)
     {
-      std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
-      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      if (CServiceBroker::GetSettings()->GetBool(SETTING_VIDEOPLAYER_NOTIFYCOMMERCIALSKIP))
+      {
+        std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
+        CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+      }
 
       m_Edl.SetLastCutTime(cut.start);
 


### PR DESCRIPTION
## Description
In response to PR #9399 causing issues with playback for myself and dislike among other users, this is a boolean setting to disable prompting for EDL/commercial skip.

## Motivation and Context
Personal: On my RPi2, when the dialog is present, the screen blanks out and does not return until the commercial skip.

For others, this is an annoyance getting in the way of a non-intrusive video player experience. It is just the ability to remove the change.

## How Has This Been Tested?
I do not have a built environment that I can test this in. No compile or run tests were performed.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed