### PR TITLE
Fix Trac 17273

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -183,6 +183,7 @@
   </Home>
   <VirtualKeyboard>
     <keyboard>
+      <c mod="longpress">noop</c>
       <left>Left</left>
       <right>Right</right>
       <up>Up</up>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -921,7 +921,7 @@ bool CButtonTranslator::HasLonpressMapping(int window, const CKey &key)
     buttonMap::const_iterator it2 = (*it).second.find(code);
 
     if (it2 != (*it).second.end())
-      return true;
+      return it2->second.id != ACTION_NOOP;
 
 #ifdef TARGET_POSIX
     // Some buttoncodes changed in Hardy


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Add the ability to disable longpress-mappings in sub windows and disable the longpress-mapping for `c` in `VirtualKeyboard`.
<!--- Describe your change in detail -->

## Motivation and Context
Fixes http://trac.kodi.tv/ticket/17273.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Runtime tested.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
