### PR TITLE
[addons] remove no more needed lib incluce folders

### DIFF
--- a/addons/library.kodi.audioengine/.gitignore
+++ b/addons/library.kodi.audioengine/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/addons/library.kodi.game/.gitignore
+++ b/addons/library.kodi.game/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/addons/library.kodi.guilib/.gitignore
+++ b/addons/library.kodi.guilib/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/addons/library.kodi.inputstream/.gitignore
+++ b/addons/library.kodi.inputstream/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/addons/library.kodi.peripheral/.gitignore
+++ b/addons/library.kodi.peripheral/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/addons/library.xbmc.addon/.gitignore
+++ b/addons/library.xbmc.addon/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/addons/library.xbmc.codec/.gitignore
+++ b/addons/library.xbmc.codec/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
## Description
Since the shared add-on libraries are no more present are also the folders
no more needed and becomes removed with them.

## Motivation and Context
Binary add-on system rework

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
