### PR TITLE
[xbmc][win32][backport][fix] Remove the special windows free_string_val, it's not needed now that …

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -755,14 +755,10 @@ void dumpPlist(DllLibPlist *pLibPlist, plist_t *dict)
 std::string getStringFromPlist(DllLibPlist *pLibPlist,plist_t node)
 {
   std::string ret;
-  char *tmpStr = NULL;
+  char *tmpStr = nullptr;
   pLibPlist->plist_get_string_val(node, &tmpStr);
   ret = tmpStr;
-#ifdef TARGET_WINDOWS
-  pLibPlist->plist_free_string_val(tmpStr);
-#else
   free(tmpStr);
-#endif
   return ret;
 }
 

--- a/xbmc/network/DllLibPlist.h
+++ b/xbmc/network/DllLibPlist.h
@@ -36,9 +36,6 @@ public:
   virtual void        plist_get_real_val    (plist_t node,            double *val                       )=0;
   virtual plist_t     plist_dict_get_item   (plist_t node,            const char* key                   )=0;
   virtual void        plist_free            (plist_t plist                                              )=0;
-#ifdef TARGET_WINDOWS
-  virtual void        plist_free_string_val (char *val                                                  )=0;
-#endif
   virtual void        plist_to_xml          (plist_t plist,           char **plist_xml, uint32_t * length)=0;
   virtual void        plist_dict_new_iter   (plist_t node,            plist_dict_iter *iter             )=0;
   virtual void        plist_dict_next_item  (plist_t node,            plist_dict_iter iter, char **key, plist_t *val) = 0;
@@ -58,9 +55,6 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
   DEFINE_METHOD3(void,          plist_from_bin,       (const char *p1,  uint32_t p2, plist_t *p3))
   DEFINE_METHOD3(void,          plist_to_xml,         (plist_t p1,      char **p2, uint32_t *p3));
   DEFINE_METHOD4(void,          plist_dict_next_item, (plist_t p1, plist_dict_iter p2, char **p3, plist_t *p4))
-#ifdef TARGET_WINDOWS
-  DEFINE_METHOD1(void,          plist_free_string_val, (char *p1))
-#endif
 
 
   BEGIN_METHOD_RESOLVE()
@@ -74,9 +68,6 @@ class DllLibPlist : public DllDynamic, DllLibPlistInterface
     RESOLVE_METHOD_RENAME(plist_dict_new_iter,    plist_dict_new_iter)
     RESOLVE_METHOD_RENAME(plist_dict_next_item,   plist_dict_next_item)
     RESOLVE_METHOD_RENAME(plist_to_xml,           plist_to_xml)
-#ifdef TARGET_WINDOWS
-    RESOLVE_METHOD_RENAME(plist_free_string_val,  plist_free_string_val)
-#endif
 
   END_METHOD_RESOLVE()
 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Remove the use of an old compatibility method required because of the use of different crt versions
## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed