### PR TITLE
added: Expose audio bitrate info in VideoPlayer (fixes #17029)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9406,6 +9406,9 @@ void CGUIInfoManager::UpdateAVInfo()
 
       m_videoInfo = video;
       m_audioInfo = audio;
+      printf("debug arate=%i\n", audio.bitrate);
+      printf("codec=%s\n", audio.audioCodecName.c_str());
+      printf("channel=%i\n", audio.channels);
 
       m_isPvrChannelPreview = g_PVRManager.IsChannelPreview();
     }

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -132,7 +132,6 @@ public:
   virtual void SetMute(bool bOnOff) {};
   virtual void SetDynamicRangeCompression(long drc) = 0;
   virtual std::string GetPlayerInfo() = 0;
-  virtual int GetAudioBitrate() = 0;
   virtual int GetAudioChannels() = 0;
   virtual double GetCurrentPts() = 0;
   virtual bool IsStalled() const = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -528,6 +528,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::
       s.name = stream->GetStreamName();
       s.codec    = demuxer->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
       s.channels = 0; // Default to 0. Overwrite if STREAM_AUDIO below.
+      //s.bitrate = 0;  // Default to 0. Overwrite if STREAM_AUDIO below.
       if(stream->type == STREAM_VIDEO)
       {
         s.width = ((CDemuxStreamVideo*)stream)->iWidth;
@@ -545,6 +546,8 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::
           s.name += type;
         }
         s.channels = ((CDemuxStreamAudio*)stream)->iChannels;
+        s.bitrate = ((CDemuxStreamAudio*)stream)->iBitRate;
+        printf("debug bitrate VP %i\n", s.bitrate);
       }
       Update(s);
     }
@@ -3422,7 +3425,6 @@ void CVideoPlayer::UpdateStreamInfos()
   if (streamId >= 0 && streamId < GetVideoStreamCount())
   {
     SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, streamId);
-    s.bitrate = m_VideoPlayerVideo->GetVideoBitrate();
     s.aspect_ratio = m_renderManager.GetAspectRatio();
     CRect viewRect;
     m_renderManager.GetVideoRect(s.SrcRect, s.DestRect, viewRect);
@@ -3456,13 +3458,14 @@ void CVideoPlayer::UpdateStreamInfos()
   if (streamId >= 0 && streamId < GetAudioStreamCount())
   {
     SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, streamId);
-    s.bitrate = m_VideoPlayerAudio->GetAudioBitrate();
+    //s.bitrate = m_VideoPlayerAudio->GetAudioBitrate();
     s.channels = m_VideoPlayerAudio->GetAudioChannels();
 
     CDemuxStream* stream = m_pDemuxer->GetStream(m_CurrentAudio.demuxerId, m_CurrentAudio.id);
     if (stream && stream->type == STREAM_AUDIO)
     {
       s.codec = m_pDemuxer->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      s.bitrate = ((CDemuxStreamAudio*)stream)->iBitRate;
     }
   }
 }
@@ -4874,8 +4877,9 @@ void CVideoPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
   if (s.type == STREAM_NONE)
     info.name += " (Invalid)";
 
-  info.valid = true;
   info.bitrate = s.bitrate;
+  info.valid = true;
+  printf("CVideoPlayer::GetAudioStreamInfo: bitrate=%i\n", s.bitrate);
   info.channels = s.channels;
   info.audioCodecName = s.codec;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -210,7 +210,7 @@ void CVideoPlayerAudio::UpdatePlayerInfo()
 {
   std::ostringstream s;
   s << "aq:"     << std::setw(2) << std::min(99,m_messageQueue.GetLevel()) << "%";
-  s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)GetAudioBitrate() / 1024.0;
+  s << ", Kb/s:" << std::fixed << std::setprecision(2) << (double)m_audioStats.GetBitrate() / 1024.0;
 
   //print the inverse of the resample ratio, since that makes more sense
   //if the resample ratio is 0.5, then we're playing twice as fast
@@ -616,11 +616,6 @@ std::string CVideoPlayerAudio::GetPlayerInfo()
 {
   CSingleLock lock(m_info_section);
   return m_info.info;
-}
-
-int CVideoPlayerAudio::GetAudioBitrate()
-{
-  return (int)m_audioStats.GetBitrate();
 }
 
 int CVideoPlayerAudio::GetAudioChannels()

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -60,7 +60,7 @@ public:
 
 
   std::string GetPlayerInfo();
-  int GetAudioBitrate();
+//  int GetAudioBitrate();
   int GetAudioChannels();
 
   // holds stream information for current playing stream


### PR DESCRIPTION
This allows eg. skins to show the codec's (average) audio bitrate again, like with Jarvis.


## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No codec average audio bit rate info in skins
<!--- If it fixes an open issue, please link to the issue here -->
http://trac.kodi.tv/ticket/17029

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
