### PR TITLE
[PVR][music][video] Video Fullscreen/Music Visualisation: Fix hiding of player info

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -188,7 +188,7 @@
       <right>StepForward</right>
       <up>ChapterOrBigStepForward</up>
       <down>ChapterOrBigStepBack</down>
-      <back>Back</back>
+      <back>Fullscreen</back>
       <menu>OSD</menu>
       <contentsmenu>OSD</contentsmenu>
       <rootmenu>OSD</rootmenu>
@@ -251,7 +251,7 @@
       <down>SkipPrevious</down>
       <pageplus>IncreaseRating</pageplus>
       <pageminus>DecreaseRating</pageminus>
-      <back>Back</back>
+      <back>Fullscreen</back>
       <title>PlayerProcessInfo</title>
       <select>OSD</select>
       <menu>OSD</menu>

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -82,11 +82,19 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
     return true;
 
   case ACTION_SHOW_GUI:
-    // save the settings
-    CServiceBroker::GetSettings().Save();
-    g_windowManager.PreviousWindow();
+    if (g_infoManager.GetShowInfo())
+    {
+      // if player info is shown, hide it
+      g_infoManager.SetShowInfo(false);
+    }
+    else
+    {
+      // save the settings
+      CServiceBroker::GetSettings().Save();
+      // switch back to the menu
+      g_windowManager.PreviousWindow();
+    }
     return true;
-    break;
 
   case ACTION_VIS_PRESET_LOCK:
     { // show the locked icon + fall through so that the vis handles the locking

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -128,8 +128,16 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
   case ACTION_SHOW_GUI:
     {
-      // switch back to the menu
-      g_windowManager.PreviousWindow();
+      if (g_infoManager.GetShowInfo())
+      {
+        // if player info is shown, hide it
+        g_infoManager.SetShowInfo(false);
+      }
+      else
+      {
+        // switch back to the menu
+        g_windowManager.PreviousWindow();
+      }
       return true;
     }
     break;


### PR DESCRIPTION
Ever wondered why the normal way of closing dialogs (using esc key or back button on your remote) does not close the player info in video fullscreen or music visualisation, but exits fullscreen to previous window? This is because player info internally is 'something else' than most other dialogs and closing it technically is different form closing a dialog.

This PR fixes this. Now esc key, back button on remote closes the player info if open and exits fullscreen if player info is not open. Feels 'naturally' and consistent now, imo. 

This was tested on latest master on LInux and macOS.

For those not knowing what 'player info' is - for live tv it's this:

![screenshot007](https://cloud.githubusercontent.com/assets/3226626/21550333/41dd9eec-cdf9-11e6-8164-2af79d1a3558.png)

It pops for instance up, if you press up/down while in fullscreen live tv window. ;-)

@Jalle19 for review, please?