### PR TITLE
Revert "[cmake/win32] Don't use system wide installed dependencies"

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -18,12 +18,6 @@ list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependenci
 
 set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/python)
 
-# The find_* functions prefer PATH over CMAKE_PREFIX_PATH for dependencies.
-# Emptying PATH so that system installed libraries (MySql, Python) are not picked up.
-# The VS/bin directory has to be in PATH for example for NMake.
-get_filename_component(TOOLCHAIN_PATH ${CMAKE_CXX_COMPILER} DIRECTORY)
-set(ENV{PATH} "${TOOLCHAIN_PATH}")
-
 
 # -------- Compiler options ---------
 


### PR DESCRIPTION
Reverts xbmc/xbmc#11246

testing