### PR TITLE
Workaround the skin unload bug - force close TextureBundle

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -369,6 +369,9 @@ const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const std::string
 
 void CSkinInfo::OnPreInstall()
 {
+  bool skinLoaded = g_SkinInfo != nullptr;
+  if (IsInUse() && skinLoaded)
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "UnloadSkin");
 }
 
 void CSkinInfo::OnPostInstall(bool update, bool modal)

--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -78,6 +78,12 @@ int CTextureBundle::LoadAnim(const std::string& Filename, CBaseTexture*** ppText
   return 0;
 }
 
+void CTextureBundle::Close()
+{
+  if (m_useXBT)
+    m_tbXBT.CloseBundle();
+}
+
 void CTextureBundle::SetThemeBundle(bool themeBundle)
 {
   m_tbXBT.SetThemeBundle(themeBundle);

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -39,7 +39,7 @@ public:
   bool LoadTexture(const std::string& Filename, CBaseTexture** ppTexture, int &width, int &height);
 
   int LoadAnim(const std::string& Filename, CBaseTexture*** ppTextures, int &width, int &height, int& nLoops, int** ppDelays);
-
+  void Close();
 private:
   CTextureBundleXBT m_tbXBT;
 

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -55,6 +55,11 @@ CTextureBundleXBT::CTextureBundleXBT(bool themeBundle)
 
 CTextureBundleXBT::~CTextureBundleXBT(void)
 {
+  CloseBundle();
+}
+
+void CTextureBundleXBT::CloseBundle()
+{
   if (m_XBTFReader != nullptr && m_XBTFReader->IsOpen())
   {
     XFILE::CXbtManager::GetInstance().Release(CURL(m_path));

--- a/xbmc/guilib/TextureBundleXBT.h
+++ b/xbmc/guilib/TextureBundleXBT.h
@@ -48,6 +48,8 @@ public:
                 int &width, int &height, int& nLoops, int** ppDelays);
 
   static uint8_t* UnpackFrame(const CXBTFReader& reader, const CXBTFFrame& frame);
+  
+  void CloseBundle();
 
 private:
   bool OpenBundle();

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -548,7 +548,8 @@ void CGUITextureManager::Cleanup()
     delete pMap;
     i = m_vecTextures.erase(i);
   }
-
+  m_TexBundle[0].Close();
+  m_TexBundle[1].Close();
   m_TexBundle[0] = CTextureBundle(true);
   m_TexBundle[1] = CTextureBundle();
   FreeUnusedTextures();


### PR DESCRIPTION
The migration step and the unloadSkin meassage/action yield a deadlock.