### PR TITLE
fix skip specified amount

### DIFF
--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -361,6 +361,7 @@ bool CSeekHandler::SeekTimeCode(const CAction &action)
     case ACTION_STEP_BACK:
     case ACTION_BIG_STEP_BACK:
     case ACTION_CHAPTER_OR_BIG_STEP_BACK:
+    case ACTION_MOVE_LEFT:
     {
       SeekSeconds(-GetTimeCodeSeconds());
       return true;
@@ -368,6 +369,7 @@ bool CSeekHandler::SeekTimeCode(const CAction &action)
     case ACTION_STEP_FORWARD:
     case ACTION_BIG_STEP_FORWARD:
     case ACTION_CHAPTER_OR_BIG_STEP_FORWARD:
+    case ACTION_MOVE_RIGHT:
     {
       SeekSeconds(GetTimeCodeSeconds());
       return true;


### PR DESCRIPTION
as reported on the forum: http://forum.kodi.tv/showthread.php?tid=304515
forward/backward skipping a specified amount of time is currently broken
(http://kodi.wiki/view/Skip_steps#Skip_the_specified_amount)

i'm unsure if this is the correct way to fix it, as we never needed these key mappings before.

@afedchin 