### PR TITLE
[PVR] Fix deadlock (can occure while installing/uninstalling pvr client addon).

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -180,9 +180,13 @@ int CPVRClients::GetFirstConnectedClientID(void)
 int CPVRClients::EnabledClientAmount(void) const
 {
   int iReturn(0);
-  CSingleLock lock(m_critSection);
+  PVR_CLIENTMAP clientMap;
+  {
+    CSingleLock lock(m_critSection);
+    clientMap = m_clientMap;
+  }
 
-  for (const auto &client : m_clientMap)
+  for (const auto &client : clientMap)
     if (!CAddonMgr::GetInstance().IsAddonDisabled(client.second->ID()))
       ++iReturn;
 
@@ -191,7 +195,13 @@ int CPVRClients::EnabledClientAmount(void) const
 
 bool CPVRClients::HasEnabledClients(void) const
 {
-  for (const auto &client : m_clientMap)
+  PVR_CLIENTMAP clientMap;
+  {
+    CSingleLock lock(m_critSection);
+    clientMap = m_clientMap;
+  }
+
+  for (const auto &client : clientMap)
     if (!CAddonMgr::GetInstance().IsAddonDisabled(client.second->ID()))
       return true;
   return false;


### PR DESCRIPTION
Reported in the forum: http://forum.kodi.tv/showthread.php?tid=304545

Tested on latest master on Linux and macOS.

Stacks:

thread 1
<pre>
Not Flagged        7616    0    Worker Thread    thread_start<unsigned int (__stdcall*)(void *)>    RtlpWaitOnAddress    Idle
                             ntdll.dll!_NtWaitForAlertByThreadId@8()  + 0xc bytes    
                             ntdll.dll!@RtlpWaitOnAddressWithTimeout@16()  + 0x33 bytes    
                             ntdll.dll!RtlpWaitOnAddress()  + 0xa5 bytes    
                             ntdll.dll!RtlpWaitOnCriticalSection()  + 0xaa bytes    
                             ntdll.dll!RtlpEnterCriticalSectionContended()  + 0xd5 bytes    
                             ntdll.dll!_RtlEnterCriticalSection@4()  + 0x45 bytes    
                             kodi.exe!XbmcThreads::windows::RecursiveMutex::lock()  Line 54 + 0xc bytes    
                             kodi.exe!XbmcThreads::CountingLockable<XbmcThreads::windows::RecursiveMutex>::lock()  Line 60 + 0x16 bytes    
                             kodi.exe!XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock<CCriticalSection>(CCriticalSection & lockable)  Line 127 + 0x19 bytes    
                             kodi.exe!CSingleLock::CSingleLock(const CCriticalSection & cs)  Line 39 + 0x1a bytes    
==> wants pvr clients mutex  
                             kodi.exe!PVR::CPVRClients::GetClient(const std::basic_string<char,std::char_traits<char>,std::allocator<char> > & strId, std::shared_ptr<ADDON::IAddon> & addon)  Line 1180 + 0xf bytes  
                             kodi.exe!PVR::CPVRClient::GetRunningInstance()  Line 126 + 0x5b bytes    
                             kodi.exe!ADDON::CAddonMgr::GetAddonsInternal(const ADDON::TYPE & type, std::vector<std::shared_ptr<ADDON::IAddon>,std::allocator<std::shared_ptr<ADDON::IAddon> > > & addons, bool enabledOnly)  Line 593 + 0x30 bytes    
                             kodi.exe!ADDON::CAddonMgr::GetAddons(std::vector<std::shared_ptr<ADDON::IAddon>,std::allocator<std::shared_ptr<ADDON::IAddon> > > & addons)  Line 474    
                             kodi.exe!ADDON::CAddonMgr::GetAvailableUpdates()  Line 456    
==> has addon mgr mutex
                             kodi.exe!ADDON::CAddonMgr::HasAvailableUpdates()  Line 468 + 0xc bytes    
                             kodi.exe!XFILE::RootDirectory(CFileItemList & items)  Line 442 + 0xc bytes    
                             kodi.exe!XFILE::CAddonsDirectory::GetDirectory(const CURL & url, CFileItemList & items)  Line 498 + 0x9 bytes    
                             kodi.exe!CGetDirectory::CGetJob::DoWork()  Line 68 + 0x3d bytes    
                             kodi.exe!CJobWorker::Process()  Line 69 + 0xf bytes    
                             kodi.exe!CThread::Action()  Line 221 + 0xf bytes    
                             kodi.exe!CThread::staticThread(void * data)  Line 134    
                             ucrtbased.dll!invoke_thread_procedure(unsigned int (void *)* const procedure, void * const context)  Line 92    
                             ucrtbased.dll!thread_start<unsigned int (__stdcall*)(void *)>(void * const parameter)  Line 115 + 0x10 bytes    
                             kernel32.dll!@BaseThreadInitThunk@12()  + 0x24 bytes    
                             ntdll.dll!__RtlUserThreadStart()  + 0x2f bytes    
                             ntdll.dll!__RtlUserThreadStart@8()  + 0x1b bytes
</pre>

thread 2
<pre>
Not Flagged        5920    0    Worker Thread    thread_start<unsigned int (__stdcall*)(void *)>    RtlpWaitOnAddress    Below Normal
                             ntdll.dll!_NtWaitForAlertByThreadId@8()  + 0xc bytes    
                             ntdll.dll!@RtlpWaitOnAddressWithTimeout@16()  + 0x33 bytes    
                             ntdll.dll!RtlpWaitOnAddress()  + 0xa5 bytes    
                             ntdll.dll!RtlpWaitOnCriticalSection()  + 0xaa bytes    
                             ntdll.dll!RtlpEnterCriticalSectionContended()  + 0xd5 bytes    
                             ntdll.dll!_RtlEnterCriticalSection@4()  + 0x45 bytes    
                             kodi.exe!XbmcThreads::windows::RecursiveMutex::lock()  Line 54 + 0xc bytes    
                             kodi.exe!XbmcThreads::CountingLockable<XbmcThreads::windows::RecursiveMutex>::lock()  Line 60 + 0x16 bytes    
                             kodi.exe!XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock<CCriticalSection>(CCriticalSection & lockable)  Line 127 + 0x19 bytes    
                             kodi.exe!CSingleLock::CSingleLock(CCriticalSection & cs)  Line 38 + 0x1a bytes    
==> wants addon mgr mutex
                             kodi.exe!ADDON::CAddonMgr::IsAddonDisabled(const 
std::basic_string<char,std::char_traits<char>,std::allocator<char> > & ID)  Line 812 + 0xf bytes    
==> has pvr clients mutex
                             kodi.exe!PVR::CPVRClients::EnabledClientAmount()  Line 185 + 0x45 bytes    
                             kodi.exe!PVR::CPVRChannelGroup::Renumber()  Line 877 + 0x50 bytes    
                             kodi.exe!PVR::CPVRChannelGroups::SetSelectedGroup(std::shared_ptr<PVR::CPVRChannelGroup> group)  Line 486 + 0x1a bytes    
                             kodi.exe!PVR::CPVRChannelGroups::Load()  Line 322    
                             kodi.exe!PVR::CPVRChannelGroupsContainer::Load()  Line 71 + 0xb bytes    
                             kodi.exe!PVR::CPVRManager::Load(bool bShowProgress)  Line 661 + 0x15 bytes    
                             kodi.exe!PVR::CPVRManager::Process()  Line 550 + 0x29 bytes    
                             kodi.exe!CThread::Action()  Line 221 + 0xf bytes    
                             kodi.exe!CThread::staticThread(void * data)  Line 134    
                             ucrtbased.dll!invoke_thread_procedure(unsigned int (void *)* const procedure, void * const context)  Line 92    
                             ucrtbased.dll!thread_start<unsigned int (__stdcall*)(void *)>(void * const parameter)  Line 115 + 0x10 bytes    
                             kernel32.dll!@BaseThreadInitThunk@12()  + 0x24 bytes    
                             ntdll.dll!__RtlUserThreadStart()  + 0x2f bytes    
                             ntdll.dll!__RtlUserThreadStart@8()  + 0x1b bytes
</pre>

@Jalle19 might be in the mood doing the review. ;-)