### PR TITLE
Resolution: Do not switch resolutions when in 3D (only refreshrates)

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -224,11 +224,13 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
       // evaluate all higher modes and evaluate them
       // concerning dimension and refreshrate weight
       // skip lower resolutions
+      // don't change resolutions when 3D is wanted
       if ((width < orig.iScreenWidth) || // orig res large enough
          (info.iScreenWidth < orig.iScreenWidth) || // new res is smaller
          (info.iScreenHeight < orig.iScreenHeight) || // new height would be smaller
          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) || // don't switch to interlaced modes
-         (info.iScreen != curr.iScreen)) // skip not current displays
+         (info.iScreen != curr.iScreen) || // skip not current displays
+         is3D) // skip res changing when doing 3D
       {
         continue;
       }


### PR DESCRIPTION
Since my updates to the Adjust Refreshrate to match video logic I received not too much negative feedback, besides some driver bugs and AVRs suddenly confronted with 4k there was only this one thing.

For 3D if the resolution is given with computed SAR, e.g. 2:1 for a 1920 source would end up with 3840 but TVs most likely only do their 3D mode in 1920 x 1080 I workaround this.

I don't have a 3D TV and cannot test it, this might fix:  http://trac.kodi.tv/ticket/17251 - as the user uses LibreELEC, he cannot verify or help me testing. Perhaps @lrusak @MilhouseVH can provide help there.