### PR TITLE
Align the settings level for the 2 different character set settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17326,7 +17326,7 @@ msgstr ""
 #. Description of setting with label #14091 "Character set"
 #: system/settings/settings.xml
 msgctxt "#36116"
-msgid "Choose which character set is used for displaying text in the user interface."
+msgid "Choose which character set is used for displaying text in the user interface. This doesn't change the character set used for subtitles, for that go to Player > Language."
 msgstr ""
 
 #. Description of setting with label #14079 "Timezone country"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -665,11 +665,22 @@
           <control type="spinner" format="integer" delayed="true"/>
         </setting>
         <setting id="subtitles.font" type="string" label="14089" help="36185">
-          <level>3</level>
+          <level>1</level>
           <default>arial.ttf</default>
           <constraints>
             <options>fonts</options>
           </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="subtitles.charset" type="string" parent="subtitles.font" label="735" help="36189">
+          <level>1</level>
+          <default>DEFAULT</default>
+          <constraints>
+            <options>charsets</options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
+          </dependencies>
           <control type="list" format="string" />
         </setting>
         <setting id="subtitles.height" type="integer" parent="subtitles.font" label="289" help="36186">
@@ -715,17 +726,6 @@
               <option label="766">6</option> <!-- Light grey -->
               <option label="767">7</option> <!-- Grey -->
             </options>
-          </constraints>
-          <dependencies>
-            <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />
-          </dependencies>
-          <control type="list" format="string" />
-        </setting>
-        <setting id="subtitles.charset" type="string" parent="subtitles.font" label="735" help="36189">
-          <level>3</level>
-          <default>DEFAULT</default>
-          <constraints>
-            <options>charsets</options>
           </constraints>
           <dependencies>
             <dependency type="enable" on="property" name="IsUsingTTFSubtitles" setting="subtitles.font" />


### PR DESCRIPTION
Changing the Player -> Language -> Subtitles -> "Character set" setting level to Standard (this also required changing the parent "subtitles.font" setting) to match the setting level of the Interface -> Regional -> Language -> "Character set" setting. Help string is also updated to inform users there is another "character set" setting for subtitles.

This is being changed after user feedback that they saw the "character set" setting in Interface -> Regional and thought it would apply to both the UI and to subtitles. 

@MartijnKaijser Your opinion? is it too late for for Krypton if it is an acceptable change?

Note that @stefansaraev has https://github.com/xbmc/xbmc/pull/11386 also open which in my opinion doesn't go far enough.