### PR TITLE
[lang] update skin path of estuary in language key usage docs

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23,33 +23,33 @@ msgstr ""
 
 #: xbmc/addons/Addon.cpp
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#0"
 msgid "Programs"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Custom_1103_SourcesDialog.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Custom_1103_SourcesDialog.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#1"
 msgid "Pictures"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/Custom_1103_SourcesDialog.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/Custom_1103_SourcesDialog.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#2"
 msgid "Music"
 msgstr ""
 
 #: system/settings/settings.xml
 #: xbmc/media/MediaTypes.cpp
-#: addons/skin.estuary/1080i/Custom_1103_SourcesDialog.xml
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Custom_1103_SourcesDialog.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#3"
 msgid "Videos"
 msgstr ""
@@ -59,7 +59,7 @@ msgid "TV guide"
 msgstr ""
 
 #: xbmc/windows/GUIWindowFileManager.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#5"
 msgid "Settings"
 msgstr ""
@@ -77,9 +77,9 @@ msgctxt "#7"
 msgid "File manager"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Includes.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#8"
 msgid "Weather"
 msgstr ""
@@ -429,7 +429,7 @@ msgctxt "#111"
 msgid "Shortcuts"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#112"
 msgid "Paused"
 msgstr ""
@@ -516,8 +516,8 @@ msgstr ""
 
 #: xbmc/addons/guidialogaddonsettings.cpp
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/SettingsProfile.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/SettingsProfile.xml
 msgctxt "#128"
 msgid "General"
 msgstr ""
@@ -551,7 +551,7 @@ msgstr ""
 #: xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#133"
 msgid "Artists"
 msgstr ""
@@ -578,13 +578,13 @@ msgid "Playlists"
 msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#137"
 msgid "Search"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#138"
 msgid "System information"
 msgstr ""
@@ -609,7 +609,7 @@ msgctxt "#143"
 msgid "Current:"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#144"
 msgid "Build:"
 msgstr ""
@@ -665,7 +665,7 @@ msgid "Free"
 msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#157"
 msgid "Video"
 msgstr ""
@@ -683,7 +683,7 @@ msgctxt "#160"
 msgid "Free"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#161"
 msgid "Unavailable"
 msgstr ""
@@ -722,7 +722,7 @@ msgid "%s- %s"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#169"
 msgid "Resolution"
 msgstr ""
@@ -747,13 +747,13 @@ msgctxt "#173"
 msgid "Display 4:3 videos as"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#174"
 msgid "Compiled:"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#175"
 msgid "Moods"
 msgstr ""
@@ -784,9 +784,9 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/xbmc/pvr/windows/GUIViewStatePVR.cpp
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/View_51_Poster.xml
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/View_51_Poster.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#180"
 msgid "Duration"
 msgstr ""
@@ -816,7 +816,7 @@ msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/dialogs/GUIDialogSelect.cpp
-#: addons/skin.estuary/1080i/DialogPVRGroupManager.xml
+#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
 msgctxt "#186"
 msgid "OK"
 msgstr ""
@@ -916,24 +916,24 @@ msgctxt "#205"
 msgid "Votes"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 msgctxt "#206"
 msgid "Cast"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
-#: addons/skin.estuary/1080i/Includes_PVR.xml
-#: addons/skin.estuary/1080i/MyVideoNav.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/Includes_PVR.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
 msgctxt "#207"
 msgid "Plot"
 msgstr ""
 
 #. generic "play" (some sort of media) label used in different places
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: xbmc/dialogs/GUIDialogPlayEject.cpp
 #: xbmc/games/windows/GUIWindowGames.cpp
 #: xbmc/video/ContextMenus.cpp
@@ -944,7 +944,7 @@ msgid "Play"
 msgstr ""
 
 #. used as label for an action/button to play or navigate to the next item
-#: addons/skin.estuary/1080i/VideoOSD.xml
+#: addons/skin.estuary/xml/VideoOSD.xml
 msgctxt "#209"
 msgid "Next"
 msgstr ""
@@ -1017,7 +1017,7 @@ msgctxt "#221"
 msgid "Network is not connected"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogKeyboard.xml
+#: addons/skin.estuary/xml/DialogKeyboard.xml
 msgctxt "#222"
 msgid "Cancel"
 msgstr ""
@@ -1117,7 +1117,7 @@ msgctxt "#243"
 msgid "Refresh rate"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#244"
 msgid "Full screen"
 msgstr ""
@@ -1147,7 +1147,7 @@ msgid "Music"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
+#: addons/skin.estuary/xml/Custom_1105_MusicOSDSettings.xml
 msgctxt "#250"
 msgid "Visualisation"
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#264"
 msgid "Record"
 msgstr ""
@@ -1328,7 +1328,7 @@ msgid "Font"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#289"
 msgid "Size"
 msgstr ""
@@ -1365,8 +1365,8 @@ msgctxt "#297"
 msgid "Audio offset"
 msgstr ""
 
-#: addons/skin.estuary/1080i/VideoOSD.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/VideoOSD.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#298"
 msgid "Bookmarks"
 msgstr ""
@@ -1566,8 +1566,8 @@ msgid "Play disc"
 msgstr ""
 
 #: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
 msgctxt "#342"
 msgid "Movies"
 msgstr ""
@@ -1583,7 +1583,7 @@ msgctxt "#344"
 msgid "Actors"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#345"
 msgid "Year"
 msgstr ""
@@ -1859,7 +1859,7 @@ msgid "Temp"
 msgstr ""
 
 #: xbmc/windows/GUIWindowWeather.cpp
-#: addons/skin.estuary/1080i/MyWeather.xml
+#: addons/skin.estuary/xml/MyWeather.xml
 msgctxt "#402"
 msgid "Feels like"
 msgstr ""
@@ -1916,7 +1916,7 @@ msgid "Downloading thumbnail..."
 msgstr ""
 
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 msgctxt "#416"
 msgid "Not available"
 msgstr ""
@@ -2088,7 +2088,7 @@ msgctxt "#455"
 msgid "Rows"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 msgctxt "#456"
 msgid "Mode"
 msgstr ""
@@ -2137,7 +2137,7 @@ msgctxt "#466"
 msgid "Gamma"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#467"
 msgid "Type"
 msgstr ""
@@ -2185,7 +2185,7 @@ msgid "Skin & language"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#480"
 msgid "Appearance"
 msgstr ""
@@ -2204,8 +2204,8 @@ msgctxt "#485"
 msgid "Delete album"
 msgstr ""
 
-#: addons/skin.estuary/1080i/PlayerControls.xml
-#: addons/skin.estuary/1080i/MusicOSD.xml
+#: addons/skin.estuary/xml/PlayerControls.xml
+#: addons/skin.estuary/xml/MusicOSD.xml
 msgctxt "#486"
 msgid "Repeat"
 msgstr ""
@@ -2319,13 +2319,13 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/MyPVRRecordings.xml
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
-#: addons/skin.estuary/1080i/MyPVRGuide.xml
-#: addons/skin.estuary/1080i/View_51_Poster.xml
-#: addons/skin.estuary/1080i/Includes_PVR.xml
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/MyPVRRecordings.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/MyPVRGuide.xml
+#: addons/skin.estuary/xml/View_51_Poster.xml
+#: addons/skin.estuary/xml/Includes_PVR.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#515"
 msgid "Genre"
 msgstr ""
@@ -2406,8 +2406,8 @@ msgctxt "#534"
 msgid "View: %s"
 msgstr ""
 
-#: addons/skin.estuary/1080i/View_50_List.xml
-#: addons/skin.estuary/1080i/EventLog.xml
+#: addons/skin.estuary/xml/View_50_List.xml
+#: addons/skin.estuary/xml/EventLog.xml
 msgctxt "#535"
 msgid "List"
 msgstr ""
@@ -2487,7 +2487,7 @@ msgid "Name"
 msgstr ""
 
 #. generic "date" label used in different places
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/xbmc/pvr/windows/GUIViewStatePVR.cpp
 msgctxt "#552"
 msgid "Date"
@@ -2510,7 +2510,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#556"
 msgid "Title"
 msgstr ""
@@ -2519,7 +2519,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#557"
 msgid "Artist"
 msgstr ""
@@ -2528,7 +2528,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#558"
 msgid "Album"
 msgstr ""
@@ -2558,8 +2558,8 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 msgctxt "#563"
 msgid "Rating"
 msgstr ""
@@ -2580,7 +2580,7 @@ msgid "Album artist"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#567"
 msgid "Play count"
 msgstr ""
@@ -2594,7 +2594,7 @@ msgid "Last played"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#569"
 msgid "Comment"
 msgstr ""
@@ -2665,13 +2665,13 @@ msgid "Remember views for different folders"
 msgstr ""
 
 #: xbmc/view/GUIViewState.cpp
-#: addons/skin.estuary/1080i/EventLog.xml
+#: addons/skin.estuary/xml/EventLog.xml
 msgctxt "#584"
 msgid "Ascending"
 msgstr ""
 
 #: xbmc/view/GUIViewState.cpp
-#: addons/skin.estuary/1080i/EventLog.xml
+#: addons/skin.estuary/xml/EventLog.xml
 msgctxt "#585"
 msgid "Descending"
 msgstr ""
@@ -2680,7 +2680,7 @@ msgctxt "#586"
 msgid "Edit playlist"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 msgctxt "#587"
 msgid "Filter"
 msgstr ""
@@ -2689,15 +2689,15 @@ msgctxt "#588"
 msgid "Cancel party mode"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyVideoNav.xml
-#: addons/skin.estuary/1080i/MyMusicNav.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
+#: addons/skin.estuary/xml/MyMusicNav.xml
 msgctxt "#589"
 msgid "Party mode"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/PlayerControls.xml
-#: addons/skin.estuary/1080i/MusicOSD.xml
+#: addons/skin.estuary/xml/PlayerControls.xml
+#: addons/skin.estuary/xml/MusicOSD.xml
 msgctxt "#590"
 msgid "Random"
 msgstr ""
@@ -2785,13 +2785,13 @@ msgctxt "#611"
 msgid "Enter number"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#612"
 msgid "Bits/sample"
 msgstr ""
 
 #: xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#613"
 msgid "Sample rate"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgid "Quality"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#623"
 msgid "Bitrate"
 msgstr ""
@@ -2957,8 +2957,8 @@ msgctxt "#652"
 msgid "Years"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/MyVideoNav.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
 msgctxt "#653"
 msgid "Update library"
 msgstr ""
@@ -3228,7 +3228,7 @@ msgid "Character set"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#736"
 msgid "Style"
 msgstr ""
@@ -3365,7 +3365,7 @@ msgctxt "#772"
 msgid "Audio"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#773"
 msgid "Seeking"
 msgstr ""
@@ -3788,7 +3788,7 @@ msgctxt "#1007"
 msgid "Add network location"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNetworkSetup.xml
+#: addons/skin.estuary/xml/DialogNetworkSetup.xml
 msgctxt "#1008"
 msgid "Protocol"
 msgstr ""
@@ -3813,12 +3813,12 @@ msgctxt "#1012"
 msgid "Shared folder"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNetworkSetup.xml
+#: addons/skin.estuary/xml/DialogNetworkSetup.xml
 msgctxt "#1013"
 msgid "Port"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNetworkSetup.xml
+#: addons/skin.estuary/xml/DialogNetworkSetup.xml
 msgctxt "#1014"
 msgid "Username"
 msgstr ""
@@ -3851,13 +3851,13 @@ msgstr ""
 #empty string with id 1020
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
-#: addons/skin.estuary/1080i/DialogMediaSource.xml
+#: addons/skin.estuary/xml/DialogMediaSource.xml
 msgctxt "#1021"
 msgid "Enter the paths or browse for the media locations."
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
-#: addons/skin.estuary/1080i/DialogMediaSource.xml
+#: addons/skin.estuary/xml/DialogMediaSource.xml
 msgctxt "#1022"
 msgid "Enter a name for this media source."
 msgstr ""
@@ -3867,8 +3867,8 @@ msgctxt "#1023"
 msgid "Browse for new share"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNetworkSetup.xml
-#: addons/skin.estuary/1080i/SmartPlaylistRule.xml
+#: addons/skin.estuary/xml/DialogNetworkSetup.xml
+#: addons/skin.estuary/xml/SmartPlaylistRule.xml
 msgctxt "#1024"
 msgid "Browse"
 msgstr ""
@@ -3929,19 +3929,19 @@ msgid "Favourites"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#1037"
 msgid "Video add-ons"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#1038"
 msgid "Music add-ons"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#1039"
 msgid "Picture add-ons"
 msgstr ""
@@ -4687,7 +4687,7 @@ msgstr ""
 
 #: xbmc/addons/GUIDialogAddonSettings.cpp
 #: xbmc/guilib/WindowIDs.h
-#: addons/skin.estuary/1080i/AddonBrowser.xml
+#: addons/skin.estuary/xml/AddonBrowser.xml
 #: xbmc/settings/dialogs/GUIDialogContentSettings.cpp
 msgctxt "#10004"
 msgid "Settings"
@@ -4990,7 +4990,7 @@ msgctxt "#10139"
 msgid "Pictures / Info"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyGames.xml
+#: addons/skin.estuary/xml/MyGames.xml
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#10140"
 msgid "Add-on settings"
@@ -5203,61 +5203,61 @@ msgstr ""
 
 #empty strings from id 12024 to 12309
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12310"
 msgid "0"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12311"
 msgid "1"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12312"
 msgid "2"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12313"
 msgid "3"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12314"
 msgid "4"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12315"
 msgid "5"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12316"
 msgid "6"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12317"
 msgid "7"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12318"
 msgid "8"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 #: addons/skin.estouchy/xml/DialogNumeric.xml
 msgctxt "#12319"
 msgid "9"
@@ -5522,7 +5522,7 @@ msgid "System uptime"
 msgstr ""
 
 #: xbmc/utils/SystemInfo.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#12391"
 msgid "Minutes"
 msgstr ""
@@ -5570,7 +5570,7 @@ msgstr ""
 #string id 12902 to 12905 match in WindowIDs.h
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#13000"
 msgid "System"
 msgstr ""
@@ -5614,25 +5614,25 @@ msgid "Quit"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#13010"
 msgid "Hibernate"
 msgstr ""
 
 #: system/settings/settings.xml
 #: system/peripherals.xml
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#13011"
 msgid "Suspend"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 #: addons/skin.estouchy/xml/Home.xml
 msgctxt "#13012"
 msgid "Exit"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#13013"
 msgid "Reboot"
 msgstr ""
@@ -5647,17 +5647,17 @@ msgctxt "#13015"
 msgid "Power button action"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#13016"
 msgid "Power off system"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#13017"
 msgid "Inhibit idle shutdown"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#13018"
 msgid "Allow idle shutdown"
 msgstr ""
@@ -5919,7 +5919,7 @@ msgstr ""
 
 #empty strings from id 13163 to 13169
 
-#: addons/skin.estuary/1080i/SettingsProfile.xml
+#: addons/skin.estuary/xml/SettingsProfile.xml
 msgctxt "#13170"
 msgid "Never"
 msgstr ""
@@ -5949,8 +5949,8 @@ msgstr ""
 #: addons/skin.estouchy/xml/SettingsProfile.xml
 #: xbmc/profiles/ProfilesManager.cpp
 #: xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
-#: addons/skin.estuary/1080i/SettingsProfile.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/SettingsProfile.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#13200"
 msgid "Profiles"
 msgstr ""
@@ -6060,7 +6060,7 @@ msgid "Hardware:"
 msgstr ""
 
 #: xbmc/windows/GUIWindowSystemInfo.cpp
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#13271"
 msgid "System CPU usage:"
 msgstr ""
@@ -6079,7 +6079,7 @@ msgctxt "#13276"
 msgid "DVD-ROM"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#13277"
 msgid "Storage"
 msgstr ""
@@ -6088,17 +6088,17 @@ msgctxt "#13278"
 msgid "Default"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#13279"
 msgid "Network"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#13280"
 msgid "Video"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#13281"
 msgid "Hardware"
 msgstr ""
@@ -6229,18 +6229,18 @@ msgctxt "#13316"
 msgid "Recursive thumbnails"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyPics.xml
+#: addons/skin.estuary/xml/MyPics.xml
 msgctxt "#13317"
 msgid "View slideshow"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyPics.xml
+#: addons/skin.estuary/xml/MyPics.xml
 msgctxt "#13318"
 msgid "Recursive slideshow"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/MyPics.xml
+#: addons/skin.estuary/xml/MyPics.xml
 msgctxt "#13319"
 msgid "Randomise"
 msgstr ""
@@ -6370,8 +6370,8 @@ msgctxt "#13352"
 msgid "Scan item to library"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyVideoNav.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#13353"
 msgid "Stop scanning"
 msgstr ""
@@ -6464,7 +6464,7 @@ msgctxt "#13387"
 msgid "Track naming template - right"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#13388"
 msgid "Preset"
 msgstr ""
@@ -6499,15 +6499,15 @@ msgid "Calculating folder size"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/Custom_1106_VideoOSDSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/Custom_1106_VideoOSDSettings.xml
 msgctxt "#13395"
 msgid "Video settings"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
-#: addons/skin.estuary/1080i/Custom_1106_VideoOSDSettings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Custom_1106_VideoOSDSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#13396"
 msgid "Audio and subtitle settings"
 msgstr ""
@@ -7036,7 +7036,7 @@ msgctxt "#14017"
 msgid "Percentage of thumbs"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 msgctxt "#14018"
 msgid "View options"
 msgstr ""
@@ -7118,7 +7118,7 @@ msgid "Local network"
 msgstr ""
 
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#14036"
 msgid "Services"
 msgstr ""
@@ -7941,8 +7941,8 @@ msgctxt "#15019"
 msgid "Add"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Custom_1106_VideoOSDSettings.xml
-#: addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
+#: addons/skin.estuary/xml/Custom_1106_VideoOSDSettings.xml
+#: addons/skin.estuary/xml/Custom_1105_MusicOSDSettings.xml
 msgctxt "#15020"
 msgid "Audio DSP manager"
 msgstr ""
@@ -8046,7 +8046,7 @@ msgctxt "#15041"
 msgid "Unknown mode name"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAudioDSPSettings.xml
+#: addons/skin.estuary/xml/DialogAudioDSPSettings.xml
 msgctxt "#15042"
 msgid "Content:"
 msgstr ""
@@ -8056,7 +8056,7 @@ msgstr ""
 #. Label for a context menu entry and dialog button to open audio DSP settings dialog
 #: xbmc/pvr/PVRContextMenus.cpp
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
-#: addons/skin.estuary/1080i/Custom_1105_MusicOSDSettings.xml
+#: addons/skin.estuary/xml/Custom_1105_MusicOSDSettings.xml
 msgctxt "#15047"
 msgid "Audio DSP settings"
 msgstr ""
@@ -8073,7 +8073,7 @@ msgctxt "#15051"
 msgid "Active modes"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNetworkSetup.xml
+#: addons/skin.estuary/xml/DialogNetworkSetup.xml
 msgctxt "#15052"
 msgid "Password"
 msgstr ""
@@ -8081,31 +8081,31 @@ msgstr ""
 #empty strings from id 15053 to 15056
 
 #. Chain select button name
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15057"
 msgid "Input resampling"
 msgstr ""
 
 #. Chain select button name
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15058"
 msgid "Pre-processing"
 msgstr ""
 
 #. Chain select button name
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15059"
 msgid "Master processing"
 msgstr ""
 
 #. Chain select button name
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15060"
 msgid "Post-processing"
 msgstr ""
 
 #. Chain select button name
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15061"
 msgid "Output resampling"
 msgstr ""
@@ -8123,7 +8123,7 @@ msgid "No description available"
 msgstr ""
 
 #. DSP manager boolean enable/disable value text
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15064"
 msgid "Apply changes directly"
 msgstr ""
@@ -8305,27 +8305,27 @@ msgctxt "#15112"
 msgid "Default theme"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15113"
 msgid "Here you can configure pre-processing modes. This processing stage only change the input data stream."
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15114"
 msgid "Here you can configure an input resampling process. Notice: Only one active mode is allowed!"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15115"
 msgid "Here you can configure master processing modes. Notice: On playback only one active mode can be selected!"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15116"
 msgid "Here you can configure a output resampling process. Notice: Only one active mode is allowed!"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAudioDSPManager.xml
+#: addons/skin.estuary/xml/DialogAudioDSPManager.xml
 msgctxt "#15117"
 msgid "Here you can configure post-processing modes. This processing stage can be used for equalizing and volume correction..."
 msgstr ""
@@ -8592,7 +8592,7 @@ msgctxt "#16101"
 msgid "Unwatched"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#16102"
 msgid "Watched"
 msgstr ""
@@ -8893,12 +8893,12 @@ msgctxt "#19000"
 msgid "Switch to channel"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19001"
 msgid "Separate the search words by using AND, OR and / or NOT."
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19002"
 msgid "or use phrases to find an exact match, like \"The wizard of Oz\"."
 msgstr ""
@@ -8921,37 +8921,37 @@ msgid "PVR stream information"
 msgstr ""
 
 #. label for 'tuner name' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19006"
 msgid "Receiving device"
 msgstr ""
 
 #. label for 'device status' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19007"
 msgid "Device status"
 msgstr ""
 
 #. label for 'signal quality' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19008"
 msgid "Signal quality"
 msgstr ""
 
 #. label for 'signal noise ratio' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19009"
 msgid "SNR"
 msgstr ""
 
 #. label for 'bit error ratio' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19010"
 msgid "BER"
 msgstr ""
 
 #. label for 'number of uncorrected errors' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19011"
 msgid "UNC"
 msgstr ""
@@ -8975,7 +8975,7 @@ msgid "Fixed"
 msgstr ""
 
 #. label for 'channel encryption' in pvr player information dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19015"
 msgid "Encryption"
 msgstr ""
@@ -8986,8 +8986,8 @@ msgid "PVR backend %i - %s"
 msgstr ""
 
 #. generic label for pvr recordings used in different places
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 #: xbmc/filesystem/PVRDirectory.cpp
 msgctxt "#19017"
@@ -9001,20 +9001,20 @@ msgid "Folder with channel icons"
 msgstr ""
 
 #. label for PVR backend number of channels in system information's PVR section
-#: addons/skin.estuary/1080i/DialogPVRGuideOSD.xml
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
-#: addons/skin.estuary/1080i/DialogPVRChannelsOSD.xml
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/DialogPVRGuideOSD.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/Home.xml
 #: xbmc/windows/GUIWindowSystemInfo.cpp
 msgctxt "#19019"
 msgid "Channels"
 msgstr ""
 
 #. generic label for 'Live TV' used in different places
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml:
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/SkinSettings.xml:
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
 #: xbmc/pvr/PVRManager.cpp
 msgctxt "#19020"
@@ -9022,9 +9022,9 @@ msgid "TV"
 msgstr ""
 
 #. generic label for pvr-provided 'Radio' used in different places
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
 #: xbmc/pvr/PVRManager.cpp
 msgctxt "#19021"
@@ -9040,16 +9040,16 @@ msgstr ""
 
 #. generic label for 'Live TV channels' used in different places
 #: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19023"
 msgid "TV channels"
 msgstr ""
 
 #. generic label for pvr-provided 'Radio channels' used in different places
 #: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#19024"
 msgid "Radio channels"
 msgstr ""
@@ -9079,7 +9079,7 @@ msgid "No guide entries"
 msgstr ""
 
 #. generic 'channel' label used in different places
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 #: xbmc/filesystem/PluginDirectory.cpp
 #: xbmc/pvr/channels/PVRChannel.cpp
 #: xbmc/pvr/PVRGUIActions.cpp
@@ -9089,24 +9089,24 @@ msgid "Channel"
 msgstr ""
 
 #. generic 'now' label used in different places
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
-#: addons/skin.estuary/1080i/MyWeather.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/MyWeather.xml
 #: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
 msgctxt "#19030"
 msgid "Now"
 msgstr ""
 
 #. generic 'next' label used in different places in pvr context
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
-#: addons/skin.estuary/1080i/MyPVRChannels.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/MyPVRChannels.xml
 #: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
 msgctxt "#19031"
 msgid "Next"
 msgstr ""
 
 #. 'timeline' label used in pvr guide window
-#: addons/skin.estuary/1080i/MyPVRGuide.xml
+#: addons/skin.estuary/xml/MyPVRGuide.xml
 #. xbmc/pvr/windows/GUIWindowPVRGuide.cpp
 msgctxt "#19032"
 msgid "Timeline"
@@ -9124,7 +9124,7 @@ msgstr ""
 #: xbmc/pvr/PVRGUIActions.cpp
 #: xbmc/pvr/PVRManager.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
-#: addons/skin.estuary/1080i/VideoOSD.xml
+#: addons/skin.estuary/xml/VideoOSD.xml
 msgctxt "#19033"
 msgid "Information"
 msgstr ""
@@ -9167,7 +9167,7 @@ msgctxt "#19039"
 msgid "Are you sure you want to hide this channel?"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#19040"
 msgid "Timers"
 msgstr ""
@@ -9229,7 +9229,7 @@ msgctxt "#19050"
 msgid "Show visible channels"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 msgctxt "#19051"
 msgid "Show hidden channels"
 msgstr ""
@@ -9252,14 +9252,14 @@ msgid "Hide channel"
 msgstr ""
 
 #. generic text used in several places to state that there is no information available
-#: addons/skin.estuary/1080i/DialogMusicInfo.xml
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
-#: addons/skin.estuary/1080i/Includes_PVR.xml
-#: addons/skin.estuary/1080i/MyGames.xml
-#: addons/skin.estuary/1080i/MyMusicNav.xml
-#: addons/skin.estuary/1080i/MyPics.xml
-#: addons/skin.estuary/1080i/MyVideoNav.xml
-#: addons/skin.estuary/1080i/View_50_List.xml
+#: addons/skin.estuary/xml/DialogMusicInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/Includes_PVR.xml
+#: addons/skin.estuary/xml/MyGames.xml
+#: addons/skin.estuary/xml/MyMusicNav.xml
+#: addons/skin.estuary/xml/MyPics.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
+#: addons/skin.estuary/xml/View_50_List.xml
 #: xbmc/epg/EpgInfoTag.cpp
 #: xbmc/FileItem.cpp
 #: xbmc/GUIInfoManager.cpp
@@ -9304,7 +9304,7 @@ msgstr ""
 
 #. Label for a context menu entry to open the timer settings dialog
 #: xbmc/pvr/PVRContextMenus.cpp
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 msgctxt "#19061"
 msgid "Add timer"
 msgstr ""
@@ -9352,7 +9352,7 @@ msgid "This recording couldn't be deleted. Check the log for more information ab
 msgstr ""
 
 #. Electronic program guide
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#19069"
 msgid "Guide"
 msgstr ""
@@ -9381,7 +9381,7 @@ msgctxt "#19073"
 msgid "Delay channel switch"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19074"
 msgid "Active"
 msgstr ""
@@ -9398,7 +9398,7 @@ msgctxt "#19076"
 msgid "Folder"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 msgctxt "#19077"
 msgid "Hide disabled"
 msgstr ""
@@ -9530,19 +9530,19 @@ msgid "Warning!"
 msgstr ""
 
 #. service label in pvr info dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19099"
 msgid "Service"
 msgstr ""
 
 #. mux label in pvr info dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19100"
 msgid "Mux"
 msgstr ""
 
 #. provider label in pvr info dialog
-#: addons/skin.estuary/1080i/DialogPlayerProcessInfo.xml
+#: addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
 msgctxt "#19101"
 msgid "Provider"
 msgstr ""
@@ -9664,7 +9664,7 @@ msgctxt "#19120"
 msgid "Client number"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19121"
 msgid "Avoid repeats"
 msgstr ""
@@ -9675,75 +9675,75 @@ msgctxt "#19122"
 msgid "This timer is still recording. Are you sure you want to delete this timer?"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19123"
 msgid "Free to air channels only"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19124"
 msgid "Ignore present timers"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19125"
 msgid "Ignore present recordings"
 msgstr ""
 
 #. Label of "Start time" spinner in PVR timer settings dialog
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19126"
 msgid "Start time"
 msgstr ""
 
 #. Label of "End time" edit field in PVR timer settings dialog
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19127"
 msgid "End time"
 msgstr ""
 
 #. Label of "Start date" spinner field in PVR timer settings dialog
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19128"
 msgid "Start date"
 msgstr ""
 
 #. Label of "End date" edit field in PVR timer settings dialog
 #: xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19129"
 msgid "End date"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19130"
 msgid "Minimum duration"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19131"
 msgid "Maximum duration"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19132"
 msgid "Include unknown genres"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19133"
 msgid "Search string"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19134"
 msgid "Include description"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19135"
 msgid "Case sensitive"
 msgstr ""
@@ -9760,7 +9760,7 @@ msgid "No groups defined. Please create a group first"
 msgstr ""
 
 #. Label of timer rules tv/radio home submenu item
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#19138"
 msgid "Timer rules"
 msgstr ""
@@ -9778,19 +9778,19 @@ msgid "Search..."
 msgstr ""
 
 #. part of PVR window's active channel group label (e.g. "Group: HD Sports Channels")
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 #: xbmc/pvr/windows/GUIWindowPVRBase.cpp
 msgctxt "#19141"
 msgid "Group"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19142"
 msgid "Search guide"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGroupManager.xml
+#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
 msgctxt "#19143"
 msgid "Group management"
 msgstr ""
@@ -9805,7 +9805,7 @@ msgctxt "#19145"
 msgid "Grouped"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelsOSD.xml
+#: addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
 msgctxt "#19146"
 msgid "Groups"
 msgstr ""
@@ -9816,8 +9816,8 @@ msgctxt "#19147"
 msgid "The PVR backend does not support this action. Check the log for more information about this message."
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRGuideSearch.xml
 msgctxt "#19148"
 msgid "Channel"
 msgstr ""
@@ -9869,12 +9869,12 @@ msgctxt "#19156"
 msgid "from"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#19157"
 msgid "Next recording"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#19158"
 msgid "Currently recording"
 msgstr ""
@@ -9915,7 +9915,7 @@ msgctxt "#19164"
 msgid "Can't start recording. Check the log for more information about this message."
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
 msgctxt "#19165"
 msgid "Switch"
 msgstr ""
@@ -10028,7 +10028,7 @@ msgid "Radio channels"
 msgstr ""
 
 #. label for "deleted recordings" data source in media source window
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 #: xbmc/dialogs/GUIDialogMediaSource.cpp
 msgctxt "#19184"
 msgid "Deleted recordings"
@@ -10070,7 +10070,7 @@ msgctxt "#19190"
 msgid "Background"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#19191"
 msgid "PVR service"
 msgstr ""
@@ -10118,22 +10118,22 @@ msgstr ""
 
 #. pvr settings "channel manager" action button label
 #: system/settings/settings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#19199"
 msgid "Channel manager"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19200"
 msgid "Guide source:"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19201"
 msgid "Channel name:"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19202"
 msgid "Channel icon:"
 msgstr ""
@@ -10144,18 +10144,18 @@ msgid "Edit channel"
 msgstr ""
 
 #. initial name for new channels, used in pvr channel manager dialog
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
 msgctxt "#19204"
 msgid "New channel"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19205"
 msgid "Group management"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19206"
 msgid "Activate guide:"
 msgstr ""
@@ -10177,7 +10177,7 @@ msgid "Kodi virtual backend"
 msgstr ""
 
 #. pvr channel manager "epg source" selector value
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
 msgctxt "#19210"
 msgid "Client"
@@ -10513,7 +10513,7 @@ msgctxt "#19266"
 msgid "Parental locked"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
+#: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19267"
 msgid "Parental locked:"
 msgstr ""
@@ -10527,7 +10527,7 @@ msgstr ""
 # empty string with id 19269
 
 #. Label of the option to switch between a grouped recordings list and a non-grouped recordings list in pvr recordings window.
-#: addons/skin.estuary/1080i/Includes_MediaMenu.xml
+#: addons/skin.estuary/xml/Includes_MediaMenu.xml
 msgctxt "#19270"
 msgid "Group Items"
 msgstr ""
@@ -10638,7 +10638,7 @@ msgid "Foreground"
 msgstr ""
 
 #. Label for button to hide a group in the group manager
-#: addons/skin.estuary/1080i/DialogPVRGroupManager.xml
+#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
 msgctxt "#19289"
 msgid "Hide group"
 msgstr ""
@@ -11422,14 +11422,14 @@ msgstr ""
 
 #. Name of an artwork type
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
-#: addons/skin.estuary/1080i/View_501_Banner.xml
+#: addons/skin.estuary/xml/View_501_Banner.xml
 msgctxt "#20020"
 msgid "Banner"
 msgstr ""
 
 #. Name of an artwork type
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
-#: addons/skin.estuary/1080i/View_51_Poster.xml
+#: addons/skin.estuary/xml/View_51_Poster.xml
 msgctxt "#20021"
 msgid "Poster"
 msgstr ""
@@ -11468,7 +11468,7 @@ msgctxt "#20036"
 msgid "%s (%s)"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SettingsSystemInfo.xml
+#: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#20037"
 msgid "Summary"
 msgstr ""
@@ -11501,12 +11501,12 @@ msgctxt "#20044"
 msgid "Start fresh"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#20045"
 msgid "Enter master mode"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#20046"
 msgid "Leave master mode"
 msgstr ""
@@ -11563,7 +11563,7 @@ msgctxt "#20059"
 msgid "Query info for all albums"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20060"
 msgid "Media info"
 msgstr ""
@@ -11608,7 +11608,7 @@ msgid "Couldn't create folder"
 msgstr ""
 
 #: xbmc/windows/GUIWindowFileManager.cpp
-#: addons/skin.estuary/1080i/ProfileSettings.xml
+#: addons/skin.estuary/xml/ProfileSettings.xml
 msgctxt "#20070"
 msgid "Profile directory"
 msgstr ""
@@ -11704,12 +11704,12 @@ msgctxt "#20092"
 msgid "Load profile"
 msgstr ""
 
-#: addons/skin.estuary/1080i/ProfileSettings.xml
+#: addons/skin.estuary/xml/ProfileSettings.xml
 msgctxt "#20093"
 msgid "Profile name"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#20094"
 msgid "Media sources"
 msgstr ""
@@ -11842,7 +11842,7 @@ msgctxt "#20125"
 msgid "Logged on as"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#20126"
 msgid "Log off"
 msgstr ""
@@ -11939,12 +11939,12 @@ msgctxt "#20149"
 msgid "Shutdown in 120 minutes"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#20150"
 msgid "Custom shutdown timer"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogButtonMenu.xml
+#: addons/skin.estuary/xml/DialogButtonMenu.xml
 msgctxt "#20151"
 msgid "Cancel shutdown timer"
 msgstr ""
@@ -12012,7 +12012,7 @@ msgctxt "#20165"
 msgid "Not locked"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#20166"
 msgid "Locked"
 msgstr ""
@@ -12058,18 +12058,18 @@ msgctxt "#20176"
 msgid "Show video information"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogNumeric.xml
-#: addons/skin.estuary/1080i/DialogKeyboard.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogKeyboard.xml
 msgctxt "#20177"
 msgid "Done"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogKeyboard.xml
+#: addons/skin.estuary/xml/DialogKeyboard.xml
 msgctxt "#20178"
 msgid "Shift"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogKeyboard.xml
+#: addons/skin.estuary/xml/DialogKeyboard.xml
 msgctxt "#20179"
 msgid "Caps Lock"
 msgstr ""
@@ -12078,13 +12078,13 @@ msgctxt "#20180"
 msgid "Symbols"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogKeyboard.xml
-#: addons/skin.estuary/1080i/DialogNumeric.xml
+#: addons/skin.estuary/xml/DialogKeyboard.xml
+#: addons/skin.estuary/xml/DialogNumeric.xml
 msgctxt "#20181"
 msgid "Backspace"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogKeyboard.xml
+#: addons/skin.estuary/xml/DialogKeyboard.xml
 msgctxt "#20182"
 msgid "Space"
 msgstr ""
@@ -12114,7 +12114,7 @@ msgctxt "#20188"
 msgid "Announce library updates"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SkinSettings.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
 msgctxt "#20189"
 msgid "Enable auto scrolling for plot & review"
 msgstr ""
@@ -12208,7 +12208,7 @@ msgctxt "#20243"
 msgid "Android photos"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#20244"
 msgid "Android apps"
 msgstr ""
@@ -12395,7 +12395,7 @@ msgctxt "#20335"
 msgid "Look for content recursively?"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyVideoNav.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
 msgctxt "#20336"
 msgid "Unlock sources"
 msgstr ""
@@ -12415,10 +12415,10 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
-#: addons/skin.estuary/1080i/View_51_Poster.xml
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/View_51_Poster.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20339"
 msgid "Director"
 msgstr ""
@@ -12436,7 +12436,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/media/MediaTypes.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20342"
 msgid "Movies"
 msgstr ""
@@ -12444,14 +12444,14 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
 #: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
-#: addons/skin.estuary/1080i/Home.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Home.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20343"
 msgid "TV shows"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogContentSettings.xml
+#: addons/skin.estuary/xml/DialogContentSettings.xml
 msgctxt "#20344"
 msgid "This directory contains"
 msgstr ""
@@ -12525,8 +12525,8 @@ msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20359"
 msgid "Episode"
 msgstr ""
@@ -12536,8 +12536,8 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/View_51_Poster.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/View_51_Poster.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20360"
 msgid "Episodes"
 msgstr ""
@@ -12569,7 +12569,7 @@ msgctxt "#20366"
 msgid "* All seasons"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyVideoNav.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
 msgctxt "#20367"
 msgid "Hide watched"
 msgstr ""
@@ -12597,8 +12597,8 @@ msgstr ""
 
 #: xbmc/media/MediaTypes.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20373"
 msgid "Season"
 msgstr ""
@@ -12675,7 +12675,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
 #: xbmc/media/MediaTypes.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20389"
 msgid "Music videos"
 msgstr ""
@@ -12795,17 +12795,17 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/Variables.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#20416"
 msgid "First aired"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
-#: addons/skin.estuary/1080i/DialogPVRInfo.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogPVRInfo.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20417"
 msgid "Writer"
 msgstr ""
@@ -12940,7 +12940,7 @@ msgid "Add to library"
 msgstr ""
 
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: addons/skin.estuary/1080i/View_502_FanArt.xml
+#: addons/skin.estuary/xml/View_502_FanArt.xml
 msgctxt "#20445"
 msgid "Fanart"
 msgstr ""
@@ -12979,7 +12979,7 @@ msgctxt "#20452"
 msgid "episode"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#20453"
 msgid "episodes"
 msgstr ""
@@ -13299,8 +13299,8 @@ msgctxt "#21395"
 msgid "Unable to cache files bigger than 4GB"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogSeekBar.xml
-#: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
+#: addons/skin.estuary/xml/DialogSeekBar.xml
+#: addons/skin.estuary/xml/DialogFullScreenInfo.xml
 msgctxt "#21396"
 msgid "Chapter"
 msgstr ""
@@ -13421,7 +13421,7 @@ msgctxt "#21421"
 msgid "Smart playlist rule"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistRule.xml
+#: addons/skin.estuary/xml/SmartPlaylistRule.xml
 msgctxt "#21422"
 msgid "Match items where"
 msgstr ""
@@ -13431,7 +13431,7 @@ msgctxt "#21423"
 msgid "New rule..."
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21424"
 msgid "Items must match"
 msgstr ""
@@ -13446,7 +13446,7 @@ msgctxt "#21426"
 msgid "one or more of the rules"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21427"
 msgid "Limit to"
 msgstr ""
@@ -13456,17 +13456,17 @@ msgctxt "#21428"
 msgid "No limit"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21429"
 msgid "Order by"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21430"
 msgid "ascending"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21431"
 msgid "descending"
 msgstr ""
@@ -13475,7 +13475,7 @@ msgctxt "#21432"
 msgid "Edit smart playlist"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21433"
 msgid "Playlist name"
 msgstr ""
@@ -13523,7 +13523,7 @@ msgid "Video resolution"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#21444"
 msgid "Audio channels"
 msgstr ""
@@ -13534,7 +13534,7 @@ msgid "Video codec"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
+#: addons/skin.estuary/xml/MusicVisualisation.xml
 msgctxt "#21446"
 msgid "Audio codec"
 msgstr ""
@@ -13567,12 +13567,12 @@ msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
-#: addons/skin.estuary/1080i/MyPrograms.xml
-#: addons/skin.estuary/1080i/Includes.xml
-#: addons/skin.estuary/1080i/MyVideoNav.xml
-#: addons/skin.estuary/1080i/MyPics.xml
-#: addons/skin.estuary/1080i/MyMusicNav.xml
-#: addons/skin.estuary/1080i/MyGames.xml
+#: addons/skin.estuary/xml/MyPrograms.xml
+#: addons/skin.estuary/xml/Includes.xml
+#: addons/skin.estuary/xml/MyVideoNav.xml
+#: addons/skin.estuary/xml/MyPics.xml
+#: addons/skin.estuary/xml/MyMusicNav.xml
+#: addons/skin.estuary/xml/MyGames.xml
 msgctxt "#21452"
 msgid "Get more..."
 msgstr ""
@@ -13599,12 +13599,12 @@ msgctxt "#21457"
 msgid "Watched episode count"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21458"
 msgid "Group by"
 msgstr ""
 
-#: addons/skin.estuary/1080i/SmartPlaylistEditor.xml
+#: addons/skin.estuary/xml/SmartPlaylistEditor.xml
 msgctxt "#21459"
 msgid "mixed"
 msgstr ""
@@ -13795,7 +13795,7 @@ msgctxt "#21822"
 msgid "Camera make"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21823"
 msgid "Camera model"
 msgstr ""
@@ -13808,12 +13808,12 @@ msgctxt "#21825"
 msgid "Firmware"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21826"
 msgid "Aperture"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21827"
 msgid "Focal length"
 msgstr ""
@@ -13826,7 +13826,7 @@ msgctxt "#21829"
 msgid "Exposure"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21830"
 msgid "Exposure time"
 msgstr ""
@@ -13967,7 +13967,7 @@ msgctxt "#21874"
 msgid "State"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#21875"
 msgid "Country"
 msgstr ""
@@ -14021,13 +14021,13 @@ msgstr ""
 
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21887"
 msgid "Biography"
 msgstr ""
 
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21888"
 msgid "Discography"
 msgstr ""
@@ -14077,13 +14077,13 @@ msgctxt "#21897"
 msgid "Died"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21898"
 msgid "Years active"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#21899"
 msgid "Label"
 msgstr ""
@@ -14310,9 +14310,9 @@ msgid "Add-on"
 msgstr ""
 
 #: xbmc/filesystem/AddonsDirectory.cpp
-#: addons/skin.estuary/1080i/Includes.xml
-#: addons/skin.estuary/1080i/SkinSettings.xml
-#: addons/skin.estuary/1080i/Home.xml
+#: addons/skin.estuary/xml/Includes.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Home.xml
 msgctxt "#24001"
 msgid "Add-ons"
 msgstr ""
@@ -14370,7 +14370,7 @@ msgid "Add-on repository"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#24012"
 msgid "Subtitles"
 msgstr ""
@@ -14401,7 +14401,7 @@ msgid "Artist information"
 msgstr ""
 
 #: xbmc/addons/Addon.cpp
-#: addons/skin.estuary/1080i/DialogSubtitles.xml
+#: addons/skin.estuary/xml/DialogSubtitles.xml
 msgctxt "#24018"
 msgid "Services"
 msgstr ""
@@ -14479,7 +14479,7 @@ msgctxt "#24033"
 msgid "Install from repository"
 msgstr ""
 
-#: addons/skin.estuary/1080i/AddonBrowser.xml
+#: addons/skin.estuary/xml/AddonBrowser.xml
 #: xbmc/addons/ContextMenus.h
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 msgctxt "#24034"
@@ -14567,7 +14567,7 @@ msgctxt "#24051"
 msgid "Version:"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAddonInfo.xml
+#: addons/skin.estuary/xml/DialogAddonInfo.xml
 #: addons/skin.estouchy/xml/DialogAddonInfo.xml
 msgctxt "#24052"
 msgid "Disclaimer"
@@ -14578,7 +14578,7 @@ msgctxt "#24053"
 msgid "License:"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogAddonInfo.xml
+#: addons/skin.estuary/xml/DialogAddonInfo.xml
 msgctxt "#24054"
 msgid "What's new"
 msgstr ""
@@ -14791,7 +14791,7 @@ msgid "Local package cache"
 msgstr ""
 
 #: xbmc/addons/Repository.cpp
-#: addons/skin.estuary/1080i/DialogAddonInfo.xml
+#: addons/skin.estuary/xml/DialogAddonInfo.xml
 msgctxt "#24096"
 msgid "Add-on is incompatible or has been marked broken in repository."
 msgstr ""
@@ -15141,7 +15141,7 @@ msgid "My add-ons"
 msgstr ""
 
 #. Used in add-on browser
-#: addons/skin.estuary/1080i/AddonBrowser.xml
+#: addons/skin.estuary/xml/AddonBrowser.xml
 msgctxt "#24999"
 msgid "Hide incompatible"
 msgstr ""
@@ -15152,7 +15152,7 @@ msgid "Notifications"
 msgstr ""
 
 #. Used in add-on browser
-#: addons/skin.estuary/1080i/AddonBrowser.xml
+#: addons/skin.estuary/xml/AddonBrowser.xml
 msgctxt "#25001"
 msgid "Hide foreign"
 msgstr ""
@@ -15238,94 +15238,94 @@ msgid "Radiotext Plus info"
 msgstr ""
 
 #. Music band name which make the song (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29901"
 msgid "Band"
 msgstr ""
 
 #. Style of the current playing radio
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29902"
 msgid "Style"
 msgstr ""
 
 #. Concert composer of the music (if present)
 #: Label of ListItem.Property(Role.Composer)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29903"
 msgid "Composer"
 msgstr ""
 
 #. Artists which sing the music (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29904"
 msgid "Artist"
 msgstr ""
 
 #. Conductor of the classic music (if present)
 #: Label of ListItem.Property(Role.Conductor)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29905"
 msgid "Conductor"
 msgstr ""
 
 #. Moderator currently on radio (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29906"
 msgid "Moderator"
 msgstr ""
 
 #. List of editoral staff (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29907"
 msgid "Editorial Staff"
 msgstr ""
 
 #. Current playing program name
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29908"
 msgid "Program"
 msgstr ""
 
 #. Studio name (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#29909"
 msgid "Studio"
 msgstr ""
 
 #. Phone number (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29910"
 msgid "Phone"
 msgstr ""
 
 #. EMail address (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29911"
 msgid "EMail"
 msgstr ""
 
 #. SMS message number (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29912"
 msgid "SMS"
 msgstr ""
 
 #. Hotline phone (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29913"
 msgid "Hotline"
 msgstr ""
 
 #. Website address (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29914"
 msgid "Website"
 msgstr ""
 
 #. General information news, in list selector (if present)
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
+#: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
 msgctxt "#29915"
 msgid "Info"
 msgstr ""
@@ -15899,12 +15899,12 @@ msgctxt "#33034"
 msgid "36-hour"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyWeather.xml
+#: addons/skin.estuary/xml/MyWeather.xml
 msgctxt "#33035"
 msgid "Maps"
 msgstr ""
 
-#: addons/skin.estuary/1080i/MyWeather.xml
+#: addons/skin.estuary/xml/MyWeather.xml
 msgctxt "#33036"
 msgid "Hourly"
 msgstr ""
@@ -15953,7 +15953,7 @@ msgstr ""
 
 #: xbmc/filesystem/VideoDatabaseDirectory.cpp
 #: xbmc/media/MediaTypes.cpp
-#: addons/skin.estuary/1080i/View_51_Poster.xml
+#: addons/skin.estuary/xml/View_51_Poster.xml
 msgctxt "#33054"
 msgid "Seasons"
 msgstr ""
@@ -15998,7 +15998,7 @@ msgctxt "#33062"
 msgid "Play the"
 msgstr ""
 
-#: addons/skin.estuary/1080i/Includes.xml
+#: addons/skin.estuary/xml/Includes.xml
 msgctxt "#33063"
 msgid "Options"
 msgstr ""
@@ -16463,7 +16463,7 @@ msgid "A new controller has been detected. Configuration can be done at any time
 msgstr ""
 
 #. Label of the button to fix the bug where buttons are skipped in the controller dialog
-#: addons/skin.estuary/1080i/DialogGameControllers.xml
+#: addons/skin.estuary/xml/DialogGameControllers.xml
 msgctxt "#35013"
 msgid "Fix skipping"
 msgstr ""
@@ -16505,7 +16505,7 @@ msgid "Game add-ons"
 msgstr ""
 
 #. Name of controller add-ons
-#: addons/skin.estuary/1080i/DialogGameControllers.xml
+#: addons/skin.estuary/xml/DialogGameControllers.xml
 #: xbmc/addons/Addon.cpp
 #: xbmc/games/controllers/windows/GUIControllerWindow.cpp
 msgctxt "#35050"
@@ -16535,13 +16535,13 @@ msgstr ""
 #empty strings from id 35056 to 35057
 
 #. Title of controller configuration window
-#: addons/skin.estuary/1080i/DialogGameControllers.xml
+#: addons/skin.estuary/xml/DialogGameControllers.xml
 msgctxt "#35058"
 msgid "Controller Configuration"
 msgstr ""
 
 #. Heading for controller buttons list in controller configuration window
-#: addons/skin.estuary/1080i/DialogGameControllers.xml
+#: addons/skin.estuary/xml/DialogGameControllers.xml
 msgctxt "#35059"
 msgid "Buttons"
 msgstr ""
@@ -17196,7 +17196,7 @@ msgstr ""
 #. Name of an action to perform on a specific event, like changing the CEC source away from Kodi
 #: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
 #: system/peripherals.xml
-#: addons/skin.estuary/1080i/Variables.xml
+#: addons/skin.estuary/xml/Variables.xml
 msgctxt "#36044"
 msgid "Stop Playback"
 msgstr ""
@@ -19745,7 +19745,7 @@ msgid "season"
 msgstr ""
 
 #: xbmc/media/MediaType.cpp
-#: addons/skin.estuary/1080i/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
 msgctxt "#36905"
 msgid "seasons"
 msgstr ""


### PR DESCRIPTION
Small search/replace of `1080i` with `xml` in the language key docs for our default language file.

@ronie or @MartijnKaijser mind taking a look.