### PR TITLE
[PVR] trac17040: fix crashes on pvr manager deinit/reinit.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1336,6 +1336,7 @@ void CApplication::StopPVRManager()
     StopPlaying();
   // stop pvr manager thread and clear all pvr data
   g_PVRManager.Stop();
+  g_PVRManager.Clear();
   // stop epg container thread and clear all epg data
   g_EpgContainer.Stop();
   g_EpgContainer.Clear();

--- a/xbmc/epg/Epg.cpp
+++ b/xbmc/epg/Epg.cpp
@@ -293,20 +293,25 @@ std::vector<CEpgInfoTagPtr> CEpg::GetTagsBetween(const CDateTime &beginTime, con
 void CEpg::AddEntry(const CEpgInfoTag &tag)
 {
   CEpgInfoTagPtr newTag;
-  CSingleLock lock(m_critSection);
-  std::map<CDateTime, CEpgInfoTagPtr>::iterator itr = m_tags.find(tag.StartAsUTC());
-  if (itr != m_tags.end())
-    newTag = itr->second;
-  else
+  CPVRChannelPtr channel;
   {
-    newTag.reset(new CEpgInfoTag(this, m_pvrChannel, m_strName, m_pvrChannel ? m_pvrChannel->IconPath() : ""));
-    m_tags.insert(make_pair(tag.StartAsUTC(), newTag));
+    CSingleLock lock(m_critSection);
+    std::map<CDateTime, CEpgInfoTagPtr>::iterator itr = m_tags.find(tag.StartAsUTC());
+    if (itr != m_tags.end())
+      newTag = itr->second;
+    else
+    {
+      newTag.reset(new CEpgInfoTag(this, m_pvrChannel, m_strName, m_pvrChannel ? m_pvrChannel->IconPath() : ""));
+      m_tags.insert(make_pair(tag.StartAsUTC(), newTag));
+    }
+
+    channel = m_pvrChannel;
   }
 
   if (newTag)
   {
     newTag->Update(tag);
-    newTag->SetPVRChannel(m_pvrChannel);
+    newTag->SetPVRChannel(channel);
     newTag->SetEpg(this);
     newTag->SetTimer(g_PVRTimers->GetTimerForEpgTag(newTag));
     newTag->SetRecording(g_PVRRecordings->GetRecordingForEpgTag(newTag));

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -180,18 +180,24 @@ void CEpgContainer::Start(bool bAsync)
 
   LoadFromDB();
 
-  CSingleLock lock(m_critSection);
-  if (!m_bStop)
+  bool bStop = false;
   {
-    CheckPlayingEvents();
+    CSingleLock lock(m_critSection);
+    bStop = m_bStop;
+    if (!m_bStop)
+    {
+      CheckPlayingEvents();
 
-    Create();
-    SetPriority(-1);
+      Create();
+      SetPriority(-1);
 
-    m_bStarted = true;
+      m_bStarted = true;
+    }
+  }
 
+  if (!bStop)
+  {
     g_PVRManager.TriggerEpgsCreate();
-
     CLog::Log(LOGNOTICE, "%s - EPG thread started", __FUNCTION__);
   }
 }
@@ -773,24 +779,36 @@ int CEpgContainer::GetEPGSearch(CFileItemList &results, const EpgSearchFilter &f
 bool CEpgContainer::CheckPlayingEvents(void)
 {
   bool bReturn(false);
-  time_t iNow;
   bool bFoundChanges(false);
 
   {
-    CSingleLock lock(m_critSection);
+    time_t iNextEpgActiveTagCheck;
+    {
+      CSingleLock lock(m_critSection);
+      iNextEpgActiveTagCheck = m_iNextEpgActiveTagCheck;
+    }
+
+    time_t iNow;
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
-    if (iNow >= m_iNextEpgActiveTagCheck)
+    if (iNow >= iNextEpgActiveTagCheck)
     {
       for (const auto &epgEntry : m_epgs)
         bFoundChanges = epgEntry.second->CheckPlayingEvent() || bFoundChanges;
-      CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgActiveTagCheck);
-      m_iNextEpgActiveTagCheck += g_advancedSettings.m_iEpgActiveTagCheckInterval;
+
+      CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNextEpgActiveTagCheck);
+      iNextEpgActiveTagCheck += g_advancedSettings.m_iEpgActiveTagCheckInterval;
 
       /* pvr tags always start on the full minute */
       if (g_PVRManager.IsStarted())
-        m_iNextEpgActiveTagCheck -= m_iNextEpgActiveTagCheck % 60;
+        iNextEpgActiveTagCheck -= iNextEpgActiveTagCheck % 60;
 
       bReturn = true;
+    }
+
+    if (bReturn)
+    {
+      CSingleLock lock(m_critSection);
+      m_iNextEpgActiveTagCheck = iNextEpgActiveTagCheck;
     }
   }
 

--- a/xbmc/epg/EpgInfoTag.cpp
+++ b/xbmc/epg/EpgInfoTag.cpp
@@ -341,18 +341,22 @@ int CEpgInfoTag::GetDuration(void) const
   return end - start > 0 ? end - start : 3600;
 }
 
+bool CEpgInfoTag::IsParentalLocked() const
+{
+  CPVRChannelPtr channel;
+  {
+    CSingleLock lock(m_critSection);
+    channel = m_pvrChannel;
+  }
+
+  return channel && g_PVRManager.IsParentalLocked(channel);
+}
+
 std::string CEpgInfoTag::Title(bool bOverrideParental /* = false */) const
 {
   std::string strTitle;
-  bool bParentalLocked(false);
 
-  {
-    CSingleLock lock(m_critSection);
-    if (m_pvrChannel)
-      bParentalLocked = g_PVRManager.IsParentalLocked(m_pvrChannel);
-  }
-
-  if (!bOverrideParental && bParentalLocked)
+  if (!bOverrideParental && IsParentalLocked())
     strTitle = g_localizeStrings.Get(19266); // parental locked
   else if (m_strTitle.empty() && !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
     strTitle = g_localizeStrings.Get(19055); // no information available
@@ -366,11 +370,8 @@ std::string CEpgInfoTag::PlotOutline(bool bOverrideParental /* = false */) const
 {
   std::string retVal;
 
-  {
-    CSingleLock lock(m_critSection);
-    if (bOverrideParental || !m_pvrChannel || !g_PVRManager.IsParentalLocked(m_pvrChannel))
-      retVal = m_strPlotOutline;
-  }
+  if (bOverrideParental || !IsParentalLocked())
+    retVal = m_strPlotOutline;
 
   return retVal;
 }
@@ -379,11 +380,8 @@ std::string CEpgInfoTag::Plot(bool bOverrideParental /* = false */) const
 {
   std::string retVal;
 
-  {
-    CSingleLock lock(m_critSection);
-    if (bOverrideParental || !m_pvrChannel || !g_PVRManager.IsParentalLocked(m_pvrChannel))
-      retVal = m_strPlot;
-  }
+  if (bOverrideParental || !IsParentalLocked())
+    retVal = m_strPlot;
 
   return retVal;
 }
@@ -392,11 +390,8 @@ std::string CEpgInfoTag::OriginalTitle(bool bOverrideParental /* = false */) con
 {
   std::string retVal;
 
-  {
-    CSingleLock lock(m_critSection);
-    if (bOverrideParental || !m_pvrChannel || !g_PVRManager.IsParentalLocked(m_pvrChannel))
-      retVal = m_strOriginalTitle;
-  }
+  if (bOverrideParental || !IsParentalLocked())
+    retVal = m_strOriginalTitle;
 
   return retVal;
 }

--- a/xbmc/epg/EpgInfoTag.h
+++ b/xbmc/epg/EpgInfoTag.h
@@ -170,6 +170,12 @@ namespace EPG
     int GetDuration(void) const;
 
     /*!
+     * @brief Check whether this event is parental locked.
+     * @return True if whether this event is parental locked, false otherwise.
+     */
+    bool IsParentalLocked() const;
+
+    /*!
      * @brief Get the title of this event.
      * @param bOverrideParental True to override parental control, false check it.
      * @return The title.

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -62,8 +62,8 @@ JSONRPC_STATUS CPVROperations::GetChannelGroups(const std::string &method, ITran
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
   
-  CPVRChannelGroupsContainer *channelGroupContainer = g_PVRChannelGroups;
-  if (channelGroupContainer == NULL)
+  CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRChannelGroups;
+  if (!channelGroupContainer)
     return FailedToExecute;
 
   CPVRChannelGroups *channelGroups = channelGroupContainer->Get(parameterObject["channeltype"].asString().compare("radio") == 0);
@@ -85,8 +85,8 @@ JSONRPC_STATUS CPVROperations::GetChannelGroupDetails(const std::string &method,
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRChannelGroupsContainer *channelGroupContainer = g_PVRChannelGroups;
-  if (channelGroupContainer == NULL)
+  CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRChannelGroups;
+  if (!channelGroupContainer)
     return FailedToExecute;
   
   CPVRChannelGroupPtr channelGroup;
@@ -109,8 +109,8 @@ JSONRPC_STATUS CPVROperations::GetChannels(const std::string &method, ITransport
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
   
-  CPVRChannelGroupsContainer *channelGroupContainer = g_PVRChannelGroups;
-  if (channelGroupContainer == NULL)
+  CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRChannelGroups;
+  if (!channelGroupContainer)
     return FailedToExecute;
   
   CPVRChannelGroupPtr channelGroup;
@@ -137,8 +137,8 @@ JSONRPC_STATUS CPVROperations::GetChannelDetails(const std::string &method, ITra
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
   
-  CPVRChannelGroupsContainer *channelGroupContainer = g_PVRChannelGroups;
-  if (channelGroupContainer == NULL)
+  CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRChannelGroups;
+  if (!channelGroupContainer)
     return FailedToExecute;
   
   CPVRChannelPtr channel = channelGroupContainer->GetChannelById((int)parameterObject["channelid"].asInteger());
@@ -155,8 +155,8 @@ JSONRPC_STATUS CPVROperations::GetBroadcasts(const std::string &method, ITranspo
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRChannelGroupsContainer *channelGroupContainer = g_PVRManager.ChannelGroups();
-  if (channelGroupContainer == NULL)
+  CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRManager.ChannelGroups();
+  if (!channelGroupContainer)
     return FailedToExecute;
 
   CPVRChannelPtr channel = channelGroupContainer->GetChannelById((int)parameterObject["channelid"].asInteger());
@@ -214,8 +214,8 @@ JSONRPC_STATUS CPVROperations::Record(const std::string &method, ITransportLayer
   }
   else if (channel.isInteger())
   {
-    CPVRChannelGroupsContainer *channelGroupContainer = g_PVRManager.ChannelGroups();
-    if (channelGroupContainer == NULL)
+    CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRManager.ChannelGroups();
+    if (!channelGroupContainer)
       return FailedToExecute;
 
     pChannel = channelGroupContainer->GetChannelById((int)channel.asInteger());
@@ -307,7 +307,7 @@ JSONRPC_STATUS CPVROperations::GetTimers(const std::string &method, ITransportLa
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRTimers* timers = g_PVRTimers;
+  CPVRTimersPtr timers = g_PVRTimers;
   if (!timers)
     return FailedToExecute;
 
@@ -324,7 +324,7 @@ JSONRPC_STATUS CPVROperations::GetTimerDetails(const std::string &method, ITrans
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRTimers* timers = g_PVRTimers;
+  CPVRTimersPtr timers = g_PVRTimers;
   if (!timers)
     return FailedToExecute;
 
@@ -387,7 +387,9 @@ JSONRPC_STATUS CPVROperations::DeleteTimer(const std::string &method, ITransport
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRTimers* timers = g_PVRTimers;
+  CPVRTimersPtr timers = g_PVRTimers;
+  if (!timers)
+    return FailedToExecute;
 
   CPVRTimerInfoTagPtr timer = timers->GetById(parameterObject["timerid"].asInteger());
   if (!timer)
@@ -444,7 +446,7 @@ JSONRPC_STATUS CPVROperations::GetRecordings(const std::string &method, ITranspo
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRRecordings* recordings = g_PVRRecordings;
+  CPVRRecordingsPtr recordings = g_PVRRecordings;
   if (!recordings)
     return FailedToExecute;
 
@@ -461,7 +463,7 @@ JSONRPC_STATUS CPVROperations::GetRecordingDetails(const std::string &method, IT
   if (!g_PVRManager.IsStarted())
     return FailedToExecute;
 
-  CPVRRecordings* recordings = g_PVRRecordings;
+  CPVRRecordingsPtr recordings = g_PVRRecordings;
   if (!recordings)
     return FailedToExecute;
 

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -571,8 +571,8 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (!g_PVRManager.IsStarted())
       return FailedToExecute;
 
-    CPVRChannelGroupsContainer *channelGroupContainer = g_PVRChannelGroups;
-    if (channelGroupContainer == NULL)
+    CPVRChannelGroupsContainerPtr channelGroupContainer = g_PVRChannelGroups;
+    if (!channelGroupContainer)
       return FailedToExecute;
 
     CPVRChannelPtr channel = channelGroupContainer->GetChannelById((int)parameterObject["item"]["channelid"].asInteger());
@@ -596,8 +596,8 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (!g_PVRManager.IsStarted())
       return FailedToExecute;
 
-    CPVRRecordings *recordingsContainer = g_PVRRecordings;
-    if (recordingsContainer == NULL)
+    CPVRRecordingsPtr recordingsContainer = g_PVRRecordings;
+    if (!recordingsContainer)
       return FailedToExecute;
 
     CFileItemPtr fileItem = recordingsContainer->GetById((int)parameterObject["item"]["recordingid"].asInteger());

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1896,8 +1896,10 @@ bool CPVRManager::CreateChannelEpgs(void)
   if (EpgsCreated())
     return true;
 
+  bool bEpgsCreated = m_channelGroups->CreateChannelEpgs();
+
   CSingleLock lock(m_critSection);
-  m_bEpgsCreated = m_channelGroups->CreateChannelEpgs();
+  m_bEpgsCreated = bEpgsCreated;
   return m_bEpgsCreated;
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -125,25 +125,25 @@ namespace PVR
      * @brief Get the channel groups container.
      * @return The groups container.
      */
-    CPVRChannelGroupsContainer *ChannelGroups(void) const { return m_channelGroups.get(); }
+    CPVRChannelGroupsContainerPtr ChannelGroups(void) const;
 
     /*!
      * @brief Get the recordings container.
      * @return The recordings container.
      */
-    CPVRRecordings *Recordings(void) const { return m_recordings.get(); }
+    CPVRRecordingsPtr Recordings(void) const;
 
     /*!
      * @brief Get the timers container.
      * @return The timers container.
      */
-    CPVRTimers *Timers(void) const { return m_timers.get(); }
+    CPVRTimersPtr Timers(void) const;
 
     /*!
      * @brief Get the timers container.
      * @return The timers container.
      */
-    CPVRClients *Clients(void) const { return m_addons.get(); }
+    CPVRClientsPtr Clients(void) const;
 
     /*!
      * @brief Init PVRManager.
@@ -156,14 +156,14 @@ namespace PVR
     void Reinit(void);
 
     /*!
-     * @brief Stop the PVRManager and destroy all objects it created.
+     * @brief Stop the PVRManager.
      */
     void Stop(void);
 
     /*!
-     * @brief Delete PVRManager's objects.
+     * @brief Destroy PVRManager's objects.
      */
-    void Cleanup(void);
+    void Clear(void);
 
     /*!
      * @brief Get the TV database.
@@ -661,11 +661,11 @@ namespace PVR
 
     /** @name containers */
     //@{
-    std::unique_ptr<CPVRChannelGroupsContainer>    m_channelGroups;               /*!< pointer to the channel groups container */
-    std::unique_ptr<CPVRRecordings>                m_recordings;                  /*!< pointer to the recordings container */
-    std::unique_ptr<CPVRTimers>                    m_timers;                      /*!< pointer to the timers container */
-    std::unique_ptr<CPVRClients>                   m_addons;                      /*!< pointer to the pvr addon container */
-    std::unique_ptr<CPVRGUIInfo>                   m_guiInfo;                     /*!< pointer to the guiinfo data */
+    CPVRChannelGroupsContainerPtr  m_channelGroups;               /*!< pointer to the channel groups container */
+    CPVRRecordingsPtr              m_recordings;                  /*!< pointer to the recordings container */
+    CPVRTimersPtr                  m_timers;                      /*!< pointer to the timers container */
+    const CPVRClientsPtr           m_addons;                      /*!< pointer to the pvr addon container */
+    std::unique_ptr<CPVRGUIInfo>   m_guiInfo;                     /*!< pointer to the guiinfo data */
     //@}
 
     CCriticalSection                m_critSectionTriggers;         /*!< critical section for triggered updates */

--- a/xbmc/pvr/PVRTypes.h
+++ b/xbmc/pvr/PVRTypes.h
@@ -29,17 +29,29 @@ namespace PVR
   class CPVRChannelGroup;
   typedef std::shared_ptr<CPVRChannelGroup> CPVRChannelGroupPtr;
 
+  class CPVRChannelGroupsContainer;
+  typedef std::shared_ptr<CPVRChannelGroupsContainer> CPVRChannelGroupsContainerPtr;
+
+  class CPVRClients;
+  typedef std::shared_ptr<CPVRClients> CPVRClientsPtr;
+
   class CPVRRadioRDSInfoTag;
   typedef std::shared_ptr<CPVRRadioRDSInfoTag> CPVRRadioRDSInfoTagPtr;
 
   class CPVRRecording;
   typedef std::shared_ptr<CPVRRecording> CPVRRecordingPtr;
 
+  class CPVRRecordings;
+  typedef std::shared_ptr<CPVRRecordings> CPVRRecordingsPtr;
+
   class CPVRTimerInfoTag;
   typedef std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTagPtr;
 
   class CPVRTimerType;
   typedef std::shared_ptr<CPVRTimerType> CPVRTimerTypePtr;
+
+  class CPVRTimers;
+  typedef std::shared_ptr<CPVRTimers> CPVRTimersPtr;
 
 } // namespace PVR
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -198,6 +198,9 @@ bool CPVRClients::HasEnabledClients(void) const
 
 bool CPVRClients::StopClient(const AddonPtr &client, bool bRestart)
 {
+  /* stop playback */
+  CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+
   CSingleLock lock(m_critSection);
   int iId = GetClientId(client);
   PVR_CLIENT mappedClient;

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -160,7 +160,6 @@ bool CPVRChannelGroupInternal::AddToGroup(const CPVRChannelPtr &channel, int iCh
 
 bool CPVRChannelGroupInternal::RemoveFromGroup(const CPVRChannelPtr &channel)
 {
-  CSingleLock lock(m_critSection);
   assert(channel.get());
 
   if (!IsGroupMember(channel))
@@ -173,6 +172,8 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(const CPVRChannelPtr &channel)
     CGUIDialogOK::ShowAndGetInput(CVariant{19098}, CVariant{19102});
     return false;
   }
+
+  CSingleLock lock(m_critSection);
 
   /* switch the hidden flag */
   if (!channel->IsHidden())

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -519,6 +519,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
   }
 
   bool bFound(false);
+  CPVRChannelGroupPtr playingGroup;
 
   // delete the group in this container
   {
@@ -530,7 +531,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
         // update the selected group in the gui if it's deleted
         CPVRChannelGroupPtr selectedGroup = GetSelectedGroup();
         if (selectedGroup && *selectedGroup == group)
-          g_PVRManager.SetPlayingGroup(GetGroupAll());
+          playingGroup = GetGroupAll();
 
         it = m_groups.erase(it);
         bFound = true;
@@ -541,6 +542,9 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
       }
     }
   }
+
+  if (playingGroup)
+    g_PVRManager.SetPlayingGroup(playingGroup);
 
   if (group.GroupID() > 0)
   {

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -165,9 +165,9 @@ void CPVRRecordings::Update(void)
 
   lock.Enter();
   m_bIsUpdating = false;
-  g_PVRManager.SetChanged();
   lock.Leave();
 
+  g_PVRManager.SetChanged();
   g_PVRManager.NotifyObservers(ObservableMessageRecordings);
   g_PVRManager.PublishEvent(RecordingsInvalidated);
 }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -1016,8 +1016,10 @@ CPVRChannelPtr CPVRTimerInfoTag::ChannelTag(void) const
 
 CPVRChannelPtr CPVRTimerInfoTag::UpdateChannel(void)
 {
+  const CPVRChannelPtr channel(g_PVRChannelGroups->Get(m_bIsRadio)->GetGroupAll()->GetByUniqueID(m_iClientChannelUid, m_iClientId));
+
   CSingleLock lock(m_critSection);
-  m_channel = g_PVRChannelGroups->Get(m_bIsRadio)->GetGroupAll()->GetByUniqueID(m_iClientChannelUid, m_iClientId);
+  m_channel = channel;
   return m_channel;
 }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -167,7 +167,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers, const std::vector<int> 
           bChanged = true;
           existingTimer->ResetChildState();
 
-          if (bStateChanged && g_PVRManager.IsStarted())
+          if (bStateChanged)
           {
             std::string strMessage;
             existingTimer->GetNotificationText(strMessage);
@@ -203,12 +203,9 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers, const std::vector<int> 
         bChanged = true;
         bAddedOrDeleted = true;
 
-        if (g_PVRManager.IsStarted())
-        {
-          std::string strMessage;
-          newTimer->GetNotificationText(strMessage);
-          timerNotifications.push_back(std::make_pair(newTimer->m_iClientId, strMessage));
-        }
+         std::string strMessage;
+         newTimer->GetNotificationText(strMessage);
+         timerNotifications.push_back(std::make_pair(newTimer->m_iClientId, strMessage));
 
         CLog::Log(LOGDEBUG,"PVRTimers - %s - added timer %d on client %d",
             __FUNCTION__, (*timerIt)->m_iClientIndex, (*timerIt)->m_iClientId);
@@ -247,8 +244,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers, const std::vector<int> 
         CLog::Log(LOGDEBUG,"PVRTimers - %s - deleted timer %d on client %d",
             __FUNCTION__, timer->m_iClientIndex, timer->m_iClientId);
 
-        if (g_PVRManager.IsStarted())
-          timerNotifications.push_back(std::make_pair(timer->m_iClientId, timer->GetDeletedNotificationText()));
+        timerNotifications.push_back(std::make_pair(timer->m_iClientId, timer->GetDeletedNotificationText()));
 
         ClearEpgTagTimer(timer);
 
@@ -324,24 +320,27 @@ bool CPVRTimers::UpdateEntries(const CPVRTimers &timers, const std::vector<int> 
   if (bChanged)
   {
     UpdateChannels();
-    g_PVRManager.SetChanged();
     lock.Leave();
 
+    g_PVRManager.SetChanged();
     g_PVRManager.NotifyObservers(bAddedOrDeleted ? ObservableMessageTimersReset : ObservableMessageTimers);
 
-    /* queue notifications / fill eventlog */
-    for (const auto &entry : timerNotifications)
+    if (g_PVRManager.IsStarted())
     {
-      if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS))
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(19166), entry.second);
+      /* queue notifications / fill eventlog */
+      for (const auto &entry : timerNotifications)
+      {
+        if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS))
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(19166), entry.second);
 
-      std::string strName;
-      g_PVRClients->GetClientAddonName(entry.first, strName);
+        std::string strName;
+        g_PVRClients->GetClientAddonName(entry.first, strName);
 
-      std::string strIcon;
-      g_PVRClients->GetClientAddonIcon(entry.first, strIcon);
+        std::string strIcon;
+        g_PVRClients->GetClientAddonIcon(entry.first, strIcon);
 
-      CEventLog::GetInstance().Add(EventPtr(new CNotificationEvent(strName, entry.second, strIcon, EventLevel::Information)));
+        CEventLog::GetInstance().Add(EventPtr(new CNotificationEvent(strName, entry.second, strIcon, EventLevel::Information)));
+      }
     }
   }
 
@@ -643,6 +642,7 @@ bool CPVRTimers::GetDirectory(const std::string& strPath, CFileItemList &items) 
 bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDeleteTimerRules /* = true */, bool bCurrentlyActiveOnly /* = false */)
 {
   bool bReturn = false;
+  bool bChanged = false;
   {
     CSingleLock lock(m_critSection);
 
@@ -658,11 +658,14 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
         {
           CLog::Log(LOGDEBUG,"PVRTimers - %s - deleted timer %d on client %d", __FUNCTION__, (*timerIt)->m_iClientIndex, (*timerIt)->m_iClientId);
           bReturn = (*timerIt)->DeleteFromClient(true) || bReturn;
-          g_PVRManager.SetChanged();
+          bChanged = true;
         }
       }
     }
   }
+
+  if (bChanged)
+    g_PVRManager.SetChanged();
 
   g_PVRManager.NotifyObservers(ObservableMessageTimersReset);
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -88,17 +88,20 @@ void CGUIWindowPVRBase::UpdateSelectedItemPath()
 
 void CGUIWindowPVRBase::RegisterObservers(void)
 {
-  CSingleLock lock(m_critSection);
   g_PVRManager.RegisterObserver(this);
+
+  CSingleLock lock(m_critSection);
   if (m_channelGroup)
     m_channelGroup->RegisterObserver(this);
 };
 
 void CGUIWindowPVRBase::UnregisterObservers(void)
 {
-  CSingleLock lock(m_critSection);
-  if (m_channelGroup)
-    m_channelGroup->UnregisterObserver(this);
+  {
+    CSingleLock lock(m_critSection);
+    if (m_channelGroup)
+      m_channelGroup->UnregisterObserver(this);
+  }
   g_PVRManager.UnregisterObserver(this);
 };
 
@@ -311,18 +314,26 @@ CPVRChannelGroupPtr CGUIWindowPVRBase::GetChannelGroup(void)
 
 void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group)
 {
-  CSingleLock lock(m_critSection);
   if (!group)
     return;
 
-  if (m_channelGroup != group)
+  CPVRChannelGroupPtr channelGroup;
   {
-    if (m_channelGroup)
-      m_channelGroup->UnregisterObserver(this);
-    m_channelGroup = group;
-    // we need to register the window to receive changes from the new group
-    m_channelGroup->RegisterObserver(this);
-    g_PVRManager.SetPlayingGroup(m_channelGroup);
+    CSingleLock lock(m_critSection);
+    if (m_channelGroup != group)
+    {
+      if (m_channelGroup)
+        m_channelGroup->UnregisterObserver(this);
+      m_channelGroup = group;
+      // we need to register the window to receive changes from the new group
+      m_channelGroup->RegisterObserver(this);
+      channelGroup = m_channelGroup;
+    }
+  }
+
+  if (channelGroup)
+  {
+    g_PVRManager.SetPlayingGroup(channelGroup);
     Update(GetDirectoryPath());
   }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -45,7 +45,6 @@ using namespace EPG;
 
 CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
   CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_GUIDE : WINDOW_TV_GUIDE, "MyPVRGuide.xml"),
-  m_refreshTimelineItemsThread(new CPVRRefreshTimelineItemsThread(this)),
   m_cachedChannelGroup(new CPVRChannelGroup)
 {
   m_bRefreshTimelineItems = false;
@@ -109,12 +108,14 @@ void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
 void CGUIWindowPVRGuide::StartRefreshTimelineItemsThread()
 {
   StopRefreshTimelineItemsThread();
+  m_refreshTimelineItemsThread.reset(new CPVRRefreshTimelineItemsThread(this));
   m_refreshTimelineItemsThread->Create();
 }
 
 void CGUIWindowPVRGuide::StopRefreshTimelineItemsThread()
 {
-  m_refreshTimelineItemsThread->StopThread(false);
+  if (m_refreshTimelineItemsThread)
+    m_refreshTimelineItemsThread->StopThread(false);
 }
 
 void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage msg)


### PR DESCRIPTION
This fixes several crashes on pvr manager reinit and deinit, like trac#17040 (http://trac.kodi.tv/ticket/17040)

PVR manager gets reinited at runtime under certain circumstances, like disabling or uninstalling pvr client addons. Objects managed by PVR manager (timers, recordings, channels, ...) are accessed from various kodi threads. During reinit the above mentioned objects will be destroyed and recreated.

For unknown reasons  neither the destruct/recreate sequence of the pvr objects nor the access to these objects were protected by pvr manager's lock.

Moreover, the objects exposed by PVR manager were raw pointers.

This PR makes PVR manager reinit/deinit thread safe and raw pointers are replaced by shared pointers to ensure pvr objects stay alive once they have been obtained.

Also necessary for fixing trac17040 is to stop playback before stopping a pvr client (for instance upon update/disable/deinstall). This fix is also part of this PR.

The change has been tested on macOS, latest Kodi master.

@ace20022 would be great if you could runtime test this.
@MilhouseVH could you please include this patch in your build to get broader feedback on possible regressions?