### PR TITLE
Fix game add-ons not loading

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -30,6 +30,7 @@
 #include "ContextMenuManager.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
 #include "RepositoryUpdater.h"
 #include "settings/Settings.h"
 #include "ServiceBroker.h"
@@ -331,7 +332,19 @@ std::string CAddon::LibPath() const
 {
   if (m_props.libname.empty())
     return "";
-  return URIUtils::AddFileToFolder(m_props.path, m_props.libname);
+
+  std::string strLibPath = URIUtils::AddFileToFolder(m_props.path, m_props.libname);
+
+  // Check if add-on library has been installed to the binaries path instead
+  std::string strSharePath = CSpecialProtocol::TranslatePath("special://xbmc/");
+  const bool bIsInSharePath = StringUtils::StartsWith(strLibPath, strSharePath);
+  if (bIsInSharePath && !CFile::Exists(strLibPath))
+  {
+    std::string strBinPath = CSpecialProtocol::TranslatePath("special://xbmcbin/");
+    strLibPath.replace(0, strSharePath.length(), strBinPath);
+  }
+
+  return strLibPath;
 }
 
 AddonVersion CAddon::GetDependencyVersion(const std::string &dependencyID) const


### PR DESCRIPTION
This is the fix I've been using in my RP branch for over a year to fix game add-ons not loading. The problem is that Kodi is trying to load the shared library from `/usr/share/kodi/addons/` instead of `/usr/lib/kodi/addons/`.

This successfully fixes game add-ons not loading, but I have reports from users that it breaks PVR add-ons loading. I figured that I'd post this fix and we could go from there.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)