### PR TITLE
Don't assign wrong InfoTags to items in the JSON handler

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -387,41 +387,26 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
 
 bool CFileItemHandler::FillFileItemList(const CVariant &parameterObject, CFileItemList &list)
 {
-  CAudioLibrary::FillFileItemList(parameterObject, list);
-  CVideoLibrary::FillFileItemList(parameterObject, list);
-  CFileOperations::FillFileItemList(parameterObject, list);
-
-  std::string file = parameterObject["file"].asString();
-  if (!file.empty() && (URIUtils::IsURL(file) || (CFile::Exists(file) && !CDirectory::Exists(file))))
+  if (parameterObject.isMember("file"))
   {
-    bool added = false;
-    for (int index = 0; index < list.Size(); index++)
-    {
-      if (list[index]->GetPath() == file || list[index]->GetMusicInfoTag()->GetURL() == file || list[index]->GetVideoInfoTag()->GetPath() == file)
-      {
-        added = true;
-        break;
-      }
-    }
-
-    if (!added)
+    std::string file = parameterObject["file"].asString();
+    if (!file.empty() && (URIUtils::IsURL(file) || (CFile::Exists(file) && !CDirectory::Exists(file))))
     {
       CFileItemPtr item = CFileItemPtr(new CFileItem(file, false));
-      if (item->IsPicture())
-      {
-        CPictureInfoTag picture;
-        picture.Load(item->GetPath());
-        *item->GetPictureInfoTag() = picture;
-      }
-      if (item->GetLabel().empty())
-      {
-        item->SetLabel(CUtil::GetTitleFromPath(file, false));
-        if (item->GetLabel().empty())
-          item->SetLabel(URIUtils::GetFileName(file));
-      }
       list.Add(item);
     }
   }
+  else if (parameterObject.isMember("directory"))
+    CFileOperations::FillFileItemList(parameterObject, list);
+  else if (parameterObject.isMember("movieid")
+        || parameterObject.isMember("episodeid")
+        || parameterObject.isMember("musicvideoid"))
+    CVideoLibrary::FillFileItemList(parameterObject, list);
+  else if (parameterObject.isMember("artistid")
+        || parameterObject.isMember("albumid")
+        || parameterObject.isMember("songid")
+        || parameterObject.isMember("genreid"))
+    CAudioLibrary::FillFileItemList(parameterObject, list);
 
   return (list.Size() > 0);
 }


### PR DESCRIPTION
In interfaces/json-rpc/FileItemHandler.cpp method FillFileItemList in some cases assigns wrong InfoTags to FileItems. One way this becomes apparent is when you add to the picture playlist and then try to open it using JSON queries like these:

`{"params": {"item": [{"file": "/pics/pic1.jpg"}, {"file": "/pics/pic2.jpg"}, {"file": "/pics/pic3.jpg"}], "playlistid": 2}, "jsonrpc": "2.0", "id": 1, "method": "Playlist.Add"}`

`{"params": {"item": {"position": 1, "playlistid": 2}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`

With the pictures having VideoInfoTags the slideshow will not work. This patch will have the method create InfoTags only as needed, which in some cases is not at all where the players can handle FileItems without them.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
