### PR TITLE
[PVR] Fix guide window: do not jump to grid start on channel group change; go to 'now' instead

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -239,6 +239,7 @@
       <e>PreviousMenu</e>
       <t>ShowTimerRule</t>
       <epg>PreviousMenu</epg>
+      <g>NextChannelGroup</g>
       <backspace mod="longpress">Number0</backspace> <!-- 0 key goes to "now" on EPG timeline -->
       <browser_back mod="longpress">Number0</browser_back> <!-- 0 key goes to "now" on EPG timeline -->
     </keyboard>

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -602,7 +602,7 @@ void CGUIEPGGridContainer::UpdateItems()
     }
   }
 
-  if (prevSelectedEpgTag)
+  if (prevSelectedEpgTag && (oldChannelIndex != 0 || oldBlockIndex != 0))
   {
     if (m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag() != prevSelectedEpgTag)
       m_gridModel->FindChannelAndBlockIndex(channelUid, broadcastUid, eventOffset, newChannelIndex, newBlockIndex);


### PR DESCRIPTION
Backport of #11263 

@Jalle19 for review?