### PR TITLE
jemalloc depend build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if(UNIX)
     option(ENABLE_X11         "Enable X11 support?" ON)
     option(ENABLE_AML         "Enable AML?" OFF)
     option(ENABLE_IMX         "Enable IMX?" OFF)
+    option(ENABLE_JEMALLOC    "Enable JEMALLOC?" OFF)
   endif()
 endif()
 # System options
@@ -115,7 +116,7 @@ if(CORE_SYSTEM_NAME STREQUAL android)
 endif()
 
 # Optional dependencies
-set(optional_deps MicroHttpd MySqlClient SSH XSLT
+set(optional_deps MicroHttpd MySqlClient SSH XSLT JEMALLOC
                   Alsa UDEV DBus Avahi MDNS SmbClient CCache
                   PulseAudio VDPAU VAAPI Bluetooth CAP Python)
 

--- a/cmake/cpack/deb/packages/kodi.txt.in
+++ b/cmake/cpack/deb/packages/kodi.txt.in
@@ -16,7 +16,7 @@ PACKAGE_SECTION video
 PACKAGE_PRIORITY optional
 PACKAGE_SHLIBDEPS
 PACKAGE_DEPENDS @APP_NAME_LC@-bin (>= @CPACK_DEBIAN_PACKAGE_VERSION@), @APP_NAME_LC@-bin (<< @CPACK_DEBIAN_PACKAGE_VERSION@.1~), curl, libcurl3, mesa-utils, x11-utils, fonts-liberation | ttf-liberation, fonts-dejavu-core | ttf-dejavu-core, python-bluez | python-lightblue, python-imaging, python-simplejson, libass5 | libass4, libgif5 | libgif7, libssh-4 | libssh2-1, libnfs8 | libnfs4 | libnfs1, libbluray1, libshairplay0, libvorbisfile3, libaacs0, libcec4, libgnutls30 | libgnutls-deb0-28 | libgnutls28 | libgnutls26, libxslt1.1, libyajl2
-PACKAGE_RECOMMENDS libvdpau1, libva-intel-vaapi-driver, libva1
+PACKAGE_RECOMMENDS libvdpau1, libva-intel-vaapi-driver, libva1, libjemalloc-dev
 PACKAGE_SUGGESTS @APP_NAME_LC@-pvr-mythtv, @APP_NAME_LC@-pvr-vuplus, @APP_NAME_LC@-pvr-vdr-vnsi, @APP_NAME_LC@-pvr-njoy, @APP_NAME_LC@-pvr-nextpvr, @APP_NAME_LC@-pvr-mediaportal-tvserver, @APP_NAME_LC@-pvr-tvheadend-hts, @APP_NAME_LC@-pvr-dvbviewer, @APP_NAME_LC@-pvr-argustv, @APP_NAME_LC@-pvr-iptvsimple, @APP_NAME_LC@-audioencoder-vorbis, @APP_NAME_LC@-audioencoder-flac, @APP_NAME_LC@-audioencoder-lame
 PACKAGE_BREAKS xbmc (<< 2:14.0~git20141019), xbmc-data, xbmc-standalone
 PACKAGE_REPLACES xbmc (<< 2:14.0~git20141019), xbmc-data, xbmc-standalone

--- a/cmake/modules/FindJEMALLOC.cmake
+++ b/cmake/modules/FindJEMALLOC.cmake
@@ -1,0 +1,44 @@
+#.rst:
+# FindJEMALLOC
+# -------
+# Finds the JEMALLOC library
+#
+# This will will define the following variables::
+#
+# JEMALLOC_FOUND - system has JEMALLOC
+# JEMALLOC_INCLUDE_DIRS - the JEMALLOC include directory
+# JEMALLOC_LIBRARIES - the JEMALLOC libraries
+#
+# and the following imported targets::
+#
+#   JEMALLOC::JEMALLOC   - The JEMALLOC library
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_JEMALLOC libjemalloc QUIET)
+endif()
+
+find_path(JEMALLOC_INCLUDE_DIR NAMES jemalloc/jemalloc.h
+                          PATHS ${PC_JEMALLOC_INCLUDEDIR})
+find_library(JEMALLOC_LIBRARY NAMES jemalloc_pic libjemalloc_pic
+                         PATHS ${PC_JEMALLOC_LIBDIR})
+
+set(JEMALLOC_VERSION ${PC_JEMALLOC_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(JEMALLOC
+                                  REQUIRED_VARS JEMALLOC_LIBRARY JEMALLOC_INCLUDE_DIR
+                                  VERSION_VAR JEMALLOC_VERSION)
+
+if(JEMALLOC_FOUND)
+  set(JEMALLOC_LIBRARIES ${JEMALLOC_LIBRARY})
+  set(JEMALLOC_INCLUDE_DIRS ${JEMALLOC_INCLUDE_DIR})
+
+  if(NOT TARGET JEMALLOC::JEMALLOC)
+    add_library(JEMALLOC::JEMALLOC UNKNOWN IMPORTED)
+    set_target_properties(JEMALLOC::JEMALLOC PROPERTIES
+                                   IMPORTED_LOCATION "${JEMALLOC_LIBRARY}"
+                                   INTERFACE_INCLUDE_DIRECTORIES "${JEMALLOC_INCLUDE_DIR}")
+  endif()
+endif()
+
+mark_as_advanced(JEMALLOC_INCLUDE_DIR JEMALLOC_LIBRARY)

--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -44,3 +44,7 @@ endif()
 if(ENABLE_MIR)
   set(ENABLE_VDPAU OFF CACHE BOOL "Disabling VDPAU since no Mir support" FORCE)
 endif()
+
+if(CPU MATCHES 64 AND (NOT (DEFINED ENABLE_JEMALLOC) ) )
+  set(ENABLE_JEMALLOC ON CACHE BOOL "Enable jmalloc allocator for 64-bit linux builds" FORCE)
+endif()

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -25,7 +25,7 @@ ifeq ($(CROSS_COMPILING), yes)
   ffmpg_config += --arch=$(CPU) --enable-cross-compile
 endif
 ifeq ($(OS), linux)
-  ffmpg_config += --target-os=$(OS) --cpu=$(CPU)
+  ffmpg_config += --target-os=$(OS)
   ffmpg_config += --enable-vdpau --enable-vaapi --enable-pic
 endif
 ifeq ($(OS), android)

--- a/tools/depends/target/libjemalloc/Makefile
+++ b/tools/depends/target/libjemalloc/Makefile
@@ -1,0 +1,44 @@
+include ../../Makefile.include
+DEPS= ../../Makefile.include Makefile
+
+# lib name, version
+LIBNAME=libjemalloc
+VERSION=3
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+
+# configuration settings
+CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
+          ./configure --prefix=$(PREFIX)
+
+LIBDYLIB=$(PLATFORM)/$(LIBNAME)/.libs/$(LIBNAME).a
+
+CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
+
+all: .installed-$(PLATFORM)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	$(info $(AUTORECONF))
+	cd $(PLATFORM); $(AUTOCONF)
+	cd $(PLATFORM); $(CONFIGURE)
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM) build_lib_static
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM) install_include
+	$(MAKE) -C $(PLATFORM) install_lib_static
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+


### PR DESCRIPTION
Use jemalloc for 64-bit linux builds

## Description
This PR links jemalloc static library to kodi wich hooks / overrides all memory functions from stdlib.
This step is necessary because linux memory allocator fails for certain situations: keyword: milhouse script with 16 threads importing a fake library with 1000 movies

## Motivation and Context
Reduce / speedup memory allocation

## How Has This Been Tested?
odroid-C2 / milhouse script / nedscotts fake library.
RES value changes from 800MB down to 90 MB

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
