### PR TITLE
[cmake] don't use hardcoded 'kodi' paths

### DIFF
--- a/cmake/addons/CMakeLists.txt
+++ b/cmake/addons/CMakeLists.txt
@@ -138,7 +138,7 @@ if(ADDON_SRC_PREFIX)
 endif()
 
 if(NOT APP_LIB_DIR)
-  set(APP_LIB_DIR "${ADDON_DEPENDS_PATH}/lib/kodi")
+  set(APP_LIB_DIR "${ADDON_DEPENDS_PATH}/lib/${APP_NAME_LC}")
 else()
   file(TO_CMAKE_PATH "${APP_LIB_DIR}" APP_LIB_DIR)
 endif()

--- a/cmake/scripts/common/CheckTargetPlatform.cmake
+++ b/cmake/scripts/common/CheckTargetPlatform.cmake
@@ -47,8 +47,8 @@ function(check_install_permissions install_dir have_perms)
   # param[in] install_dir directory to check for write permissions
   # param[out] have_perms wether we have permissions to install to install_dir
 
-  set(testfile_lib ${install_dir}/lib/kodi/.cmake-inst-test)
-  set(testfile_share ${install_dir}/share/kodi/.cmake-inst-test)
+  set(testfile_lib ${install_dir}/lib/${APP_NAME_LC}/.cmake-inst-test)
+  set(testfile_share ${install_dir}/share/${APP_NAME_LC}/.cmake-inst-test)
   get_filename_component(testdir_lib ${testfile_lib} DIRECTORY)
   get_filename_component(testdir_share ${testfile_share} DIRECTORY)
 


### PR DESCRIPTION
currently building binary addons fails / get installed in the wrong directory if you rebrand kodi.

@fetzerch @wsnipex 