### PR TITLE
cmake: findembedded: fix IMX(FB) header file name

### DIFF
--- a/cmake/modules/FindEMBEDDED.cmake
+++ b/cmake/modules/FindEMBEDDED.cmake
@@ -13,4 +13,4 @@ if(NOT KODI_DEPENDSBUILD AND NOT TARGET_ARCH_ARM)
   return()
 endif()
 
-find_path(EMBEDDED_FOUND NAMES include/linux/imxfb.h include/bcm_host.h PATHS /opt/vc)
+find_path(EMBEDDED_FOUND NAMES include/linux/mxcfb.h include/bcm_host.h PATHS /opt/vc)


### PR DESCRIPTION
## Description
fix IMX(FB) header file name

## How Has This Been Tested?
FSL FB layer uses mxcfb.h file name.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed