### PR TITLE
[Backport]Restore caching for slow plugins

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -227,7 +227,7 @@ void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceList
     return;
 
   // set cache to disc
-  dir->m_listItems->SetCacheToDisc(CFileItemList::CACHE_NEVER);
+  dir->m_listItems->SetCacheToDisc(cacheToDisc ? CFileItemList::CACHE_IF_SLOW : CFileItemList::CACHE_NEVER);
 
   dir->m_success = success;
   dir->m_listItems->SetReplaceListing(replaceListing);

--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.h
@@ -131,8 +131,8 @@ namespace XBMCAddon
     /// @param updateListing        [opt] bool - True=this folder should
     ///                             update the current listing/False=Folder
     ///                             is a subfolder(Default).
-    /// @param cacheToDisc          [opt] bool - True=Allow folder to be cached
-    ///                             (default)/False=this folder
+    /// @param cacheToDisc          [opt] bool - True=Folder will cache if
+    ///                             extended time(default)/False=this folder
     ///                             will never cache to disc.
     ///
     ///


### PR DESCRIPTION
A backport of #11478 - see discussion there

This effectively reverts #10394 that removed caching for all plugins, and fixes ticket http://trac.kodi.tv/ticket/17211