### PR TITLE
System > Audio option "Maintain original volume on downmix" wording change

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1590,7 +1590,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#346"
-msgid "Maintain original volume on downmix"
+msgid "Reduce loud sounds"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -19289,10 +19289,10 @@ msgctxt "#36532"
 msgid "Same as movie"
 msgstr ""
 
-#. Description of setting with label #346 "Normalize levels on downmix"
+#. Description of setting with label #346 "Reduce loud sounds"
 #: settings/DisplaySettings.cpp
 msgctxt "#36533"
-msgid "Select how audio is downmixed, e.g. from 5.1 to 2.0.[CR][Enabled] Maintains volume level of the original audio source however the dynamic range is compressed.[CR][Disabled] Maintains the dynamic range of the original audio source when downmixed however volume will be lower. Note: Dynamic range is the difference between the quietest and loudest sounds in an audio source. Enable this setting if movie dialogues are barely audible."
+msgid "Turn on Reduce loud sounds to enjoy films and music without disturbing others. Experience softer sound effects and music, but keep all the detail of the original sound level."
 msgstr ""
 
 #. Description of setting with label #668 "Component-specific logging..."


### PR DESCRIPTION
Freely taken from the ATV4 settings, I thought that this option can be worded in a less technical form as the ATV4 does.

## Motivation and Context
reduce technical jargon where we can

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
