### PR TITLE
Crash on view current playlist with many items Ticket #17188 

### DIFF
--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -160,7 +160,8 @@ void CGUIDialogProgress::SetProgressAdvance(int nSteps/*=1*/)
   if (m_iCurrent>m_iMax)
     m_iCurrent=0;
 
-  SetPercentage((m_iCurrent*100)/m_iMax);
+  if (m_iMax > 0)
+    SetPercentage((m_iCurrent*100)/m_iMax);
 }
 
 bool CGUIDialogProgress::Abort()


### PR DESCRIPTION
This fixes the RC3 crash that happens on trying to view the current playlist when it contains a large number of items. See Trac Ticket http://trac.kodi.tv/ticket/17188 and discussed on the forum http://forum.kodi.tv/showthread.php?tid=304133

If the current playlist was large enough (relative to processor power) to need to show the progress dialog then Kodi would crash shortly after this was closed. Reported on Windows as a music library issue, but probably would effect Video too if the playlst was large. Also seem in testing on Linux (LE) - I think the same issue but have been unable to prove it. The issue was a zero divide.

On GUI_MSG_WINDOW_DEINIT CGUIDialogProgress::Reset sets m_iMax = 0. But subsequently
CMusicInfoLoader::LoadItemLookup calls CGUIDialogProgress::SetProgressAdvance causing a zero over zero division.

Crash not always easy to reproduce as seems to be compiler optimisation dependant (0 / 0 being handled differently?). While I could catch the issue while debugging the Jenkins build of RC3, I could not repeat it in any of my local builds. It also seems to ocurrs in v16.1 on LE, but much harder to reproduce and I could not catch in the debug.

Too test queue a large number of songs to play e.g. ~4000 songs on Windows, say from Genres node, or even unscanned music files from file view, and then click "Goto playlist" on the sideblade. If you have selected a sufficient number of tracks the progress dialog will be displayed until the current playlist is on view.

Has been backported as #11474 