### PR TITLE
Fix 3D OSD Aspect Ratio (Ticket #16727)

### DIFF
--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -414,6 +414,7 @@ void CGUIWindowFullScreen::RenderEx()
   CGUIWindow::RenderEx();
   g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetVideoResolution(), false);
   g_application.m_pPlayer->Render(false, 255, false);
+  g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
 }
 
 void CGUIWindowFullScreen::SeekChapter(int iChapter)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Fix for TRAC Ticket <a href="http://trac.kodi.tv/ticket/16727">#16727</a> (OSD 3D Mode Aspect Ratio might get broken).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When playing 3D video the first time the OSD is displayed RadioButtons are scaled correctly, but subsequently they are scaled a second time, resulting in the wrong aspect ratio at a quarter of the original resolution.

Fix identified by comparing the working Milhouse Kodi 15.0 Build <a href="http://forum.kodi.tv/showthread.php?tid=211501&pid=1879769#pid1879769">#102</a> with Build <a href="http://forum.kodi.tv/showthread.php?tid=211501&pid=1879769#pid1879769">#103</a>. The breaking change was the <a href="https://github.com/xbmc/xbmc/commit/4248210dcd0a3d29b0d0c2d81530d94bbb556dab">squash me</a> commit in Popcornmix's newclock4 branch. This was narrowed down further to the file "xbmc/video/windows/GUIWindowFullScreen.cpp".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
The change has been runtime tested.

## Screenshots (if appropriate):
Initial correct 3D TAB OSD:
![screenshot000](https://cloud.githubusercontent.com/assets/24828644/21579800/ca523b44-cfba-11e6-852f-d9fd99d0ceb6.png)

Subsequent incorrect 3D TAB OSD:
![screenshot001](https://cloud.githubusercontent.com/assets/24828644/21579801/cd63b0a6-cfba-11e6-8422-d5e6b012c730.png)

Initial correct 3D SBS OSD:
![screenshot002](https://cloud.githubusercontent.com/assets/24828644/21579803/dac04fd4-cfba-11e6-98df-8aef9eec957d.png)

Subsequent incorrect 3D SBS OSD:
![screenshot003](https://cloud.githubusercontent.com/assets/24828644/21579805/e3caaade-cfba-11e6-9530-2d0f085016f1.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
