### PR TITLE
fixed: do not use move into member variable here

### DIFF
--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -81,7 +81,7 @@ bool CAddonButtonMap::Load(void)
     CSingleLock lock(m_mutex);
     m_features = std::move(features);
     m_driverMap = std::move(driverMap);
-    m_ignoredPrimitives = std::move(CPeripheralAddonTranslator::TranslatePrimitives(ignoredPrimitives));
+    m_ignoredPrimitives = CPeripheralAddonTranslator::TranslatePrimitives(ignoredPrimitives);
   }
 
   return true;


### PR DESCRIPTION
clang points out that it actually hinders copy elusion, not aids it.