### PR TITLE
[win32][depends]Update taglib to v1.11.1 [backport]

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -41,7 +41,7 @@ python-2.7.11-win32-vc140-v2.7z
 shairplay-0.9.0-win32-vc140-v2.7z
 sqlite-3.10.2-win32-vc140.7z
 swig-3.0.10-win32.7z
-taglib-1.11-win32-vc140-v2.7z
+taglib-1.11.1-win32-vc140.7z
 texturepacker-1.1.1-win32.7z
 tinyxmlstl-2.6.2-win32-vc140-v2.7z
 zlib-1.2.8-win32-vc140-v3.7z


### PR DESCRIPTION
Backport of #11522
Update TagLib to v1.11.1 for win32 to bring it in line with the package changes for other platforms made by #11101 

Update TagLib to v1.11.1 for win32 to bring it in line with the package changes for other platforms made by #11101

v1.11.1 is the most recent official version of TagLib, released 24th Oct 2016. 

Note this does **not** solve the issue Kodi has with (Shoutcast) internet radio streams ending ".mp3". Because the name ends ".mp3" these get passed to TabLib as if they have ID3 tags, and TabLib can spend 10 mins looking for them. Shoutcast has its own metadata protocol , not ID3. This regression in TagLib (since 1.9) is expected to be resolved in a sebsequent release.