### PR TITLE
[pydocs] Corrections on the xbmcvfs/file examples

### DIFF
--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -43,11 +43,10 @@ namespace XBMCAddon
     /// \python_class{ xbmcvfs.File(filepath, [mode]) }
     ///
     /// @param filepath             string Selected file path
-    /// @param mode                 [opt] string Additional mode options
+    /// @param mode                 [opt] string Additional mode options (if no mode is supplied, the default is Open for Read).
     ///   |  Mode  | Description                     |
     ///   |:------:|:--------------------------------|
     ///   |   w    | Open for write                  |
-    ///
     ///
     ///
     ///--------------------------------------------------------------------------
@@ -55,7 +54,7 @@ namespace XBMCAddon
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
     /// ..
-    /// f = xbmcvfs.File(file, ['w'])
+    /// f = xbmcvfs.File(file, 'w')
     /// ..
     /// ~~~~~~~~~~~~~
     //
@@ -150,7 +149,7 @@ namespace XBMCAddon
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
       /// ..
-      /// f = xbmcvfs.File(file, 'w', True)
+      /// f = xbmcvfs.File(file, 'w')
       /// result = f.write(buffer)
       /// f.close()
       /// ..


### PR DESCRIPTION
This PR applies some fixes to the examples provided in the documentation for the `xbmcvfs` module / `File`.

## Description
`xbmcvfs.File()` receives only 2 arguments: the file (string) and the mode which is optional ('w'). Examples provided in the documentation are not in agreement with the method definition. One of the examples use a list for the argument `mode`. The other uses a third argument that does not exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested the provided examples in Python (they lead to errors) and also checked the code in the header file.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
