### PR TITLE
[python] add mediatype to musicinfotag

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -52,6 +52,11 @@ namespace XBMCAddon
       return infoTag->GetTitle();
     }
 
+    String InfoTagMusic::getMediaType()
+    {
+      return infoTag->GetType();
+    }
+
     String InfoTagMusic::getArtist()
     {
       return infoTag->GetArtistString();

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -103,6 +103,30 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ getMediaType() }
+      ///-----------------------------------------------------------------------
+      /// Get the media type of the music item.
+      ///
+      /// @return [string] media type
+      ///
+      /// Available strings about media type for music:
+      /// | String         | Description                                       |
+      /// |---------------:|:--------------------------------------------------|
+      /// | artist         | If it is defined as an artist
+      /// | album          | If it is defined as an album
+      /// | song           | If it is defined as a song
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 New function added.
+      ///
+      getMediaType();
+#else
+      String getMediaType();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
       /// @brief \python_func{ getArtist() }
       ///-----------------------------------------------------------------------
       /// Returns the artist from music as string if present.


### PR DESCRIPTION
allow to retrieve the mediatype from the musicinfotag of a listitem.