### PR TITLE
highlight programinfo instead of channelname

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelsOSD.xml
@@ -62,7 +62,7 @@
 							<width>600</width>
 							<aligny>top</aligny>
 							<animation effect="slide" start="0,0" end="0,18" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
-							<label>$INFO[ListItem.Label]</label>
+							<label>$INFO[ListItem.Title]</label>
 							<font>font14</font>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
@@ -73,7 +73,7 @@
 							<width>580</width>
 							<aligny>top</aligny>
 							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
+							<label>$INFO[ListItem.Label]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 						<control type="label">
@@ -118,7 +118,7 @@
 							<height>90</height>
 							<width>640</width>
 							<aligny>top</aligny>
-							<label>$INFO[ListItem.Label]</label>
+							<label>$INFO[ListItem.Title]</label>
 							<font>font14</font>
 							<animation effect="slide" start="0,0" end="0,18" time="0" condition="String.IsEmpty(ListItem.Title)">Conditional</animation>
 							<shadowcolor>text_shadow</shadowcolor>
@@ -130,7 +130,7 @@
 							<width>580</width>
 							<aligny>top</aligny>
 							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
+							<label>$INFO[ListItem.Label]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 							<textcolor>grey</textcolor>
 						</control>

--- a/addons/skin.estuary/xml/MyPVRChannels.xml
+++ b/addons/skin.estuary/xml/MyPVRChannels.xml
@@ -67,7 +67,7 @@
 							<aligny>top</aligny>
 							<font>font14</font>
 							<animation effect="slide" start="0,0" end="0,18" time="0">Conditional</animation>
-							<label>$INFO[ListItem.Label]</label>
+							<label>$INFO[ListItem.Title]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 						<control type="label">
@@ -77,7 +77,7 @@
 							<right>120</right>
 							<aligny>top</aligny>
 							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
+							<label>$INFO[ListItem.Label]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 						<control type="label">
@@ -124,7 +124,7 @@
 							<right>120</right>
 							<aligny>top</aligny>
 							<font>font14</font>
-							<label>$INFO[ListItem.Label]</label>
+							<label>$INFO[ListItem.Title]</label>
 							<animation effect="slide" start="0,0" end="0,18" time="0">Conditional</animation>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
@@ -135,7 +135,7 @@
 							<right>120</right>
 							<aligny>top</aligny>
 							<font>font12</font>
-							<label>$INFO[ListItem.Title]</label>
+							<label>$INFO[ListItem.Label]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 							<textcolor>grey</textcolor>
 						</control>


### PR DESCRIPTION
Highlight programinfo instead of channelname

## Description
In the channellist the programinfo is the more important information compared to the channelname. So the programinfo should be at the top and use the big font.

## Motivation and Context
Better overview in channellist.

## How Has This Been Tested?
Tested in current krypton release

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
