### PR TITLE
[backport] [OverlayRendererDX] fix renderer after 489e82ad086c683d8e814dc8401dd36887d629ab

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -164,6 +164,10 @@ void COverlayQuadsDX::Render(SRenderState &state)
   if (m_count == 0)
     return;
 
+  ID3D11Buffer* vertexBuffer = m_vertex.Get();
+  if (vertexBuffer == nullptr)
+    return;
+
   ID3D11DeviceContext* pContext = g_Windowing.Get3D11Context();
   CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
 
@@ -186,7 +190,6 @@ void COverlayQuadsDX::Render(SRenderState &state)
   const unsigned stride = sizeof(Vertex);
   const unsigned offset = 0;
 
-  ID3D11Buffer* vertexBuffer = m_vertex.Get();
   // Set the vertex buffer to active in the input assembler so it can be rendered.
   pContext->IASetVertexBuffers(0, 1, &vertexBuffer, &stride, &offset);
   // Set the type of primitive that should be rendered from this vertex buffer, in this case triangles.
@@ -329,6 +332,10 @@ void COverlayImageDX::Load(uint32_t* rgba, int width, int height, int stride)
 
 void COverlayImageDX::Render(SRenderState &state)
 {
+  ID3D11Buffer* vertexBuffer = m_vertex.Get();
+  if (vertexBuffer == nullptr)
+    return;
+
   ID3D11DeviceContext* pContext = g_Windowing.Get3D11Context();
   CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
 
@@ -353,7 +360,6 @@ void COverlayImageDX::Render(SRenderState &state)
   const unsigned stride = m_vertex.GetStride();
   const unsigned offset = 0;
 
-  ID3D11Buffer* vertexBuffer = m_vertex.Get();
   pContext->IASetVertexBuffers(0, 1, &vertexBuffer, &stride, &offset);
   pContext->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -151,14 +151,12 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, int width, int height)
     CLog::Log(LOGERROR, "%s - failed to create vertex buffer", __FUNCTION__);
     m_texture.Release();
   }
-  else
-    g_Windowing.Register(this);
+
   delete[] vt;
 }
 
 COverlayQuadsDX::~COverlayQuadsDX()
 {
-  g_Windowing.Unregister(this);
 }
 
 void COverlayQuadsDX::Render(SRenderState &state)
@@ -206,18 +204,8 @@ void COverlayQuadsDX::Render(SRenderState &state)
   pGUIShader->RestoreBuffers();
 }
 
-void COverlayQuadsDX::OnDestroyDevice(bool fatal)
-{
-  // fatal means that we have no valid buffer anymore
-  // resetting m_count will cause no rendering
-  if (fatal) 
-    m_count = 0; 
-}
-
-
 COverlayImageDX::~COverlayImageDX()
 {
-  g_Windowing.Unregister(this);
 }
 
 COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
@@ -283,7 +271,6 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o)
     m_width  = (float)o->width;
     m_height = (float)o->height;
   }
-  g_Windowing.Register(this);
 }
 
 COverlayImageDX::COverlayImageDX(CDVDOverlaySpu* o)
@@ -305,8 +292,6 @@ COverlayImageDX::COverlayImageDX(CDVDOverlaySpu* o)
   m_y      = (float)(min_y + o->y);
   m_width  = (float)(max_x - min_x);
   m_height = (float)(max_y - min_y);
-
-  g_Windowing.Register(this);
 }
 
 void COverlayImageDX::Load(uint32_t* rgba, int width, int height, int stride)
@@ -344,9 +329,6 @@ void COverlayImageDX::Load(uint32_t* rgba, int width, int height, int stride)
 
 void COverlayImageDX::Render(SRenderState &state)
 {
-  if (m_type == TYPE_NONE)
-    return;
-
   ID3D11DeviceContext* pContext = g_Windowing.Get3D11Context();
   CGUIShaderDX* pGUIShader = g_Windowing.GetGUIShader();
 
@@ -385,14 +367,6 @@ void COverlayImageDX::Render(SRenderState &state)
   // restoring transformation
   pGUIShader->SetWVP(world, view, proj);
   pGUIShader->RestoreBuffers();
-}
-
-void OVERLAY::COverlayImageDX::OnDestroyDevice(bool fatal)
-{
-  // fatal means that we have no valid texture and buffer anymore
-  // resetting m_type will cause no rendering
-  if (fatal)
-    m_type = TYPE_NONE;
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -35,15 +35,12 @@ namespace OVERLAY {
 
   class COverlayQuadsDX
     : public COverlay
-    , public ID3DResource
   {
   public:
     COverlayQuadsDX(ASS_Image* images, int width, int height);
     virtual ~COverlayQuadsDX();
 
     void Render(SRenderState& state);
-    void OnCreateDevice() override {}
-    void OnDestroyDevice(bool fatal) override;
 
     int                    m_count;
     DWORD                  m_fvf;
@@ -53,7 +50,6 @@ namespace OVERLAY {
 
   class COverlayImageDX
     : public COverlay
-    , public ID3DResource
   {
   public:
     COverlayImageDX(CDVDOverlayImage* o);
@@ -62,8 +58,6 @@ namespace OVERLAY {
 
     void Load(uint32_t* rgba, int width, int height, int stride);
     void Render(SRenderState& state);
-    void OnCreateDevice() override {}
-    void OnDestroyDevice(bool fatal) override;
 
     DWORD                  m_fvf;
     CD3DTexture            m_texture;


### PR DESCRIPTION
fix regression of #11551 