### PR TITLE
convolution-6x6: Fix assignemnt of vec4

### DIFF
--- a/system/shaders/convolution-6x6.glsl
+++ b/system/shaders/convolution-6x6.glsl
@@ -106,7 +106,7 @@ vec4 process()
   vec3 xpos1 = vec3(xystart.x, xystart.x + stepxy.x, xystart.x + stepxy.x * 2.0);
   vec3 xpos2 = vec3(xystart.x + stepxy.x * 3.0, xystart.x + stepxy.x * 4.0, xystart.x + stepxy.x * 5.0);
 
-  rgb =
+  rgb.rgb =
    line(xystart.y                 , xpos1, xpos2, linetaps1, linetaps2) * columntaps1.r +
    line(xystart.y + stepxy.y      , xpos1, xpos2, linetaps1, linetaps2) * columntaps2.r +
    line(xystart.y + stepxy.y * 2.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.g +


### PR DESCRIPTION
Nobodoy realized that hqscalers don't work. Reason: It was hidden behind an advancedsetting that most likely no one ever used. See linux forum report. Fix is trivial.