### PR TITLE
Move game extensions to advanced settings

### DIFF
--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -29,6 +29,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "settings/AdvancedSettings.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -182,60 +183,9 @@ bool CGameUtils::HasGameExtension(const std::string &path)
     return false;
 
   StringUtils::ToLower(extension);
+  extension.append("|");
 
-  // Look for a game client that supports this extension
-  VECADDONS gameClients;
-  CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
-  addonCache.GetAddons(gameClients, ADDON_GAMEDLL);
-  for (auto& gameClient : gameClients)
-  {
-    GameClientPtr gc(std::static_pointer_cast<CGameClient>(gameClient));
-    if (gc->IsExtensionValid(extension))
-      return true;
-  }
-
-  // Check remote add-ons
-  gameClients.clear();
-  if (CAddonMgr::GetInstance().GetInstallableAddons(gameClients, ADDON_GAMEDLL))
-  {
-    for (auto& gameClient : gameClients)
-    {
-      GameClientPtr gc(std::static_pointer_cast<CGameClient>(gameClient));
-      if (gc->IsExtensionValid(extension))
-        return true;
-    }
-  }
-
-  return false;
-}
-
-std::set<std::string> CGameUtils::GetGameExtensions()
-{
-  using namespace ADDON;
-
-  std::set<std::string> extensions;
-
-  VECADDONS gameClients;
-  CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
-  addonCache.GetAddons(gameClients, ADDON_GAMEDLL);
-  for (auto& gameClient : gameClients)
-  {
-    GameClientPtr gc(std::static_pointer_cast<CGameClient>(gameClient));
-    extensions.insert(gc->GetExtensions().begin(), gc->GetExtensions().end());
-  }
-
-  // Check remote add-ons
-  gameClients.clear();
-  if (CAddonMgr::GetInstance().GetInstallableAddons(gameClients, ADDON_GAMEDLL))
-  {
-    for (auto& gameClient : gameClients)
-    {
-      GameClientPtr gc(std::static_pointer_cast<CGameClient>(gameClient));
-      extensions.insert(gc->GetExtensions().begin(), gc->GetExtensions().end());
-    }
-  }
-
-  return extensions;
+  return g_advancedSettings.GetGameExtensions().find(extension) != std::string::npos;
 }
 
 bool CGameUtils::IsStandaloneGame(const ADDON::AddonPtr& addon)

--- a/xbmc/games/GameUtils.h
+++ b/xbmc/games/GameUtils.h
@@ -57,8 +57,6 @@ namespace GAME
      */
     static bool HasGameExtension(const std::string& path);
 
-    static std::set<std::string> GetGameExtensions();
-
     /*!
      * \brief Check if game script or game add-on can be launched directly
      *

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -21,11 +21,11 @@
 #include "GUIViewStateWindowGames.h"
 #include "addons/BinaryAddonCache.h"
 #include "games/addons/GameClient.h"
-#include "games/GameUtils.h"
 #include "guilib/GraphicContext.h" // include before ViewState.h
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/Key.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
@@ -74,15 +74,7 @@ std::string CGUIViewStateWindowGames::GetLockType()
 
 std::string CGUIViewStateWindowGames::GetExtensions()
 {
-  using namespace ADDON;
-
-  std::set<std::string> exts = CGameUtils::GetGameExtensions();
-
-  // Ensure .zip appears
-  if (std::find(exts.begin(), exts.end(), ".zip") == exts.end())
-    exts.insert(".zip");
-
-  return StringUtils::Join(exts, "|");
+  return g_advancedSettings.GetGameExtensions();
 }
 
 VECSOURCES& CGUIViewStateWindowGames::GetSources()

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -19,23 +19,13 @@
  */
 
 #include "GUIViewStateWindowGames.h"
-#include "addons/BinaryAddonCache.h"
-#include "games/addons/GameClient.h"
-#include "guilib/GraphicContext.h" // include before ViewState.h
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
-#include "input/Key.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
-#include "settings/Settings.h"
-#include "utils/StringUtils.h"
 #include "view/ViewState.h"
 #include "view/ViewStateSettings.h"
 #include "FileItem.h"
-#include "ServiceBroker.h"
-
-#include <assert.h>
-#include <set>
 
 using namespace GAME;
 

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -25,8 +25,6 @@
 #include "dialogs/GUIDialogMediaSource.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "FileItem.h"
-#include "games/tags/GameInfoTag.h"
-#include "games/addons/GameClient.h"
 #include "games/addons/savestates/SavestateDatabase.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
@@ -38,8 +36,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
-
-#include <algorithm>
+#include "utils/URIUtils.h"
 
 using namespace GAME;
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -359,6 +359,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     //! \brief Returns a list of music extension for filtering in the GUI
     std::string GetMusicExtensions() const;
 
+    //! \brief Returns a list of game extensions for filtering in the GUI
+    std::string GetGameExtensions() const;
+
     void SetDebugMode(bool debug);
 
     //! \brief Toggles dirty-region visualization
@@ -369,6 +372,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_videoExtensions;
     std::string m_discStubExtensions;
     std::string m_subtitlesExtensions;
+    std::string m_gameExtensions;
 
     std::string m_stereoscopicregex_3d;
     std::string m_stereoscopicregex_sbs;


### PR DESCRIPTION
This imports the 97 game extensions used by our 58 libretro cores to advanced settings.

Previously, the set of game extensions was generated dynamically from the enabled game add-ons, plus all remote game add-ons. Using remote add-ons allows for just-in-time installation, because Kodi is able to show the game in MyGames even if the add-ons isn't installed yet.

However, this caused two problems. First, UX was impacted because even though a file is a game, if no local or remote add-ons could play it, then it wouldn't show up in MyGames. This was especially confusing if no game add-ons or game add-on repos were installed, because then MyGames would be completely empty. The second problem was a performance impact due to hitting the add-on DB for remote game extensions whenever all game extensions were needed.