### PR TITLE
[gui] add option to only show full lines for textboxes

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -671,6 +671,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   std::string strLabel;
   int iUrlSet=0;
   std::string toggleSelect;
+  bool cutLastLine = false;
 
   float spinWidth = 16;
   float spinHeight = 16;
@@ -866,6 +867,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   XMLUtils::GetString(pControlNode, "usealttexture", toggleSelect);
   XMLUtils::GetString(pControlNode, "selected", toggleSelect);
+
+  XMLUtils::GetBoolean(pControlNode, "cutlastline", cutLastLine);
 
   XMLUtils::GetBoolean(pControlNode, "haspath", bHasPath);
 
@@ -1413,6 +1416,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       CGUITextBox* tcontrol = static_cast<CGUITextBox*>(control);
 
       tcontrol->SetPageControl(pageControl);
+      tcontrol->SetCutLastLine(cutLastLine);
       if (infoLabels.size())
         tcontrol->SetInfo(infoLabels[0]);
       tcontrol->SetAutoScrolling(pControlNode);

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -216,7 +216,7 @@ void CGUITextBox::Render()
       {
         float textHeight = m_font->GetTextHeight(std::min((unsigned int)m_lines.size(), m_itemsPerPage));
 
-        if (textHeight <= m_renderHeight)
+        if (textHeight < m_renderHeight)
           posY += (m_renderHeight - textHeight) * 0.5f;
       }
 

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -103,8 +103,12 @@ void CGUITextBox::UpdateInfo(const CGUIListItem *item)
   float textHeight = m_font ? m_font->GetTextHeight(m_lines.size()) : m_itemHeight * m_lines.size();
   float maxHeight = m_height ? m_height : textHeight;
   m_renderHeight = m_minHeight ? CLAMP(textHeight, m_minHeight, maxHeight) : m_height;
-  m_itemsPerPage = (unsigned int)(m_renderHeight / m_itemHeight);
-
+  m_itemsPerPage = static_cast<unsigned int>(m_renderHeight / m_itemHeight);
+  if (m_cutLastLine && !(m_label.align & XBFONT_CENTER_Y))
+  {
+    unsigned int visibleLines = std::min(static_cast<unsigned int>(m_lines.size()), m_itemsPerPage);
+    m_renderHeight = m_font ? m_font->GetTextHeight(visibleLines) : m_itemHeight * visibleLines;
+  }
   UpdatePageControl();
 }
 
@@ -324,6 +328,11 @@ void CGUITextBox::UpdatePageControl()
 bool CGUITextBox::CanFocus() const
 {
   return false;
+}
+
+void CGUITextBox::SetCutLastLine(bool cutLastLine)
+{
+  m_cutLastLine = cutLastLine;
 }
 
 void CGUITextBox::SetPageControl(int pageControl)

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -45,6 +45,7 @@ public:
   void SetPageControl(int pageControl);
 
   bool CanFocus() const override;
+  void SetCutLastLine(bool cutLastLine);
   void SetInfo(const KODI::GUILIB::GUIINFO::CGUIInfoLabel &info);
   void SetAutoScrolling(const TiXmlNode *node);
   void SetAutoScrolling(int delay, int time, int repeatTime, const std::string &condition = "");
@@ -93,5 +94,6 @@ protected:
   int m_pageControl;
 
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_info;
+  bool m_cutLastLine = false;
 };
 


### PR DESCRIPTION
Next scaling-related one:
Add an option for skinners to only show full lines for textboxes. Esp. useful when havin several fontsets with different sizing.
` <showfulllines>true</showfulllines>`

I would even be tempted to make this behaviour default since in 95% of cases cut-off textboxes are not wanted I think.