### PR TITLE
initialize anondata

### DIFF
--- a/tools/depends/target/mdnsresponder/02-initialize_anondata.patch
+++ b/tools/depends/target/mdnsresponder/02-initialize_anondata.patch
@@ -1,0 +1,10 @@
+--- mDNSShared/dnssd_clientshim_orig.c	2016-12-31 13:31:09.687948146 +0100
++++ mDNSShared/dnssd_clientshim.c	2016-12-31 13:05:12.159906389 +0100
+@@ -271,6 +271,7 @@
+     x->autorename = mDNSfalse;
+     x->name = n;
+     x->host = h;
++    x->s.AnonData = 0;
+ 
+     // Do the operation
+     err = mDNS_RegisterService(&mDNSStorage, &x->s,

--- a/tools/depends/target/mdnsresponder/Makefile
+++ b/tools/depends/target/mdnsresponder/Makefile
@@ -21,6 +21,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 < ../01-android-embedded.patch
+	cd $(PLATFORM); patch -p0 < ../02-initialize_anondata.patch
 	cd $(PLATFORM); cp ../makefile.internal Makefile
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
Crashfix at least for android, probably for other platforms as well

## Description
zeroconf / mdns tries a strlen on anaondata wich address is not initialized. 

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
