### PR TITLE
[cmake/depends] Add info about Android SDK/NDK to Toolchain_binaddons…

### DIFF
--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -48,6 +48,14 @@ if(CORE_SYSTEM_NAME STREQUAL rbpi)
   list(APPEND CMAKE_INCLUDE_PATH @CMAKE_FIND_ROOT_PATH@/include:@use_firmware@/opt/vc/include)
 endif()
 
+# add Android directories and tools
+if(CORE_SYSTEM_NAME STREQUAL android)
+  set(NDKROOT @use_ndk@)
+  set(SDKROOT @use_sdk_path@)
+  set(SDK_PLATFORM @use_sdk@)
+  string(REPLACE ":" ";" SDK_BUILDTOOLS_PATH "@build_tools_path@")
+endif()
+
 set(CMAKE_C_FLAGS "@platform_cflags@ @platform_includes@")
 set(CMAKE_CXX_FLAGS "@platform_cxxflags@ @platform_includes@")
 set(CMAKE_CPP_FLAGS "@platform_cflags@ @platform_includes@")


### PR DESCRIPTION
….cmake.in

Copied from Toolchain.cmake.in. This is necessary to build libretro cores with the Android NDK where we need access to NDKROOT/ndk-build.

@garbear: please pick