### PR TITLE
[depends] explictly disable building curl with rtmp support

### DIFF
--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -13,7 +13,7 @@ ARCHIVE=$(SOURCE).tar.bz2
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) \
-          --without-libssh2 --disable-ntlm-wb --enable-ipv6
+          --without-libssh2 --disable-ntlm-wb --enable-ipv6 --without-librtmp
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 


### PR DESCRIPTION
If build environment wasn't cleaned yet curl might be build with rtmp support. Explicitly disable it.