### PR TITLE
Fix performace problem with CFileItem::IsGame unnecessarily accessing addon db for PVR content.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -916,6 +916,9 @@ bool CFileItem::IsGame() const
   if (HasPictureInfoTag())
     return false;
 
+  if (IsPVR())
+    return false;
+
   if (HasAddonInfo())
     return CGameUtils::IsStandaloneGame(std::const_pointer_cast<ADDON::IAddon>(GetAddonInfo()));
 


### PR DESCRIPTION
Fixes https://github.com/xbmc/skin.estuary/issues/194

@garbear fyi, mind doing the review