### PR TITLE
[pydocs] add missing content type "videos"

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.h
@@ -339,9 +339,11 @@ namespace XBMCAddon
     /// |:--------:|:--------:|:--------:|:--------:|
     /// |  files   |  songs   | artists  | albums
     /// | movies   | tvshows  | episodes | musicvideos
+    /// | videos   | images   | 
     ///
-    ///
-    ///
+    /// @remark Use **videos** for all videos which do not apply to the 
+    /// more specific mentioned ones like "movies", "episodes" etc.
+    /// A good example is youtube.
     /// ------------------------------------------------------------------------
     ///
     /// **Example:**


### PR DESCRIPTION
We forgot to add this to list...