### PR TITLE
Replace raw new/delete with unique_ptr in GUIWindowSlideShow

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -150,7 +150,6 @@ void CBackgroundPicLoader::LoadPic(int iPic, int iSlideNumber, const std::string
 CGUIWindowSlideShow::CGUIWindowSlideShow(void)
     : CGUIDialog(WINDOW_SLIDESHOW, "SlideShow.xml")
 {
-  m_pBackgroundLoader = NULL;
   m_Resolution = RES_INVALID;
   m_loadType = KEEP_IN_MEMORY;
   m_bLoadNextPic = false;
@@ -259,8 +258,7 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
       // stop the thread
       CLog::Log(LOGDEBUG,"Stopping BackgroundLoader thread");
       m_pBackgroundLoader->StopThread();
-      delete m_pBackgroundLoader;
-      m_pBackgroundLoader = NULL;
+      m_pBackgroundLoader.reset();
     }
     // and close the images.
     m_Image[0].Close();
@@ -398,12 +396,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   // Create our background loader if necessary
   if (!m_pBackgroundLoader)
   {
-    m_pBackgroundLoader = new CBackgroundPicLoader();
-
-    if (!m_pBackgroundLoader)
-    {
-      throw 1;
-    }
+    m_pBackgroundLoader.reset(new CBackgroundPicLoader());
     m_pBackgroundLoader->Create(this);
   }
 

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include <memory>
 #include <set>
 #include "guilib/GUIDialog.h"
 #include "threads/Thread.h"
@@ -152,7 +153,7 @@ private:
 
   int m_iCurrentPic;
   // background loader
-  CBackgroundPicLoader* m_pBackgroundLoader;
+  std::unique_ptr<CBackgroundPicLoader> m_pBackgroundLoader;
   int m_iLastFailedNextSlide;
   bool m_bLoadNextPic;
   RESOLUTION m_Resolution;


### PR DESCRIPTION
## Description
Replace raw new/delete with unique_ptr in GUIWindowSlideShow.

## Motivation and Context
General exception safety.

## How Has This Been Tested?
There no automated tests covering this component specifically and it looks difficult to add them at present given the dependencies of this component.

I have tested manually by adding some pictures, both valid and corrupt, and viewed them in the slideshow in Kodi. The slideshow worked both before & after this change. I tested on x86_64 Ubuntu only.

The changes should be localised in this component.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
