### PR TITLE
Revert "This makes the SubtitleDialog remember the last service used,…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -144,7 +144,6 @@
 
 // Dialog includes
 #include "video/dialogs/GUIDialogVideoBookmarks.h"
-#include "video/dialogs/GUIDialogSubtitles.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSubMenu.h"
@@ -3869,12 +3868,6 @@ void CApplication::StopPlaying()
   if ( m_pPlayer->IsPlaying() )
   {
     m_pPlayer->CloseFile();
-
-    // When playback stops we must clear the saved subtitle search from the SubtitleDialog since the dialog is preserved in memory
-    // Otherwise the next time the dialogs open any previous search from a previous movie will be shown
-    CGUIDialogSubtitles *dialog = (CGUIDialogSubtitles*)g_windowManager.GetWindow(WINDOW_DIALOG_SUBTITLES);
-    CGUIMessage msg(GUI_MSG_WINDOW_RESET, dialog->GetID(), 0);
-    dialog->OnMessage(msg);
 
     // turn off visualisation window when stopping
     if ((iWin == WINDOW_VISUALISATION

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -162,14 +162,8 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
 
     CGUIDialog::OnMessage(message);
 
-    return true;
-  }
-  else if (message.GetMessage() == GUI_MSG_WINDOW_RESET)
-  {
-    CGUIDialog::OnMessage(message);
-    
-    // Clear saved subtitles from any previous subtitle search
     ClearSubtitles();
+    ClearServices();
     return true;
   }
   return CGUIDialog::OnMessage(message);
@@ -187,10 +181,7 @@ void CGUIDialogSubtitles::OnInitWindow()
 
   FillServices();
   CGUIWindow::OnInitWindow();
-
-  // Only do a inital search for subtitles if there isn't a saved search
-  if (m_subtitles->IsEmpty())
-    Search();
+  Search();
 }
 
 void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
@@ -240,7 +231,6 @@ void CGUIDialogSubtitles::Process(unsigned int currentTime, CDirtyRegionList &di
 
 void CGUIDialogSubtitles::FillServices()
 {
-  std::string previousService = m_currentService;
   ClearServices();
 
   VECADDONS addons;
@@ -267,8 +257,7 @@ void CGUIDialogSubtitles::FillServices()
   {
     CFileItemPtr item(CAddonsDirectory::FileItemFromAddon(*addonIt, "plugin://" + (*addonIt)->ID(), false));
     m_serviceItems->Add(item);
-    // If we don't have used a previous service use the default service, otherwise use the previous service
-    if ((previousService.empty() && (*addonIt)->ID() == defaultService) || (*addonIt)->ID() == previousService)
+    if ((*addonIt)->ID() == defaultService)
       service = (*addonIt)->ID();
   }
 


### PR DESCRIPTION
Reverts #9660 
#9660 introduced remembering last service used, effectively rendering the default tvshow and movie service settings useless.
Also noticed issues where the status of the subtitle dialog was on downloading when opened and focus was lost.

@phil65 @arnova 