### PR TITLE
[skins] show video indicator in slideshow window

### DIFF
--- a/addons/skin.estouchy/xml/SlideShow.xml
+++ b/addons/skin.estouchy/xml/SlideShow.xml
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<controls>
+		<control type="image">
+			<centerleft>50%</centerleft>
+			<centertop>50%</centertop>
+			<width>283</width>
+			<height>283</height>
+			<texture>icon_settings_player.png</texture>
+			<visible>SlideShow.IsVideo + [![Player.Playing + Player.HasVideo] | SlideShow.IsPaused]</visible>
+		</control>
+	</controls>
 </window>

--- a/addons/skin.estuary/xml/SlideShow.xml
+++ b/addons/skin.estuary/xml/SlideShow.xml
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
+	<controls>
+		<control type="image">
+			<centerleft>50%</centerleft>
+			<centertop>50%</centertop>
+			<width>256</width>
+			<height>256</height>
+			<texture>icons/settings/player.png</texture>
+			<visible>SlideShow.IsVideo + [![Player.Playing + Player.HasVideo] | SlideShow.IsPaused]</visible>
+		</control>
+	</controls>
 </window>


### PR DESCRIPTION
display an indicator (instead of a black screen) when you manually skip through a slideshow and the current slideshow item is a video.

@da-anda 