### PR TITLE
Explicitly check/find libva-drm in CMake

### DIFF
--- a/project/cmake/modules/FindVAAPI.cmake
+++ b/project/cmake/modules/FindVAAPI.cmake
@@ -24,6 +24,8 @@ find_library(VAAPI_libva_LIBRARY NAMES va
                                  PATHS ${PC_VAAPI_libva_LIBDIR})
 find_library(VAAPI_libva-x11_LIBRARY NAMES va-x11
                                      PATHS ${PC_VAAPI_libva_LIBDIR})
+find_library(VAAPI_libva-drm_LIBRARY NAMES va-drm
+                                     PATHS ${PC_VAAPI_libva_LIBDIR})
 
 if(PC_VAAPI_libva_VERSION)
   set(VAAPI_VERSION_STRING ${PC_VAAPI_libva_VERSION})
@@ -39,12 +41,12 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(VAAPI
-                                  REQUIRED_VARS VAAPI_libva_LIBRARY VAAPI_libva-x11_LIBRARY VAAPI_INCLUDE_DIR
+                                  REQUIRED_VARS VAAPI_libva_LIBRARY VAAPI_libva-x11_LIBRARY VAAPI_libva-drm_LIBRARY VAAPI_INCLUDE_DIR
                                   VERSION_VAR VAAPI_VERSION_STRING)
 
 if(VAAPI_FOUND)
   set(VAAPI_INCLUDE_DIRS ${VAAPI_INCLUDE_DIR})
-  set(VAAPI_LIBRARIES ${VAAPI_libva_LIBRARY} ${VAAPI_libva-x11_LIBRARY})
+  set(VAAPI_LIBRARIES ${VAAPI_libva_LIBRARY} ${VAAPI_libva-x11_LIBRARY} ${VAAPI_libva-drm_LIBRARY})
   set(VAAPI_DEFINITIONS -DHAVE_LIBVA=1)
 
   if(NOT TARGET VAAPI::VAAPI_X11)
@@ -52,14 +54,19 @@ if(VAAPI_FOUND)
     set_target_properties(VAAPI::VAAPI_X11 PROPERTIES
                                            IMPORTED_LOCATION "${VAAPI_libva-x11_LIBRARY}")
   endif()
+  if (NOT TARGET VAAPI::VAAPI_DRM)
+    add_library(VAAPI::VAAPI_DRM UNKNOWN IMPORTED)
+    set_target_properties(VAAPI::VAAPI_DRM PROPERTIES
+                                           IMPORTED_LOCATION "${VAAPI_libva-drm_LIBRARY}")
+  endif()
   if(NOT TARGET VAAPI::VAAPI)
     add_library(VAAPI::VAAPI UNKNOWN IMPORTED)
     set_target_properties(VAAPI::VAAPI PROPERTIES
                                        IMPORTED_LOCATION "${VAAPI_libva_LIBRARY}"
                                        INTERFACE_INCLUDE_DIRECTORIES "${VAAPI_INCLUDE_DIR}"
                                        INTERFACE_COMPILE_DEFINITIONS HAVE_LIBVA=1
-                                       INTERFACE_LINK_LIBRARIES VAAPI::VAAPI_X11)
+                                       INTERFACE_LINK_LIBRARIES "VAAPI::VAAPI_X11 VAAPI::VAAPI_DRM")
   endif()
 endif()
 
-mark_as_advanced(VAAPI_INCLUDE_DIR VAAPI_libva_LIBRARY VAAPI_libva-x11_LIBRARY)
+mark_as_advanced(VAAPI_INCLUDE_DIR VAAPI_libva_LIBRARY VAAPI_libva-x11_LIBRARY VAAPI_libva-drm_LIBRARY)


### PR DESCRIPTION
Explicitly check/find libva-drm

## Description
As of right now we implicitly get -lva-drm added to the building of xbmc. We should explicitly find it in case others are building their own toolchains.

## Motivation and Context
This fixes issues of where -lva-drm is not being found when building through cmake.

## How Has This Been Tested?
Everything still compile for me and Neil MacLeod tested this patch against his build which was failing before with out it.

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

