### PR TITLE
AESinkAudioTrack: Use more alsa like settings

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -432,7 +432,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
         m_sink_frameSize = 2 * CAEUtil::DataFormatToBits(AE_FMT_S16LE) / 8; // sending via 2 channels 2 * 16 / 8 = 4
       else
         m_sink_frameSize = m_format.m_frameSize;
-      m_format.m_frames = (int)(m_min_buffer_size / m_format.m_frameSize) / 2;
+      m_format.m_frames = (int)(m_min_buffer_size / m_format.m_frameSize) / 4;
     }
 
     if (m_passthrough && !m_info.m_wantsIECPassthrough)


### PR DESCRIPTION
In fact most android devices speak ALSA under the hood. the m_frames are directly comparable to periodSize in ALSA wording. Having the periods half the buffer produces huge packages to be added and also the sink's delay can only be estimated as good as half of buffer size. Let's use 1/4 of it.

This is the same what ALSA aims at.

Needs some testing with
a) PT Codecs (DTS, DTS-HD, TrueHD, AC3) (IEC only)
b) FLAC 192/24 and multi channel flac with high samplerate