### PR TITLE
[addons] remove try, catch from CAddonDll

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -49,7 +49,6 @@ namespace ADDON
     bool DllLoaded(void) const;
 
   protected:
-    void HandleException(std::exception &e, const char* context);
     bool Initialized() { return m_initialized; }
     virtual bool LoadSettings();
     static uint32_t GetChildCount() { static uint32_t childCounter = 0; return childCounter++; }


### PR DESCRIPTION
Like on #11179 becomes with them the try and catch removed from CAddonDll

## Description
The try catch was never really used and also is in handling not the best, with them becomes it removed from binary add-on handling

## Motivation and Context
Continued cleanup to bring complete rework step by step in.

## How Has This Been Tested?
With binary add-on's.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
