### PR TITLE
Fix DynamicDll.h with use of 'RESOLVE_METHOD_OPTIONAL'

### DIFF
--- a/xbmc/DynamicDll.h
+++ b/xbmc/DynamicDll.h
@@ -391,6 +391,7 @@ public: \
 //
 
 #define RESOLVE_METHOD_OPTIONAL(method) \
+   m_##method##_ptr = nullptr; \
    m_dll->ResolveExport( #method , & m_##method##_ptr );
 
 #define RESOLVE_METHOD_OPTIONAL_FP(method) \


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This is a small fix to Dynamic Dll loading. With the `RESOLVE_METHOD_OPTIONAL` macro before was it not possible to make a check like:
```cpp
  m_interface.AddonMain = (*(int (*)())m_pDll->Get_AddonMain());
  if (m_interface.AddonMain != nullptr)
```
to check the optional function is present.

To have a optional part not comparable is not optional for me :)

This Macro is currently nowhere used on Kodi, but becomes a part on my rework.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
