### PR TITLE
[PVR][jsonrpc] CPVROperations::ToggleTimer: fix crash

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -403,6 +403,9 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
   else
   {
     timer = CPVRTimerInfoTag::CreateFromEpg(epgTag, timerrule);
+    if (!timer)
+      return InvalidParams;
+
     sentOkay = g_PVRTimers->AddTimer(timer);
   }
 


### PR DESCRIPTION
CPVROperations::ToggleTimer: fix crash due to invalid epg tag given (e.g. event end time is in the past, thus no timer can be created)

@joethefox could you please runtime test and report back?

@Jalle19 for review?