### PR TITLE
[python] browse dialog - list network and/or local paths

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -31,6 +31,7 @@
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "settings/MediaSourceSettings.h"
+#include "storage/MediaManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "ModuleXbmcgui.h"
 #include "guilib/GUIKeyboardFactory.h"
@@ -226,19 +227,30 @@ namespace XBMCAddon
       std::string value;
       std::string mask = maskparam;
       VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(s_shares);
+
+      VECSOURCES localShares;
       if (!shares)
-        throw WindowException("Error: GetSources given %s is NULL.",s_shares.c_str());
+      {
+        g_mediaManager.GetLocalDrives(localShares);
+        if (strcmpi(s_shares.c_str(), "local") != 0)
+          g_mediaManager.GetNetworkLocations(localShares);
+      }
+      else // always append local drives
+      {
+        localShares = *shares;
+        g_mediaManager.GetLocalDrives(localShares);
+      }
 
       if (useFileDirectories && !maskparam.empty())
         mask += "|.rar|.zip";
 
       value = defaultt;
       if (type == 1)
-          CGUIDialogFileBrowser::ShowAndGetFile(*shares, mask, heading, value, useThumbs, useFileDirectories);
+          CGUIDialogFileBrowser::ShowAndGetFile(localShares, mask, heading, value, useThumbs, useFileDirectories);
       else if (type == 2)
-        CGUIDialogFileBrowser::ShowAndGetImage(*shares, heading, value);
+        CGUIDialogFileBrowser::ShowAndGetImage(localShares, heading, value);
       else
-        CGUIDialogFileBrowser::ShowAndGetDirectory(*shares, heading, value, type != 0);
+        CGUIDialogFileBrowser::ShowAndGetDirectory(localShares, heading, value, type != 0);
       return value;
     }
 
@@ -250,16 +262,27 @@ namespace XBMCAddon
       VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(s_shares);
       std::vector<String> valuelist;
       String lmask = mask;
+
+      VECSOURCES localShares;
       if (!shares)
-        throw WindowException("Error: GetSources given %s is NULL.",s_shares.c_str());
+      {
+        g_mediaManager.GetLocalDrives(localShares);
+        if (strcmpi(s_shares.c_str(), "local") != 0)
+          g_mediaManager.GetNetworkLocations(localShares);
+      }
+      else // always append local drives
+      {
+        localShares = *shares;
+        g_mediaManager.GetLocalDrives(localShares);
+      }
 
       if (useFileDirectories && !lmask.empty())
         lmask += "|.rar|.zip";
 
       if (type == 1)
-        CGUIDialogFileBrowser::ShowAndGetFileList(*shares, lmask, heading, valuelist, useThumbs, useFileDirectories);
+        CGUIDialogFileBrowser::ShowAndGetFileList(localShares, lmask, heading, valuelist, useThumbs, useFileDirectories);
       else if (type == 2)
-        CGUIDialogFileBrowser::ShowAndGetImageList(*shares, heading, valuelist);
+        CGUIDialogFileBrowser::ShowAndGetImageList(localShares, heading, valuelist);
       else
         throw WindowException("Error: Cannot retrieve multiple directories using browse %s is NULL.",s_shares.c_str());
 

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -331,7 +331,17 @@ namespace XBMCAddon
       /// |   2   | ShowAndGetImage                 |
       /// |   3   | ShowAndGetWriteableDirectory    |
       /// @param heading        string or unicode - dialog heading.
-      /// @param shares         string or unicode - from [sources.xml](http://kodi.wiki/view/Sources.xml) . (i.e. 'myprograms')
+      /// @param shares         string or unicode - from [sources.xml](http://kodi.wiki/view/Sources.xml)
+      /// | Param          | Name                                         |
+      /// |:--------------:|:---------------------------------------------|
+      /// |   "programs"   | list program addons
+      /// |   "video"      | list video sources
+      /// |   "music"      | list music sources
+      /// |   "pictures"   | list picture sources
+      /// |   "files"      | list file sources (added through filemanager)
+      /// |   "games"      | list game sources
+      /// |   "local"      | list local drives
+      /// |   ""           | list local drives and network shares
       /// @param mask           [opt] string or unicode - '|' separated file mask. (i.e. '.jpg|.png')
       /// @param useThumbs      [opt] boolean - if True autoswitch to Thumb view if files exist.
       /// @param treatAsFolder  [opt] boolean - if True playlists and archives act as folders.
@@ -347,6 +357,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
+      /// @python_v18 New option added to browse network and/or local drives.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -386,7 +397,17 @@ namespace XBMCAddon
       /// |   2   | ShowAndGetImage
       /// |   3   | ShowAndGetWriteableDirectory
       /// @param heading        string or unicode - dialog heading.
-      /// @param shares         string or unicode - from [sources.xml](http://kodi.wiki/view/Sources.xml) . (i.e. 'myprograms')
+      /// @param shares         string or unicode - from [sources.xml](http://kodi.wiki/view/Sources.xml)
+      /// | Param          | Name                                         |
+      /// |:--------------:|:---------------------------------------------|
+      /// |   "programs"   | list program addons
+      /// |   "video"      | list video sources
+      /// |   "music"      | list music sources
+      /// |   "pictures"   | list picture sources
+      /// |   "files"      | list file sources (added through filemanager)
+      /// |   "games"      | list game sources
+      /// |   "local"      | list local drives
+      /// |   ""           | list local drives and network shares
       /// @param mask           [opt] string or unicode - '|' separated file mask. (i.e. '.jpg|.png')
       /// @param useThumbs      [opt] boolean - if True autoswitch to Thumb view if files exist (default=false).
       /// @param treatAsFolder  [opt] boolean - if True playlists and archives act as folders (default=false).
@@ -398,6 +419,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
+      /// @python_v18 New option added to browse network and/or local drives.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -435,7 +457,17 @@ namespace XBMCAddon
       /// |   1   | ShowAndGetFile
       /// |   2   | ShowAndGetImage
       /// @param heading        string or unicode - dialog heading.
-      /// @param shares         string or unicode - from [sources.xml](http://kodi.wiki/view/Sources.xml) . (i.e. 'myprograms')
+      /// @param shares         string or unicode - from [sources.xml](http://kodi.wiki/view/Sources.xml)
+      /// | Param          | Name                                         |
+      /// |:--------------:|:---------------------------------------------|
+      /// |   "programs"   | list program addons
+      /// |   "video"      | list video sources
+      /// |   "music"      | list music sources
+      /// |   "pictures"   | list picture sources
+      /// |   "files"      | list file sources (added through filemanager)
+      /// |   "games"      | list game sources
+      /// |   "local"      | list local drives
+      /// |   ""           | list local drives and network shares
       /// @param mask           [opt] string or unicode - '|' separated file mask. (i.e. '.jpg|.png')
       /// @param useThumbs      [opt] boolean - if True autoswitch to Thumb view if files exist (default=false).
       /// @param treatAsFolder  [opt] boolean - if True playlists and archives act as folders (default=false).
@@ -445,6 +477,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
+      /// @python_v18 New option added to browse network and/or local drives.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}


### PR DESCRIPTION
if you open the browse dialog from addon settings, it can list both local drives and network shares.
but if you call the browse dialog from the addon itself, no such option existed.

this to great annoyances of several (including me) python devs.
http://forum.kodi.tv/showthread.php?tid=290651

this pr unifies things by adding the same local/network drives option to xbmgui.Dialog.browse()


@phil65 @tamland 