### PR TITLE
android:debuggable support

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -13,6 +13,12 @@ if(NOT ZIPALIGN_EXECUTABLE)
   message(FATAL_ERROR "Could NOT find zipalign executable")
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  set(ANDROID_DEBUGGABLE true)
+else()
+  set(ANDROID_DEBUGGABLE false)
+endif()
+
 # Configure files into packaging environment.
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/Makefile.in
                ${CMAKE_BINARY_DIR}/tools/android/packaging/Makefile @ONLY)

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -25,7 +25,8 @@
     <application android:icon="@drawable/ic_launcher"
 				android:logo="@drawable/banner"
 				android:label="@string/app_name"
-				android:hasCode="true">
+				android:hasCode="true"
+				android:debuggable="@ANDROID_DEBUGGABLE@">
         <activity
             android:name=".Splash"
             android:configChanges="orientation|keyboard|keyboardHidden|navigation|touchscreen|screenLayout|screenSize"


### PR DESCRIPTION
Set android:debuggable=[true/false] regarding the cmake build type

## Description
There are some operations on android for that the ap has to be debugable.
For example run-as commands in adb shell on devices without root access.

This PR sets the application::android:debuggable value regarding the cmake build type

## Motivation and Context
We need run-as org.xbmc.kodi kill -6 [pid] to generate tombstone.
