### PR TITLE
[cmake] Fix make binary-addons when crosscompiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,7 +428,7 @@ endif()
 # Use make binary-addons ADDONS="visualization.spectrum" to select the addons to build.
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
   if(CMAKE_CROSSCOMPILING)
-    set(_cross_args CROSS_COMPILING=yes TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+    set(_cross_args CROSS_COMPILING=yes)
   endif()
   if(NOT CORE_SYSTEM_NAME STREQUAL android)
     set(_prefix ${CMAKE_BINARY_DIR}/addons)


### PR DESCRIPTION
@wsnipex: This works as long as you have the toolchain file in tools/depends.
I'd prefer if it would work also with the installed one so that we can have a clean source dir.
But at least it doesn't use the wrong file anymore.