### PR TITLE
CAddonInstallJob: disable add-on after update, if it is marked as broken

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14783,7 +14783,10 @@ msgctxt "#24093"
 msgid "Checking %s..."
 msgstr ""
 
-#empty string with id 24094
+#: xbmc/addons/AddonInstaller.cpp
+msgctxt "#24094"
+msgid "Add-on has been marked broken in repository, so it will get disabled."
+msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
 msgctxt "#24095"

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -619,6 +619,9 @@ bool CAddonInstallJob::DoWork()
   {
     CAddonMgr::GetInstance().DisableAddon(m_addon->ID());
     CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: disabled because addon is marked as broken", m_addon->ID().c_str());
+    CEventLog::GetInstance().Add(
+      EventPtr(new CAddonManagementEvent(m_addon, 24094)),
+      !IsModal() && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS), false);
     return false;
   }
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -615,6 +615,13 @@ bool CAddonInstallJob::DoWork()
       database.SetLastUpdated(m_addon->ID(), CDateTime::GetCurrentDateTime());
   }
 
+  if (!m_addon->Broken().empty())
+  {
+    CAddonMgr::GetInstance().DisableAddon(m_addon->ID());
+    CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: disabled because addon is marked as broken", m_addon->ID().c_str());
+    return false;
+  }
+
   CEventLog::GetInstance().Add(
     EventPtr(new CAddonManagementEvent(m_addon, m_update ? 24065 : 24064)),
     !IsModal() && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS), false);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Disable broken add-ons after update.
<!--- Describe your change in detail -->

## Motivation and Context
Add-ons which are marked as broken can't be installed, but they don't get disabled if they were already installed before getting marked as broken.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Runtime tested
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
