### PR TITLE
fix invalid output from JsonSchemaBuilder

### DIFF
--- a/tools/depends/native/JsonSchemaBuilder/src/JsonSchemaBuilder.cpp
+++ b/tools/depends/native/JsonSchemaBuilder/src/JsonSchemaBuilder.cpp
@@ -64,6 +64,11 @@ void print_json(ifstream &in, ofstream &out)
     closing = false;
     for (string::iterator itr = line.begin(); itr != line.end(); itr++)
     {
+      // Skip \r characters
+      if (*itr == '\r') {
+        break;
+      }
+
       // Count opening { but ignore the first one
       if (*itr == '{')
       {


### PR DESCRIPTION
## Description

The scanner scans up until an `\n` character, which means a potential `\r` might sneak in. When each character is looped over there was no handling for `\r` so they got streamed to the output, resulting in bogus new lines in the output file.

## Motivation and Context

Without this I can't build Kodi, the build will fail with thousands of lines of `missing termination character "`

## How Has This Been Tested?

It builds

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

ping @wsnipex since I believe you wrote this?