### PR TITLE
enable transfer of encrypted stream infos from inputstream to kodi

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -412,6 +412,26 @@ void CInputStream::UpdateStreams()
         demuxStream->ExtraData[j] = stream.m_ExtraData[j];
     }
 
+    if (stream.crypto_key_system != INPUTSTREAM_INFO::CRYPTO_KEY_SYSTEM_NONE)
+    {
+      switch (stream.crypto_key_system) {
+      case INPUTSTREAM_INFO::CRYPTO_KEY_SYSTEM_WIDEVINE:
+        demuxStream->crypto_key_system = STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE;
+        break;
+      case INPUTSTREAM_INFO::CRYPTO_KEY_SYSTEM_PLAYREADY:
+        demuxStream->crypto_key_system = STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY;
+        break;
+      default:;
+      }
+
+      if (demuxStream->crypto_key_system != STREAM_CRYPTO_KEY_SYSTEM_NONE)
+      {
+        demuxStream->crypto_session_id_size = stream.crypto_session_id_size;
+        demuxStream->crypto_session_id = new char[stream.crypto_session_id_size];
+        memcpy(demuxStream->crypto_session_id, stream.crypto_session_id, stream.crypto_session_id_size);
+      }
+    }
+
     m_streams[demuxStream->uniqueId] = demuxStream;
   }
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -31,7 +31,7 @@
 #endif
 
 /* current API version */
-#define INPUTSTREAM_API_VERSION "1.0.6"
+#define INPUTSTREAM_API_VERSION "1.0.7"
 
 extern "C" {
 
@@ -119,6 +119,15 @@ extern "C" {
     unsigned int m_BitRate;              /*!< @brief (required) bit rate */
     unsigned int m_BitsPerSample;        /*!< @brief (required) bits per sample */
     unsigned int m_BlockAlign;
+
+    enum CRYPTO_KEY_SYSTEM :uint16_t
+    {
+      CRYPTO_KEY_SYSTEM_NONE = 0,
+      CRYPTO_KEY_SYSTEM_WIDEVINE,
+      CRYPTO_KEY_SYSTEM_PLAYREADY
+    } crypto_key_system;                 /*!< @brief keysystem for encrypted media, KEY_SYSTEM_NONE for unencrypted media */
+    char * crypto_session_id;            /*!< @brief The crypto session key id */
+    uint16_t crypto_session_id_size;     /*!< @brief The size of the crypto session key id */
   } INPUTSTREAM_INFO;
 
   /*!

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -64,6 +64,13 @@ enum StreamSource {
   STREAM_SOURCE_VIDEOMUX      = 0x500
 };
 
+enum StreamCryptoKeySystem :uint16_t
+{
+  STREAM_CRYPTO_KEY_SYSTEM_NONE,
+  STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE,
+  STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY
+};
+
 #define STREAM_SOURCE_MASK(a) ((a) & 0xf00)
 
 /*
@@ -94,11 +101,15 @@ public:
     flags = FLAG_NONE;
     realtime = false;
     bandwidth = 0;
+    crypto_key_system = STREAM_CRYPTO_KEY_SYSTEM_NONE;
+    crypto_session_id = nullptr;
+    crypto_session_id_size = 0;
   }
 
   virtual ~CDemuxStream()
   {
     delete [] ExtraData;
+    delete[] crypto_session_id;
   }
 
   virtual std::string GetStreamName();
@@ -126,6 +137,11 @@ public:
   std::string codecName;
 
   int  changes; // increment on change which player may need to know about
+
+  // encryped stream infos
+  char * crypto_session_id;
+  uint16_t crypto_session_id_size;
+  StreamCryptoKeySystem crypto_key_system;
 
   enum EFlags
   { FLAG_NONE             = 0x0000 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
@@ -25,6 +25,18 @@
 #define DMX_SPECIALID_STREAMINFO    -10
 #define DMX_SPECIALID_STREAMCHANGE  -11
 
+typedef struct DemuxCryptoInfo
+{
+  uint16_t numSubSamples; //number of subsamples
+  uint16_t flags; //flags for later use
+
+  uint16_t *clearBytes; // numSubSamples uint16_t's wich define the size of clear size of a subsample
+  uint32_t *cipherBytes; // numSubSamples uint32_t's wich define the size of cipher size of a subsample
+
+  uint8_t iv[16]; // initialization vector
+  uint8_t kid[16]; // key id
+}DemuxCryptoInfo;
+
 typedef struct DemuxPacket
 {
   unsigned char* pData;   // data
@@ -32,10 +44,11 @@ typedef struct DemuxPacket
   int iStreamId; // integer representing the stream index
   int64_t demuxerId; // id of the demuxer that created the packet
   int iGroupId;  // the group this data belongs to, used to group data from different streams together
+  int dispTime;
 
   double pts; // pts in DVD_TIME_BASE
   double dts; // dts in DVD_TIME_BASE
   double duration; // duration in DVD_TIME_BASE if available
 
-  int dispTime;
+  DemuxCryptoInfo *cryptoInfo; //necessary information to decrypt a packet; nullptr if not encrypted
 } DemuxPacket;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -39,6 +39,12 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
   if (pPacket)
   {
     try {
+      if (pPacket->cryptoInfo)
+      {
+        delete[] pPacket->cryptoInfo->clearBytes;
+        delete[] pPacket->cryptoInfo->cipherBytes;
+        delete pPacket->cryptoInfo;
+      }
       if (pPacket->pData) _aligned_free(pPacket->pData);
       delete pPacket;
     }
@@ -48,7 +54,7 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
   }
 }
 
-DemuxPacket* CDVDDemuxUtils::AllocateDemuxPacket(int iDataSize)
+DemuxPacket* CDVDDemuxUtils::AllocateDemuxPacket(int iDataSize, unsigned int encryptedSubsampleCount)
 {
   DemuxPacket* pPacket = new DemuxPacket;
   if (!pPacket) return NULL;
@@ -77,6 +83,24 @@ DemuxPacket* CDVDDemuxUtils::AllocateDemuxPacket(int iDataSize)
 
       // reset the last 8 bytes to 0;
       memset(pPacket->pData + iDataSize, 0, FF_INPUT_BUFFER_PADDING_SIZE);
+
+      if (encryptedSubsampleCount)
+      {
+        pPacket->cryptoInfo = new DemuxCryptoInfo;
+        if (!pPacket->cryptoInfo)
+        {
+          FreeDemuxPacket(pPacket);
+          return NULL;
+        }
+        pPacket->cryptoInfo->numSubSamples = encryptedSubsampleCount;
+        pPacket->cryptoInfo->clearBytes = new uint16_t[encryptedSubsampleCount];
+        pPacket->cryptoInfo->cipherBytes = new uint32_t[encryptedSubsampleCount];
+        if (!pPacket->cryptoInfo->clearBytes || !pPacket->cryptoInfo->cipherBytes)
+        {
+          FreeDemuxPacket(pPacket);
+          return NULL;
+        }
+      }
     }
 
     // setup defaults

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
@@ -26,6 +26,6 @@ class CDVDDemuxUtils
 {
 public:
   static void FreeDemuxPacket(DemuxPacket* pPacket);
-  static DemuxPacket* AllocateDemuxPacket(int iDataSize = 0);
+  static DemuxPacket* AllocateDemuxPacket(int iDataSize = 0, unsigned int encryptedSubsampleCount = 0);
 };
 


### PR DESCRIPTION
Enable transfer of encrypted stream infos from inputstream to kodi

## Description
see title

## Motivation and Context
This PR provides the necessary definitions to allow encrypted media beeing transfered from Inputstream addon to kodi. Androids MediaCodec (MediaCrypto) and soon ffmpeg allow the DRM handling of encrypted streams. There are discussions with linaro / wdevine / mcrosoft as well to get solutions for linux / windows as well.

## How Has This Been Tested?
compile test only

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
