### PR TITLE
[AML] read display modes optionally from file

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -23,6 +23,7 @@
 #include "utils/AMLUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/SysfsUtils.h"
+#include "filesystem/SpecialProtocol.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -152,8 +153,14 @@ bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
 
 bool CEGLNativeTypeAmlogic::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
 {
-  std::string valstr;
-  SysfsUtils::GetString("/sys/class/amhdmitx/amhdmitx0/disp_cap", valstr);
+  std::string valstr, dcapfile;
+  dcapfile = CSpecialProtocol::TranslatePath("special://home/userdata/disp_cap");
+
+  if (SysfsUtils::GetString(dcapfile, valstr) < 0)
+  {
+    if (SysfsUtils::GetString("/sys/class/amhdmitx/amhdmitx0/disp_cap", valstr) < 0)
+      return false;
+  }
   std::vector<std::string> probe_str = StringUtils::Split(valstr, "\n");
 
   resolutions.clear();


### PR DESCRIPTION
[AML] read display modes optionally from file

## Description
AML often looses the settings in /sys/class/amhdmitx/amhdmitx0/disp_cap.
In case of failure they are either empty or contain only 720p and 1080p (on my odroid)
This PR looks first for the existance of a file, if present it uses the values in there, otherwise the information is used from /sys/class/amhdmitx/amhdmitx0/disp_cap

## Motivation and Context
1.) Loosing EDID information is annoying because no framerate adjustment occurs
2.) My EDID information does not contain 24hz, Using this file let me force the monitor to it.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
