### PR TITLE
[cmake] fix building when fribidi was built with glib

### DIFF
--- a/project/cmake/modules/FindFribidi.cmake
+++ b/project/cmake/modules/FindFribidi.cmake
@@ -32,12 +32,16 @@ find_package_handle_standard_args(FriBidi
 if(FRIBIDI_FOUND)
   set(FRIBIDI_LIBRARIES ${FRIBIDI_LIBRARY})
   set(FRIBIDI_INCLUDE_DIRS ${FRIBIDI_INCLUDE_DIR})
+  if(PC_FRIBIDI_CFLAGS)
+    set(FRIBIDI_DEFINITIONS ${PC_FRIBIDI_CFLAGS})
+  endif()
 
   if(NOT TARGET FriBidi::FriBidi)
     add_library(FriBidi::FriBidi UNKNOWN IMPORTED)
     set_target_properties(FriBidi::FriBidi PROPERTIES
                                            IMPORTED_LOCATION "${FRIBIDI_LIBRARY}"
-                                           INTERFACE_INCLUDE_DIRECTORIES "${FRIBIDI_INCLUDE_DIR}")
+                                           INTERFACE_INCLUDE_DIRECTORIES "${FRIBIDI_INCLUDE_DIR}"
+                                           INTERFACE_COMPILE_OPTIONS "${FRIBIDI_DEFINITIONS}")
   endif()
 endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->


## Description
<!--- Describe your change in detail -->
If fribidi was built with glib we must use correct cflags

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
fixes http://trac.kodi.tv/ticket/17107

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



