### PR TITLE
Fix freezing when some buttons are held

### DIFF
--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -139,6 +139,25 @@ bool CKeymapHandler::SendDigitalAction(unsigned int keyId, unsigned int holdTime
   CAction action(CButtonTranslator::GetInstance().GetAction(g_windowManager.GetActiveWindowID(), CKey(keyId, holdTimeMs)));
   if (action.GetID() > 0)
   {
+    //! @todo Add "holdtime" parameter to joystick.xml. For now we MUST only
+    // send held actions for basic navigation commands!
+    if (holdTimeMs > 0)
+    {
+      switch (action.GetID())
+      {
+      case ACTION_MOVE_LEFT:
+      case ACTION_MOVE_RIGHT:
+      case ACTION_MOVE_UP:
+      case ACTION_MOVE_DOWN:
+      case ACTION_PAGE_UP:
+      case ACTION_PAGE_DOWN:
+        break;
+
+      default:
+        return true;
+      }
+    }
+
     CInputManager::GetInstance().QueueAction(action);
     return true;
   }


### PR DESCRIPTION
Long presses aren't implemented for joysticks, so holding a button will send the action in rapid succession. If the action is select, this will queue hundreds of select commands and freeze Kodi.

In the long run, I plan to implement long presses for joysticks. For Krypton, however, this simple fix should suffice.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
