### PR TITLE
[PVR] PVR windows: Fix channelgroup listener registration.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -300,9 +300,10 @@ bool CGUIWindowPVRBase::InitChannelGroup()
     if (m_channelGroup != group)
     {
       m_viewControl.SetSelectedItem(0);
-      m_channelGroup = group;
-      m_vecItems->SetPath(GetDirectoryPath());
+      SetChannelGroup(group, false);
     }
+    // Path might have changed since last init. Set it always, not just on group change.
+    m_vecItems->SetPath(GetDirectoryPath());
     return true;
   }
   return false;
@@ -314,7 +315,7 @@ CPVRChannelGroupPtr CGUIWindowPVRBase::GetChannelGroup(void)
   return m_channelGroup;
 }
 
-void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group)
+void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group, bool bUpdate /* = true */)
 {
   if (!group)
     return;
@@ -333,7 +334,7 @@ void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group)
     }
   }
 
-  if (channelGroup)
+  if (bUpdate && channelGroup)
   {
     g_PVRManager.SetPlayingGroup(channelGroup);
     Update(GetDirectoryPath());

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -82,9 +82,24 @@ namespace PVR
 
     virtual void ClearData();
 
+    /*!
+     * @brief Init this window's channel group with the currently active (the "playing") channel group.
+     * @return true if group could be set, false otherwise.
+     */
     bool InitChannelGroup(void);
-    virtual CPVRChannelGroupPtr GetChannelGroup(void);
-    virtual void SetChannelGroup(const CPVRChannelGroupPtr &group);
+
+    /*!
+     * @brief Get the channel group for this window.
+     * @return the group or null, if no group set.
+     */
+   virtual CPVRChannelGroupPtr GetChannelGroup(void);
+
+    /*!
+     * @brief Set a new channel group, start listening to this group, optionally update window content.
+     * @param group The new group.
+     * @param bUpdate if true, window content will be updated.
+     */
+    void SetChannelGroup(const CPVRChannelGroupPtr &group, bool bUpdate = true);
 
     virtual void UpdateSelectedItemPath();
 


### PR DESCRIPTION
This fixes a regression that slipped in due to the pvr window listener logic changes I did some months ago.

Visual effects of the issue are for instance an empty channel window after changing kodi's ui language and no live update of the channel or guide window in case channels get added or removed in the backend.

Fix has been runtime tested on Linux and macOS on latest Kodi master.

@Jalle19 mind doing the review.