### PR TITLE
[PVR] fix crash stopping manager: addons should be destroyed as soon as possible

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -348,6 +348,10 @@ void CPVRManager::Stop(void)
     CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
   }
 
+  /* destroy addons */
+  m_addons->Unload();
+  CLog::Log(LOGNOTICE, "PVRManager - clients unloaded");
+
   /* stop all update threads */
   SetState(ManagerStateInterrupted);
 


### PR DESCRIPTION
Fix crash every time kodi stop running pvr manager.

Program terminated with signal SIGSEGV, Segmentation fault.
0  __GI___pthread_mutex_lock (mutex=0x0) at ../nptl/pthread_mutex_lock.c:66
1  0x0000000001085ad3 in PVR::CPVRManager::QueueJob(CJob*) ()
2  0x00007f5328529794 in PVRClientMythTV::RunHouseKeeping() ()
3  0x00007f5328529968 in PVRClientMythTV::HandleBackendMessage(Myth::shared_ptr<Myth::EventMessage>)

Addons callback have to be closed before freeing of PVRManager resources.
