### PR TITLE
fixed: tag updates on shoutcast streams with low meta data intervals

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.h
+++ b/xbmc/filesystem/ShoutcastFile.h
@@ -64,6 +64,7 @@ protected:
 
   CFileCache* m_cacheReader;
   CEvent m_tagChange;
+  CCriticalSection m_tagSection;
   int64_t m_tagPos;
 };
 }


### PR DESCRIPTION
a new tag came in and updated the position before the previous
tag had been processed, meaning the tag never updated after
stream start. fixes some trac ticket.