### PR TITLE
Recalculate SyncClock after reconfigure

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -319,6 +319,7 @@ bool CRenderManager::Configure()
     m_renderedOverlay = false;
     m_renderDebug = false;
     m_clockSync.Reset();
+    CheckEnableClockSync();
 
     m_renderState = STATE_CONFIGURED;
 


### PR DESCRIPTION
Recalculate SyncClock after reconfigure

## Description
On Streamchange the Sync-Clock stays disabled, if the frame rate does not change.
This PR checks at configure time, if the sync clock must be setup.
