### PR TITLE
Basic audiobooks support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20419,3 +20419,8 @@ msgstr ""
 msgctxt "#39015"
 msgid "Image decoder"
 msgstr ""
+
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+msgctxt "#39016"
+msgid "Resume audiobook"
+msgstr ""

--- a/project/Win32BuildSetup/AppxManifest.xml.in
+++ b/project/Win32BuildSetup/AppxManifest.xml.in
@@ -79,6 +79,7 @@
               <uap:FileType>.m3u</uap:FileType>
               <uap:FileType>.m3u8</uap:FileType>
               <uap:FileType>.m4a</uap:FileType>
+              <uap:FileType>.m4b</uap:FileType>
               <uap:FileType>.mac</uap:FileType>
               <uap:FileType>.mk3d</uap:FileType>
               <uap:FileType>.mka</uap:FileType>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3839,6 +3839,11 @@ void CApplication::UpdateFileState()
           m_progressTrackingVideoResumeBookmark.timeInSeconds = 0.0f;
         }
       }
+      if (m_pPlayer->IsPlayingAudio() && !m_pPlayer->IsPlayingGame())
+      {
+        if (m_progressTrackingItem->IsAudioBook())
+          m_progressTrackingVideoResumeBookmark.timeInSeconds = GetTime();
+      }
     }
   }
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -911,6 +911,11 @@ bool CFileItem::IsDeleted() const
   return false;
 }
 
+bool CFileItem::IsAudioBook() const
+{
+  return IsType(".m4b") || IsType(".mka");
+}
+
 bool CFileItem::IsGame() const
 {
   if (HasGameInfoTag())
@@ -994,6 +999,7 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
     || IsRAR()
     || IsRSS()
     || IsType(".iso")
+    || IsAudioBook()
     || IsType(".ogg|.oga|.nsf|.sid|.sap|.xbt|.xsp")
 #if defined(TARGET_ANDROID)
     || IsType(".apk")

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -182,6 +182,12 @@ public:
    */
   bool IsDeleted() const;
 
+  /*!
+   \brief Check whether an item is an audio book item.
+   \return true if item is audiobook, false otherwise.
+   */
+  bool IsAudioBook() const;
+
   bool IsGame() const;
   bool IsCUESheet() const;
   bool IsInternetStream(const bool bStrictCheck = false) const;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -284,6 +284,13 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   /* trigger playback start */
   m_isPlaying = true;
   m_startEvent.Set();
+
+  if (options.startpercent > 0.0)
+  {
+    Sleep(50);
+    SeekPercentage(options.startpercent);
+  }
+
   return true;
 }
 

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -22,6 +22,7 @@
 #include "FileItem.h"
 #include "utils/StringUtils.h"
 #include "music/tags/MusicInfoTag.h"
+#include "TextureDatabase.h"
 #include "guilib/LocalizeStrings.h"
 #include "URL.h"
 
@@ -79,6 +80,10 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
       author = tag->value;
   }
 
+  std::string thumb;
+  if (m_fctx->nb_chapters > 1)
+    thumb = CTextureUtils::GetWrappedImageURL(url.Get(), "music");
+
   for (size_t i=0;i<m_fctx->nb_chapters;++i)
   {
     tag=nullptr;
@@ -125,6 +130,8 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     item->m_lEndOffset *= 75;
     item->GetMusicInfoTag()->SetDuration((item->m_lEndOffset-item->m_lStartOffset)/75);
     item->SetProperty("item_start", item->m_lStartOffset);
+    if (!thumb.empty())
+      item->SetArt("thumb", thumb);
     items.Add(item);
   }
 

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -1,0 +1,173 @@
+/*
+ *      Copyright (C) 2014 Arne Morten Kvarving
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AudioBookFileDirectory.h"
+#include "filesystem/File.h"
+#include "FileItem.h"
+#include "utils/StringUtils.h"
+#include "music/tags/MusicInfoTag.h"
+#include "guilib/LocalizeStrings.h"
+#include "URL.h"
+
+using namespace XFILE;
+
+static int cfile_file_read(void *h, uint8_t* buf, int size)
+{
+  CFile* pFile = static_cast<CFile*>(h);
+  return pFile->Read(buf, size);
+}
+
+static int64_t cfile_file_seek(void *h, int64_t pos, int whence)
+{
+  CFile* pFile = static_cast<CFile*>(h);
+  if(whence == AVSEEK_SIZE)
+    return pFile->GetLength();
+  else
+    return pFile->Seek(pos, whence & ~AVSEEK_FORCE);
+}
+
+CAudioBookFileDirectory::CAudioBookFileDirectory(void) :
+  m_ioctx(nullptr), m_fctx(nullptr)
+{
+}
+
+CAudioBookFileDirectory::~CAudioBookFileDirectory(void)
+{
+  if (m_fctx)
+    avformat_close_input(&m_fctx);
+  if (m_ioctx)
+  {
+    av_free(m_ioctx->buffer);
+    av_free(m_ioctx);
+  }
+}
+
+bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
+                                           CFileItemList &items)
+{
+  if (!m_fctx && !ContainsFiles(url))
+    return true;
+
+  std::string title;
+  std::string author;
+  std::string album;
+
+  AVDictionaryEntry* tag=nullptr;
+  while ((tag = av_dict_get(m_fctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
+  {
+    if (strcasecmp(tag->key,"title") == 0)
+      title = tag->value;
+    else if (strcasecmp(tag->key,"album") == 0)
+      album = tag->value;
+    else if (strcasecmp(tag->key,"artist") == 0)
+      author = tag->value;
+  }
+
+  for (size_t i=0;i<m_fctx->nb_chapters;++i)
+  {
+    tag=nullptr;
+    std::string chaptitle = StringUtils::Format(g_localizeStrings.Get(25010).c_str(), i+1);
+    std::string chapauthor;
+    std::string chapalbum;
+    while ((tag=av_dict_get(m_fctx->chapters[i]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
+    {
+      if (strcasecmp(tag->key,"title") == 0)
+        chaptitle = tag->value;
+      else if (strcasecmp(tag->key,"artist") == 0)
+        chapauthor = tag->value;
+      else if (strcasecmp(tag->key,"album") == 0)
+        chapalbum = tag->value;
+    }
+    CFileItemPtr item(new CFileItem(url.Get(),false));
+    item->GetMusicInfoTag()->SetTrackNumber(i+1);
+    item->GetMusicInfoTag()->SetLoaded(true);
+    item->GetMusicInfoTag()->SetTitle(chaptitle);
+    if (album.empty())
+      item->GetMusicInfoTag()->SetAlbum(title);
+    else if (chapalbum.empty())
+      item->GetMusicInfoTag()->SetAlbum(album);
+    else
+      item->GetMusicInfoTag()->SetAlbum(chapalbum);
+    if (chapauthor.empty())
+      item->GetMusicInfoTag()->SetArtist(author);
+    else
+      item->GetMusicInfoTag()->SetArtist(chapauthor);
+
+    item->SetLabel(StringUtils::Format("%02" PRIdS ". %s - %s",i+1,
+                   item->GetMusicInfoTag()->GetAlbum().c_str(),
+                   item->GetMusicInfoTag()->GetTitle().c_str()));
+    item->m_lStartOffset = m_fctx->chapters[i]->start*av_q2d(m_fctx->chapters[i]->time_base)*75;
+    item->m_lEndOffset = m_fctx->chapters[i]->end*av_q2d(m_fctx->chapters[i]->time_base);
+    int compare = m_fctx->duration / (AV_TIME_BASE);
+    if (item->m_lEndOffset < 0 || item->m_lEndOffset > compare)
+    {
+      if (i < m_fctx->nb_chapters-1)
+        item->m_lEndOffset = m_fctx->chapters[i+1]->start*av_q2d(m_fctx->chapters[i+1]->time_base);
+      else
+        item->m_lEndOffset = compare;
+    }
+    item->m_lEndOffset *= 75;
+    item->GetMusicInfoTag()->SetDuration((item->m_lEndOffset-item->m_lStartOffset)/75);
+    item->SetProperty("item_start", item->m_lStartOffset);
+    items.Add(item);
+  }
+
+  return true;
+}
+
+bool CAudioBookFileDirectory::Exists(const CURL& url)
+{
+  return CFile::Exists(url) && ContainsFiles(url);
+}
+
+bool CAudioBookFileDirectory::ContainsFiles(const CURL& url)
+{
+  CFile file;
+  if (!file.Open(url))
+    return false;
+
+  uint8_t* buffer = (uint8_t*)av_malloc(32768);
+  m_ioctx = avio_alloc_context(buffer, 32768, 0, &file, cfile_file_read,
+                               nullptr, cfile_file_seek);
+
+  m_fctx = avformat_alloc_context();
+  m_fctx->pb = m_ioctx;
+
+  if (file.IoControl(IOCTRL_SEEK_POSSIBLE, nullptr) == 0)
+    m_ioctx->seekable = 0;
+
+  m_ioctx->max_packet_size = 32768;
+
+  AVInputFormat* iformat=nullptr;
+  av_probe_input_buffer(m_ioctx, &iformat, url.Get().c_str(), nullptr, 0, 0);
+
+  bool contains = false;
+  if (avformat_open_input(&m_fctx, url.Get().c_str(), iformat, nullptr) < 0)
+  {
+    if (m_fctx)
+      avformat_close_input(&m_fctx);
+    av_free(m_ioctx->buffer);
+    av_free(m_ioctx);
+    return false;
+  }
+
+  contains = m_fctx->nb_chapters > 1;
+
+  return contains;
+}

--- a/xbmc/filesystem/AudioBookFileDirectory.h
+++ b/xbmc/filesystem/AudioBookFileDirectory.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2014 Arne Morten Kvarving
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include "IFileDirectory.h"
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+namespace XFILE
+{
+  class CAudioBookFileDirectory : public IFileDirectory
+  {
+    public:
+      CAudioBookFileDirectory(void);
+      virtual ~CAudioBookFileDirectory(void);
+      virtual bool GetDirectory(const CURL& url, CFileItemList &items);
+      virtual bool Exists(const CURL& url);
+      virtual bool ContainsFiles(const CURL& url);
+      virtual bool IsAllowed(const CURL& url) const { return true; };
+    protected:
+      AVIOContext* m_ioctx;
+      AVFormatContext* m_fctx;
+  };
+}

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES AddonsDirectory.cpp
+            AudioBookFileDirectory.cpp
             CacheStrategy.cpp
             CDDADirectory.cpp
             CDDAFile.cpp

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -47,6 +47,7 @@
 #include "addons/AudioDecoder.h"
 #include "addons/VFSEntry.h"
 #include "addons/BinaryAddonCache.h"
+#include "AudioBookFileDirectory.h"
 
 using namespace ADDON;
 using namespace XFILE;
@@ -253,6 +254,17 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
         return pDir;
     }
     delete pDir;
+    return NULL;
+  }
+
+  if (pItem->IsAudioBook())
+  {
+    if (!pItem->HasMusicInfoTag() || pItem->m_lEndOffset <= 0)
+    {
+      std::unique_ptr<CAudioBookFileDirectory> pDir(new CAudioBookFileDirectory);
+      if (pDir->ContainsFiles(url))
+        return pDir.release();
+    }
     return NULL;
   }
   return NULL;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -250,6 +250,13 @@ public:
   bool HasAlbumBeenScraped(int idAlbum);
   int  AddAlbumInfoSong(int idAlbum, const CSong& song);
 
+  /////////////////////////////////////////////////
+  // Audiobook
+  /////////////////////////////////////////////////
+  bool AddAudioBook(const CFileItem& item);
+  bool SetResumeBookmarkForAudioBook(const CFileItem& item, int bookmark);
+  bool GetResumeBookmarkForAudioBook(const std::string& path, int& bookmark);
+
   /*! \brief Checks if the given path is inside a folder that has already been scanned into the library
    \param path the path we want to check
    */

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -83,7 +83,8 @@ void CMusicInfoLoader::OnLoaderStart()
 
 bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 {
-  if (!pItem || pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+  if (!pItem || (pItem->m_bIsFolder && !pItem->IsAudio()) ||
+      pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
     return false;
 
   if (pItem->GetProperty("hasfullmusictag") == "true")
@@ -135,7 +136,8 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+  if ((pItem->m_bIsFolder && !pItem->IsAudio()) ||
+       pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
     return false;
 
   // Get thumb for item
@@ -149,7 +151,8 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+  if ((pItem->m_bIsFolder && !pItem->IsAudio()) || pItem->IsPlayList() ||
+       pItem->IsNFO() || pItem->IsInternetStream())
     return false;
 
   if (!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded())

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -77,7 +77,7 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& i
       strExtension == "mp3" || 
       strExtension == "wma" || 
       strExtension == "flac" || 
-      strExtension == "m4a" || strExtension == "mp4" ||
+      strExtension == "m4a" || strExtension == "mp4" || strExtension == "m4b" ||
       strExtension == "mpc" || strExtension == "mpp" || strExtension == "mp+" ||
       strExtension == "ogg" || strExtension == "oga" || strExtension == "oggstream" ||
       strExtension == "opus" ||

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -807,6 +807,12 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
         {
             buttons.Add(CONTEXT_BUTTON_PLAY_PARTYMODE, 15216); // Play in Partymode
         }
+        if (item->IsAudioBook())
+        {
+          int bookmark;
+          if (m_musicdatabase.GetResumeBookmarkForAudioBook(item->GetPath(), bookmark) && bookmark > 0)
+            buttons.Add(CONTEXT_BUTTON_RESUME_ITEM, 39016);
+        }
 
         if (item->IsSmartPlayList() || m_vecItems->IsSmartPlayList())
           buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
@@ -936,6 +942,19 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     if (m_musicdatabase.LookupCDDBInfo(true))
       Refresh();
     return true;
+
+  case CONTEXT_BUTTON_RESUME_ITEM: //audiobooks
+    {
+      Update(item->GetPath());
+      int bookmark;
+      m_musicdatabase.GetResumeBookmarkForAudioBook(item->GetPath(), bookmark);
+      int i=0;
+      while (i < m_vecItems->Size() && bookmark > m_vecItems->Get(i)->m_lEndOffset)
+        ++i;
+      CFileItem resItem(*m_vecItems->Get(i));
+      resItem.SetProperty("StartPercent", ((double)bookmark-resItem.m_lStartOffset)/(resItem.m_lEndOffset-resItem.m_lStartOffset)*100);
+      g_application.PlayFile(resItem, "", false);
+    }
 
   default:
     break;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -384,7 +384,7 @@ void CAdvancedSettings::Initialize()
   m_databaseVideo.Reset();
 
   m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.rss|.webp|.jp2|.apng";
-  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf";
+  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b";
   m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.rar|.zip";
   m_discStubExtensions = ".disc";

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -163,9 +163,9 @@ bool CSaveFileStateJob::DoWork()
       std::string redactPath = CURL::GetRedacted(progressTrackingFile);
       CLog::Log(LOGDEBUG, "%s - Saving file state for audio item %s", __FUNCTION__, redactPath.c_str());
 
+      CMusicDatabase musicdatabase;
       if (m_updatePlayCount)
       {
-        CMusicDatabase musicdatabase;
         if (!musicdatabase.Open())
         {
           CLog::Log(LOGWARNING, "%s - Unable to open music database. Can not save file state!", __FUNCTION__);
@@ -188,6 +188,13 @@ bool CSaveFileStateJob::DoWork()
             ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
           }
         }
+      }
+
+      if (m_item.IsAudioBook())
+      {
+        musicdatabase.Open();
+        musicdatabase.SetResumeBookmarkForAudioBook(m_item, m_item.m_lStartOffset+m_bookmark.timeInSeconds*75);
+        musicdatabase.Close();
       }
     }
 


### PR DESCRIPTION
This is some very basic stuff to support audio books. There is no library integration as that part was shot down in earlier attempts. This adds

- support for .m4b and .mka
- a filedirectory for audiobooks. this allows browsing into the m4b/mka to list chapters etc
- basic resume support.

i'm not too happy about the sleep required in paplayer, but i have found no other way to make sure the decoder threads have started up and done their stuff before seek command lands.