### PR TITLE
AML: Make DTS-HD, TrueHD work on IEC61937 backport work

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -303,6 +303,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
         m_format.m_channelLayout = AE_CH_LAYOUT_2_0;
         m_format.m_sampleRate     = m_sink_sampleRate;
         m_encoding = CJNIAudioFormat::ENCODING_PCM_16BIT;
+        CLog::Log(LOGDEBUG, "Fallback to PCM passthrough mode - this might not work!");
       }
     }
   }
@@ -325,9 +326,14 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(m_format.m_channelLayout);
   m_format.m_channelLayout  = AUDIOTRACKChannelMaskToAEChannelMap(atChannelMask);
   if (m_encoding == CJNIAudioFormat::ENCODING_IEC61937)
-    atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
+  {
+    // keep above channel output if we do IEC61937 and got DTSHD or TrueHD by AudioEngine
+    if (m_format.m_streamInfo.m_type != CAEStreamInfo::STREAM_TYPE_DTSHD && m_format.m_streamInfo.m_type != CAEStreamInfo::STREAM_TYPE_TRUEHD)
+      atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
+  }
 
-  if (aml_present() && m_passthrough && m_info.m_wantsIECPassthrough)
+  // old aml without IEC61937 passes everything via 2 channels
+  if (aml_present() && m_passthrough && m_info.m_wantsIECPassthrough && (CJNIAudioFormat::ENCODING_IEC61937 == -1))
     atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
 
   while (!m_at_jni)
@@ -408,16 +414,21 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       if (m_passthrough)
       {
         m_min_buffer_size *= 2;
-        if (m_sink_sampleRate > 48000)
-          m_min_buffer_size *= (m_sink_sampleRate / 48000); // same amount of buffer in seconds as for 48 khz
-        else if (m_sink_sampleRate < m_format.m_sampleRate) // eac3
-          m_min_buffer_size *= (m_format.m_sampleRate / m_sink_sampleRate);
+        // AML in old mode needs more buffer or it stutters when faking PT
+        if (aml_present() && m_passthrough && m_info.m_wantsIECPassthrough && (CJNIAudioFormat::ENCODING_IEC61937 == -1))
+        {
+          if (m_sink_sampleRate > 48000)
+            m_min_buffer_size *= (m_sink_sampleRate / 48000); // same amount of buffer in seconds as for 48 khz
+          else if (m_sink_sampleRate < m_format.m_sampleRate) // eac3
+            m_min_buffer_size *= (m_format.m_sampleRate / m_sink_sampleRate);
+        }
       }
       else
         m_min_buffer_size *= 2;
 
       m_format.m_frameSize = m_format.m_channelLayout.Count() * (CAEUtil::DataFormatToBits(m_format.m_dataFormat) / 8);
-      if (m_passthrough)
+      // again a workaround for AML old code
+      if (m_passthrough && aml_present() && m_info.m_wantsIECPassthrough && (CJNIAudioFormat::ENCODING_IEC61937 == -1))
         m_sink_frameSize = 2 * CAEUtil::DataFormatToBits(AE_FMT_S16LE) / 8; // sending via 2 channels 2 * 16 / 8 = 4
       else
         m_sink_frameSize = m_format.m_frameSize;
@@ -772,14 +783,21 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
     m_info.m_wantsIECPassthrough = false;
     m_info.m_dataFormats.push_back(AE_FMT_RAW);
     if (CJNIAudioFormat::ENCODING_AC3 != -1)
+    {
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
+      CLog::Log(LOGDEBUG, "Firmware implements AC3 RAW");
+    }
 
     // EAC3 working on shield, broken on FireTV
     if (CJNIAudioFormat::ENCODING_E_AC3 != -1)
+    {
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
+      CLog::Log(LOGDEBUG, "Firmware implements EAC3 RAW");
+    }
 
     if (CJNIAudioFormat::ENCODING_DTS != -1)
     {
+      CLog::Log(LOGDEBUG, "Firmware implements DTS RAW");
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
       m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
@@ -822,9 +840,15 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
       if (CJNIAudioManager::GetSDKVersion() >= 23)
       {
         if (CJNIAudioFormat::ENCODING_DTS_HD != -1)
+        {
+          CLog::Log(LOGDEBUG, "Firmware implements DTS-HD RAW");
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+        }
         if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)
+        {
+          CLog::Log(LOGDEBUG, "Firmware implements TrueHD RAW");
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+        }
       }
       // Android v24 and backports can do real IEC API
       if (CJNIAudioFormat::ENCODING_IEC61937 != -1)
@@ -837,13 +861,19 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
         m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
+        CLog::Log(LOGDEBUG, "AESinkAUDIOTrack: Using IEC PT mode: %d", CJNIAudioFormat::ENCODING_IEC61937);
 
         if (supports_192khz)
         {
           m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-          // not working yet
-          // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-          // m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+          // Check for IEC 8 channel 192 khz PT
+          int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1);
+          if (IsSupported(192000, atChannelMask, CJNIAudioFormat::ENCODING_IEC61937))
+          {
+            m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+            m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+            CLog::Log(LOGDEBUG, "8 Channel PT via IEC61937 is supported");
+          }
         }
       }
     }


### PR DESCRIPTION
This implements IEC mode also for 192 / 8 channels which is for example implemented by AMLogic upcoming firmware. It was succesfully tested by @MartijnKaijser .

It properly checks for 8/192 and if available it enables DTS-HD / TrueHD.

There is a minor EAC3 issue in the firmware only happening with some files, which we reported to them.

Most of the code added is to keep "old" aml stuff working.

This is safe for Krypton.