### PR TITLE
[CEC] Cosmetic fix of libCEC version check, added hibernate on TV

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -16,7 +16,7 @@
     <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
     <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
     <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
-    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011|13009|36044|36045" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011|13010|13009|36044|36045" />
     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="10" />
     <setting key="pause_playback_on_deactivate" type="bool" value="1" label="36033" configurable="0" />

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -43,7 +43,7 @@ using namespace PERIPHERALS;
 using namespace ANNOUNCEMENT;
 using namespace CEC;
 
-#define CEC_LIB_SUPPORTED_VERSION LIBCEC_VERSION_TO_UINT(4, 0, 0)
+#define CEC_LIB_SUPPORTED_VERSION LIBCEC_VERSION_TO_UINT(4, 0, 1)
 
 /* time in seconds to ignore standby commands from devices after the screensaver has been activated */
 #define SCREENSAVER_TIMEOUT       20
@@ -57,6 +57,7 @@ using namespace CEC;
 #define LOCALISED_ID_PAUSE        36045
 #define LOCALISED_ID_POWEROFF     13005
 #define LOCALISED_ID_SUSPEND      13011
+#define LOCALISED_ID_HIBERNATE    13010
 #define LOCALISED_ID_QUIT         13009
 #define LOCALISED_ID_IGNORE       36028
 
@@ -636,6 +637,10 @@ void CPeripheralCecAdapter::OnTvStandby(void)
     m_bStarted = false;
     g_application.ExecuteXBMCAction("Suspend");
     break;
+  case LOCALISED_ID_HIBERNATE:
+    m_bStarted = false;
+    g_application.ExecuteXBMCAction("Hibernate");
+    break;    
   case LOCALISED_ID_QUIT:
     m_bStarted = false;
     g_application.ExecuteXBMCAction("Quit");
@@ -1312,7 +1317,7 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
 void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
 {
   // client version matches the version of libCEC that we originally used the API from
-  m_configuration.clientVersion = LIBCEC_VERSION_TO_UINT(4, 0, 0);
+  m_configuration.clientVersion = CEC_LIB_SUPPORTED_VERSION;
 
   // device name 'XBMC'
   snprintf(m_configuration.strDeviceName, 13, "%s", GetSettingString("device_name").c_str());
@@ -1388,7 +1393,7 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
 
   // read the mutually exclusive boolean settings
   int iStandbyAction(GetSettingInt("standby_pc_on_tv_standby"));
-  m_configuration.bPowerOffOnStandby = iStandbyAction == LOCALISED_ID_SUSPEND ? 1 : 0;
+  m_configuration.bPowerOffOnStandby = (iStandbyAction == LOCALISED_ID_SUSPEND || iStandbyAction == LOCALISED_ID_HIBERNATE) ? 1 : 0;
   m_bShutdownOnStandby = iStandbyAction == LOCALISED_ID_POWEROFF;
 
 #if defined(CEC_DOUBLE_TAP_TIMEOUT_MS_OLD)


### PR DESCRIPTION
standby

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Cosmetic change of libCEC version check
Added hibernate mode on TV standby

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Hibernate is using less power than suspend mode

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
