### PR TITLE
[PVR] Allow custom genre on recordings

### DIFF
--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="5.2.1" provider-name="Team-Kodi">
-  <backwards-compatibility abi="5.2.1"/>
+<addon id="xbmc.pvr" version="5.2.2" provider-name="Team-Kodi">
+  <backwards-compatibility abi="5.2.2"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -78,10 +78,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "5.2.1"
+#define XBMC_PVR_API_VERSION "5.2.2"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "5.2.1"
+#define XBMC_PVR_MIN_API_VERSION "5.2.2"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -466,33 +466,34 @@ extern "C" {
    * @brief Representation of a recording.
    */
   typedef struct PVR_RECORDING {
-    char   strRecordingId[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (required) unique id of the recording on the client. */
-    char   strTitle[PVR_ADDON_NAME_STRING_LENGTH];        /*!< @brief (required) the title of this recording */
-    char   strEpisodeName[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (optional) episode name (also known as subtitle) */
-    int    iSeriesNumber;                                 /*!< @brief (optional) series number (usually called season). Set to "0" for specials/pilot. For 'invalid' see iEpisodeNumber or set to -1 */
-    int    iEpisodeNumber;                                /*!< @brief (optional) episode number within the "iSeriesNumber" season. For 'invalid' set to -1 or iSeriesNumber=iEpisodeNumber=0 to show both are invalid */
-    int    iYear;                                         /*!< @brief (optional) year of first release (use to identify a specific movie re-make) / first airing for TV shows. Set to '0' for invalid. */
-
-    char   strStreamURL[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (required) stream URL to access this recording */
-    char   strDirectory[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (optional) directory of this recording on the client */
-    char   strPlotOutline[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) plot outline */
-    char   strPlot[PVR_ADDON_DESC_STRING_LENGTH];         /*!< @brief (optional) plot */
-    char   strChannelName[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (optional) channel name */
-    char   strIconPath[PVR_ADDON_URL_STRING_LENGTH];      /*!< @brief (optional) icon path */
-    char   strThumbnailPath[PVR_ADDON_URL_STRING_LENGTH]; /*!< @brief (optional) thumbnail path */
-    char   strFanartPath[PVR_ADDON_URL_STRING_LENGTH];    /*!< @brief (optional) fanart path */
-    time_t recordingTime;                                 /*!< @brief (optional) start time of the recording */
-    int    iDuration;                                     /*!< @brief (optional) duration of the recording in seconds */
-    int    iPriority;                                     /*!< @brief (optional) priority of this recording (from 0 - 100) */
-    int    iLifetime;                                     /*!< @brief (optional) life time in days of this recording */
-    int    iGenreType;                                    /*!< @brief (optional) genre type */
-    int    iGenreSubType;                                 /*!< @brief (optional) genre sub type */
-    int    iPlayCount;                                    /*!< @brief (optional) play count of this recording on the client */
-    int    iLastPlayedPosition;                           /*!< @brief (optional) last played position of this recording on the client */
-    bool   bIsDeleted;                                    /*!< @brief (optional) shows this recording is deleted and can be undelete */
-    unsigned int iEpgEventId;                             /*!< @brief (optional) EPG event id associated with this recording. Valid ids must be greater than EPG_TAG_INVALID_UID. */
-    int    iChannelUid;                                   /*!< @brief (optional) unique identifier of the channel for this recording. PVR_CHANNEL_INVALID_UID denotes that channel uid is not available. */
-    PVR_RECORDING_CHANNEL_TYPE channelType;               /*!< @brief (optional) channel type. Set to PVR_RECORDING_CHANNEL_TYPE_UNKNOWN if the type cannot be determined. */
+    char   strRecordingId[PVR_ADDON_NAME_STRING_LENGTH];      /*!< @brief (required) unique id of the recording on the client. */
+    char   strTitle[PVR_ADDON_NAME_STRING_LENGTH];            /*!< @brief (required) the title of this recording */
+    char   strEpisodeName[PVR_ADDON_NAME_STRING_LENGTH];      /*!< @brief (optional) episode name (also known as subtitle) */
+    int    iSeriesNumber;                                     /*!< @brief (optional) series number (usually called season). Set to "0" for specials/pilot. For 'invalid' see iEpisodeNumber or set to -1 */
+    int    iEpisodeNumber;                                    /*!< @brief (optional) episode number within the "iSeriesNumber" season. For 'invalid' set to -1 or iSeriesNumber=iEpisodeNumber=0 to show both are invalid */
+    int    iYear;                                             /*!< @brief (optional) year of first release (use to identify a specific movie re-make) / first airing for TV shows. Set to '0' for invalid. */
+                                                              
+    char   strStreamURL[PVR_ADDON_URL_STRING_LENGTH];         /*!< @brief (required) stream URL to access this recording */
+    char   strDirectory[PVR_ADDON_URL_STRING_LENGTH];         /*!< @brief (optional) directory of this recording on the client */
+    char   strPlotOutline[PVR_ADDON_DESC_STRING_LENGTH];      /*!< @brief (optional) plot outline */
+    char   strPlot[PVR_ADDON_DESC_STRING_LENGTH];             /*!< @brief (optional) plot */
+    char   strGenreDescription[PVR_ADDON_DESC_STRING_LENGTH]; /*!< @brief (optional) genre. Will be used only when iGenreType = EPG_GENRE_USE_STRING */
+    char   strChannelName[PVR_ADDON_NAME_STRING_LENGTH];      /*!< @brief (optional) channel name */
+    char   strIconPath[PVR_ADDON_URL_STRING_LENGTH];          /*!< @brief (optional) icon path */
+    char   strThumbnailPath[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (optional) thumbnail path */
+    char   strFanartPath[PVR_ADDON_URL_STRING_LENGTH];        /*!< @brief (optional) fanart path */
+    time_t recordingTime;                                     /*!< @brief (optional) start time of the recording */
+    int    iDuration;                                         /*!< @brief (optional) duration of the recording in seconds */
+    int    iPriority;                                         /*!< @brief (optional) priority of this recording (from 0 - 100) */
+    int    iLifetime;                                         /*!< @brief (optional) life time in days of this recording */
+    int    iGenreType;                                        /*!< @brief (optional) genre type */
+    int    iGenreSubType;                                     /*!< @brief (optional) genre sub type */
+    int    iPlayCount;                                        /*!< @brief (optional) play count of this recording on the client */
+    int    iLastPlayedPosition;                               /*!< @brief (optional) last played position of this recording on the client */
+    bool   bIsDeleted;                                        /*!< @brief (optional) shows this recording is deleted and can be undelete */
+    unsigned int iEpgEventId;                                 /*!< @brief (optional) EPG event id associated with this recording. Valid ids must be greater than EPG_TAG_INVALID_UID. */
+    int    iChannelUid;                                       /*!< @brief (optional) unique identifier of the channel for this recording. PVR_CHANNEL_INVALID_UID denotes that channel uid is not available. */
+    PVR_RECORDING_CHANNEL_TYPE channelType;                   /*!< @brief (optional) channel type. Set to PVR_RECORDING_CHANNEL_TYPE_UNKNOWN if the type cannot be determined. */
   } ATTRIBUTE_PACKED PVR_RECORDING;
 
   /*!

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -95,7 +95,6 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_strPlotOutline                 = recording.strPlotOutline;
   m_strStreamURL                   = recording.strStreamURL;
   m_strChannelName                 = recording.strChannelName;
-  m_genre                          = StringUtils::Split(CEpg::ConvertGenreIdToString(recording.iGenreType, recording.iGenreSubType), g_advancedSettings.m_videoItemSeparator);
   m_strIconPath                    = recording.strIconPath;
   m_strThumbnailPath               = recording.strThumbnailPath;
   m_strFanartPath                  = recording.strFanartPath;
@@ -103,6 +102,7 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_iEpgEventId                    = recording.iEpgEventId;
   m_iChannelUid                    = recording.iChannelUid;
 
+  SetGenre(recording.iGenreType, recording.iGenreSubType, recording.strGenreDescription);
   CVideoInfoTag::SetPlayCount(recording.iPlayCount);
   CVideoInfoTag::SetResumePoint(recording.iLastPlayedPosition, recording.iDuration);
   SetDuration(recording.iDuration);
@@ -503,4 +503,19 @@ bool CPVRRecording::IsInProgress() const
   //       actually is recording this.
 
   return g_PVRTimers->HasRecordingTimerForRecording(*this);
+}
+
+void CPVRRecording::SetGenre(int iGenreType, int iGenreSubType, const std::string &strGenre)
+{
+  if ((iGenreType == EPG_GENRE_USE_STRING) && !strGenre.empty())
+  {
+    /* Type and sub type are not given.
+    * Use the provided genre description if available. */
+    m_genre = StringUtils::Split(strGenre, g_advancedSettings.m_videoItemSeparator);
+  }
+  else
+  {
+    /* Determine the genre description from the type and subtype IDs */
+    m_genre = StringUtils::Split(CEpg::ConvertGenreIdToString(iGenreType, iGenreSubType), g_advancedSettings.m_videoItemSeparator);
+  }
 }

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -267,6 +267,14 @@ namespace PVR
      */
     bool IsInProgress() const;
 
+    /*!
+    * @brief set the genre for this recording.
+    * @param iGenreType The genre type ID. If set to EPG_GENRE_USE_STRING, set genre to the value provided with strGenre. Otherwise, compile the genre string from the values given by iGenreType and iGenreSubType
+    * @param iGenreSubType The genre subtype ID
+    * @param strGenre The genre
+    */
+   void SetGenre( int iGenreType, int iGenreSubType, const std::string &strGenre);
+
   private:
     CDateTime    m_recordingTime; /*!< start time of the recording */
     bool         m_bGotMetaData;


### PR DESCRIPTION
This is a resubmit of PR [#10856](https://github.com/xbmc/xbmc/pull/10856)

Allow PVR plugins to set custom genre strings for recordings the same way EPG can.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Allows PVR plugins to set custom text for genre type the same way EPG is already doing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
By default Kodi only supports a hand full of genre types. In the PVR EPG there is already a workaround
for letting the PVR plugin use localized strings as genre. This adds that functionality to the PVR recording screen.

## Screenshots (if appropriate):
[before](http://imgur.com/rXQCsSjl)
[after](http://imgur.com/pPWPLHW)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
