### PR TITLE
FileBrowser: fix multiple item selection

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -145,6 +145,11 @@
       <hash>Rename</hash>
     </remote>
   </FileManager>
+  <FileBrowser>
+    <remote>
+      <zero>Highlight</zero>
+    </remote>
+  </FileBrowser>
   <MusicPlaylist>
     <remote>
       <clear>Delete</clear>

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -186,20 +186,19 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         int iItem = m_viewControl.GetSelectedItem();
         int iAction = message.GetParam1();
         if (iItem < 0) break;
-        if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK)
+        CFileItemPtr pItem = (*m_vecItems)[iItem];
+        if ((iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK) &&
+           (!m_multipleSelection || pItem->m_bIsShareOrDrive || pItem->m_bIsFolder))
         {
           OnClick(iItem);
           return true;
         }
-        else if (iAction == ACTION_HIGHLIGHT_ITEM && m_multipleSelection)
+        else if ((iAction == ACTION_HIGHLIGHT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK || iAction == ACTION_SELECT_ITEM) &&
+                (m_multipleSelection && !pItem->m_bIsShareOrDrive && !pItem->m_bIsFolder))
         {
-          CFileItemPtr pItem = (*m_vecItems)[iItem];
-          if (!pItem->m_bIsShareOrDrive && !pItem->m_bIsFolder)
-          {
-            pItem->Select(!pItem->IsSelected());
-            CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), message.GetSenderId(), iItem + 1);
-            OnMessage(msg);
-          }
+          pItem->Select(!pItem->IsSelected());
+          CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), message.GetSenderId(), iItem + 1);
+          OnMessage(msg);
         }
       }
       else if (message.GetSenderId() == CONTROL_OK)


### PR DESCRIPTION
it was not possible to select multiple items in the filebrowser dialog with either a remote or mouse (only keyboard would work).

fixes:
- allow multiple selections with remote (keymap change)
- allow multiple selections with mouse


enhancements:
- keyboard: allow multiple item selection by pressing 'enter' (currently you have to press 'spacebar')
- remote: allow multiple item selection by pressing 'ok' (currently you have to press '0')

(this makes it similar to how you select multiple items in the select dialog and is far more intuitive)


see: http://forum.kodi.tv/showthread.php?tid=298294