### PR TITLE
[peripherals] fix screensaver shot away

### DIFF
--- a/xbmc/input/joysticks/JoystickMonitor.cpp
+++ b/xbmc/input/joysticks/JoystickMonitor.cpp
@@ -23,6 +23,10 @@
 #include "input/InputManager.h"
 #include "ServiceBroker.h"
 
+#include <cmath>
+
+#define AXIS_THRESHOLD       0.75f // Axis must exceed this value to be mapped
+
 using namespace KODI;
 using namespace JOYSTICK;
 
@@ -50,7 +54,9 @@ bool CJoystickMonitor::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
 
 bool CJoystickMonitor::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
-  if (position)
+  const bool bIsActive = (std::abs(position) >= AXIS_THRESHOLD);
+
+  if (bIsActive)
   {
     CServiceBroker::GetInputManager().SetMouseActive(false);
     return ResetTimers();


### PR DESCRIPTION
## Description
<!--- Describe your change in detail -->

The Joystick monitor triggers always a "OnAxisMotion(...)" also without a
real axis change.

This fix the always direct cone away mouse pointer after mouse move and the
screensavers who are startet and immediately stopped.

@garbear can you check this is OK
<!--- Provide a general summary of your change in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
