### PR TITLE
Backport Fix Party Mode and Singles Node missing song information  - ticket 17142

### DIFF
--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -629,7 +629,7 @@ bool CPartyModeManager::AddInitialSongs(std::vector< std::pair<int,int > > &song
       sqlWhereMusic[sqlWhereMusic.size() - 1] = ')'; // replace the last comma with closing bracket
       CMusicDatabase database;
       database.Open();
-      database.GetSongsByWhere("musicdb://songs/", sqlWhereMusic, items);
+      database.GetSongsFullByWhere("musicdb://songs/", sqlWhereMusic, items, SortDescription(), true);
     }
     if (sqlWhereVideo.size() > 19)
     {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -35,7 +35,7 @@ bool CDirectoryNodeSingles::GetContent(CFileItemList& items) const
   if (!musicdatabase.Open())
     return false;
 
-  bool bSuccess=musicdatabase.GetSongsByWhere(BuildPath(), CDatabase::Filter(), items);
+  bool bSuccess = musicdatabase.GetSongsFullByWhere(BuildPath(), CDatabase::Filter(), items, SortDescription(), true);
 
   musicdatabase.Close();
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5257,17 +5257,15 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &f
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    // We don't use PrepareSQL here, as the WHERE clause is already formatted
-    std::string strSQL = PrepareSQL("select %s from songview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    // Get a random song that matches filter criteria (which may exclude some songs)
+    // We don't use PrepareSQL here, as the WHERE clause is already formatted but must
+    // use songview as that is what the WHERE clause has as reference table
+    std::string strSQL = "SELECT idSong FROM songview ";
     Filter extFilter = filter;
     extFilter.AppendOrder(PrepareSQL("RANDOM()"));
     extFilter.limit = "1";
-
     if (!CDatabase::BuildSQL(strSQL, extFilter, strSQL))
       return false;
-
-    CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
-    // run query
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -5276,10 +5274,19 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &f
       m_pDS->close();
       return false;
     }
-    GetFileItemFromDataset(item, CMusicDbUrl());
     idSong = m_pDS->fv("songview.idSong").get_asInt();
     m_pDS->close();
-    return true;
+
+    // Fetch the full song details, including contributors
+    std::string baseDir = StringUtils::Format("musicdb://songs/?songid=%d", idSong);
+    CFileItemList items;
+    GetSongsFullByWhere(baseDir, Filter(), items, SortDescription(), true);
+    if (items.Size() > 0)
+    {
+      *item = *items[0];      
+      return true;
+    }
+    return false;
   }
   catch(...)
   {
@@ -6584,6 +6591,9 @@ bool CMusicDatabase::GetFilter(CDbUrl &musicUrl, Filter &filter, SortDescription
     option = options.find("compilation");
     if (option != options.end())
       filter.AppendWhere(PrepareSQL("songview.bCompilation = %i", option->second.asBoolean() ? 1 : 0));
+    
+    if (idSong > 0)
+      filter.AppendWhere(PrepareSQL("songview.idSong = %i", idSong));
 
     if (idAlbum > 0)
       filter.AppendWhere(PrepareSQL("songview.idAlbum = %i", idAlbum));


### PR DESCRIPTION
This is a backport of #11286 it fixes Trac ticket #17142
When showing Song Info dialog for items in current playlist in party mode, or in the Singles node, the contributors (control 50) control list is empty. 

This is because the contributor data was not being fetched from the database by `CMusicDatabase::GetRandomSong`, and `CPartyModeManager::AddInitialSongs` was not calling  `CMusicDatabase::GetSongsFullByWhere`. Likewise with `CDirectoryNodeSingles::GetContent`.
