### PR TITLE
[cmake] [linux] Don't compile/add WiiRemote if libcwiid-dev is not present

### DIFF
--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -7,6 +7,6 @@ if(ENABLE_X11 AND X_FOUND AND XRANDR_FOUND)
 endif()
 
 # WiiRemote
-if(ENABLE_EVENTCLIENTS AND BLUETOOTH_FOUND)
+if(ENABLE_EVENTCLIENTS AND BLUETOOTH_FOUND AND CWIID_FOUND)
   add_subdirectory(${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/WiiRemote build/WiiRemote)
 endif()


### PR DESCRIPTION
## Description
WiiRemote will fail if libcwiid-dev is not present in the system, so don't add it to the build.

Topic: http://forum.kodi.tv/showthread.php?tid=305169 

## Motivation and Context

## How Has This Been Tested?
Building kodi

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
