### PR TITLE
unify library node names

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1694,9 +1694,6 @@ msgctxt "#368"
 msgid "IMDb"
 msgstr ""
 
-#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
-#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
-#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowOverview.cpp
 msgctxt "#369"
 msgid "Title"
 msgstr ""
@@ -2553,9 +2550,6 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
-#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
-#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
-#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowOverview.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#562"
 msgid "Year"
@@ -2955,6 +2949,9 @@ msgid "Browse for library"
 msgstr ""
 
 #: xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowOverview.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#652"
 msgid "Years"
@@ -4778,7 +4775,14 @@ msgctxt "#10021"
 msgid "Settings - TV"
 msgstr ""
 
-#empty strings from id 10022 to 10024
+#empty strings from id 10022 to 10023
+
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowOverview.cpp
+msgctxt "#10024"
+msgid "Titles"
+msgstr ""
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10025"

--- a/system/library/music/musicvideos/titles.xml
+++ b/system/library/music/musicvideos/titles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="2" type="filter">
-	<label>369</label>
+	<label>10024</label>
 	<icon>DefaultMusicVideoTitle.png</icon>
 	<content>musicvideos</content>
 	<order direction="ascending">title</order>

--- a/system/library/music/musicvideos/years.xml
+++ b/system/library/music/musicvideos/years.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="3" type="filter">
-	<label>562</label>
+	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>musicvideos</content>
 	<group>years</group>

--- a/system/library/video/movies/titles.xml
+++ b/system/library/video/movies/titles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="2" type="filter">
-	<label>369</label>
+	<label>10024</label>
 	<icon>DefaultMovieTitle.png</icon>
 	<content>movies</content>
 	<order direction="ascending">sorttitle</order>

--- a/system/library/video/movies/years.xml
+++ b/system/library/video/movies/years.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="3" type="filter">
-	<label>562</label>
+	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>movies</content>
 	<group>years</group>

--- a/system/library/video/musicvideos/titles.xml
+++ b/system/library/video/musicvideos/titles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="2" type="filter">
-	<label>369</label>
+	<label>10024</label>
 	<icon>DefaultMusicVideoTitle.png</icon>
 	<content>musicvideos</content>
 	<order direction="ascending">title</order>

--- a/system/library/video/musicvideos/years.xml
+++ b/system/library/video/musicvideos/years.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="3" type="filter">
-	<label>562</label>
+	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>musicvideos</content>
 	<group>years</group>

--- a/system/library/video/tvshows/titles.xml
+++ b/system/library/video/tvshows/titles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="2" type="filter">
-	<label>369</label>
+	<label>10024</label>
 	<icon>DefaultTVShowTitle.png</icon>
 	<content>tvshows</content>
 	<order direction="ascending">sorttitle</order>

--- a/system/library/video/tvshows/years.xml
+++ b/system/library/video/tvshows/years.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <node order="3" type="filter">
-	<label>562</label>
+	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>tvshows</content>
 	<group>years</group>

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -29,8 +29,8 @@ using namespace XFILE::VIDEODATABASEDIRECTORY;
 
 Node MovieChildren[] = {
                         { NODE_TYPE_GENRE,        "genres",     135 },
-                        { NODE_TYPE_TITLE_MOVIES, "titles",     369 },
-                        { NODE_TYPE_YEAR,         "years",      562 },
+                        { NODE_TYPE_TITLE_MOVIES, "titles",     10024 },
+                        { NODE_TYPE_YEAR,         "years",      652 },
                         { NODE_TYPE_ACTOR,        "actors",     344 },
                         { NODE_TYPE_DIRECTOR,     "directors",  20348 },
                         { NODE_TYPE_STUDIO,       "studios",    20388 },

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -28,8 +28,8 @@ using namespace XFILE::VIDEODATABASEDIRECTORY;
 
 Node MusicVideoChildren[] = {
                               { NODE_TYPE_GENRE,             "genres",    135 },
-                              { NODE_TYPE_TITLE_MUSICVIDEOS, "titles",    369 },
-                              { NODE_TYPE_YEAR,              "years",     562 },
+                              { NODE_TYPE_TITLE_MUSICVIDEOS, "titles",    10024 },
+                              { NODE_TYPE_YEAR,              "years",     652 },
                               { NODE_TYPE_ACTOR,             "artists",   133 },
                               { NODE_TYPE_MUSICVIDEOS_ALBUM, "albums",    132 },
                               { NODE_TYPE_DIRECTOR,          "directors", 20348 },

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -28,8 +28,8 @@ using namespace XFILE::VIDEODATABASEDIRECTORY;
 
 Node TvShowChildren[] = {
                           { NODE_TYPE_GENRE,         "genres",   135 },
-                          { NODE_TYPE_TITLE_TVSHOWS, "titles",   369 },
-                          { NODE_TYPE_YEAR,          "years",    562 },
+                          { NODE_TYPE_TITLE_TVSHOWS, "titles",   10024 },
+                          { NODE_TYPE_YEAR,          "years",    652 },
                           { NODE_TYPE_ACTOR,         "actors",   344 },
                           { NODE_TYPE_STUDIO,        "studios",  20388 },
                           { NODE_TYPE_TAGS,          "tags",     20459 }


### PR DESCRIPTION
use 'Years' / 'Titles' in library listings, as we use plurals for all other node names as well.

@HitcherUK @BigNoid @phil65 