### PR TITLE
[guilib] allow more flexible hitrects

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -504,17 +504,21 @@ bool CGUIControlFactory::GetActions(const TiXmlNode* pRootNode, const char* strT
   return action.m_actions.size() > 0;
 }
 
-bool CGUIControlFactory::GetHitRect(const TiXmlNode *control, CRect &rect)
+bool CGUIControlFactory::GetHitRect(const TiXmlNode *control, CRect &rect, const CRect &parentRect)
 {
   const TiXmlElement* node = control->FirstChildElement("hitrect");
   if (node)
   {
-    node->QueryFloatAttribute("x", &rect.x1);
-    node->QueryFloatAttribute("y", &rect.y1);
+    rect.x1 = ParsePosition(node->Attribute("x"), parentRect.Width());
+    rect.y1 = ParsePosition(node->Attribute("y"), parentRect.Height());
     if (node->Attribute("w"))
       rect.x2 = (float)atof(node->Attribute("w")) + rect.x1;
+    else if (node->Attribute("right"))
+      rect.x2 = std::min(ParsePosition(node->Attribute("right"), parentRect.Width()), rect.x1);
     if (node->Attribute("h"))
       rect.y2 = (float)atof(node->Attribute("h")) + rect.y1;
+    else if (node->Attribute("bottom"))
+      rect.y2 = std::min(ParsePosition(node->Attribute("bottom"), parentRect.Height()), rect.y1);
     return true;
   }
   return false;
@@ -804,7 +808,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   XMLUtils::GetFloat(pControlNode, "offsety", offset.y);
 
   hitRect.SetRect(posX, posY, posX + width, posY + height);
-  GetHitRect(pControlNode, hitRect);
+  GetHitRect(pControlNode, hitRect, rect);
 
   GetInfoColor(pControlNode, "hitrectcolor", hitColor, parentID);
 

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -101,7 +101,7 @@ public:
   static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition);
   static bool GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& actions);
   static void GetRectFromString(const std::string &string, CRect &rect);
-  static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect);
+  static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect, const CRect &parentRect);
   static bool GetScroller(const TiXmlNode *pControlNode, const std::string &scrollerTag, CScroller& scroller);
 private:
   static std::string GetType(const TiXmlElement *pControlNode);

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -180,7 +180,8 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
   CGUIControlFactory::GetInfoColor(pRootElement, "backgroundcolor", m_clearBackground, GetID());
   CGUIControlFactory::GetActions(pRootElement, "onload", m_loadActions);
   CGUIControlFactory::GetActions(pRootElement, "onunload", m_unloadActions);
-  CGUIControlFactory::GetHitRect(pRootElement, m_hitRect);
+  CRect parentRect(0, 0, static_cast<float>(m_coordsRes.iWidth), static_cast<float>(m_coordsRes.iHeight));
+  CGUIControlFactory::GetHitRect(pRootElement, m_hitRect, parentRect);
 
   TiXmlElement *pChild = pRootElement->FirstChildElement();
   while (pChild)


### PR DESCRIPTION
- Allow to use "bottom" / "right" attributes instead of "width" / "height".
- Allow r/% values for "x", "y", "right", "bottom" attribute.

@xbmc/team-skinners 