### PR TITLE
AESinkAudioTrack: Make people stop going on my nerves

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -33,6 +33,9 @@
 
 #include "utils/AMLUtils.h"
 
+// pcm hack setting
+#include "settings/AdvancedSettings.h"
+
 //#define DEBUG_VERBOSE 1
 
 // This is an alternative to the linear weighted delay smoothing
@@ -779,6 +782,11 @@ void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
   m_info.m_wantsIECPassthrough = true;
   if (!CXBMCApp::IsHeadsetPlugged())
   {
+    if (g_advancedSettings.forcepcmpassthrough)
+    {
+      CLog::Log(LOGWARNING, "You are using PCM passthrough - you were warned!");
+      CJNIAudioFormat::ENCODING_IEC61937 = CJNIAudioFormat::ENCODING_PCM_16BIT;
+    }
     m_info.m_deviceType = AE_DEVTYPE_HDMI;
     m_info.m_wantsIECPassthrough = false;
     m_info.m_dataFormats.push_back(AE_FMT_RAW);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -114,6 +114,7 @@ void CAdvancedSettings::Initialize()
   m_ac3Gain = 12.0f;
   m_audioApplyDrc = -1.0f;
   m_VideoPlayerIgnoreDTSinWAV = false;
+  forcepcmpassthrough = false;
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
   m_limiterHold = 0.025f;
@@ -499,6 +500,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "ac3downmixgain", m_ac3Gain, -96.0f, 96.0f);
     XMLUtils::GetInt(pElement, "headroom", m_audioHeadRoom, 0, 12);
     XMLUtils::GetString(pElement, "defaultplayer", m_audioDefaultPlayer);
+    XMLUtils::GetBoolean(pElement, "forcepcmpassthrough", forcepcmpassthrough);
     // 101 on purpose - can be used to never automark as watched
     XMLUtils::GetFloat(pElement, "playcountminimumpercent", m_audioPlayCountMinimumPercent, 0.0f, 101.0f);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -138,6 +138,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     int m_audioHeadRoom;
     float m_ac3Gain;
+    // Android only Setting to make PT on v21, v22 work
+    // while sending it via PCM and 16 bit
+    bool forcepcmpassthrough;
     std::string m_audioDefaultPlayer;
     float m_audioPlayCountMinimumPercent;
     bool m_VideoPlayerIgnoreDTSinWAV;


### PR DESCRIPTION
I am fed up. There is no. In numbers: 0 FW out there that works properly for Android v21, v22.

FTV1: AC3, EAC3 RAW broken, DTS not existent
FTV2: 192 kbps AC3 broken, 2.0 AC3 broken, 5.1 EAC3 working, 7.1 EAC3 broken, DTS not existent
Sony-TVs: AC3 640kbps broken (renders Transcoding unusable).

That PR basically means I give up for old API versions. 

Verified NOT working (DTS, AC3): KD-55XD8005
Verified working (DTS, AC3): FireTV1 and FireTV2