### PR TITLE
[Krypton] Controller dialog: Update button label

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16036,7 +16036,7 @@ msgstr ""
 #. Label of the button to fix the bug where buttons are skipped in the controller dialog
 #: addons/skin.estuary/1080i/DialogGameControllers.xml
 msgctxt "#35013"
-msgid "Fix skipping"
+msgid "Ignore input"
 msgstr ""
 
 #. Help text of the button to fix the bug where buttons are skipped in the controller dialog. %s - list of disabled buttons and axes


### PR DESCRIPTION
After #11571 goes in, skipping during button-mapping is greatly reduced. Therefore, the "Fix skipping" title becomes largely useless. "Ignore input" is a much more appropriate name.

I have already included this title in the documentation: http://kodi.wiki/view/HOW-TO:Fix_buttons_skipped_while_mapping

This should go in before final release to avoid issues with translations.

## Screenshots (if appropriate):

After the rename:

![ignore_input 5 44 07 pm](https://cloud.githubusercontent.com/assets/531482/22492715/258c11f0-e7e0-11e6-8def-5469be2ee708.jpg)
