### PR TITLE
[Win32] D3DResource improvements.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -147,7 +147,7 @@ protected:
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}
-  void OnDestroyDevice() override { CSingleLock lock(m_section); m_state = DXVA_LOST;  m_event.Reset(); }
+  void OnDestroyDevice(bool fatal) override { CSingleLock lock(m_section); m_state = DXVA_LOST;  m_event.Reset(); }
   void OnLostDevice() override    { CSingleLock lock(m_section); m_state = DXVA_LOST;  m_event.Reset(); }
   void OnResetDevice() override   { CSingleLock lock(m_section); m_state = DXVA_RESET; m_event.Set();   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -64,7 +64,7 @@ public:
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}
-  void OnDestroyDevice() override { CSingleLock lock(m_section); UnInit(); }
+  void OnDestroyDevice(bool fatal) override { CSingleLock lock(m_section); UnInit(); }
   void OnLostDevice() override    { CSingleLock lock(m_section); UnInit(); }
   void OnResetDevice() override   { CSingleLock lock(m_section); Close();  }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -35,12 +35,15 @@ namespace OVERLAY {
 
   class COverlayQuadsDX
     : public COverlay
+    , public ID3DResource
   {
   public:
     COverlayQuadsDX(ASS_Image* images, int width, int height);
     virtual ~COverlayQuadsDX();
 
     void Render(SRenderState& state);
+    void OnCreateDevice() override {}
+    void OnDestroyDevice(bool fatal) override;
 
     int                    m_count;
     DWORD                  m_fvf;
@@ -50,6 +53,7 @@ namespace OVERLAY {
 
   class COverlayImageDX
     : public COverlay
+    , public ID3DResource
   {
   public:
     COverlayImageDX(CDVDOverlayImage* o);
@@ -58,6 +62,8 @@ namespace OVERLAY {
 
     void Load(uint32_t* rgba, int width, int height, int stride);
     void Render(SRenderState& state);
+    void OnCreateDevice() override {}
+    void OnDestroyDevice(bool fatal) override;
 
     DWORD                  m_fvf;
     CD3DTexture            m_texture;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.cpp
@@ -507,7 +507,7 @@ void CRenderCaptureDX::OnLostDevice()
   SetState(CAPTURESTATE_FAILED);
 }
 
-void CRenderCaptureDX::OnDestroyDevice()
+void CRenderCaptureDX::OnDestroyDevice(bool fatal)
 {
   CleanupDX();
   SetState(CAPTURESTATE_FAILED);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCapture.h
@@ -210,7 +210,7 @@ class CRenderCaptureDX : public CRenderCaptureBase, public ID3DResource
     void EndRender();
     void ReadOut();
     
-    virtual void OnDestroyDevice();
+    virtual void OnDestroyDevice(bool fatal);
     virtual void OnLostDevice();
     virtual void OnCreateDevice() {};
 

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -383,16 +383,13 @@ void CD3DTexture::SaveTexture()
   }
 }
 
-void CD3DTexture::OnDestroyDevice()
+void CD3DTexture::OnDestroyDevice(bool fatal)
 {
-  SaveTexture();
+  if (!fatal)
+    SaveTexture();
   SAFE_RELEASE(m_texture);
   SAFE_RELEASE(m_textureView);
   SAFE_RELEASE(m_renderTarget);
-}
-
-void CD3DTexture::OnLostDevice()
-{
 }
 
 void CD3DTexture::RestoreTexture()
@@ -414,10 +411,6 @@ void CD3DTexture::RestoreTexture()
 void CD3DTexture::OnCreateDevice()
 {
   RestoreTexture();
-}
-
-void CD3DTexture::OnResetDevice()
-{
 }
 
 unsigned int CD3DTexture::GetMemoryUsage(unsigned int pitch) const
@@ -533,10 +526,10 @@ bool CD3DEffect::Create(const std::string &effectString, DefinesMap* defines)
 void CD3DEffect::Release()
 {
   g_Windowing.Unregister(this);
-  OnDestroyDevice();
+  OnDestroyDevice(false);
 }
 
-void CD3DEffect::OnDestroyDevice()
+void CD3DEffect::OnDestroyDevice(bool fatal)
 {
   SAFE_RELEASE(m_effect);
   m_techniquie = nullptr;
@@ -790,8 +783,14 @@ bool CD3DBuffer::Unmap()
   return false;
 }
 
-void CD3DBuffer::OnDestroyDevice()
+void CD3DBuffer::OnDestroyDevice(bool fatal)
 {
+  if (fatal)
+  {
+    SAFE_RELEASE(m_buffer);
+    return;
+  }
+
   ID3D11Device* pDevice = g_Windowing.Get3D11Device();
   ID3D11DeviceContext* pContext = g_Windowing.GetImmediateContext();
 
@@ -1005,7 +1004,7 @@ void CD3DVertexShader::OnCreateDevice()
     m_inited = CreateInternal();
 }
 
-void CD3DVertexShader::OnDestroyDevice()
+void CD3DVertexShader::OnDestroyDevice(bool fatal)
 {
   ReleaseShader();
 }
@@ -1130,7 +1129,7 @@ void CD3DPixelShader::OnCreateDevice()
     m_inited = CreateInternal();
 }
 
-void CD3DPixelShader::OnDestroyDevice()
+void CD3DPixelShader::OnDestroyDevice(bool fatal)
 {
   ReleaseShader();
 }

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -58,10 +58,11 @@ class ID3DResource
 public:
   virtual ~ID3DResource() {};
 
-  virtual void OnDestroyDevice()=0;
+  virtual void OnDestroyDevice(bool fatal)=0;
   virtual void OnCreateDevice()=0;
   virtual void OnLostDevice() {};
   virtual void OnResetDevice() {};
+  virtual void OnDestroyDevice() { OnDestroyDevice(false); }
 };
 
 class CD3DHelper
@@ -137,10 +138,8 @@ public:
   static void DrawQuad(const CRect &coords, color_t color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords,
     SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
 
-  virtual void OnDestroyDevice();
-  virtual void OnCreateDevice();
-  virtual void OnLostDevice();
-  virtual void OnResetDevice();
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
 
 private:
   unsigned int GetMemoryUsage(unsigned int pitch) const;
@@ -191,8 +190,8 @@ public:
 
   ID3DX11Effect *Get() const { return m_effect; };
 
-  virtual void OnDestroyDevice();
-  virtual void OnCreateDevice();
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
 
 private:
   bool         CreateEffect();
@@ -218,8 +217,8 @@ public:
   DXGI_FORMAT GetFormat() { return m_format; }
   ID3D11Buffer* Get() const { return m_buffer; };
 
-  virtual void OnDestroyDevice();
-  virtual void OnCreateDevice();
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
 private:
   bool CreateBuffer(const void *pData);
   D3D11_BIND_FLAG  m_type;
@@ -247,8 +246,8 @@ public:
   void Release();
   bool IsInited() { return m_inited; }
 
-  virtual void OnDestroyDevice();
-  virtual void OnCreateDevice();
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
 
 private:
   bool CreateInternal();
@@ -275,8 +274,8 @@ public:
   void Release();
   bool IsInited() { return m_inited; }
 
-  virtual void OnDestroyDevice();
-  virtual void OnCreateDevice();
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
 
 private:
   bool CreateInternal();

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -348,7 +348,7 @@ void CGUIFontTTFDX::CreateStaticIndexBuffer(void)
 bool CGUIFontTTFDX::m_staticIndexBufferCreated = false;
 ID3D11Buffer* CGUIFontTTFDX::m_staticIndexBuffer = nullptr;
 
-void CGUIFontTTFDX::OnDestroyDevice(void)
+void CGUIFontTTFDX::OnDestroyDevice(bool fatal)
 {
   SAFE_RELEASE(m_staticIndexBuffer);
   m_staticIndexBufferCreated = false;

--- a/xbmc/guilib/GUIFontTTFDX.h
+++ b/xbmc/guilib/GUIFontTTFDX.h
@@ -44,21 +44,21 @@ public:
   CGUIFontTTFDX(const std::string& strFileName);
   virtual ~CGUIFontTTFDX(void);
 
-  virtual bool FirstBegin();
-  virtual void LastEnd();
-  virtual CVertexBuffer CreateVertexBuffer(const std::vector<SVertex> &vertices) const;
-  virtual void DestroyVertexBuffer(CVertexBuffer &bufferHandle) const;
+  bool FirstBegin() override;
+  void LastEnd() override;
+  CVertexBuffer CreateVertexBuffer(const std::vector<SVertex> &vertices) const override;
+  void DestroyVertexBuffer(CVertexBuffer &bufferHandle) const override;
 
-  virtual void OnDestroyDevice();
-  virtual void OnCreateDevice();
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
 
   static void CreateStaticIndexBuffer(void);
   static void DestroyStaticIndexBuffer(void);
 
 protected:
-  virtual CBaseTexture* ReallocTexture(unsigned int& newHeight);
-  virtual bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
-  virtual void DeleteHardwareTexture();
+  CBaseTexture* ReallocTexture(unsigned int& newHeight) override;
+  bool CopyCharToTexture(FT_BitmapGlyph bitGlyph, unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2) override;
+  void DeleteHardwareTexture() override;
 
 private:
   bool UpdateDynamicVertexBuffer(const SVertex* pSysMem, unsigned int count);

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -29,6 +29,7 @@
 #include "guilib/GUIShaderDX.h"
 #include "guilib/GUITextureD3D.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
@@ -1289,6 +1290,8 @@ bool CRenderSystemDX::BeginRender()
     {
       OnDeviceLost();
       OnDeviceReset();
+      if (m_bRenderCreated)
+        KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, "ReloadSkin");
     }
     return false;
   }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -416,7 +416,14 @@ void CRenderSystemDX::DeleteDevice()
 
   // tell any shared resources
   for (std::vector<ID3DResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
-    (*i)->OnDestroyDevice();
+  {
+    // the most of resources like textures and buffers try to 
+    // receive and save their status from current device.
+    // m_nDeviceStatus contains the last device status and
+    // DXGI_ERROR_DEVICE_REMOVED means that we have no possibility
+    // to use the device anymore, tell all resouces about this.
+    (*i)->OnDestroyDevice(DXGI_ERROR_DEVICE_REMOVED == m_nDeviceStatus);
+  }
 
   if (m_pSwapChain)
     m_pSwapChain->SetFullscreenState(false, nullptr);


### PR DESCRIPTION
- [x] re-factor ID3DResource to make possible tell to a resource that device is not valid anymore.
- [x] made a bit more safest OverlayRendererDX
- [x] reload a skin after a driver failure.

## Description
The most of DirectX resources like textures and buffers try to receive and save their status from current device before destroying device completely. A driver failure makes this approach impossible because a driver doesn't service device anymore that may cause a segfault inside a bad designed driver (you know). This fix implements a possibility to tell a resource to do not use device that makes a resurrection faster and safest.

Also after a driver failure Kodi's UI become unusable till skin reload. This adds reloading a skin after a driver failure.

## How Has This Been Tested?
It was tested localy on unstable driver.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
