### PR TITLE
Do not try to load folder thumbs for plugin:// folders

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3093,6 +3093,9 @@ std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.
   if (IsMultiPath())
     strFolder = CMultiPathDirectory::GetFirstPath(m_strPath);
 
+  if (IsPlugin())
+    return "";
+
   return URIUtils::AddFileToFolder(strFolder, folderJPG);
 }
 

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -55,7 +55,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberDigit(int iDigit)
 
   CSingleLock lock(m_mutex);
 
-  if (m_digits.size() == m_iMaxDigits)
+  if (m_digits.size() == (size_t)m_iMaxDigits)
     m_digits.pop_front();
 
   m_digits.emplace_back(iDigit);


### PR DESCRIPTION
Two small fixes;
- do not try to load folder thumbs for plugin:// folders
- quell signed/unsigned comparison warning