### PR TITLE
[PVR][jsonrpc] Krypton: CPVROperations::ToggleTimer: fix crash due to invalid …

### DIFF
--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -403,6 +403,9 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
   else
   {
     timer = CPVRTimerInfoTag::CreateFromEpg(epgTag, timerrule);
+    if (!timer)
+      return InvalidParams;
+
     sentOkay = g_PVRTimers->AddTimer(timer);
   }
 


### PR DESCRIPTION
…epg tag given (e.g. event end time is in the past, thus no timer can be created)

Backport of #11594

@joethefox fyi

@Jalle19 mind doing the code review.
