### PR TITLE
[osx] - fix refclock after refreshrate change and re-add videoscreen.delayrefreshchange

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -79,6 +79,7 @@ public:
 
   void        AnnounceOnLostDevice();
   void        AnnounceOnResetDevice();
+  void        HandleOnResetDevice();
   void        StartLostDeviceTimer();
   void        StopLostDeviceTimer();
   
@@ -119,6 +120,8 @@ protected:
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;
   CTimer                       m_lostDeviceTimer;
+  bool                         m_delayDispReset;
+  XbmcThreads::EndTime         m_dispResetTimer;
 };
 
 #endif

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -516,7 +516,7 @@ static void DisplayReconfigured(CGDirectDisplayID display,
     if (flags & kCGDisplaySetModeFlag || flags == 0)
     {
       winsys->StopLostDeviceTimer(); // no need to timeout - we've got the callback
-      winsys->AnnounceOnResetDevice();
+      winsys->HandleOnResetDevice();
     }
   }
   
@@ -540,6 +540,7 @@ CWinSystemOSX::CWinSystemOSX() : CWinSystemBase(), m_lostDeviceTimer(this)
   m_lastDisplayNr = -1;
   m_movedToOtherScreen = false;
   m_refreshRate = 0.0;
+  m_delayDispReset = false;
 }
 
 CWinSystemOSX::~CWinSystemOSX()
@@ -561,7 +562,7 @@ void CWinSystemOSX::StopLostDeviceTimer()
 
 void CWinSystemOSX::OnTimeout()
 {
-  AnnounceOnResetDevice();
+  HandleOnResetDevice();
 }
 
 bool CWinSystemOSX::InitWindowSystem()
@@ -1739,6 +1740,21 @@ void CWinSystemOSX::AnnounceOnLostDevice()
   CLog::Log(LOGDEBUG, "CWinSystemOSX::AnnounceOnLostDevice");
   for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
     (*i)->OnLostDisplay();
+}
+
+void CWinSystemOSX::HandleOnResetDevice()
+{
+  
+  int delay = CSettings::GetInstance().GetInt("videoscreen.delayrefreshchange");
+  if (delay > 0)
+  {
+    m_delayDispReset = true;
+    m_dispResetTimer.Set(delay * 100);
+  }
+  else
+  {
+    AnnounceOnResetDevice();
+  }
 }
 
 void CWinSystemOSX::AnnounceOnResetDevice()

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1743,6 +1743,16 @@ void CWinSystemOSX::AnnounceOnLostDevice()
 
 void CWinSystemOSX::AnnounceOnResetDevice()
 {
+  double currentFps = m_refreshRate;
+  int w = 0;
+  int h = 0;
+  int currentScreenIdx = GetCurrentScreen();
+  // ensure that graphics context knows about the current refreshrate before
+  // doing the callbacks
+  GetScreenResolution(&w, &h, &currentFps, currentScreenIdx);
+
+  g_graphicsContext.SetFPS(currentFps);
+
   CSingleLock lock(m_resourceSection);
   // tell any shared resources
   CLog::Log(LOGDEBUG, "CWinSystemOSX::AnnounceOnResetDevice");

--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -41,6 +41,12 @@ void CWinSystemOSXGL::PresentRenderImpl(bool rendered)
 {
   if (rendered)
     FlushBuffer();
+  
+  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
+  {
+    m_delayDispReset = false;
+    AnnounceOnResetDevice();
+  }
 }
 
 void CWinSystemOSXGL::SetVSyncImpl(bool enable)


### PR DESCRIPTION
backport of #11388