### PR TITLE
[videoplayer] Fix accidental modification of m_streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -292,8 +292,7 @@ DemuxPacket* CDVDDemuxClient::Read()
   {
     RequestStreams();
   }
-  else if (pPacket->iStreamId >= 0 &&
-           m_streams[pPacket->iStreamId])
+  else if (pPacket->iStreamId >= 0 && m_streams.count(pPacket->iStreamId) > 0)
   {
     ParsePacket(pPacket);
   }


### PR DESCRIPTION
This accidentally lead to empty shared pointers being inserted into the stream map if a demux packet with an unknown stream ID was encountered.

Fixes https://github.com/kodi-pvr/pvr.hts/issues/264

## Description

Check the size of the map with `count()` instead.

## Motivation and Context

Watching particular channels with many streams can crash Kodi.

## How Has This Been Tested?

Runtime tested on Linux

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

ping @FernetMenta since you were the one to touch this last
@ksooo @popcornmix do you think you could try that Travel channel with a vanilla pvr.hts (i.e. without https://github.com/kodi-pvr/pvr.hts/pull/272 applied)? I need to go to work...
