### PR TITLE
(Potentially) fix generic touch swipe detector

### DIFF
--- a/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
+++ b/xbmc/input/touch/generic/GenericTouchSwipeDetector.cpp
@@ -117,8 +117,8 @@ bool CGenericTouchSwipeDetector::OnTouchMove(unsigned int index, const Pointer &
     return false;
   }
 
-  float deltaXabs = abs(pointer.current.x - pointer.down.x);
-  float deltaYabs = abs(pointer.current.y - pointer.down.y);
+  float deltaXabs = fabs(pointer.current.x - pointer.down.x);
+  float deltaYabs = fabs(pointer.current.y - pointer.down.y);
   float varXabs = deltaYabs * SWIPE_MAX_VARIANCE_ANGLE + (m_dpi * SWIPE_MAX_VARIANCE) / 2;
   float varYabs = deltaXabs * SWIPE_MAX_VARIANCE_ANGLE + (m_dpi * SWIPE_MAX_VARIANCE) / 2;
 

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -132,7 +132,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
               if (window)
               {
                 CFileItem item(*m_song);
-                std::string path = StringUtils::Format("musicdb://artists/%li", idArtist);
+                std::string path = StringUtils::Format("musicdb://artists/%i", idArtist);
                 item.SetPath(path);
                 item.m_bIsFolder = true;
                 window->OnItemInfo(&item, true);


### PR DESCRIPTION
use fabs(), even if abs() (ie implicit cast to int) probably did the job. But this has the potential to change behavior so carefully consider whether to backport.

this is not an attack: can the windows developers explain what is making them consistently add compiler warnings like the format errors? i assume they drown in other sorts of warnings? can we do something about that so you actually get to see the things that are of interest?