### PR TITLE
[cmake/win32] Don't use system wide installed dependencies

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -18,6 +18,12 @@ list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependenci
 
 set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/python)
 
+# The find_* functions prefer PATH over CMAKE_PREFIX_PATH for dependencies.
+# Emptying PATH so that system installed libraries (MySql, Python) are not picked up.
+# The VS/bin directory has to be in PATH for example for NMake.
+get_filename_component(TOOLCHAIN_PATH ${CMAKE_CXX_COMPILER} DIRECTORY)
+set(ENV{PATH} "${TOOLCHAIN_PATH}")
+
 
 # -------- Compiler options ---------
 


### PR DESCRIPTION
Don't let cmake detect system wide installed libraries on windows.

## Description
Empty PATH (except VS Toolchain/bin) so that CMake won't pick up system wide installed dependencies (such as MySql or Python).

## Motivation and Context
I want to bring this up for discussion again, as we now had a few cases where cmake detected system wide installed libs on windows leading into compile errors. Old PR was https://github.com/xbmc/xbmc/pull/10194

## How Has This Been Tested?
by @phate89 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@Paxxi I know that you didn't like it last time I suggested this. I think it's still better than wasting time to debug weird errors on dev machines.
Ping some more win devs: @afedchin, @AchimTuran 