### PR TITLE
Recalculate SyncClock after reconfigure

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -318,6 +318,7 @@ bool CRenderManager::Configure()
     m_renderedOverlay = false;
     m_renderDebug = false;
     m_clockSync.Reset();
+    CheckEnableClockSync();
 
     m_renderState = STATE_CONFIGURED;
 


### PR DESCRIPTION
backport of https://github.com/xbmc/xbmc/pull/11273