### PR TITLE
Kryptonfail

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -675,8 +675,6 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
       xbmc_jnienv()->ExceptionClear();
   }
   ReleaseSurfaceTexture();
-  if (m_render_surface)
-    CXBMCApp::get()->clearVideoView();
 
   SAFE_DELETE(m_bitstream);
   s_instances--;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -338,6 +338,8 @@ void CDVDMediaCodecInfo::RenderUpdate(const CRect &SrcRect, const CRect &DestRec
 
 /*****************************************************************************/
 /*****************************************************************************/
+int CDVDVideoCodecAndroidMediaCodec::s_instances = 0;
+
 CDVDVideoCodecAndroidMediaCodec::CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo, bool surface_render)
 : CDVDVideoCodec(processInfo)
 , m_formatname("mediacodec")
@@ -359,6 +361,10 @@ CDVDVideoCodecAndroidMediaCodec::~CDVDVideoCodecAndroidMediaCodec()
 
 bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+
+  if (s_instances > 0)
+    return false;
+
   // mediacodec crashes with null size. Trap this...
   if (!hints.width || !hints.height)
   {
@@ -620,6 +626,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   CLog::Log(LOGINFO, "CDVDVideoCodecAndroidMediaCodec:: "
     "Open Android MediaCodec %s", m_codecname.c_str());
 
+  s_instances++;
   m_opened = true;
   memset(&m_demux_pkt, 0, sizeof(m_demux_pkt));
 
@@ -672,6 +679,7 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
     CXBMCApp::get()->clearVideoView();
 
   SAFE_DELETE(m_bitstream);
+  s_instances--;
 }
 
 int CDVDVideoCodecAndroidMediaCodec::Decode(uint8_t *pData, int iSize, double dts, double pts)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -443,6 +443,11 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           SAFE_DELETE(m_bitstream);
         }
       }
+      else
+      {
+        CLog::Log(LOGWARNING, "CDVDVideoCodecAndroidMediaCodec::Open - No extradata found");
+        return false;
+      }
       break;
     case AV_CODEC_ID_HEVC:
       m_mime = "video/hevc";
@@ -455,6 +460,11 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         {
           SAFE_DELETE(m_bitstream);
         }
+      }
+      else
+      {
+        CLog::Log(LOGWARNING, "CDVDVideoCodecAndroidMediaCodec::Open - No extradata found");
+        return false;
       }
       break;
     case AV_CODEC_ID_WMV3:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -98,6 +98,8 @@ public:
   CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo, bool surface_render = false);
   virtual ~CDVDVideoCodecAndroidMediaCodec();
 
+  // track instances - we can only allow exactly one
+  static int s_instances;
   // required overrides
   virtual bool    Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
   virtual int     Decode(uint8_t *pData, int iSize, double dts, double pts);


### PR DESCRIPTION
Krypton only.

This stops MediaCodec from crashing when an instance is already running. It won't help to open a second decoder properly. For LiveTV that means: HW -> switch -> SW -> switch -> HW. Better than HW -> switch -> crash -> kodi exit.

The second one was asked for by peak3d - that thingy is racy as hell anyways. Removing another direct call into the App can only make it better.

For master and v18 the proper interface change is already available. Krypton on Android is in very bad shape, but we don't need to release it crashing.