### PR TITLE
[Fix] Multiple changes of song rating from player OSD (ticket #17190)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4685,6 +4685,11 @@ const std::string& CApplication::CurrentFile()
   return m_itemCurrentFile->GetPath();
 }
 
+std::shared_ptr<CFileItem> CApplication::CurrentFileItemPtr()
+{
+  return m_itemCurrentFile;
+}
+
 CFileItem& CApplication::CurrentFileItem()
 {
   return *m_itemCurrentFile;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -164,6 +164,7 @@ public:
   void ReloadSkin(bool confirm = false);
   const std::string& CurrentFile();
   CFileItem& CurrentFileItem();
+  std::shared_ptr<CFileItem> CurrentFileItemPtr();
   void SetCurrentFileItem(const CFileItem &item);
   CFileItem& CurrentUnstackedItem();
   virtual bool OnMessage(CGUIMessage& message) override;

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -92,7 +92,7 @@ bool CGUIDialogMusicOSD::OnAction(const CAction &action)
         for (int i = 1; i <= 10; i++)
           dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
 
-        auto track = std::make_shared<CFileItem>(g_application.CurrentFileItem());
+        auto track = g_application.CurrentFileItemPtr();
         dialog->SetSelected(track->GetMusicInfoTag()->GetUserrating());
 
         dialog->Open();


### PR DESCRIPTION
This fixes trac http://trac.kodi.tv/ticket/17190,  that was actually a known design issue since implementation of update of song user rating from music OSD  in #9094

As @Razzeee said about this new feature at the time "The only drawback is, that as long as the song you just rated is playing, you can reopen the rating dialog and won't see the rating preselected. "
To reproduce some of the symptoms:

Start playback of a track that is currently unrated
Set the rating to, let's say, 3
Click the rating button **again** and you'll notice the selection dialog does not represent the current rating 
Select 'no rating' and your rating will still be 3

The issue was that whilst the db was being correcly updated, as were any other windows, the rating value was not set in `g_application.CurrentFileItem`.  Using  std::make_shared<CFileItem> this could never work.

@Paxxi and @fritsch kindly helped with a simple solution, adding a method to CApplication, thank you both. 
@ronie it seems I got to fix this anyway, perhaps you and @Razzeee could test.

I have tested setting rating during playback in as many ways as I can, but it helps to have more.  It is even happy if the playback has moved to a new song before the rating is selected.

If it looks good then I will backport soonest