### PR TITLE
[GUI] remember last used keyboard layout

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3275,6 +3275,10 @@
             <multiselect>true</multiselect>
           </control>
         </setting>
+        <setting id="locale.activekeyboardlayout" type="string" label="0" help="0">
+          <level>4</level>
+          <default>English QWERTY</default>
+        </setting>
       </group>
       <group id="2" label="14270">
         <setting id="locale.country" type="string" label="14271" help="36115">

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -133,12 +133,17 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   m_layouts.clear();
   const KeyboardLayouts& keyboardLayouts = CKeyboardLayoutManager::GetInstance().GetLayouts();
   std::vector<CVariant> layoutNames = CServiceBroker::GetSettings().GetList(CSettings::SETTING_LOCALE_KEYBOARDLAYOUTS);
+  std::string activeLayout = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT);
 
   for (std::vector<CVariant>::const_iterator layoutName = layoutNames.begin(); layoutName != layoutNames.end(); ++layoutName)
   {
     KeyboardLayouts::const_iterator keyboardLayout = keyboardLayouts.find(layoutName->asString());
     if (keyboardLayout != keyboardLayouts.end())
+    {
       m_layouts.push_back(keyboardLayout->second);
+      if (layoutName->asString() == activeLayout)
+        m_currentLayout = m_layouts.size() - 1;
+    }
   }
 
   // set alphabetic (capitals)
@@ -525,6 +530,8 @@ void CGUIDialogKeyboardGeneric::OnLayout()
   m_currentLayout++;
   if (m_currentLayout >= m_layouts.size())
     m_currentLayout = 0;
+  CKeyboardLayout layout = m_layouts.empty() ? CKeyboardLayout() : m_layouts[m_currentLayout];
+  CServiceBroker::GetSettings().SetString(CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT, layout.GetName());
   UpdateButtons();
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -106,6 +106,7 @@ const std::string CSettings::SETTING_LOCALE_LANGUAGE = "locale.language";
 const std::string CSettings::SETTING_LOCALE_COUNTRY = "locale.country";
 const std::string CSettings::SETTING_LOCALE_CHARSET = "locale.charset";
 const std::string CSettings::SETTING_LOCALE_KEYBOARDLAYOUTS = "locale.keyboardlayouts";
+const std::string CSettings::SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT = "locale.activekeyboardlayout";
 const std::string CSettings::SETTING_LOCALE_TIMEZONECOUNTRY = "locale.timezonecountry";
 const std::string CSettings::SETTING_LOCALE_TIMEZONE = "locale.timezone";
 const std::string CSettings::SETTING_LOCALE_SHORTDATEFORMAT = "locale.shortdateformat";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -62,6 +62,7 @@ public:
   static const std::string SETTING_LOCALE_COUNTRY;
   static const std::string SETTING_LOCALE_CHARSET;
   static const std::string SETTING_LOCALE_KEYBOARDLAYOUTS;
+  static const std::string SETTING_LOCALE_ACTIVEKEYBOARDLAYOUT;
   static const std::string SETTING_LOCALE_TIMEZONECOUNTRY;
   static const std::string SETTING_LOCALE_TIMEZONE;
   static const std::string SETTING_LOCALE_SHORTDATEFORMAT;


### PR DESCRIPTION
When having multiple keyboard layouts selected, the OSD keyboard will always show the first layout in the list. With this change, Kodi will remember the last used keyboard layout and will use that instead.

## Description
A hidden setting has been added which will be updated each time the layout is being changed.

## Motivation and Context
There is currently no way to define a preferred keyboard layout. Even when you select the keyboard layouts in a specific order, they will always be stored in alphabetical order. Remembering the last used layout makes a custom order superflous and is even more flexible.

## How Has This Been Tested?
runtime tested

## Types of change
added hidden setting to store the last active keyboard layout
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)