### PR TITLE
Peripherals: Add setting to hide notifications

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16499,7 +16499,19 @@ msgctxt "#35018"
 msgid "Controller configuration depends on a disabled add-on. Would you like to enable it?"
 msgstr ""
 
-#empty strings from id 35019 to 35048
+#. Name of setting for enabling notifications when a peripheral is plugged in
+#: system/settings/settings.xml
+msgctxt "#35019"
+msgid "Notify when device is connected"
+msgstr ""
+
+#. Description of setting with label #35019 "Notify when device is connected"
+#: system/settings/settings.xml
+msgctxt "#35020"
+msgid "Show notification when a device is connected or removed."
+msgstr ""
+
+#empty strings from id 35021 to 35048
 
 #. Name of game add-ons category
 #: xbmc/addons/Addon.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2739,6 +2739,11 @@
           </dependencies>
           <control type="button" format="action" />
         </setting>
+        <setting id="input.notifyperipherals" type="boolean" label="35019" help="35020">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="2" label="14094">
         <setting id="input.enablemouse" type="boolean" label="21369" help="36377">

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -64,6 +64,7 @@
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
+#include "ServiceBroker.h"
 
 #if defined(HAVE_LIBCEC)
 #include "bus/virtual/PeripheralBusCEC.h"
@@ -376,6 +377,10 @@ void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &p
   if (peripheral.Type() == PERIPHERAL_JOYSTICK_EMULATION) //! @todo Change to peripheral.IsEmulated()
     bNotify = false;
 
+  // don't show a notification if disabled in settings
+  if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_INPUT_NOTIFY_PERIPHERALS))
+    bNotify = false;
+
   if (bNotify)
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral.DeviceName());
 }
@@ -388,6 +393,10 @@ void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral 
 
   // don't show a notification for emulated peripherals
   if (peripheral.Type() == PERIPHERAL_JOYSTICK_EMULATION) //! @todo Change to peripheral.IsEmulated()
+    bNotify = false;
+
+  // don't show a notification if disabled in settings
+  if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_INPUT_NOTIFY_PERIPHERALS))
     bNotify = false;
 
   if (bNotify)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -372,6 +372,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH = "audiooutpu
 const std::string CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH = "audiooutput.dtshdpassthrough";
 const std::string CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS = "audiooutput.volumesteps";
 const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
+const std::string CSettings::SETTING_INPUT_NOTIFY_PERIPHERALS = "input.notifyperipherals";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
 const std::string CSettings::SETTING_INPUT_ASKNEWCONTROLLERS = "input.asknewcontrollers";
 const std::string CSettings::SETTING_INPUT_CONTROLLERCONFIG = "input.controllerconfig";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -328,6 +328,7 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH;
   static const std::string SETTING_AUDIOOUTPUT_VOLUMESTEPS;
   static const std::string SETTING_INPUT_PERIPHERALS;
+  static const std::string SETTING_INPUT_NOTIFY_PERIPHERALS;
   static const std::string SETTING_INPUT_ENABLEMOUSE;
   static const std::string SETTING_INPUT_ASKNEWCONTROLLERS;
   static const std::string SETTING_INPUT_CONTROLLERCONFIG;


### PR DESCRIPTION
A user has [reported](http://forum.kodi.tv/showthread.php?tid=298891) that a Sony TV running Marshmallow 6.0 continuously connects/disconnects the remote (probably due to the bluetooth bus powering down). As I can't think of any way to detect this, I've added a setting to manually disable the notifications.

## Screenshots (if appropriate):
![notify peripherals](https://cloud.githubusercontent.com/assets/531482/20901475/90592ed0-bae7-11e6-9ca9-be598f0e9d98.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
