### PR TITLE
[cmake] fix building when fribidi was built with glib

### DIFF
--- a/project/cmake/modules/FindFribidi.cmake
+++ b/project/cmake/modules/FindFribidi.cmake
@@ -32,12 +32,16 @@ find_package_handle_standard_args(FriBidi
 if(FRIBIDI_FOUND)
   set(FRIBIDI_LIBRARIES ${FRIBIDI_LIBRARY})
   set(FRIBIDI_INCLUDE_DIRS ${FRIBIDI_INCLUDE_DIR})
+  if(PC_FRIBIDI_CFLAGS)
+    set(FRIBIDI_DEFINITIONS ${PC_FRIBIDI_CFLAGS})
+  endif()
 
   if(NOT TARGET FriBidi::FriBidi)
     add_library(FriBidi::FriBidi UNKNOWN IMPORTED)
     set_target_properties(FriBidi::FriBidi PROPERTIES
                                            IMPORTED_LOCATION "${FRIBIDI_LIBRARY}"
-                                           INTERFACE_INCLUDE_DIRECTORIES "${FRIBIDI_INCLUDE_DIR}")
+                                           INTERFACE_INCLUDE_DIRECTORIES "${FRIBIDI_INCLUDE_DIR}"
+                                           INTERFACE_COMPILE_OPTIONS "${FRIBIDI_DEFINITIONS}")
   endif()
 endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
fix building when fribidi was built with glib
## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

