### PR TITLE
Have the JSON handler sent a custom CEvent to the slideshow class

### DIFF
--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1156,7 +1156,7 @@ JSONRPC_STATUS CPlayerOperations::StartSlideshow(const std::string& path, bool r
   g_application.WakeUpScreenSaverAndDPMS();
   CGUIMessage msg(GUI_MSG_START_SLIDESHOW, 0, 0, flags);
   msg.SetStringParams(params);
-  CApplicationMessenger::GetInstance().SendGUIMessage(msg, WINDOW_SLIDESHOW, true);
+  CApplicationMessenger::GetInstance().SendGUIMessage(msg, WINDOW_SLIDESHOW);
 
   return ACK;
 }


### PR DESCRIPTION
When you successfully start a picture slideshow with a JSON query you won't receive a response until the slideshow has been closed. To reproduce send a query like this:

`{"params": {"item": {"path": "/path/to/pictures/"}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`

The reason being that the slideshow runs a new nested main loop and so, until it's closed, doesn't release the lock of the ThreadMessage the JSON handler is waiting at. With this patch a custom CEvent will be attached to the GUIMessage, which the slideshow class will temporarily set as a member variable to be pulsed as soon as processing of the slideshow begins. All of this takes place before the new main loop processes other messages.
A simpler fix would be to send a non-waiting GUIMessage, but then the caller would receive an ACK before the slideshow begins handling the request.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
