### PR TITLE
[PVR] Fix stack overflow while trying to get play resume point from PVR client

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -42,6 +42,7 @@
 #include "PVRClient.h"
 
 #include <assert.h>
+#include <cmath>
 #include <memory>
 #include <algorithm>
 
@@ -279,8 +280,8 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording &xbmcRecording, PV
   addonRecording.iDuration           = xbmcRecording.GetDuration();
   addonRecording.iPriority           = xbmcRecording.m_iPriority;
   addonRecording.iLifetime           = xbmcRecording.m_iLifetime;
-  addonRecording.iPlayCount          = xbmcRecording.GetPlayCount();
-  addonRecording.iLastPlayedPosition = (int)xbmcRecording.GetResumePoint().timeInSeconds;
+  addonRecording.iPlayCount          = xbmcRecording.GetLocalPlayCount();
+  addonRecording.iLastPlayedPosition = lrint(xbmcRecording.GetLocalResumePoint().timeInSeconds);
   addonRecording.bIsDeleted          = xbmcRecording.IsDeleted();
   strncpy(addonRecording.strDirectory, xbmcRecording.m_strDirectory.c_str(), sizeof(addonRecording.strDirectory) - 1);
   strncpy(addonRecording.strStreamURL, xbmcRecording.m_strStreamURL.c_str(), sizeof(addonRecording.strStreamURL) - 1);

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -286,6 +286,19 @@ bool CPVRRecording::SetPlayCount(int count)
   return CVideoInfoTag::SetPlayCount(count);
 }
 
+bool CPVRRecording::IncrementPlayCount()
+{
+  PVR_ERROR error;
+  if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId) &&
+      !g_PVRClients->SetRecordingPlayCount(*this, CVideoInfoTag::GetPlayCount(), &error))
+  {
+    DisplayError(error);
+    return false;
+  }
+
+  return CVideoInfoTag::IncrementPlayCount();
+}
+
 bool CPVRRecording::SetResumePoint(const CBookmark &resumePoint)
 {
   PVR_ERROR error;
@@ -297,6 +310,19 @@ bool CPVRRecording::SetResumePoint(const CBookmark &resumePoint)
   }
 
   return CVideoInfoTag::SetResumePoint(resumePoint);
+}
+
+bool CPVRRecording::SetResumePoint(double timeInSeconds, double totalTimeInSeconds, const std::string &playerState /* = "" */)
+{
+  PVR_ERROR error;
+  if (g_PVRClients->SupportsLastPlayedPosition(m_iClientId) &&
+      !g_PVRClients->SetRecordingLastPlayedPosition(*this, lrint(timeInSeconds), &error))
+  {
+    DisplayError(error);
+    return false;
+  }
+
+  return CVideoInfoTag::SetResumePoint(timeInSeconds, totalTimeInSeconds, playerState);
 }
 
 CBookmark CPVRRecording::GetResumePoint() const
@@ -386,8 +412,8 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   m_iChannelUid       = tag.m_iChannelUid;
   m_bRadio            = tag.m_bRadio;
 
-  SetPlayCount(tag.GetPlayCount());
-  SetResumePoint(tag.GetResumePoint());
+  CVideoInfoTag::SetPlayCount(tag.GetLocalPlayCount());
+  CVideoInfoTag::SetResumePoint(tag.GetLocalResumePoint());
   SetDuration(tag.GetDuration());
 
   //Old Method of identifying TV show title and subtitle using m_strDirectory and strPlotOutline (deprecated)

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -126,24 +126,51 @@ namespace PVR
     bool Rename(const std::string &strNewName);
 
     /*!
-     * @brief Set this recording's play count on the client (if supported).
+     * @brief Set this recording's play count. The value will be transferred to the backend if it supports server-side play counts.
      * @param count play count.
      * @return True if play count was set successfully, false otherwise.
      */
     bool SetPlayCount(int count) override;
 
     /*!
-     * @brief Set this videos's resume point.
+     * @brief Increment this recording's play count. The value will be transferred to the backend if it supports server-side play counts.
+     * @return True if play count was increased successfully, false otherwise.
+     */
+    bool IncrementPlayCount() override;
+
+   /*!
+     * @brief Get this recording's local play count. The value will not be obtained from the backend, even if it supports server-side play counts.
+     * @return the play count.
+     */
+    int GetLocalPlayCount() const { return CVideoInfoTag::GetPlayCount(); }
+
+    /*!
+     * @brief Set this recording's resume point. The value will be transferred to the backend if it supports server-side resume points.
      * @param resumePoint resume point.
      * @return True if resume point was set successfully, false otherwise.
      */
     bool SetResumePoint(const CBookmark &resumePoint) override;
 
     /*!
-     * @brief Get this recording's resume point.
+     * @brief Set this recording's resume point. The value will be transferred to the backend if it supports server-side resume points.
+     * @param timeInSeconds the time of the resume point
+     * @param totalTimeInSeconds the total time of the video
+     * @param playerState the player state
+     * @return True if resume point was set successfully, false otherwise.
+     */
+    bool SetResumePoint(double timeInSeconds, double totalTimeInSeconds, const std::string &playerState = "") override;
+
+    /*!
+     * @brief Get this recording's resume point. The value will be obtained from the backend if it supports server-side resume points.
      * @return the resume point.
      */
     CBookmark GetResumePoint() const override;
+
+    /*!
+     * @brief Get this recording's local resume point. The value will not be obtained from the backend even if it supports server-side resume points.
+     * @return the resume point.
+     */
+    CBookmark GetLocalResumePoint() const { return CVideoInfoTag::GetResumePoint(); }
 
     /*!
      * @brief Retrieve the edit decision list (EDL) of a recording on the backend.

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -57,7 +57,6 @@ namespace PVR
     virtual void OnInitWindow(void) override;
     virtual void OnDeinitWindow(int nextWindowID) override;
     virtual bool OnMessage(CGUIMessage& message) override;
-    virtual bool OnContextButton(const CFileItem &item, CONTEXT_BUTTON button) { return false; };
     virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
     virtual void UpdateButtons(void) override;
     virtual bool OnAction(const CAction &action) override;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1546,7 +1546,7 @@ bool CVideoInfoTag::SetPlayCount(int count)
 
 bool CVideoInfoTag::IncrementPlayCount()
 {
-  SetPlayCount(GetPlayCount() + 1); // note: not just m_playCount++; call possibly overridden (G|S)etPlayCount
+  m_playCount++;
   return true;
 }
 
@@ -1568,5 +1568,7 @@ bool CVideoInfoTag::SetResumePoint(double timeInSeconds, double totalTimeInSecon
   resumePoint.totalTimeInSeconds = totalTimeInSeconds;
   resumePoint.playerState = playerState;
   resumePoint.type = CBookmark::RESUME;
-  return SetResumePoint(resumePoint); // note: not just m_resumePoint = resumePoint; call the possibly overridden SetResumePoint
+
+  m_resumePoint = resumePoint;
+  return true;
 }

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -208,7 +208,7 @@ public:
    * @param playerState the player state
    * @return True if resume point was set successfully, false otherwise.
    */
-  bool SetResumePoint(double timeInSeconds, double totalTimeInSeconds, const std::string &playerState = "");
+  virtual bool SetResumePoint(double timeInSeconds, double totalTimeInSeconds, const std::string &playerState = "");
 
   std::string m_basePath; // the base path of the video, for folder-based lookups
   int m_parentPathID;      // the parent path id where the base path of the video lies


### PR DESCRIPTION
This is a bugfix followup to #11115. 

There was a crash caused by a stack overflow reported in the forum:  http://forum.kodi.tv/showthread.php?tid=298461&pid=2481973#pid2481973

Interesting part of the user supplied crash log:

<pre>
...
#2892 0x007cb5ec in PVR::CPVRRecording::GetResumePoint() const ()
#2893 0x00710cf0 in PVR::CPVRClient::WriteClientRecordingInfo(PVR::CPVRRecording const&, PVR_RECORDING&) ()
#2894 0x00711010 in PVR::CPVRClient::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2895 0x007ee1d4 in PVR::CPVRClients::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2896 0x007cb5ec in PVR::CPVRRecording::GetResumePoint() const ()
#2897 0x00710cf0 in PVR::CPVRClient::WriteClientRecordingInfo(PVR::CPVRRecording const&, PVR_RECORDING&) ()
#2898 0x00711010 in PVR::CPVRClient::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2899 0x007ee1d4 in PVR::CPVRClients::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2900 0x007cb5ec in PVR::CPVRRecording::GetResumePoint() const ()
#2901 0x00710cf0 in PVR::CPVRClient::WriteClientRecordingInfo(PVR::CPVRRecording const&, PVR_RECORDING&) ()
#2902 0x00711010 in PVR::CPVRClient::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2903 0x007ee1d4 in PVR::CPVRClients::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2904 0x007cb5ec in PVR::CPVRRecording::GetResumePoint() const ()
#2905 0x00710cf0 in PVR::CPVRClient::WriteClientRecordingInfo(PVR::CPVRRecording const&, PVR_RECORDING&) ()
#2906 0x00711010 in PVR::CPVRClient::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2907 0x007ee1d4 in PVR::CPVRClients::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2908 0x007cb5ec in PVR::CPVRRecording::GetResumePoint() const ()
#2909 0x00710cf0 in PVR::CPVRClient::WriteClientRecordingInfo(PVR::CPVRRecording const&, PVR_RECORDING&) ()
#2910 0x00711010 in PVR::CPVRClient::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2911 0x007ee1d4 in PVR::CPVRClients::GetRecordingLastPlayedPosition(PVR::CPVRRecording const&) ()
#2912 0x007cb5ec in PVR::CPVRRecording::GetResumePoint() const ()
#2913 0x00710cf0 in PVR::CPVRClient::WriteClientRecordingInfo(PVR::CPVRRecording const&, PVR_RECORDING&) ()
#2914 0x00710fa0 in PVR::CPVRClient::SetRecordingLastPlayedPosition(PVR::CPVRRecording const&, int) ()
#2915 0x007ee12c in PVR::CPVRClients::SetRecordingLastPlayedPosition(PVR::CPVRRecording const&, int, PVR_ERROR*) ()
#2916 0x007cb380 in PVR::CPVRRecording::SetResumePoint(CBookmark const&) ()
#2917 0x00579188 in CVideoInfoTag::SetResumePoint(double, double, std::string const&) ()
#2918 0x007cbe28 in PVR::CPVRRecording::CPVRRecording(PVR_RECORDING const&, unsigned int) ()
#2919 0x006d42a0 in KodiAPI::PVR::CAddonCallbacksPVR::PVRTransferRecordingEntry(void*, ADDON_HANDLE_STRUCT*, PVR_RECORDING const*) ()
#2920 0x6b775fd4 in cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE_STRUCT*) () from /usr/lib/kodi/addons/pvr.mediaportal.tvserver/pvr.mediaportal.tvserver.so.3.0.2
#2921 0x0070ff18 in PVR::CPVRClient::GetRecordings(PVR::CPVRRecordings*, bool) ()
#2922 0x007f0524 in PVR::CPVRClients::GetRecordings(PVR::CPVRRecordings*, bool) ()
#2923 0x007ccb84 in PVR::CPVRRecordings::UpdateFromClients() ()
#2924 0x007cc52c in PVR::CPVRRecordings::Update() ()
#2925 0x007cc5b4 in PVR::CPVRRecordings::Load() ()
#2926 0x007f6604 in PVR::CPVRManager::Load(bool) ()
#2927 0x007f86a0 in PVR::CPVRManager::Process() ()
#2928 0x005f36ec in CThread::Action() ()
#2929 0x005f3dd0 in CThread::staticThread(void*) ()
#2930 0x76efaf40 in start_thread (arg=0x5b88d3a0) at pthread_create.c:335
#2931 0x75339e18 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:86 from /usr/lib/libc.so.6
</pre>

@Jalle19 mind doing the review.
@MilhouseVH could you please include this PR into your build and ask 'bmonster' whether this fixes his issue?