### PR TITLE
Websocket connection header is case-insensitive

### DIFF
--- a/xbmc/network/websocket/WebSocketV13.cpp
+++ b/xbmc/network/websocket/WebSocketV13.cpp
@@ -102,7 +102,7 @@ bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &resp
 
   // There must be a "Connection" header with the value "Upgrade"
   value = header.getValue(WS_HEADER_CONNECTION_LC);
-  if (value == NULL || strstr(value, WS_HEADER_UPGRADE) == NULL)
+  if (value == NULL || strnicmp(value, WS_HEADER_UPGRADE, strlen(WS_HEADER_UPGRADE)) != 0)
   {
     CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_CONNECTION_LC);
     return true;


### PR DESCRIPTION
## Description
This change makes the websocket connection header check case insensitive. Per [RFC 6455, 4.2.1.4](https://tools.ietf.org/html/rfc6455#section-4.2.1), this check should be case insensitive.

## Motivation and Context
Not all websocket clients will send the connection header using the same case that Kodi is expecting. See KeepSafe/aiohttp#1495.

## How Has This Been Tested?
This has been tested by connecting to Kodi using Python's aiohttp v1.2.0, using the following test script:

```python
import aiohttp
import asyncio

@asyncio.coroutine
def main(loop):
    client = aiohttp.ClientSession(loop=loop)
    ws = yield from client.ws_connect('ws://192.168.1.193:9090/jsonrpc')
    while True:
        msg = yield from ws.receive()
        if msg.type == aiohttp.WSMsgType.TEXT:
            print(msg)
        elif msg.type == aiohttp.WSMsgType.CLOSED:
            break
        elif msg.type == aiohttp.WSMsgType.ERROR:
            break

loop = asyncio.get_event_loop()
loop.run_until_complete(main(loop))
```

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
