### PR TITLE
Hide device event notifications

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -384,7 +384,8 @@ void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral 
 {
   OnDeviceChanged();
 
-  bool bNotify = true;
+  //! @todo Improve device notifications in v18
+  bool bNotify = false;
 
   // don't show a notification for emulated peripherals
   if (peripheral.Type() == PERIPHERAL_JOYSTICK_EMULATION) //! @todo Change to peripheral.IsEmulated()


### PR DESCRIPTION
Until device notifications are better implemented (or we decide to remove them), disable them for now.

I'll backport to Krypton. I sent the initial PR to master to minimize branch divergence.