### PR TITLE
[gui] improve scaling support for container layouts.

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -1567,7 +1567,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   {
     CGUIListItemLayout itemLayout;
-    itemLayout.LoadLayout(itemElement, GetParentID(), false);
+    itemLayout.LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     m_channelLayouts.push_back(itemLayout);
     itemElement = itemElement->NextSiblingElement("channellayout");
   }
@@ -1575,7 +1575,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   {
     CGUIListItemLayout itemLayout;
-    itemLayout.LoadLayout(itemElement, GetParentID(), true);
+    itemLayout.LoadLayout(itemElement, GetParentID(), true, m_width, m_height);
     m_focusedChannelLayouts.push_back(itemLayout);
     itemElement = itemElement->NextSiblingElement("focusedchannellayout");
   }
@@ -1585,7 +1585,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   {
     CGUIListItemLayout itemLayout;
-    itemLayout.LoadLayout(itemElement, GetParentID(), true);
+    itemLayout.LoadLayout(itemElement, GetParentID(), true, m_width, m_height);
     m_focusedProgrammeLayouts.push_back(itemLayout);
     itemElement = itemElement->NextSiblingElement("focusedlayout");
   }
@@ -1593,7 +1593,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   {
     CGUIListItemLayout itemLayout;
-    itemLayout.LoadLayout(itemElement, GetParentID(), false);
+    itemLayout.LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     m_programmeLayouts.push_back(itemLayout);
     itemElement = itemElement->NextSiblingElement("itemlayout");
   }
@@ -1603,7 +1603,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   {
     CGUIListItemLayout itemLayout;
-    itemLayout.LoadLayout(itemElement, GetParentID(), false);
+    itemLayout.LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     m_rulerDateLayouts.push_back(itemLayout);
     itemElement = itemElement->NextSiblingElement("rulerdatelayout");
   }
@@ -1613,7 +1613,7 @@ void CGUIEPGGridContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   {
     CGUIListItemLayout itemLayout;
-    itemLayout.LoadLayout(itemElement, GetParentID(), false);
+    itemLayout.LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     m_rulerLayouts.push_back(itemLayout);
     itemElement = itemElement->NextSiblingElement("rulerlayout");
   }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1145,14 +1145,14 @@ void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
   while (itemElement)
   { // we have a new item layout
     m_layouts.emplace_back();
-    m_layouts.back().LoadLayout(itemElement, GetParentID(), false);
+    m_layouts.back().LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     itemElement = itemElement->NextSiblingElement("itemlayout");
   }
   itemElement = layout->FirstChildElement("focusedlayout");
   while (itemElement)
   { // we have a new item layout
     m_focusedLayouts.emplace_back();
-    m_focusedLayouts.back().LoadLayout(itemElement, GetParentID(), true);
+    m_focusedLayouts.back().LoadLayout(itemElement, GetParentID(), true, m_width, m_height);
     itemElement = itemElement->NextSiblingElement("focusedlayout");
   }
 }

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -167,7 +167,7 @@ void CGUIListItemLayout::LoadControl(TiXmlElement *child, CGUIControlGroup *grou
   }
 }
 
-void CGUIListItemLayout::LoadLayout(TiXmlElement *layout, int context, bool focused)
+void CGUIListItemLayout::LoadLayout(TiXmlElement *layout, int context, bool focused, float maxWidth, float maxHeight)
 {
   m_focused = focused;
   layout->QueryFloatAttribute("width", &m_width);
@@ -176,17 +176,22 @@ void CGUIListItemLayout::LoadLayout(TiXmlElement *layout, int context, bool focu
   if (condition)
     m_condition = g_infoManager.Register(condition, context);
   m_isPlaying.Parse("listitem.isplaying", context);
-  TiXmlElement *child = layout->FirstChildElement("control");
+  // ensure width and height are valid
+  if (!m_width)
+    m_width = maxWidth;
+  if (!m_height)
+    m_height = maxHeight;
+  m_width = std::max(1.0f, m_width);
+  m_height = std::max(1.0f, m_height);
   m_group.SetWidth(m_width);
   m_group.SetHeight(m_height);
+
+  TiXmlElement *child = layout->FirstChildElement("control");
   while (child)
   {
     LoadControl(child, &m_group);
     child = child->NextSiblingElement("control");
   }
-  // ensure width and height are valid
-  m_width = std::max(1.0f, m_width);
-  m_height = std::max(1.0f, m_height);
 }
 
 //#ifdef GUILIB_PYTHON_COMPATIBILITY

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -34,7 +34,7 @@ public:
   CGUIListItemLayout();
   CGUIListItemLayout(const CGUIListItemLayout &from);
   virtual ~CGUIListItemLayout();
-  void LoadLayout(TiXmlElement *layout, int context, bool focused);
+  void LoadLayout(TiXmlElement *layout, int context, bool focused, float maxWidth, float maxHeight);
   void Process(CGUIListItem *item, int parentID, unsigned int currentTime, CDirtyRegionList &dirtyregions);
   void Render(CGUIListItem *item, int parentID);
   float Size(ORIENTATION orientation) const;


### PR DESCRIPTION
improve scaling support by inheriting listitemlayout width/height from container control width/height in case nothing is explicitely set.
In other words: the width/height of a layout will get set to the container width/height in case it is not defined explicitely via "width"/"height" attribute.
This will allow me to drop largest parts of constants_1920.xml and constants_2560.xml in estuary.

@ronie @BigNoid for testing, @ksooo perhaps for review?		