### PR TITLE
[Fix] Multiple changes of song rating from player OSD

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4649,6 +4649,11 @@ const std::string& CApplication::CurrentFile()
   return m_itemCurrentFile->GetPath();
 }
 
+std::shared_ptr<CFileItem> CApplication::CurrentFileItemPtr()
+{
+  return m_itemCurrentFile;
+}
+
 CFileItem& CApplication::CurrentFileItem()
 {
   return *m_itemCurrentFile;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -164,6 +164,7 @@ public:
   void ReloadSkin(bool confirm = false);
   const std::string& CurrentFile();
   CFileItem& CurrentFileItem();
+  std::shared_ptr<CFileItem> CurrentFileItemPtr();
   void SetCurrentFileItem(const CFileItem &item);
   CFileItem& CurrentUnstackedItem();
   virtual bool OnMessage(CGUIMessage& message) override;

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -91,7 +91,7 @@ bool CGUIDialogMusicOSD::OnAction(const CAction &action)
         for (int i = 1; i <= 10; i++)
           dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
 
-        auto track = std::make_shared<CFileItem>(g_application.CurrentFileItem());
+        auto track = g_application.CurrentFileItemPtr();
         dialog->SetSelected(track->GetMusicInfoTag()->GetUserrating());
 
         dialog->Open();


### PR DESCRIPTION
Backport of #11513 
This fixes trac http://trac.kodi.tv/ticket/17190, that was actually a known design issue since implementation of update of song user rating from music OSD in #9094