### PR TITLE
[PVR] Fix PVR channel OSD display conditions.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1424,7 +1424,8 @@ bool CPVRManager::PerformChannelSwitch(const CPVRChannelPtr &channel, bool bPrev
 
     if (bPreview)
     {
-      if (!g_infoManager.GetShowInfo())
+      if (!g_infoManager.GetShowInfo() &&
+          CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT) == 0)
       {
         // no need to do anything
         return true;


### PR DESCRIPTION
Regression introduced with #10995. Did not work if "channel switch with ok" is deactivated an "channel switch delay" > 0.

nobrainer. :-/