### PR TITLE
[Fix] Restore caching for slow plugins Ticket #17211

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -228,7 +228,7 @@ void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceList
     return;
 
   // set cache to disc
-  dir->m_listItems->SetCacheToDisc(CFileItemList::CACHE_NEVER);
+  dir->m_listItems->SetCacheToDisc(cacheToDisc ? CFileItemList::CACHE_IF_SLOW : CFileItemList::CACHE_NEVER);
 
   dir->m_success = success;
   dir->m_listItems->SetReplaceListing(replaceListing);

--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.h
@@ -131,8 +131,8 @@ namespace XBMCAddon
     /// @param updateListing        [opt] bool - True=this folder should
     ///                             update the current listing/False=Folder
     ///                             is a subfolder(Default).
-    /// @param cacheToDisc          [opt] bool - True=Allow folder to be cached
-    ///                             (default)/False=this folder
+    /// @param cacheToDisc          [opt] bool - True=Folder will cache if
+    ///                             extended time(default)/False=this folder
     ///                             will never cache to disc.
     ///
     ///

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -498,7 +498,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       }
       if (message.GetParam2() == PLUGIN_REFRESH_DELAY)
       {
-        Refresh();
+        Refresh(true);
         SetInitialVisibility();
         RestoreControlStates();
         SetInitialVisibility();


### PR DESCRIPTION
This effectively reverts #10394 that removed caching for all plugins, and fixes ticket http://trac.kodi.tv/ticket/17211 It needs to be backported.

As discussed on the internal forum, the radical change in caching policy is a regression for those plugins that fetch data online. The user temporarily switching to say player OSD or current playlist should not require the plugin to requery the online data.  The radio addon is a clear example, populating the list of online radio stations available is a slow query. 

Like that example, much plugin content is pretty static, so it is unnecessary to keep fetching the same listings over and over again. It is also unfriendly, putting an additional load on the servers of the source sites, and where the API keys are limited by the amount of call you're allowed to make will run the risk of running out of credits.

Any future changes to the plugin caching policy need to be done in a measured way, not just dropped.

This does leave the issue with TV shows added to favorites http://trac.kodi.tv/ticket/16560 unresolved (this is what #9898 and #10394 were attempting to solve). 
