### PR TITLE
Remove remaining references to libmad

### DIFF
--- a/docs/README.armel
+++ b/docs/README.armel
@@ -217,7 +217,7 @@ These are python and liblzo2
 
 For Angstrom:
     $ opkg update
-    $ opkg install subversion make g++ gcc gawk pmount libtool automake gperf unzip bison libsdl-1.2-dev libsdl-image-1.2-dev libsdl-gfx-dev libsdl-mixer-1.2-dev libfribidi-dev liblzo-dev libfreetype-dev libsqlite3-dev libasound2 python-sqlite3 libcurl4 libxrandr-dev libxrender-dev libmad-dev libmysqlclient-dev libpcre-dev libdbus-glib-1-dev hal-dev libfontconfig-dev libxt-dev libxmu-dev libpng-dev libjpeg-dev
+    $ opkg install subversion make g++ gcc gawk pmount libtool automake gperf unzip bison libsdl-1.2-dev libsdl-image-1.2-dev libsdl-gfx-dev libsdl-mixer-1.2-dev libfribidi-dev liblzo-dev libfreetype-dev libsqlite3-dev libasound2 python-sqlite3 libcurl4 libxrandr-dev libxrender-dev libmysqlclient-dev libpcre-dev libdbus-glib-1-dev hal-dev libfontconfig-dev libxt-dev libxmu-dev libpng-dev libjpeg-dev
 
 Unfortunately this will only install the packages that are available through opkg. There will be further packages that need to be installed.
 Either use the method mentioned below, or selectively find and install packages, mentioned at the bottom of this README.

--- a/project/cmake/cpack/deb/packages/kodi.txt.in
+++ b/project/cmake/cpack/deb/packages/kodi.txt.in
@@ -15,7 +15,7 @@ PACKAGE_ARCHITECTURE all
 PACKAGE_SECTION video
 PACKAGE_PRIORITY optional
 PACKAGE_SHLIBDEPS
-PACKAGE_DEPENDS @APP_NAME_LC@-bin (>= @CPACK_DEBIAN_PACKAGE_VERSION@), @APP_NAME_LC@-bin (<< @CPACK_DEBIAN_PACKAGE_VERSION@.1~), curl, libcurl3, mesa-utils, x11-utils, fonts-liberation | ttf-liberation, fonts-dejavu-core | ttf-dejavu-core, python-bluez | python-lightblue, python-imaging, python-simplejson, libmad0, libass5 | libass4, libgif5 | libgif7, libssh-4 | libssh2-1, libnfs8 | libnfs4 | libnfs1, libbluray1, libshairplay0, libvorbisfile3, libaacs0, libcec3, librtmp1 | librtmp0, libgnutls30 | libgnutls-deb0-28 | libgnutls28 | libgnutls26, libxslt1.1, libyajl2
+PACKAGE_DEPENDS @APP_NAME_LC@-bin (>= @CPACK_DEBIAN_PACKAGE_VERSION@), @APP_NAME_LC@-bin (<< @CPACK_DEBIAN_PACKAGE_VERSION@.1~), curl, libcurl3, mesa-utils, x11-utils, fonts-liberation | ttf-liberation, fonts-dejavu-core | ttf-dejavu-core, python-bluez | python-lightblue, python-imaging, python-simplejson, libass5 | libass4, libgif5 | libgif7, libssh-4 | libssh2-1, libnfs8 | libnfs4 | libnfs1, libbluray1, libshairplay0, libvorbisfile3, libaacs0, libcec3, librtmp1 | librtmp0, libgnutls30 | libgnutls-deb0-28 | libgnutls28 | libgnutls26, libxslt1.1, libyajl2
 PACKAGE_RECOMMENDS libvdpau1, libva-intel-vaapi-driver, libva1
 PACKAGE_SUGGESTS @APP_NAME_LC@-pvr-mythtv, @APP_NAME_LC@-pvr-vuplus, @APP_NAME_LC@-pvr-vdr-vnsi, @APP_NAME_LC@-pvr-njoy, @APP_NAME_LC@-pvr-nextpvr, @APP_NAME_LC@-pvr-mediaportal-tvserver, @APP_NAME_LC@-pvr-tvheadend-hts, @APP_NAME_LC@-pvr-dvbviewer, @APP_NAME_LC@-pvr-argustv, @APP_NAME_LC@-pvr-iptvsimple, @APP_NAME_LC@-audioencoder-vorbis, @APP_NAME_LC@-audioencoder-flac, @APP_NAME_LC@-audioencoder-lame
 PACKAGE_BREAKS xbmc (<< 2:14.0~git20141019), xbmc-data, xbmc-standalone


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Remove remaining reference to libmad.
libmad was removed in #4499 - this one reference erroneously remained.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Trying to keep the documentation accurate.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
It's just a documentation update.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

libmad was removed in https://github.com/xbmc/xbmc/pull/4499 - this one reference erroneously remained.