### PR TITLE
[gui] remove old code for viewtype parsing

### DIFF
--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -664,17 +664,6 @@ void CGUIControlGroup::ClearAll()
   SetInvalid();
 }
 
-void CGUIControlGroup::GetContainers(std::vector<CGUIControl *> &containers) const
-{
-  for (auto *control : m_children)
-  {
-    if (control->IsContainer())
-      containers.push_back(control);
-    else if (control->IsGroup())
-      ((CGUIControlGroup *)control)->GetContainers(containers);
-  }
-}
-
 #ifdef _DEBUG
 void CGUIControlGroup::DumpTextureUse()
 {

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -73,7 +73,6 @@ public:
   const CGUIControl *GetControl(int id) const;
   CGUIControl *GetControl(int id);
   virtual CGUIControl *GetFirstFocusableControl(int id);
-  void GetContainers(std::vector<CGUIControl *> &containers) const;
 
   virtual void AddControl(CGUIControl *control, int position = -1);
   bool InsertControl(CGUIControl *control, const CGUIControl *insertPoint);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -79,9 +79,6 @@
 
 #define CONTROL_LABELFILES          12
 
-#define CONTROL_VIEW_START          50
-#define CONTROL_VIEW_END            59
-
 #define PROPERTY_PATH_DB            "path.db"
 #define PROPERTY_SORT_ORDER         "sort.order"
 #define PROPERTY_SORT_ASCENDING     "sort.ascending"
@@ -126,17 +123,6 @@ void CGUIMediaWindow::LoadAdditionalTags(TiXmlElement *root)
       int controlID = atol(i->c_str());
       CGUIControl *control = GetControl(controlID);
       if (control && control->IsContainer())
-        m_viewControl.AddView(control);
-    }
-  }
-  else
-  { // backward compatibility
-    std::vector<CGUIControl *> controls;
-    GetContainers(controls);
-    for (ciControls it = controls.begin(); it != controls.end(); it++)
-    {
-      CGUIControl *control = *it;
-      if (control->GetID() >= CONTROL_VIEW_START && control->GetID() <= CONTROL_VIEW_END)
         m_viewControl.AddView(control);
     }
   }


### PR DESCRIPTION
Removes the old-school way of adding viewtypes to mediawindows (without `<views>`tag). I´m quite sure this isnt used anymore at all.
@ronie 