### PR TITLE
FIX: [droid;dyload] never dyload dependent sytem libs

### DIFF
--- a/xbmc/platform/android/loader/AndroidDyload.cpp
+++ b/xbmc/platform/android/loader/AndroidDyload.cpp
@@ -284,14 +284,16 @@ void* CAndroidDyload::Open_Internal(std::string filename, bool checkSystem)
     if (*j == libName.c_str())
       continue;
 
+    // Don't dlopen system libs
+    if (IsSystemLib(*j))
+      continue;
+
     if (FindInDeps(*j))
       continue;
 
     handle = Find(*j);
     if (handle)
     {
-      if (IsSystemLib(*j) && !checkSystem)
-        continue;
       recursivelibdep dep;
       dep.handle = handle;
       dep.filename = *j;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Fixes the surge of crashes with some amlogic firmwares

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

