### PR TITLE
[cmake] don't abort building binary addons if an addon cannot be downloaded

### DIFF
--- a/cmake/addons/CMakeLists.txt
+++ b/cmake/addons/CMakeLists.txt
@@ -327,7 +327,12 @@ foreach(addon ${addons})
             file(DOWNLOAD "${url}" "${BUILD_DIR}/download/${archive_name}.tar.gz" STATUS dlstatus LOG dllog SHOW_PROGRESS)
             list(GET dlstatus 0 retcode)
             if(NOT ${retcode} EQUAL 0)
-              message(FATAL_ERROR "ERROR downloading ${url} - status: ${dlstatus} log: ${dllog}")
+              file(REMOVE ${BUILD_DIR}/download/${archive_name}.tar.gz)
+              message(STATUS "ERROR downloading ${url} - status: ${dlstatus} log: ${dllog}")
+              # add a dummy target for addons to get it in addons failure file
+              list(APPEND ALL_ADDONS_BUILDING ${id})
+              add_custom_target(${id} COMMAND ${CMAKE_COMMAND} -E echo "IGNORED ${id} - download failed" COMMAND exit 1)
+              continue()
             endif()
           endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Don't abort building of binary addons if an addon cannot be dowloaded.
Instead mark this addon as failed and continue.
<!--- Describe your change in detail -->

## Motivation and Context
Jenkins had no binary addons in the last days.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
