### PR TITLE
Replace 3 raw pointers in CApplication with unique_ptrs

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -257,6 +257,9 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 //extern IDirectSoundRenderer* m_pAudioDecoder;
 CApplication::CApplication(void)
   : m_pPlayer(new CApplicationPlayer)
+#ifdef HAS_DVD_DRIVE
+  , m_Autorun(new CAutorun())
+#endif
   , m_iScreenSaveLock(0)
   , m_bPlaybackStarting(false)
   , m_ePlayState(PLAY_STATE_NONE)
@@ -269,6 +272,7 @@ CApplication::CApplication(void)
   , m_dpmsIsActive(false)
   , m_dpmsIsManual(false)
   , m_itemCurrentFile(new CFileItem)
+  , m_currentStack(new CFileItemList)
   , m_stackFileItemToUpdate(new CFileItem)
   , m_threadID(0)
   , m_bInitializing(true)
@@ -298,23 +302,11 @@ CApplication::CApplication(void)
 #ifdef HAS_GLX
   XInitThreads();
 #endif
-
-  /* for now always keep this around */
-  m_currentStack = new CFileItemList;
-
-#ifdef HAS_DVD_DRIVE
-  m_Autorun = new CAutorun();
-#endif
 }
 
 CApplication::~CApplication(void)
 {
-  delete m_musicInfoScanner;
   delete &m_progressTrackingVideoResumeBookmark;
-#ifdef HAS_DVD_DRIVE
-  delete m_Autorun;
-#endif
-  delete m_currentStack;
 
   delete m_pInertialScrollingHandler;
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -291,19 +291,20 @@ public:
   static bool OnEvent(XBMC_Event& newEvent);
 
   CNetwork& getNetwork();
+
 #ifdef HAS_PERFORMANCE_SAMPLE
   CPerformanceStats &GetPerformanceStats();
 #endif
 
+  std::unique_ptr<CApplicationPlayer> m_pPlayer;
+
 #ifdef HAS_DVD_DRIVE
-  MEDIA_DETECT::CAutorun* m_Autorun;
+  std::unique_ptr<MEDIA_DETECT::CAutorun> m_Autorun;
 #endif
 
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
   MEDIA_DETECT::CDetectDVDMedia m_DetectDVDType;
 #endif
-
-  std::unique_ptr<CApplicationPlayer> m_pPlayer;
 
   inline bool IsInScreenSaver() { return m_bScreenSave; };
   inline bool IsDPMSActive() { return m_dpmsIsActive; };
@@ -460,7 +461,7 @@ protected:
   bool m_dpmsIsManual;
 
   CFileItemPtr m_itemCurrentFile;
-  CFileItemList* m_currentStack;
+  std::unique_ptr<CFileItemList> m_currentStack;
   CFileItemPtr m_stackFileItemToUpdate;
 
   std::string m_prevMedia;
@@ -483,7 +484,7 @@ protected:
   bool m_bTestMode;
   bool m_bSystemScreenSaverEnable;
 
-  MUSIC_INFO::CMusicInfoScanner *m_musicInfoScanner;
+  std::unique_ptr<MUSIC_INFO::CMusicInfoScanner> m_musicInfoScanner;
 
   bool m_muted;
   float m_volumeLevel;


### PR DESCRIPTION
## Description
Replace 3 raw pointers in CApplication with unique_ptrs.

## Motivation and Context
General exception safety, code cleanup.

## How Has This Been Tested?
On x86_64 Ubuntu, did manual tests by loading Kodi. Also ran existing unit tests. All passed.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
