### PR TITLE
[Fix]Clear plugin directory cache on window init Ticket #16560

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -511,7 +511,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       }
       if (message.GetParam2() == PLUGIN_REFRESH_DELAY)
       {
-        Refresh();
+        Refresh(true);
         SetInitialVisibility();
         RestoreControlStates();
         SetInitialVisibility();


### PR DESCRIPTION
Backport of the second commit of #11478, see discussion there. It fixes ticket http://trac.kodi.tv/ticket/16560 the issue with TV shows etc. added to favorites (what #9898 and #10394 were attempting to solve).