### PR TITLE
FIX: [regression] URL encoding is case-insentive

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -705,7 +705,7 @@ std::string CURL::Encode(const std::string& strURLData)
     if (StringUtils::isasciialphanum(kar) || kar == '-' || kar == '.' || kar == '_' || kar == '!' || kar == '(' || kar == ')')
       strResult.push_back(kar);
     else
-      strResult += StringUtils::Format("%%%2.2X", (unsigned int)((unsigned char)kar));
+      strResult += StringUtils::Format("%%%2.2x", (unsigned int)((unsigned char)kar));
   }
 
   return strResult;


### PR DESCRIPTION
Partial revert of 932b0d2cec13970bf1f1e78cb6642e3890ce9d68
URL encoding is case-insentive according to https://tools.ietf.org/html/rfc3986#section-2.1 , so the move from lower to upper case is not required, but causes regression
Fixes #17266

Backport of https://github.com/xbmc/xbmc/pull/11587