### PR TITLE
[PVR] Fix channelgroups deadlock.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1310,8 +1310,11 @@ bool CPVRManager::OpenLiveStream(const CFileItem &fileItem)
     if(m_currentFile)
       delete m_currentFile;
     m_currentFile = new CFileItem(fileItem);
+  }
 
-    CPVRChannelPtr channel(m_addons->GetPlayingChannel());
+  if (bReturn)
+  {
+    const CPVRChannelPtr channel(m_addons->GetPlayingChannel());
     if (channel)
     {
       SetPlayingGroup(channel);
@@ -1340,8 +1343,6 @@ bool CPVRManager::OpenRecordedStream(const CPVRRecordingPtr &tag)
 
 void CPVRManager::CloseStream(void)
 {
-  CSingleLock lock(m_critSection);
-
   CPVRChannelPtr channel(m_addons->GetPlayingChannel());
   if (channel)
   {
@@ -1351,8 +1352,10 @@ void CPVRManager::CloseStream(void)
     g_application.SaveFileState();
   }
 
-  m_isChannelPreview = false;
   m_addons->CloseStream();
+
+  CSingleLock lock(m_critSection);
+  m_isChannelPreview = false;
   SAFE_DELETE(m_currentFile);
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -220,13 +220,16 @@ bool CPVRChannelGroups::Update(bool bChannelsOnly /* = false */)
     GetGroupsFromClients();
 
   // sync channels in groups
+  std::vector<CPVRChannelGroupPtr> groups;
   {
     CSingleLock lock(m_critSection);
-    for (std::vector<CPVRChannelGroupPtr>::iterator it = m_groups.begin(); it != m_groups.end(); ++it)
-    {
-      if (bUpdateAllGroups || (*it)->IsInternalGroup())
-        bReturn = (*it)->Update() && bReturn;
-    }
+    groups = m_groups;
+  }
+
+  for (const auto &group : groups)
+  {
+    if (bUpdateAllGroups || group->IsInternalGroup())
+      bReturn = group->Update() && bReturn;
   }
 
   // persist changes


### PR DESCRIPTION
Deadlock while opening a channel. Reported here, but this is not an addon issue: https://github.com/kodi-pvr/pvr.hts/issues/235#issuecomment-270179082

Interesting part of the stacktrace posted in the pvr.hts issue (annotated by me):

<pre>
Deadlock pvrmanager mutex vs. channelgroups mutex
========================================

Thread 1 (Thread 0x7f9989ffb700 (LWP 741)):
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:58
#1  0x00007f9a234973ba in __GI_abort () at abort.c:89
#2  0x00007f9a2348ede7 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x7f9a27839e60 "INTERNAL_SYSCALL_ERRNO (e, __err) != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", file=file@entry=0x7f9a27839e25 "../nptl/pthread_mutex_lock.c", line=line@entry=349, function=function@entry=0x7f9a27839f90 <__PRETTY_FUNCTION__.8633> "__pthread_mutex_lock_full") at assert.c:92
#3  0x00007f9a2348ee92 in __GI___assert_fail (assertion=assertion@entry=0x7f9a27839e60 "INTERNAL_SYSCALL_ERRNO (e, __err) != EDEADLK || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)", file=file@entry=0x7f9a27839e25 "../nptl/pthread_mutex_lock.c", line=line@entry=349, function=function@entry=0x7f9a27839f90 <__PRETTY_FUNCTION__.8633> "__pthread_mutex_lock_full") at assert.c:101
#4  0x00007f9a278309d1 in __pthread_mutex_lock_full (mutex=0x3390d00) at ../nptl/pthread_mutex_lock.c:347
#5  0x00000000008222b3 in XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock() ()
=> wants pvr manager mutex
#6  0x0000000000c783b3 in PVR::CPVRManager::ChannelGroups() const ()
#7  0x0000000000c621ec in PVR::CPVRChannelGroup::RemoveDeletedChannels(PVR::CPVRChannelGroup const&) ()
#8  0x0000000000c63893 in PVR::CPVRChannelGroup::UpdateGroupEntries(PVR::CPVRChannelGroup const&) ()
#9  0x0000000000c66dda in PVR::CPVRChannelGroupInternal::UpdateGroupEntries(PVR::CPVRChannelGroup const&) ()
#10 0x0000000000c668ed in PVR::CPVRChannelGroupInternal::Update() ()
=> owns channelgroups mutex
#11 0x0000000000c67889 in PVR::CPVRChannelGroups::Update(bool) ()
#12 0x0000000000c69d5b in PVR::CPVRChannelGroupsContainer::Update(bool) ()
#13 0x0000000000c78a59 in PVR::CPVRChannelGroupsUpdateJob::DoWork() ()
#14 0x0000000000c7a989 in PVR::CPVRManager::ExecutePendingJobs() ()
#15 0x0000000000c7c618 in PVR::CPVRManager::Process() ()
#16 0x0000000000a43ca1 in CThread::Action() ()
#17 0x0000000000a44345 in CThread::staticThread(void*) ()
#18 0x00007f9a2782e444 in start_thread (arg=0x7f9989ffb700) at pthread_create.c:333
#19 0x00007f9a2354a86f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105

Thread 38 (Thread 0x7f99dfae5700 (LWP 2695)):
#0  __pthread_mutex_lock_full (mutex=0x7f99a0541b98) at ../nptl/pthread_mutex_lock.c:343
#1  0x00000000008222b3 in XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock() ()
=> wants channelgroups mutex
#2  0x0000000000c67612 in PVR::CPVRChannelGroups::GetSelectedGroup() const ()
#3  0x0000000000c69ccd in PVR::CPVRChannelGroupsContainer::GetSelectedGroup(bool) const ()
#4  0x0000000000c77dac in PVR::CPVRManager::GetPlayingGroup(bool) ()
#5  0x0000000000c78d99 in PVR::CPVRManager::UpdateLastWatched(std::shared_ptr<PVR::CPVRChannel> const&) ()
==> owns pvr manager mutex
#6  0x0000000000c79adf in PVR::CPVRManager::OpenLiveStream(CFileItem const&) ()
#7  0x00000000008e2c48 in CDVDInputStreamPVRManager::Open() ()
#8  0x0000000000923987 in CVideoPlayer::OpenInputStream() ()
#9  0x0000000000924fad in CVideoPlayer::Process() ()
#10 0x0000000000a43ca1 in CThread::Action() ()
#11 0x0000000000a44345 in CThread::staticThread(void*) ()
#12 0x00007f9a2782e444 in start_thread (arg=0x7f99dfae5700) at pthread_create.c:333
#13 0x00007f9a2354a86f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105
</pre>

Runtime-tested on macOS and Linux, latest Kodi master.

@Jalle19 mind doing the review.

