### PR TITLE
Autotools: Fake empty AE override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -564,3 +564,6 @@ exclude_dll.txt
 
 #certificates
 /system/certs/
+
+#Workaround for autotools right before final Krypton
+xbmc/cores/AudioEngine/AEDefines_override.h

--- a/xbmc/cores/AudioEngine/Makefile.in
+++ b/xbmc/cores/AudioEngine/Makefile.in
@@ -83,6 +83,6 @@ SRCS += Utils/AELimiter.cpp
 SRCS += Encoders/AEEncoderFFmpeg.cpp
 
 LIB   = audioengine.a
-
+$(shell touch AEDefines_override.h)
 include @abs_top_srcdir@/Makefile.include
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
Fixes autotools on Krypton. Tested on linux. Any other platforms rely on autotools? Also: No idea if this is good or not ... it feels like a pain.