### PR TITLE
[PVR] PVR windows: Fix item selection on window update.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -348,7 +348,29 @@ bool CGUIWindowPVRBase::Update(const std::string &strDirectory, bool updateFilte
     return false;
   }
 
-  return CGUIMediaWindow::Update(strDirectory, updateFilterPath);
+  int iOldCount = m_vecItems->GetObjectCount();
+  int iSelectedItem = m_viewControl.GetSelectedItem();
+  const std::string oldPath = m_vecItems->GetPath();
+
+  bool bReturn = CGUIMediaWindow::Update(strDirectory, updateFilterPath);
+
+  if (bReturn &&
+      iSelectedItem != -1 && // something must have been selected
+      iOldCount > 0) // more than only ".." item or nothing in previous item list
+  {
+    int iNewCount = m_vecItems->GetObjectCount();
+    if (iOldCount > iNewCount && // at least one item removed by Update()
+        oldPath == m_vecItems->GetPath()) // update not due changing into another folder
+    {
+      // restore selected item if we just deleted one or more items.
+      if (iSelectedItem >= iNewCount)
+        iSelectedItem = iNewCount - 1;
+
+      m_viewControl.SetSelectedItem(iSelectedItem);
+    }
+  }
+
+  return bReturn;
 }
 
 void CGUIWindowPVRBase::UpdateButtons(void)


### PR DESCRIPTION
After deleting a recording/timer/timer rule/channel using the respective pvr window, the first item in the item list was selected. This is very annoying behavior, for instance if you want to delete some items in a row. Example: you have ten items and want to delete item 5 to 10:

Old behavior:
- travel to item 5
- delete item 5 => item disappears, item 1 gets selected
- travel down from item 1 to the new item 5
- delete item 5 => item disappears, item 1 gets selected
- travel down from item 1 to the new item 5
...

New behavior:
- travel to item 5
- delete item 5 => item disappears, new item 5 gets selected
- delete new item 5 => item disappears, new item 5 gets selected
...
- delete item 5 that was originally item 10 => item disappears, item 4 gets selected

Runtime-tested on latest linux and macOS master.

@Jalle19 mind doing the review
