### PR TITLE
[addons] move installer temp dir to addons/temp/

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1059,6 +1059,7 @@ void CApplication::CreateUserDirs() const
   CDirectory::Create("special://home/");
   CDirectory::Create("special://home/addons");
   CDirectory::Create("special://home/addons/packages");
+  CDirectory::Create("special://home/addons/temp");
   CDirectory::Create("special://home/media");
   CDirectory::Create("special://home/system");
   CDirectory::Create("special://masterprofile/");

--- a/xbmc/addons/FilesystemInstaller.cpp
+++ b/xbmc/addons/FilesystemInstaller.cpp
@@ -31,7 +31,7 @@ using namespace XFILE;
 CFilesystemInstaller::CFilesystemInstaller()
 {
   m_addonFolder = CSpecialProtocol::TranslatePath("special://home/addons/");
-  m_tempFolder = CSpecialProtocol::TranslatePath("special://home/temp/");
+  m_tempFolder = CSpecialProtocol::TranslatePath("special://home/addons/temp/");
 }
 
 bool CFilesystemInstaller::InstallToFilesystem(const std::string& archive, const std::string& addonId)


### PR DESCRIPTION
This is mostly cosmetic change to hopefully prevent more issues such as http://trac.kodi.tv/ticket/17049 and #10904. In short, this temp directory must be on the same filesystem special://home/addons/ for the safety to be achieved (otherwise there is no way to move and it will fallback to copy+delete). So safest thing is to just keep it in inside the addons folder.
