### PR TITLE
cmake: fix handling of X11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ endif()
 
 if(NOT WIN32)
   core_optional_dep(OpenGl)
-  if(OPENGL_FOUND)
+  if(OPENGL_FOUND AND NOT APPLE)
     if(ENABLE_MIR)
       core_require_dep(Mir ENABLE_MIR)
       core_optional_dep(LibDRM ENABLE_MIR)

--- a/cmake/treedata/linux/subdirs.txt
+++ b/cmake/treedata/linux/subdirs.txt
@@ -10,4 +10,5 @@ xbmc/storage/linux         storage/linux
 xbmc/filesystem/posix      filesystem/posix
 xbmc/utils/posix           utils_posix
 xbmc/windowing/egl         windowing/egl
+xbmc/windowing/X11         windowing/X11
 xbmc/platform/posix        posix

--- a/cmake/treedata/optional/common/X11.txt
+++ b/cmake/treedata/optional/common/X11.txt
@@ -1,1 +1,0 @@
-xbmc/windowing/X11 windowing/X11 # X11

--- a/xbmc/windowing/X11/CMakeLists.txt
+++ b/xbmc/windowing/X11/CMakeLists.txt
@@ -1,17 +1,21 @@
-set(SOURCES GLContextEGL.cpp
-            GLContextGLX.cpp
-            GLContext.cpp
-            WinSystemX11.cpp
-            WinSystemX11GLContext.cpp
-            WinSystemX11GLESContext.cpp
-            XRandR.cpp)
+if (X_FOUND)
 
-set(HEADERS GLContext.h
-            GLContextEGL.h
-            GLContextGLX.h
-            WinSystemX11.h
-            WinSystemX11GLContext.h
-            WinSystemX11GLESContext.h
-            XRandR.h)
+  set(SOURCES GLContextEGL.cpp
+              GLContextGLX.cpp
+              GLContext.cpp
+              WinSystemX11GLContext.cpp
+              WinSystemX11GLESContext.cpp
+              XRandR.cpp
+              WinSystemX11.cpp)
 
-core_add_library(windowing_X11)
+  set(HEADERS GLContext.h
+              GLContextEGL.h
+              GLContextGLX.h
+              WinSystemX11GLContext.h
+              WinSystemX11GLESContext.h
+              XRandR.h
+              WinSystemX11.h)
+
+  core_add_library(windowing_X11)
+
+endif()


### PR DESCRIPTION
X11 is a platform, not an option. It requires packages like OpenGL, EG, VDPAU, etc. Currently this is handles completely wrong in the build system.
This fixes just the biggest issues like X11 showing up in XCode and being built for Pi.