### PR TITLE
[PVR] Use FormattedChannelNumber in PVR Timer Settings dialog

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -778,7 +778,7 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   {
     const CPVRChannelPtr channel(channelsList[i]->GetPVRChannelInfoTag());
     std::string channelDescription(
-      StringUtils::Format("%i %s", channel->ChannelNumber(), channel->ChannelName().c_str()));
+      StringUtils::Format("%s %s", channel->FormattedChannelNumber().c_str(), channel->ChannelName().c_str()));
     m_channelEntries.insert(
       std::make_pair(i, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)));
   }


### PR DESCRIPTION
(Note: resubmitted pull request -- messed up the original branch on my fork by inadvertently adding a second, unrelated, code change)

Use the formatted channel number to expose channel.subchannel
designations from the PVR addon when "use channel numbers from backend"
option has been enabled.

## Description
This change uses the FormattedChannelNumber string rather than the channel number integer in the PVR Timer Settings dialog.  When "use channel numbers from the backend" is enabled, the dialog would not expose the channel.subchannel designations.  For example, the existing dialog may display "2 WMARDT", "2 WMARDT2", "2 WMARDT3".  This change exposes the full channel numbers, changing the output to the expected "2.1 WMARDT", "2.2 WMARDT2", "2.3 WMARDT3".  If the user has not enabled "use channel numbers from the backend", there is no outwardly visible change and the internal PVR channel numbers are still used.

## Motivation and Context
This change provides a more appropriate channel description in the PVR Timer Settings dialog.

## How Has This Been Tested?
I tested this change on Windows, Krypton rc4 (Windows 10 14393 x64, Visual Studio 2015).  Testing included toggling the "use channel numbers from backend" on and off and ensuring that the dialog produced expected channel descriptions in all cases.  Installed and tested against different PVR addons, including one of my own (currently unpublished).
There should be no impact to any other portion of Kodi, including the PVR.  The channel description string being modified is not used for anything other than display purposes in this dialog.

## Screenshots (if appropriate):

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
