### PR TITLE
Use the formatted channel number in PVR timer settings dialog

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1263,7 +1263,12 @@ bool CPVRTimersUpdateJob::DoWork(void)
 
 bool CPVRChannelsUpdateJob::DoWork(void)
 {
-  return g_PVRChannelGroups->Update(true);
+	bool bReturn = g_PVRChannelGroups->Update(true);
+
+	if(bReturn && g_PVRManager.IsStarted()) 
+		bReturn = g_PVRChannelGroups->CreateChannelEpgs();
+
+	return bReturn;
 }
 
 bool CPVRChannelGroupsUpdateJob::DoWork(void)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -778,7 +778,7 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   {
     const CPVRChannelPtr channel(channelsList[i]->GetPVRChannelInfoTag());
     std::string channelDescription(
-      StringUtils::Format("%i %s", channel->ChannelNumber(), channel->ChannelName().c_str()));
+      StringUtils::Format("%s %s", channel->FormattedChannelNumber().c_str(), channel->ChannelName().c_str()));
     m_channelEntries.insert(
       std::make_pair(i, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)));
   }


### PR DESCRIPTION
When the backend channel numbers are used the dialog would display only
the primary channel number and ignore subchannel numbers, causing the
potential for multiple entries with the same number.  For example, "2
WMARDT", "2 WMARDT2", "2 WMARDT3".  Expectation would be to see "2
WMARDT", "2.2 WMARDT2", "2.3 WMARDT3".  Using the string-based
FormattedChannelNumber property rather than the integer-based
ChannelNumber property allows the backend channels to display more
naturally.

The pull request was tested on Windows, Krypton branch, built with Visual Studio 2015.
Ensured that toggling the "use backend channel numbers" setting ON properly brought in the backend channel.subchannel numbers as appropriate
Ensured that toggling the "use backend channel numbers" setting OFF properly brought in the Kodi channel numbers as appropriate
I don't forsee any impact to any other portions of Kodi, this field is being used for display purposes only

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
