### PR TITLE
[cmake] linux: install docs into docdir

### DIFF
--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -129,7 +129,7 @@ install(FILES ${CORE_SOURCE_DIR}/copying.txt
               ${CORE_SOURCE_DIR}/LICENSE.GPL
               ${CORE_SOURCE_DIR}/version.txt
               ${CORE_SOURCE_DIR}/docs/README.linux
-        DESTINATION ${datarootdir}/doc/${APP_NAME_LC}
+        DESTINATION ${docdir}
         COMPONENT kodi)
 
 install(FILES ${CORE_SOURCE_DIR}/privacy-policy.txt

--- a/project/cmake/scripts/linux/PathSetup.cmake
+++ b/project/cmake/scripts/linux/PathSetup.cmake
@@ -34,6 +34,7 @@ list(APPEND final_message "Bindir: ${bindir}")
 list(APPEND final_message "Includedir: ${includedir}")
 list(APPEND final_message "Datarootdir: ${datarootdir}")
 list(APPEND final_message "Datadir: ${datadir}")
+list(APPEND final_message "Docdir: ${docdir}")
 
 set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/kodi\"
                    -DINSTALL_PATH=\"${datarootdir}/kodi\")


### PR DESCRIPTION
## Description
Install LICENSE.GPL, version.txt and README.linux into the user's chosen ${docdir}.
Also output ${docdir} during configuration step as with the other installation variables.

## Motivation and Context
By convention Linux user expects this control, and is used by distributions that have their own naming convention in /usr/share/doc/.
Code examples already are already installed in ${docdir}

## How Has This Been Tested?
Tested by passing -Ddocdir=/usr/share/doc/${PF} inside Gentoo ebuild.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
