### PR TITLE
[win32][depends]Patch TagLib to v1.11.1 + d2e0e55 to fix regression causing hangs

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -41,7 +41,7 @@ python-2.7.11-win32-vc140-v2.7z
 shairplay-0.9.0-win32-vc140-v2.7z
 sqlite-3.10.2-win32-vc140.7z
 swig-3.0.10-win32.7z
-taglib-1.11-win32-vc140-v2.7z
+taglib-1.11.1_80df30-win32-vc140.7z
 texturepacker-1.1.1-win32.7z
 tinyxmlstl-2.6.2-win32-vc140-v2.7z
 zlib-1.2.8-win32-vc140-v3.7z


### PR DESCRIPTION
For win32 update TagLib to v1.11.1 with  https://github.com/taglib/taglib/commit/d2e0e5522308ce4c905c205c7bf5972ea71cd6e5 as a patch to fix regression causing hangs with (Shoutcast) internet radio streams. See ticket http://trac.kodi.tv/ticket/17210 .
(Shoutcast) internet radio streams ending ".mp3" get passed to TabLib as if they have ID3 tags, and TabLib was spending upto 10 mins looking for them, looking for the end of the file incase the tags were there. 

The step to v1.11.1 brings win32  in line with the package changes for other platforms made by #11101
and the patch to match  #11543 

This change has already been backported to v17 by #11547 

Note for future update to TagLib - it is worth testing with Shoutcasts, as well as other music file formats.
