### PR TITLE
[cmake] Add support for LCMS2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
       sudo apt-get install -qq automake autopoint build-essential cmake curl default-jre gawk gdb gdc
       gettext git-core gperf libasound2-dev libass-dev libbz2-dev libcap-dev libcdio-dev libcec4-dev libcrossguid-dev libcurl3
       libcurl4-openssl-dev libdbus-1-dev libfmt3-dev libfontconfig-dev libegl1-mesa-dev libfreetype6-dev libfribidi-dev libgif-dev
-      libiso9660-dev libjpeg-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmysqlclient-dev libnfs-dev
+      libiso9660-dev libjpeg-dev liblcms2-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmysqlclient-dev libnfs-dev
       libpcre3-dev libplist-dev libpng-dev libpulse-dev libsdl2-dev libsmbclient-dev libsqlite3-dev libssh-dev
       libssl-dev libtag1-dev libtinyxml-dev libtool libudev-dev libusb-dev libva-dev libvdpau-dev
       libxml2-dev libxmu-dev libxrandr-dev libxrender-dev libxslt1-dev libxt-dev libyajl-dev mesa-utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(CORE_SYSTEM_NAME STREQUAL android)
 endif()
 
 # Optional dependencies
-set(optional_deps MicroHttpd MySqlClient SSH XSLT
+set(optional_deps LCMS2 MicroHttpd MySqlClient SSH XSLT
                   Alsa UDEV DBus Avahi MDNS SmbClient CCache
                   PulseAudio VDPAU VAAPI Bluetooth CAP Python)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,10 +101,21 @@ endif()
 find_package(Threads REQUIRED QUIET)
 list(APPEND DEPLIBS ${CMAKE_THREAD_LIBS_INIT})
 
-# Required dependencies
-set(required_deps Sqlite3 FreeType PCRE Cpluff LibDvd
-                  TinyXML Yajl Cdio Fmt
-                  Lzo2 Fribidi TagLib FFMPEG CrossGUID)
+# Required dependencies. Keep in alphabetical order please
+set(required_deps Cdio
+                  Cpluff
+                  CrossGUID
+                  FFMPEG
+                  Fmt
+                  FreeType
+                  Fribidi
+                  LibDvd
+                  Lzo2
+                  PCRE
+                  Sqlite3
+                  TagLib
+                  TinyXML
+                  Yajl)
 if(NOT WIN32)
   list(APPEND required_deps ZLIB)
 else()
@@ -114,16 +125,35 @@ if(CORE_SYSTEM_NAME STREQUAL android)
   list(APPEND required_deps Zip)
 endif()
 
-# Optional dependencies
-set(optional_deps LCMS2 MicroHttpd MySqlClient SSH XSLT
-                  Alsa UDEV DBus Avahi MDNS SmbClient CCache
-                  PulseAudio VDPAU VAAPI Bluetooth CAP Python)
+# Optional dependencies. Keep in alphabetical order please
+set(optional_deps Alsa
+                  Avahi
+                  Bluetooth
+                  CAP
+                  CCache
+                  DBus
+                  LCMS2
+                  MDNS
+                  MicroHttpd
+                  MySqlClient
+                  PulseAudio
+                  Python
+                  SmbClient
+                  SSH
+                  UDEV
+                  VAAPI
+                  VDPAU
+                  XSLT)
 
-# Required, dyloaded deps
-set(required_dyload Curl ASS)
+# Required, dyloaded deps. Keep in alphabetical order please
+set(required_dyload ASS
+                    Curl)
 
-# Optional, dyloaded deps
-set(dyload_optional CEC Bluray Plist NFS)
+# Optional, dyloaded deps. Keep in alphabetical order please
+set(dyload_optional Bluray
+                    CEC
+                    NFS
+                    Plist)
 
 # Required by shared objects we link
 set(required_dep_libs EXPAT)

--- a/cmake/modules/FindLCMS2.cmake
+++ b/cmake/modules/FindLCMS2.cmake
@@ -1,0 +1,48 @@
+#.rst:
+# FindLCMS2
+# -----------
+# Finds the LCMS Color Management library
+#
+# This will will define the following variables::
+#
+# LCMS2_FOUND - system has LCMS Color Management
+# LCMS2_INCLUDE_DIRS - the LCMS Color Management include directory
+# LCMS2_LIBRARIES - the LCMS Color Management libraries
+# LCMS2_DEFINITIONS - the LCMS Color Management definitions
+#
+# and the following imported targets::
+#
+#   LCMS2::LCMS2   - The LCMS Color Management library
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_LCMS2 lcms2 QUIET)
+endif()
+
+find_path(LCMS2_INCLUDE_DIR NAMES lcms2.h
+                            PATHS ${PC_LCMS2_INCLUDEDIR})
+find_library(LCMS2_LIBRARY NAMES lcms2 liblcms2
+                           PATHS ${PC_LCMS2_LIBDIR})
+
+set(LCMS2_VERSION ${PC_LCMS2_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LCMS2
+                                  REQUIRED_VARS LCMS2_LIBRARY LCMS2_INCLUDE_DIR
+                                  VERSION_VAR LCMS2_VERSION)
+
+if(LCMS2_FOUND)
+  set(LCMS2_LIBRARIES ${LCMS2_LIBRARY})
+  set(LCMS2_INCLUDE_DIRS ${LCMS2_INCLUDE_DIR})
+  set(LCMS2_DEFINITIONS -DHAVE_LCMS2=1)
+
+  if(NOT TARGET LCMS2::LCMS2)
+    add_library(LCMS2::LCMS2 UNKNOWN IMPORTED)
+    set_target_properties(LCMS2::LCMS2 PROPERTIES
+                                       IMPORTED_LOCATION "${LCMS2_LIBRARY}"
+                                       INTERFACE_INCLUDE_DIRECTORIES "${LCMS2_INCLUDE_DIR}"
+                                       INTERFACE_COMPILE_DEFINITIONS HAVE_LCMS2=1)
+  endif()
+endif()
+
+mark_as_advanced(LCMS2_INCLUDE_DIR LCMS2_LIBRARY)
+


### PR DESCRIPTION
## Description
Add missing icc support to color management.

## Motivation and Context
Fix http://trac.kodi.tv/ticket/17106

## How Has This Been Tested?
Built and briefly runtime tested with and without liblcms2 present in system.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

ping @fetzerch and @wsnipex 