### PR TITLE
[settings] restore show EXIF picture information setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20417,6 +20417,8 @@ msgctxt "#38207"
 msgid "Show EXIF picture information"
 msgstr ""
 
+#. Help text of setting "Pictures -> Show EXIF picture information" with label #38208
+#: system/settings/settings.xml
 msgctxt "#38208"
 msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20410,3 +20410,13 @@ msgstr ""
 msgctxt "#39013"
 msgid "Virtual filesystems"
 msgstr ""
+
+#. Description of setting "Pictures -> Show EXIF picture information" with label #38207
+#: system/settings/settings.xml
+msgctxt "#38207"
+msgid "Show EXIF picture information"
+msgstr ""
+
+msgctxt "#38208"
+msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1172,6 +1172,11 @@
     </category>
     <category id="pictures" label="14217" help="38109">
       <group id="1" label="744">
+        <setting id="pictures.usetags" type="boolean" label="38207" help="38208">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="pictures.generatethumbs" type="boolean" label="13360" help="36307">
           <level>0</level>
           <default>true</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1173,7 +1173,7 @@
     <category id="pictures" label="14217" help="38109">
       <group id="1" label="744">
         <setting id="pictures.usetags" type="boolean" label="38207" help="38208">
-          <level>0</level>
+          <level>1</level>
           <default>true</default>
           <control type="toggle" />
         </setting>

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -204,7 +204,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
     if (StringUtils::EqualsNoCase(items[i]->GetLabel(), "folder.jpg"))
       items.Remove(i);
 
-  if (items.GetFolderCount() == items.Size())
+  if (items.GetFolderCount() == items.Size() || !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PICTURES_USETAGS))
     return;
 
   // Start the music info loader thread

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -20,6 +20,7 @@
 
 #include "PictureInfoLoader.h"
 #include "PictureInfoTag.h"
+#include "ServiceBroker.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
 
@@ -43,6 +44,7 @@ void CPictureInfoLoader::OnLoaderStart()
   m_mapFileItems->SetFastLookup(true);
 
   m_tagReads = 0;
+  m_loadTags = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PICTURES_USETAGS);
 
   if (m_pProgressCallback)
     m_pProgressCallback->SetProgressMax(m_pVecItems->GetFileCount());
@@ -87,8 +89,11 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (pItem->HasPictureInfoTag())
     return false;
 
-  pItem->GetPictureInfoTag()->Load(pItem->GetPath());
-  m_tagReads++;
+  if (m_loadTags)
+  { // Nothing found, load tag from file
+    pItem->GetPictureInfoTag()->Load(pItem->GetPath());
+    m_tagReads++;
+  }
 
   return true;
 }

--- a/xbmc/pictures/PictureInfoLoader.h
+++ b/xbmc/pictures/PictureInfoLoader.h
@@ -39,5 +39,6 @@ protected:
 
   CFileItemList* m_mapFileItems;
   unsigned int m_tagReads;
+  bool m_loadTags;
 };
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -298,6 +298,7 @@ const std::string CSettings::SETTING_AUDIOCDS_SETTINGS = "audiocds.settings";
 const std::string CSettings::SETTING_AUDIOCDS_EJECTONRIP = "audiocds.ejectonrip";
 const std::string CSettings::SETTING_MYMUSIC_SONGTHUMBINVIS = "mymusic.songthumbinvis";
 const std::string CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW = "mymusic.defaultlibview";
+const std::string CSettings::SETTING_PICTURES_USETAGS = "pictures.usetags";
 const std::string CSettings::SETTING_PICTURES_GENERATETHUMBS = "pictures.generatethumbs";
 const std::string CSettings::SETTING_PICTURES_SHOWVIDEOS = "pictures.showvideos";
 const std::string CSettings::SETTING_PICTURES_DISPLAYRESOLUTION = "pictures.displayresolution";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -254,6 +254,7 @@ public:
   static const std::string SETTING_AUDIOCDS_EJECTONRIP;
   static const std::string SETTING_MYMUSIC_SONGTHUMBINVIS;
   static const std::string SETTING_MYMUSIC_DEFAULTLIBVIEW;
+  static const std::string SETTING_PICTURES_USETAGS;
   static const std::string SETTING_PICTURES_GENERATETHUMBS;
   static const std::string SETTING_PICTURES_SHOWVIDEOS;
   static const std::string SETTING_PICTURES_DISPLAYRESOLUTION;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This reverts a change from https://github.com/xbmc/xbmc/pull/7992

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
See: http://forum.kodi.tv/showthread.php?tid=304156
Loading exif information is quite expensive in both time and memory used.
Users with large photo libraries or running on low powered hardware may prefer to avoid this.

## How Has This Been Tested?
It has been in milhouse/newclock5 builds for ages
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
