### PR TITLE
Update movie and TV library nodes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12638,7 +12638,10 @@ msgctxt "#20381"
 msgid "Specials"
 msgstr ""
 
-#empty string with id 20382
+#: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+msgctxt "#20382"
+msgid "Recently added"
+msgstr ""
 
 msgctxt "#20383"
 msgid "Selected folder contains a single video"

--- a/system/library/video/movies/actors.xml
+++ b/system/library/video/movies/actors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="4" type="filter">
+<node order="5" type="filter">
 	<label>344</label>
 	<icon>DefaultActor.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/country.xml
+++ b/system/library/video/movies/country.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="8" type="filter">
+<node order="9" type="filter">
 	<label>20451</label>
 	<icon>DefaultCountry.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/directors.xml
+++ b/system/library/video/movies/directors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="5" type="filter">
+<node order="6" type="filter">
 	<label>20348</label>
 	<icon>DefaultDirector.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/genres.xml
+++ b/system/library/video/movies/genres.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="1" type="filter">
+<node order="2" type="filter">
 	<label>135</label>
 	<icon>DefaultGenre.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/recentlyaddedmovies.xml
+++ b/system/library/video/movies/recentlyaddedmovies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="10" type="folder">
-	<label>20386</label>
+<node order="1" type="folder">
+	<label>20382</label>
 	<icon>DefaultRecentlyAddedMovies.png</icon>
 	<path>videodb://recentlyaddedmovies/</path>
 </node>

--- a/system/library/video/movies/sets.xml
+++ b/system/library/video/movies/sets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="7" type="filter" visible="Library.HasContent(MovieSets)">
+<node order="8" type="filter" visible="Library.HasContent(MovieSets)">
 	<label>20434</label>
 	<icon>DefaultSets.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/studios.xml
+++ b/system/library/video/movies/studios.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="6" type="filter">
+<node order="7" type="filter">
 	<label>20388</label>
 	<icon>DefaultStudios.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/tags.xml
+++ b/system/library/video/movies/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="9" type="filter">
+<node order="10" type="filter">
 	<label>20459</label>
 	<icon>DefaultTags.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/titles.xml
+++ b/system/library/video/movies/titles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="2" type="filter">
+<node order="3" type="filter">
 	<label>10024</label>
 	<icon>DefaultMovieTitle.png</icon>
 	<content>movies</content>

--- a/system/library/video/movies/years.xml
+++ b/system/library/video/movies/years.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="3" type="filter">
+<node order="4" type="filter">
 	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>movies</content>

--- a/system/library/video/musicvideos/albums.xml
+++ b/system/library/video/musicvideos/albums.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="5" type="filter">
+<node order="6" type="filter">
 	<label>132</label>
 	<icon>DefaultMusicAlbums.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/artists.xml
+++ b/system/library/video/musicvideos/artists.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="4" type="filter">
+<node order="5" type="filter">
 	<label>133</label>
 	<icon>DefaultMusicArtists.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/directors.xml
+++ b/system/library/video/musicvideos/directors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="6" type="filter">
+<node order="7" type="filter">
  <label>20348</label>
 	<icon>DefaultDirector.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/genres.xml
+++ b/system/library/video/musicvideos/genres.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="1" type="filter">
+<node order="2" type="filter">
 	<label>135</label>
 	<icon>DefaultGenre.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/recentlyaddedmusicvideos.xml
+++ b/system/library/video/musicvideos/recentlyaddedmusicvideos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="12" type="folder">
-	<label>20390</label>
+<node order="1" type="folder">
+	<label>20382</label>
 	<icon>DefaultRecentlyAddedMusicVideos.png</icon>
 	<path>videodb://recentlyaddedmusicvideos/</path>
 </node>

--- a/system/library/video/musicvideos/studios.xml
+++ b/system/library/video/musicvideos/studios.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="7" type="filter">
+<node order="8" type="filter">
 	<label>20388</label>
 	<icon>DefaultStudios.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/tags.xml
+++ b/system/library/video/musicvideos/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="8" type="filter">
+<node order="9" type="filter">
 	<label>20459</label>
 	<icon>DefaultTags.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/titles.xml
+++ b/system/library/video/musicvideos/titles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="2" type="filter">
+<node order="3" type="filter">
 	<label>10024</label>
 	<icon>DefaultMusicVideoTitle.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/years.xml
+++ b/system/library/video/musicvideos/years.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="3" type="filter">
+<node order="4" type="filter">
 	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/tvshows/actors.xml
+++ b/system/library/video/tvshows/actors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="4" type="filter">
+<node order="6" type="filter">
 	<label>344</label>
 	<icon>DefaultActor.png</icon>
 	<content>tvshows</content>

--- a/system/library/video/tvshows/genres.xml
+++ b/system/library/video/tvshows/genres.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="1" type="filter">
+<node order="3" type="filter">
 	<label>135</label>
 	<icon>DefaultGenre.png</icon>
 	<content>tvshows</content>

--- a/system/library/video/tvshows/inprogressshows.xml
+++ b/system/library/video/tvshows/inprogressshows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="4" type="folder">
-	<label>626</label>
+<node order="2" type="folder">
+	<label>575</label>
 	<icon>DefaultInProgressShows.png</icon>
 	<path>videodb://inprogresstvshows/</path>
 </node>

--- a/system/library/video/tvshows/recentlyaddedepisodes.xml
+++ b/system/library/video/tvshows/recentlyaddedepisodes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="11" type="folder">
-	<label>20387</label>
+<node order="1" type="folder">
+	<label>20382</label>
 	<icon>DefaultRecentlyAddedEpisodes.png</icon>
 	<path>videodb://recentlyaddedepisodes/</path>
 </node>

--- a/system/library/video/tvshows/studios.xml
+++ b/system/library/video/tvshows/studios.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="5" type="filter">
+<node order="7" type="filter">
 	<label>20388</label>
 	<icon>DefaultStudios.png</icon>
 	<content>tvshows</content>

--- a/system/library/video/tvshows/tags.xml
+++ b/system/library/video/tvshows/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="6" type="filter">
+<node order="8" type="filter">
 	<label>20459</label>
 	<icon>DefaultTags.png</icon>
 	<content>tvshows</content>

--- a/system/library/video/tvshows/titles.xml
+++ b/system/library/video/tvshows/titles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="2" type="filter">
+<node order="4" type="filter">
 	<label>10024</label>
 	<icon>DefaultTVShowTitle.png</icon>
 	<content>tvshows</content>

--- a/system/library/video/tvshows/years.xml
+++ b/system/library/video/tvshows/years.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="3" type="filter">
+<node order="5" type="filter">
 	<label>652</label>
 	<icon>DefaultYear.png</icon>
 	<content>tvshows</content>


### PR DESCRIPTION
## Description
Re-order and re-label the nodes so 'Recently added' and 'In progress'
are at the top and drop 'movies' and 'TV shows' from the label.

## Motivation and Context
Puts the most used items at the forefront.

## How Has This Been Tested?
Tested with Confluence and Estuary.

## Screenshots (if appropriate):
![screenshot000](https://cloud.githubusercontent.com/assets/133808/22289261/96c5284a-e2f2-11e6-925f-7b1518ac974d.png)
![screenshot001](https://cloud.githubusercontent.com/assets/133808/22289263/96c84aa2-e2f2-11e6-9a60-67a32fcae9b8.png)
![screenshot002](https://cloud.githubusercontent.com/assets/133808/22289262/96c6e964-e2f2-11e6-8b90-23a394dd42e6.png)
![screenshot003](https://cloud.githubusercontent.com/assets/133808/22289264/96ca2ba6-e2f2-11e6-9862-7dc31645acb6.png)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
