### PR TITLE
ListItems: Rename "emulator" property to "gameclient"

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -639,7 +639,7 @@ namespace XBMCAddon
             item->GetGameInfoTag()->SetOverview(value);
           else if (key == "year")
             item->GetGameInfoTag()->SetYear(strtol(value.c_str(), NULL, 10));
-          else if (key == "emulator")
+          else if (key == "gameclient")
             item->GetGameInfoTag()->SetGameClient(value);
         }
       }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -640,7 +640,7 @@ namespace XBMCAddon
       /// | developer     | string (Square)
       /// | overview      | string (Long Description)
       /// | year          | integer (1980)
-      /// | emulator      | string (game.libretro.fceumm)
+      /// | gameclient    | string (game.libretro.fceumm)
       ///
       ///
       ///-----------------------------------------------------------------------
@@ -650,6 +650,7 @@ namespace XBMCAddon
       /// @python_v17
       /// Added labels **setid**, **set**, **imdbnumber**, **code**, **dbid**, **path** and **userrating**.
       /// Expanded the possible infoLabels for the option **mediatype**.
+      /// @python_v18 Added new **game** type and associated infolabels.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}


### PR DESCRIPTION
From commit description:

This change apparently got dropped in a RetroPlayer rebase. The reason is because gameclient is more generic than emulator, as the game might be a launchable asset instead of a ROM. Also, I would expect "emulator" to be a human-readable string, e.g. "PCSX Re-armed", whereas "gameclient" is more obviously an add-on ID.

I wanted to get this in ASAP before add-ons start using this value.