### PR TITLE
Android: Override ProcessInfo to use yadif half as fallback

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/overrides/android/ProcessInfoAndroid.cpp
+++ b/xbmc/cores/VideoPlayer/Process/overrides/android/ProcessInfoAndroid.cpp
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2005-2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ProcessInfoAndroid.h"
+
+// Override for platform ports
+#if defined(TARGET_ANDROID)
+
+CProcessInfo* CProcessInfo::CreateInstance()
+{
+  return new CProcessInfoAndroid();
+}
+
+
+// base class definitions
+CProcessInfoAndroid::CProcessInfoAndroid()
+{
+  
+}
+
+CProcessInfoAndroid::~CProcessInfoAndroid()
+{
+  
+}
+
+EINTERLACEMETHOD CProcessInfoAndroid::GetFallbackDeintMethod()
+{
+  return EINTERLACEMETHOD::VS_INTERLACEMETHOD_DEINTERLACE_HALF;
+}
+#endif
+

--- a/xbmc/cores/VideoPlayer/Process/overrides/android/ProcessInfoAndroid.h
+++ b/xbmc/cores/VideoPlayer/Process/overrides/android/ProcessInfoAndroid.h
@@ -1,0 +1,31 @@
+/*
+ *      Copyright (C) 2005-2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "cores/IPlayer.h"
+#include "../../ProcessInfo.h"
+
+class CProcessInfoAndroid : public CProcessInfo
+{
+public:
+  CProcessInfoAndroid();
+  virtual ~CProcessInfoAndroid();
+  EINTERLACEMETHOD GetFallbackDeintMethod() override;
+};


### PR DESCRIPTION
Perhaps a more sane default. Basically I don't know when YADIF in general came to Android. Wasn't it disabled earlier?