### PR TITLE
[Fix]Freeze on opening some (Shoutcast) internet radio station streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -167,6 +167,8 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
           delete pRedirectEx;
         }
       }
+      if (curlFile.IsShoutcast())
+        finalFileitem.SetProperty("isshoutcast", true);      
     }
 
     if (finalFileitem.IsType(".m3u8"))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -183,6 +183,7 @@ public:
   virtual IDisplayTime* GetIDisplayTime() { return nullptr; }
 
   const CVariant &GetProperty(const std::string key){ return m_item.GetProperty(key); }
+  bool HasProperty(const std::string key) { return m_item.HasProperty(key); }
 
 protected:
   DVDStreamType m_streamType;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -178,19 +178,22 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     return false;
   }
 
-  //  Extract ReplayGain info
-  // tagLoaderTagLib.Load will try to determine tag type by file extension, so set fallback by contentType
-  std::string strFallbackFileExtension = "";
-  if (m_strContentType == "audio/aacp" ||
-      m_strContentType == "audio/aac")
-    strFallbackFileExtension = "m4a";
-  else if (m_strContentType == "audio/x-ms-wma")
-    strFallbackFileExtension = "wma";
-  else if (m_strContentType == "audio/x-ape" ||
-           m_strContentType == "audio/ape")
-    strFallbackFileExtension = "ape";
-  CTagLoaderTagLib tagLoaderTagLib;
-  tagLoaderTagLib.Load(strFile, m_tag, strFallbackFileExtension);
+  if (!m_pInputStream->HasProperty("isshoutcast"))
+  {
+    //  Extract ReplayGain info
+    // tagLoaderTagLib.Load will try to determine tag type by file extension, so set fallback by contentType
+    std::string strFallbackFileExtension = "";
+    if (m_strContentType == "audio/aacp" ||
+        m_strContentType == "audio/aac")
+      strFallbackFileExtension = "m4a";
+    else if (m_strContentType == "audio/x-ms-wma")
+      strFallbackFileExtension = "wma";
+    else if (m_strContentType == "audio/x-ape" ||
+             m_strContentType == "audio/ape")
+      strFallbackFileExtension = "ape";
+    CTagLoaderTagLib tagLoaderTagLib;
+    tagLoaderTagLib.Load(strFile, m_tag, strFallbackFileExtension);
+  }
 
   // we have to decode initial data in order to get channels/samplerate
   // for sanity - we read no more than 10 packets

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1045,6 +1045,7 @@ bool CCurlFile::Open(const CURL& url)
      || !m_state->m_httpheader.GetValue("icy-name").empty()
      || !m_state->m_httpheader.GetValue("icy-br").empty()) && !m_skipshout)
   {
+    m_isshoutcast = true;
     CLog::Log(LOGDEBUG,"CCurlFile::Open - File <%s> is a shoutcast stream. Re-opening", redactPath.c_str());
     throw new CRedirectException(new CShoutcastFile);
   }

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -105,6 +105,8 @@ namespace XFILE
       /* static function that will get cookies stored by CURL in RFC 2109 format */
       static bool GetCookies(const CURL &url, std::string &cookies);
 
+      bool IsShoutcast() { return m_isshoutcast; }
+
       class CReadState
       {
       public:
@@ -209,5 +211,6 @@ namespace XFILE
       MAPHTTPHEADERS m_requestheaders;
 
       long            m_httpresponse;
+      bool            m_isshoutcast;
   };
 }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -75,6 +75,7 @@ bool CShoutcastFile::Open(const CURL& url)
   bool result = m_file.Open(url2);
   if (result)
   {
+    m_tag.SetType(MediaTypeShoutcast);
     m_tag.SetTitle(m_file.GetHttpHeader().GetValue("icy-name"));
     if (m_tag.GetTitle().empty())
       m_tag.SetTitle(m_file.GetHttpHeader().GetValue("ice-name")); // icecast

--- a/xbmc/media/MediaType.h
+++ b/xbmc/media/MediaType.h
@@ -37,6 +37,7 @@ using MediaType = std::string;
 #define MediaTypeTvShow           "tvshow"
 #define MediaTypeSeason           "season"
 #define MediaTypeEpisode          "episode"
+#define MediaTypeShoutcast        "shoutcast"
 
 class CMediaTypes
 {


### PR DESCRIPTION
This fixes http://trac.kodi.tv/ticket/17210, Kodi freezing on opening some internet radio station streams,
by avoiding futilely trying to read ID3 tags from Shoutcasts (when they never have that metadata).

Some radio station streams with ".mp3" at the end of their stream name cause Kodi from v17 A2 onwards to lock the UI for 5 to 10 mins before starting playback. The delay takes place in TagLib, while it attempts to find ID3 metadata in a stream that does not contain any. The issue only appears on platforms that have deployed TagLib v1.11 (that includes win32 and LE). It is a regression in TabLib since v1.9, and the TagLib team have produced a commit that fixes the issue. However this is not at a stable state that we are happy to use in with Kodi.

While in the longer term TagLib will resolve the delay issue with a maintenance release , this PR seeks a more **immediate solution that can hopefully be backported to v1**7.

Although the stream content is mp3, the metadata is not ID3 format, Shoutcast has its own metadata protocol. Hence having tagLib scan the stream, that we know is a Shoutcast, and know does not contain any metatdata that TabLib can read, seems inefficient and an unnecessary risk.  Better to avoid calling TagLib at all for streams of the Shoutcast protocal.

Radio stations for testing (ending ".mp3") include 
- 90.9 Jazzy rádió - ​http://94.199.183.186/jazzy.mp3 
- Radio Svoboda - ​http://rfe-channel-04.akacast.akamaistream.net/7/885/229654/v1/ibb.akacast.akamaistream.net/rfe_channel_04.mp3 
- 89.5 Music FM - ​http://stream.musicfm.hu:8000/musicfm.mp3 Klasszik Rádió 92.1 - ​http://online.klasszikradio.hu/klasszik.mp3 
- Magyar katolikus rádió - ​http://katolikusradio.hu:9000/live_hi.mp3

@fritsch if you could check this over, after our discussion on Slack it was the most direct and encapsulated approach I could find.
Assuming that such a checking approach is acceptable @FernetMenta ?