### PR TITLE
Fix queueing .strm and .pls music files

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -668,7 +668,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
       return;
     }
   }
-  if (pItem->m_bIsFolder || (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_NAV && pItem->IsPlayList()))
+  if (pItem->m_bIsFolder)
   {
     // Check if we add a locked share
     if ( pItem->m_bIsShareOrDrive )
@@ -995,7 +995,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
 #endif
 
   // if its a folder, build a playlist
-  if ((pItem->m_bIsFolder && !pItem->IsPlugin()) || (g_windowManager.GetActiveWindow() == WINDOW_MUSIC_NAV && pItem->IsPlayList()))
+  if (pItem->m_bIsFolder && !pItem->IsPlugin())
   {
     // make a copy so that we can alter the queue state
     CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));


### PR DESCRIPTION
.strm and .pls music (playlist) files cannot be queued but are treated instead as directories when in the Music Navigation screen, leading to errors. Other music playlist files (e.g. .m3u) can be queued.

This is a Krypton backport of https://github.com/xbmc/xbmc/pull/11175.
## Description
Queueing was not possible for music playlist items because the playlist would be processed as a directory resulting in the error:
`DEBUG: CGUIMediaWindow::GetDirectory (<path>/test.strm)`
`XFILE::CDirectory::GetDirectory - Error getting <path>/test.strm`

To my knowledge and tests, the former if statements are incorrect. There is no possibility for .strm and .pls files (playlist files) to be listed as a directory, and this part can therefore be removed. This fixes the queuing these files. Other music files such as .m3u can be listed as directories, but are caught by the if statement as virtual folder.

## How Has This Been Tested?
By queuing an .strm file containing an http link to a music file; didn't work before the fix, did work after the fix (with a reboot and user setting reset to get rid of the memorized path).

## Types of change
- [X]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)