### PR TITLE
[EPG] Fix CEpgSearchFilter::Reset - CID 1399697:  Uninitialized members  (UNINIT_CTOR)

### DIFF
--- a/xbmc/epg/EpgSearchFilter.cpp
+++ b/xbmc/epg/EpgSearchFilter.cpp
@@ -54,12 +54,13 @@ void CEpgSearchFilter::Reset()
   m_bRemoveDuplicates        = false;
 
   /* pvr specific filters */
+  m_bIsRadio                 = false;
   m_iChannelNumber           = EPG_SEARCH_UNSET;
   m_bFreeToAirOnly           = false;
   m_iChannelGroup            = EPG_SEARCH_UNSET;
   m_bIgnorePresentTimers     = true;
   m_bIgnorePresentRecordings = true;
-  m_iUniqueBroadcastId	     = EPG_TAG_INVALID_UID;
+  m_iUniqueBroadcastId       = EPG_TAG_INVALID_UID;
 }
 
 bool CEpgSearchFilter::MatchGenre(const CEpgInfoTagPtr &tag) const


### PR DESCRIPTION
CID 1399697:  Uninitialized members  (UNINIT_CTOR)
    Non-static class member "m_bIsRadio" is not initialized in this constructor nor in any functions that it calls.

@Jalle19 mind doing the review

