### PR TITLE
[fix][audio] quick fix for some decoder that cannot accept empty package

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -503,6 +503,9 @@ void CVideoPlayerAudio::Process()
         // guess next pts
         m_audioClock += audioframe.duration;
 
+		if (consumed >= pPacket->iSize) // quick fix for some decoder like wmalossless that cannot accept empty package
+			break;
+			
         int ret = m_pAudioCodec->Decode(nullptr, 0, DVD_NOPTS_VALUE, DVD_NOPTS_VALUE);
         if (ret < 0)
         {


### PR DESCRIPTION
## Description
Some .wmv video with audio in WMALossLess may decode fail.
It seems that ffmpeg's wmalossless decoder cannot accept empty (or zero sized) package data.

## Motivation and Context
This quick fix solved that.

## How Has This Been Tested?
Test environment: Win10x64, VS2017RC
I tested with some local media files and nothing bad caused.
WMV with WMALossLess now sounds OK.
Tested other media files like avi with mp3, standalone WMALossLess and normal wma, FLAC file, and working fine.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
