### PR TITLE
context menu - fix positioning

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -653,8 +653,7 @@ void CGUIDialogContextMenu::PositionAtCurrentFocus()
     const CGUIControl *focusedControl = window->GetFocusedControl();
     if (focusedControl)
     {
-      CPoint pos = focusedControl->GetRenderPosition() + CPoint(focusedControl->GetWidth() * 0.5f, focusedControl->GetHeight() * 0.5f)
-                   + window->GetRenderPosition();
+      CPoint pos = focusedControl->GetRenderPosition() + CPoint(focusedControl->GetWidth() * 0.5f, focusedControl->GetHeight() * 0.5f);
       SetPosition(m_coordX + pos.x - GetWidth() * 0.5f, m_coordY + pos.y - GetHeight() * 0.5f);
       return;
     }


### PR DESCRIPTION
the context menu was positioned incorrectly when called from a dialog.

(we don't need to take the render position offset of the window into account,
as that's already included in the offset of the focused control)

before:
![before](https://cloud.githubusercontent.com/assets/687265/21544857/0837a71c-cdd3-11e6-8263-54a8e75f0553.jpg)

after:
![after](https://cloud.githubusercontent.com/assets/687265/21544860/108a5a36-cdd3-11e6-8aca-52a9b80d1ac6.jpg)

@HitcherUK @BigNoid @phil65 