### PR TITLE
[cmake] Fixes cpack support and WiiRemote packaging for rpi

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -352,7 +352,7 @@ endforeach()
 
 # generate packages? yes please, if everything checks out
 if(CPACK_GENERATOR)
-  if(CPACK_GENERATOR STREQUAL DEB AND CORE_SYSTEM_NAME STREQUAL linux)
+  if(CPACK_GENERATOR STREQUAL DEB AND ( CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL rbpi ) )
     if(CMAKE_BUILD_TYPE STREQUAL Debug)
       message(STATUS "DEB Generator: Build type is set to 'Debug'. Packaged binaries will be unstripped.")
     endif()

--- a/cmake/scripts/rbpi/ExtraTargets.cmake
+++ b/cmake/scripts/rbpi/ExtraTargets.cmake
@@ -1,0 +1,1 @@
+../linux/ExtraTargets.cmake


### PR DESCRIPTION
## Description
This pull request provides two fixes:
- Prevents cmake from not allowing to create DEBs due to treating rbpi differently to linux.
- WiiRemote was not build and thus packaging was failing, due to not having the WiiRemote target defined. 

This will also require a backport to v17. PR: #11332

Forum topic: http://forum.kodi.tv/showthread.php?tid=302406

## Motivation and Context
See above

## How Has This Been Tested?
Built kodi with CPACK_GENERATOR=DEB option.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
