### PR TITLE
Fix key length in UNIQUE INDEX idxArtist1

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -210,7 +210,7 @@ void CMusicDatabase::CreateAnalytics()
   m_pDS->exec("CREATE INDEX idxGenre ON genre(strGenre(255))");
 
   m_pDS->exec("CREATE INDEX idxArtist ON artist(strArtist(255))");
-  m_pDS->exec("CREATE UNIQUE INDEX idxArtist1 ON artist(strMusicBrainzArtistID(36))");
+  m_pDS->exec("CREATE UNIQUE INDEX idxArtist1 ON artist(strMusicBrainzArtistID(255))");
 
   m_pDS->exec("CREATE INDEX idxPath ON path(strPath(255))");
 


### PR DESCRIPTION
This patch changes the key length on the idxArtist1 index from 36 to 255 chars.

## Description

This changes a textual SQL command in xbmc/music/MusicDatabase.cpp
void CMusicDatabase::CreateAnalytics()

## Motivation and Context

The strMusicBrainzArtistID is usually a simple UUID (36 characters).
Collaborations ("feat.") are given as UUID"/"UUID (73 characters) though.

E.g.

```
The Crystal Method  aaf09f31-bb5c-43e5-9f54-bb6554c33a71
```
and
```
The Crystal Method feat. Justin Warfield  aaf09f31-bb5c-43e5-9f54-bb6554c33a71/2a5b713c-839e-4392-b344-59829ec77613
```

Creating the idxArtist1 index with just 36 characters will result in collisions.
This is especially bad when trying to upgrade the library to a newer version:

## How Has This Been Tested?

Tested with an upgrade install of Kodi 17.0 Krypton

## Screenshots (if appropriate):

```
NOTICE: Old database found - updating from version 56 to 60
[MyMusic60] Undefined MySQL error: Code (1062)
Query: CREATE UNIQUE INDEX idxArtist1 ON artist(strMusicBrainzArtistID(36))
```

(the actual error is: `ERROR 1062 (23000): Duplicate entry 'NULL' for key 'idxArtist1'`)

## Types of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
