### PR TITLE
vtb: fix inverted logic for fence

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
@@ -246,10 +246,10 @@ bool CRendererVTB::NeedBuffer(int idx)
 
   if (vtbdata->m_fence && glIsFenceAPPLE(vtbdata->m_fence))
   {
-    if (glTestFenceAPPLE(vtbdata->m_fence))
-      return false;
+    if (!glTestFenceAPPLE(vtbdata->m_fence))
+      return true;
   }
 
-  return true;
+  return false;
 }
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGLES.cpp
@@ -270,10 +270,10 @@ bool CRendererVTB::NeedBuffer(int idx)
   {
     int syncState = GL_UNSIGNALED_APPLE;
     glGetSyncivAPPLE(buf.m_fence, GL_SYNC_STATUS_APPLE, 1, nullptr, &syncState);
-    if (syncState == GL_SIGNALED_APPLE)
-      return false;
+    if (syncState != GL_SIGNALED_APPLE)
+      return true;
   }
   
-  return true;
+  return false;
 }
 #endif


### PR DESCRIPTION
the old code did hold a buffer if there was no fence. that lead to video stuttering