### PR TITLE
VideoPlayer: Don't add timestamp offsets to DVD_NOPTS_VALUE

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1610,9 +1610,9 @@ void CVideoPlayer::Process()
       if (CDVDInputStream::IMenus* menu = dynamic_cast<CDVDInputStream::IMenus*>(m_pInputStream))
       {
         double correction = menu->GetTimeStampCorrection();
-        if (pPacket->dts > correction)
+        if (pPacket->dts != DVD_NOPTS_VALUE && pPacket->dts > correction)
           pPacket->dts -= correction;
-        if (pPacket->pts > correction)
+        if (pPacket->pts != DVD_NOPTS_VALUE && pPacket->pts > correction)
           pPacket->pts -= correction;
       }
       if (m_dvd.syncClock)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
VideoPlayer: Don't add timestamp offsets to DVD_NOPTS_VALUE

## Motivation and Context
I have a dvd menu that results in a renderer configure timeout.
The dts and pts timestamps are wild.
I've traced it back to pts=DVD_NOPTS_VALUE being adjusted and so no longer being treated as invalid

## How Has This Been Tested?
Fixes a timeout in renderer configure with The Avengers DVD folder structure.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
