### PR TITLE
Replace raw pointer in CApplication

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -266,7 +266,6 @@ CApplication::CApplication(void)
   , m_autoExecScriptExecuted(false)
   , m_bScreenSave(false)
   , m_bInhibitIdleShutdown(false)
-  , m_dpms(nullptr)
   , m_dpmsIsActive(false)
   , m_dpmsIsManual(false)
   , m_itemCurrentFile(new CFileItem)
@@ -317,9 +316,7 @@ CApplication::~CApplication(void)
 #endif
   delete m_currentStack;
 
-  delete m_dpms;
   delete m_pInertialScrollingHandler;
-  delete m_pPlayer;
 
   m_actionListeners.clear();
 }
@@ -1144,7 +1141,7 @@ bool CApplication::Initialize()
   StartServices();
 
   // Init DPMS, before creating the corresponding setting control.
-  m_dpms = new DPMSSupport();
+  m_dpms.reset(new DPMSSupport());
   bool uiInitializationFinished = true;
   if (g_windowManager.Initialized())
   {

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -303,7 +303,7 @@ public:
   MEDIA_DETECT::CDetectDVDMedia m_DetectDVDType;
 #endif
 
-  CApplicationPlayer* m_pPlayer;
+  std::unique_ptr<CApplicationPlayer> m_pPlayer;
 
   inline bool IsInScreenSaver() { return m_bScreenSave; };
   inline bool IsDPMSActive() { return m_dpmsIsActive; };
@@ -455,7 +455,7 @@ protected:
 
   bool m_bInhibitIdleShutdown;
 
-  DPMSSupport* m_dpms;
+  std::unique_ptr<DPMSSupport> m_dpms;
   bool m_dpmsIsActive;
   bool m_dpmsIsManual;
 


### PR DESCRIPTION
## Description
Replace CApplicationPlayer raw pointer in CApplication with unique_ptr.

## Motivation and Context
General exception safety / code simplification.

## How Has This Been Tested?
On x86_64 Ubuntu ran existing unit tests and manually tested Kodi by playing a sample video.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
