### PR TITLE
[PVR] Trac 17246: Fix deadlock that might occur during initial channel icon search.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -540,4 +540,18 @@ namespace PVR
   private:
     CPVRChannelGroupPtr m_group;
   };
+
+  class CPVRSearchAndSetChannelIcons : public CJob
+  {
+  public:
+    CPVRSearchAndSetChannelIcons(const PVR_CHANNEL_GROUP_MEMBERS &groupMembers, bool bUpdateDb)
+    : m_groupMembers(groupMembers), m_bUpdateDb(bUpdateDb) {}
+    virtual ~CPVRSearchAndSetChannelIcons() {}
+    virtual const char *GetType() const { return "pvr-channelgroup-searchandsetchannelicons"; }
+
+    virtual bool DoWork();
+  private:
+    PVR_CHANNEL_GROUP_MEMBERS m_groupMembers;
+    const bool m_bUpdateDb;
+  };
 }


### PR DESCRIPTION
This user reported deadlock might occur on kodi startup when switching to the channels window while user supplied channel icons are still read and set.

Fixes trac 17246: http://trac.kodi.tv/ticket/17246

Stack traces (supplied by bug reporter):
![kodi-frozen](https://cloud.githubusercontent.com/assets/3226626/22264298/b9e58f34-e277-11e6-8a7a-f423a19d87a7.png)

Ghist of the fix is to put the problematic long running and guilib-calling (g_graphicsContext locking) channel icon search and set code into a  CJob implementation.

Fix has been tested on latest master on macOS by me and using test build on Windows by the bug reporter.

@Jalle19 for review?
