### PR TITLE
video/PlayerController.cpp Bug and Fix

### DIFF
--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -252,7 +252,7 @@ bool CPlayerController::OnAction(const CAction &action)
       {
         CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio += 0.01f;
         if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio > 2.f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio = 2.f;
         CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
         g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
         ShowSlider(action.GetID(), 217, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
@@ -262,7 +262,7 @@ bool CPlayerController::OnAction(const CAction &action)
       case ACTION_DECREASE_PAR:
       {
         CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio -= 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio < 0.5f)
           CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio = 0.5f;
         CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
         g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
ACTION_INCREASE_PAR, and ACTION_DECREASE_PAR tries to clamp PixelAspectRatio to 0.5-2.0.
But it fails because of incorrect variable use.
## Description
<!--- Describe your change in detail -->
original line 255:
 CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
changed to:
CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio = 2.f;

original line 265:
if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
changed to:
if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio < 0.5f)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the current unpatched code, a script can set PixelAspectRatio to unlimited positive
and negative floating point value.
If INCREASE_PAR, and DECREASE_PAR works as intended, a script can set the PixelAspectRatio to 0.5 by decreasing 151 steps; then, starting from a known point, set any PixelAspectRatio desired.

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
compiled for Jarvis, Krypton on Android. Tested on Amazon firetv.
<!--- Include details of your testing environment, and the tests you ran to -->
Virtual Box windows 7 host, Ubuntu 16.04 LTS. Compiled for Arm. Have scripts tried
to decrease PixelAspectRatio and IncreasePixelAspectRatio to out of range. The fix works.
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x ] All new and existing tests passed
