### PR TITLE
[cmake] Fix build with -DENABLE_MICROHTTPD=no and no libmicrohttpd

### DIFF
--- a/project/cmake/treedata/common/interfaces.txt
+++ b/project/cmake/treedata/common/interfaces.txt
@@ -5,5 +5,4 @@ xbmc/interfaces/info            interfaces/info
 xbmc/interfaces/json-rpc        interfaces/json-rpc
 xbmc/interfaces/json-rpc/schema interfaces/json-rpc/schema
 xbmc/interfaces/legacy          interfaces/legacy
-xbmc/interfaces/legacy/wsgi     interfaces/legacy/wsgi
 xbmc/interfaces/python          interfaces/python

--- a/project/cmake/treedata/optional/common/webserver.txt
+++ b/project/cmake/treedata/optional/common/webserver.txt
@@ -1,2 +1,3 @@
+xbmc/interfaces/legacy/wsgi interfaces/legacy/wsgi # MICROHTTPD
 xbmc/network/httprequesthandler network/httprequesthandler # MICROHTTPD
 xbmc/network/httprequesthandler/python network/httprequesthandler/python # MICROHTTPD


### PR DESCRIPTION
## Motivation and Context
Build fails with -DENABLE_MICROHTTPD=no if libmicrohttpd is not installed:
```
In file included from /var/tmp/portage/media-tv/kodi-17.0_beta7/work/xbmc-17.0b7-Krypton/xbmc/network/httprequesthandler/python/HTTPPythonRequest.h:28:0,
                 from /var/tmp/portage/media-tv/kodi-17.0_beta7/work/xbmc-17.0b7-Krypton/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.cpp:22:
/var/tmp/portage/media-tv/kodi-17.0_beta7/work/xbmc-17.0b7-Krypton/xbmc/network/httprequesthandler/IHTTPRequestHandler.h:32:24:fatal error: microhttpd.h: No such file or directory
compilation terminated.
build/interfaces/legacy/wsgi/CMakeFiles/legacy_interface_wsgi.dir/build.make:62: recipe for target 'build/interfaces/legacy/wsgi/CMakeFiles/legacy_interface_wsgi.dir/WsgiErrorStream.cpp.o' failed
make[2]: *** [build/interfaces/legacy/wsgi/CMakeFiles/legacy_interface_wsgi.dir/WsgiErrorStream.cpp.o] Error 1
make[2]: Leaving directory '/var/tmp/portage/media-tv/kodi-17.0_beta7/work/kodi-17.0_beta7_build'
CMakeFiles/Makefile2:3430: recipe for target 'build/interfaces/legacy/wsgi/CMakeFiles/legacy_interface_wsgi.dir/all' failed
make[1]: *** [build/interfaces/legacy/wsgi/CMakeFiles/legacy_interface_wsgi.dir/all] Error 2
```
## How Has This Been Tested?
I've only tested on kodi 17.0 Beta7 with -DENABLE_MICROHTTPD=no and no libmicrohttpd.
So needs more checking and presumably applying to master too but does look like:
https://github.com/xbmc/xbmc/pull/7510/files#diff-7e056ddc530791272d363e50c1f25647

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
