### PR TITLE
[cmake][win32][fix] Don't empty path, prepend our libs to the start of it

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -22,7 +22,8 @@ set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/pyt
 # Emptying PATH so that system installed libraries (MySql, Python) are not picked up.
 # The VS/bin directory has to be in PATH for example for NMake.
 get_filename_component(TOOLCHAIN_PATH ${CMAKE_CXX_COMPILER} DIRECTORY)
-set(ENV{PATH} "${TOOLCHAIN_PATH}")
+set(TMP_PATH ENV{PATH}})
+set(ENV{PATH} "${CMAKE_SOURCE_DIR}/project/BuildDependencies;${TMP_PATH}")
 
 
 # -------- Compiler options ---------

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -19,9 +19,8 @@ list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependenci
 set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/python)
 
 # The find_* functions prefer PATH over CMAKE_PREFIX_PATH for dependencies.
-# Emptying PATH so that system installed libraries (MySql, Python) are not picked up.
-# The VS/bin directory has to be in PATH for example for NMake.
-get_filename_component(TOOLCHAIN_PATH ${CMAKE_CXX_COMPILER} DIRECTORY)
+# prepending our PATH so that our libraries are found first to avoid
+# picking up system libraries that will not build
 set(TMP_PATH ENV{PATH}})
 set(ENV{PATH} "${CMAKE_SOURCE_DIR}/project/BuildDependencies;${TMP_PATH}")
 

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -14,13 +14,13 @@ function(generate_file file)
   add_custom_command(OUTPUT ${CPP_FILE}
                      COMMAND ${SWIG_EXECUTABLE}
                      ARGS -w401 -c++ -o ${file}.xml -xml -I${CMAKE_SOURCE_DIR}/xbmc -xmllang python ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file}
-                     COMMAND ${Java_JAVA_EXECUTABLE}
+                     COMMAND ${JAVA_EXECUTABLE}
                      ARGS -cp "${classpath}" groovy.ui.GroovyMain ${CMAKE_SOURCE_DIR}/tools/codegenerator/Generator.groovy ${file}.xml ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template ${file}.cpp > ${devnull}
                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file})
   set(SOURCES ${SOURCES} "${CPP_FILE}" PARENT_SCOPE)
 endfunction()
 
-find_package(Java COMPONENTS Runtime REQUIRED)
+find_program(JAVA_EXECUTABLE Java REQUIRED)
 find_package(SWIG REQUIRED)
 
 # The generated bindings


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
empting the path caused new exciting errors, this should hopefully work
## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
