### PR TITLE
Replace raw new/delete inside CDVDFactorySubtitle 

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -34,42 +34,41 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
 {
   char line[1024];
   int i;
-  CDVDSubtitleParser* pParser = NULL;
 
   std::unique_ptr<CDVDSubtitleStream> pStream(new CDVDSubtitleStream());
   if(!pStream->Open(strFile))
   {
-    return NULL;
+    return nullptr;
   }
 
-  for (int t = 0; !pParser && t < 256; t++)
+  for (int t = 0; t < 256; t++)
   {
     if (pStream->ReadLine(line, sizeof(line)))
     {
       if ((sscanf (line, "{%d}{}", &i)==1) ||
           (sscanf (line, "{%d}{%d}", &i, &i)==2))
       {
-        pParser = new CDVDSubtitleParserMicroDVD(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserMicroDVD(std::move(pStream), strFile.c_str());
       }
       else if (sscanf(line, "[%d][%d]", &i, &i) == 2)
       {
-        pParser = new CDVDSubtitleParserMPL2(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserMPL2(std::move(pStream), strFile.c_str());
       }
       else if (sscanf(line, "%d:%d:%d%*c%d --> %d:%d:%d%*c%d", &i, &i, &i, &i, &i, &i, &i, &i) == 8)
       {
-        pParser = new CDVDSubtitleParserSubrip(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserSubrip(std::move(pStream), strFile.c_str());
       }
       else if (sscanf(line, "%d:%d:%d:", &i, &i, &i) == 3)
       {
-        pParser = new CDVDSubtitleParserVplayer(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserVplayer(std::move(pStream), strFile.c_str());
       }
       else if ((!memcmp(line, "Dialogue: Marked", 16)) || (!memcmp(line, "Dialogue: ", 10)))
       {
-        pParser =  new CDVDSubtitleParserSSA(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserSSA(std::move(pStream), strFile.c_str());
       }
       else if (strstr (line, "<SAMI>"))
       {
-        pParser = new CDVDSubtitleParserSami(std::move(pStream), strFile.c_str());
+        return new CDVDSubtitleParserSami(std::move(pStream), strFile.c_str());
       }
     }
     else
@@ -78,6 +77,6 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
     }
   }
 
-  return pParser;
+  return nullptr;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -21,7 +21,6 @@
 #include "DVDFactorySubtitle.h"
 
 #include "DVDSubtitleStream.h"
-//#include "DVDSubtitleParserSpu.h"
 #include "DVDSubtitleParserSubrip.h"
 #include "DVDSubtitleParserMicroDVD.h"
 #include "DVDSubtitleParserMPL2.h"
@@ -72,73 +71,11 @@ CDVDSubtitleParser* CDVDFactorySubtitle::CreateParser(std::string& strFile)
         pParser =  new CDVDSubtitleParserSSA(pStream, strFile.c_str());
         pStream = NULL;
       }
-      //   if (sscanf (line, "%d:%d:%d.%d,%d:%d:%d.%d",     &i, &i, &i, &i, &i, &i, &i, &i)==8){
-      //     this->uses_time=1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "subviewer subtitle format detected\n");
-      //     return FORMAT_SUBVIEWER;
-      //   }
-
-      //   if (sscanf (line, "%d:%d:%d,%d,%d:%d:%d,%d",     &i, &i, &i, &i, &i, &i, &i, &i)==8){
-      //     this->uses_time=1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "subviewer subtitle format detected\n");
-      //     return FORMAT_SUBVIEWER;
-      //   }
-
       else if (strstr (line, "<SAMI>"))
       {
         pParser = new CDVDSubtitleParserSami(pStream, strFile.c_str());
         pStream = NULL;
       }
-      //   /*
-      //   * A RealText format is a markup language, starts with <window> tag,
-      //   * options (behaviour modifiers) are possible.
-      //   */
-      //   if ( !strcasecmp(line, "<window") ) {
-      //     this->uses_time=1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "rt subtitle format detected\n");
-      //     return FORMAT_RT;
-      //   }
-      //   if ((!memcmp(line, "Dialogue: Marked", 16)) || (!memcmp(line, "Dialogue: ", 10))) {
-      //     this->uses_time=1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "ssa subtitle format detected\n");
-      //     return FORMAT_SSA;
-      //   }
-      //   if (sscanf (line, "%d,%d,\"%c", &i, &i, (char *) &i) == 3) {
-      //     this->uses_time=0;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "pjs subtitle format detected\n");
-      //     return FORMAT_PJS;
-      //   }
-      //   if (sscanf (line, "FORMAT=%d", &i) == 1) {
-      //     this->uses_time=0;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "mpsub subtitle format detected\n");
-      //     return FORMAT_MPSUB;
-      //   }
-      //   if (sscanf (line, "FORMAT=TIM%c", &p)==1 && p=='E') {
-      //     this->uses_time=1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "mpsub subtitle format detected\n");
-      //     return FORMAT_MPSUB;
-      //   }
-      //   if (strstr (line, "-->>")) {
-      //     this->uses_time=0;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "aqtitle subtitle format detected\n");
-      //     return FORMAT_AQTITLE;
-      //   }
-      //   if (sscanf(line, "@%d @%d", &i, &i) == 2 ||
-      //sscanf(line, "%d:%d:%d.%d %d:%d:%d.%d", &i, &i, &i, &i, &i, &i, &i, &i) == 8) {
-      //     this->uses_time = 1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "jacobsub subtitle format detected\n");
-      //     return FORMAT_JACOBSUB;
-      //   }
-      //   if (sscanf(line, "{T %d:%d:%d:%d",&i, &i, &i, &i) == 4) {
-      //     this->uses_time = 1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "subviewer 2.0 subtitle format detected\n");
-      //     return FORMAT_SUBVIEWER2;
-      //   }
-      //   if (sscanf(line, "[%d:%d:%d]", &i, &i, &i) == 3) {
-      //     this->uses_time = 1;
-      //     xprintf (this->stream->xine, XINE_VERBOSITY_DEBUG, "subrip 0.9 subtitle format detected\n");
-      //     return FORMAT_SUBRIP09;
-      //   }
     }
     else
     {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -24,6 +24,7 @@
 #include "DVDSubtitleStream.h"
 #include "DVDSubtitleLineCollection.h"
 
+#include <memory>
 #include <string>
 #include <stdio.h>
 
@@ -64,17 +65,13 @@ class CDVDSubtitleParserText
      : public CDVDSubtitleParserCollection
 {
 public:
-  CDVDSubtitleParserText(CDVDSubtitleStream* stream, const std::string& filename)
+  CDVDSubtitleParserText(std::unique_ptr<CDVDSubtitleStream> && stream, const std::string& filename)
     : CDVDSubtitleParserCollection(filename)
+		, m_pStream(std::move(stream)) 
   {
-    m_pStream  = stream;
   }
 
-  virtual ~CDVDSubtitleParserText()
-  {
-    if(m_pStream)
-      delete m_pStream;
-  }
+  virtual ~CDVDSubtitleParserText() = default;
 
 protected:
 
@@ -86,10 +83,10 @@ protected:
         return true;
     }
     else
-      m_pStream = new CDVDSubtitleStream();
+      m_pStream.reset(new CDVDSubtitleStream());
 
     return m_pStream->Open(m_filename);
   }
 
-  CDVDSubtitleStream* m_pStream;
+  std::unique_ptr<CDVDSubtitleStream> m_pStream;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
@@ -25,8 +25,8 @@
 #include "DVDStreamInfo.h"
 #include "DVDSubtitleTagMicroDVD.h"
 
-CDVDSubtitleParserMPL2::CDVDSubtitleParserMPL2(CDVDSubtitleStream* stream, const std::string& filename)
-    : CDVDSubtitleParserText(stream, filename), m_framerate(DVD_TIME_BASE / 10.0)
+CDVDSubtitleParserMPL2::CDVDSubtitleParserMPL2(std::unique_ptr<CDVDSubtitleStream> && stream, const std::string& filename)
+    : CDVDSubtitleParserText(std::move(stream), filename), m_framerate(DVD_TIME_BASE / 10.0)
 {
 
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.h
@@ -22,10 +22,12 @@
 
 #include "DVDSubtitleParser.h"
 
+#include <memory>
+
 class CDVDSubtitleParserMPL2 : public CDVDSubtitleParserText
 {
 public:
-  CDVDSubtitleParserMPL2(CDVDSubtitleStream* stream, const std::string& strFile);
+  CDVDSubtitleParserMPL2(std::unique_ptr<CDVDSubtitleStream> && stream, const std::string& strFile);
   virtual ~CDVDSubtitleParserMPL2();
 
   virtual bool Open(CDVDStreamInfo &hints);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
@@ -26,8 +26,8 @@
 #include "utils/log.h"
 #include "DVDSubtitleTagMicroDVD.h"
 
-CDVDSubtitleParserMicroDVD::CDVDSubtitleParserMicroDVD(CDVDSubtitleStream* stream, const std::string& filename)
-    : CDVDSubtitleParserText(stream, filename), m_framerate( DVD_TIME_BASE / 25.0 )
+CDVDSubtitleParserMicroDVD::CDVDSubtitleParserMicroDVD(std::unique_ptr<CDVDSubtitleStream> && stream, const std::string& filename)
+    : CDVDSubtitleParserText(std::move(stream), filename), m_framerate( DVD_TIME_BASE / 25.0 )
 {
 
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.h
@@ -22,10 +22,12 @@
 
 #include "DVDSubtitleParser.h"
 
+#include <memory>
+
 class CDVDSubtitleParserMicroDVD : public CDVDSubtitleParserText
 {
 public:
-  CDVDSubtitleParserMicroDVD(CDVDSubtitleStream* stream, const std::string& strFile);
+  CDVDSubtitleParserMicroDVD(std::unique_ptr<CDVDSubtitleStream> && stream, const std::string& strFile);
   virtual ~CDVDSubtitleParserMicroDVD();
 
   virtual bool Open(CDVDStreamInfo &hints);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -23,8 +23,8 @@
 #include "DVDClock.h"
 #include "utils/log.h"
 
-CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(CDVDSubtitleStream* pStream, const std::string& strFile)
-    : CDVDSubtitleParserText(pStream, strFile)
+CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile)
+    : CDVDSubtitleParserText(std::move(pStream), strFile)
 {
   m_libass = new CDVDSubtitlesLibass();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.h
@@ -23,11 +23,12 @@
 #include "DVDSubtitleParser.h"
 #include "DVDSubtitlesLibass.h"
 
+#include <memory>
 
 class CDVDSubtitleParserSSA : public CDVDSubtitleParserText
 {
 public:
-  CDVDSubtitleParserSSA(CDVDSubtitleStream* pStream, const std::string& strFile);
+  CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile);
   virtual ~CDVDSubtitleParserSSA();
 
   virtual bool Open(CDVDStreamInfo &hints);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
@@ -27,8 +27,8 @@
 #include "utils/URIUtils.h"
 #include "DVDSubtitleTagSami.h"
 
-CDVDSubtitleParserSami::CDVDSubtitleParserSami(CDVDSubtitleStream* pStream, const std::string& filename)
-    : CDVDSubtitleParserText(pStream, filename)
+CDVDSubtitleParserSami::CDVDSubtitleParserSami(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& filename)
+    : CDVDSubtitleParserText(std::move(pStream), filename)
 {
 
 }
@@ -56,7 +56,7 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo &hints)
   CDVDSubtitleTagSami TagConv;
   if (!TagConv.Init())
     return false;
-  TagConv.LoadHead(m_pStream);
+  TagConv.LoadHead(m_pStream.get());
   if (TagConv.m_Langclass.size() >= 2)
   {
     for (unsigned int i = 0; i < TagConv.m_Langclass.size(); i++)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.h
@@ -21,13 +21,16 @@
  */
 
 #include "DVDSubtitleParser.h"
+
+#include <memory>
+
 class CDVDOverlayText;
 class CRegExp;
 
 class CDVDSubtitleParserSami : public CDVDSubtitleParserText
 {
 public:
-  CDVDSubtitleParserSami(CDVDSubtitleStream* pStream, const std::string& strFile);
+  CDVDSubtitleParserSami(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile);
   virtual ~CDVDSubtitleParserSami();
   virtual bool Open(CDVDStreamInfo &hints);
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.cpp
@@ -24,8 +24,8 @@
 #include "utils/StringUtils.h"
 #include "DVDSubtitleTagSami.h"
 
-CDVDSubtitleParserSubrip::CDVDSubtitleParserSubrip(CDVDSubtitleStream* pStream, const std::string& strFile)
-    : CDVDSubtitleParserText(pStream, strFile)
+CDVDSubtitleParserSubrip::CDVDSubtitleParserSubrip(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile)
+    : CDVDSubtitleParserText(std::move(pStream), strFile)
 {
 }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.h
@@ -22,10 +22,12 @@
 
 #include "DVDSubtitleParser.h"
 
+#include <memory>
+
 class CDVDSubtitleParserSubrip : public CDVDSubtitleParserText
 {
 public:
-  CDVDSubtitleParserSubrip(CDVDSubtitleStream* pStream, const std::string& strFile);
+  CDVDSubtitleParserSubrip(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile);
   virtual ~CDVDSubtitleParserSubrip();
 
   virtual bool Open(CDVDStreamInfo &hints);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
@@ -23,8 +23,8 @@
 #include "DVDClock.h"
 #include "utils/RegExp.h"
 
-CDVDSubtitleParserVplayer::CDVDSubtitleParserVplayer(CDVDSubtitleStream* pStream, const std::string& strFile)
-    : CDVDSubtitleParserText(pStream, strFile), m_framerate(DVD_TIME_BASE)
+CDVDSubtitleParserVplayer::CDVDSubtitleParserVplayer(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile)
+    : CDVDSubtitleParserText(std::move(pStream), strFile), m_framerate(DVD_TIME_BASE)
 {
 }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.h
@@ -22,10 +22,12 @@
 
 #include "DVDSubtitleParser.h"
 
+#include <memory>
+
 class CDVDSubtitleParserVplayer : public CDVDSubtitleParserText
 {
 public:
-  CDVDSubtitleParserVplayer(CDVDSubtitleStream* pStream, const std::string& strFile);
+  CDVDSubtitleParserVplayer(std::unique_ptr<CDVDSubtitleStream> && pStream, const std::string& strFile);
   virtual ~CDVDSubtitleParserVplayer();
 
   virtual bool Open(CDVDStreamInfo &hints);


### PR DESCRIPTION
## Description
Replaced use of raw new/delete inside CDVDFactorySubtitle. Previous code is creating a CDVDSubtitleStream in CDVDFactorySubtitle then passing ownership to the relevant CDVDSubtitleParser for each subtitle format. I've replaced the raw new/delete with unique_ptr and moved ownership into the parsers. This means we can simplify the factory function a lot.

I've also deleted some commented out code that looked like it wasn't serving a purpose any more.

As this change is already getting a bit big, I deliberately avoided changing the return values of the function over to unique_ptrs as this would expand the size of the PR.

What is here I've separated out into a few commits to make it easier to read.

## Motivation and Context
The main goal is improving general exception safety. Hopefully the factory function should be a bit easier to read now.

## How Has This Been Tested?
Before starting, I added tests for CDVDFactorySubtitle to ensure I didn't break anything. I ran these both before & after making the change.

I also tested manually by loading subtitles for all of the affected subtitle formats. I ran this on x86-64 Ubuntu.

The changes should be isolated to the classes touched here.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
