### PR TITLE
Fix for deadlock in AlarmClock

### DIFF
--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -125,7 +125,7 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
   }
   else
   {
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, iter->second.m_strCommand);
+    CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, iter->second.m_strCommand);
     if (iter->second.m_loop)
     {
       iter->second.watch.Reset();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
There is a deadlock in AlarmClock for messages which execute built-in commands.  The simple fix is to Post the command from AlarmClock::Stop rather than do a blocking Send.

This can happen any time there is an AlarmClock which expires/executes/fires while something else is trying to add a new Alarm.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Here is a stack trace (from Krypton head) of the deadlock in action:
```
Thread 1 (Thread 0x7fcc8c391880 (LWP 23680)):
#0  0x00007fcc8b06e547 in __pthread_mutex_lock_full () from /usr/lib/libpthread.so.0
#1  0x000000000129a924 in XbmcThreads::pthreads::RecursiveMutex::lock (this=0x29841f0 <g_alarmClock+720>) at xbmc/threads/platform/pthreads/CriticalSection.h:49
#2  XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock (this=0x29841f0 <g_alarmClock+720>) at xbmc/threads/Lockables.h:60
#3  XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock (lockable=..., this=<synthetic pointer>) at xbmc/threads/Lockables.h:127
#4  CSingleLock::CSingleLock (cs=..., this=<synthetic pointer>) at xbmc/threads/SingleLock.h:38
#5  CAlarmClock::Stop (this=this@entry=0x2983f20 <g_alarmClock>, strName="FixSort", bSilent=bSilent@entry=true) at AlarmClock.cpp:89
#6  0x0000000000de1b9c in AlarmClock (params=std::vector of length 4, capacity 4 = {...}) at GUIBuiltins.cpp:200
#7  0x0000000000de09d5 in CBuiltins::Execute (this=0x29783c0 <CBuiltins::GetInstance()::sBuiltins>, execString="AlarmClock(FixSort,SetFocus(9949),00:00,true)") at Builtins.cpp:167
#8  0x00000000010a933d in CApplication::ExecuteXBMCAction (this=this@entry=0x33327c0, actionStr="AlarmClock(FixSort,SetFocus(9949),00:00,true)", item=std::shared_ptr (empty) 0x0)
    at Application.cpp:4400
#9  0x00000000010aa257 in CApplication::OnMessage (this=0x33327c0, message=...) at Application.cpp:4377
#10 0x000000000092fc12 in CGUIWindowManager::SendMessage (this=this@entry=0x3332010, message=...) at GUIWindowManager.cpp:447
#11 0x000000000093009b in CGUIWindowManager::DispatchThreadMessages (this=0x3332010) at GUIWindowManager.cpp:1337
#12 0x00000000010aaf4d in CApplication::Process (this=0x33327c0) at Application.cpp:4459
#13 0x000000000114da24 in CXBApplicationEx::Run (this=0x33327c0, playlist=...) at XBApplicationEx.cpp:94
#14 0x0000000000e69e9f in XBMC_Run (renderGUI=renderGUI@entry=true, playlist=...) at xbmc.cpp:89

Thread 9 (Thread 0x7fcc437fe700 (LWP 23698)):
#0  0x00007fcc8b0720f7 in pthread_cond_wait@@GLIBC_2.3.2 () from /usr/lib/libpthread.so.0
#1  0x0000000000e6ce06 in XbmcThreads::ConditionVariable::wait (lock=..., this=<optimized out>) at xbmc/threads/platform/pthreads/Condition.h:62
#2  XbmcThreads::TightConditionVariable<bool volatile&>::wait<CCriticalSection> (lock=..., this=0x7fcc38000a70) at xbmc/threads/Condition.h:49
#3  CEvent::Wait (this=0x7fcc38000a00) at xbmc/threads/Event.h:94
#4  KODI::MESSAGING::CApplicationMessenger::SendMsg(KODI::MESSAGING::ThreadMessage&&, bool) (
    this=this@entry=0x297cc40 <KODI::MESSAGING::CApplicationMessenger::GetInstance()::appMessenger>,
    message=message@entry=<unknown type in /usr/lib/kodi/kodi.bin, CU 0x42e5abe, DIE 0x42f757e>, wait=wait@entry=true) at ApplicationMessenger.cpp:142
#5  0x0000000000e6d85e in KODI::MESSAGING::CApplicationMessenger::SendMsg (this=0x297cc40 <KODI::MESSAGING::CApplicationMessenger::GetInstance()::appMessenger>,
    messageId=messageId@entry=1073741847, param1=param1@entry=-1, param2=param2@entry=-1, payload=payload@entry=0x0, strParam="SetFocus(9949)") at ApplicationMessenger.cpp:161
#6  0x000000000129ad82 in CAlarmClock::Stop (this=this@entry=0x2983f20 <g_alarmClock>, strName="fixsort", bSilent=bSilent@entry=false) at AlarmClock.cpp:128
#7  0x000000000129b086 in CAlarmClock::Process (this=0x2983f20 <g_alarmClock>) at AlarmClock.cpp:151
#8  0x0000000001f1d10f in CThread::Action (this=0x2983f20 <g_alarmClock>) at Thread.cpp:221
#9  0x0000000001f1d3bf in CThread::staticThread (data=0x2983f20 <g_alarmClock>) at Thread.cpp:131
#10 0x00007fcc8b06c454 in start_thread () from /usr/lib/libpthread.so.0
#11 0x00007fcc84ec57df in clone () from /usr/lib/libc.so.6
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested it, it fixed the deadlock.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
