### PR TITLE
properly check if a python window is a media window

### DIFF
--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -278,6 +278,14 @@ namespace XBMCAddon
       return A(m_viewControl.GetCurrentControl());
     }
 
+    bool WindowXML::IsMediaWindow()
+    {
+      XBMC_TRACE;
+      if (A(m_viewControl.GetViewModeCount()) == 0)
+        return false;
+      return true;
+    }
+
     bool WindowXML::OnAction(const CAction &action)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -381,7 +381,7 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL bool      OnDoubleClick(int iItem);
       SWIGHIDDENVIRTUAL void      Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
-      SWIGHIDDENVIRTUAL bool IsMediaWindow() const { XBMC_TRACE; return true; };
+      SWIGHIDDENVIRTUAL bool IsMediaWindow();
 
       // This method is identical to the Window::OnDeinitWindow method
       //  except it passes the message on to their respective parents.


### PR DESCRIPTION
currently implicit container referencing (https://github.com/xbmc/xbmc/pull/10883) fails for python windows.
(and likely other items depending on IsMediaWindow() don't work either)

while a python window can be a media window, in many cases it is not.

this adds a check by evaluating the number of views defined in the xml file.

@tamland @phil65 