### PR TITLE
Spelling

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -47,7 +47,7 @@ extern "C"
    * @return The XBMC_PVR_MIN_API_VERSION that was used to compile this add-on.
    * @remarks Valid implementation required.
    */
-  const char* GetMininumPVRAPIVersion(void);
+  const char* GetMinimumPVRAPIVersion(void);
 
   /*!
    * Get the XBMC_GUI_API_VERSION that was used to compile this add-on.
@@ -664,7 +664,7 @@ extern "C"
     KodiToAddonFuncTable_PVR* pClient = static_cast<KodiToAddonFuncTable_PVR*>(ptr);
     
     pClient->GetPVRAPIVersion               = GetPVRAPIVersion;
-    pClient->GetMininumPVRAPIVersion        = GetMininumPVRAPIVersion;
+    pClient->GetMinimumPVRAPIVersion        = GetMinimumPVRAPIVersion;
     pClient->GetGUIAPIVersion               = GetGUIAPIVersion;
     pClient->GetMininumGUIAPIVersion        = GetMininumGUIAPIVersion;
     pClient->GetAddonCapabilities           = GetAddonCapabilities;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -65,7 +65,7 @@ extern "C"
    * @remarks Valid implementation required.
    * @note see libKODI_guilib.h about related parts
    */
-  const char* GetMininumGUIAPIVersion(void);
+  const char* GetMinimumGUIAPIVersion(void);
 
   /*!
    * Get the list of features that this add-on provides.
@@ -666,7 +666,7 @@ extern "C"
     pClient->GetPVRAPIVersion               = GetPVRAPIVersion;
     pClient->GetMinimumPVRAPIVersion        = GetMinimumPVRAPIVersion;
     pClient->GetGUIAPIVersion               = GetGUIAPIVersion;
-    pClient->GetMininumGUIAPIVersion        = GetMininumGUIAPIVersion;
+    pClient->GetMinimumGUIAPIVersion        = GetMinimumGUIAPIVersion;
     pClient->GetAddonCapabilities           = GetAddonCapabilities;
     pClient->GetStreamProperties            = GetStreamProperties;
     pClient->GetConnectionString            = GetConnectionString;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -535,7 +535,7 @@ extern "C" {
     const char*  (__cdecl* GetPVRAPIVersion)(void);
     const char*  (__cdecl* GetMinimumPVRAPIVersion)(void);
     const char*  (__cdecl* GetGUIAPIVersion)(void);
-    const char*  (__cdecl* GetMininumGUIAPIVersion)(void);
+    const char*  (__cdecl* GetMinimumGUIAPIVersion)(void);
     PVR_ERROR    (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
     PVR_ERROR    (__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
     const char*  (__cdecl* GetBackendName)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -533,7 +533,7 @@ extern "C" {
   typedef struct KodiToAddonFuncTable_PVR
   {
     const char*  (__cdecl* GetPVRAPIVersion)(void);
-    const char*  (__cdecl* GetMininumPVRAPIVersion)(void);
+    const char*  (__cdecl* GetMinimumPVRAPIVersion)(void);
     const char*  (__cdecl* GetGUIAPIVersion)(void);
     const char*  (__cdecl* GetMininumGUIAPIVersion)(void);
     PVR_ERROR    (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);


### PR DESCRIPTION
Spelling fixes

## Description
Semi-automated spelling review of codebase (includes comments, code, public apis, documentation, etc)

## Motivation and Context
I have a toolchain which I've been evolving for a while, and I like to test it on projects, especially as a way to give a little in appreciation of projects that I may be using/have used/plan to use.

## How Has This Been Tested?
- [x] This has not been tested.

## Types of change
- [x] Breaking change
- - [x] Public APIs - I'm pretty sure I've renamed some public APIs. I'm happy to split such items out (either including backwards compat or dropping them entirely), but I'd rather have a conversation about which those things are before I eagerly split.
- - [x] Command line flags (probably)
- - [x] Console output
- - [x] Debug ouput
- - [x] CSS identifiers/rules
- [x] Comments
- [x] Local variables
- [x] Local functions
- [x] Class member and static variables
- [x] Doxygen content
- [x] English translations (but not other languages)
- [x] Addons (if they are maintained elsewhere, let me know)
- [x] Spelling only (i.e. not grammar, not even to make things agree)
- [x] No effort has been made to adjust whitespace based on the length of replacement words
- [x] External modules have been excluded to the extent that I could identify them. If I've missed things, I'll gladly toss them out, please identify them.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
