### PR TITLE
Fix silent failure when game add-on can't be installed

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1179,6 +1179,7 @@ msgid "Fetching CD information"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogFileBrowser.cpp
+#: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
 #: xbmc/pvr/PVRGUIActions.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -17079,7 +17080,13 @@ msgctxt "#35255"
 msgid "Browse all emulators"
 msgstr ""
 
-#empty strings from id 35256 to 35504
+#. Error message when a game client fails to install when a game is being launched
+#: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+msgctxt "#35256"
+msgid "Failed to install add-on."
+msgstr ""
+
+#empty strings from id 35257 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -23,6 +23,7 @@
 #include "addons/AddonManager.h"
 #include "addons/GUIWindowAddonBrowser.h"
 #include "dialogs/GUIDialogContextMenu.h"
+#include "dialogs/GUIDialogOK.h"
 #include "games/addons/GameClient.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
@@ -139,6 +140,9 @@ GameClientPtr CGUIDialogSelectGameClient::InstallGameClient(const GameClientVect
     else
     {
       CLog::Log(LOGERROR, "Select game client dialog: Failed to install %s", gameClientId.c_str());
+      // "Error"
+      // "Failed to install add-on."
+      CGUIDialogOK::ShowAndGetInput(257, 35256);
     }
   }
   else if (result == iAddonBrowser)


### PR DESCRIPTION
On the latest Milhouse builds, game add-ons can't be installed because game.libretro (a dependency) isn't in the libreelec repo. Instead of failing silently, this adds an error dialog.

## Screenshots
![error dialog](https://cloud.githubusercontent.com/assets/531482/21147521/2c17386c-c10a-11e6-8b6a-5c98f975d551.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
