### PR TITLE
Resolution: Do not switch resolutions when in 3D (only refreshrates)

### DIFF
--- a/xbmc/guilib/Resolution.cpp
+++ b/xbmc/guilib/Resolution.cpp
@@ -224,11 +224,13 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
       // evaluate all higher modes and evalute them
       // concerning dimension and refreshrate weight
       // skip lower resolutions
+      // don't change resolutions when 3D is wanted
       if ((width < orig.iScreenWidth) || // orig res large enough
          (info.iScreenWidth < orig.iScreenWidth) || // new res is smaller
          (info.iScreenHeight < orig.iScreenHeight) || // new height would be smaller
          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) || // don't switch to interlaced modes
-         (info.iScreen != curr.iScreen)) // skip not current displays
+         (info.iScreen != curr.iScreen) || // skip not current displays
+         is3D) // skip res changing when doing 3D
       {
         continue;
       }


### PR DESCRIPTION
Backport of: https://github.com/xbmc/xbmc/pull/11502#issuecomment-274327070