### PR TITLE
[PVR] Fix crashes on pvr manager deinit/reinit - part 2

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1330,25 +1330,6 @@ bool CApplication::StartServer(enum ESERVERS eServer, bool bStart, bool bWait/* 
   return ret;
 }
 
-void CApplication::StopPVRManager()
-{
-  CLog::Log(LOGINFO, "stopping PVRManager");
-  if (g_PVRManager.IsPlaying())
-    StopPlaying();
-  // stop pvr manager thread and clear all pvr data
-  g_PVRManager.Stop();
-  g_PVRManager.Clear();
-  // stop epg container thread and clear all epg data
-  g_EpgContainer.Stop();
-  g_EpgContainer.Clear();
-}
-
-void CApplication::ReinitPVRManager()
-{
-  CLog::Log(LOGINFO, "restarting PVRManager");
-  g_PVRManager.Reinit();
-}
-
 void CApplication::StartServices()
 {
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
@@ -2942,7 +2923,6 @@ void CApplication::Stop(int exitCode)
     CLog::Log(LOGNOTICE, "stop player");
     m_pPlayer->ClosePlayer();
 
-    StopPVRManager();
     StopServices();
 
 #ifdef HAS_ZEROCONF

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -156,8 +156,6 @@ public:
 
   bool StartServer(enum ESERVERS eServer, bool bStart, bool bWait = false);
 
-  void StopPVRManager();
-  void ReinitPVRManager();
   bool IsCurrentThread() const;
   void Stop(int exitCode);
   void RestartApp();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -84,6 +84,8 @@ void CServiceManager::Deinit()
 {
   m_contextMenuManager.reset();
   m_binaryAddonCache.reset();
+  if (m_PVRManager)
+    m_PVRManager->Shutdown();
   m_PVRManager.reset();
   m_ADSPManager.reset();
   m_addonMgr.reset();

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -184,20 +184,4 @@ namespace PVR
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup &group);
   };
-
-  /*!
-   * @brief Try to open the PVR database.
-   * @return The opened database or NULL if the database failed to open.
-   */
-  inline CPVRDatabase *GetPVRDatabase(void)
-  {
-    CPVRDatabase *database = g_PVRManager.GetTVDatabase();
-    if (!database || !database->IsOpen())
-    {
-      CLog::Log(LOGERROR, "PVR - failed to open the database");
-      database = NULL;
-    }
-
-    return database;
-  }
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -441,15 +441,34 @@ void CPVRManager::Stop(void)
   if (m_guiInfo)
     m_guiInfo->Stop();
 
-  /* executes the set wakeup command */
-  SetWakeupCommand();
-
   /* close database */
   const CPVRDatabasePtr database(GetTVDatabase());
   if (database->IsOpen())
     database->Close();
 
   SetState(ManagerStateStopped);
+}
+
+void CPVRManager::Unload()
+{
+  // stop pvr manager thread and clear all pvr data
+  Stop();
+  Clear();
+
+  // stop epg container thread and clear all epg data
+  g_EpgContainer.Stop();
+  g_EpgContainer.Clear();
+}
+
+void CPVRManager::Shutdown()
+{
+  // set system wakeup data
+  SetWakeupCommand();
+
+  Unload();
+
+  // release addons
+  m_addons.reset();
 }
 
 CPVRManager::ManagerState CPVRManager::GetState(void) const

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -176,14 +176,19 @@ namespace PVR
     void Reinit(void);
 
     /*!
-     * @brief Stop the PVRManager.
+     * @brief Stop PVRManager.
      */
     void Stop(void);
 
     /*!
-     * @brief Destroy PVRManager's objects.
+     * @brief Stop PVRManager, unload data.
      */
-    void Clear(void);
+    void Unload();
+
+    /*!
+     * @brief Stop PVRManager, unload data, unload addons.
+     */
+    void Shutdown();
 
     /*!
      * @brief Get the TV database.
@@ -636,6 +641,11 @@ namespace PVR
     void ResetProperties(void);
 
     /*!
+     * @brief Destroy PVRManager's objects.
+     */
+    void Clear(void);
+
+    /*!
      * @brief Called by ChannelUp() and ChannelDown() to perform a channel switch.
      * @param iNewChannelNumber The new channel number after the switch.
      * @param bPreview Preview window if true.
@@ -673,7 +683,7 @@ namespace PVR
     CPVRChannelGroupsContainerPtr  m_channelGroups;               /*!< pointer to the channel groups container */
     CPVRRecordingsPtr              m_recordings;                  /*!< pointer to the recordings container */
     CPVRTimersPtr                  m_timers;                      /*!< pointer to the timers container */
-    const CPVRClientsPtr           m_addons;                      /*!< pointer to the pvr addon container */
+    CPVRClientsPtr                 m_addons;                      /*!< pointer to the pvr addon container */
     std::unique_ptr<CPVRGUIInfo>   m_guiInfo;                     /*!< pointer to the guiinfo data */
     //@}
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -169,7 +169,7 @@ namespace PVR
      * @brief Get the TV database.
      * @return The TV database.
      */
-    CPVRDatabase *GetTVDatabase(void) const { return m_database; }
+    CPVRDatabasePtr GetTVDatabase(void) const;
 
     /*!
      * @brief Get a GUIInfoManager character string.
@@ -673,7 +673,7 @@ namespace PVR
     std::vector<CJob *>             m_pendingUpdates;              /*!< vector of pending pvr updates */
 
     CFileItem *                     m_currentFile;                 /*!< the PVR file that is currently playing */
-    CPVRDatabase *                  m_database;                    /*!< the database for all PVR related data */
+    CPVRDatabasePtr                 m_database;                    /*!< the database for all PVR related data */
     CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
     bool                            m_bFirstStart;                 /*!< true when the PVR manager was started first, false otherwise */
     bool                            m_bIsSwitchingChannels;        /*!< true while switching channels */

--- a/xbmc/pvr/PVRTypes.h
+++ b/xbmc/pvr/PVRTypes.h
@@ -23,6 +23,9 @@
 
 namespace PVR
 {
+  class CPVRDatabase;
+  typedef std::shared_ptr<CPVRDatabase> CPVRDatabasePtr;
+
   class CPVRChannel;
   typedef std::shared_ptr<CPVRChannel> CPVRChannelPtr;
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -144,7 +144,7 @@ void CPVRChannel::Serialize(CVariant& value) const
 bool CPVRChannel::Delete(void)
 {
   bool bReturn = false;
-  CPVRDatabase *database = GetPVRDatabase();
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
   if (!database)
     return bReturn;
 
@@ -218,7 +218,8 @@ bool CPVRChannel::Persist()
       return true;
   }
 
-  if (CPVRDatabase *database = GetPVRDatabase())
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
+  if (database)
   {
     bool bReturn = database->Persist(*this) && database->CommitInsertQueries();
     CSingleLock lock(m_critSection);
@@ -368,7 +369,8 @@ bool CPVRChannel::SetLastWatched(time_t iLastWatched)
       m_iLastWatched = iLastWatched;
   }
 
-  if (CPVRDatabase *database = GetPVRDatabase())
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
+  if (database)
     return database->UpdateLastWatched(*this);
 
   return false;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -272,7 +272,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
   if (iconPath.empty())
     return;
 
-  CPVRDatabase *database = GetPVRDatabase();
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
   if (!database)
     return;
 
@@ -589,7 +589,7 @@ CPVRChannelGroupPtr CPVRChannelGroup::GetPreviousGroup(void) const
 
 int CPVRChannelGroup::LoadFromDb(bool bCompress /* = false */)
 {
-  CPVRDatabase *database = GetPVRDatabase();
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
   if (!database)
     return -1;
 
@@ -706,13 +706,13 @@ bool CPVRChannelGroup::UpdateGroupEntries(const CPVRChannelGroup &channels)
   bool bChanged(false);
   bool bRemoved(false);
 
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
+  if (!database)
+    return bReturn;
+
   CSingleLock lock(m_critSection);
   /* sort by client channel number if this is the first time or if pvrmanager.backendchannelorder is true */
   bool bUseBackendChannelNumbers(m_members.empty() || m_bUsingBackendChannelOrder);
-
-  CPVRDatabase *database = GetPVRDatabase();
-  if (!database)
-    return bReturn;
 
   bRemoved = RemoveDeletedChannels(channels);
   bChanged = AddAndUpdateChannels(channels, bUseBackendChannelNumbers) || bRemoved;
@@ -844,6 +844,8 @@ bool CPVRChannelGroup::SetGroupName(const std::string &strGroupName, bool bSaveI
 bool CPVRChannelGroup::Persist(void)
 {
   bool bReturn(true);
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
+
   CSingleLock lock(m_critSection);
 
   /* only persist if the group has changes and is fully loaded or never has been saved before */
@@ -854,7 +856,7 @@ bool CPVRChannelGroup::Persist(void)
   if (m_iGroupId == -1)
     m_bLoaded = true;
 
-  if (CPVRDatabase *database = GetPVRDatabase())
+  if (database)
   {
     CLog::Log(LOGDEBUG, "CPVRChannelGroup - %s - persisting channel group '%s' with %d channels",
         __FUNCTION__, GroupName().c_str(), (int) m_members.size());
@@ -1145,6 +1147,8 @@ time_t CPVRChannelGroup::LastWatched(void) const
 
 bool CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
 {
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
+
   CSingleLock lock(m_critSection);
 
   if (m_iLastWatched != iLastWatched)
@@ -1153,7 +1157,7 @@ bool CPVRChannelGroup::SetLastWatched(time_t iLastWatched)
     lock.Leave();
 
     /* update the database immediately */
-    if (CPVRDatabase *database = GetPVRDatabase())
+    if (database)
       return database->UpdateLastWatched(*this);
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -220,7 +220,7 @@ int CPVRChannelGroupInternal::GetMembers(CFileItemList &results, bool bGroupMemb
 
 int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
 {
-  CPVRDatabase *database = GetPVRDatabase();
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
   if (!database)
     return -1;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -281,7 +281,7 @@ bool CPVRChannelGroups::LoadUserDefinedChannelGroups(void)
 
 bool CPVRChannelGroups::Load(void)
 {
-  CPVRDatabase *database = GetPVRDatabase();
+  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
   if (!database)
     return false;
 
@@ -550,7 +550,7 @@ bool CPVRChannelGroups::DeleteGroup(const CPVRChannelGroup &group)
   if (group.GroupID() > 0)
   {
     // delete the group from the database
-    CPVRDatabase *database = GetPVRDatabase();
+    const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
     return database ? database->Delete(group) : false;
   }
   return bFound;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -277,7 +277,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   ADDON::CAddonMgr::GetInstance().StopServices(true);
 
   // stop PVR related services
-  g_application.StopPVRManager();
+  CServiceBroker::GetPVRManager().Unload();
 
   // stop audio DSP services with a blocking message
   CServiceBroker::GetADSP().Deactivate();
@@ -324,7 +324,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 #endif
 
   // restart PVR services
-  g_application.ReinitPVRManager();
+  CServiceBroker::GetPVRManager().Reinit();
 
   // start services which should run on login
   ADDON::CAddonMgr::GetInstance().StartServices(false);


### PR DESCRIPTION
This is a followup to #11143 

Now, that first chunk of fixes is in master/Krypton, next (and hopefully the last) wave of followup issues arrives. First wave of fixes was definitely okay, but formerly, we did not get that far... ;-)

Crashes with stacks very similar to the following were reported on the forum (http://forum.kodi.tv/showthread.php?tid=298461&pid=2481973#pid2481973) and by @peak3d:

<pre>
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x006c98f8 in CDatabase::InitSettings (this=this@entry=0x5c12c500, dbSettings=...) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/dbwrappers/Database.cpp:404
[Current thread is 1 (Thread 0x56e233a0 (LWP 831))]

Thread 52 (Thread 0x66f023a0 (LWP 815)):
...
#29 0x007d0d28 in PVR::CPVRRecordings::CPVRRecordings (this=0x721141e8) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/pvr/recordings/PVRRecordings.cpp:51
=> PVR::CPVRManager::ResetProperties called PVR::CPVRManager::Clear() which deleted m_database and has set it to nullptr!
#30 0x007fb938 in PVR::CPVRManager::ResetProperties (this=this@entry=0x2ec7f50) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/pvr/PVRManager.cpp:281
#31 0x007fbb18 in PVR::CPVRManager::Start (this=0x2ec7f50) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/pvr/PVRManager.cpp:322
#32 0x007f0cf0 in PVR::CPVRClients::ConnectionStateChange (this=<optimized out>, client=0x721bd4d0, strConnectionString=..., newState=PVR_CONNECTION_STATE_CONNECTED, strMessage=...) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/pvr/addons/PVRClients.cpp:1543
#33 0x007fa1fc in PVR::CPVRClientConnectionJob::DoWork (this=0x5c2cd480) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/pvr/PVRManager.cpp:1884
#34 0x005b6ffc in CJobWorker::Process (this=0x4798500) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/utils/JobManager.cpp:69
#35 0x005f65c4 in CThread::Action (this=0x4798500) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/threads/Thread.cpp:221
#36 0x005f6ca8 in CThread::staticThread (data=0x4798500) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/threads/Thread.cpp:131
#37 0x76f0ff40 in start_thread (arg=0x66f023a0) at pthread_create.c:335
#38 0x7532be18 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:86 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 1 (Thread 0x56e233a0 (LWP 831)):
#0  0x006c98f8 in CDatabase::InitSettings (this=this@entry=0x5c12c500, dbSettings=...) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/dbwrappers/Database.cpp:404
=> m_database access is not protected by pvr mgr lock => ptr value may get null or invalid at any time (like happened in this case because thread 52 deleted m_database concurrently).
#1  0x006cab64 in CDatabase::Open (this=0x5c12c500, settings=...) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/dbwrappers/Database.cpp:370
#2  0x007fbc94 in PVR::CPVRManager::Process (this=0x2ec7f50) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/pvr/PVRManager.cpp:429
#3  0x005f65c4 in CThread::Action (this=0x2ec7f58) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/threads/Thread.cpp:221
#4  0x005f6ca8 in CThread::staticThread (data=0x2ec7f58) at /home/neil/projects/LibreELEC.tv/build.LibreELEC-RPi2.arm-8.0-devel-debug/kodi-17.0-beta7-7581c4a/xbmc/threads/Thread.cpp:131
#5  0x76f0ff40 in start_thread (arg=0x56e233a0) at pthread_create.c:335
#6  0x7532be18 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:86 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
</pre>

@Jalle19 mind doing the code review.
@MilhouseVH could you please include this into your build?
