### PR TITLE
[IMXEGL] reconfigure fb1 & unblank

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
@@ -263,6 +263,8 @@ bool CEGLNativeTypeIMX::SetNativeResolution(const RESOLUTION_INFO &res)
   CreateNativeDisplay();
   CreateNativeWindow();
 
+  g_IMXContext.OnResetDisplay();
+  ShowWindow(true);
   CLog::Log(LOGDEBUG, "%s: %s",__FUNCTION__, res.strId.c_str());
 
   return true;


### PR DESCRIPTION
(this was forgotten from the previous commit)

## Description
reconfigure fb1 & unblank before (hdmi)sound is resumed in WinSystem

## Motivation and Context
this should prevent resuming audio while hdmi system is still blanked (this can happen depending on order of windowing.register() calls after commit 21671109b53e714e5eea1fa1c29da39f6e8bf518)
also it makes m_delayDispReset working while keeping the proper order conf fb0 -> conf fb1 -> unblank -> resume audio 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed