### PR TITLE
add support for utf-8 formatted zip files

### DIFF
--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -34,6 +34,8 @@
 
 using namespace XFILE;
 
+static const size_t ZC_FLAG_EFS = 1 << 11; // general purpose bit 11 - zip holds utf-8 filenames
+
 CZipManager::CZipManager()
 {
 }
@@ -192,7 +194,8 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
       return false;
     std::string strName(bufName.get(), bufName.size());
     bufName.clear();
-    g_charsetConverter.unknownToUTF8(strName);
+    if ((ze.flags & ZC_FLAG_EFS) == 0)
+      g_charsetConverter.unknownToUTF8(strName);
     ZeroMemory(ze.name, 255);
     strncpy(ze.name, strName.c_str(), strName.size()>254 ? 254 : strName.size());
 

--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -195,9 +195,12 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
     std::string strName(bufName.get(), bufName.size());
     bufName.clear();
     if ((ze.flags & ZC_FLAG_EFS) == 0)
-      g_charsetConverter.unknownToUTF8(strName);
+    {
+      std::string tmp(strName);
+      g_charsetConverter.ToUtf8("CP437", tmp, strName);
+    }
     ZeroMemory(ze.name, 255);
-    strncpy(ze.name, strName.c_str(), strName.size()>254 ? 254 : strName.size());
+    strncpy(ze.name, strName.c_str(), strName.size() > 254 ? 254 : strName.size());
 
     // Jump after central file header extra field and file comment
     mFile.Seek(ze.eclength + ze.clength,SEEK_CUR);


### PR DESCRIPTION
added in zip specification v6.3.0.
note: no handling of extra field UTF-8/MAC et al as the specifications only says this will be flagged
in the extra data field without giving details. if somebody wants this, i need samples.

i noticed this looking into http://forum.kodi.tv/showthread.php?tid=304577

https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.0.TXT