### PR TITLE
[PVR] CApplication::PlayMedia: Use new PVRGUIActions functionality for playback of PVR channels and recordings.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -152,6 +152,7 @@
 #include "addons/GUIDialogAddonSettings.h"
 
 // PVR related include Files
+#include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 
 #include "epg/EpgContainer.h"
@@ -3059,7 +3060,7 @@ bool CApplication::PlayMedia(const CFileItem& item, const std::string &player, i
   }
   else if (item.IsPVR())
   {
-    return g_PVRManager.PlayMedia(item);
+    return CPVRGUIActions::GetInstance().PlayMedia(CFileItemPtr(new CFileItem(item)));
   }
 
   CURL path(item.GetPath());

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -690,6 +690,30 @@ namespace PVR
     return true;
   }
 
+  bool CPVRGUIActions::PlayMedia(const CFileItemPtr &item) const
+  {
+    CFileItemPtr pvrItem(item);
+    if (URIUtils::IsPVRChannel(item->GetPath()) && !item->HasPVRChannelInfoTag())
+      pvrItem = g_PVRChannelGroups->GetByPath(item->GetPath());
+    else if (URIUtils::IsPVRRecording(item->GetPath()) && !item->HasPVRRecordingInfoTag())
+      pvrItem = g_PVRRecordings->GetByPath(item->GetPath());
+
+    if (pvrItem->HasPVRChannelInfoTag())
+    {
+      return SwitchToChannel(pvrItem,
+                             CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_PLAYMINIMIZED),
+                             true);
+    }
+    else if (pvrItem->HasPVRRecordingInfoTag())
+    {
+      return PlayRecording(pvrItem,
+                           CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_PLAYMINIMIZED),
+                           true);
+    }
+
+    return false;
+  }
+
   bool CPVRGUIActions::HideChannel(const CFileItemPtr &item) const
   {
     const CPVRChannelPtr channel(item->GetPVRChannelInfoTag());

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -217,6 +217,13 @@ namespace PVR
     bool SwitchToChannel(const CFileItemPtr &item, bool bPlayMinimized, bool bCheckResume) const;
 
     /*!
+     * @brief Playback the given file item.
+     * @param item containing a channel or a recording.
+     * @return True if the item could be played, false otherwise.
+     */
+    bool PlayMedia(const CFileItemPtr &item) const;
+
+    /*!
      * @brief Hide a channel, always showing a confirmation dialog.
      * @param item containing a channel or an epg tag.
      * @return true on success, false otherwise.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1228,41 +1228,6 @@ void CPVRManager::CloseStream(void)
   SAFE_DELETE(m_currentFile);
 }
 
-bool CPVRManager::PlayMedia(const CFileItem& item)
-{
-  if (!g_PVRManager.IsStarted())
-  {
-    CLog::Log(LOGERROR, "CApplication - %s PVR manager not started to play file '%s'", __FUNCTION__, item.GetPath().c_str());
-    return false;
-  }
-
-  CFileItem pvrItem(item);
-  if (URIUtils::IsPVRChannel(item.GetPath()) && !item.HasPVRChannelInfoTag())
-    pvrItem = *g_PVRChannelGroups->GetByPath(item.GetPath());
-  else if (URIUtils::IsPVRRecording(item.GetPath()) && !item.HasPVRRecordingInfoTag())
-    pvrItem = *g_PVRRecordings->GetByPath(item.GetPath());
-
-  if (!pvrItem.HasPVRChannelInfoTag() && !pvrItem.HasPVRRecordingInfoTag())
-    return false;
-
-  // check parental lock if we want to play a channel
-  if (pvrItem.IsPVRChannel() && !g_PVRManager.CheckParentalLock(pvrItem.GetPVRChannelInfoTag()))
-    return false;
-
-  /* copy over resume info from original item */
-  pvrItem.m_lStartOffset = item.m_lStartOffset;
-
-  if (!g_application.IsCurrentThread())
-  {
-    CFileItemList *l = new CFileItemList; //don't delete,
-    l->Add(std::make_shared<CFileItem>(pvrItem));
-    CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
-    return true;
-  }
-
-  return g_application.PlayFile(pvrItem, "videoplayer", false) == PLAYBACK_OK;
-}
-
 void CPVRManager::UpdateCurrentChannel(void)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -321,13 +321,6 @@ namespace PVR
     bool OpenRecordedStream(const CPVRRecordingPtr &tag);
 
     /*!
-    * @brief Try to playback the given file item
-    * @param item The file item to playback.
-    * @return True if the file could be playback, otherwise false.
-    */
-    bool PlayMedia(const CFileItem& item);
-
-    /*!
      * @brief Start recording on a given channel if it is not already recording, stop if it is.
      * @param channel the channel to start/stop recording.
      * @return True if the recording was started or stopped successfully, false otherwise.

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -764,7 +764,7 @@ std::string CGUIWindowVideoBase::GetResumeString(const CFileItem &item)
 
 bool CGUIWindowVideoBase::ShowResumeMenu(CFileItem &item)
 {
-  if (!item.m_bIsFolder && !item.IsLiveTV())
+  if (!item.m_bIsFolder && !item.IsPVR())
   {
     std::string resumeString = GetResumeString(item);
     if (!resumeString.empty())


### PR DESCRIPTION
Mainly refactoring to get rid of duplicated code in PVR, but fixes also PVR channel home screen widget only to switch to fullscreen video instead of re-tuning the channel in case an already playing channel is selected from the widget.

This change has been runtime tested on latest master on LInux and macOS.

@Jalle19 for review?