### PR TITLE
libdvd: fix setting compiler when cross-compiling

### DIFF
--- a/project/cmake/modules/FindLibDvd.cmake
+++ b/project/cmake/modules/FindLibDvd.cmake
@@ -76,7 +76,7 @@ if(NOT WIN32)
     endforeach()
 
     set(DVDREAD_CFLAGS "${DVDREAD_CFLAGS} -I${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include")
-    if(KODI_DEPENDSBUILD)
+    if(CMAKE_CROSSCOMPILING)
       set(EXTRA_FLAGS "CC=${CMAKE_C_COMPILER}")
     endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description

Fix setting exact compiler when cross-compiling libdvd*

## Motivation and Context

Otherwise it can result in problems when configure decides to use
one with different ABI

```
[..]/libdvdnav.a: member [..]/libdvdnav.a(dvdnav.o) in archive is not an object
collect2: error: ld returned 1 exit status
CMakeFiles/wrap_libdvdnav.dir/build.make:63: recipe for target 'system/players/VideoPlayer/libdvdnav-arm.so' failed
```

## How Has This Been Tested?

buildroot buildsystem, rpi target

## Screenshots (if appropriate):

## Types of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
