### PR TITLE
Blacklist problematic Sony TV remote

### DIFF
--- a/xbmc/peripherals/bus/android/AndroidJoystickState.cpp
+++ b/xbmc/peripherals/bus/android/AndroidJoystickState.cpp
@@ -88,6 +88,13 @@ bool CAndroidJoystickState::Initialize(const CJNIViewInputDevice& inputDevice)
 
   const std::string deviceName = inputDevice.getName();
 
+  // Skip problematic devices
+  if (deviceName == "SONY TV RC MIC 001")
+  {
+    // Sony TV IR + bluetooth remote disconnects after a minute or so of inactivity
+    return false;
+  }
+
   // get the device ID
   m_deviceId = inputDevice.getId();
 


### PR DESCRIPTION
See discussion: http://forum.kodi.tv/showthread.php?tid=298891

Alternative to #11065 to avoid introducing a setting.

## Screenshots (if appropriate):
Before fix:
![Device removed](https://s15.postimg.org/f2aj4l0wn/IMG_20161204_114435.jpg)
![New device configured](https://s15.postimg.org/3onztdqdz/IMG_20161204_114404.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
