### PR TITLE
[keyboard] improvements to German keyboard layout

### DIFF
--- a/system/keyboardlayouts/german.xml
+++ b/system/keyboardlayouts/german.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 Please use English language names instead.
 Default font lacks support for all characters
@@ -9,13 +9,33 @@ Default font lacks support for all characters
       <row>1234567890ß</row>
       <row>qwertzuiopü</row>
       <row>asdfghjklöä</row>
-      <row>yxcvbnm</row>
+      <row>yxcvbnm.-/@</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>1234567890ß</row>
+      <row>!"§$%&amp;/()=?</row>
       <row>QWERTZUIOPÜ</row>
       <row>ASDFGHJKLÖÄ</row>
-      <row>YXCVBNM</row>
+      <row>YXCVBNM.-/@</row>
+    </keyboard>
+    <keyboard modifiers="symbol,shift+symbol">
+      <row>)!@#€§$%^&amp;*(</row>
+      <row>[]{}-_=+;:μ</row>
+      <row>'",.&lt;&gt;/?\|</row>
+      <row>`~</row>
+    </keyboard>
+  </layout>
+  <layout language="German" layout="ABC">
+    <keyboard>
+      <row>1234567890ß</row>
+      <row>abcdefghijk</row>
+      <row>lmnopqrstuv</row>
+      <row>wxyzöäü.-/@</row>
+    </keyboard>
+    <keyboard modifiers="shift">
+      <row>!"§$%&amp;/()=?</row>
+      <row>ABCDEFGHIJK</row>
+      <row>LMNOPQRSTUV</row>
+      <row>WXYZÄÖÜ.-/@</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>)!@#€§$%^&amp;*(</row>


### PR DESCRIPTION
## Description
Improves the layout of the German OSD keyboard by adding often used special chars to the default letter views like it has already been done for the English layout.

In addition, it's adding a ABC layout for German.

One change that is subject to discussion is, that I changed the number row to switch to special chars when using the SHIFT modifier, just like on regular keyboards. I'm not aware of another layout that does it, but felt it would make sense.

## Motivation and Context
current layout was annoying when typing mail-addresses or UNC paths

## How Has This Been Tested?
runtime tested

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed