### PR TITLE
Don't require an optical drive for stub file handling

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3020,18 +3020,16 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   {
 #ifdef HAS_DVD_DRIVE
     // Display the Play Eject dialog if there is any optical disc drive
-    if (g_mediaManager.HasOpticalDrive())
-    {
-      if (CGUIDialogPlayEject::ShowAndGetInput(item))
-        // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
-        // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
-        return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
-    }
-    else
+    if (CGUIDialogPlayEject::ShowAndGetInput(item))
+      // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
+      // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
+      return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
+#else
+    // Display "No optical disc drive detected" dialog
+    HELPERS::ShowOKDialogText(CVariant{435}, CVariant{436});
 #endif
-      HELPERS::ShowOKDialogText(CVariant{435}, CVariant{436});
 
-    return true;
+    return false;
   }
 
   if (item.IsPlayList())


### PR DESCRIPTION
Partially Reverted: xbmc@731a7b1
Forum discussion: http://forum.kodi.tv/showthread.php?tid=178014&page=2&highlight=stub

With this change ppl can check their stub information on systems that don't have an optical drive.
(Raspberry PI's, Android Tablets etc.)

Edit: Sorry about the lame default title, i did not create it properly.
I am still learning to work with git.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Removed HasOpticalDrive check so we can see the custom information from the stub file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
If fixes the issue where you can't "play" a stub file on a device where no optical drive is present.
Therefor you can't view custom stubfile messages, e.g. "Enter disc 46".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Not at all! I am a developer but have no expierence with building kodi (so far)
As @da-anda proposed, maybe someone can launch an automatic build?
I am having difficulty reading/following the checklist because of the server/wiki issues. 
(Cloudfare switch)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
