### PR TITLE
[PVR][application] Fix update of PVR client addons

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -951,6 +951,10 @@ bool CApplication::InitDirectoriesOSX()
   else
     userHome = "/root";
 
+  std::string binaddonAltDir;
+  if (getenv("KODI_BINADDON_PATH"))
+    binaddonAltDir = getenv("KODI_BINADDON_PATH");
+
   std::string appPath = CUtil::GetHomePath();
   setenv("KODI_HOME", appPath.c_str(), 0);
 
@@ -969,6 +973,7 @@ bool CApplication::InitDirectoriesOSX()
   {
     // map our special drives
     CSpecialProtocol::SetXBMCBinPath(appPath);
+    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
     CSpecialProtocol::SetXBMCPath(appPath);
     #if defined(TARGET_DARWIN_IOS)
       std::string appName = CCompileInfo::GetAppName();
@@ -1006,6 +1011,7 @@ bool CApplication::InitDirectoriesOSX()
     URIUtils::AddSlashAtEnd(appPath);
 
     CSpecialProtocol::SetXBMCBinPath(appPath);
+    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
     CSpecialProtocol::SetXBMCPath(appPath);
     CSpecialProtocol::SetHomePath(URIUtils::AddFileToFolder(appPath, "portable_data"));
     CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(appPath, "portable_data/userdata"));

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -103,6 +103,24 @@ void CPVRClient::OnEnabled()
   CPVRManager::GetInstance().Clients()->UpdateAddons();
 }
 
+void CPVRClient::StopRunningInstance()
+{
+  const ADDON::AddonPtr addon(GetRunningInstance());
+  if (addon)
+  {
+    // stop the pvr manager and stop and unload the running pvr addon
+    PVR::CPVRManager::GetInstance().Stop();
+    CPVRManager::GetInstance().Clients()->StopClient(addon, false);
+  }
+}
+
+void CPVRClient::OnPreInstall()
+{
+  // note: this method is also called on update; thus stop and unload possibly running instance
+  StopRunningInstance();
+  CAddon::OnPreInstall();
+}
+
 void CPVRClient::OnPostInstall(bool update, bool modal)
 {
   CAddon::OnPostInstall(update, modal);
@@ -111,8 +129,7 @@ void CPVRClient::OnPostInstall(bool update, bool modal)
 
 void CPVRClient::OnPreUnInstall()
 {
-  // stop the pvr manager, so running pvr add-ons are stopped and closed
-  PVR::CPVRManager::GetInstance().Stop();
+  StopRunningInstance();
   CAddon::OnPreUnInstall();
 }
 

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -73,6 +73,7 @@ namespace PVR
 
     virtual void OnDisabled() override;
     virtual void OnEnabled() override;
+    virtual void OnPreInstall() override;
     virtual void OnPostInstall(bool update, bool modal) override;
     virtual void OnPreUnInstall() override;
     virtual void OnPostUnInstall() override;
@@ -706,6 +707,11 @@ namespace PVR
      * @return True when it can be played, false otherwise.
      */
     bool CanPlayChannel(const CPVRChannelPtr &channel) const;
+
+    /*!
+     * @brief Stop this instance, if it is currently running.
+     */
+    void StopRunningInstance();
 
     bool LogError(const PVR_ERROR error, const char *strMethod) const;
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -220,8 +220,13 @@ bool CPVRClients::StopClient(const AddonPtr &client, bool bRestart)
     if (bRestart)
       mappedClient->ReCreate();
     else
-      mappedClient->Destroy();
+    {
+      const auto it = m_clientMap.find(iId);
+      if (it != m_clientMap.end())
+        m_clientMap.erase(it);
 
+      mappedClient->Destroy();
+    }
     return true;
   }
 


### PR DESCRIPTION
Update of PVR client addons did only work if the shared library name and or path to the shared library did not change during update, which is usually not the case as most (if not all?) shared libraries for PVR client addons have the version number in it's name.

This PR contains two commits. First commit is specific for macOS/iOS, second commit is platform independent.

First commit fixes a crash that occured on macOS while updating a pvr client addon. Due to the bug fixed by this PR, addon manager tried to load the old, already deleted shared library. This failed and led to a crash in <code>CAddonDll::LoadDll()</code> (https://github.com/xbmc/xbmc/blob/master/xbmc/addons/AddonDll.cpp#L116). It seems, that support for "alternate binary addon path" was simply forgotten for macOS/iOS, I added it, @Memphiz

Second commit fixes the actual addon update bug. Fix is in PVR code, addon manager is not affected.

Fix has been runtime tested on latest master on macOS and latest Krypton on Linux.

@Jalle19 for review?

