### PR TITLE
[cmake] Add FindMDNSEmbedded module (for Zeroconf on Android)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 # Optional dependencies
 set(optional_deps MicroHttpd MySqlClient SSH XSLT
-                  Alsa UDEV DBus Avahi SmbClient CCache
+                  Alsa UDEV DBus Avahi MDNS SmbClient CCache
                   PulseAudio VDPAU VAAPI Bluetooth CAP)
 
 # Required, dyloaded deps

--- a/cmake/modules/FindMDNS.cmake
+++ b/cmake/modules/FindMDNS.cmake
@@ -1,0 +1,47 @@
+#.rst:
+# FindMDNS
+# --------
+# Finds the mDNS library
+#
+# This will will define the following variables::
+#
+# MDNS_FOUND - system has mDNS
+# MDNS_INCLUDE_DIRS - the mDNS include directory
+# MDNS_LIBRARIES - the mDNS libraries
+# MDNS_DEFINITIONS - the mDNS definitions
+#
+# and the following imported targets::
+#
+#   MDNS::MDNS   - The mDNSlibrary
+
+find_path(MDNS_INCLUDE_DIR NAMES dmDnsEmbedded.h dns_sd.h)
+find_library(MDNS_LIBRARY NAMES mDNSEmbedded dnssd)
+
+find_path(MDNS_EMBEDDED_INCLUDE_DIR NAMES mDnsEmbedded.h)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(mDNS
+                                  REQUIRED_VARS MDNS_LIBRARY MDNS_INCLUDE_DIR)
+
+if(MDNS_FOUND)
+  set(MDNS_INCLUDE_DIRS ${MDNS_INCLUDE_DIR})
+  set(MDNS_LIBRARIES ${MDNS_LIBRARY})
+  set(MDNS_DEFINITIONS -DHAVE_LIBMDNS=1)
+  if(MDNS_EMBEDDED_INCLUDE_DIR)
+    list(APPEND MDNS_DEFINITIONS -DHAVE_LIBMDNSEMBEDDED=1)
+  endif()
+
+  if(NOT TARGET MDNS::MDNS)
+    add_library(MDNS::MDNS UNKNOWN IMPORTED)
+    set_target_properties(MDNS::MDNS PROPERTIES
+                                     IMPORTED_LOCATION "${MDNS_LIBRARY}"
+                                     INTERFACE_INCLUDE_DIRECTORIES "${MDNS_INCLUDE_DIR}"
+                                     INTERFACE_COMPILE_DEFINITIONS HAVE_LIBMDNS=1)
+    if(MDNS_EMBEDDED_INCLUDE_DIR)
+      set_target_properties(MDNS::MDNS PROPERTIES
+                                       INTERFACE_COMPILE_DEFINITIONS HAVE_LIBMDNSEMBEDDED=1)
+    endif()
+  endif()
+endif()
+
+mark_as_advanced(MDNS_INCLUDE_DIR MDNS_EMBEDDED_INCLUDE_DIR MDNS_LIBRARY)

--- a/cmake/treedata/optional/common/mdns.txt
+++ b/cmake/treedata/optional/common/mdns.txt
@@ -1,0 +1,1 @@
+xbmc/network/mdns mdns # MDNS

--- a/tools/depends/target/mdnsresponder/makefile.internal
+++ b/tools/depends/target/mdnsresponder/makefile.internal
@@ -12,6 +12,7 @@ OBJECTS += mDNSCore/DNSCommon.o mDNSShared/mDNSDebug.o mDNSShared/GenLinkedList.
 OBJECTS += mDNSCore/uDNS.o mDNSShared/PlatformCommon.o mDNSPosix/mDNSUNP.o
 OBJECTS += mDNSCore/DNSDigest.o mDNSCore/mDnsEmbedded.o mDNSShared/dnssd_clientlib.o
 OBJECTS += mDNSCore/CryptoAlg.o
+OBJECTS += mDNSCore/anonymous.o
 
 all: $(LIB)
 install: $(LIBDIR)/$(LIB) $(addprefix $(INCDIR)/,$(HEADERS))

--- a/xbmc/network/mdns/CMakeLists.txt
+++ b/xbmc/network/mdns/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(SOURCES ZeroconfBrowserMDNS.cpp
-            ZeroconfMDNS.cpp)
+if(MDNS_FOUND)
+  set(SOURCES ZeroconfBrowserMDNS.cpp
+              ZeroconfMDNS.cpp)
 
-set(HEADERS ZeroconfBrowserMDNS.h
-            ZeroconfMDNS.h)
+  set(HEADERS ZeroconfBrowserMDNS.h
+              ZeroconfMDNS.h)
 
-core_add_library(network_mdns)
+  core_add_library(network_mdns)
+endif()

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -35,8 +35,6 @@
 #include "platform/win32/WIN32Util.h"
 #endif //TARGET_WINDOWS
 
-#pragma comment(lib, "dnssd.lib")
-
 extern HWND g_hWnd;
 
 

--- a/xbmc/network/mdns/ZeroconfMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfMDNS.cpp
@@ -35,8 +35,6 @@
 #include <mDnsEmbedded.h>
 #endif //HAS_MDNS_EMBEDDED
 
-#pragma comment(lib, "dnssd.lib")
-
 extern HWND g_hWnd;
 
 void CZeroconfMDNS::Process()

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -71,10 +71,12 @@
   #define HAS_UPNP
 #endif
 
-#if defined(HAVE_LIBMDNSEMBEDDED)
+#if defined(HAVE_LIBMDNS)
   #define HAS_ZEROCONF
   #define HAS_MDNS
-  #define HAS_MDNS_EMBEDDED
+  #if defined(HAVE_LIBMDNSEMBEDDED)
+    #define HAS_MDNS_EMBEDDED
+  #endif
 #endif
 
 /**********************
@@ -93,8 +95,6 @@
 #define HAS_WIN32_NETWORK
 #define HAS_IRSERVERSUITE
 #define HAS_FILESYSTEM_SMB
-#define HAS_ZEROCONF
-#define HAS_MDNS
 
 #define DECLARE_UNUSED(a,b) a b;
 #endif


### PR DESCRIPTION
## Description
Zeroconf is not available on androd. It uses mDNSEmbedded which got forgotten when migrating to cmake.

@ping: @MartijnKaijser, @wsnipex, @hudokkow 

## Motivation and Context
Zeroconf for droids.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Compile tested.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
