### PR TITLE
[RetroPlayer] Fix crash when refresh rate changes

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -46,6 +46,8 @@ CRetroPlayer::CRetroPlayer(IPlayerCallback& callback) :
 
 CRetroPlayer::~CRetroPlayer()
 {
+  g_Windowing.Unregister(this);
+
   CloseFile();
 }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -30,7 +30,6 @@
 #include "utils/log.h"
 #include "utils/MathUtils.h"
 #include "utils/StringUtils.h"
-#include "windowing/WindowingFactory.h"
 #include "FileItem.h"
 #include "URL.h"
 
@@ -41,13 +40,10 @@ CRetroPlayer::CRetroPlayer(IPlayerCallback& callback) :
   m_renderManager(m_clock, this),
   m_processInfo(CProcessInfo::CreateInstance())
 {
-  g_Windowing.Register(this);
 }
 
 CRetroPlayer::~CRetroPlayer()
 {
-  g_Windowing.Unregister(this);
-
   CloseFile();
 }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -36,8 +36,7 @@ namespace GAME
   class CRetroPlayerVideo;
 
   class CRetroPlayer : public IPlayer,
-                       public IRenderMsg,
-                       public IDispResource
+                       public IRenderMsg
   {
   public:
     CRetroPlayer(IPlayerCallback& callback);
@@ -144,11 +143,6 @@ namespace GAME
     virtual void UpdateClockSync(bool enabled) override;
     virtual void UpdateRenderInfo(CRenderInfo &info) override;
     virtual void UpdateRenderBuffers(int queued, int discard, int free) override {}
-
-    // implementation of IDispResource
-    //virtual void OnLostDisplay() override { }
-    //virtual void OnResetDisplay() override { }
-    //virtual void OnAppFocusChange(bool focus) override { }
 
   private:
     /**


### PR DESCRIPTION
## Description
RetroPlayer didn't unregister itself from the windowing system on destruction leading into a crash whenever a display lost event occurs (for example on refresh rate change).

Steps to reproduce:
- Set 'Settings->Playback->Video->Adjust Refresh Rate' to 'On Start/Stop'
- Load a ROM with a different refresh rate than the current one
- Press stop
- Try to load the ROM again

Back trace:

    Segmentation fault at xbmc/windowing/X11/WinSystemX11.cpp:628
        628           (*i)->OnLostDisplay();

Reported in the forum: http://forum.kodi.tv/showthread.php?tid=257904&pid=2488615#pid2488615
EDIT: reporter confirmed fix.

## Motivation and Context
Fix crash.

## How Has This Been Tested?
Started a few roms with different refresh rates.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed