### PR TITLE
Revert "[CEC} fix 4.0.1 package name "

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -19,7 +19,7 @@ jsonschemabuilder-1.0.0-win32-3.7z
 libass-542975a-win32-vc140.7z
 libbluray-0.9.3-win32-vc140.7z
 libcdio-0.9.3-win32-vc140.7z
-libcec-4.0.1-win32-vc140.7z
+libcec-4.0.1-win32-vc140-2.7z
 libfribidi-0.19.2-win32.7z
 libiconv-1.14-win32-vc140-v2.7z
 libjpeg-turbo-1.4.90-win32-vc140.7z


### PR DESCRIPTION
Reverts xbmc/xbmc#11425

Had to update the package to libcec-4.0.1-win32-vc140-2.7z since it contained wrong DLL name. 