### PR TITLE
spelling: DestroyDispmanxWindow

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.cpp
@@ -166,7 +166,7 @@ bool CEGLNativeTypeRaspberryPI::DestroyNativeDisplay()
 bool CEGLNativeTypeRaspberryPI::DestroyNativeWindow()
 {
 #if defined(TARGET_RASPBERRY_PI)
-  DestroyDispmaxWindow();
+  DestroyDispmanxWindow();
   free(m_nativeWindow);
   m_nativeWindow = NULL;
   DLOG("CEGLNativeTypeRaspberryPI::DestroyNativeWindow\n");
@@ -228,7 +228,7 @@ bool CEGLNativeTypeRaspberryPI::SetNativeResolution(const RESOLUTION_INFO &res)
   if(!m_DllBcmHost || !m_nativeWindow)
     return false;
 
-  DestroyDispmaxWindow();
+  DestroyDispmanxWindow();
 
   RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
   if(GETFLAGS_GROUP(res.dwFlags) && GETFLAGS_MODE(res.dwFlags))
@@ -579,7 +579,7 @@ bool CEGLNativeTypeRaspberryPI::ShowWindow(bool show)
 }
 
 #if defined(TARGET_RASPBERRY_PI)
-void CEGLNativeTypeRaspberryPI::DestroyDispmaxWindow()
+void CEGLNativeTypeRaspberryPI::DestroyDispmanxWindow()
 {
   if(!m_DllBcmHost)
     return;
@@ -598,7 +598,7 @@ void CEGLNativeTypeRaspberryPI::DestroyDispmaxWindow()
     g_RBP.CloseDisplay(m_dispman_display);
     m_dispman_display = DISPMANX_NO_HANDLE;
   }
-  DLOG("CEGLNativeTypeRaspberryPI::DestroyDispmaxWindow\n");
+  DLOG("CEGLNativeTypeRaspberryPI::DestroyDispmanxWindow\n");
 }
 
 void CEGLNativeTypeRaspberryPI::GetSupportedModes(HDMI_RES_GROUP_T group, std::vector<RESOLUTION_INFO> &resolutions)

--- a/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
+++ b/xbmc/windowing/egl/EGLNativeTypeRaspberryPI.h
@@ -71,7 +71,7 @@ private:
   void TvServiceCallback(uint32_t reason, uint32_t param1, uint32_t param2);
   static void CallbackTvServiceCallback(void *userdata, uint32_t reason, uint32_t param1, uint32_t param2);
 
-  void DestroyDispmaxWindow();
+  void DestroyDispmanxWindow();
   int FindMatchingResolution(const RESOLUTION_INFO &res, const std::vector<RESOLUTION_INFO> &resolutions, bool desktop);
   int AddUniqueResolution(RESOLUTION_INFO &res, std::vector<RESOLUTION_INFO> &resolutions, bool desktop = false);
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Fix spelling for dispmanx

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
- [x] Travis
- [x] AppVeyor

## Screenshots (if appropriate):

## Types of change
- [x] Spelling

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document