### PR TITLE
VideoPlayer: fix unwanted kick-in of dirty regions

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -350,14 +350,13 @@ void CRenderManager::FrameWait(int ms)
     m_presentevent.wait(lock, timeout.MillisLeft());
 }
 
-bool CRenderManager::HasFrame()
+bool CRenderManager::IsPresenting()
 {
   if (!IsConfigured())
     return false;
 
   CSingleLock lock(m_presentlock);
-  if (m_presentstep == PRESENT_READY ||
-      m_presentstep == PRESENT_FRAME || m_presentstep == PRESENT_FRAME2)
+  if (!m_presentTimer.IsTimePast())
     return true;
   else
     return false;
@@ -402,6 +401,7 @@ void CRenderManager::FrameMove()
       m_pRenderer->FlipPage(m_presentsource);
       m_presentstep = PRESENT_FRAME;
       m_presentevent.notifyAll();
+      m_presentTimer.Set(1000);
     }
 
     // release all previous
@@ -980,7 +980,7 @@ bool CRenderManager::IsGuiLayer()
     if (!m_pRenderer)
       return false;
 
-    if ((m_pRenderer->IsGuiLayer() && HasFrame()) ||
+    if ((m_pRenderer->IsGuiLayer() && IsPresenting()) ||
         m_renderedOverlay || m_overlays.HasOverlay(m_presentsource))
       return true;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -393,6 +393,7 @@ void CRenderManager::FrameMove()
       m_presentstep = PRESENT_IDLE;
     }
 
+	CLog::Log(LOGNOTICE, "----------- Framemove - presentstep: %f, resenting: %d", m_presentstep, IsPresenting());
     if (m_presentstep == PRESENT_READY)
       PrepareNextRender();
 
@@ -987,6 +988,7 @@ bool CRenderManager::IsGuiLayer()
     if (m_renderDebug && m_debugTimer.IsTimePast())
       return true;
   }
+  CLog::Log(LOGNOTICE, "----------- IsGuiLayer - false");
   return false;
 }
 
@@ -1280,6 +1282,8 @@ void CRenderManager::PrepareNextRender()
   if (m_dvdClock.GetClockSpeed() < 0)
     nextFramePts = renderPts;
 
+  CLog::Log(LOGNOTICE, "----------- PrepareNextRender: queued: %d, discard: %d, free %d", m_queued.size(), m_discard.size(), m_free.size());
+
   if (m_clockSync.m_enabled)
   {
     double err = fmod(renderPts - nextFramePts, frametime);
@@ -1293,6 +1297,7 @@ void CRenderManager::PrepareNextRender()
       m_clockSync.m_errCount = 0;
 
       m_dvdClock.SetVsyncAdjust(-average);
+	  CLog::Log(LOGNOTICE, "----------- vsyncoff: %f", average);
     }
     renderPts += frametime / 2 - m_clockSync.m_syncOffset;
   }
@@ -1318,6 +1323,7 @@ void CRenderManager::PrepareNextRender()
         break;
       idx = *iter;
       ++iter;
+	  CLog::Log(LOGNOTICE, "----------- skip");
     }
 
     // skip late frames
@@ -1328,8 +1334,11 @@ void CRenderManager::PrepareNextRender()
     }
 
     int lateframes = (renderPts - m_Queue[idx].pts) * m_fps / DVD_TIME_BASE;
-    if (lateframes)
-      m_lateframes += lateframes;
+	if (lateframes)
+	{
+		CLog::Log(LOGNOTICE, "----------- lateframes curr: %d, new: %d", m_lateframes, lateframes);
+		m_lateframes += lateframes;
+	}
     else
       m_lateframes = 0;
     
@@ -1339,6 +1348,10 @@ void CRenderManager::PrepareNextRender()
     m_queued.pop_front();
     m_presentpts = m_Queue[idx].pts - totalLatency;
     m_presentevent.notifyAll();
+  }
+  else
+  {
+	  CLog::Log(LOGNOTICE, "----------- PrepareNextRender - no flip");
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -72,7 +72,6 @@ public:
   float GetAspectRatio();
   void FrameMove();
   void FrameWait(int ms);
-  bool HasFrame();
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);
   bool IsGuiLayer();
   bool IsVideoLayer();
@@ -163,6 +162,7 @@ protected:
   void PresentBlend(bool clear, DWORD flags, DWORD alpha);
 
   void PrepareNextRender();
+  bool IsPresenting();
 
   bool Configure();
   void CreateRenderer();
@@ -241,6 +241,7 @@ protected:
   int m_lateframes;
   double m_presentpts;
   EPRESENTSTEP m_presentstep;
+  XbmcThreads::EndTime m_presentTimer;
   bool m_forceNext;
   int m_presentsource;
   XbmcThreads::ConditionVariable  m_presentevent;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -1190,7 +1190,6 @@ void CRenderSystemDX::PresentRenderImpl(bool rendered)
   }
 
   FinishCommandList();
-  m_pImdContext->Flush();
 
   hr = m_pSwapChain->Present((m_bVSync ? 1 : 0), 0);
 


### PR DESCRIPTION
fix for http://trac.kodi.tv/ticket/17100

scenario:
rendering is slightly late and frames are skipped, last buffer is rendered, swapBuffers does not block   and render threads spins through without giving vp a chance to deliver a new frame. present state is set to idle and dirty regions kick in. render thread sleeps for 40ms and story continues.

now we go to idle one second after last frame was submitted to renderer