### PR TITLE
[python] allow setting the videoinfotag path

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -454,6 +454,8 @@ namespace XBMCAddon
             item->GetVideoInfoTag()->SetVotes(StringUtils::ReturnDigits(value));
           else if (key == "trailer")
             item->GetVideoInfoTag()->m_strTrailer = value;
+          else if (key == "path")
+            item->GetVideoInfoTag()->m_strPath = value;
           else if (key == "date")
           {
             if (value.length() == 10)

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -592,6 +592,7 @@ namespace XBMCAddon
       /// | album         | string (The Joshua Tree)
       /// | artist        | list (['U2'])
       /// | votes         | string (12345 votes)
+      /// | path          | string (/home/user/movie.avi)
       /// | trailer       | string (/home/user/trailer.avi)
       /// | dateadded     | string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)
       /// | mediatype     | string - "video", "movie", "tvshow", "season", "episode" or "musicvideo"
@@ -635,7 +636,7 @@ namespace XBMCAddon
       /// @python_v15 **duration** has to be set in seconds.
       /// @python_v16 Added new label **mediatype**.
       /// @python_v17
-      /// Added labels **setid**, **set**, **imdbnumber**, **code**, **dbid** and **userrating**.
+      /// Added labels **setid**, **set**, **imdbnumber**, **code**, **dbid**, **path** and **userrating**.
       /// Expanded the possible infoLabels for the option **mediatype**.
       ///
       /// **Example:**


### PR DESCRIPTION
ListItem.Path (and FolderName, FolderPath, FileNameAndPath) return empty in the videoinfo dialog for python listings (widgets and the likes).

addons creating such listings need to set the videoinfotag path.

http://forum.kodi.tv/showthread.php?tid=298028