### PR TITLE
[win][platinum] Change GWL_USERDATA to GWLP_USERDATA

### DIFF
--- a/lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
+++ b/lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
@@ -81,7 +81,7 @@ NPT_Win32WindowMessageQueue::NPT_Win32WindowMessageQueue()
                                 // is incorrectly defined, so we'll get a C4244 warning
 #endif // _MSC_VER
     if (m_WindowHandle) {
-        SetWindowLongPtr(m_WindowHandle, GWL_USERDATA, NPT_POINTER_TO_LONG(this));
+        SetWindowLongPtr(m_WindowHandle, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
     }
 #if defined(_MSC_VER)
 #pragma warning( pop )
@@ -95,7 +95,7 @@ NPT_Win32WindowMessageQueue::NPT_Win32WindowMessageQueue()
 NPT_Win32WindowMessageQueue::~NPT_Win32WindowMessageQueue() 
 {
     // remove ourself as user data to ensure we're not called anymore
-    SetWindowLongPtr(m_WindowHandle, GWL_USERDATA, 0);
+    SetWindowLongPtr(m_WindowHandle, GWLP_USERDATA, 0);
 
     // destroy the hidden window
     DestroyWindow(m_WindowHandle);
@@ -124,7 +124,7 @@ NPT_Win32WindowMessageQueue::WindowProcedure(HWND   window,
 #pragma warning( disable: 4312) // we have to test for this because GetWindowLongPtr
                                 // is incorrectly defined, so we'll get a C4244 warning
 #endif // _MSC_VER
-    NPT_Win32WindowMessageQueue* queue = reinterpret_cast<NPT_Win32WindowMessageQueue *>(GetWindowLongPtr(window, GWL_USERDATA));
+    NPT_Win32WindowMessageQueue* queue = reinterpret_cast<NPT_Win32WindowMessageQueue *>(GetWindowLongPtr(window, GWLP_USERDATA));
 #if defined(_MSC_VER)
 #pragma warning( pop )  
 #endif // _MSC_VER

--- a/lib/libUPnP/patches/0041-platinum-win-Changed-GWL_USERDATA-to-GWLP_USERDATA-a.patch
+++ b/lib/libUPnP/patches/0041-platinum-win-Changed-GWL_USERDATA-to-GWLP_USERDATA-a.patch
@@ -1,0 +1,44 @@
+From 80f22d1f8613411f85ba4826f97d92c8124d4a4b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A4r=20Bj=C3=B6rklund?= <per.bjorklund@gmail.com>
+Date: Fri, 13 Jan 2017 11:40:11 +0100
+Subject: [PATCH] [win][platinum] Changed GWL_USERDATA to GWLP_USERDATA and
+ updated pointer cast
+
+---
+ lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp b/lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
+index 921fc1af68..f415b851d5 100644
+--- a/lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
++++ b/lib/libUPnP/Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
+@@ -81,7 +81,7 @@ NPT_Win32WindowMessageQueue::NPT_Win32WindowMessageQueue()
+                                 // is incorrectly defined, so we'll get a C4244 warning
+ #endif // _MSC_VER
+     if (m_WindowHandle) {
+-        SetWindowLongPtr(m_WindowHandle, GWL_USERDATA, NPT_POINTER_TO_LONG(this));
++        SetWindowLongPtr(m_WindowHandle, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+     }
+ #if defined(_MSC_VER)
+ #pragma warning( pop )
+@@ -95,7 +95,7 @@ NPT_Win32WindowMessageQueue::NPT_Win32WindowMessageQueue()
+ NPT_Win32WindowMessageQueue::~NPT_Win32WindowMessageQueue() 
+ {
+     // remove ourself as user data to ensure we're not called anymore
+-    SetWindowLongPtr(m_WindowHandle, GWL_USERDATA, 0);
++    SetWindowLongPtr(m_WindowHandle, GWLP_USERDATA, 0);
+ 
+     // destroy the hidden window
+     DestroyWindow(m_WindowHandle);
+@@ -124,7 +124,7 @@ NPT_Win32WindowMessageQueue::WindowProcedure(HWND   window,
+ #pragma warning( disable: 4312) // we have to test for this because GetWindowLongPtr
+                                 // is incorrectly defined, so we'll get a C4244 warning
+ #endif // _MSC_VER
+-    NPT_Win32WindowMessageQueue* queue = reinterpret_cast<NPT_Win32WindowMessageQueue *>(GetWindowLongPtr(window, GWL_USERDATA));
++    NPT_Win32WindowMessageQueue* queue = reinterpret_cast<NPT_Win32WindowMessageQueue *>(GetWindowLongPtr(window, GWLP_USERDATA));
+ #if defined(_MSC_VER)
+ #pragma warning( pop )  
+ #endif // _MSC_VER
+-- 
+2.11.0
+


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Replace `GWL_USERDATA` with `GWLP_USERDATA`. They both are defined to the same value on Win32 so no real change on Win32.
Cherry picked witch permission from @Paxxi.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
On Win64 `GWL_USERDATA` is undefined and `GWLP_USERDATA` must be used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Compiled on Windows (Win32 & x64).

<!-- ## Screenshots (if appropriate): -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
