### PR TITLE
VideoPlayer: Don't add timestamp offsets to DVD_NOPTS_VALUE

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1610,9 +1610,9 @@ void CVideoPlayer::Process()
       if (CDVDInputStream::IMenus* menu = dynamic_cast<CDVDInputStream::IMenus*>(m_pInputStream))
       {
         double correction = menu->GetTimeStampCorrection();
-        if (pPacket->dts > correction)
+        if (pPacket->dts != DVD_NOPTS_VALUE && pPacket->dts > correction)
           pPacket->dts -= correction;
-        if (pPacket->pts > correction)
+        if (pPacket->pts != DVD_NOPTS_VALUE && pPacket->pts > correction)
           pPacket->pts -= correction;
       }
       if (m_dvd.syncClock)


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/11178