### PR TITLE
Unsafe dynamic_cast in libav callback caused segmentation faults

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -185,8 +185,7 @@ bool CDVDDemuxFFmpeg::Aborted()
   if(m_timeout.IsTimePast())
     return true;
 
-  CDVDInputStreamFFmpeg * input = dynamic_cast<CDVDInputStreamFFmpeg*>(m_pInput);
-  if(input && input->Aborted())
+  if (m_pInput && m_pInput->IsStreamType(DVDSTREAM_TYPE_FFMPEG) && static_cast<CDVDInputStreamFFmpeg*>(m_pInput)->Aborted())
     return true;
 
   return false;


### PR DESCRIPTION
Observed when watching IPTV and switching channels.

Reported stacktrace looked like this:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fb703751640 in __dynamic_cast () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x0000000000908c83 in CDVDDemuxFFmpeg::Aborted() ()
#2  0x0000000000908cae in ?? ()
#3  0x00007fb7047d2197 in ffurl_write () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#4  0x00007fb7048f66f9 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#5  0x00007fb7029ed696 in ?? () from /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28
#6  0x00007fb7029e8611 in ?? () from /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28
#7  0x00007fb702a08b58 in gnutls_alert_send () from /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28
#8  0x00007fb7029ea449 in gnutls_bye () from /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28
#9  0x00007fb7048f6a69 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#10 0x00007fb7047d1590 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#11 0x00007fb7048137c4 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#12 0x00007fb7047d1590 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#13 0x00007fb7047d15e3 in ffurl_close () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#14 0x00007fb70490b6b9 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#15 0x00007fb70480c579 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#16 0x00007fb70480c636 in ?? () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#17 0x00007fb704908a37 in avformat_close_input () from /usr/lib/x86_64-linux-gnu/libavformat.so.57
#18 0x000000000090a3a4 in CDVDDemuxFFmpeg::Dispose() ()
#19 0x000000000090a417 in CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg() ()
#20 0x000000000090a459 in CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg() ()
#21 0x00000000011664d5 in CDVDPlayer::HandleMessages() ()
#22 0x00000000011672f5 in CDVDPlayer::Process() ()
#23 0x000000000132fc4f in CThread::Action() ()
#24 0x000000000132ff06 in CThread::staticThread(void*) ()
#25 0x00007fb70b992064 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#26 0x00007fb70321b62d in clone () from /lib/x86_64-linux-gnu/libc.so.6
```

## Description
In the interrupt callback from libav a dynamic_cast was done on an input data structure, which might have been destroyed already (see stackstrace above). Furthermore a dynamic_cast can be avoided by verifying the input type information. Only if it matches a static_cast is performed. This combination should avoid any further segmentation faults.

## Motivation and Context
Kodi should be a stable platform for IPTV watching. It should not crash upon channel switching.

## How Has This Been Tested?
Ran compiled application and switched IPTV channels frequently.

## Screenshots (if appropriate):

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
