### PR TITLE
FFmpeg: Bump to final 3.1.6-Krypton

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.6-Krypton-Beta6
+VERSION=3.1.6-Krypton
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
This should be the version we ship with Krypton. Needs backport. After that master should go into 3.2 direction as we will hit 3.3 soon.