### PR TITLE
WIP: [cmake] linux: Add DISTRIBUTION option

### DIFF
--- a/project/cmake/CMakeLists.txt
+++ b/project/cmake/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp")
 
 # general
 option(VERBOSE            "Enable verbose output?" OFF)
+option(DISTRIBUTION       "Building for distribution?" OFF)
 option(ENABLE_DVDCSS      "Enable libdvdcss support?" ON)
 option(ENABLE_UPNP        "Enable UPnP support?" ON)
 option(ENABLE_NONFREE     "Enable non-free components?" ON)

--- a/project/cmake/scripts/linux/ArchSetup.cmake
+++ b/project/cmake/scripts/linux/ArchSetup.cmake
@@ -24,9 +24,11 @@ else()
   endif()
 endif()
 
-# Make sure we strip binaries in Release build
-if(CMAKE_BUILD_TYPE STREQUAL Release AND CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+if(NOT DISTRIBUTION)
+  # Make sure we strip binaries in Release build
+  if(CMAKE_BUILD_TYPE STREQUAL Release AND CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+  endif()
 endif()
 
 find_package(CXX11 REQUIRED)

--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -120,9 +120,11 @@ install(FILES ${CORE_SOURCE_DIR}/tools/Linux/packaging/media/icon256x256.png
         RENAME ${APP_NAME_LC}.png
         DESTINATION ${datarootdir}/icons/hicolor/256x256/apps
         COMPONENT kodi)
-install(CODE "execute_process(COMMAND gtk-update-icon-cache -f -q -t
-        $ENV{DESTDIR}${datarootdir}/icons/hicolor ERROR_QUIET)"
-        COMPONENT kodi)
+if(NOT DISTRIBUTION)
+  install(CODE "execute_process(COMMAND gtk-update-icon-cache -f -q -t
+          $ENV{DESTDIR}${datarootdir}/icons/hicolor ERROR_QUIET)"
+          COMPONENT kodi)
+endif()
 
 # Install docs
 install(FILES ${CORE_SOURCE_DIR}/copying.txt


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Skip tasks better run by package manager

## Motivation and Context
When building on Gentoo Linux updating the icon cache cannot be done within the sandbox that a package is being built in and binary stripping is something that should be left to the package manager.

I'd be quite happy to see both these dropped from Kodi but I guess they were consciously included to help an ordinary build - therefore this patch maintains the current behaviour but adds a CMake option a package manager can use to skip both these steps.

For now I've called the option DISTRIBUTION but better ideas more than welcome. LINUX_DISTRIBUTION? PACKAGE something or other? MANAGER?

Happy to update and also add any documentation required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
