### PR TITLE
Hide notifications shown on device connect

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -366,6 +366,8 @@ void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &p
 {
   OnDeviceChanged();
 
+  //! @todo Improve device notifications in v18
+#if 0
   bool bNotify = true;
 
   // don't show a notification for devices detected during the initial scan
@@ -378,6 +380,7 @@ void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &p
 
   if (bNotify)
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral.DeviceName());
+#endif
 }
 
 void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral)
@@ -385,7 +388,8 @@ void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral 
   OnDeviceChanged();
 
   //! @todo Improve device notifications in v18
-  bool bNotify = false;
+#if 0
+  bool bNotify = true;
 
   // don't show a notification for emulated peripherals
   if (peripheral.Type() == PERIPHERAL_JOYSTICK_EMULATION) //! @todo Change to peripheral.IsEmulated()
@@ -393,6 +397,7 @@ void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral 
 
   if (bNotify)
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35006), peripheral.DeviceName());
+#endif
 }
 
 void CPeripherals::OnDeviceChanged()


### PR DESCRIPTION
Follow up to #11279

Device notifications were only disabled on disconnect events, and connect events were still being shown. Fixed by using `#ifdef 0` to avoid Coverty warning:

CID 1398191: Control flow issues (DEADCODE)
