### PR TITLE
[osx/sdl] - fix wrong size in windowed mode -  backport

### DIFF
--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -355,6 +355,15 @@ bool CWinEventsSDL::MessagePump()
       }
       case SDL_VIDEORESIZE:
       {
+        // Under newer osx versions sdl is so fucked up that it even fires resize events
+        // that exceed the screen size (maybe some HiDP incompatibility in old SDL?)
+        // ensure to ignore those events because it will mess with windowed size
+        int RES_SCREEN = g_Windowing.DesktopResolution(g_Windowing.GetCurrentScreen());
+        if((event.resize.w > CDisplaySettings::GetInstance().GetResolutionInfo(RES_SCREEN).iWidth) ||
+           (event.resize.h > CDisplaySettings::GetInstance().GetResolutionInfo(RES_SCREEN).iHeight))
+        {
+          break;
+        }
         XBMC_Event newEvent;
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = event.resize.w;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1011,6 +1011,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   ShowHideNSWindow([last_view window], needtoshowme);
   // need to make sure SDL tracks any window size changes
   ResizeWindowInternal(m_nWidth, m_nHeight, -1, -1, last_view);
+  [[last_view window] setFrameOrigin:last_window_origin];
   HandlePossibleRefreshrateChange();
 
   return true;


### PR DESCRIPTION
Backport of #11062 