### PR TITLE
[cmake] Fix WinEventsLinux include

### DIFF
--- a/xbmc/windowing/CMakeLists.txt
+++ b/xbmc/windowing/CMakeLists.txt
@@ -17,7 +17,7 @@ if (NOT MIR_FOUND)
     list(APPEND HEADERS WinEventsX11.h)
   endif()
 
-  if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  if(CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT SDL_FOUND AND NOT X_FOUND)
     list(APPEND SOURCES WinEventsLinux.cpp)
     list(APPEND HEADERS WinEventsLinux.h)
   endif()


### PR DESCRIPTION
## Description
Fix WinEventsLinux include

## Motivation and Context
[Requested](https://github.com/xbmc/xbmc/commit/eacc6440409275f0f2a01051a28559dd89f16763#commitcomment-20396848) by @FernetMenta 

## How Has This Been Tested?
Build and briefly runtime tested.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project
