### PR TITLE
librarynodes - fix invalid xml

### DIFF
--- a/system/library/music/musicroles/Arrangers.xml
+++ b/system/library/music/musicroles/Arrangers.xml
@@ -2,5 +2,5 @@
 <node order="5" type="folder" visible="Library.HasContent(Role, Arranger)">
 	<label>29988</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Arranger&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=Arranger&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Composers.xml
+++ b/system/library/music/musicroles/Composers.xml
@@ -2,5 +2,5 @@
 <node order="1" type="folder" visible="Library.HasContent(Role, Composer)">
 	<label>29989</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Composer&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=Composer&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Conductors.xml
+++ b/system/library/music/musicroles/Conductors.xml
@@ -2,5 +2,5 @@
 <node order="2" type="folder" visible="Library.HasContent(Role, Conductor)">
 	<label>29990</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Conductor&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=Conductor&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/DJMixers.xml
+++ b/system/library/music/musicroles/DJMixers.xml
@@ -2,5 +2,5 @@
 <node order="6" type="folder" visible="Library.HasContent(Role, DJMixer)">
 	<label>29991</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=DJMixer&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=DJMixer&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Lyricists.xml
+++ b/system/library/music/musicroles/Lyricists.xml
@@ -2,5 +2,5 @@
 <node order="4" type="folder" visible="Library.HasContent(Role, Lyricist)">
 	<label>29992</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Lyricist&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=Lyricist&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Orchestras.xml
+++ b/system/library/music/musicroles/Orchestras.xml
@@ -2,5 +2,5 @@
 <node order="3" type="folder" visible="Library.HasContent(Role, Orchestra)">
 	<label>29993</label>
 	<icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Orchestra&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=Orchestra&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/Remixers.xml
+++ b/system/library/music/musicroles/Remixers.xml
@@ -2,5 +2,5 @@
 <node order="7" type="folder" visible="Library.HasContent(Role, Remixer)">
 	<label>29987</label>
         <icon>DefaultMusicGenres.png</icon>
-	<path>musicdb://artists/?role=Remixer&albumartistsonly=false</path>
+	<path>musicdb://artists/?role=Remixer&amp;albumartistsonly=false</path>
 </node>

--- a/system/library/music/musicroles/allcontributors.xml
+++ b/system/library/music/musicroles/allcontributors.xml
@@ -2,5 +2,5 @@
 <node order="12" type="folder">
 	<label>38045</label>
 	<icon>DefaultMusicArtists.png</icon>
-	<path>musicdb://artists/?roleid=-1000&albumartistsonly=false</path>
+	<path>musicdb://artists/?roleid=-1000&amp;albumartistsonly=false</path>
 </node>


### PR DESCRIPTION
this used to be part of https://github.com/xbmc/xbmc/pull/11017 but was dropped for the wrong reasons.

the '&' character needs to be escaped in xml documents.

@DaveTBlake 