### PR TITLE
Forced full tag rescans of music files

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20251,7 +20251,13 @@ msgctxt "#38061"
 msgid "Fetch additional information for albums and artists? This could take some time so you may prefer to do this later"
 msgstr ""
 
-#empty strings from id 38062 to 38099
+#. Full tag scanning question on library update (by default tags are only scanned when the file has changed since last time)
+#: xbmc/Application.cpp
+msgctxt "#38062"
+msgid "Do full tag scan even when music files are unchanged?"
+msgstr ""
+
+#empty strings from id 38063 to 38099
 
 #. Description of section #14200 "Player""
 #: system/settings/settings.xml

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5085,6 +5085,11 @@ void CApplication::StartMusicScan(const std::string &strDirectory, bool userInit
       flags |= CMusicInfoScanner::SCAN_ONLINE;
     if (!userInitiated || m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
       flags |= CMusicInfoScanner::SCAN_BACKGROUND;
+    // Ask for full rescan of music files
+    //! @todo replace with a music library setting in UI
+    if (g_advancedSettings.m_bMusicLibraryPromptFullTagScan)
+      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 799 }, CVariant{ 38062 }))
+        flags |= CMusicInfoScanner::SCAN_RESCAN;
   }
 
   if (!(flags & CMusicInfoScanner::SCAN_BACKGROUND))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -192,6 +192,10 @@ void CMusicDatabase::CreateTables()
 
   CLog::Log(LOGINFO, "create cue table");
   m_pDS->exec("CREATE TABLE cue (idPath integer, strFileName text, strCuesheet text)");
+
+  CLog::Log(LOGINFO, "create versiontagscan table");
+  m_pDS->exec("CREATE TABLE versiontagscan (idVersion integer, iNeedsScan integer)");
+  m_pDS->exec(PrepareSQL("INSERT INTO versiontagscan (idVersion, iNeedsScan) values(%i, 0)", GetSchemaVersion()));
 }
 
 void CMusicDatabase::CreateAnalytics()
@@ -4662,8 +4666,6 @@ void CMusicDatabase::UpdateTables(int version)
   if (version < 53)
   {
     m_pDS->exec("ALTER TABLE song ADD dateAdded text");
-    CMediaSettings::GetInstance().SetMusicNeedsUpdate(53);
-    CServiceBroker::GetSettings().Save();
   }
   if (version < 54)
   {
@@ -4958,17 +4960,78 @@ void CMusicDatabase::UpdateTables(int version)
     //Remove temp indices, full analytics for database created later
     m_pDS->exec("DROP INDEX idxSongArtist1 ON song_artist");
     m_pDS->exec("DROP INDEX idxAlbumArtist1 ON album_artist");
-
-    // Prompt for rescan of library to read tags that were not processed by previous versions
-    // and accomodate changes to the way some tags are processed
-    CMediaSettings::GetInstance().SetMusicNeedsUpdate(60);
-    CServiceBroker::GetSettings().Save();
   }
+  if (version < 61)
+  {
+    // Create versiontagscan table
+    m_pDS->exec("CREATE TABLE versiontagscan (idVersion integer, iNeedsScan integer)");
+    m_pDS->exec("INSERT INTO versiontagscan (idVersion, iNeedsScan) values(0, 0)");
+  }
+
+  // Set the verion of tag scanning required. 
+  // Not every schema change requires the tags to be rescanned, set to the highest schema version 
+  // that needs this. Forced rescanning (of music files that have not changed since they were 
+  // previously scanned) also accommodates any changes to the way tags are processed 
+  // e.g. read tags that were not processed by previous versions.
+  // The original db version when the tags were scanned, and the minimal db version needed are 
+  // later used to determine if a forced rescan should be prompted
+  
+  // The last schema change needing forced rescanning was 60.
+  // Mostly because of the new tags processed by v17 rather than a schema change.
+  SetMusicNeedsTagScan(60);
+
+  // After all updates, store the original db version. 
+  // This indicates the version of tag processing that was used to populate db
+  SetMusicTagScanVersion(version);
 }
 
 int CMusicDatabase::GetSchemaVersion() const
 {
-  return 60;
+  return 61;
+}
+
+int CMusicDatabase::GetMusicNeedsTagScan()
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return -1;
+    if (NULL == m_pDS.get()) return -1;
+
+    std::string sql = "SELECT * FROM versiontagscan";
+    if (!m_pDS->query(sql)) return -1;
+
+    if (m_pDS->num_rows() != 1)
+    {
+      m_pDS->close();
+      return -1;
+    }
+
+    int idVersion = m_pDS->fv("idVersion").get_asInt();
+    int iNeedsScan = m_pDS->fv("iNeedsScan").get_asInt();
+    m_pDS->close();
+    if (idVersion < iNeedsScan)
+      return idVersion;
+    else
+      return 0;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  }
+  return -1;
+}
+
+void CMusicDatabase::SetMusicNeedsTagScan(int version)
+{
+  m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET iNeedsScan=%i", version));
+}
+
+void CMusicDatabase::SetMusicTagScanVersion(int version /* = 0 */)
+{
+  if (version == 0)
+    m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET idVersion=%i", GetSchemaVersion()));
+  else
+    m_pDS->exec(PrepareSQL("UPDATE versiontagscan SET idVersion=%i", version));
 }
 
 unsigned int CMusicDatabase::GetSongIDs(const Filter &filter, std::vector<std::pair<int,int> > &songIDs)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4968,7 +4968,7 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->exec("INSERT INTO versiontagscan (idVersion, iNeedsScan) values(0, 0)");
   }
 
-  // Set the verion of tag scanning required. 
+  // Set the version of tag scanning required. 
   // Not every schema change requires the tags to be rescanned, set to the highest schema version 
   // that needs this. Forced rescanning (of music files that have not changed since they were 
   // previously scanned) also accommodates any changes to the way tags are processed 

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -497,6 +497,26 @@ public:
    */
   std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
 
+  /////////////////////////////////////////////////
+  // Tag Scan Version
+  /////////////////////////////////////////////////
+  /*! \brief Check if music files need all tags rescanning regardless of file being unchanged 
+  because the tag processing has changed (which may happen without db version changes) since they
+  where last scanned.
+  \return -1 if an error occured, 0 if no scan is needed, or the version number of tags if not the same as current.
+  */
+  virtual int GetMusicNeedsTagScan();
+
+  /*! \brief Set minimum version number of db needed when tag data scanned from music files
+  \param version the version number of db
+  */
+  void SetMusicNeedsTagScan(int version);
+
+  /*! \brief Set the version number of tag data 
+  \param version the version number of db when tags last scanned, 0 (default) means current db version
+  */
+  void SetMusicTagScanVersion(int version = 0);
+
 protected:
   std::map<std::string, int> m_artistCache;
   std::map<std::string, int> m_genreCache;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1308,7 +1308,7 @@ void CGUIWindowMusicBase::OnInitWindow()
   CGUIMediaWindow::OnInitWindow();
   // Prompt for rescan of library to read music file tags that were not processed by previous versions
   // and accomodate any changes to the way some tags are processed
-  if (CMediaSettings::GetInstance().GetMusicNeedsUpdate() != 0)
+  if (m_musicdatabase.GetMusicNeedsTagScan() != 0)
   {
     if (g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC) && !g_application.IsMusicScanning())
     {
@@ -1324,15 +1324,13 @@ void CGUIWindowMusicBase::OnInitWindow()
         if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
           flags |= CMusicInfoScanner::SCAN_BACKGROUND;
         g_application.StartMusicScan("", true, flags);
-        CMediaSettings::GetInstance().SetMusicNeedsUpdate(0); // once is enough (user may interrupt, but that's up to them)
-        CServiceBroker::GetSettings().Save();
+        m_musicdatabase.SetMusicTagScanVersion(); // once is enough (user may interrupt, but that's up to them)
       }
     }
     else
     {
       // no need to force a rescan if there's no music in the library or if a library scan is already active
-      CMediaSettings::GetInstance().SetMusicNeedsUpdate(0);
-      CServiceBroker::GetSettings().Save();
+      m_musicdatabase.SetMusicTagScanVersion();
     }
   }
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -275,6 +275,7 @@ void CAdvancedSettings::Initialize()
 
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryCleanOnUpdate = false;
+  m_bMusicLibraryPromptFullTagScan = false;
   m_iMusicLibraryRecentlyAddedItems = 25;
   m_strMusicLibraryAlbumFormat = "";
   m_prioritiseAPEv2tags = false;
@@ -732,6 +733,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "prioritiseapetags", m_prioritiseAPEv2tags);
     XMLUtils::GetBoolean(pElement, "allitemsonbottom", m_bMusicLibraryAllItemsOnBottom);
     XMLUtils::GetBoolean(pElement, "cleanonupdate", m_bMusicLibraryCleanOnUpdate);
+    XMLUtils::GetBoolean(pElement, "promptfulltagscan", m_bMusicLibraryPromptFullTagScan);
     XMLUtils::GetString(pElement, "albumformat", m_strMusicLibraryAlbumFormat);
     XMLUtils::GetString(pElement, "itemseparator", m_musicItemSeparator);
     XMLUtils::GetInt(pElement, "dateadded", m_iMusicLibraryDateAdded);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -256,6 +256,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_iMusicLibraryDateAdded;
     bool m_bMusicLibraryAllItemsOnBottom;
     bool m_bMusicLibraryCleanOnUpdate;
+    bool m_bMusicLibraryPromptFullTagScan;
     std::string m_strMusicLibraryAlbumFormat;
     bool m_prioritiseAPEv2tags;
     std::string m_musicItemSeparator;


### PR DESCRIPTION
Improved management of the forced full tag rescans of music files. This addresses two issues:
1) When upgrading Kodi version for a client/server system, storing the need for a forced rescan in the GUI settings means that every client attempts to force a rescan, while actually the db on the server only needs the tags rescanning once.

2) The way the music database is populated from music file tags depends upon system settings. The user can change these, but has no way to apply them. On library update, or scan to library of a source from file view, the tags are only rescanned using the new settings, if the music files have been changed. So this means either dropping the source, and thus loosing all the playcount and rating data as well as needing to rescrape, or having to make a timestamp change to all your music files.

To those ends this PR 
a) Adds a versiontagscan table to track the version of tag processing used to populate the library (effectively the db version at the time the tags were scanned). This replaces the  use of the MusicNeedsUpdate GUI setting with read/write to database.

b) Adds an advancedsetting to optionally prompt for full tag rescan, regardless of files being unchanged, every time scanning is initiated i.e. from "Update Library" and when "Scan to library" from file view

To test attempt to upgrade from earlier versions of Kodi - from v17 no forced rescan is necessary, from v16 or before one is. Try an upgrade on a client/server setup.

Subsequently add `<promptfulltagscan>true</promptfulltagscan>` to the  `<musiclibrary>` section of advancesettings.xml, and on library update you will be given the option of a full rescan regardless of files being unchanged.
