### PR TITLE
[PVR] PVR Manager/Clients: Fix stop playback on addon uninstallation.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -424,6 +424,13 @@ void CPVRManager::Stop(void)
   if (IsStopped())
     return;
 
+  /* stop playback if needed */
+  if (IsPlaying())
+  {
+    CLog::Log(LOGNOTICE,"PVRManager - %s - stopping PVR playback", __FUNCTION__);
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+  }
+
   SetState(ManagerStateStopping);
 
   m_pendingUpdates.Stop();
@@ -432,13 +439,6 @@ void CPVRManager::Stop(void)
   g_EpgContainer.Stop();
 
   CLog::Log(LOGNOTICE, "PVRManager - stopping");
-
-  /* stop playback if needed */
-  if (IsPlaying())
-  {
-    CLog::Log(LOGNOTICE,"PVRManager - %s - stopping PVR playback", __FUNCTION__);
-    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
-  }
 
   /* stop all update threads */
   SetState(ManagerStateInterrupted);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -199,8 +199,9 @@ bool CPVRClients::HasEnabledClients(void) const
 
 bool CPVRClients::StopClient(const AddonPtr &client, bool bRestart)
 {
-  /* stop playback */
-  CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
+  /* stop playback if needed */
+  if (IsPlaying())
+    CApplicationMessenger::GetInstance().SendMsg(TMSG_MEDIA_STOP);
 
   CSingleLock lock(m_critSection);
   int iId = GetClientId(client);


### PR DESCRIPTION
Possibly active pvr playback was not stopped upon addon uninstallation. The repective check was done to late. This PR fixes this.

This change has been runtime tested on latest master on macOS.

@Jalle19 for review?