### PR TITLE
Android: Fix jni local reference leak for jstring

### DIFF
--- a/xbmc/platform/android/jni/jutils.cpp
+++ b/xbmc/platform/android/jni/jutils.cpp
@@ -116,6 +116,7 @@ std::vector<std::string> jcast_helper<std::vector<std::string>, jobjectArray >::
       ret.push_back(newString);
       env->ReleaseStringUTFChars(element, newString);
     }
+    env->DeleteLocalRef(element);
   }
   return ret;
 }


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/11376
<!--- Provide a general summary of your change in the Title above -->

## Description
Delete local reference after using jstring.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When casting a java string array to std::string array, local reference leaks. This happens when calling CJNIMediaCodecInfo::getSupportedTypes() in CDVDVideoCodecAndroidMediaCodec::Open.

After play video using mediacodec many times Kodi crashs, logcat shows 'JNI ERROR (app bug): local reference table overflow (max=512)'. Calling CJNIMediaCodecInfo::getSupportedTypes() in a loop for 512 times can reproduce the problem quickly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
