### PR TITLE
[guiinfo][PVR] Fix 'player.starttime' and 'player.finishtime'

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7941,32 +7941,18 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   }
   else if (info.m_info == PLAYER_FINISH_TIME)
   {
-    CDateTime time;
-    CEpgInfoTagPtr currentTag(GetEpgInfoTag());
-    if (currentTag)
-      time = currentTag->EndAsLocalTime();
-    else
-    {
-      time = CDateTime::GetCurrentDateTime();
-      int playTimeRemaining = GetPlayTimeRemaining();
-      float speed = g_application.m_pPlayer->GetPlaySpeed();
-      if (speed >= 0.75 && speed <= 1.55)
-        playTimeRemaining /= speed;
-      time += CDateTimeSpan(0, 0, 0, playTimeRemaining);
-    }
+    CDateTime time(CDateTime::GetCurrentDateTime());
+    int playTimeRemaining = GetPlayTimeRemaining();
+    float speed = g_application.m_pPlayer->GetPlaySpeed();
+    if (speed >= 0.75 && speed <= 1.55)
+      playTimeRemaining /= speed;
+    time += CDateTimeSpan(0, 0, 0, playTimeRemaining);
     return LocalizeTime(time, (TIME_FORMAT)info.GetData1());
   }
   else if (info.m_info == PLAYER_START_TIME)
   {
-    CDateTime time;
-    CEpgInfoTagPtr currentTag(GetEpgInfoTag());
-    if (currentTag)
-      time = currentTag->StartAsLocalTime();
-    else
-    {
-      time = CDateTime::GetCurrentDateTime();
-      time -= CDateTimeSpan(0, 0, 0, (int)GetPlayTime());
-    }
+    CDateTime time(CDateTime::GetCurrentDateTime());
+    time -= CDateTimeSpan(0, 0, 0, static_cast<int>(GetPlayTime()));
     return LocalizeTime(time, (TIME_FORMAT)info.GetData1());
   }
   else if (info.m_info == PLAYER_TIME_SPEED)


### PR DESCRIPTION
Fix 'player.starttime' and 'player.finishtime' info labels to properly support live tv timeshifting.

These info labels did not take live tv timeshifting into account as they always took static start and end time from the epg event currently played which is not correct when timeshifting live tv.

![screenshot002](https://cloud.githubusercontent.com/assets/3226626/21521698/acd40b78-ccff-11e6-8529-72449c0ef5ac.png)

 Fix was pretty easy, the special epg tag handling for these info labels could just be removed, as player (nowadays) handles this internally and correct.

 Runtime tested on latest master on macOS and Linux.

@phil65 fyi
@Jalle19 i would like to ask you to do the code review
