### PR TITLE
Fix analog sticks

### DIFF
--- a/xbmc/input/joysticks/DriverPrimitive.cpp
+++ b/xbmc/input/joysticks/DriverPrimitive.cpp
@@ -146,7 +146,7 @@ bool CDriverPrimitive::IsValid(void) const
     }
     case 0:
     {
-      if (m_semiAxisDirection != SEMIAXIS_DIRECTION::POSITIVE ||
+      if (m_semiAxisDirection != SEMIAXIS_DIRECTION::POSITIVE &&
           m_semiAxisDirection != SEMIAXIS_DIRECTION::NEGATIVE)
         return false;
       break;

--- a/xbmc/input/joysticks/IButtonMap.h
+++ b/xbmc/input/joysticks/IButtonMap.h
@@ -226,6 +226,17 @@ namespace JOYSTICK
     virtual bool IsIgnored(const CDriverPrimitive& primitive) = 0;
 
     /*!
+     * \brief Get the properties of an axis
+     *
+     * \param axisIndex The index of the axis to check
+     * \param center[out] The center, if known
+     * \param range[out] The range, if known
+     *
+     * \return True if the properties are known, false otherwise
+     */
+    virtual bool GetAxisProperties(unsigned int axisIndex, int& center, unsigned int& range) = 0;
+
+    /*!
      * \brief Save the button map
      */
     virtual void SaveButtonMap() = 0;

--- a/xbmc/input/joysticks/IDriverHandler.h
+++ b/xbmc/input/joysticks/IDriverHandler.h
@@ -60,10 +60,12 @@ namespace JOYSTICK
      *
      * \param axisIndex   The index of the axis as reported by the driver
      * \param position    The position of the axis in the closed interval [-1.0, 1.0]
+     * \param center      The center point of the axis (either -1, 0 or 1)
+     * \param range       The maximum distance the axis can move (either 1 or 2)
      *
      * \return True if the motion was handled, false otherwise
      */
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) = 0;
+    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) = 0;
 
     /*!
      * \brief Handle buffered axis positions for features that require multiple axes

--- a/xbmc/input/joysticks/JoystickMonitor.cpp
+++ b/xbmc/input/joysticks/JoystickMonitor.cpp
@@ -46,7 +46,7 @@ bool CJoystickMonitor::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   return false;
 }
 
-bool CJoystickMonitor::OnAxisMotion(unsigned int axisIndex, float position)
+bool CJoystickMonitor::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
   if (position)
   {

--- a/xbmc/input/joysticks/JoystickMonitor.h
+++ b/xbmc/input/joysticks/JoystickMonitor.h
@@ -34,7 +34,7 @@ namespace JOYSTICK
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
     virtual bool OnHatMotion(unsigned int hatIndex, HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
+    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
     virtual void ProcessAxisMotions(void) override { }
 
   private:

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -325,7 +325,7 @@ bool CButtonMapping::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   return GetHat(hatIndex).OnMotion(state);
 }
 
-bool CButtonMapping::OnAxisMotion(unsigned int axisIndex, float position)
+bool CButtonMapping::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
   return GetAxis(axisIndex).OnMotion(position);
 }

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -93,55 +93,25 @@ CAxisDetector::CAxisDetector(CButtonMapping* buttonMapping, unsigned int axisInd
   m_config(config),
   m_state(AXIS_STATE::INACTIVE),
   m_type(AXIS_TYPE::UNKNOWN),
-  m_bContinuous(false),
   m_initialPositionKnown(false),
   m_initialPosition(0.0f),
   m_initialPositionChanged(false),
-  m_bDiscreteDpadMapped(false),
   m_activationTimeMs(0)
 {
 }
 
 bool CAxisDetector::OnMotion(float position)
 {
-  if (m_type == AXIS_TYPE::UNKNOWN)
-  {
-    if (m_config.bKnown)
-    {
-      if (m_config.center == 0)
-        m_type = AXIS_TYPE::NORMAL;
-      else
-        m_type = AXIS_TYPE::OFFSET;
-    }
-    else
-    {
-      DetectType(position);
-    }
-  }
+  DetectType(position);
 
   if (m_type != AXIS_TYPE::UNKNOWN)
   {
-    // Update range if a range of > 1 is observed
-    if (std::abs(position - m_config.center) > 1.0f)
-      m_config.range = 2;
-
     // Update position if this axis is an anomalous trigger
     if (m_type == AXIS_TYPE::OFFSET)
       position = (position - m_config.center) / m_config.range;
 
-    // We must observe two integer values to detect a discrete D-pad. In this
-    // case, the first value is the one that should be mapped. We only need to
-    // do this once.
-    if (!m_bContinuous && !m_bDiscreteDpadMapped)
-    {
-      if (m_initialPosition != 0.0f)
-        position = m_initialPosition;
-
-      m_bDiscreteDpadMapped = true; // position must be non-zero
-    }
-
     // Reset state if position crosses zero
-    if (m_state != AXIS_STATE::INACTIVE)
+    if (m_state == AXIS_STATE::MAPPED)
     {
       SEMIAXIS_DIRECTION activatedDir = m_activatedPrimitive.SemiAxisDirection();
       SEMIAXIS_DIRECTION newDir = CJoystickTranslator::PositionToSemiAxisDirection(position);
@@ -196,9 +166,7 @@ void CAxisDetector::ProcessMotion()
       // Map primitive
       if (!m_buttonMapping->MapPrimitive(m_activatedPrimitive))
       {
-        if (!m_bContinuous)
-          CLog::Log(LOGDEBUG, "Mapping discrete D-pad on axis %u failed", m_axisIndex);
-        else if (m_type == AXIS_TYPE::OFFSET)
+        if (m_type == AXIS_TYPE::OFFSET)
           CLog::Log(LOGDEBUG, "Mapping offset axis %u failed", m_axisIndex);
         else
           CLog::Log(LOGDEBUG, "Mapping normal axis %u failed", m_axisIndex);
@@ -209,27 +177,31 @@ void CAxisDetector::ProcessMotion()
   }
 }
 
+void CAxisDetector::SetEmitted(const CDriverPrimitive& activePrimitive)
+{
+  m_state = AXIS_STATE::MAPPED;
+  m_activatedPrimitive = activePrimitive;
+}
+
 void CAxisDetector::DetectType(float position)
 {
-  // Calculate center based on initial position.
-  //
-  // The idea behind this is that "initial perturbations are minimal". This
-  // means that, assuming the timestep is small enough, that the position will
-  // only have moved a small distance from the rest state.
-  //
-  // In practice, this assumption breaks for fast movements, especially on OSX
-  // where events are asynchronous and occur at larger timesteps. There's
-  // nothing we can do about this, so the user will have to try again with
-  // slower motion.
-  //
-  // To differentiate discrete D-pads from anomalous triggers, we need to use a
-  // second position value. If the position jumps discretely it's a discrete
-  // D-pad, if it travels continuously then it's an anomalous trigger.
-  //
+  // Update range if a range of > 1 is observed
+  if (std::abs(position - m_config.center) > 1.0f)
+    m_config.range = 2;
 
-  // Update state
-  if (position != -1.0f && position != 0.0f && position != 1.0f)
-    m_bContinuous = true;
+  if (m_type != AXIS_TYPE::UNKNOWN)
+    return;
+
+  if (m_config.bKnown)
+  {
+    if (m_config.center == 0)
+      m_type = AXIS_TYPE::NORMAL;
+    else
+      m_type = AXIS_TYPE::OFFSET;
+  }
+
+  if (m_type != AXIS_TYPE::UNKNOWN)
+    return;
 
   if (!m_initialPositionKnown)
   {
@@ -237,19 +209,19 @@ void CAxisDetector::DetectType(float position)
     m_initialPosition = position;
   }
 
-  if (!m_initialPositionChanged && position != m_initialPosition)
+  if (position != m_initialPosition)
     m_initialPositionChanged = true;
 
-  // Apply conditions for type detection
-  if (m_bContinuous)
+  if (m_initialPositionChanged)
   {
-    if (position < -0.5f)
+    // Calculate center based on initial position.
+    if (m_initialPosition < -0.5f)
     {
       m_config.center = -1;
       m_type = AXIS_TYPE::OFFSET;
       CLog::Log(LOGDEBUG, "Anomalous trigger detected on axis %u with center %d", m_axisIndex, m_config.center);
     }
-    else if (position > 0.5f)
+    else if (m_initialPosition > 0.5f)
     {
       m_config.center = 1;
       m_type = AXIS_TYPE::OFFSET;
@@ -258,15 +230,7 @@ void CAxisDetector::DetectType(float position)
     else
     {
       m_type = AXIS_TYPE::NORMAL;
-    }
-  }
-  else
-  {
-    // Detect a discrete D-pad when two discrete values have been observed
-    if (m_initialPositionChanged)
-    {
-      m_type = AXIS_TYPE::NORMAL; // Axis is a discrete D-pad
-      CLog::Log(LOGDEBUG, "Discrete D-pad detected on axis %u", m_axisIndex);
+      CLog::Log(LOGDEBUG, "Normal axis detected on axis %u", m_axisIndex);
     }
   }
 }
@@ -310,7 +274,7 @@ CButtonMapping::CButtonMapping(IButtonMapper* buttonMapper, IButtonMap* buttonMa
       axisConfig.center = primitive.Center();
       axisConfig.range = primitive.Range();
 
-      GetAxis(primitive.Index(), axisConfig).SetEmitted();
+      GetAxis(primitive.Index(), axisConfig).SetEmitted(primitive);
     }
   }
 }

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -113,7 +113,7 @@ namespace JOYSTICK
      * mapping begins. This function is used to indicate that the axis shouldn't
      * be mapped until after it crosses zero again.
      */
-    void SetEmitted() { m_state = AXIS_STATE::MAPPED; }
+    void SetEmitted(const CDriverPrimitive& activePrimitive);
 
   private:
     enum class AXIS_STATE
@@ -178,11 +178,9 @@ namespace JOYSTICK
     AXIS_STATE m_state;
     CDriverPrimitive m_activatedPrimitive;
     AXIS_TYPE m_type;
-    bool m_bContinuous; // false until a non-integer value is observed
     bool m_initialPositionKnown; // set to true on first motion
     float m_initialPosition; // set to position of first motion
     bool m_initialPositionChanged; // set to true when position differs from the initial position
-    bool m_bDiscreteDpadMapped; // set to true when a discrete D-pad axis has been mapped
     unsigned int m_activationTimeMs; // only used to delay anomalous trigger mapping to detect full range
   };
 

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -218,7 +218,7 @@ namespace JOYSTICK
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
     virtual bool OnHatMotion(unsigned int hatIndex, HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
+    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
     virtual void ProcessAxisMotions(void) override;
 
     // implementation of IButtonMapCallback

--- a/xbmc/input/joysticks/generic/InputHandling.cpp
+++ b/xbmc/input/joysticks/generic/InputHandling.cpp
@@ -59,43 +59,26 @@ bool CInputHandling::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   return bHandled;
 }
 
-bool CInputHandling::OnAxisMotion(unsigned int axisIndex, float position)
+bool CInputHandling::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
   bool bHandled = false;
 
-  // Check for anomalous triggers that have an offset (non-zero) rest position
-  const std::array<int, 2> centers = { { -1, 1 } };
-  const std::array<unsigned int, 2> ranges = { { 1, 2 } };
-  for (auto center : centers)
+  if (center != 0)
   {
-    for (auto range : ranges)
-    {
-      float magnitude = std::abs(position - center) / range;
+    float translatedPostion = std::min((position - center) / range, 1.0f);
 
-      if (magnitude > 1.0f)
-        magnitude = 1.0f;
+    // Calculate the direction the trigger travels from the center point
+    SEMIAXIS_DIRECTION dir;
+    if (center > 0)
+      dir = SEMIAXIS_DIRECTION::NEGATIVE;
+    else
+      dir = SEMIAXIS_DIRECTION::POSITIVE;
 
-      // Calculate the direction the trigger travels from the center point
-      SEMIAXIS_DIRECTION dir;
-      if (center > 0)
-        dir = SEMIAXIS_DIRECTION::NEGATIVE;
-      else
-        dir = SEMIAXIS_DIRECTION::POSITIVE;
+    CDriverPrimitive offsetSemiaxis(axisIndex, center, dir, range);
 
-      CDriverPrimitive offsetSemiaxis(axisIndex, center, dir, range);
-
-      if (OnAnalogMotion(offsetSemiaxis, magnitude))
-      {
-        bHandled = true;
-        break;
-      }
-    }
-
-    if (bHandled)
-      break;
+    bHandled = OnAnalogMotion(offsetSemiaxis, translatedPostion);
   }
-
-  if (!bHandled)
+  else
   {
     CDriverPrimitive positiveSemiaxis(axisIndex, 0, SEMIAXIS_DIRECTION::POSITIVE, 1);
     CDriverPrimitive negativeSemiaxis(axisIndex, 0, SEMIAXIS_DIRECTION::NEGATIVE, 1);

--- a/xbmc/input/joysticks/generic/InputHandling.h
+++ b/xbmc/input/joysticks/generic/InputHandling.h
@@ -55,7 +55,7 @@ namespace JOYSTICK
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
     virtual bool OnHatMotion(unsigned int hatIndex, HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
+    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
     virtual void ProcessAxisMotions(void) override;
 
   private:

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -268,6 +268,28 @@ bool CAddonButtonMap::IsIgnored(const JOYSTICK::CDriverPrimitive& primitive)
   return std::find(m_ignoredPrimitives.begin(), m_ignoredPrimitives.end(), primitive) != m_ignoredPrimitives.end();
 }
 
+bool CAddonButtonMap::GetAxisProperties(unsigned int axisIndex, int& center, unsigned int& range)
+{
+  CSingleLock lock(m_mutex);
+
+  for (auto it : m_driverMap)
+  {
+    const CDriverPrimitive& primitive = it.first;
+
+    if (primitive.Type() != PRIMITIVE_TYPE::SEMIAXIS)
+      continue;
+
+    if (primitive.Index() != axisIndex)
+      continue;
+
+    center = primitive.Center();
+    range = primitive.Range();
+    return true;
+  }
+
+  return false;
+}
+
 void CAddonButtonMap::SaveButtonMap()
 {
   if (auto addon = m_addon.lock())

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -98,6 +98,8 @@ namespace PERIPHERALS
 
     virtual bool IsIgnored(const JOYSTICK::CDriverPrimitive& primitive) override;
 
+    virtual bool GetAxisProperties(unsigned int axisIndex, int& center, unsigned int& range) override;
+
     virtual void SaveButtonMap() override;
 
     virtual void RevertButtonMap() override;

--- a/xbmc/peripherals/addons/AddonButtonMapping.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMapping.cpp
@@ -73,10 +73,10 @@ bool CAddonButtonMapping::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   return false;
 }
 
-bool CAddonButtonMapping::OnAxisMotion(unsigned int axisIndex, float position)
+bool CAddonButtonMapping::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
   if (m_buttonMapping)
-    return m_buttonMapping->OnAxisMotion(axisIndex, position);
+    return m_buttonMapping->OnAxisMotion(axisIndex, position, center, range);
 
   return false;
 }

--- a/xbmc/peripherals/addons/AddonButtonMapping.h
+++ b/xbmc/peripherals/addons/AddonButtonMapping.h
@@ -46,7 +46,7 @@ namespace PERIPHERALS
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
     virtual bool OnHatMotion(unsigned int hatIndex, JOYSTICK::HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
+    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
     virtual void ProcessAxisMotions(void) override;
 
     // implementation of IButtonMapCallback

--- a/xbmc/peripherals/addons/AddonInputHandling.cpp
+++ b/xbmc/peripherals/addons/AddonInputHandling.cpp
@@ -84,10 +84,10 @@ bool CAddonInputHandling::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   return false;
 }
 
-bool CAddonInputHandling::OnAxisMotion(unsigned int axisIndex, float position)
+bool CAddonInputHandling::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
 {
   if (m_driverHandler)
-    return m_driverHandler->OnAxisMotion(axisIndex, position);
+    return m_driverHandler->OnAxisMotion(axisIndex, position, center, range);
 
   return false;
 }

--- a/xbmc/peripherals/addons/AddonInputHandling.h
+++ b/xbmc/peripherals/addons/AddonInputHandling.h
@@ -46,7 +46,7 @@ namespace PERIPHERALS
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
     virtual bool OnHatMotion(unsigned int hatIndex, JOYSTICK::HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
+    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
     virtual void ProcessAxisMotions(void) override;
 
     // implementation of IInputReceiver

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -218,17 +218,23 @@ bool CPeripheralJoystick::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
 
 bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
 {
-  CSingleLock lock(m_handlerMutex);
+  // Get axis properties
+  int center = 0;
+  unsigned int range = 1;
+  if (m_buttonMap)
+    m_buttonMap->GetAxisProperties(axisIndex, center, range);
 
   // Apply deadzone filtering
-  if (m_deadzoneFilter)
+  if (center == 0 && m_deadzoneFilter)
     position = m_deadzoneFilter->FilterAxis(axisIndex, position);
+
+  CSingleLock lock(m_handlerMutex);
 
   // Process promiscuous handlers
   for (std::vector<DriverHandler>::iterator it = m_driverHandlers.begin(); it != m_driverHandlers.end(); ++it)
   {
     if (it->bPromiscuous)
-      it->handler->OnAxisMotion(axisIndex, position);
+      it->handler->OnAxisMotion(axisIndex, position, center, range);
   }
 
   bool bHandled = false;
@@ -238,17 +244,11 @@ bool CPeripheralJoystick::OnAxisMotion(unsigned int axisIndex, float position)
   {
     if (!it->bPromiscuous)
     {
-      bHandled |= it->handler->OnAxisMotion(axisIndex, position);
+      bHandled |= it->handler->OnAxisMotion(axisIndex, position, center, range);
 
       // If axis is centered, force bHandled to false to notify all handlers.
       // This avoids "sticking".
-      //
-      //! @todo This fails for anomalous triggers! If a trigger travels from -1
-      // to +1, then at 0.0 the input will fall through to the next handler.
-      // And the next handler will get stuck, because it won't receive any more
-      // updates until the first handler is unregistered! We need to translate
-      // the position inside this class before calling OnAxisMotion().
-      if (position == 0.0f)
+      if (position == static_cast<float>(center))
         bHandled = false;
 
       // Once an axis is handled, we're done

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -21,7 +21,6 @@
 
 #include "Peripheral.h"
 #include "input/joysticks/DefaultJoystick.h"
-#include "input/joysticks/IDriverHandler.h"
 #include "input/joysticks/IDriverReceiver.h"
 #include "input/joysticks/JoystickMonitor.h"
 #include "input/joysticks/JoystickTypes.h"
@@ -37,12 +36,12 @@ namespace JOYSTICK
 {
   class CDeadzoneFilter;
   class IButtonMap;
+  class IDriverHandler;
 }
 
 namespace PERIPHERALS
 {
   class CPeripheralJoystick : public CPeripheral, //! @todo extend CPeripheralHID
-                              public JOYSTICK::IDriverHandler,
                               public JOYSTICK::IDriverReceiver
   {
   public:
@@ -54,16 +53,15 @@ namespace PERIPHERALS
     virtual bool InitialiseFeature(const PeripheralFeature feature) override;
     virtual void OnUserNotification() override;
     virtual bool TestFeature(PeripheralFeature feature) override;
-    virtual void RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous) override;
-    virtual void UnregisterJoystickDriverHandler(IDriverHandler* handler) override;
+    virtual void RegisterJoystickDriverHandler(JOYSTICK::IDriverHandler* handler, bool bPromiscuous) override;
+    virtual void UnregisterJoystickDriverHandler(JOYSTICK::IDriverHandler* handler) override;
     virtual JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }
     virtual JOYSTICK::IActionMap* GetActionMap() override { return &m_defaultInputHandler; }
 
-    // implementation of IDriverHandler
-    virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
-    virtual bool OnHatMotion(unsigned int hatIndex, JOYSTICK::HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position) override;
-    virtual void ProcessAxisMotions(void) override;
+    bool OnButtonMotion(unsigned int buttonIndex, bool bPressed);
+    bool OnHatMotion(unsigned int hatIndex, JOYSTICK::HAT_STATE state);
+    bool OnAxisMotion(unsigned int axisIndex, float position);
+    void ProcessAxisMotions(void);
 
     // implementation of IDriverReceiver
     virtual bool SetMotorState(unsigned int motorIndex, float magnitude) override;


### PR DESCRIPTION
The first fix is for a logic error in #11571 that breaks analog sticks.

Also included is a fix for an edge case documented in bd6697b.

Another two fixes have been PRed to https://github.com/xbmc/peripheral.joystick/pull/84