### PR TITLE
FIX: [droid] Copy splash to xxxhdpi drawable

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -117,6 +117,7 @@ res:
 	cp -fp media/drawable-mdpi/ic_launcher.png xbmc/res/drawable-mdpi/ic_launcher.png
 	cp -fp media/drawable-xhdpi/ic_launcher.png xbmc/res/drawable-xhdpi/ic_launcher.png
 	cp -fp media/drawable-xxhdpi/ic_launcher.png xbmc/res/drawable-xxhdpi/ic_launcher.png
+	cp -fp $(CORE_SOURCE_DIR)/media/Splash.png xbmc/res/drawable-xxxhdpi/splash.png
 	cp -fp media/drawable-xxxhdpi/ic_launcher.png xbmc/res/drawable-xxxhdpi/ic_launcher.png
 	cp -fp media/drawable-xhdpi/banner.png xbmc/res/drawable-xhdpi/banner.png
 	cp xbmc/strings.xml xbmc/res/values/


### PR DESCRIPTION
Prevents crash on very large dpi devices, as a "plain" drawable is assumed mdpi

Not very bright, I must say, but I see no alternative.

@da-anda we should probably have a 720p and 1080p splash for droid, or we end up adding 1.8Mb to the apk for not much. At least a 720p for lower dpi would limit the damages.
