### PR TITLE
[PVR] Fix guide window: do not jump to grid start on channel group change; go to 'now' instead

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -240,6 +240,7 @@
       <e>PreviousMenu</e>
       <t>ShowTimerRule</t>
       <epg>PreviousMenu</epg>
+      <g>NextChannelGroup</g>
       <backspace mod="longpress">Number0</backspace> <!-- 0 key goes to "now" on EPG timeline -->
       <browser_back mod="longpress">Number0</browser_back> <!-- 0 key goes to "now" on EPG timeline -->
     </keyboard>

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -748,7 +748,7 @@ void CGUIEPGGridContainer::UpdateItems()
     }
   }
 
-  if (prevSelectedEpgTag)
+  if (prevSelectedEpgTag && (oldChannelIndex != 0 || oldBlockIndex != 0))
   {
     if (m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag() != prevSelectedEpgTag)
       m_gridModel->FindChannelAndBlockIndex(channelUid, broadcastUid, eventOffset, newChannelIndex, newBlockIndex);


### PR DESCRIPTION
Reported in the forum (http://forum.kodi.tv/showthread.php?tid=301765). Annoying bug. 

Additionally, I added a keyboard shortcut key for switching channel groups as it is very complicated to do otherwise (scroll left to begin of grid, open side blade, select new channel group, close side blade).

@Jalle19 mind doing the review