### PR TITLE
[cmake] Only install VideoPlayer fontconfig configuration files on Apple

### DIFF
--- a/cmake/installdata/common/common.txt
+++ b/cmake/installdata/common/common.txt
@@ -2,7 +2,6 @@ media/*
 sounds/*
 system/keymaps/*
 system/library/*
-system/players/VideoPlayer/etc/*
 system/shaders/*
 system/settings/*
 userdata/*

--- a/cmake/installdata/ios/fontconfig.txt
+++ b/cmake/installdata/ios/fontconfig.txt
@@ -1,0 +1,1 @@
+system/players/VideoPlayer/etc/*


### PR DESCRIPTION
## Motivation and Context
VideoPlayer fontconfig files are not needed, and removed downstream:
https://gitweb.gentoo.org/repo/gentoo.git/tree/media-tv/kodi/kodi-17.0_rc2.ebuild#n228
https://bugs.gentoo.org/show_bug.cgi?id=605712
## How Has This Been Tested?
Only tested on Linux

Don't know whether `if (APPLE)` is the wrong match.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
