### PR TITLE
Revert: [settings] remove show EXIF picture information setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19654,7 +19654,21 @@ msgctxt "#38111"
 msgid "This category contains other settings for the GUI interface"
 msgstr ""
 
-#empty strings from id 38112 to 38999
+#empty strings from id 38112 to 38206
+
+#. Description of setting "Pictures -> Show EXIF picture information" with label #38207
+#: system/settings/settings.xml
+msgctxt "#38207"
+msgid "Show EXIF picture information"
+msgstr ""
+
+#. Help text of setting "Pictures -> Show EXIF picture information" with label #38208
+#: system/settings/settings.xml
+msgctxt "#38208"
+msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
+msgstr ""
+
+#empty strings from id 38209 to 38999
 
 #: system/settings/settings.xml
 msgctxt "#39000"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -581,6 +581,11 @@
     </category>
     <category id="pictures" label="14217" help="38105">
       <group id="1" label="108">
+        <setting id="pictures.usetags" type="boolean" label="38207" help="38208">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="slideshow.staytime" type="integer" label="12378" help="36312">
           <level>0</level>
           <default>5</default>

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -203,7 +203,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
     if (StringUtils::EqualsNoCase(items[i]->GetLabel(), "folder.jpg"))
       items.Remove(i);
 
-  if (items.GetFolderCount() == items.Size())
+  if (items.GetFolderCount()==items.Size() || !CSettings::GetInstance().GetBool(CSettings::SETTING_PICTURES_USETAGS))
     return;
 
   // Start the music info loader thread

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -43,6 +43,7 @@ void CPictureInfoLoader::OnLoaderStart()
   m_mapFileItems->SetFastLookup(true);
 
   m_tagReads = 0;
+  m_loadTags = CSettings::GetInstance().GetBool(CSettings::SETTING_PICTURES_USETAGS);
 
   if (m_pProgressCallback)
     m_pProgressCallback->SetProgressMax(m_pVecItems->GetFileCount());
@@ -87,8 +88,11 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (pItem->HasPictureInfoTag())
     return false;
 
-  pItem->GetPictureInfoTag()->Load(pItem->GetPath());
-  m_tagReads++;
+  if (m_loadTags)
+  { // Nothing found, load tag from file
+    pItem->GetPictureInfoTag()->Load(pItem->GetPath());
+    m_tagReads++;
+  }
 
   return true;
 }

--- a/xbmc/pictures/PictureInfoLoader.h
+++ b/xbmc/pictures/PictureInfoLoader.h
@@ -39,5 +39,6 @@ protected:
 
   CFileItemList* m_mapFileItems;
   unsigned int m_tagReads;
+  bool m_loadTags;
 };
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -296,6 +296,7 @@ const std::string CSettings::SETTING_AUDIOCDS_SETTINGS = "audiocds.settings";
 const std::string CSettings::SETTING_AUDIOCDS_EJECTONRIP = "audiocds.ejectonrip";
 const std::string CSettings::SETTING_MYMUSIC_SONGTHUMBINVIS = "mymusic.songthumbinvis";
 const std::string CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW = "mymusic.defaultlibview";
+const std::string CSettings::SETTING_PICTURES_USETAGS = "pictures.usetags";
 const std::string CSettings::SETTING_PICTURES_GENERATETHUMBS = "pictures.generatethumbs";
 const std::string CSettings::SETTING_PICTURES_SHOWVIDEOS = "pictures.showvideos";
 const std::string CSettings::SETTING_PICTURES_DISPLAYRESOLUTION = "pictures.displayresolution";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -253,6 +253,7 @@ public:
   static const std::string SETTING_AUDIOCDS_EJECTONRIP;
   static const std::string SETTING_MYMUSIC_SONGTHUMBINVIS;
   static const std::string SETTING_MYMUSIC_DEFAULTLIBVIEW;
+  static const std::string SETTING_PICTURES_USETAGS;
   static const std::string SETTING_PICTURES_GENERATETHUMBS;
   static const std::string SETTING_PICTURES_SHOWVIDEOS;
   static const std::string SETTING_PICTURES_DISPLAYRESOLUTION;


### PR DESCRIPTION
e7d90188436b6966eff23fd695e1a9d18f4af1b4

Manual Backport and adjustment of:  https://github.com/xbmc/xbmc/pull/11457