### PR TITLE
[binary-addons] bootstrap: don't filter addons when auto bootstrappin…

### DIFF
--- a/cmake/addons/bootstrap/CMakeLists.txt
+++ b/cmake/addons/bootstrap/CMakeLists.txt
@@ -50,7 +50,6 @@ function(bootstrap_repo repo_id repo_url repo_revision)
                                       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
                                       -DPROJECT_SOURCE_DIR=<SOURCE_DIR>
                                       -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-                                      -DADDONS_TO_BUILD=${ADDONS_TO_BUILD}
                                       -P ${PROJECT_SOURCE_DIR}/Bootstrap.cmake
                       )
 endfunction()


### PR DESCRIPTION
…g addon definitions

fixes "no addon found" errors when trying to build addons that were filtered during the first implicit bootstrap
and therefore no definition file exists

<!--- Provide a general summary of your change in the Title above -->
replaces https://github.com/xbmc/xbmc/pull/11444

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


