### PR TITLE
VideoPlayer: make sure streams are not discarded after a program change

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1294,6 +1294,7 @@ void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
       // discard all unneeded streams
       for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
       {
+        m_pFormatContext->streams[i]->discard = AVDISCARD_NONE;
         if (GetStream(i) == nullptr)
           m_pFormatContext->streams[i]->discard = AVDISCARD_ALL;
       }


### PR DESCRIPTION
Backport of: https://github.com/xbmc/xbmc/pull/11048 - fixes a severe issue. Was tested by me and @MartijnKaijser 