### PR TITLE
fixed: add appropriate using statements where virtual methods and overloading is mixed

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -167,7 +167,7 @@ bool CAddon::MeetsVersion(const AddonVersion &version) const
  */
 bool CAddon::HasSettings()
 {
-  return LoadSettings();
+  return LoadSettings(false);
 }
 
 bool CAddon::LoadSettings(bool bForce /* = false*/)
@@ -201,7 +201,7 @@ bool CAddon::LoadSettings(bool bForce /* = false*/)
 
 bool CAddon::HasUserSettings()
 {
-  if (!LoadSettings())
+  if (!LoadSettings(false))
     return false;
 
   return m_userSettingsLoaded;
@@ -257,7 +257,7 @@ void CAddon::SaveSettings(void)
 
 std::string CAddon::GetSetting(const std::string& key)
 {
-  if (!LoadSettings())
+  if (!LoadSettings(false))
     return ""; // no settings available
 
   std::map<std::string, std::string>::const_iterator i = m_settings.find(key);
@@ -268,7 +268,7 @@ std::string CAddon::GetSetting(const std::string& key)
 
 void CAddon::UpdateSetting(const std::string& key, const std::string& value)
 {
-  LoadSettings();
+  LoadSettings(false);
   if (key.empty()) return;
   m_settings[key] = value;
 }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -193,7 +193,7 @@ protected:
    \return true if settings exist, false otherwise
    \sa LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  virtual bool LoadSettings(bool bForce = false);
+  bool LoadSettings(bool bForce);
 
   /*! \brief Load the user settings
    \return true if user settings exist, false otherwise

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -66,7 +66,7 @@ namespace ADDON
   protected:
     void HandleException(std::exception &e, const char* context);
     bool Initialized() { return m_initialized; }
-    virtual bool LoadSettings();
+    bool LoadSettings();
     static uint32_t GetChildCount() { static uint32_t childCounter = 0; return childCounter++; }
     TheStruct* m_pStruct;
     TheProps*     m_pInfo;
@@ -75,6 +75,7 @@ namespace ADDON
     std::string m_parentLib;
 
   private:
+    using CAddon::LoadSettings;
     TheDll* m_pDll;
     bool m_initialized;
     bool LoadDll();
@@ -424,7 +425,7 @@ bool CAddonDll<TheDll, TheStruct, TheProps>::LoadSettings()
     CAddon::SettingsFromXML(m_addonXmlDoc, true);
   }
   else
-    return CAddon::LoadSettings();
+    return CAddon::LoadSettings(true);
 
   m_settingsLoaded = true;
   CAddon::LoadUserSettings();

--- a/xbmc/addons/GUIDialogAddonSettings.h
+++ b/xbmc/addons/GUIDialogAddonSettings.h
@@ -75,6 +75,7 @@ private:
   void UpdateFromControls();
   void EnableControls();
   void SetDefaultSettings();
+  using CGUIDialogBoxBase::GetCondition;
   bool GetCondition(const std::string &condition, const int controlId);
 
   void SaveSettings(void);

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -185,7 +185,7 @@ bool CScraper::Supports(const CONTENT_TYPE &content) const
 bool CScraper::SetPathSettings(CONTENT_TYPE content, const std::string& xml)
 {
   m_pathContent = content;
-  if (!LoadSettings())
+  if (!LoadSettings(false))
     return false;
 
   if (xml.empty())
@@ -200,7 +200,7 @@ bool CScraper::SetPathSettings(CONTENT_TYPE content, const std::string& xml)
 
 std::string CScraper::GetPathSettings()
 {
-  if (!LoadSettings())
+  if (!LoadSettings(false))
     return "";
 
   std::stringstream stream;

--- a/xbmc/addons/binary/interfaces/api1/GUI/AddonGUIWindow.h
+++ b/xbmc/addons/binary/interfaces/api1/GUI/AddonGUIWindow.h
@@ -61,6 +61,7 @@ public:
   bool OnClick(int iItem, const std::string &player = "") override;
 
 protected:
+  using CGUIMediaWindow::Update;
   void Update();
   void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
   void SetupShares() override;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -97,6 +97,7 @@ class CActiveAEBufferPoolResample : public CActiveAEBufferPool
 public:
   CActiveAEBufferPoolResample(AEAudioFormat inputFormat, AEAudioFormat outputFormat, AEQuality quality);
   virtual ~CActiveAEBufferPoolResample();
+  using CActiveAEBufferPool::Create;
   bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true, bool useDSP = false);
   void SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
   bool ResampleBuffers(int64_t timestamp = 0);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -77,7 +77,7 @@ public:
   }
 
 protected:
-
+  using CDVDSubtitleParserCollection::Open;
   bool Open()
   {
     if(m_pStream)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
@@ -44,8 +44,9 @@ public:
   COverlayText(CDVDOverlayText* src);
   virtual ~COverlayText();
   virtual void Render(SRenderState& state);
-  virtual void PrepareRender(const std::string &font, int color, int height, int style,
-                             const std::string &fontcache, const std::string &fontbordercache);
+  using COverlay::PrepareRender;
+  void PrepareRender(const std::string &font, int color, int height, int style,
+                     const std::string &fontcache, const std::string &fontbordercache);
   virtual CGUITextLayout* GetFontLayout(const std::string &font, int color, int height, int style,
                                         const std::string &fontcache, const std::string &fontbordercache);
 

--- a/xbmc/dialogs/GUIDialogKeyboardTouch.h
+++ b/xbmc/dialogs/GUIDialogKeyboardTouch.h
@@ -35,6 +35,7 @@ public:
 
 protected:
   void OnInitWindow() override;
+  using CGUIControlGroup::Process;
   void Process() override;
 
   char_callback_t m_pCharCallback;

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -217,7 +217,7 @@ public:
   void SetVisibleCondition(const std::string &expression, const std::string &allowHiddenFocus = "");
   bool HasVisibleCondition() const { return m_visibleCondition != NULL; };
   void SetEnableCondition(const std::string &expression);
-  virtual void UpdateVisibility(const CGUIListItem *item = NULL);
+  virtual void UpdateVisibility(const CGUIListItem *item);
   virtual void SetInitialVisibility();
   virtual void SetEnabled(bool bEnable);
   virtual void SetInvalid() { m_bInvalidated = true; };

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -100,7 +100,7 @@ void CGUIControlGroup::Process(unsigned int currentTime, CDirtyRegionList &dirty
   CRect rect;
   for (auto *control : m_children)
   {
-    control->UpdateVisibility();
+    control->UpdateVisibility(nullptr);
     unsigned int oldDirty = dirtyregions.size();
     control->DoProcess(currentTime, dirtyregions);
     if (control->IsVisible() || (oldDirty != dirtyregions.size())) // visible or dirty (was visible?)

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -55,7 +55,7 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
   {
     CGUIControl *control = *it;
     GUIPROFILER_VISIBILITY_BEGIN(control);
-    control->UpdateVisibility();
+    control->UpdateVisibility(nullptr);
     GUIPROFILER_VISIBILITY_END(control);
   }
 

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -70,6 +70,7 @@ public:
 protected:
   virtual void SetDefaults();
   virtual void OnWindowLoaded();
+  using CGUIWindow::UpdateVisibility;
   virtual void UpdateVisibility();
 
   virtual void Open_Internal(const std::string &param = "");

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -577,7 +577,7 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CLog::Log(LOGDEBUG, "------ Window Init (%s) ------", GetProperty("xmlfile").c_str());
-      if (m_dynamicResourceAlloc || !m_bAllocated) AllocResources();
+      if (m_dynamicResourceAlloc || !m_bAllocated) AllocResources(false);
       OnInitWindow();
       return true;
     }
@@ -828,7 +828,7 @@ bool CGUIWindow::Initialize()
   if(!NeedXMLReload())
     return true;
   if(g_application.IsCurrentThread())
-    AllocResources();
+    AllocResources(false);
   else
   {
     // if not app thread, send gui msg via app messenger
@@ -860,7 +860,7 @@ bool CGUIWindow::CheckAnimation(ANIMATION_TYPE animType)
       return false;
     // make sure we update our visibility prior to queuing the window close anim
     for (unsigned int i = 0; i < m_children.size(); i++)
-      m_children[i]->UpdateVisibility();
+      m_children[i]->UpdateVisibility(nullptr);
   }
   return true;
 }

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -126,7 +126,9 @@ public:
   // and does not need to be passed further down the line (to our global action handlers)
   virtual bool OnAction(const CAction &action);
   
+  using CGUIControlGroup::OnBack;
   virtual bool OnBack(int actionID);
+  using CGUIControlGroup::OnInfo;
   virtual bool OnInfo(int actionID) { return false; };
 
   /*! \brief Clear the background (if necessary) prior to rendering the window
@@ -143,6 +145,7 @@ public:
   int GetPreviousWindow() { return m_previousWindow; };
   CRect GetScaledBounds() const;
   virtual void ClearAll();
+  using CGUIControlGroup::AllocResources;
   virtual void AllocResources(bool forceLoad = false);
   virtual void FreeResources(bool forceUnLoad = false);
   virtual void DynamicResourceAlloc(bool bOnOff);

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -42,7 +42,7 @@ public:
   virtual bool Save(TiXmlNode *settings) const override;
   virtual void Clear() override;
 
-  virtual void OnSettingAction(const CSetting *setting);
+  void OnSettingAction(const CSetting *setting) override;
   virtual bool OnSettingChanging(const CSetting *setting) override;
   virtual bool OnSettingUpdate(CSetting* &setting, const char *oldSettingId, const TiXmlNode *oldSettingNode) override;
 

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -42,6 +42,7 @@ public:
   void SetSources(const std::vector<std::string> &sources) { m_sources = sources; }
 
 private:
+  using CSettingString::copy;
   void copy(const CSettingPath &setting);
 
   bool m_writable;

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -76,6 +76,7 @@ protected:
 private:
   void SetLabel2(const std::string &settingid, const std::string &label);
   void ToggleState(const std::string &settingid, bool enabled);
+  using CGUIDialogSettingsManualBase::SetFocus;
   void SetFocus(const std::string &settingid);
 
   /*!

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -220,7 +220,8 @@ public:
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pImage; }
   virtual bool OnClick() { return false; }
-  virtual void Update() {}
+  using CGUIControlBaseSetting::Update;
+  void Update() {}
   virtual void Clear() { m_pImage = NULL; }
 private:
   CGUIImage *m_pImage;
@@ -234,7 +235,8 @@ public:
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pLabel; }
   virtual bool OnClick() { return false; }
-  virtual void Update() {}
+  using CGUIControlBaseSetting::Update;
+  void Update() {}
   virtual void Clear() { m_pLabel = NULL; }
 private:
   CGUILabelControl *m_pLabel;

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -127,11 +127,6 @@ bool CXBMCTinyXML::SaveFile(const std::string& filename) const
   return false;
 }
 
-bool CXBMCTinyXML::Parse(const char *_data, TiXmlEncoding encoding)
-{
-  return Parse(std::string(_data), encoding);
-}
-
 bool CXBMCTinyXML::Parse(const std::string& data, const std::string& dataCharset)
 {
   m_SuggestedCharset = dataCharset;
@@ -262,7 +257,7 @@ bool CXBMCTinyXML::Test()
                   "http://api.themoviedb.org/3/movie/12244"
                   "?api_key=57983e31fb435df4df77afb854740ea9"
                   "&language=en&#x3f;&#x003F;&#0063;</url></details>");
-  doc.Parse(data.c_str());
+  doc.Parse(data.c_str(), TIXML_DEFAULT_ENCODING);
   TiXmlNode *root = doc.RootElement();
   if (root && root->ValueStr() == "details")
   {

--- a/xbmc/utils/XBMCTinyXML.h
+++ b/xbmc/utils/XBMCTinyXML.h
@@ -59,13 +59,13 @@ public:
   bool LoadFile(FILE*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool SaveFile(const char*) const;
   bool SaveFile(const std::string& filename) const;
-  bool Parse(const char*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool Parse(const std::string& data, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
   bool Parse(const std::string& data, const std::string& dataCharset);
   inline std::string GetSuggestedCharset(void) const { return m_SuggestedCharset; }
   inline std::string GetUsedCharset(void) const      { return m_UsedCharset; }
   static bool Test();
 protected:
+  using TiXmlDocument::Parse;
   bool TryParse(const std::string& data, const std::string& tryDataCharset);
   bool InternalParse(const std::string& rawdata, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
 

--- a/xbmc/utils/test/TestXBMCTinyXML.cpp
+++ b/xbmc/utils/test/TestXBMCTinyXML.cpp
@@ -34,7 +34,7 @@ TEST(TestXBMCTinyXML, ParseFromString)
                   "http://api.themoviedb.org/3/movie/12244"
                   "?api_key=57983e31fb435df4df77afb854740ea9"
                   "&language=en&#x3f;&#x003F;&#0063;</url></details>");
-  doc.Parse(data.c_str());
+  doc.Parse(data);
   TiXmlNode *root = doc.RootElement();
   if (root && root->ValueStr() == "details")
   {

--- a/xbmc/utils/test/TestXMLUtils.cpp
+++ b/xbmc/utils/test/TestXMLUtils.cpp
@@ -29,7 +29,7 @@ TEST(TestXMLUtils, GetHex)
   CXBMCTinyXML a;
   uint32_t ref, val;
 
-  a.Parse("<root><node>0xFF</node></root>");
+  a.Parse(std::string("<root><node>0xFF</node></root>"));
   EXPECT_TRUE(XMLUtils::GetHex(a.RootElement(), "node", val));
 
   ref = 0xFF;
@@ -41,7 +41,7 @@ TEST(TestXMLUtils, GetUInt)
   CXBMCTinyXML a;
   uint32_t ref, val;
 
-  a.Parse("<root><node>1000</node></root>");
+  a.Parse(std::string("<root><node>1000</node></root>"));
   EXPECT_TRUE(XMLUtils::GetUInt(a.RootElement(), "node", val));
 
   ref = 1000;
@@ -53,7 +53,7 @@ TEST(TestXMLUtils, GetLong)
   CXBMCTinyXML a;
   long ref, val;
 
-  a.Parse("<root><node>1000</node></root>");
+  a.Parse(std::string("<root><node>1000</node></root>"));
   EXPECT_TRUE(XMLUtils::GetLong(a.RootElement(), "node", val));
 
   ref = 1000;
@@ -65,7 +65,7 @@ TEST(TestXMLUtils, GetFloat)
   CXBMCTinyXML a;
   float ref, val;
 
-  a.Parse("<root><node>1000.1f</node></root>");
+  a.Parse(std::string("<root><node>1000.1f</node></root>"));
   EXPECT_TRUE(XMLUtils::GetFloat(a.RootElement(), "node", val));
   EXPECT_TRUE(XMLUtils::GetFloat(a.RootElement(), "node", val, 1000.0f,
                                  1000.2f));
@@ -79,7 +79,7 @@ TEST(TestXMLUtils, GetDouble)
   double val;
   std::string refstr, valstr;
 
-  a.Parse("<root><node>1000.1f</node></root>");
+  a.Parse(std::string("<root><node>1000.1f</node></root>"));
   EXPECT_TRUE(XMLUtils::GetDouble(a.RootElement(), "node", val));
 
   refstr = "1000.100000";
@@ -92,7 +92,7 @@ TEST(TestXMLUtils, GetInt)
   CXBMCTinyXML a;
   int ref, val;
 
-  a.Parse("<root><node>1000</node></root>");
+  a.Parse(std::string("<root><node>1000</node></root>"));
   EXPECT_TRUE(XMLUtils::GetInt(a.RootElement(), "node", val));
   EXPECT_TRUE(XMLUtils::GetInt(a.RootElement(), "node", val, 999, 1001));
 
@@ -105,7 +105,7 @@ TEST(TestXMLUtils, GetBoolean)
   CXBMCTinyXML a;
   bool ref, val;
 
-  a.Parse("<root><node>true</node></root>");
+  a.Parse(std::string("<root><node>true</node></root>"));
   EXPECT_TRUE(XMLUtils::GetBoolean(a.RootElement(), "node", val));
 
   ref = true;
@@ -117,7 +117,7 @@ TEST(TestXMLUtils, GetString)
   CXBMCTinyXML a;
   std::string ref, val;
 
-  a.Parse("<root><node>some string</node></root>");
+  a.Parse(std::string("<root><node>some string</node></root>"));
   EXPECT_TRUE(XMLUtils::GetString(a.RootElement(), "node", val));
 
   ref = "some string";
@@ -129,26 +129,26 @@ TEST(TestXMLUtils, GetAdditiveString)
   CXBMCTinyXML a, b;
   std::string ref, val;
 
-  a.Parse("<root>\n"
+  a.Parse(std::string("<root>\n"
           "  <node>some string1</node>\n"
           "  <node>some string2</node>\n"
           "  <node>some string3</node>\n"
           "  <node>some string4</node>\n"
           "  <node>some string5</node>\n"
-          "</root>\n");
+          "</root>\n"));
   EXPECT_TRUE(XMLUtils::GetAdditiveString(a.RootElement(), "node", ",", val));
 
   ref = "some string1,some string2,some string3,some string4,some string5";
   EXPECT_STREQ(ref.c_str(), val.c_str());
 
   val.clear();
-  b.Parse("<root>\n"
+  b.Parse(std::string("<root>\n"
           "  <node>some string1</node>\n"
           "  <node>some string2</node>\n"
           "  <node clear=\"true\">some string3</node>\n"
           "  <node>some string4</node>\n"
           "  <node>some string5</node>\n"
-          "</root>\n");
+          "</root>\n"));
   EXPECT_TRUE(XMLUtils::GetAdditiveString(b.RootElement(), "node", ",", val));
 
   ref = "some string3,some string4,some string5";
@@ -160,13 +160,13 @@ TEST(TestXMLUtils, GetStringArray)
   CXBMCTinyXML a;
   std::vector<std::string> strarray;
 
-  a.Parse("<root>\n"
+  a.Parse(std::string("<root>\n"
           "  <node>some string1</node>\n"
           "  <node>some string2</node>\n"
           "  <node>some string3</node>\n"
           "  <node>some string4</node>\n"
           "  <node>some string5</node>\n"
-          "</root>\n");
+          "</root>\n"));
   EXPECT_TRUE(XMLUtils::GetStringArray(a.RootElement(), "node", strarray));
 
   EXPECT_STREQ("some string1", strarray.at(0).c_str());
@@ -181,14 +181,14 @@ TEST(TestXMLUtils, GetPath)
   CXBMCTinyXML a, b;
   std::string ref, val;
 
-  a.Parse("<root><node urlencoded=\"yes\">special://xbmc/</node></root>");
+  a.Parse(std::string("<root><node urlencoded=\"yes\">special://xbmc/</node></root>"));
   EXPECT_TRUE(XMLUtils::GetPath(a.RootElement(), "node", val));
 
   ref = "special://xbmc/";
   EXPECT_STREQ(ref.c_str(), val.c_str());
 
   val.clear();
-  b.Parse("<root><node>special://xbmcbin/</node></root>");
+  b.Parse(std::string("<root><node>special://xbmcbin/</node></root>"));
   EXPECT_TRUE(XMLUtils::GetPath(b.RootElement(), "node", val));
 
   ref = "special://xbmcbin/";
@@ -200,7 +200,7 @@ TEST(TestXMLUtils, GetDate)
   CXBMCTinyXML a;
   CDateTime ref, val;
 
-  a.Parse("<root><node>2012-07-08</node></root>");
+  a.Parse(std::string("<root><node>2012-07-08</node></root>"));
   EXPECT_TRUE(XMLUtils::GetDate(a.RootElement(), "node", val));
   ref.SetDate(2012, 7, 8);
   EXPECT_TRUE(ref == val);
@@ -211,7 +211,7 @@ TEST(TestXMLUtils, GetDateTime)
   CXBMCTinyXML a;
   CDateTime ref, val;
 
-  a.Parse("<root><node>2012-07-08 01:02:03</node></root>");
+  a.Parse(std::string("<root><node>2012-07-08 01:02:03</node></root>"));
   EXPECT_TRUE(XMLUtils::GetDateTime(a.RootElement(), "node", val));
   ref.SetDateTime(2012, 7, 8, 1, 2, 3);
   EXPECT_TRUE(ref == val);
@@ -222,7 +222,7 @@ TEST(TestXMLUtils, SetString)
   CXBMCTinyXML a;
   std::string ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetString(a.RootElement(), "node", "some string");
   EXPECT_TRUE(XMLUtils::GetString(a.RootElement(), "node", val));
 
@@ -235,7 +235,7 @@ TEST(TestXMLUtils, SetAdditiveString)
   CXBMCTinyXML a;
   std::string ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetAdditiveString(a.RootElement(), "node", ",",
     "some string1,some string2,some string3,some string4,some string5");
   EXPECT_TRUE(XMLUtils::GetAdditiveString(a.RootElement(), "node", ",", val));
@@ -254,7 +254,7 @@ TEST(TestXMLUtils, SetStringArray)
   strarray.push_back("some string4");
   strarray.push_back("some string5");
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetStringArray(a.RootElement(), "node", strarray);
   EXPECT_TRUE(XMLUtils::GetStringArray(a.RootElement(), "node", strarray));
 
@@ -270,7 +270,7 @@ TEST(TestXMLUtils, SetInt)
   CXBMCTinyXML a;
   int ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetInt(a.RootElement(), "node", 1000);
   EXPECT_TRUE(XMLUtils::GetInt(a.RootElement(), "node", val));
 
@@ -283,7 +283,7 @@ TEST(TestXMLUtils, SetFloat)
   CXBMCTinyXML a;
   float ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetFloat(a.RootElement(), "node", 1000.1f);
   EXPECT_TRUE(XMLUtils::GetFloat(a.RootElement(), "node", val));
 
@@ -296,7 +296,7 @@ TEST(TestXMLUtils, SetBoolean)
   CXBMCTinyXML a;
   bool ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetBoolean(a.RootElement(), "node", true);
   EXPECT_TRUE(XMLUtils::GetBoolean(a.RootElement(), "node", val));
 
@@ -309,7 +309,7 @@ TEST(TestXMLUtils, SetHex)
   CXBMCTinyXML a;
   uint32_t ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetHex(a.RootElement(), "node", 0xFF);
   EXPECT_TRUE(XMLUtils::GetHex(a.RootElement(), "node", val));
 
@@ -322,7 +322,7 @@ TEST(TestXMLUtils, SetPath)
   CXBMCTinyXML a;
   std::string ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetPath(a.RootElement(), "node", "special://xbmc/");
   EXPECT_TRUE(XMLUtils::GetPath(a.RootElement(), "node", val));
 
@@ -335,7 +335,7 @@ TEST(TestXMLUtils, SetLong)
   CXBMCTinyXML a;
   long ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   XMLUtils::SetLong(a.RootElement(), "node", 1000);
   EXPECT_TRUE(XMLUtils::GetLong(a.RootElement(), "node", val));
 
@@ -348,7 +348,7 @@ TEST(TestXMLUtils, SetDate)
   CXBMCTinyXML a;
   CDateTime ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   ref.SetDate(2012, 7, 8);
   XMLUtils::SetDate(a.RootElement(), "node", ref);
   EXPECT_TRUE(XMLUtils::GetDate(a.RootElement(), "node", val));
@@ -360,7 +360,7 @@ TEST(TestXMLUtils, SetDateTime)
   CXBMCTinyXML a;
   CDateTime ref, val;
 
-  a.Parse("<root></root>");
+  a.Parse(std::string("<root></root>"));
   ref.SetDateTime(2012, 7, 8, 1, 2, 3);
   XMLUtils::SetDateTime(a.RootElement(), "node", ref);
   EXPECT_TRUE(XMLUtils::GetDateTime(a.RootElement(), "node", val));

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -122,6 +122,7 @@ protected:
   void PlayItem(int iItem, const std::string &player = "");
   virtual bool OnPlayMedia(int iItem, const std::string &player = "") override;
   virtual bool OnPlayAndQueueMedia(const CFileItemPtr &item, std::string player = "") override;
+  using CGUIMediaWindow::LoadPlayList;
   void LoadPlayList(const std::string& strPlayList, int iPlayList = PLAYLIST_VIDEO);
 
   bool ShowIMDB(CFileItemPtr item, const ADDON::ScraperPtr& content, bool fromDB);

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -352,7 +352,7 @@ void CGUIViewControl::UpdateViewVisibility()
     CGUIControl *view = m_allViews[i];
     if (view->HasVisibleCondition())
     {
-      view->UpdateVisibility();
+      view->UpdateVisibility(nullptr);
       if (view->IsVisibleFromSkin())
         m_visibleViews.push_back(view);
     }


### PR DESCRIPTION
quells a shitload of clang warnings.

for a couple of these methods were marked virtual, but they were not overriding anything. that made the diff a bit larger as i have to select the correct overload explicitly (i have to remove the default param or it gets ambigious with parent method).