### PR TITLE
VideoPlayer: make sure streams are not discarded after a program change

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1295,6 +1295,7 @@ void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
       // discard all unneeded streams
       for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
       {
+        m_pFormatContext->streams[i]->discard = AVDISCARD_NONE;
         if (GetStream(i) == nullptr)
           m_pFormatContext->streams[i]->discard = AVDISCARD_ALL;
       }


### PR DESCRIPTION
see title
fixes i.e. missing audio streams for mpegts