### PR TITLE
[cmake] fix: command not found "GIT_SHALLOW 1"

### DIFF
--- a/project/cmake/scripts/common/HandleDepends.cmake
+++ b/project/cmake/scripts/common/HandleDepends.cmake
@@ -176,7 +176,7 @@ function(add_addon_depends addon searchpath)
                                   PATCH_COMMAND ${PATCH_COMMAND}
                                   "${INSTALL_COMMAND}")
 
-        if(CMAKE_VERSION VERSION_GREATER 3.5)
+        if(CMAKE_VERSION VERSION_GREATER 3.5.9)
           list(APPEND EXTERNALPROJECT_SETUP GIT_SHALLOW 1)
         endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
only cmake 3.6 support this, older versions seem to _not_ ignore that option

## Motivation and Context
fixes:
>cd /data/src/xbmc/project/cmake/addons/build/build/p8-platform/src/p8-platform && GIT_SHALLOW 1
/bin/sh: 1: GIT_SHALLOW: not found
depends/CMakeFiles/p8-platform.dir/build.make:98: recipe for target 'build/p8-platform/src/p8-platform-stamp/p8-platform-patch' failed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

