### PR TITLE
[PVR] Fix PVR Manager crash on startup

### DIFF
--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -701,6 +701,8 @@ namespace PVR
     ManagerState                    m_managerState;
     std::unique_ptr<CStopWatch>     m_parentalTimer;
 
+    CCriticalSection                m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */
+
     std::atomic_bool m_isChannelPreview;
     CEventSource<PVREvent> m_events;
   };

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -85,7 +85,7 @@ void CThread::Create(bool bAutoDelete, unsigned stacksize)
 {
   if (m_ThreadId != 0)
   {
-    LOG(LOGERROR, "%s - fatal error creating thread- old thread id not null", __FUNCTION__);
+    LOG(LOGERROR, "%s - fatal error creating thread %s - old thread id not null", __FUNCTION__, m_ThreadName.c_str());
     exit(1);
   }
   m_iLastTime = XbmcThreads::SystemClockMillis() * 10000;


### PR DESCRIPTION
This fixes a race condition in CPVRManager that might lead to a crash during pvr startup/restart.

The problem was reported in the forum (http://forum.kodi.tv/showthread.php?tid=300054&pid=2485565#pid2485565 ff) and by @peak3d 

This fix has been runtime tested by me (Linux, macOS), the guy that reported the problem in the forum (Windows) and by @peak3d.

The solution to introduce a separate mutex to protect start/restart of pvr manager was discussed Team Kodi internally.

@Jalle19 mind doing the review
@fritsch @Paxxi fyi