### PR TITLE
[Python] add setContent for mediawindows

### DIFF
--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -271,6 +271,13 @@ namespace XBMCAddon
       A(m_vecItems)->SetProperty(key, value);
     }
 
+    void WindowXML::setContent(const String& value)
+    {
+      XBMC_TRACE;
+      LOCKGUI;
+      A(m_vecItems)->SetContent(value);
+    }
+
     int WindowXML::getCurrentContainerId()
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -352,6 +352,56 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_window_xml
+      /// @brief \python_func{ setContent(value) }
+      ///-----------------------------------------------------------------------
+      /// Sets the content type of the container.
+      ///
+      /// @param value          string or unicode - content value.
+      ///
+      /// __Available content types__
+      /// | Name        | Media                                    |
+      /// |:-----------:|:-----------------------------------------|
+      /// | actors      | Videos
+      /// | addons      | Addons, Music, Pictures, Programs, Videos
+      /// | albums      | Music, Videos
+      /// | artists     | Music, Videos
+      /// | countries   | Music, Videos
+      /// | directors   | Videos
+      /// | files       | Music, Videos
+      /// | games       | Games
+      /// | genres      | Music, Videos
+      /// | images      | Pictures
+      /// | mixed       | Music, Videos
+      /// | movies      | Videos
+      /// | Musicvideos | Music, Videos
+      /// | playlists   | Music, Videos
+      /// | seasons     | Videos
+      /// | sets        | Videos
+      /// | songs       | Music
+      /// | studios     | Music, Videos
+      /// | tags        | Music, Videos
+      /// | tvshows     | Videos
+      /// | videos      | Videos
+      /// | years       | Music, Videos
+      ///
+      /// ------------------------------------------------------------------------
+      /// @python_v18 Added new function.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// self.setContent('movies')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      setContent(...);
+#else
+      SWIGHIDDENVIRTUAL void setContent(const String &strValue);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_window_xml
       /// @brief \python_func{ getCurrentContainerId() }
       ///-----------------------------------------------------------------------
       /// Get the id of the currently visible container.


### PR DESCRIPTION
allow addons that use WindowXML to create a mediawindow to set the content type of the container.

@tamland / @phil65 