### PR TITLE
App-name fixes for master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include(cmake/scripts/common/AddOptions.cmake)
 include(cmake/scripts/common/ArchSetup.cmake)
 include(cmake/scripts/common/Macros.cmake)
 include(cmake/scripts/common/ProjectMacros.cmake)
+core_find_versions()
 include(cmake/scripts/${CORE_SYSTEM_NAME}/PathSetup.cmake)
 include(ExternalProject)
 
@@ -76,7 +77,6 @@ else()
 endif()
 
 core_find_git_rev(APP_SCMID FULL)
-core_find_versions()
 
 # Dynamically loaded libraries built with the project
 add_custom_target(${APP_NAME_LC}-libraries)

--- a/cmake/scripts/android/PathSetup.cmake
+++ b/cmake/scripts/android/PathSetup.cmake
@@ -29,5 +29,5 @@ list(APPEND final_message "Includedir: ${includedir}")
 list(APPEND final_message "Datarootdir: ${datarootdir}")
 list(APPEND final_message "Datadir: ${datadir}")
 
-set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/kodi\"
-                   -DINSTALL_PATH=\"${datarootdir}/kodi\")
+set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/${APP_NAME_LC}\"
+                   -DINSTALL_PATH=\"${datarootdir}/${APP_NAME_LC}\")

--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -41,6 +41,10 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/KodiConfig.cmake.in
 
 # Configure xsession entry
 configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi-xsession.desktop.in
+               ${CORE_BUILD_DIR}/${APP_NAME_LC}-xsession.desktop @ONLY)
+
+# Configure desktop entry
+configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi.desktop.in
                ${CORE_BUILD_DIR}/${APP_NAME_LC}.desktop @ONLY)
 
 # Install app
@@ -78,12 +82,13 @@ foreach(file ${install_data})
 endforeach()
 
 # Install xsession entry
-install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${APP_NAME_LC}.desktop
+install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${APP_NAME_LC}-xsession.desktop
+        RENAME ${APP_NAME_LC}.desktop
         DESTINATION ${datarootdir}/xsessions
         COMPONENT kodi)
 
 # Install desktop entry
-install(FILES ${CMAKE_SOURCE_DIR}/tools/Linux/kodi.desktop
+install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${APP_NAME_LC}.desktop
         DESTINATION ${datarootdir}/applications
         COMPONENT kodi)
 

--- a/cmake/scripts/linux/PathSetup.cmake
+++ b/cmake/scripts/linux/PathSetup.cmake
@@ -36,5 +36,5 @@ list(APPEND final_message "Datarootdir: ${datarootdir}")
 list(APPEND final_message "Datadir: ${datadir}")
 list(APPEND final_message "Docdir: ${docdir}")
 
-set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/kodi\"
-                   -DINSTALL_PATH=\"${datarootdir}/kodi\")
+set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/${APP_NAME_LC}\"
+                   -DINSTALL_PATH=\"${datarootdir}/${APP_NAME_LC}\")

--- a/cmake/scripts/osx/PathSetup.cmake
+++ b/cmake/scripts/osx/PathSetup.cmake
@@ -28,5 +28,5 @@ list(APPEND final_message "Includedir: ${includedir}")
 list(APPEND final_message "Datarootdir: ${datarootdir}")
 list(APPEND final_message "Datadir: ${datadir}")
 
-set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/kodi\"
-                   -DINSTALL_PATH=\"${datarootdir}/kodi\")
+set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/${APP_NAME_LC}\"
+                   -DINSTALL_PATH=\"${datarootdir}/${APP_NAME_LC}\")

--- a/cmake/scripts/windows/PathSetup.cmake
+++ b/cmake/scripts/windows/PathSetup.cmake
@@ -30,5 +30,5 @@ list(APPEND final_message "Includedir: ${includedir}")
 list(APPEND final_message "Datarootdir: ${datarootdir}")
 list(APPEND final_message "Datadir: ${datadir}")
 
-set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/kodi\"
-                   -DINSTALL_PATH=\"${datarootdir}/kodi\")
+set(PATH_DEFINES -DBIN_INSTALL_PATH=\"${libdir}/${APP_NAME_LC}\"
+                   -DINSTALL_PATH=\"${datarootdir}/${APP_NAME_LC}\")

--- a/tools/Linux/kodi.desktop.in
+++ b/tools/Linux/kodi.desktop.in
@@ -1,11 +1,11 @@
 [Desktop Entry]
 Version=1.0
-Name=Kodi
+Name=@APP_NAME@
 GenericName=Media Center
 Comment=Manage and view your media
 Comment[ru]=Просмотр и управление мультимедиа
-Exec=kodi
-Icon=kodi
+Exec=@APP_NAME_LC@
+Icon=@APP_NAME_LC@
 Terminal=false
 Type=Application
 Categories=AudioVideo;Video;Player;TV;
@@ -14,8 +14,8 @@ Actions=Fullscreen;Standalone;
 
 [Desktop Action Fullscreen]
 Name=Open in fullscreen
-Exec=kodi -fs
+Exec=@APP_NAME_LC@ -fs
 
 [Desktop Action Standalone]
 Name=Open in standalone mode
-Exec=kodi --standalone
+Exec=@APP_NAME_LC@ --standalone


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This PR contains fixes to make Kodi more app-name friendly:
- Installs `<app-name>.desktop` into `usr/share/applications/` instead of `kodi.desktop`
- Uses `${APP_NAME_LC}` in `PathSetup.cmake` instead of `kodi`
- ~~Generates `KodiConfig.cmake` instead of `${APP_NAME}Config.cmake` as all binary addons looks for a `Kodi` package and `KODI_INCLUDE_DIR`~~

This is the same as #11447 but for master.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Building Kodi using a different app-name (OpenPHT in my case) leaves some parts with kodi in the name or path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Clean builds of Kodi and binary addons with this PR on Windows, macOS and Ubuntu Xenial.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
