### PR TITLE
[linux] Remove deprecated OnlyShowIn from desktop file

### DIFF
--- a/tools/Linux/kodi.desktop
+++ b/tools/Linux/kodi.desktop
@@ -14,9 +14,7 @@ Actions=Fullscreen;Standalone;
 [Desktop Action Fullscreen]
 Name=Open in fullscreen
 Exec=kodi -fs
-OnlyShowIn=Unity;
 
 [Desktop Action Standalone]
 Name=Open in standalone mode
 Exec=kodi --standalone
-OnlyShowIn=Unity;


### PR DESCRIPTION
## Description
Remove OnlyShowIn entries from kodi.desktop

## Motivation and Context
OnlyShowIn is deprecated by xdg
https://cgit.freedesktop.org/xdg/desktop-file-utils/commit/?id=9075a05a384998ab96ad707b412a54fa5a8ddf48

and for me GNOME 3.22 just ignores it and offers the actions anyway.

## How Has This Been Tested?
Updated file installed and desktop icon still shown with actions.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

