### PR TITLE
[PVR] Fix trac17246 - another approach

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10619,13 +10619,13 @@ msgctxt "#19285"
 msgid "Browse for icon"
 msgstr ""
 
-#. unused?
+#. Label for channel icon search progress dialog
+#: xbmc/pvr/channels/PVRChannelGroup.cpp
 msgctxt "#19286"
 msgid "Searching for channel icons"
 msgstr ""
 
 #. Label for the default pvr channel group
-#: xbmc/pvr/channels/PVRChannelGroup.cpp
 #: xbmc/pvr/channels/PVRChannelGroupInternal.cpp
 msgctxt "#19287"
 msgid "All channels"

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -160,7 +160,8 @@ CPVRManager::CPVRManager(void) :
     m_bFirstStart(true),
     m_bIsSwitchingChannels(false),
     m_bEpgsCreated(false),
-    m_progressHandle(NULL),
+    m_progressBar(nullptr),
+    m_progressHandle(nullptr),
     m_managerState(ManagerStateStopped),
     m_isChannelPreview(false)
 {
@@ -376,6 +377,14 @@ void CPVRManager::Init()
   settingSet.insert(CSettings::SETTING_EPG_DAYSTODISPLAY);
   settingSet.insert(CSettings::SETTING_PVRPARENTAL_ENABLED);
   CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
+
+  // Note: we're holding the progress bar dialog instance pointer in a member because it is needed by pvr core
+  //       components. The latter might run in a different thread than the gui and g_windowManager.GetWindow()
+  //       locks the global graphics mutex, which easily can lead to deadlocks.
+  m_progressBar = dynamic_cast<CGUIDialogExtendedProgressBar *>(g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS));
+
+  if (!m_progressBar)
+    CLog::Log(LOGERROR, "CPVRManager - %s - unable to get WINDOW_DIALOG_EXT_PROGRESS!", __FUNCTION__);
 
   // initial check for enabled addons
   // if at least one pvr addon is enabled, PVRManager start up
@@ -691,14 +700,14 @@ bool CPVRManager::Load(bool bShowProgress)
 
 void CPVRManager::ShowProgressDialog(const std::string &strText, int iProgress)
 {
-  if (!m_progressHandle)
-  {
-    CGUIDialogExtendedProgressBar *loadingProgressDialog = (CGUIDialogExtendedProgressBar *)g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS);
-    m_progressHandle = loadingProgressDialog->GetHandle(g_localizeStrings.Get(19235)); // PVR manager is starting up
-  }
+  if (!m_progressHandle && m_progressBar)
+    m_progressHandle = m_progressBar->GetHandle(g_localizeStrings.Get(19235)); // PVR manager is starting up
 
-  m_progressHandle->SetPercentage((float)iProgress);
-  m_progressHandle->SetText(strText);
+  if (m_progressHandle)
+  {
+    m_progressHandle->SetPercentage(static_cast<float>(iProgress));
+    m_progressHandle->SetText(strText);
+  }
 }
 
 void CPVRManager::HideProgressDialog(void)
@@ -708,6 +717,14 @@ void CPVRManager::HideProgressDialog(void)
     m_progressHandle->MarkFinished();
     m_progressHandle = NULL;
   }
+}
+
+CGUIDialogProgressBarHandle* CPVRManager::ShowProgressDialog(const std::string &strTitle) const
+{
+  if (m_progressBar)
+    return m_progressBar->GetHandle(strTitle);
+
+  return nullptr;
 }
 
 bool CPVRManager::ChannelSwitchById(unsigned int iChannelId)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <vector>
 
+class CGUIDialogExtendedProgressBar;
 class CGUIDialogProgressBarHandle;
 class CStopWatch;
 class CAction;
@@ -603,6 +604,13 @@ namespace PVR
      */
     void PublishEvent(PVREvent state);
 
+    /*!
+     * @brief Show an extended progress bar dialog.
+     * @param strTitle the title for the dialog.
+     * @return the handle that can be used to control the progress dialog.
+     */
+    CGUIDialogProgressBarHandle* ShowProgressDialog(const std::string &strTitle) const;
+
   protected:
     /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
@@ -695,6 +703,7 @@ namespace PVR
     bool                            m_bFirstStart;                 /*!< true when the PVR manager was started first, false otherwise */
     bool                            m_bIsSwitchingChannels;        /*!< true while switching channels */
     bool                            m_bEpgsCreated;                /*!< true if epg data for channels has been created */
+    CGUIDialogExtendedProgressBar * m_progressBar;                 /*!< extended progress dialog instance pointer */
     CGUIDialogProgressBarHandle *   m_progressHandle;              /*!< progress dialog that is displayed while the pvrmanager is loading */
 
     CCriticalSection                m_managerStateMutex;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -272,10 +272,6 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
   if (iconPath.empty())
     return;
 
-  const CPVRDatabasePtr database(g_PVRManager.GetTVDatabase());
-  if (!database)
-    return;
-
   /* fetch files in icon path for fast lookup */
   CFileItemList fileItemList;
   XFILE::CDirectory::GetDirectory(iconPath, fileItemList, ".jpg|.png|.tbn");

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -28,7 +28,6 @@
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "epg/EpgContainer.h"
 #include "filesystem/Directory.h"
-#include "guilib/GUIWindowManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -279,8 +278,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
   if (fileItemList.IsEmpty())
     return;
 
-  CGUIDialogExtendedProgressBar* dlgProgress = (CGUIDialogExtendedProgressBar*)g_windowManager.GetWindow(WINDOW_DIALOG_EXT_PROGRESS);
-  CGUIDialogProgressBarHandle* dlgProgressHandle = dlgProgress ? dlgProgress->GetHandle(g_localizeStrings.Get(19287)) : NULL;
+  CGUIDialogProgressBarHandle* dlgProgressHandle = g_PVRManager.ShowProgressDialog(g_localizeStrings.Get(19287));
 
   CSingleLock lock(m_critSection);
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -278,7 +278,7 @@ void CPVRChannelGroup::SearchAndSetChannelIcons(bool bUpdateDb /* = false */)
   if (fileItemList.IsEmpty())
     return;
 
-  CGUIDialogProgressBarHandle* dlgProgressHandle = g_PVRManager.ShowProgressDialog(g_localizeStrings.Get(19287));
+  CGUIDialogProgressBarHandle* dlgProgressHandle = g_PVRManager.ShowProgressDialog(g_localizeStrings.Get(19286)); // Searching for channel icons
 
   CSingleLock lock(m_critSection);
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -540,18 +540,4 @@ namespace PVR
   private:
     CPVRChannelGroupPtr m_group;
   };
-
-  class CPVRSearchAndSetChannelIcons : public CJob
-  {
-  public:
-    CPVRSearchAndSetChannelIcons(const PVR_CHANNEL_GROUP_MEMBERS &groupMembers, bool bUpdateDb)
-    : m_groupMembers(groupMembers), m_bUpdateDb(bUpdateDb) {}
-    virtual ~CPVRSearchAndSetChannelIcons() {}
-    virtual const char *GetType() const { return "pvr-channelgroup-searchandsetchannelicons"; }
-
-    virtual bool DoWork();
-  private:
-    PVR_CHANNEL_GROUP_MEMBERS m_groupMembers;
-    const bool m_bUpdateDb;
-  };
 }


### PR DESCRIPTION
This is a fix for trac 17246: http://trac.kodi.tv/ticket/17246

Completely new approach this time, which should no longer lead to crashes the previous approach has caused. ;-)

The gist of the fix is to obtain and remember the pointer to the extended progress bar dialog instance early (PVR Manager init), avoiding the deadly <code>g_WindowManager.GetWindow()</code> call.

I discovered other scenarios which could lead to the same deadlock (in <code>CPVRMananger::ShowProgressDialog(string,int)</code>)which are are also fixed now.

The stack trace of one of the possible deadlocks:
![kodi-frozen](https://cloud.githubusercontent.com/assets/3226626/22620341/2c48227c-eb0a-11e6-8b42-0fe1ad2d4b2f.png)

@Jalle19 for review?