### PR TITLE
VideoPlayer: ffmpeg decoder - implement fail-safe for missing key frames

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -594,7 +594,12 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
     return VC_ERROR;
 
   if (pData)
+  {
     m_iLastKeyframe++;
+    // put a limit on convergence count to avoid huge mem usage on streams without keyframes
+    if (m_iLastKeyframe > 300)
+      m_iLastKeyframe = 300;
+  }
 
   if (m_pHardware)
   {
@@ -701,6 +706,9 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
 
   if (!m_started)
   {
+    if (m_iLastKeyframe >= 300 && m_pDecodedFrame->pict_type == AV_PICTURE_TYPE_I)
+      m_started = true;
+
     av_frame_unref(m_pDecodedFrame);
     return VC_BUFFER;
   }
@@ -709,10 +717,6 @@ int CDVDVideoCodecFFmpeg::Decode(uint8_t* pData, int iSize, double dts, double p
     m_interlaced = true;
   else
     m_interlaced = false;
-
-  // put a limit on convergence count to avoid huge mem usage on streams without keyframes
-  if (m_iLastKeyframe > 300)
-    m_iLastKeyframe = 300;
 
   //! @todo check if this work-around is still required
   if(m_pCodecContext->codec_id == AV_CODEC_ID_SVQ3)


### PR DESCRIPTION
fix http://trac.kodi.tv/ticket/17272