### PR TITLE
CMake: Fix TexturePacker installation directory

### DIFF
--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -138,7 +138,7 @@ install(FILES ${CORE_SOURCE_DIR}/privacy-policy.txt
 
 # Install kodi-tools-texturepacker
 if(NOT WITH_TEXTUREPACKER)
-  install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/texturepacker/TexturePacker
+  install(PROGRAMS $<TARGET_FILE:TexturePacker::TexturePacker>
           DESTINATION ${bindir}
           COMPONENT kodi-tools-texturepacker)
 endif()


### PR DESCRIPTION
This fixes a problem I hit when running `make install` on a depends-based build. Error was:

```
CMake Error at cmake_install.cmake:15813 (file):
  file INSTALL cannot find
  "/home/garrett/workspace/kodi/build/build/texturepacker/TexturePacker".


Makefile:61: recipe for target 'install' failed
make: *** [install] Error 1
```

thanks to fetzerch