### PR TITLE
log: Don't force logging with a debug build

### DIFF
--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -175,9 +175,6 @@ bool CLog::IsLogLevelLogged(int loglevel)
   if (extras != 0 && (s_globals.m_extraLogLevels & extras) == 0)
     return false;
 
-#if defined(_DEBUG) || defined(PROFILE)
-  return true;
-#else
   if (s_globals.m_logLevel >= LOG_LEVEL_DEBUG)
     return true;
   if (s_globals.m_logLevel <= LOG_LEVEL_NONE)
@@ -185,7 +182,6 @@ bool CLog::IsLogLevelLogged(int loglevel)
 
   // "m_logLevel" is "LOG_LEVEL_NORMAL"
   return (loglevel & LOGMASK) >= LOGNOTICE;
-#endif
 }
 
 


### PR DESCRIPTION
## Description
Don't force logging with a debug build

## Motivation and Context
A debug build is to allow use of a debugger and shouldn't be tied to logging level.
There are perfectly good ways of enabling debug logging anyway.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed