### PR TITLE
Mediacodec: Workaround LiveTV

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -131,7 +131,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
 
   options.m_opaque_pointer = info.opaque_pointer;
 
-  if (!hint.software)
+  if (!(hint.codecOptions & CODEC_FORCE_SOFRWARE))
   {
 #if defined(HAS_LIBAMCODEC)
     // Amlogic can be present on multiple platforms (Linux, Android)
@@ -150,7 +150,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
 #elif defined(HAS_MMAL)
     pCodec = OpenCodec(new CMMALVideo(processInfo), hint, options);
 #endif
-    if (pCodec)
+    if (pCodec || !(hint.codecOptions & CODEC_ALLOW_FALLBACK))
       return pCodec;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -359,6 +359,10 @@ CDVDVideoCodecAndroidMediaCodec::~CDVDVideoCodecAndroidMediaCodec()
 
 bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+
+  if (CDVDVideoCodecAndroidMediaCodec::instances > 0)
+    return false;
+
   // mediacodec crashes with null size. Trap this...
   if (!hints.width || !hints.height)
   {
@@ -615,6 +619,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   CLog::Log(LOGINFO, "CDVDVideoCodecAndroidMediaCodec:: "
     "Open Android MediaCodec %s", m_codecname.c_str());
 
+  CDVDVideoCodecAndroidMediaCodec::instances++;
   m_opened = true;
   memset(&m_demux_pkt, 0, sizeof(m_demux_pkt));
 
@@ -667,6 +672,7 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
     CXBMCApp::get()->clearVideoView();
 
   SAFE_DELETE(m_bitstream);
+  CDVDVideoCodecAndroidMediaCodec::instances--;
 }
 
 int CDVDVideoCodecAndroidMediaCodec::Decode(uint8_t *pData, int iSize, double dts, double pts)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -98,6 +98,8 @@ public:
   CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo, bool surface_render = false);
   virtual ~CDVDVideoCodecAndroidMediaCodec();
 
+  // track instances - we can only allow exactly one
+  static int instances;
   // required overrides
   virtual bool    Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
   virtual int     Decode(uint8_t *pData, int iSize, double dts, double pts);
@@ -158,3 +160,4 @@ protected:
   int             m_src_offset[4];
   int             m_src_stride[4];
 };
+CDVDVideoCodecAndroidMediaCodec::instances = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -341,7 +341,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_pCodecContext->codec_tag = hints.codec_tag;
 
   // setup threading model
-  if (!hints.software)
+  if (!(hints.codecOptions & CODEC_FORCE_SOFRWARE))
   {
     bool tryhw = false;
 #ifdef HAVE_LIBVDPAU

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -199,7 +199,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
     std::unique_ptr<CProcessInfo> pProcessInfo(CProcessInfo::CreateInstance());
 
     CDVDStreamInfo hint(*pDemuxer->GetStream(demuxerId, nVideoStream), true);
-    hint.software = true;
+    hint.codecOptions = CODEC_FORCE_SOFRWARE;
 
     pVideoCodec = CDVDFactoryCodec::CreateVideoCodec(hint, *pProcessInfo);
 

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -43,9 +43,7 @@ public:
   {
     NONE = 1000,
 
-
     // messages used in the whole system
-
     GENERAL_RESYNC,                 //
     GENERAL_FLUSH,                  // flush all buffers
     GENERAL_RESET,                  // reset codecs for new data
@@ -56,7 +54,6 @@ public:
     GENERAL_EOF,                    // eof of stream
 
     // player core related messages (cVideoPlayer.cpp)
-
     PLAYER_SET_AUDIOSTREAM,         //
     PLAYER_SET_VIDEOSTREAM,         //
     PLAYER_SET_SUBTITLESTREAM,      //
@@ -75,20 +72,17 @@ public:
     PLAYER_CHANNEL_SELECT,          // switches to the provided channel
     PLAYER_STARTED,                 // sent whenever a sub player has finished it's first frame after open
     PLAYER_AVCHANGE,                // signal a change in audio or video parameters
+    PLAYER_ABORT,
 
     // demuxer related messages
-
     DEMUXER_PACKET,                 // data packet
     DEMUXER_RESET,                  // reset the demuxer
 
-
     // video related messages
-
     VIDEO_SET_ASPECT,               // set aspectratio of video
     VIDEO_DRAIN,                    // wait for decoder to output last frame
 
     // audio related messages
-
     AUDIO_SILENCE,
 
     // subtitle related messages

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -41,7 +41,7 @@ void CDVDStreamInfo::Clear()
   type = STREAM_NONE;
   uniqueId = -1;
   realtime = false;
-  software = false;
+  codecOptions = 0;
   codec_tag  = 0;
   flags = 0;
   filename.clear();
@@ -173,7 +173,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   orientation = right.orientation;
   bitsperpixel = right.bitsperpixel;
   vfr = right.vfr;
-  software = right.software;
+  codecOptions = right.codecOptions;
   stereo_mode = right.stereo_mode;
 
   // AUDIO

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -26,6 +26,9 @@ extern "C" {
 #include "libavcodec/avcodec.h"
 }
 
+#define CODEC_FORCE_SOFRWARE 0x01
+#define CODEC_ALLOW_FALLBACK 0x02
+
 class CDemuxStream;
 
 class CDVDStreamInfo
@@ -49,10 +52,9 @@ public:
   int uniqueId;
   bool realtime;
   int flags;
-  bool software;  //force software decoding
   std::string filename;
   bool dvd;
-
+  int codecOptions;
 
   // VIDEO
   int fpsscale; // scale of 1001 and a rate of 60000 will result in 59.94 fps

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3029,6 +3029,11 @@ void CVideoPlayer::HandleMessages()
       CServiceBroker::GetDataCacheCore().SignalAudioInfoChange();
       CServiceBroker::GetDataCacheCore().SignalVideoInfoChange();
     }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_ABORT))
+    {
+      CLog::Log(LOGDEBUG, "CVideoPlayer - CDVDMsg::PLAYER_ABORT");
+      m_bAbortRequest = true;
+    }
 
     pMsg->Release();
   }


### PR DESCRIPTION
Last resort - to get this unmaintained platform kind of running for v17. Thanks for @FernetMenta for helping out once again. Needs testing first.

This change introduces poor man's ref counting to only have a decoder at a time. The other change by fernet makes it possible to reopen with hw decoding capabilities.