### PR TITLE
[addon] remove not needed 'GetInfo(...)' call for ScreenSaver

### DIFF
--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -92,12 +92,6 @@ void CScreenSaver::Render()
   if (Initialized()) m_pStruct->Render();
 }
 
-void CScreenSaver::GetInfo(SCR_INFO *info)
-{
-  // get info from screensaver
-  if (Initialized()) m_pStruct->GetInfo(info);
-}
-
 void CScreenSaver::Destroy()
 {
 #ifdef HAS_PYTHON

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -39,7 +39,6 @@ public:
   bool CreateScreenSaver();
   void Start();
   void Render();
-  void GetInfo(SCR_INFO *info);
   void Destroy();
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
@@ -29,14 +29,12 @@ extern "C"
   // Functions that your visualisation must implement
   void Start();
   void Render();
-  void GetInfo(SCR_INFO* pInfo);
 
   // function to export the above structure to XBMC
   void __declspec(dllexport) get_addon(struct ScreenSaver* pScr)
   {
     pScr->Start = Start;
     pScr->Render = Render;
-    pScr->GetInfo = GetInfo;
   };
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
@@ -22,11 +22,6 @@
 
 extern "C"
 {
-  struct SCR_INFO
-  {
-    int dummy;
-  };
-
   struct SCR_PROPS
   {
     void *device;
@@ -44,7 +39,6 @@ extern "C"
   {
     void (__cdecl* Start) ();
     void (__cdecl* Render) ();
-    void (__cdecl* GetInfo)(SCR_INFO *info);
   };
 }
 


### PR DESCRIPTION
Remove not needed 'GetInfo(...)' call for ScreenSaver

## Description
The Getinfo was never used from any add-on also was never something added in Kodi to handle them.
Was on begin added from me to have equal functions with PVR and have them predefined if needed.

For me makes it no more sense to have a never used function present.

## Motivation and Context
Cleanup the binary add-on's

## How Has This Been Tested?
Build of kodi and test with add-on's

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
