### PR TITLE
Revert "DVDVideoCodecAndroidMediaCodec: Don't call into App while oth…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -685,6 +685,8 @@ void CDVDVideoCodecAndroidMediaCodec::Dispose()
       xbmc_jnienv()->ExceptionClear();
   }
   ReleaseSurfaceTexture();
+  if (m_render_surface)
+    CXBMCApp::get()->clearVideoView();
 
   SAFE_DELETE(m_bitstream);
   s_instances--;


### PR DESCRIPTION
This will be needed when decoder reconfiguring is implemented, but for now it keeps the last frame on screen which we don't want. So plain revert it.