### PR TITLE
[osx] - fix refclock after refreshrate change and re-add videoscreen.delayrefreshchange

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -79,6 +79,7 @@ public:
 
   void        AnnounceOnLostDevice();
   void        AnnounceOnResetDevice();
+  void        HandleOnResetDevice();
   void        StartLostDeviceTimer();
   void        StopLostDeviceTimer();
   
@@ -119,6 +120,8 @@ protected:
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;
   CTimer                       m_lostDeviceTimer;
+  bool                         m_delayDispReset;
+  XbmcThreads::EndTime         m_dispResetTimer;
 };
 
 #endif

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1744,6 +1744,16 @@ void CWinSystemOSX::AnnounceOnLostDevice()
 
 void CWinSystemOSX::AnnounceOnResetDevice()
 {
+  double currentFps = m_refreshRate;
+  int w = 0;
+  int h = 0;
+  int currentScreenIdx = GetCurrentScreen();
+  // ensure that graphics context knows about the current refreshrate before
+  // doing the callbacks
+  GetScreenResolution(&w, &h, &currentFps, currentScreenIdx);
+
+  g_graphicsContext.SetFPS(currentFps);
+
   CSingleLock lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemOSX::AnnounceOnResetDevice");

--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -41,6 +41,12 @@ void CWinSystemOSXGL::PresentRenderImpl(bool rendered)
 {
   if (rendered)
     FlushBuffer();
+  
+  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
+  {
+    m_delayDispReset = false;
+    AnnounceOnResetDevice();
+  }
 }
 
 void CWinSystemOSXGL::SetVSyncImpl(bool enable)


### PR DESCRIPTION
This fixes a problem where after changing refreshrate the VideoPlayer still uses the old fps. It also re-adds the videoscreen.delayrefreshchange which got lost somewhere during the cycle (used the same pattern as on WindowingX11.

@FernetMenta so far what we gathered i guess. Fine with this?

Also the user which reported the choppy vtb (which you fixed with the fence logic inversion) stated that its smooth now - but it gets choppy as soon as an overlay comes into play :(. So this issue is still left then.