### PR TITLE
use video disptime only in case video is running

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5004,7 +5004,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       if (state.dts != DVD_NOPTS_VALUE)
       {
         int dispTime = 0;
-        if (m_CurrentVideo.dispTime)
+        if (m_CurrentVideo.id >= 0 && m_CurrentVideo.dispTime)
           dispTime = m_CurrentVideo.dispTime;
         else if (m_CurrentAudio.dispTime)
           dispTime = m_CurrentAudio.dispTime;


### PR DESCRIPTION
See title

## Description
If Inputstream provides only audio data, the not initialized disptime from video is taken to calculate time offsets wich are displayed later in the UI. This PR fixes the use of this not initialzed value.

## How Has This Been Tested?
Win10 before / after test

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
