### PR TITLE
follow up to 4cf4253b1fd3e65d1efe8d15cf86489b0738e75d

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -731,8 +731,9 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
     if (bitGlyph->left < 0)
       m_posX += -bitGlyph->left;
 
-    // check we have enough room for the character
-    if ((m_posX + bitGlyph->left + bitmap.width) > m_textureWidth)
+    // check we have enough room for the character.
+    // cast-fest is here to avoid warnings due to freeetype version differences (signedness of width).
+    if (static_cast<int>(m_posX + bitGlyph->left + bitmap.width) > static_cast<int>(m_textureWidth))
     { // no space - gotta drop to the next line (which means creating a new texture and copying it across)
       m_posX = 0;
       m_posY += GetTextureLineHeight();


### PR DESCRIPTION
turns out signedness of width varies across freetype differences.
explicitly cast both sides of comparison to handle both cases.

it's either this or you bump freetype to >= 2.5.4 in depends. ref discussion in https://github.com/xbmc/xbmc/pull/11384