### PR TITLE
wait for network after resuming from suspend

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20394,3 +20394,14 @@ msgstr ""
 msgctxt "#39010"
 msgid "Select sort method"
 msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39011"
+msgid "Maximum wait time for network"
+msgstr ""
+
+#. Description of setting with label #39011 "Maximum wait time for network"
+#: system/settings/settings.xml
+msgctxt "#39012"
+msgid "Set the maximum time to wait for the network to come up after waking up. When time has passed before network is up startup will continue."
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2890,6 +2890,18 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="powermanagement.waitnetafterwakeup" type="integer" label="39011" help="39012">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum label="351">0</minimum>
+            <step>1</step>
+            <maximum>30</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>14045</formatlabel>
+          </control>
+        </setting>
       </group>
       <group id="2" label="14256">
         <setting id="powermanagement.wakeonaccess" type="boolean" label="13026" help="36350">

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -32,6 +32,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
+#include "network/Network.h"
 #include "pvr/PVRManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -55,6 +56,10 @@
 #elif defined(TARGET_WINDOWS)
 #include "powermanagement/windows/Win32PowerSyscall.h"
 extern HWND g_hWnd;
+#endif
+
+#if defined(TARGET_POSIX)
+#include "linux/XTimeUtils.h"
 #endif
 
 using namespace ANNOUNCEMENT;
@@ -270,6 +275,12 @@ void CPowerManager::OnWake()
 {
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
 
+  {
+    const int waitNetTimeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_POWERMANAGEMENT_WAITNETAFTERWAKEUP);
+    if (waitNetTimeout > 0)
+      WaitForNet(waitNetTimeout);
+  }
+
   // reset out timers
   g_application.ResetShutdownTimers();
 
@@ -326,4 +337,32 @@ void CPowerManager::SettingOptionsShutdownStatesFiller(const CSetting *setting, 
     list.push_back(make_pair(g_localizeStrings.Get(13014), POWERSTATE_MINIMIZE));
 #endif
   }
+}
+
+void CPowerManager::WaitForNet(int timeout) const
+{
+  CNetwork& net = g_application.getNetwork();
+
+  // check if we have at least one network interface to wait for
+  if (!net.IsAvailable())
+    return;
+
+  CLog::Log(LOGNOTICE, "%s: Waiting for a network interface to come up (Timeout: %d s)", __FUNCTION__, timeout);
+
+  const static int intervalMs = 200;
+  const int numMaxTries = (timeout * 1000) / intervalMs;
+
+  for(int i=0; i < numMaxTries; ++i)
+  {
+    if (i > 0)
+      Sleep(intervalMs);
+
+    if (net.IsConnected())
+    {
+      CLog::Log(LOGNOTICE, "%s: A network interface is up after waiting %d ms", __FUNCTION__, i * intervalMs);
+      return;
+    }
+  }
+
+  CLog::Log(LOGNOTICE, "%s: No network interface did come up within %d s... Giving up...", __FUNCTION__, timeout);
 }

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -93,6 +93,8 @@ private:
 
   void OnLowBattery();
 
+  void WaitForNet(int timeout) const;
+
   IPowerSyscall *m_instance;
 };
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -392,6 +392,7 @@ const std::string CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF = "powermanagem
 const std::string CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNTIME = "powermanagement.shutdowntime";
 const std::string CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE = "powermanagement.shutdownstate";
 const std::string CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS = "powermanagement.wakeonaccess";
+const std::string CSettings::SETTING_POWERMANAGEMENT_WAITNETAFTERWAKEUP = "powermanagement.waitnetafterwakeup";
 const std::string CSettings::SETTING_DEBUG_SHOWLOGINFO = "debug.showloginfo";
 const std::string CSettings::SETTING_DEBUG_EXTRALOGGING = "debug.extralogging";
 const std::string CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL = "debug.setextraloglevel";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -348,6 +348,7 @@ public:
   static const std::string SETTING_POWERMANAGEMENT_SHUTDOWNTIME;
   static const std::string SETTING_POWERMANAGEMENT_SHUTDOWNSTATE;
   static const std::string SETTING_POWERMANAGEMENT_WAKEONACCESS;
+  static const std::string SETTING_POWERMANAGEMENT_WAITNETAFTERWAKEUP;
   static const std::string SETTING_DEBUG_SHOWLOGINFO;
   static const std::string SETTING_DEBUG_EXTRALOGGING;
   static const std::string SETTING_DEBUG_SETEXTRALOGLEVEL;


### PR DESCRIPTION
Makes Kodi wait for network connection after resuming from suspend.

## Description
This introduces a function `WaitForNet` in Kodi's power manager which will block (with a timeout) until at least one network interface is initialized and connected. This function is invoked in `OnWake` so it is triggered on every wake up.
This behavior is disabled by default and has to be activated by a new advanced setting:
```
    <suspend>
        <waitnetonwakeup>true</waitnetonwakeup>
    </suspend>
```

This new setting would have to be documented on the Wiki I guess.

## Motivation and Context
When waking the machine from sleep/suspend and directly trying to access network resources (e.g. playing a video or reading from the MySQL DB) then Kodi will fail cause the network has not been initialized yet.
I have experienced and described this issue here:
http://forum.kodi.tv/showthread.php?tid=301976

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
I tested it on a Intel NUC i5 using LibreELEC 7.02 using a wired network. I tested it by suspending the machine and waking it up again. Then I observed the behavior with and without this setting enabled. With the setting enabled Kodi blocked for several seconds and put something like this in the logfile:

```
12:51:10 T:140441393608768  NOTICE: OnWake: Running resume jobs
12:51:10 T:140441393608768  NOTICE: WaitForNet: Waiting for first network interface to come up
12:51:18 T:140441393608768  NOTICE: WaitForNet: network interface 'eth0' is up after waiting 7400 ms
12:51:18 T:140441393608768  NOTICE: OnWake: Restarting lirc
```

After this I could use Kodi and directly access network resources without issues.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
