### PR TITLE
Remove CBackgroundPlayer

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -110,17 +110,6 @@ struct ReplayGainSettings
   int iType;
 };
 
-class CBackgroundPlayer : public CThread
-{
-public:
-  CBackgroundPlayer(const CFileItem &item, int iPlayList);
-  virtual ~CBackgroundPlayer();
-  virtual void Process();
-protected:
-  CFileItem *m_item;
-  int       m_iPlayList;
-};
-
 class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMsgTargetCallback,
                      public ISettingCallback, public ISettingsHandler, public ISubSettings,
                      public KODI::MESSAGING::IMessageTarget

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -114,7 +114,6 @@ class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMs
                      public ISettingCallback, public ISettingsHandler, public ISubSettings,
                      public KODI::MESSAGING::IMessageTarget
 {
-  friend class CApplicationPlayer;
 public:
 
   enum ESERVERS


### PR DESCRIPTION
## Description
The CBackgroundPlayer class doesn't appear to be defined or used anywhere. Remove it.

## Motivation and Context
Will make code shorter, easier to navigate and marginally faster to compile.

## How Has This Been Tested?
I grepped all .h/.cpp files in the tree and none matched other than this. On x86_64 Ubuntu, I ran all the existing tests & they passed. I also did a manual test of playing a video, including in the background.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
