### PR TITLE
[cmake] fix libdvd depends build

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -1,5 +1,5 @@
 if(NOT WIN32)
-  if(KODI_DEPENDSBUILD)
+  if(NOT KODI_DEPENDSBUILD)
     set(_dvdlibs dvdread dvdnav)
     set(_handlevars LIBDVD_INCLUDE_DIRS DVDREAD_LIBRARY DVDNAV_LIBRARY)
     if(ENABLE_DVDCSS)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

libdvd{read,css,nav} should be built when KODI_DEPENDSBUILD is set, not the other way around.

Instead of the `NOT` I can flop the logic around instead if desired.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

libdvd{read,css,nav} should not be downloaded/built when not doing a depends build

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

build tested in LibreELEC

With this it now finds and links the correct libraries
```
DVDREAD_LIBRARY:FILEPATH=/home/lukas/libreelec/build.LibreELEC-RPi2.arm-8.0-devel/toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/usr/lib/libdvdread.a
DVDCSS_LIBRARY:FILEPATH=/home/lukas/libreelec/build.LibreELEC-RPi2.arm-8.0-devel/toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/usr/lib/libdvdcss.a
DVDNAV_LIBRARY:FILEPATH=/home/lukas/libreelec/build.LibreELEC-RPi2.arm-8.0-devel/toolchain/armv7ve-libreelec-linux-gnueabi/sysroot/usr/lib/libdvdnav.a
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
