### PR TITLE
Remove reference to libxinerama-dev

### DIFF
--- a/docs/README.linux
+++ b/docs/README.linux
@@ -55,7 +55,7 @@ Build-Depends: autoconf, automake, autopoint, autotools-dev, cmake, curl,
   libpcre3-dev, libplist-dev, libpng12-dev | libpng-dev, libpulse-dev, librtmp-dev,libsdl2-dev,
   libshairplay-dev, libsmbclient-dev, libsqlite3-dev, libssh-dev, libssl-dev, libswscale-dev,
   libtag1-dev (>= 1.8), libtinyxml-dev (>= 2.6.2), libtool, libudev-dev,
-  libusb-dev, libva-dev, libvdpau-dev, libxinerama-dev, libxml2-dev,
+  libusb-dev, libva-dev, libvdpau-dev, libxml2-dev,
   libxmu-dev, libxrandr-dev, libxslt1-dev, libxt-dev, libyajl-dev (>=2.0), lsb-release,
   nasm [!amd64], python-dev, python-imaging, python-support, swig, unzip, uuid-dev, yasm,
   zip, zlib1g-dev


### PR DESCRIPTION
libxinerama-dev is not used so don't document it as a dependency

## Description
Just updating the linux documentation to not reference libxinerama-dev.

## Motivation and Context
Just a simple documentation update to make the documentation match the reality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
It's just documentation - no testing is applicable.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

libxinerama-dev is not used so don't document it as a dependency