### PR TITLE
move the touch command to the codegenerator makefile which runs on all platforms

### DIFF
--- a/codegenerator.mk
+++ b/codegenerator.mk
@@ -69,3 +69,4 @@ else
 #build json builder - ".." because makefile is in the parent dir of "bin"
 	$(MAKE) -C $(abspath $(@D)/..)
 endif
+$(shell touch $(TOPDIR)/xbmc/cores/AudioEngine/AEDefines_override.h)

--- a/xbmc/cores/AudioEngine/Makefile.in
+++ b/xbmc/cores/AudioEngine/Makefile.in
@@ -83,6 +83,5 @@ SRCS += Utils/AELimiter.cpp
 SRCS += Encoders/AEEncoderFFmpeg.cpp
 
 LIB   = audioengine.a
-$(shell touch AEDefines_override.h)
 include @abs_top_srcdir@/Makefile.include
 -include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
this should fix building with autotools/xcode again after #11400