### PR TITLE
ADD: "Clean thumbnails" functionality

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4619,7 +4619,12 @@ msgctxt "#1450"
 msgid "Put display to sleep when idle"
 msgstr ""
 
-#empty strings from id 1451 to 2049
+#: system/settings/settings.xml
+msgctxt "#1451"
+msgid "Clean thumbnails"
+msgstr ""
+
+#empty strings from id 1452 to 2049
 #strings through to 1470 reserved for power-saving
 
 msgctxt "#2050"
@@ -20037,7 +20042,12 @@ msgctxt "#37045"
 msgid "Extract chapter thumbnails for presentation in the chapters / bookmarks dialogue. This might increase CPU load."
 msgstr ""
 
-#empty strings from id 37046 to 38009
+#: system/settings/settings.xml
+msgctxt "#37046"
+msgid "Remove dangling thumbnails."
+msgstr ""
+
+#empty strings from id 37047 to 38009
 
 #: system/settings/rbp.xml
 msgctxt "#38010"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -863,6 +863,10 @@
           <level>2</level>
           <control type="button" format="action" />
         </setting>
+        <setting id="thumbnails.cleanup" type="action" label="1451" help="37046">
+          <level>2</level>
+          <control type="button" format="action" />
+        </setting>
         <setting id="videolibrary.export" type="action" label="14248" help="36149">
           <level>2</level>
           <control type="button" format="action" />

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5060,6 +5060,11 @@ void CApplication::StartVideoScan(const std::string &strDirectory, bool userInit
   CVideoLibraryQueue::GetInstance().ScanLibrary(strDirectory, scanAll, userInitiated);
 }
 
+void CApplication::StartThumbnailsCleanup(bool userInitiated /* = true */)
+{
+  CTextureCache::GetInstance().AddJob(new CTextureCleanupJob());
+}
+
 void CApplication::StartMusicCleanup(bool userInitiated /* = true */)
 {
   if (m_musicInfoScanner->IsScanning())

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -257,6 +257,12 @@ public:
   void StartVideoScan(const std::string &path, bool userInitiated = true, bool scanAll = false);
 
   /*!
+   \brief Starts a thumbnail cleanup.
+   \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
+   */
+  void StartThumbnailsCleanup(bool userInitiated = true);
+
+  /*!
   \brief Starts a music library cleanup.
   \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
   */

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -25,6 +25,7 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "filesystem/File.h"
+#include "filesystem/SpecialProtocolDirectory.h"
 #include "pictures/Picture.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -272,6 +273,72 @@ bool CTextureUseCountJob::DoWork()
     for (std::vector<CTextureDetails>::const_iterator i = m_textures.begin(); i != m_textures.end(); ++i)
       db.IncrementUseCount(*i);
     db.CommitTransaction();
+  }
+  return true;
+}
+
+CTextureCleanupJob::CTextureCleanupJob()
+{
+}
+
+bool CTextureCleanupJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(),GetType()) == 0)
+  {
+    const CTextureCleanupJob* useJob = dynamic_cast<const CTextureCleanupJob*>(job);
+    if (useJob)
+      return true;
+  }
+  return false;
+}
+
+bool CTextureCleanupJob::DoWork()
+{
+  CTextureDatabase db;
+  if (db.Open())
+  {
+    std::string path;
+    std::string fn;
+    std::string prevPath = "";
+    std::vector<std::string> pathContent;
+
+    XFILE::CSpecialProtocolDirectory thumbDir;
+    CFileItemList files;
+    int fileIdx = 0;
+    int totdel = 0;
+
+    auto deleteFile = [&]()
+    {
+      std::string todel = files.Get(fileIdx)->GetPath();
+      CLog::Log(LOGDEBUG, "CTextureCleanupJob: deleting %s", todel.c_str());
+      XFILE::CFile::Delete(todel);
+      totdel++;
+      fileIdx++;
+    };
+
+    std::vector<std::string> urls = db.GetCachedTextureUrls();
+    for (const auto &url : urls)
+    {
+      URIUtils::Split(url, path, fn);
+      std::string cmpurl = "special://thumbnails/" + url;
+      if (path != prevPath)
+      {
+        while (fileIdx < files.Size())
+          deleteFile();
+        files.Clear();
+        thumbDir.GetDirectory(CURL("special://thumbnails/" + path), files);
+        files.Sort(SortByPath, SortOrderAscending);
+        prevPath = path;
+        fileIdx = 0;
+      }
+      while (fileIdx < files.Size() && files.Get(fileIdx)->GetPath() < cmpurl)
+        deleteFile();
+      if (fileIdx < files.Size() && files.Get(fileIdx)->GetPath() == cmpurl)
+        fileIdx++;
+    }
+    while (fileIdx < files.Size())
+      deleteFile();
+    CLog::Log(LOGDEBUG, "CTextureCleanupJob: %d thumbnails deleted", totdel);
   }
   return true;
 }

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -141,3 +141,15 @@ public:
 private:
   std::vector<CTextureDetails> m_textures;
 };
+
+/* \brief Job class for storing the use count of textures
+ */
+class CTextureCleanupJob : public CJob
+{
+public:
+  CTextureCleanupJob();
+
+  virtual const char* GetType() const { return "cleanup"; };
+  virtual bool operator==(const CJob *job) const;
+  virtual bool DoWork();
+};

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -282,6 +282,31 @@ bool CTextureDatabase::GetCachedTexture(const std::string &url, CTextureDetails 
   return false;
 }
 
+std::vector<std::string> CTextureDatabase::GetCachedTextureUrls()
+{
+  std::vector<std::string>  urls;
+
+  try
+  {
+    if (NULL == m_pDB.get()) return urls;
+    if (NULL == m_pDS.get()) return urls;
+
+    std::string sql = PrepareSQL("SELECT cachedurl FROM texture ORDER BY cachedurl");
+    m_pDS->query(sql);
+    while (!m_pDS->eof())
+    {
+      urls.push_back(m_pDS->fv(0).get_asString());
+      m_pDS->next();
+    }
+    m_pDS->close();
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s, failed", __FUNCTION__);
+  }
+  return urls;
+}
+
 bool CTextureDatabase::GetTextures(CVariant &items, const Filter &filter)
 {
   try

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -75,6 +75,7 @@ public:
   virtual bool Open();
 
   bool GetCachedTexture(const std::string &originalURL, CTextureDetails &details);
+  std::vector<std::string> GetCachedTextureUrls();
   bool AddCachedTexture(const std::string &originalURL, const CTextureDetails &details);
   bool SetCachedTextureValid(const std::string &originalURL, bool updateable);
   bool ClearCachedTexture(const std::string &originalURL, std::string &cacheFile);

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -348,6 +348,11 @@ void CMediaSettings::OnSettingAction(const CSetting *setting)
       videodatabase.Close();
     }
   }
+  else if (settingId == CSettings::SETTING_THUMBNAILS_CLEANUP)
+  {
+    if (HELPERS::ShowYesNoDialogText(CVariant{313}, CVariant{333}) == DialogResponse::YES)
+      g_application.StartThumbnailsCleanup(true);
+  }
 }
 
 int CMediaSettings::GetWatchedMode(const std::string &content) const

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -436,6 +436,7 @@ const std::string CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_8 = "gameskeybo
 const std::string CSettings::SETTING_GAMES_ENABLE = "gamesgeneral.enable";
 const std::string CSettings::SETTING_GAMES_ENABLEREWIND = "gamesgeneral.enablerewind";
 const std::string CSettings::SETTING_GAMES_REWINDTIME = "gamesgeneral.rewindtime";
+const std::string CSettings::SETTING_THUMBNAILS_CLEANUP = "thumbnails.cleanup";
 
 CSettings::CSettings()
   : m_initialized(false)
@@ -1038,6 +1039,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_CLEANUP);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_IMPORT);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_EXPORT);
+  settingSet.insert(CSettings::SETTING_THUMBNAILS_CLEANUP);
   m_settingsManager->RegisterCallback(&CMediaSettings::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -377,6 +377,7 @@ public:
   static const std::string SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES;
   static const std::string SETTING_GENERAL_ADDONFOREIGNFILTER;
   static const std::string SETTING_GENERAL_ADDONBROKENFILTER;
+  static const std::string SETTING_THUMBNAILS_CLEANUP;
   static const std::string SETTING_SOURCE_VIDEOS;
   static const std::string SETTING_SOURCE_MUSIC;
   static const std::string SETTING_SOURCE_PICTURES;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Picked from spmc https://github.com/koying/SPMC/commit/3f255975618e697d018d74feb2e19e9624c72be2#diff-92b91a5c902936f6e9a03f26b054d7d6

Haven't really looked at the code yet.

I made some small string changes and moved it into a category that makes more sense, I think.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Compiles and seem to work fine, I just don't have any thumbs on my dev pc right now. But I think it's in spmc for a while now already.


## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/5943908/22306705/7e6bb69e-e340-11e6-86c8-30d75e509c07.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
