### PR TITLE
[addons] change binary add-on version check way

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -5043,6 +5043,7 @@
 		EDE8C7231C7F618500A86ECC /* xbmc_scr_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xbmc_scr_types.h; path = "kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h"; sourceTree = "<group>"; };
 		EDE8C7251C7F618500A86ECC /* xbmc_vis_dll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xbmc_vis_dll.h; path = "kodi-addon-dev-kit/include/kodi/xbmc_vis_dll.h"; sourceTree = "<group>"; };
 		EDE8C7261C7F618500A86ECC /* xbmc_vis_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = xbmc_vis_types.h; path = "kodi-addon-dev-kit/include/kodi/xbmc_vis_types.h"; sourceTree = "<group>"; };
+		EDE8C7271C7F618500A86ECC /* versions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = versions.h; path = "kodi-addon-dev-kit/include/kodi/versions.h"; sourceTree = "<group>"; };
 		EDED2E861C878DE8000F5E80 /* AddonCallbacksPVR.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AddonCallbacksPVR.cpp; path = addons/interfaces/PVR/AddonCallbacksPVR.cpp; sourceTree = "<group>"; };
 		EDED2E871C878DE8000F5E80 /* AddonCallbacksPVR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AddonCallbacksPVR.h; path = addons/interfaces/PVR/AddonCallbacksPVR.h; sourceTree = "<group>"; };
 		EDED2E891C878E62000F5E80 /* AddonCallbacksGUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AddonCallbacksGUI.cpp; path = addons/interfaces/GUI/AddonCallbacksGUI.cpp; sourceTree = "<group>"; };
@@ -9576,6 +9577,7 @@
 				EDE8C7231C7F618500A86ECC /* xbmc_scr_types.h */,
 				EDE8C7251C7F618500A86ECC /* xbmc_vis_dll.h */,
 				EDE8C7261C7F618500A86ECC /* xbmc_vis_types.h */,
+				EDE8C7271C7F618500A86ECC /* versions.h */,
 			);
 			name = kodi;
 			sourceTree = "<group>";

--- a/addons/audioencoder.xbmc.builtin.aac/addon.xml
+++ b/addons/audioencoder.xbmc.builtin.aac/addon.xml
@@ -5,7 +5,7 @@
   name="AAC encoder"
   provider-name="spiff">
   <requires>
-    <import addon="xbmc.audioencoder" version="1.0.0"/>
+    <import addon="xbmc.audioencoder" version="1.1.0"/>
   </requires>
   <extension
     point="xbmc.audioencoder"

--- a/addons/audioencoder.xbmc.builtin.wma/addon.xml
+++ b/addons/audioencoder.xbmc.builtin.wma/addon.xml
@@ -5,7 +5,7 @@
   name="WMA encoder"
   provider-name="spiff">
   <requires>
-    <import addon="xbmc.audioencoder" version="1.0.0"/>
+    <import addon="xbmc.audioencoder" version="1.1.0"/>
   </requires>
   <extension
     point="xbmc.audioencoder"

--- a/addons/kodi.adsp/addon.xml
+++ b/addons/kodi.adsp/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.adsp" version="0.1.8" provider-name="Team KODI">
-  <backwards-compatibility abi="0.1.8"/>
+<addon id="kodi.adsp" version="0.2.0" provider-name="Team KODI">
+  <backwards-compatibility abi="0.2.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/kodi.audiodecoder/addon.xml
+++ b/addons/kodi.audiodecoder/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.audiodecoder" version="1.0.0" provider-name="Team Kodi">
-  <backwards-compatibility abi="1.0.0"/>
+<addon id="kodi.audiodecoder" version="1.1.0" provider-name="Team Kodi">
+  <backwards-compatibility abi="1.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/kodi.game/addon.xml
+++ b/addons/kodi.game/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.game" version="1.0.28" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.28"/>
+<addon id="kodi.game" version="1.1.0" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.1.0"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/kodi.guilib/addon.xml
+++ b/addons/kodi.guilib/addon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon id="kodi.guilib" version="5.11.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="5.11.0"/>
+  <requires>
+    <import addon="xbmc.core" version="0.1.0"/>
+  </requires>
+</addon>

--- a/addons/kodi.guilib/addon.xml.in
+++ b/addons/kodi.guilib/addon.xml.in
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.guilib" version="@guilib_version@" provider-name="Team-Kodi">
-  <backwards-compatibility abi="@guilib_version_min@"/>
-  <requires>
-    <import addon="xbmc.core" version="0.1.0"/>
-  </requires>
-</addon>

--- a/addons/kodi.inputstream/addon.xml
+++ b/addons/kodi.inputstream/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.inputstream" version="1.0.6" provider-name="Team Kodi">
-  <backwards-compatibility abi="1.0.6"/>
+<addon id="kodi.inputstream" version="1.1.0" provider-name="Team Kodi">
+  <backwards-compatibility abi="1.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.2.1" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.2.0"/>
+<addon id="kodi.peripheral" version="1.3.0" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.3.0"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14738,7 +14738,11 @@ msgctxt "#24083"
 msgid "Information libraries"
 msgstr ""
 
-#empty string with id 24084
+#. The label in the add-ons dll class to report about outdated add-on api version
+#: xbmc/addons/AddonDll.cpp
+msgctxt "#24084"
+msgid "Using incompatible API version for instance type '%s'.\nKodi API version = '%s', add-on API version '%s'\n\nPlease check for updates or contact developer of add-on."
+msgstr ""
 
 #. Used as a text in the progress dialog when installing an add-on
 #: xbmc/addons/AddonInstaller.cpp

--- a/addons/xbmc.audioencoder/addon.xml
+++ b/addons/xbmc.audioencoder/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.audioencoder" version="1.0.0" provider-name="Team Kodi">
-  <backwards-compatibility abi="1.0.0"/>
+<addon id="xbmc.audioencoder" version="1.1.0" provider-name="Team Kodi">
+  <backwards-compatibility abi="1.1.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="5.2.1" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.2.1"/>
+<addon id="xbmc.pvr" version="5.3.0" provider-name="Team-Kodi">
+  <backwards-compatibility abi="5.3.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -234,7 +234,6 @@ endif()
 # Compile Info
 add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                           ${CMAKE_BINARY_DIR}/addons/xbmc.addon/addon.xml
-                          ${CMAKE_BINARY_DIR}/addons/kodi.guilib/addon.xml
                    COMMAND ${CMAKE_COMMAND} -DCORE_SOURCE_DIR=${CORE_SOURCE_DIR}
                                             -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
                                             -DCORE_BUILD_DIR=${CORE_BUILD_DIR}
@@ -245,11 +244,9 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                                             -P ${PROJECT_SOURCE_DIR}/scripts/common/GenerateVersionedFiles.cmake
                   DEPENDS ${CORE_SOURCE_DIR}/version.txt
                           ${CORE_SOURCE_DIR}/addons/xbmc.addon/addon.xml.in
-                          ${CORE_SOURCE_DIR}/addons/kodi.guilib/addon.xml.in
                           ${CORE_SOURCE_DIR}/xbmc/CompileInfo.cpp.in)
 list(APPEND install_data addons/xbmc.addon/addon.xml)
 list(APPEND install_data addons/xbmc.json/addon.xml)
-list(APPEND install_data addons/kodi.guilib/addon.xml)
 add_library(compileinfo OBJECT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)
 set_target_properties(compileinfo PROPERTIES FOLDER "Build Utilities")
 target_compile_options(compileinfo PRIVATE "${SYSTEM_DEFINES}")

--- a/project/cmake/installdata/common/addons.txt
+++ b/project/cmake/installdata/common/addons.txt
@@ -5,6 +5,7 @@ addons/game.controller.default/*
 addons/kodi.adsp/*
 addons/kodi.audiodecoder/*
 addons/kodi.game/*
+addons/kodi.guilib/*
 addons/kodi.inputstream/*
 addons/kodi.peripheral/*
 addons/kodi.resource/*

--- a/project/cmake/scripts/common/GenerateVersionedFiles.cmake
+++ b/project/cmake/scripts/common/GenerateVersionedFiles.cmake
@@ -2,7 +2,6 @@ include(${CORE_SOURCE_DIR}/project/cmake/scripts/common/Macros.cmake)
 
 core_find_versions()
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/addons/xbmc.addon)
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/addons/kodi.guilib)
 
 # configure_file without dependency tracking
 # configure_file would register additional file dependencies that interfere
@@ -14,5 +13,4 @@ function(generate_versioned_file _SRC _DEST)
 endfunction()
 
 generate_versioned_file(addons/xbmc.addon/addon.xml.in addons/xbmc.addon/addon.xml)
-generate_versioned_file(addons/kodi.guilib/addon.xml.in addons/kodi.guilib/addon.xml)
 generate_versioned_file(xbmc/CompileInfo.cpp.in ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)

--- a/project/cmake/scripts/common/Macros.cmake
+++ b/project/cmake/scripts/common/Macros.cmake
@@ -566,7 +566,7 @@ function(core_find_git_rev stamp)
   endif()
 endfunction()
 
-# Parses version.txt and libKODI_guilib.h and sets variables
+# Parses version.txt and sets variables
 # used to construct dirs structure, file naming, API version, etc.
 #
 # The following variables are set from version.txt:
@@ -581,10 +581,6 @@ endfunction()
 #   APP_VERSION - the app version (${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}-${APP_VERSION_TAG})
 #   APP_ADDON_API - the addon API version in the form of 16.9.702
 #   FILE_VERSION - file version in the form of 16,9,702,0 - Windows only
-#
-# The following variables are set from libKODI_guilib.h:
-#   guilib_version - current ADDONGUI API version
-#   guilib_version_min - minimal ADDONGUI API version
 macro(core_find_versions)
   include(CMakeParseArguments)
   core_file_read_filtered(version_list ${CORE_SOURCE_DIR}/version.txt)
@@ -601,10 +597,6 @@ macro(core_find_versions)
     string(TOLOWER ${APP_VERSION_TAG} APP_VERSION_TAG_LC)
   endif()
   string(REPLACE "." "," FILE_VERSION ${APP_ADDON_API}.0)
-  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h guilib_version REGEX "^.*INSTANCE_VERSION_GUI (.*)$")
-  string(REGEX REPLACE ".*\"(.*)\"" "\\1" guilib_version ${guilib_version})
-  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h guilib_version_min REGEX "^.*INSTANCE_MIN_VERSION_GUI (.*)$")
-  string(REGEX REPLACE ".*\"(.*)\"" "\\1" guilib_version_min ${guilib_version_min})
   # unset variables not used anywhere else
   unset(version_list)
   unset(APP_APP_NAME)
@@ -612,11 +604,6 @@ macro(core_find_versions)
   # bail if we can't parse version.txt
   if(NOT DEFINED APP_VERSION_MAJOR OR NOT DEFINED APP_VERSION_MINOR)
     message(FATAL_ERROR "Could not determine app version! Make sure that ${CORE_SOURCE_DIR}/version.txt exists")
-  endif()
-
-  # bail if we can't parse versions.h
-  if(NOT DEFINED guilib_version OR NOT DEFINED guilib_version_min)
-    message(FATAL_ERROR "Could not determine add-on API version! Make sure that ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h exists")
   endif()
 endmacro()
 

--- a/project/cmake/scripts/common/Macros.cmake
+++ b/project/cmake/scripts/common/Macros.cmake
@@ -601,9 +601,9 @@ macro(core_find_versions)
     string(TOLOWER ${APP_VERSION_TAG} APP_VERSION_TAG_LC)
   endif()
   string(REPLACE "." "," FILE_VERSION ${APP_ADDON_API}.0)
-  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h guilib_version REGEX "^.*GUILIB_API_VERSION (.*)$")
+  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h guilib_version REGEX "^.*INSTANCE_VERSION_GUI (.*)$")
   string(REGEX REPLACE ".*\"(.*)\"" "\\1" guilib_version ${guilib_version})
-  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h guilib_version_min REGEX "^.*GUILIB_MIN_API_VERSION (.*)$")
+  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h guilib_version_min REGEX "^.*INSTANCE_MIN_VERSION_GUI (.*)$")
   string(REGEX REPLACE ".*\"(.*)\"" "\\1" guilib_version_min ${guilib_version_min})
   # unset variables not used anywhere else
   unset(version_list)
@@ -614,9 +614,9 @@ macro(core_find_versions)
     message(FATAL_ERROR "Could not determine app version! Make sure that ${CORE_SOURCE_DIR}/version.txt exists")
   endif()
 
-  # bail if we can't parse libKODI_guilib.h
+  # bail if we can't parse versions.h
   if(NOT DEFINED guilib_version OR NOT DEFINED guilib_version_min)
-    message(FATAL_ERROR "Could not determine add-on API version! Make sure that ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h exists")
+    message(FATAL_ERROR "Could not determine add-on API version! Make sure that ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h exists")
   endif()
 endmacro()
 

--- a/project/cmake/scripts/common/PrepareEnv.cmake
+++ b/project/cmake/scripts/common/PrepareEnv.cmake
@@ -1,4 +1,4 @@
-# parse version.txt and libKODI_guilib.h to get the version and API info
+# parse version.txt and versions.h to get the version and API info
 include(${CORE_SOURCE_DIR}/project/cmake/scripts/common/Macros.cmake)
 core_find_versions()
 

--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -159,6 +159,7 @@ install(FILES ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kod
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_types.h
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_codec_types.h
+              ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
               ${CORE_SOURCE_DIR}/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
               ${CORE_SOURCE_DIR}/xbmc/filesystem/IFileTypes.h
               ${CORE_SOURCE_DIR}/xbmc/input/XBMC_vkeys.h

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -169,7 +169,7 @@ bool CAddonDll::LoadDll()
   return true;
 }
 
-ADDON_STATUS CAddonDll::Create(void* funcTable, void* info)
+ADDON_STATUS CAddonDll::Create(int instanceType, void* funcTable, void* info)
 {
   /* ensure that a previous instance is destroyed */
   Destroy();
@@ -183,11 +183,20 @@ ADDON_STATUS CAddonDll::Create(void* funcTable, void* info)
   if (!LoadDll())
     return ADDON_STATUS_PERMANENT_FAILURE;
 
+  /* Check version of requested instance type */
+  if (!CheckAPIVersion(instanceType))
+    return ADDON_STATUS_PERMANENT_FAILURE;
+
+  /* Check versions about global parts on add-on (parts used on all types) */
+  for (unsigned int id = ADDON_INSTANCE_MAIN; id <= ADDON_INSTANCE_GLOBAL_MAX; ++id)
+  {
+    if (!CheckAPIVersion(id))
+      return ADDON_STATUS_PERMANENT_FAILURE;
+  }
+  
   /* Load add-on function table (written by add-on itself) */
   m_pDll->GetAddon(funcTable);
 
-  if (!CheckAPIVersion())
-    return ADDON_STATUS_PERMANENT_FAILURE;
 
   /* Allocate the helper function class to allow crosstalk over
      helper libraries */
@@ -274,6 +283,32 @@ void CAddonDll::Destroy()
     CLog::Log(LOGINFO, "ADDON: Dll Destroyed - %s", Name().c_str());
   }
   m_initialized = false;
+}
+
+bool CAddonDll::CheckAPIVersion(int instanceType)
+{
+  /* check the API version */
+  const char* kodiVersion = kodi::addon::GetInstanceVersion(instanceType);
+  const char* addonVersion = m_pDll->GetAddonInstanceVersion(instanceType);
+
+  if (AddonVersion(addonVersion) != AddonVersion(kodiVersion))
+  {
+    CLog::Log(LOGERROR, "Add-on '%s' is using an incompatible API version for instance type '%s'. Kodi API version = '%s', add-on API version '%s'",
+                            Name().c_str(),
+                            kodi::addon::GetInstanceName(instanceType),
+                            kodiVersion,
+                            addonVersion);
+
+    std::string heading = StringUtils::Format("%s: %s", TranslateType(Type(), true).c_str(), Name().c_str());
+    std::string text = StringUtils::Format(g_localizeStrings.Get(24084).c_str(),
+                                           kodi::addon::GetInstanceName(instanceType),
+                                           kodiVersion,
+                                           addonVersion);
+    CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{text});
+    return false;
+  }
+
+  return true;
 }
 
 bool CAddonDll::DllLoaded(void) const

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -181,7 +181,10 @@ ADDON_STATUS CAddonDll::Create(int instanceType, void* funcTable, void* info)
   m_initialized = false;
 
   if (!LoadDll())
+  {
+    CGUIDialogOK::ShowAndGetInput(CVariant{24070}, CVariant{16029});
     return ADDON_STATUS_PERMANENT_FAILURE;
+  }
 
   /* Check version of requested instance type */
   if (!CheckAPIVersion(instanceType))

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -23,6 +23,7 @@
 #include "DllAddon.h"
 #include "AddonManager.h"
 #include "addons/interfaces/AddonInterfaces.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/versions.h"
 #include "utils/XMLUtils.h"
 
 namespace ADDON
@@ -41,9 +42,8 @@ namespace ADDON
     virtual void SaveSettings();
     virtual std::string GetSetting(const std::string& key);
 
-    ADDON_STATUS Create(void* funcTable, void* info);
+    ADDON_STATUS Create(int instanceType, void* funcTable, void* info);
     virtual void Stop();
-    virtual bool CheckAPIVersion(void) { return true; }
     void Destroy();
 
     bool DllLoaded(void) const;
@@ -64,6 +64,7 @@ namespace ADDON
 
     virtual ADDON_STATUS TransferSettings();
     TiXmlElement MakeSetting(DllSetting& setting) const;
+    bool CheckAPIVersion(int instanceType);
 
     static void AddOnStatusCallback(void *userData, const ADDON_STATUS status, const char* msg);
     static bool AddOnGetSetting(void *userData, const char *settingName, void *settingValue);

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -53,7 +53,7 @@ CAudioDecoder::~CAudioDecoder()
 
 bool CAudioDecoder::Create()
 {
-  return CAddonDll::Create(&m_struct, &m_info) == ADDON_STATUS_OK;
+  return CAddonDll::Create(ADDON_INSTANCE_AUDIODECODER, &m_struct, &m_info) == ADDON_STATUS_OK;
 }
 
 bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)

--- a/xbmc/addons/AudioEncoder.cpp
+++ b/xbmc/addons/AudioEncoder.cpp
@@ -34,7 +34,7 @@ CAudioEncoder::CAudioEncoder(AddonProps props, std::string _extension)
 
 bool CAudioEncoder::Create()
 {
-  return CAddonDll::Create(&m_struct, &m_info) == ADDON_STATUS_OK;
+  return CAddonDll::Create(ADDON_INSTANCE_AUDIOENCODER, &m_struct, &m_info) == ADDON_STATUS_OK;
 }
 
 bool CAudioEncoder::Init(audioenc_callbacks &callbacks)

--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -21,6 +21,7 @@
 
 #include "DynamicDll.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_cpp_dll.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/versions.h"
 
 class DllAddonInterface
 {
@@ -35,6 +36,7 @@ public:
   virtual unsigned int GetSettings(ADDON_StructSetting*** sSet)=0;
   virtual void FreeSettings()=0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
+  virtual const char* GetAddonInstanceVersion(int instanceType)=0;
 };
 
 class DllAddon : public DllDynamic, public DllAddonInterface
@@ -50,6 +52,7 @@ public:
   DEFINE_METHOD0(void, FreeSettings)
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (void* p1))
+  DEFINE_METHOD1(const char*, GetAddonInstanceVersion, (int p1))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
@@ -60,6 +63,7 @@ public:
     RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetSettings, GetSettings)
     RESOLVE_METHOD_RENAME(ADDON_FreeSettings, FreeSettings)
+    RESOLVE_METHOD_RENAME(ADDON_GetInstanceVersion, GetAddonInstanceVersion)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -75,7 +75,7 @@ CInputStream::CInputStream(const AddonProps& props,
 
 bool CInputStream::Create()
 {
-  return CAddonDll::Create(&m_struct, &m_info) == ADDON_STATUS_OK;
+  return CAddonDll::Create(ADDON_INSTANCE_INPUTSTREAM, &m_struct, &m_info) == ADDON_STATUS_OK;
 }
 
 void CInputStream::SaveSettings()
@@ -102,7 +102,7 @@ void CInputStream::CheckConfig()
 void CInputStream::UpdateConfig()
 {
   std::string pathList;
-  ADDON_STATUS status = CAddonDll::Create(&m_struct, &m_info);
+  ADDON_STATUS status = CAddonDll::Create(ADDON_INSTANCE_INPUTSTREAM, &m_struct, &m_info);
 
   if (status != ADDON_STATUS_PERMANENT_FAILURE)
   {

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -78,18 +78,6 @@ bool CInputStream::Create()
   return CAddonDll::Create(&m_struct, &m_info) == ADDON_STATUS_OK;
 }
 
-bool CInputStream::CheckAPIVersion()
-{
-  std::string dllVersion = m_struct.GetApiVersion();
-  if (dllVersion.compare(INPUTSTREAM_API_VERSION) != 0)
-  {
-    CLog::Log(LOGERROR, "CInputStream::CheckAPIVersion - API version does not match");
-    return false;
-  }
-
-  return true;
-}
-
 void CInputStream::SaveSettings()
 {
   CAddon::SaveSettings();

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -47,7 +47,6 @@ namespace ADDON
     virtual ~CInputStream() {}
 
     virtual void SaveSettings() override;
-    virtual bool CheckAPIVersion(void) override;
 
     bool Create();
 

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -166,7 +166,7 @@ ADDON_STATUS CPVRClient::Create(int iClientId)
   /* initialise the add-on */
   bool bReadyToUse(false);
   CLog::Log(LOGDEBUG, "PVR - %s - creating PVR add-on instance '%s'", __FUNCTION__, Name().c_str());
-  if ((status = CAddonDll::Create(&m_struct, &m_info)) == ADDON_STATUS_OK)
+  if ((status = CAddonDll::Create(ADDON_INSTANCE_PVR, &m_struct, &m_info)) == ADDON_STATUS_OK)
     bReadyToUse = GetAddonProperties();
 
   m_bReadyToUse = bReadyToUse;

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -355,47 +355,6 @@ void CPVRClient::WriteClientChannelInfo(const CPVRChannelPtr &xbmcChannel, PVR_C
   strncpy(addonChannel.strStreamURL, xbmcChannel->StreamURL().c_str(), sizeof(addonChannel.strStreamURL) - 1);
 }
 
-bool CPVRClient::IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version)
-{
-  AddonVersion myMinVersion = AddonVersion(XBMC_PVR_MIN_API_VERSION);
-  AddonVersion myVersion = AddonVersion(XBMC_PVR_API_VERSION);
-  return (version >= myMinVersion && minVersion <= myVersion);
-}
-
-bool CPVRClient::IsCompatibleGUIAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version)
-{
-  AddonVersion myMinVersion = AddonVersion(KODI_GUILIB_MIN_API_VERSION);
-  AddonVersion myVersion = AddonVersion(KODI_GUILIB_API_VERSION);
-  return (version >= myMinVersion && minVersion <= myVersion);
-}
-
-bool CPVRClient::CheckAPIVersion(void)
-{
-  /* check the API version */
-  AddonVersion minVersion = AddonVersion(XBMC_PVR_MIN_API_VERSION);
-  m_apiVersion = AddonVersion(m_struct.GetPVRAPIVersion());
-
-  if (!IsCompatibleAPIVersion(minVersion, m_apiVersion))
-  {
-    CLog::Log(LOGERROR, "PVR - Add-on '%s' is using an incompatible API version. XBMC minimum API version = '%s', add-on API version '%s'", Name().c_str(), minVersion.asString().c_str(), m_apiVersion.asString().c_str());
-    return false;
-  }
-
-  /* check the GUI API version */
-  AddonVersion guiVersion = AddonVersion("0.0.0");
-  minVersion = AddonVersion(KODI_GUILIB_MIN_API_VERSION);
-  guiVersion = AddonVersion(m_struct.GetGUIAPIVersion());
-
-  /* Only do the check, if add-on depends on GUI API. */
-  if (!guiVersion.empty() && !IsCompatibleGUIAPIVersion(minVersion, guiVersion))
-  {
-    CLog::Log(LOGERROR, "PVR - Add-on '%s' is using an incompatible GUI API version. XBMC minimum GUI API version = '%s', add-on GUI API version '%s'", Name().c_str(), minVersion.asString().c_str(), guiVersion.asString().c_str());
-    return false;
-  }
-
-  return true;
-}
-
 bool CPVRClient::GetAddonProperties(void)
 {
   std::string strBackendName, strConnectionString, strFriendlyName, strBackendVersion, strBackendHostname;

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -646,28 +646,6 @@ namespace PVR
 
   private:
     /*!
-     * @brief Checks whether the provided API version is compatible with XBMC
-     * @param minVersion The add-on's XBMC_PVR_MIN_API_VERSION version
-     * @param version The add-on's XBMC_PVR_API_VERSION version
-     * @return True when compatible, false otherwise
-     */
-    static bool IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version);
-
-    /*!
-     * @brief Checks whether the provided GUI API version is compatible with XBMC
-     * @param minVersion The add-on's XBMC_GUI_MIN_API_VERSION version
-     * @param version The add-on's XBMC_GUI_API_VERSION version
-     * @return True when compatible, false otherwise
-     */
-    static bool IsCompatibleGUIAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version);
-
-    /*!
-     * @brief Request the API version from the add-on, and check if it's compatible
-     * @return True when compatible, false otherwise.
-     */
-    bool CheckAPIVersion(void) override;
-
-    /*!
      * @brief Resets all class members to their defaults. Called by the constructors.
      */
     void ResetProperties(int iClientId = PVR_INVALID_CLIENT_ID);

--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -76,7 +76,7 @@ bool CScreenSaver::CreateScreenSaver()
   m_info.presets    = strdup(CSpecialProtocol::TranslatePath(Path()).c_str());
   m_info.profile    = strdup(CSpecialProtocol::TranslatePath(Profile()).c_str());
 
-  if (CAddonDll::Create(&m_struct, &m_info) == ADDON_STATUS_OK)
+  if (CAddonDll::Create(ADDON_INSTANCE_SCREENSAVER, &m_struct, &m_info) == ADDON_STATUS_OK)
     return true;
 
   return false;

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -86,7 +86,7 @@ bool CVisualisation::Create(int x, int y, int w, int h, void *device)
   m_info.profile = strdup(CSpecialProtocol::TranslatePath(Profile()).c_str());
   m_info.submodule = NULL;
 
-  if (CAddonDll::Create(&m_struct, &m_info) == ADDON_STATUS_OK)
+  if (CAddonDll::Create(ADDON_INSTANCE_VISUALIZATION, &m_struct, &m_info) == ADDON_STATUS_OK)
   {
     // Start the visualisation
     std::string strFile = URIUtils::GetFileName(g_application.CurrentFile());

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -37,6 +37,7 @@ BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_inputstream.h
 BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_peripheral.h
 BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h
 BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_codec.h
+BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
 BINDINGS+=xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
 BINDINGS+=xbmc/cores/AudioEngine/Utils/AEChannelData.h
 BINDINGS+=xbmc/filesystem/IFileTypes.h

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
@@ -97,39 +97,6 @@ extern "C"
   /*! @name Audio DSP add-on methods */
   //@{
   /*!
-   * Get the KODI_AE_DSP_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with KODI.
-   * @return The KODI_AE_DSP_API_VERSION that was used to compile this add-on.
-   * @remarks Valid implementation required.
-   */
-  const char* GetAudioDSPAPIVersion(void);
-
-  /*!
-   * Get the KODI_AE_DSP_MIN_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with KODI.
-   * @return The KODI_AE_DSP_MIN_API_VERSION that was used to compile this add-on.
-   * @remarks Valid implementation required.
-   */
-  const char* GetMinimumAudioDSPAPIVersion(void);
-
-  /*!
-   * @brief Get the KODI_GUI_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with KODI.
-   * @return The KODI_GUI_API_VERSION that was used to compile this add-on.
-   * @remarks Valid implementation required.
-   */
-  const char* GetGUIAPIVersion(void);
-
-  /*!
-   * @brief Get the KODI_GUI_MIN_API_VERSION that was used to compile this
-   * add-on.
-   * Used to check if this add-on is compatible with KODI.
-   * @return The KODI_GUI_MIN_API_VERSION that was used to compile this add-on.
-   * @remarks Valid implementation required.
-   */
-  const char* GetMinimumGUIAPIVersion(void);
-
-  /*!
    * @brief Get the list of features that this add-on provides.
    * Called by KODI to query the add-ons capabilities.
    * Used to check which options should be presented in the DSP, which methods
@@ -521,10 +488,6 @@ extern "C"
   {
     KodiToAddonFuncTable_AudioDSP* pDSP = static_cast<KodiToAddonFuncTable_AudioDSP*>(ptr);
 
-    pDSP->GetAudioDSPAPIVersion                 = GetAudioDSPAPIVersion;
-    pDSP->GetMinimumAudioDSPAPIVersion          = GetMinimumAudioDSPAPIVersion;
-    pDSP->GetGUIAPIVersion                      = GetGUIAPIVersion;
-    pDSP->GetMinimumGUIAPIVersion               = GetMinimumGUIAPIVersion;
     pDSP->GetAddonCapabilities                  = GetAddonCapabilities;
     pDSP->GetDSPName                            = GetDSPName;
     pDSP->GetDSPVersion                         = GetDSPVersion;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
@@ -61,12 +61,6 @@
 #define AE_DSP_STREAM_MAX_STREAMS               8
 #define AE_DSP_STREAM_MAX_MODES                 32
 
-/* current Audio DSP API version */
-#define KODI_AE_DSP_API_VERSION                 "0.1.8"
-
-/* min. Audio DSP API version */
-#define KODI_AE_DSP_MIN_API_VERSION             "0.1.8"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -476,10 +470,6 @@ extern "C" {
    */
   typedef struct KodiToAddonFuncTable_AudioDSP
   {
-    const char*  (__cdecl* GetAudioDSPAPIVersion)                (void);
-    const char*  (__cdecl* GetMinimumAudioDSPAPIVersion)         (void);
-    const char*  (__cdecl* GetGUIAPIVersion)                     (void);
-    const char*  (__cdecl* GetMinimumGUIAPIVersion)              (void);
     AE_DSP_ERROR (__cdecl* GetAddonCapabilities)                 (AE_DSP_ADDON_CAPABILITIES*);
     const char*  (__cdecl* GetDSPName)                           (void);
     const char*  (__cdecl* GetDSPVersion)                        (void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -26,28 +26,6 @@
 extern "C" {
 #endif
 
-// --- Game API operations -----------------------------------------------------
-
-/*!
- * \brief Return GAME_API_VERSION_STRING
- *
- * The add-on is backwards compatible with the frontend if this API version is
- * is at least the frontend's minimum API version.
- *
- * \return Must be GAME_API_VERSION_STRING
- */
-const char* GetGameAPIVersion(void);
-
-/*!
- * \brief Return GAME_MIN_API_VERSION_STRING
- *
- * The add-on is forwards compatible with the frontend if this minimum version
- * is no more than the frontend's API version.
- *
- * \return Must be GAME_MIN_API_VERSION_STRING
- */
-const char* GetMininumGameAPIVersion(void);
-
 // --- Game operations ---------------------------------------------------------
 
 /*!
@@ -258,8 +236,6 @@ void __declspec(dllexport) get_addon(void* ptr)
 {
   KodiToAddonFuncTable_Game* pClient = static_cast<KodiToAddonFuncTable_Game*>(ptr);
 
-  pClient->GetGameAPIVersion        = GetGameAPIVersion;
-  pClient->GetMininumGameAPIVersion = GetMininumGameAPIVersion;
   pClient->LoadGame                 = LoadGame;
   pClient->LoadGameSpecial          = LoadGameSpecial;
   pClient->LoadStandalone           = LoadStandalone;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -20,12 +20,6 @@
 #ifndef KODI_GAME_TYPES_H_
 #define KODI_GAME_TYPES_H_
 
-/* current game API version */
-#define GAME_API_VERSION                "1.0.28"
-
-/* min. game API version */
-#define GAME_MIN_API_VERSION            "1.0.28"
-
 #include <stddef.h>
 #include <stdint.h>
 
@@ -456,8 +450,6 @@ typedef struct game_client_properties
 /*! Structure to transfer the methods from kodi_game_dll.h to Kodi */
 typedef struct KodiToAddonFuncTable_Game
 {
-  const char* (__cdecl* GetGameAPIVersion)(void);
-  const char* (__cdecl* GetMininumGameAPIVersion)(void);
   GAME_ERROR  (__cdecl* LoadGame)(const char*);
   GAME_ERROR  (__cdecl* LoadGameSpecial)(SPECIAL_GAME_TYPE, const char**, size_t);
   GAME_ERROR  (__cdecl* LoadStandalone)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
@@ -214,12 +214,6 @@ extern "C"
   */
   bool IsRealTimeStream();
 
-  const char* GetApiVersion()
-  {
-    static const char *ApiVersion = INPUTSTREAM_API_VERSION;
-    return ApiVersion;
-  }
-
   /*!
   * Called by XBMC to assign the function pointers of this add-on to pClient.
   * @param pClient The struct to assign the function pointers to.
@@ -232,7 +226,6 @@ extern "C"
     pClient->Close = Close;
     pClient->GetPathList = GetPathList;
     pClient->GetCapabilities = GetCapabilities;
-    pClient->GetApiVersion = GetApiVersion;
 
     pClient->GetStreamIds = GetStreamIds;
     pClient->GetStream = GetStream;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -37,9 +37,6 @@
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h"
 #endif
 
-/* current API version */
-#define INPUTSTREAM_API_VERSION "1.0.6"
-
 extern "C" {
 
   // this are properties given to the addon on create
@@ -137,7 +134,6 @@ extern "C" {
     void (__cdecl* Close)(void);
     const char* (__cdecl* GetPathList)(void);
     struct INPUTSTREAM_CAPABILITIES (__cdecl* GetCapabilities)(void);
-    const char* (__cdecl* GetApiVersion)(void);
 
     // IDemux
     struct INPUTSTREAM_IDS (__cdecl* GetStreamIds)();

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
@@ -32,24 +32,6 @@ extern "C"
   /// @name Peripheral operations
   ///{
   /*!
-   * @brief  Get the PERIPHERAL_API_VERSION used to compile this peripheral add-on
-   * @return KODI_PERIPHERAL_API_VERSION from kodi_peripheral_types.h
-   * @remarks Valid implementation required
-   *
-   * Used to check if the implementation is compatible with the frontend.
-   */
-  const char* GetPeripheralAPIVersion(void);
-
-  /*!
-   * @brief Get the KODI_PERIPHERAL_MIN_API_VERSION used to compile this peripheral add-on
-   * @return KODI_PERIPHERAL_MIN_API_VERSION from kodi_peripheral_types.h
-   * @remarks Valid implementation required
-   *
-   * Used to check if the implementation is compatible with the frontend.
-   */
-  const char* GetMinimumPeripheralAPIVersion(void);
-
-  /*!
    * @brief Get the list of features that this add-on provides
    * @param pCapabilities The add-on's capabilities.
    * @return PERIPHERAL_NO_ERROR if the properties were fetched successfully.
@@ -234,8 +216,6 @@ extern "C"
   {
     KodiToAddonFuncTable_Peripheral* pClient = static_cast<KodiToAddonFuncTable_Peripheral*>(ptr);
 
-    pClient->GetPeripheralAPIVersion        = GetPeripheralAPIVersion;
-    pClient->GetMinimumPeripheralAPIVersion = GetMinimumPeripheralAPIVersion;
     pClient->GetAddonCapabilities           = GetAddonCapabilities;
     pClient->PerformDeviceScan              = PerformDeviceScan;
     pClient->FreeScanResults                = FreeScanResults;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -50,12 +50,6 @@
   #define PRAGMA_PACK 1
 #endif
 
-/* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.2.1"
-
-/* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.2.0"
-
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
 
@@ -290,8 +284,6 @@ extern "C"
    */
   typedef struct KodiToAddonFuncTable_Peripheral
   {
-    const char*      (__cdecl* GetPeripheralAPIVersion)(void);
-    const char*      (__cdecl* GetMinimumPeripheralAPIVersion)(void);
     PERIPHERAL_ERROR (__cdecl* GetAddonCapabilities)(PERIPHERAL_CAPABILITIES*);
     PERIPHERAL_ERROR (__cdecl* PerformDeviceScan)(unsigned int*, PERIPHERAL_INFO**);
     void             (__cdecl* FreeScanResults)(unsigned int, PERIPHERAL_INFO*);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -1,0 +1,167 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *------------------------------------------------------------------------------
+ * This header is only be used for Kodi itself and internally (not for add-on
+ * development) to identify the several instance types.
+ *
+ * With this reason is also no doxygen part with "///" here used.
+ * -----------------------------------------------------------------------------
+ */
+
+/*
+ * Versions of all add-on instances are defined below.
+ *
+ * This is added here and not in related header to prevent not
+ * needed includes during compile. Also have it here a better
+ * overview.
+ */
+
+#define INSTANCE_VERSION_MAIN                   "1.0.0"
+#define INSTANCE_VERSION_GUI                    "5.11.0"
+#define INSTANCE_VERSION_ADSP                   "0.2.0"
+#define INSTANCE_VERSION_AUDIODECODER           "1.1.0"
+#define INSTANCE_VERSION_AUDIOENCODER           "1.1.0"
+#define INSTANCE_VERSION_GAME                   "1.1.0"
+#define INSTANCE_VERSION_INPUTSTREAM            "1.1.0"
+#define INSTANCE_VERSION_PERIPHERAL             "1.3.0"
+#define INSTANCE_VERSION_PVR                    "5.3.0"
+#define INSTANCE_VERSION_SCREENSAVER            "1.0.0"
+#define INSTANCE_VERSION_VISUALIZATION          "1.0.0"
+
+/*
+ * The currently used instance types for Kodi add-ons
+ *
+ * @note For add of new instance type take a new number on end. To change
+ * existing numbers can be make problems on already compiled add-ons.
+ */
+typedef enum ADDON_INSTANCE_TYPE
+{
+  /* addon global instances */
+  ADDON_INSTANCE_MAIN = 0,
+  ADDON_INSTANCE_GUI = 1,
+  ADDON_INSTANCE_GLOBAL_MAX = 1, // Last used global id, used in loops to check versions. Need to change if new global type becomes added.
+
+  /* addon type instances */
+  ADDON_INSTANCE_ADSP = 101,
+  ADDON_INSTANCE_AUDIODECODER = 102,
+  ADDON_INSTANCE_AUDIOENCODER = 103,
+  ADDON_INSTANCE_GAME = 104,
+  ADDON_INSTANCE_INPUTSTREAM = 105,
+  ADDON_INSTANCE_PERIPHERAL = 106,
+  ADDON_INSTANCE_PVR = 107,
+  ADDON_INSTANCE_SCREENSAVER = 108,
+  ADDON_INSTANCE_VISUALIZATION = 109,
+} ADDON_INSTANCE_TYPE;
+
+#ifdef __cplusplus
+extern "C" {
+namespace kodi {
+namespace addon {
+#endif
+
+/*
+ * This is used from Kodi to get the active version of add-on instances.
+ * It is compiled in add-on and also in Kodi itself, with this can be Kodi
+ * compare the version from him with them on add-on.
+ *
+ * Call for inside Kodi: kodi::addon::GetInstanceVersion(...)
+ * Call to ask addon:    m_interface.toAddon.GetInstanceVersion(...)
+ *
+ * @param[in] instanceType The with 'enum ADDON_INSTANCE_TYPE' type to ask
+ * @return version The current instance version of asked type
+ *
+ * The Kodi side is done in AddonDll.cpp by CAddonDll::CreateInstance(...)
+ * call.
+ */
+inline const char* GetInstanceVersion(int instanceType)
+{
+  switch (instanceType)
+  {
+    case ADDON_INSTANCE_MAIN:
+      return INSTANCE_VERSION_MAIN;
+    case ADDON_INSTANCE_GUI:
+      return INSTANCE_VERSION_GUI;
+    case ADDON_INSTANCE_ADSP:
+      return INSTANCE_VERSION_ADSP;
+    case ADDON_INSTANCE_AUDIODECODER:
+      return INSTANCE_VERSION_AUDIODECODER;
+    case ADDON_INSTANCE_AUDIOENCODER:
+      return INSTANCE_VERSION_AUDIOENCODER;
+    case ADDON_INSTANCE_GAME:
+      return INSTANCE_VERSION_GAME;
+    case ADDON_INSTANCE_INPUTSTREAM:
+      return INSTANCE_VERSION_INPUTSTREAM;
+    case ADDON_INSTANCE_PERIPHERAL:
+      return INSTANCE_VERSION_PERIPHERAL;
+    case ADDON_INSTANCE_PVR:
+      return INSTANCE_VERSION_PVR;
+    case ADDON_INSTANCE_SCREENSAVER:
+      return INSTANCE_VERSION_SCREENSAVER;
+    case ADDON_INSTANCE_VISUALIZATION:
+      return INSTANCE_VERSION_VISUALIZATION;
+  }
+  return "0.0.0";
+}
+
+/*
+ * Function used internally on add-on and in Kodi itself to get instance name
+ * about given type.
+ *
+ * @param[in] instanceType The with 'enum ADDON_INSTANCE_TYPE' type to ask
+ * @return Name of the asked instance type
+ */
+inline const char* GetInstanceName(int instanceType)
+{
+  switch (instanceType)
+  {
+    case ADDON_INSTANCE_MAIN:
+      return "Addon";
+    case ADDON_INSTANCE_GUI:
+      return "GUI";
+    case ADDON_INSTANCE_ADSP:
+      return "ADSP";
+    case ADDON_INSTANCE_AUDIODECODER:
+      return "AudioDecoder";
+    case ADDON_INSTANCE_AUDIOENCODER:
+      return "AudioEncoder";
+    case ADDON_INSTANCE_GAME:
+      return "Game";
+    case ADDON_INSTANCE_INPUTSTREAM:
+      return "Inputstream";
+    case ADDON_INSTANCE_PERIPHERAL:
+      return "Peripheral";
+    case ADDON_INSTANCE_PVR:
+      return "PVR";
+    case ADDON_INSTANCE_SCREENSAVER:
+      return "ScreenSaver";
+    case ADDON_INSTANCE_VISUALIZATION:
+      return "Visualization";
+  }
+  return "unknown";
+}
+
+#ifdef __cplusplus
+} /* namespace addon */
+} /* namespace kodi */
+} /* extern "C" */
+#endif

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
@@ -32,6 +32,7 @@
 #endif
 
 #include "xbmc_addon_types.h"
+#include "versions.h"
 
 #ifdef __cplusplus
 extern "C" { 
@@ -45,6 +46,10 @@ extern "C" {
   unsigned int __declspec(dllexport) ADDON_GetSettings(ADDON_StructSetting ***sSet);
   ADDON_STATUS __declspec(dllexport) ADDON_SetSetting(const char *settingName, const void *settingValue);
   void         __declspec(dllexport) ADDON_FreeSettings();
+  const char* __declspec(dllexport) ADDON_GetInstanceVersion(int instanceType)
+  {
+    return kodi::addon::GetInstanceVersion(instanceType);
+  }
 
 #ifdef __cplusplus
 };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -34,40 +34,6 @@ extern "C"
   /*! @name PVR add-on methods */
   //@{
   /*!
-   * Get the XBMC_PVR_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with XBMC.
-   * @return The XBMC_PVR_API_VERSION that was used to compile this add-on.
-   * @remarks Valid implementation required.
-   */
-  const char* GetPVRAPIVersion(void);
-
-  /*!
-   * Get the XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with XBMC.
-   * @return The XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
-   * @remarks Valid implementation required.
-   */
-  const char* GetMininumPVRAPIVersion(void);
-
-  /*!
-   * Get the XBMC_GUI_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with XBMC.
-   * @return The XBMC_GUI_API_VERSION that was used to compile this add-on or empty string if this add-on does not depend on Kodi GUI API.
-   * @remarks Valid implementation required.
-   * @note see libKODI_guilib.h about related parts
-   */
-  const char* GetGUIAPIVersion(void);
-
-  /*!
-   * Get the XBMC_GUI_MIN_API_VERSION that was used to compile this add-on.
-   * Used to check if this add-on is compatible with XBMC.
-   * @return The XBMC_GUI_MIN_API_VERSION that was used to compile this add-on or empty string if this add-on does not depend on Kodi GUI API.
-   * @remarks Valid implementation required.
-   * @note see libKODI_guilib.h about related parts
-   */
-  const char* GetMininumGUIAPIVersion(void);
-
-  /*!
    * Get the list of features that this add-on provides.
    * Called by XBMC to query the add-on's capabilities.
    * Used to check which options should be presented in the UI, which methods to call, etc.
@@ -663,10 +629,6 @@ extern "C"
   {
     KodiToAddonFuncTable_PVR* pClient = static_cast<KodiToAddonFuncTable_PVR*>(ptr);
     
-    pClient->GetPVRAPIVersion               = GetPVRAPIVersion;
-    pClient->GetMininumPVRAPIVersion        = GetMininumPVRAPIVersion;
-    pClient->GetGUIAPIVersion               = GetGUIAPIVersion;
-    pClient->GetMininumGUIAPIVersion        = GetMininumGUIAPIVersion;
     pClient->GetAddonCapabilities           = GetAddonCapabilities;
     pClient->GetStreamProperties            = GetStreamProperties;
     pClient->GetConnectionString            = GetConnectionString;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -77,12 +77,6 @@ struct DemuxPacket;
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20
 
-/* current PVR API version */
-#define XBMC_PVR_API_VERSION "5.2.1"
-
-/* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "5.2.1"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -532,10 +526,6 @@ extern "C" {
    */
   typedef struct KodiToAddonFuncTable_PVR
   {
-    const char*  (__cdecl* GetPVRAPIVersion)(void);
-    const char*  (__cdecl* GetMininumPVRAPIVersion)(void);
-    const char*  (__cdecl* GetGUIAPIVersion)(void);
-    const char*  (__cdecl* GetMininumGUIAPIVersion)(void);
     PVR_ERROR    (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
     PVR_ERROR    (__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
     const char*  (__cdecl* GetBackendName)(void);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
@@ -121,7 +121,7 @@ ADDON_STATUS CActiveAEDSPAddon::Create(int iClientId)
   /* initialise the add-on */
   bool bReadyToUse(false);
   CLog::Log(LOGDEBUG, "ActiveAE DSP - %s - creating audio dsp add-on instance '%s'", __FUNCTION__, Name().c_str());
-  if ((status = CAddonDll::Create(&m_struct, &m_info)) == ADDON_STATUS_OK)
+  if ((status = CAddonDll::Create(ADDON_INSTANCE_ADSP, &m_struct, &m_info)) == ADDON_STATUS_OK)
     bReadyToUse = GetAddonProperties();
 
   m_bReadyToUse = bReadyToUse;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
@@ -174,45 +174,6 @@ bool CActiveAEDSPAddon::IsInUse() const
   return m_isInUse;
 };
 
-bool CActiveAEDSPAddon::IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version)
-{
-  AddonVersion myMinVersion = AddonVersion(KODI_AE_DSP_MIN_API_VERSION);
-  AddonVersion myVersion = AddonVersion(KODI_AE_DSP_API_VERSION);
-  return (version >= myMinVersion && minVersion <= myVersion);
-}
-
-bool CActiveAEDSPAddon::IsCompatibleGUIAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version)
-{
-  AddonVersion myMinVersion = AddonVersion(KODI_GUILIB_MIN_API_VERSION);
-  AddonVersion myVersion = AddonVersion(KODI_GUILIB_API_VERSION);
-  return (version >= myMinVersion && minVersion <= myVersion);
-}
-
-bool CActiveAEDSPAddon::CheckAPIVersion(void)
-{
-  /* check the API version */
-  AddonVersion minVersion = AddonVersion(KODI_AE_DSP_MIN_API_VERSION);
-  m_apiVersion = AddonVersion(m_struct.GetAudioDSPAPIVersion());
-
-  if (!IsCompatibleAPIVersion(minVersion, m_apiVersion))
-  {
-    CLog::Log(LOGERROR, "ActiveAE DSP - Add-on '%s' is using an incompatible API version. KODI minimum API version = '%s', add-on API version '%s'", Name().c_str(), minVersion.asString().c_str(), m_apiVersion.asString().c_str());
-    return false;
-  }
-
-  /* check the GUI API version */
-  AddonVersion guiVersion = AddonVersion(m_struct.GetGUIAPIVersion());
-  minVersion = AddonVersion(KODI_GUILIB_MIN_API_VERSION);
-
-  if (!IsCompatibleGUIAPIVersion(minVersion, guiVersion))
-  {
-    CLog::Log(LOGERROR, "ActiveAE DSP - Add-on '%s' is using an incompatible GUI API version. KODI minimum GUI API version = '%s', add-on GUI API version '%s'", Name().c_str(), minVersion.asString().c_str(), guiVersion.asString().c_str());
-    return false;
-  }
-
-  return true;
-}
-
 bool CActiveAEDSPAddon::GetAddonProperties(void)
 {
   AE_DSP_ADDON_CAPABILITIES addonCapabilities;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
@@ -375,28 +375,6 @@ namespace ActiveAE
 
   private:
     /*!
-     * @brief Checks whether the provided API version is compatible with KODI
-     * @param minVersion The add-on's KODI_AE_DSP_MIN_API_VERSION version
-     * @param version The add-on's KODI_AE_DSP_API_VERSION version
-     * @return True when compatible, false otherwise
-     */
-    static bool IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version);
-
-    /*!
-     * @brief Checks whether the provided GUI API version is compatible with KODI
-     * @param minVersion The add-on's KODI_GUILIB_MIN_API_VERSION version
-     * @param version The add-on's KODI_GUILIB_API_VERSION version
-     * @return True when compatible, false otherwise
-     */
-    static bool IsCompatibleGUIAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version);
-
-    /*!
-     * @brief Request the API version from the add-on, and check if it's compatible
-     * @return True when compatible, false otherwise.
-     */
-    bool CheckAPIVersion(void);
-
-    /*!
      * @brief Resets all class members to their defaults. Called by the constructors.
      */
     void ResetProperties(int iClientId = AE_DSP_INVALID_ADDON_ID);

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -219,7 +219,7 @@ bool CGameClient::Initialize(void)
 
   m_libraryProps.InitializeProperties();
 
-  if (Create(&m_struct, m_info) == ADDON_STATUS_OK)
+  if (Create(ADDON_INSTANCE_GAME, &m_struct, m_info) == ADDON_STATUS_OK)
   {
     LogAddonProperties();
     return true;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -133,7 +133,7 @@ ADDON_STATUS CPeripheralAddon::CreateAddon(void)
 
   // Initialise the add-on
   CLog::Log(LOGDEBUG, "PERIPHERAL - %s - creating peripheral add-on instance '%s'", __FUNCTION__, Name().c_str());
-  ADDON_STATUS status = CAddonDll::Create(&m_struct, &m_info);
+  ADDON_STATUS status = CAddonDll::Create(ADDON_INSTANCE_PERIPHERAL, &m_struct, &m_info);
   if (status == ADDON_STATUS_OK)
   {
     if (!GetAddonProperties())

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -178,28 +178,6 @@ bool CPeripheralAddon::GetAddonProperties(void)
   return true;
 }
 
-bool CPeripheralAddon::CheckAPIVersion(void)
-{
-  // Check the API version
-  ADDON::AddonVersion minVersion = ADDON::AddonVersion(PERIPHERAL_MIN_API_VERSION);
-  m_apiVersion = ADDON::AddonVersion(m_struct.GetPeripheralAPIVersion());
-
-  if (!IsCompatibleAPIVersion(minVersion, m_apiVersion))
-  {
-    CLog::Log(LOGERROR, "PERIPHERAL - Add-on '%s' is using an incompatible API version. XBMC minimum API version = '%s', add-on API version '%s'", Name().c_str(), minVersion.asString().c_str(), m_apiVersion.asString().c_str());
-    return false;
-  }
-
-  return true;
-}
-
-bool CPeripheralAddon::IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version)
-{
-  ADDON::AddonVersion myMinVersion = ADDON::AddonVersion(PERIPHERAL_MIN_API_VERSION);
-  ADDON::AddonVersion myVersion = ADDON::AddonVersion(PERIPHERAL_API_VERSION);
-  return (version >= myMinVersion && minVersion <= myVersion);
-}
-
 bool CPeripheralAddon::Register(unsigned int peripheralIndex, const PeripheralPtr& peripheral)
 {
   if (!peripheral)

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -97,14 +97,6 @@ namespace PERIPHERALS
     void UnregisterButtonMap(JOYSTICK::IButtonMap* buttonMap);
     void RefreshButtonMaps(const std::string& strDeviceName = "");
 
-  protected:
-    /*!
-     * @brief Request the API version from the add-on, and check if it's compatible
-     * @return True when compatible, false otherwise.
-     * @remark Implementation of CAddonDll
-     */
-    virtual bool CheckAPIVersion(void) override;
-
   private:
     void UnregisterButtonMap(CPeripheral* device);
 
@@ -125,14 +117,6 @@ namespace PERIPHERALS
      * @brief Retrieve add-on properties from the add-on
      */
     bool GetAddonProperties(void);
-
-    /*!
-     * @brief Checks whether the provided API version is compatible with XBMC
-     * @param minVersion The add-on's XBMC_PERIPHERAL_MIN_API_VERSION version
-     * @param version The add-on's XBMC_PERIPHERAL_API_VERSION version
-     * @return True when compatible, false otherwise
-     */
-    static bool IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version);
 
     bool LogError(const PERIPHERAL_ERROR error, const char *strMethod) const;
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1127,7 +1127,6 @@ void CPVRClients::UpdateAddons(void)
         CLog::Log(LOGERROR, "%s - failed to create add-on %s, status = %d", __FUNCTION__, addon->Name().c_str(), status);
         if (status == ADDON_STATUS_PERMANENT_FAILURE)
         {
-          CGUIDialogOK::ShowAndGetInput(CVariant{24070}, CVariant{16029});
           CAddonMgr::GetInstance().DisableAddon(addon->ID());
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This add a new global add-on function with `GetInstanceVersion` who can called from Kodi and from add-on.

Everything about them is inserted to https://github.com/AlwinEsch/kodi/blob/change-addon-version-way2/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h and more clear on reviews about changes.

To call add-on is the new function `const char* __declspec(dllexport) ADDON_GetInstanceVersion(int instanceType)` used.

## Motivation and Context
Binary add-on system rework.

## How Has This Been Tested?
With binary add-on's.

## Screenshots (if appropriate):
![bildschirmfoto vom 2016-12-17 15-13-47](https://cloud.githubusercontent.com/assets/6879739/21287486/e919014c-c46c-11e6-8a72-9403bb113b7b.png)

![bildschirmfoto vom 2016-12-19 19-47-42](https://cloud.githubusercontent.com/assets/6879739/21324944/2f1634ea-c624-11e6-8c2b-e7c4cb39d7cb.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
