### PR TITLE
[osx/sdl] - fix wrong size in windowed mode

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -355,6 +355,15 @@ bool CWinEventsSDL::MessagePump()
       }
       case SDL_VIDEORESIZE:
       {
+        // Under newer osx versions sdl is so fucked up that it even fires resize events
+        // that exceed the screen size (maybe some HiDP incompatibility in old SDL?)
+        // ensure to ignore those events because it will mess with windowed size
+        int RES_SCREEN = g_Windowing.DesktopResolution(g_Windowing.GetCurrentScreen());
+        if((event.resize.w > CDisplaySettings::GetInstance().GetResolutionInfo(RES_SCREEN).iWidth) ||
+           (event.resize.h > CDisplaySettings::GetInstance().GetResolutionInfo(RES_SCREEN).iHeight))
+        {
+          break;
+        }
         XBMC_Event newEvent;
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = event.resize.w;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1012,6 +1012,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   ShowHideNSWindow([last_view window], needtoshowme);
   // need to make sure SDL tracks any window size changes
   ResizeWindowInternal(m_nWidth, m_nHeight, -1, -1, last_view);
+  [[last_view window] setFrameOrigin:last_window_origin];
   HandlePossibleRefreshrateChange();
 
   return true;


### PR DESCRIPTION
This fixes a bug we have since osx 10.x i think. When going from Fullscreen to windowed mode the window was all over the place and way bigger then the screen. Distorted rendering was one of the results of this.

## Description
1. Ensure that resize events from SDL which are bigger then screensize are ignored (those might come from some osx HiDIP feature that our SDL doesn't support
2. Reset the window origin after all the resizing is done so that the window not only has the proper size, but also the correct position on the screen.

## How Has This Been Tested?
Tested by me on osx 10.11.6 and 12.1. Also tested be the user who reported the bug here:
http://forum.kodi.tv/showthread.php?tid=298657&pid=2469793#pid2469793

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
