### PR TITLE
Bitstream refactor / VC1Bitstream parser

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -32,6 +32,8 @@
 #include "messaging/ApplicationMessenger.h"
 #include "DVDClock.h"
 #include "utils/BitstreamConverter.h"
+#include "utils/BitstreamWriter.h"
+
 #include "utils/CPUInfo.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 #include "VTB.h"
 #include "utils/BitstreamConverter.h"
+#include "utils/BitstreamReader.h"
 
 extern "C" {
 #include "libavcodec/videotoolbox.h"

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2010-2013 Team XBMC
+ *      Copyright (C) 2010-2017 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -26,6 +26,8 @@
 #endif
 
 #include "BitstreamConverter.h"
+#include "BitstreamReader.h"
+#include "BitstreamWriter.h"
 
 enum {
     AVC_NAL_SLICE=1,
@@ -128,9 +130,9 @@ next_byte:
 
   // bring the required bits down and truncate
   if ((shift = bs->head - n) > 0)
-    res = bs->cache >> shift;
+    res = static_cast<uint32_t>(bs->cache >> shift);
   else
-    res = bs->cache;
+    res = static_cast<uint32_t>(bs->cache);
 
   // mask out required bits
   if (n < 32)
@@ -209,50 +211,6 @@ static const uint8_t* avc_find_startcode(const uint8_t *p, const uint8_t *end)
 /////////////////////////////////////////////////////////////////////////////////////////////
 CBitstreamParser::CBitstreamParser()
 {
-}
-
-CBitstreamParser::~CBitstreamParser()
-{
-  Close();
-}
-
-bool CBitstreamParser::Open()
-{
-  return true;
-}
-
-void CBitstreamParser::Close()
-{
-}
-
-const uint8_t* CBitstreamParser::find_start_code(const uint8_t *p,
-  const uint8_t *end, uint32_t *state)
-{
-  assert(p <= end);
-  if (p >= end)
-    return end;
-
-  for (int i = 0; i < 3; i++) {
-    uint32_t tmp = *state << 8;
-    *state = tmp + *(p++);
-    if (tmp == 0x100 || p == end)
-      return p;
-  }
-
-  while (p < end) {
-    if      (p[-1] > 1      ) p += 3;
-    else if (p[-2]          ) p += 2;
-    else if (p[-3]|(p[-1]-1)) p++;
-    else {
-      p++;
-      break;
-    }
-  }
-
-  p = FFMIN(p, end) - 4;
-  *state = BS_RB32(p);
-
-  return p + 4;
 }
 
 bool CBitstreamParser::FindIdrSlice(const uint8_t *buf, int buf_size)
@@ -1068,185 +1026,6 @@ const int CBitstreamConverter::isom_write_avcc(AVIOContext *pb, const uint8_t *d
   return 0;
 }
 
-void CBitstreamConverter::bits_reader_set( bits_reader_t *br, uint8_t *buf, int len )
-{
-  br->buffer = br->start = buf;
-  br->offbits = 0;
-  br->length = len;
-  br->oflow = 0;
-}
-
-uint32_t CBitstreamConverter::read_bits( bits_reader_t *br, int nbits )
-{
-  int i, nbytes;
-  uint32_t ret = 0;
-  uint8_t *buf;
-
-  buf = br->buffer;
-  nbytes = (br->offbits + nbits)/8;
-  if ( ((br->offbits + nbits) %8 ) > 0 )
-    nbytes++;
-  if ( (buf + nbytes) > (br->start + br->length) ) {
-    br->oflow = 1;
-    return 0;
-  }
-  for ( i=0; i<nbytes; i++ )
-    ret += buf[i]<<((nbytes-i-1)*8);
-  i = (4-nbytes)*8+br->offbits;
-  ret = ((ret<<i)>>i)>>((nbytes*8)-nbits-br->offbits);
-
-  br->offbits += nbits;
-  br->buffer += br->offbits / 8;
-  br->offbits %= 8;
-
-  return ret;
-}
-
-void CBitstreamConverter::skip_bits( bits_reader_t *br, int nbits )
-{
-  br->offbits += nbits;
-  br->buffer += br->offbits / 8;
-  br->offbits %= 8;
-  if ( br->buffer > (br->start + br->length) ) {
-    br->oflow = 1;
-  }
-}
-
-uint32_t CBitstreamConverter::get_bits( bits_reader_t *br, int nbits )
-{
-  int i, nbytes;
-  uint32_t ret = 0;
-  uint8_t *buf;
-
-  buf = br->buffer;
-  nbytes = (br->offbits + nbits)/8;
-  if ( ((br->offbits + nbits) %8 ) > 0 )
-    nbytes++;
-  if ( (buf + nbytes) > (br->start + br->length) ) {
-    br->oflow = 1;
-    return 0;
-  }
-  for ( i=0; i<nbytes; i++ )
-    ret += buf[i]<<((nbytes-i-1)*8);
-  i = (4-nbytes)*8+br->offbits;
-  ret = ((ret<<i)>>i)>>((nbytes*8)-nbits-br->offbits);
-
-  return ret;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////////////
-void CBitstreamConverter::init_bits_writer(bits_writer_t *s, uint8_t *buffer, int buffer_size, int writer_le)
-{
-  if (buffer_size < 0)
-  {
-    buffer_size = 0;
-    buffer      = NULL;
-  }
-
-  s->size_in_bits = 8 * buffer_size;
-  s->buf          = buffer;
-  s->buf_end      = s->buf + buffer_size;
-  s->buf_ptr      = s->buf;
-  s->bit_left     = 32;
-  s->bit_buf      = 0;
-  s->writer_le    = writer_le;
-}
-
-void CBitstreamConverter::write_bits(bits_writer_t *s, int n, unsigned int value)
-{
-  // Write up to 32 bits into a bitstream.
-  unsigned int bit_buf;
-  int bit_left;
-
-  if (n == 32)
-  {
-    // Write exactly 32 bits into a bitstream.
-    // danger, recursion in play.
-    int lo = value & 0xffff;
-    int hi = value >> 16;
-    if (s->writer_le)
-    {
-      write_bits(s, 16, lo);
-      write_bits(s, 16, hi);
-    }
-    else
-    {
-      write_bits(s, 16, hi);
-      write_bits(s, 16, lo);
-    }
-    return;
-  }
-
-  bit_buf  = s->bit_buf;
-  bit_left = s->bit_left;
-
-  if (s->writer_le)
-  {
-    bit_buf |= value << (32 - bit_left);
-    if (n >= bit_left) {
-      BS_WL32(s->buf_ptr, bit_buf);
-      s->buf_ptr += 4;
-      bit_buf     = (bit_left == 32) ? 0 : value >> bit_left;
-      bit_left   += 32;
-    }
-    bit_left -= n;
-  }
-  else
-  {
-    if (n < bit_left) {
-      bit_buf     = (bit_buf << n) | value;
-      bit_left   -= n;
-    } else {
-      bit_buf   <<= bit_left;
-      bit_buf    |= value >> (n - bit_left);
-      BS_WB32(s->buf_ptr, bit_buf);
-      s->buf_ptr += 4;
-      bit_left   += 32 - n;
-      bit_buf     = value;
-    }
-  }
-
-  s->bit_buf  = bit_buf;
-  s->bit_left = bit_left;
-}
-
-void CBitstreamConverter::skip_bits(bits_writer_t *s, int n)
-{
-  // Skip the given number of bits.
-  // Must only be used if the actual values in the bitstream do not matter.
-  // If n is 0 the behavior is undefined.
-  s->bit_left -= n;
-  s->buf_ptr  -= 4 * (s->bit_left >> 5);
-  s->bit_left &= 31;
-}
-
-void CBitstreamConverter::flush_bits(bits_writer_t *s)
-{
-  if (!s->writer_le)
-  {
-    if (s->bit_left < 32)
-      s->bit_buf <<= s->bit_left;
-  }
-  while (s->bit_left < 32)
-  {
-
-    if (s->writer_le)
-    {
-      *s->buf_ptr++ = s->bit_buf;
-      s->bit_buf  >>= 8;
-    }
-    else
-    {
-      *s->buf_ptr++ = s->bit_buf >> 24;
-      s->bit_buf  <<= 8;
-    }
-    s->bit_left  += 8;
-  }
-  s->bit_left = 32;
-  s->bit_buf  = 0;
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
 bool CBitstreamConverter::mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence)
@@ -1299,17 +1078,17 @@ bool CBitstreamConverter::mpeg2_sequence_header(const uint8_t *data, const uint3
       switch(ratio_info)
       {
         case 0x01:
-          ratio = 1.0;
+          ratio = 1.0f;
           break;
         default:
         case 0x02:
-          ratio = 4.0/3.0;
+          ratio = 4.0f/3;
           break;
         case 0x03:
-          ratio = 16.0/9.0;
+          ratio = 16.0f/9;
           break;
         case 0x04:
-          ratio = 2.21;
+          ratio = 2.21f;
           break;
       }
       if (ratio_info != sequence->ratio_info)
@@ -1327,28 +1106,28 @@ bool CBitstreamConverter::mpeg2_sequence_header(const uint8_t *data, const uint3
       {
         default:
         case 0x01:
-          rate = 24000.0 / 1001.0;
+          rate = static_cast<float>(24000.0 / 1001.0);
           break;
         case 0x02:
-          rate = 24000.0 / 1000.0;
+          rate = 24.0f;
           break;
         case 0x03:
-          rate = 25000.0 / 1000.0;
+          rate = 25.0f;
           break;
         case 0x04:
-          rate = 30000.0 / 1001.0;
+          rate = static_cast<float>(30000.0 / 1001.0);
           break;
         case 0x05:
-          rate = 30000.0 / 1000.0;
+          rate = 30.0f;
           break;
         case 0x06:
-          rate = 50000.0 / 1000.0;
+          rate = 50.0f;
           break;
         case 0x07:
-          rate = 60000.0 / 1001.0;
+          rate = static_cast<float>(60000.0 / 1001.0);
           break;
         case 0x08:
-          rate = 60000.0 / 1000.0;
+          rate = 60.0f;
           break;
       }
       if (rate_info != sequence->rate_info)

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2010-2015 Team Kodi
+ *      Copyright (C) 2010-2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -28,54 +28,6 @@ extern "C" {
 #include "libavfilter/avfilter.h"
 #include "libavcodec/avcodec.h"
 }
-
-typedef struct {
-  int       writer_le;
-  uint32_t  bit_buf;
-  int       bit_left;
-  uint8_t   *buf, *buf_ptr, *buf_end;
-  int       size_in_bits;
-} bits_writer_t;
-
-typedef struct {
-  uint8_t *buffer, *start;
-  int      offbits, length, oflow;
-} bits_reader_t;
-
-////////////////////////////////////////////////////////////////////////////////////////////
-//! @todo refactor this so as not to need these ffmpeg routines.
-//! These are not exposed in ffmpeg's API so we dupe them here.
-// AVC helper functions for muxers,
-//  * Copyright (c) 2006 Baptiste Coudurier <baptiste.coudurier@smartjog.com>
-// This is part of FFmpeg
-//  * License as published by the Free Software Foundation; either
-//  * version 2.1 of the License, or (at your option) any later version.
-#define BS_RB16(x)                          \
-  ((((const uint8_t*)(x))[0] <<  8) |        \
-   ((const uint8_t*)(x)) [1])
-
-#define BS_RB24(x)                          \
-  ((((const uint8_t*)(x))[0] << 16) |        \
-   (((const uint8_t*)(x))[1] <<  8) |        \
-   ((const uint8_t*)(x))[2])
-
-#define BS_RB32(x)                          \
-  ((((const uint8_t*)(x))[0] << 24) |        \
-   (((const uint8_t*)(x))[1] << 16) |        \
-   (((const uint8_t*)(x))[2] <<  8) |        \
-   ((const uint8_t*)(x))[3])
-
-#define BS_WB32(p, d) { \
-  ((uint8_t*)(p))[3] = (d); \
-  ((uint8_t*)(p))[2] = (d) >> 8; \
-  ((uint8_t*)(p))[1] = (d) >> 16; \
-  ((uint8_t*)(p))[0] = (d) >> 24; }
-
-#define BS_WL32(p, d) { \
-  ((uint8_t*)(p))[0] = (d); \
-  ((uint8_t*)(p))[1] = (d) >> 8; \
-  ((uint8_t*)(p))[2] = (d) >> 16; \
-  ((uint8_t*)(p))[3] = (d) >> 24; }
 
 typedef struct
 {
@@ -135,12 +87,7 @@ public:
   CBitstreamParser();
   ~CBitstreamParser();
 
-  static bool Open();
-  static void Close();
   static bool FindIdrSlice(const uint8_t *buf, int buf_size);
-
-protected:
-  static const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);
 };
 
 class CBitstreamConverter
@@ -157,16 +104,6 @@ public:
   int               GetConvertSize() const;
   uint8_t*          GetExtraData(void) const;
   int               GetExtraSize() const;
-
-  static void       bits_reader_set( bits_reader_t *br, uint8_t *buf, int len );
-  static uint32_t   read_bits( bits_reader_t *br, int nbits );
-  static void       skip_bits( bits_reader_t *br, int nbits );
-  static uint32_t   get_bits( bits_reader_t *br, int nbits );
-
-  static void       init_bits_writer(bits_writer_t *s, uint8_t *buffer, int buffer_size, int writer_le);
-  static void       write_bits(bits_writer_t *s, int n, unsigned int value);
-  static void       skip_bits( bits_writer_t *s, int n);
-  static void       flush_bits(bits_writer_t *s);
 
   static void       parseh264_sps(const uint8_t *sps, const uint32_t sps_size, bool *interlaced, int32_t *max_ref_frames);
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
@@ -208,4 +145,3 @@ protected:
   bool              m_convert_bytestream;
   AVCodecID         m_codec;
 };
-

--- a/xbmc/utils/BitstreamReader.cpp
+++ b/xbmc/utils/BitstreamReader.cpp
@@ -1,0 +1,108 @@
+/*
+*      Copyright (C) 2017 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "BitstreamReader.h"
+
+CBitstreamReader::CBitstreamReader(const uint8_t *buf, int len)
+  : buffer(buf)
+  , start(buf)
+  , offbits(0)
+  , length(len)
+  , oflow(0)
+{
+}
+
+uint32_t CBitstreamReader::ReadBits(int nbits)
+{
+  uint32_t ret = GetBits(nbits);
+
+  offbits += nbits;
+  buffer += offbits / 8;
+  offbits %= 8;
+
+  return ret;
+}
+
+void CBitstreamReader::SkipBits(int nbits)
+{
+  offbits += nbits;
+  buffer += offbits / 8;
+  offbits %= 8;
+
+  if (buffer > (start + length))
+    oflow = 1;
+}
+
+uint32_t CBitstreamReader::GetBits(int nbits)
+{
+  int i, nbytes;
+  uint32_t ret = 0;
+  const uint8_t *buf;
+
+  buf = buffer;
+  nbytes = (offbits + nbits) / 8;
+
+  if (((offbits + nbits) % 8) > 0)
+    nbytes++;
+
+  if ((buf + nbytes) > (start + length))
+  {
+    oflow = 1;
+    return 0;
+  }
+  for (i = 0; i<nbytes; i++)
+    ret += buf[i] << ((nbytes - i - 1) * 8);
+
+  i = (4 - nbytes) * 8 + offbits;
+
+  ret = ((ret << i) >> i) >> ((nbytes * 8) - nbits - offbits);
+
+  return ret;
+}
+
+const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state)
+{
+  if (p >= end)
+    return end;
+
+  for (int i = 0; i < 3; i++)
+  {
+    uint32_t tmp = *state << 8;
+    *state = tmp + *(p++);
+    if (tmp == 0x100 || p == end)
+      return p;
+  }
+
+  while (p < end)
+  {
+    if (p[-1] > 1) p += 3;
+    else if (p[-2]) p += 2;
+    else if (p[-3] | (p[-1] - 1)) p++;
+    else {
+      p++;
+      break;
+    }
+  }
+
+  p = (p < end)? p - 4 : end - 4;
+  *state = BS_RB32(p);
+
+  return p + 4;
+}

--- a/xbmc/utils/BitstreamReader.h
+++ b/xbmc/utils/BitstreamReader.h
@@ -1,0 +1,60 @@
+#pragma once
+/*
+*      Copyright (C) 2017 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <stdint.h>
+
+class CBitstreamReader
+{
+public:
+  CBitstreamReader(const uint8_t *buf, int len);
+  uint32_t   ReadBits(int nbits);
+  void       SkipBits(int nbits);
+  uint32_t   GetBits(int nbits);
+
+private:
+  const uint8_t *buffer, *start;
+  int      offbits, length, oflow;
+};
+
+const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);
+
+////////////////////////////////////////////////////////////////////////////////////////////
+//! @todo refactor this so as not to need these ffmpeg routines.
+//! These are not exposed in ffmpeg's API so we dupe them here.
+// AVC helper functions for muxers,
+//  * Copyright (c) 2006 Baptiste Coudurier <baptiste.coudurier@smartjog.com>
+// This is part of FFmpeg
+//  * License as published by the Free Software Foundation; either
+//  * version 2.1 of the License, or (at your option) any later version.
+#define BS_RB16(x)                          \
+  ((((const uint8_t*)(x))[0] <<  8) |        \
+   ((const uint8_t*)(x)) [1])
+
+#define BS_RB24(x)                          \
+  ((((const uint8_t*)(x))[0] << 16) |        \
+   (((const uint8_t*)(x))[1] <<  8) |        \
+   ((const uint8_t*)(x))[2])
+
+#define BS_RB32(x)                          \
+  ((((const uint8_t*)(x))[0] << 24) |        \
+   (((const uint8_t*)(x))[1] << 16) |        \
+   (((const uint8_t*)(x))[2] <<  8) |        \
+   ((const uint8_t*)(x))[3])

--- a/xbmc/utils/BitstreamWriter.cpp
+++ b/xbmc/utils/BitstreamWriter.cpp
@@ -1,0 +1,127 @@
+/*
+*      Copyright (C) 2017 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "BitstreamWriter.h"
+
+CBitstreamWriter::CBitstreamWriter(uint8_t *buffer, unsigned int buffer_size, int writer_le)
+  : writer_le(writer_le)
+  , bit_buf(0)
+  , bit_left(32)
+  , buf(buffer)
+  , buf_ptr(buf)
+  , buf_end(buf + buffer_size)
+  , size_in_bits(8 * buffer_size)
+{
+}
+
+void CBitstreamWriter::WriteBits(int n, unsigned int value)
+{
+  // Write up to 32 bits into a bitstream.
+  unsigned int bit_buf;
+  int bit_left;
+
+  if (n == 32)
+  {
+    // Write exactly 32 bits into a bitstream.
+    // danger, recursion in play.
+    int lo = value & 0xffff;
+    int hi = value >> 16;
+    if (writer_le)
+    {
+      WriteBits(16, lo);
+      WriteBits(16, hi);
+    }
+    else
+    {
+      WriteBits(16, hi);
+      WriteBits(16, lo);
+    }
+    return;
+  }
+
+  bit_buf = this->bit_buf;
+  bit_left = this->bit_left;
+
+  if (writer_le)
+  {
+    bit_buf |= value << (32 - bit_left);
+    if (n >= bit_left) {
+      BS_WL32(buf_ptr, bit_buf);
+      buf_ptr += 4;
+      bit_buf = (bit_left == 32) ? 0 : value >> bit_left;
+      bit_left += 32;
+    }
+    bit_left -= n;
+  }
+  else
+  {
+    if (n < bit_left) {
+      bit_buf = (bit_buf << n) | value;
+      bit_left -= n;
+    }
+    else {
+      bit_buf <<= bit_left;
+      bit_buf |= value >> (n - bit_left);
+      BS_WB32(buf_ptr, bit_buf);
+      buf_ptr += 4;
+      bit_left += 32 - n;
+      bit_buf = value;
+    }
+  }
+
+  this->bit_buf = bit_buf;
+  this->bit_left = bit_left;
+}
+
+void CBitstreamWriter::SkipBits(int n)
+{
+  // Skip the given number of bits.
+  // Must only be used if the actual values in the bitstream do not matter.
+  // If n is 0 the behavior is undefined.
+  bit_left -= n;
+  buf_ptr -= 4 * (bit_left >> 5);
+  bit_left &= 31;
+}
+
+void CBitstreamWriter::FlushBits()
+{
+  if (!writer_le)
+  {
+    if (bit_left < 32)
+      bit_buf <<= bit_left;
+  }
+  while (bit_left < 32)
+  {
+
+    if (writer_le)
+    {
+      *buf_ptr++ = bit_buf;
+      bit_buf >>= 8;
+    }
+    else
+    {
+      *buf_ptr++ = bit_buf >> 24;
+      bit_buf <<= 8;
+    }
+    bit_left += 8;
+  }
+  bit_left = 32;
+  bit_buf = 0;
+}

--- a/xbmc/utils/BitstreamWriter.h
+++ b/xbmc/utils/BitstreamWriter.h
@@ -1,0 +1,59 @@
+#pragma once
+/*
+*      Copyright (C) 2017 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <stdint.h>
+
+class CBitstreamWriter 
+{
+public:
+  CBitstreamWriter(uint8_t *buffer, unsigned int buffer_size, int writer_le);
+  void WriteBits(int n, unsigned int value);
+  void SkipBits(int n);
+  void FlushBits();
+
+private:
+  int       writer_le;
+  uint32_t  bit_buf;
+  int       bit_left;
+  uint8_t   *buf, *buf_ptr, *buf_end;
+  int       size_in_bits;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////
+//! @todo refactor this so as not to need these ffmpeg routines.
+//! These are not exposed in ffmpeg's API so we dupe them here.
+// AVC helper functions for muxers,
+//  * Copyright (c) 2006 Baptiste Coudurier <baptiste.coudurier@smartjog.com>
+// This is part of FFmpeg
+//  * License as published by the Free Software Foundation; either
+//  * version 2.1 of the License, or (at your option) any later version.
+
+#define BS_WB32(p, d) { \
+  ((uint8_t*)(p))[3] = (d); \
+  ((uint8_t*)(p))[2] = (d) >> 8; \
+  ((uint8_t*)(p))[1] = (d) >> 16; \
+  ((uint8_t*)(p))[0] = (d) >> 24; }
+
+#define BS_WL32(p, d) { \
+  ((uint8_t*)(p))[0] = (d); \
+  ((uint8_t*)(p))[1] = (d) >> 8; \
+  ((uint8_t*)(p))[2] = (d) >> 16; \
+  ((uint8_t*)(p))[3] = (d) >> 24; }

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -5,7 +5,9 @@ set(SOURCES ActorProtocol.cpp
             auto_buffer.cpp
             Base64.cpp
             BitstreamConverter.cpp
+            BitstreamReader.cpp
             BitstreamStats.cpp
+            BitstreamWriter.cpp
             BooleanLogic.cpp
             CharsetConverter.cpp
             CharsetDetection.cpp
@@ -68,6 +70,7 @@ set(SOURCES ActorProtocol.cpp
             UrlOptions.cpp
             Utf8Utils.cpp
             Variant.cpp
+            VC1BitstreamParser.cpp
             Vector.cpp
             Weather.cpp
             XBMCTinyXML.cpp
@@ -80,7 +83,9 @@ set(HEADERS ActorProtocol.h
             auto_buffer.h
             Base64.h
             BitstreamConverter.h
+            BitstreamReader.h
             BitstreamStats.h
+            BitstreamWriter.h
             BooleanLogic.h
             CharsetConverter.h
             CharsetDetection.h
@@ -156,6 +161,7 @@ set(HEADERS ActorProtocol.h
             Utf8Utils.h
             uXstrings.h
             Variant.h
+            VC1BitstreamParser.h
             Vector.h
             Weather.h
             XBMCTinyXML.h

--- a/xbmc/utils/VC1BitstreamParser.cpp
+++ b/xbmc/utils/VC1BitstreamParser.cpp
@@ -1,0 +1,160 @@
+/*
+*      Copyright (C) 2017 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "VC1BitstreamParser.h"
+#include "BitstreamReader.h"
+
+enum
+{
+  VC1_PROFILE_SIMPLE,
+  VC1_PROFILE_MAIN,
+  VC1_PROFILE_RESERVED,
+  VC1_PROFILE_ADVANCED,
+  VC1_PROFILE_NOPROFILE
+};
+
+enum
+{
+  VC1_END_OF_SEQ = 0x0A,
+  VC1_SLICE = 0x0B,
+  VC1_FIELD = 0x0C,
+  VC1_FRAME = 0x0D,
+  VC1_ENTRYPOINT = 0x0E,
+  VC1_SEQUENCE = 0x0F,
+  VC1_SLICE_USER = 0x1B,
+  VC1_FIELD_USER = 0x1C,
+  VC1_FRAME_USER = 0x1D,
+  VC1_ENTRY_POINT_USER = 0x1E,
+  VC1_SEQUENCE_USER = 0x1F
+};
+
+enum
+{
+  VC1_FRAME_PROGRESSIVE = 0x0,
+  VC1_FRAME_INTERLACE = 0x10,
+  VC1_FIELD_INTERLACE = 0x11
+};
+
+CVC1BitstreamParser::CVC1BitstreamParser()
+{
+  Reset();
+}
+
+void CVC1BitstreamParser::Reset()
+{
+  m_Profile = VC1_PROFILE_NOPROFILE;
+}
+
+bool CVC1BitstreamParser::IsRecoveryPoint(const uint8_t *buf, int buf_size)
+{
+  return vc1_parse_frame(buf, buf + buf_size, true);
+};
+
+bool CVC1BitstreamParser::IsIFrame(const uint8_t *buf, int buf_size)
+{
+  return vc1_parse_frame(buf, buf + buf_size, false);
+};
+
+bool CVC1BitstreamParser::vc1_parse_frame(const uint8_t *buf, const uint8_t *buf_end, bool sequence_only)
+{
+  uint32_t state = -1;
+  for (;;)
+  {
+    buf = find_start_code(buf, buf_end, &state);
+    if (buf >= buf_end)
+      break;
+    if (buf[-1] == VC1_SEQUENCE)
+    {
+      if (m_Profile != VC1_PROFILE_NOPROFILE)
+        return false;
+      CBitstreamReader br(buf, buf_end - buf);
+      // Read the profile
+      m_Profile = static_cast<uint8_t>(br.ReadBits(2));
+      if (m_Profile == VC1_PROFILE_ADVANCED)
+      {
+        br.SkipBits(39);
+        m_AdvInterlace = br.ReadBits(1);
+      }
+      else
+      {
+        br.SkipBits(22);
+
+        m_SimpleSkipBits = 2;
+        if (br.ReadBits(1)) //rangered
+          ++m_SimpleSkipBits;
+
+        m_MaxBFrames = br.ReadBits(3);
+
+        br.SkipBits(2); // quantizer
+        if (br.ReadBits(1)) //finterpflag
+          ++m_SimpleSkipBits;
+      }
+      if (sequence_only)
+        return true;
+    }
+    else if (buf[-1] == VC1_FRAME)
+    {
+      CBitstreamReader br(buf, buf_end - buf);
+
+      if (sequence_only)
+        return false;
+      if (m_Profile == VC1_PROFILE_ADVANCED)
+      {
+        uint8_t fcm;
+        if (m_AdvInterlace) {
+          fcm = br.ReadBits(1);
+          if (fcm)
+            fcm = br.ReadBits(1) + 1;
+        }
+        else
+          fcm = VC1_FRAME_PROGRESSIVE;
+        if (fcm == VC1_FIELD_INTERLACE) {
+          uint8_t pic = br.ReadBits(3);
+          return pic == 0x00 || pic == 0x01;
+        }
+        else
+        {
+          uint8_t pic(0);
+          while (pic < 4 && br.ReadBits(1))++pic;
+          return pic == 2;
+        }
+        return false;
+      }
+      else if (m_Profile != VC1_PROFILE_NOPROFILE)
+      {
+        br.SkipBits(m_SimpleSkipBits); // quantizer
+        uint8_t pic(br.ReadBits(1));
+        if (m_MaxBFrames) {
+          if (!pic) {
+            pic = br.ReadBits(1);
+            return pic != 0;
+          }
+          else
+            return false;
+        }
+        else
+          return pic != 0;
+      }
+      else
+        break;
+    }
+  }
+  return false;
+}

--- a/xbmc/utils/VC1BitstreamParser.h
+++ b/xbmc/utils/VC1BitstreamParser.h
@@ -1,0 +1,43 @@
+#pragma once
+
+/*
+*      Copyright (C) 2017 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <stdint.h>
+
+class CVC1BitstreamParser
+{
+public:
+  CVC1BitstreamParser();
+  ~CVC1BitstreamParser() {};
+
+  void Reset();
+
+  inline bool IsRecoveryPoint(const uint8_t *buf, int buf_size);
+  inline bool IsIFrame(const uint8_t *buf, int buf_size);
+
+protected:
+  bool vc1_parse_frame(const uint8_t *buf, const uint8_t *buf_end, bool sequenceOnly);
+private:
+  uint8_t m_Profile;
+  uint8_t m_MaxBFrames;
+  uint8_t m_SimpleSkipBits;
+  uint8_t m_AdvInterlace;
+};


### PR DESCRIPTION
Implement VC1-Packet Bitstream parser

## Motivation and Context
VC-1 in mkv container sometimes have only DTS but no PTS values.
AML decoder needs from time to time a safe PTS value wich will be set on I-Frames.

This PR implements both I-Frame detection and Recovery point detection.

## How Has This Been Tested?
Separate test environment

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
