### PR TITLE
Add dialog for delayed axis detection

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16465,16 +16465,19 @@ msgstr ""
 #empty string with id 35013
 
 #. Help text of the button to fix the bug where buttons are skipped in the controller dialog. %s - list of disabled buttons and axes
+#: xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
 msgctxt "#35014"
 msgid "Some controllers have buttons and axes that interfere with mapping. Press these now to disable them:[CR]%s"
 msgstr ""
 
-#. Name of a controller button, e.g. Button 1. %d - button index
+#. Name of a controller button, e.g. "Button 1". %d - button index
+#: xbmc/input/joysticks/JoystickTranslator.cpp
 msgctxt "#35015"
 msgid "Button %d"
 msgstr ""
 
-#. Name of a controller axis, e.g. Axis 2. %d - axis index
+#. Name of a controller axis, e.g. "Axis 2". %d - axis index
+#: xbmc/input/joysticks/JoystickTranslator.cpp
 msgctxt "#35016"
 msgid "Axis %d"
 msgstr ""
@@ -16498,7 +16501,13 @@ msgctxt "#35019"
 msgid "Ignore input"
 msgstr ""
 
-#empty strings from id 35020 to 35048
+#. Help text of the dialog to detect analog buttons on controllers. %s - list of detected axes
+#: xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+msgctxt "#35020"
+msgid "Press all analog buttons now to detect them:[CR][CR]%s"
+msgstr ""
+
+#empty strings from id 35021 to 35048
 
 #. Name of game add-ons category
 #: xbmc/addons/Addon.cpp

--- a/xbmc/games/controllers/dialogs/CMakeLists.txt
+++ b/xbmc/games/controllers/dialogs/CMakeLists.txt
@@ -1,5 +1,11 @@
-set(SOURCES GUIDialogButtonCapture.cpp)
+set(SOURCES GUIDialogAxisDetection.cpp
+            GUIDialogButtonCapture.cpp
+            GUIDialogIgnoreInput.cpp
+)
 
-set(HEADERS GUIDialogButtonCapture.h)
+set(HEADERS GUIDialogAxisDetection.h
+            GUIDialogButtonCapture.h
+            GUIDialogIgnoreInput.h
+)
 
 core_add_library(games_controller_dialogs)

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -1,0 +1,83 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIDialogAxisDetection.h"
+#include "guilib/LocalizeStrings.h"
+#include "input/joysticks/DriverPrimitive.h"
+#include "input/joysticks/IButtonMap.h"
+#include "input/joysticks/JoystickTranslator.h"
+#include "utils/StringUtils.h"
+
+#include <algorithm>
+
+using namespace KODI;
+using namespace GAME;
+
+std::string CGUIDialogAxisDetection::GetDialogText()
+{
+  // "Press all analog buttons now to detect them:[CR][CR]%s"
+  std::string dialogText = g_localizeStrings.Get(35020);
+
+  std::vector<std::string> primitives;
+
+  for (const auto& axisEntry : m_detectedAxes)
+  {
+    JOYSTICK::CDriverPrimitive axis(axisEntry.second, 0, JOYSTICK::SEMIAXIS_DIRECTION::POSITIVE, 1);
+    primitives.emplace_back(JOYSTICK::CJoystickTranslator::GetPrimitiveName(axis));
+  }
+
+  return StringUtils::Format(dialogText.c_str(), StringUtils::Join(primitives, " | ").c_str());
+}
+
+std::string CGUIDialogAxisDetection::GetDialogHeader()
+{
+  return g_localizeStrings.Get(35058); // "Controller Configuration"
+}
+
+bool CGUIDialogAxisDetection::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap,
+                                                   JOYSTICK::IActionMap* actionMap,
+                                                   const JOYSTICK::CDriverPrimitive& primitive)
+{
+  if (primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS)
+    AddAxis(buttonMap->DeviceName(), primitive.Index());
+
+  return true;
+}
+
+void CGUIDialogAxisDetection::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap, unsigned int axisIndex)
+{
+  AddAxis(buttonMap->DeviceName(), axisIndex);
+}
+
+void CGUIDialogAxisDetection::AddAxis(const std::string& deviceName, unsigned int axisIndex)
+{
+  auto it = std::find_if(m_detectedAxes.begin(), m_detectedAxes.end(),
+    [&deviceName, axisIndex](const AxisEntry& axis)
+    {
+      return axis.first == deviceName &&
+             axis.second == axisIndex;
+    });
+
+  if (it == m_detectedAxes.end())
+  {
+    m_detectedAxes.emplace_back(std::make_pair(deviceName, axisIndex));
+    m_captureEvent.Set();
+  }
+}

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "GUIDialogButtonCapture.h"
+
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace GAME
+{
+  class CGUIDialogAxisDetection : public CGUIDialogButtonCapture
+  {
+  public:
+    CGUIDialogAxisDetection() = default;
+
+    virtual ~CGUIDialogAxisDetection() = default;
+
+    // specialization of IButtonMapper via CGUIDialogButtonCapture
+    void OnLateAxis(const KODI::JOYSTICK::IButtonMap* buttonMap, unsigned int axisIndex) override;
+
+  protected:
+    // implementation of CGUIDialogButtonCapture
+    virtual std::string GetDialogText() override;
+    virtual std::string GetDialogHeader() override;
+    virtual bool MapPrimitiveInternal(KODI::JOYSTICK::IButtonMap* buttonMap,
+                                      KODI::JOYSTICK::IActionMap* actionMap,
+                                      const KODI::JOYSTICK::CDriverPrimitive& primitive) override;
+    virtual void OnClose(bool bAccepted) override { }
+
+  private:
+    void AddAxis(const std::string& deviceName, unsigned int axisIndex);
+
+    // Axis types
+    using DeviceName = std::string;
+    using AxisIndex = unsigned int;
+    using AxisEntry = std::pair<DeviceName, AxisIndex>;
+    using AxisVector = std::vector<AxisEntry>;
+
+    // Axis detection
+    AxisVector m_detectedAxes;
+  };
+}

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -21,17 +21,14 @@
 #include "GUIDialogButtonCapture.h"
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/DefaultJoystick.h"
 #include "input/joysticks/IActionMap.h"
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/IButtonMapCallback.h"
 #include "input/joysticks/JoystickUtils.h"
-#include "input/Key.h"
-#include "utils/log.h"
+#include "input/ActionIDs.h"
 #include "peripherals/Peripherals.h"
-#include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 #include <algorithm>
@@ -60,27 +57,13 @@ void CGUIDialogButtonCapture::Show()
 
     Create();
 
-    bool bAccepted = CGUIDialogOK::ShowAndGetInput(CVariant{ 35019 }, CVariant{ GetDialogText() }); // "Ignore input"
+    bool bAccepted = CGUIDialogOK::ShowAndGetInput(CVariant{ GetDialogHeader() }, CVariant{ GetDialogText() });
 
     StopThread(false);
 
     m_captureEvent.Set();
 
-    for (auto& callback : ButtonMapCallbacks())
-    {
-      if (bAccepted)
-      {
-        // See documentation of IButtonMapCallback::ResetIgnoredPrimitives()
-        // for why this call is needed
-        if (m_deviceName.empty())
-          callback.second->ResetIgnoredPrimitives();
-
-        if (m_deviceName.empty() || m_deviceName == callback.first)
-          callback.second->SaveButtonMap();
-      }
-      else
-        callback.second->RevertButtonMap();
-    }
+    OnClose(bAccepted);
 
     RemoveHooks();
   }
@@ -127,71 +110,7 @@ bool CGUIDialogButtonCapture::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
     }
   }
 
-  // Check if we have already started capturing primitives for a device
-  const bool bHasDevice = !m_deviceName.empty();
-
-  // If a primitive comes from a different device, ignore it
-  if (bHasDevice && m_deviceName != buttonMap->DeviceName())
-  {
-    CLog::Log(LOGDEBUG, "%s: ignoring input from device %s", buttonMap->ControllerID().c_str(), buttonMap->DeviceName().c_str());
-    return false;
-  }
-
-  if (!bHasDevice)
-  {
-    CLog::Log(LOGDEBUG, "%s: capturing input for device %s", buttonMap->ControllerID().c_str(), buttonMap->DeviceName().c_str());
-    m_deviceName = buttonMap->DeviceName();
-  }
-
-  if (AddPrimitive(primitive))
-  {
-    buttonMap->SetIgnoredPrimitives(m_capturedPrimitives);
-    m_captureEvent.Set();
-  }
-
-  return true;
-}
-
-bool CGUIDialogButtonCapture::AddPrimitive(const JOYSTICK::CDriverPrimitive& primitive)
-{
-  bool bValid = false;
-
-  if (primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::BUTTON ||
-      primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS)
-  {
-    auto PrimitiveMatch = [&primitive](const JOYSTICK::CDriverPrimitive& other)
-      {
-        return primitive.Type() == other.Type() &&
-               primitive.Index() == other.Index();
-      };
-
-    bValid = std::find_if(m_capturedPrimitives.begin(), m_capturedPrimitives.end(), PrimitiveMatch) == m_capturedPrimitives.end();
-  }
-
-  if (bValid)
-  {
-    m_capturedPrimitives.emplace_back(primitive);
-    return true;
-  }
-
-  return false;
-}
-
-std::string CGUIDialogButtonCapture::GetDialogText()
-{
-  // "Some controllers have buttons and axes that interfere with mapping. Press
-  // these now to disable them:[CR][CR]%s"
-  std::string dialogText = g_localizeStrings.Get(35014);
-
-  std::vector<std::string> primitives;
-
-  std::transform(m_capturedPrimitives.begin(), m_capturedPrimitives.end(), std::back_inserter(primitives),
-    [](const JOYSTICK::CDriverPrimitive& primitive)
-    {
-      return GetPrimitiveName(primitive);
-    });
-
-  return StringUtils::Format(dialogText.c_str(), StringUtils::Join(primitives, " | ").c_str());
+  return MapPrimitiveInternal(buttonMap, actionMap, primitive);
 }
 
 void CGUIDialogButtonCapture::InstallHooks(void)
@@ -225,22 +144,4 @@ void CGUIDialogButtonCapture::Notify(const Observable& obs, const ObservableMess
   default:
     break;
   }
-}
-
-std::string CGUIDialogButtonCapture::GetPrimitiveName(const JOYSTICK::CDriverPrimitive& primitive)
-{
-  std::string primitiveTemplate;
-
-  switch (primitive.Type())
-  {
-    case JOYSTICK::PRIMITIVE_TYPE::BUTTON:
-      primitiveTemplate = g_localizeStrings.Get(35015); // "Button %d"
-      break;
-    case JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS:
-      primitiveTemplate = g_localizeStrings.Get(35016); // "Axis %d"
-      break;
-    default: break;
-  }
-
-  return StringUtils::Format(primitiveTemplate.c_str(), primitive.Index());
 }

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.h
@@ -19,12 +19,12 @@
  */
 #pragma once
 
-#include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMapper.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
 #include "utils/Observer.h"
 
+#include <string>
 #include <vector>
 
 namespace GAME
@@ -35,6 +35,8 @@ namespace GAME
   {
   public:
     CGUIDialogButtonCapture();
+
+    virtual ~CGUIDialogButtonCapture() = default;
 
     // implementation of IButtonMapper
     virtual std::string ControllerID(void) const override;
@@ -50,25 +52,26 @@ namespace GAME
     // implementation of Observer
     virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
 
+    /*!
+     * \brief Show the dialog
+     */
     void Show();
 
   protected:
     // implementation of CThread
     virtual void Process() override;
 
+    virtual std::string GetDialogText() = 0;
+    virtual std::string GetDialogHeader() = 0;
+    virtual bool MapPrimitiveInternal(KODI::JOYSTICK::IButtonMap* buttonMap,
+                                      KODI::JOYSTICK::IActionMap* actionMap,
+                                      const KODI::JOYSTICK::CDriverPrimitive& primitive) = 0;
+    virtual void OnClose(bool bAccepted) = 0;
+
+    CEvent m_captureEvent;
+
   private:
-    bool AddPrimitive(const KODI::JOYSTICK::CDriverPrimitive& primitive);
-
-    std::string GetDialogText();
-
     void InstallHooks();
     void RemoveHooks();
-
-    static std::string GetPrimitiveName(const KODI::JOYSTICK::CDriverPrimitive& primitive);
-
-    // Button capture parameters
-    std::string m_deviceName;
-    std::vector<KODI::JOYSTICK::CDriverPrimitive> m_capturedPrimitives;
-    CEvent m_captureEvent;
   };
 }

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -1,0 +1,129 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIDialogIgnoreInput.h"
+#include "guilib/LocalizeStrings.h"
+#include "input/joysticks/IButtonMap.h"
+#include "input/joysticks/IButtonMapCallback.h"
+#include "input/joysticks/JoystickTranslator.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <algorithm>
+#include <iterator>
+
+using namespace KODI;
+using namespace GAME;
+
+std::string CGUIDialogIgnoreInput::GetDialogText()
+{
+  // "Some controllers have buttons and axes that interfere with mapping. Press
+  // these now to disable them:[CR]%s"
+  std::string dialogText = g_localizeStrings.Get(35014);
+
+  std::vector<std::string> primitives;
+
+  std::transform(m_capturedPrimitives.begin(), m_capturedPrimitives.end(), std::back_inserter(primitives),
+    [](const JOYSTICK::CDriverPrimitive& primitive)
+    {
+      return JOYSTICK::CJoystickTranslator::GetPrimitiveName(primitive);
+    });
+
+  return StringUtils::Format(dialogText.c_str(), StringUtils::Join(primitives, " | ").c_str());
+}
+
+std::string CGUIDialogIgnoreInput::GetDialogHeader()
+{
+  
+  return g_localizeStrings.Get(35019); // "Ignore input"
+}
+
+bool CGUIDialogIgnoreInput::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap,
+                                                 JOYSTICK::IActionMap* actionMap,
+                                                 const JOYSTICK::CDriverPrimitive& primitive)
+{
+  // Check if we have already started capturing primitives for a device
+  const bool bHasDevice = !m_deviceName.empty();
+
+  // If a primitive comes from a different device, ignore it
+  if (bHasDevice && m_deviceName != buttonMap->DeviceName())
+  {
+    CLog::Log(LOGDEBUG, "%s: ignoring input from device %s", buttonMap->ControllerID().c_str(), buttonMap->DeviceName().c_str());
+    return false;
+  }
+
+  if (!bHasDevice)
+  {
+    CLog::Log(LOGDEBUG, "%s: capturing input for device %s", buttonMap->ControllerID().c_str(), buttonMap->DeviceName().c_str());
+    m_deviceName = buttonMap->DeviceName();
+  }
+
+  if (AddPrimitive(primitive))
+  {
+    buttonMap->SetIgnoredPrimitives(m_capturedPrimitives);
+    m_captureEvent.Set();
+  }
+
+  return true;
+}
+
+void CGUIDialogIgnoreInput::OnClose(bool bAccepted)
+{
+  for (auto& callback : ButtonMapCallbacks())
+  {
+    if (bAccepted)
+    {
+      // See documentation of IButtonMapCallback::ResetIgnoredPrimitives()
+      // for why this call is needed
+      if (m_deviceName.empty())
+        callback.second->ResetIgnoredPrimitives();
+
+      if (m_deviceName.empty() || m_deviceName == callback.first)
+        callback.second->SaveButtonMap();
+    }
+    else
+      callback.second->RevertButtonMap();
+  }
+}
+
+bool CGUIDialogIgnoreInput::AddPrimitive(const JOYSTICK::CDriverPrimitive& primitive)
+{
+  bool bValid = false;
+
+  if (primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::BUTTON ||
+      primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS)
+  {
+    auto PrimitiveMatch = [&primitive](const JOYSTICK::CDriverPrimitive& other)
+      {
+        return primitive.Type() == other.Type() &&
+               primitive.Index() == other.Index();
+      };
+
+    bValid = std::find_if(m_capturedPrimitives.begin(), m_capturedPrimitives.end(), PrimitiveMatch) == m_capturedPrimitives.end();
+  }
+
+  if (bValid)
+  {
+    m_capturedPrimitives.emplace_back(primitive);
+    return true;
+  }
+
+  return false;
+}

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "GUIDialogButtonCapture.h"
+#include "input/joysticks/DriverPrimitive.h"
+
+#include <string>
+#include <vector>
+
+namespace GAME
+{
+  class CGUIDialogIgnoreInput : public CGUIDialogButtonCapture
+  {
+  public:
+    CGUIDialogIgnoreInput() = default;
+
+    virtual ~CGUIDialogIgnoreInput() = default;
+
+  protected:
+    // implementation of CGUIDialogButtonCapture
+    virtual std::string GetDialogText() override;
+    virtual std::string GetDialogHeader() override;
+    virtual bool MapPrimitiveInternal(KODI::JOYSTICK::IButtonMap* buttonMap,
+                                      KODI::JOYSTICK::IActionMap* actionMap,
+                                      const KODI::JOYSTICK::CDriverPrimitive& primitive) override;
+    void OnClose(bool bAccepted) override;
+
+  private:
+    bool AddPrimitive(const KODI::JOYSTICK::CDriverPrimitive& primitive);
+
+    std::string m_deviceName;
+    std::vector<KODI::JOYSTICK::CDriverPrimitive> m_capturedPrimitives;
+  };
+}

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -92,7 +92,7 @@ void CGUIConfigurationWizard::OnUnfocus(IFeatureButton* button)
 
 bool CGUIConfigurationWizard::Abort(bool bWait /* = true */)
 {
-  if (IsRunning())
+  if (!m_bStop)
   {
     StopThread(false);
 

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIConfigurationWizard.h"
+#include "games/controllers/dialogs/GUIDialogAxisDetection.h"
 #include "games/controllers/guicontrols/GUIFeatureButton.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
@@ -57,6 +58,7 @@ void CGUIConfigurationWizard::InitializeState(void)
   m_currentButton = nullptr;
   m_currentDirection = JOYSTICK::ANALOG_STICK_DIRECTION::UNKNOWN;
   m_history.clear();
+  m_lateAxisDetected = false;
 }
 
 void CGUIConfigurationWizard::Run(const std::string& strControllerId, const std::vector<IFeatureButton*>& buttons)
@@ -113,6 +115,8 @@ void CGUIConfigurationWizard::Process(void)
 
   InstallHooks();
 
+  bool bLateAxisDetected = false;
+
   {
     CSingleLock lock(m_stateMutex);
     for (IFeatureButton* button : m_buttons)
@@ -145,6 +149,8 @@ void CGUIConfigurationWizard::Process(void)
         break;
     }
 
+    bLateAxisDetected = m_lateAxisDetected;
+
     // Finished mapping
     InitializeState();
   }
@@ -152,17 +158,27 @@ void CGUIConfigurationWizard::Process(void)
   for (auto callback : ButtonMapCallbacks())
     callback.second->SaveButtonMap();
 
-  bool bInMotion;
-
+  if (bLateAxisDetected)
   {
-    CSingleLock lock(m_motionMutex);
-    bInMotion = !m_bInMotion.empty();
+    CGUIDialogAxisDetection dialog;
+    dialog.Show();
   }
-
-  if (bInMotion)
+  else
   {
-    CLog::Log(LOGDEBUG, "Configuration wizard: waiting %ums for axes to neutralize", POST_MAPPING_WAIT_TIME_MS);
-    m_motionlessEvent.WaitMSec(POST_MAPPING_WAIT_TIME_MS);
+    // Wait for motion to stop to avoid sending analog actions for the button
+    // that is pressed immediately after button mapping finishes.
+    bool bInMotion;
+
+    {
+      CSingleLock lock(m_motionMutex);
+      bInMotion = !m_bInMotion.empty();
+    }
+
+    if (bInMotion)
+    {
+      CLog::Log(LOGDEBUG, "Configuration wizard: waiting %ums for axes to neutralize", POST_MAPPING_WAIT_TIME_MS);
+      m_motionlessEvent.WaitMSec(POST_MAPPING_WAIT_TIME_MS);
+    }
   }
 
   RemoveHooks();
@@ -252,7 +268,10 @@ void CGUIConfigurationWizard::OnEventFrame(const JOYSTICK::IButtonMap* buttonMap
 
 void CGUIConfigurationWizard::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap, unsigned int axisIndex)
 {
-  //! @todo
+  CSingleLock lock(m_stateMutex);
+
+  m_lateAxisDetected = true;
+  Abort(false);
 }
 
 void CGUIConfigurationWizard::OnMotion(const JOYSTICK::IButtonMap* buttonMap)

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -109,6 +109,7 @@ namespace GAME
     IFeatureButton*                      m_currentButton;
     KODI::JOYSTICK::ANALOG_STICK_DIRECTION     m_currentDirection;
     std::set<KODI::JOYSTICK::CDriverPrimitive> m_history; // History to avoid repeated features
+    bool                                 m_lateAxisDetected; // Set to true if an axis is detected during button mapping
     CCriticalSection                     m_stateMutex;
 
     // Synchronization events

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -26,7 +26,7 @@
 #include "addons/GUIWindowAddonBrowser.h"
 #include "addons/IAddon.h"
 #include "addons/AddonManager.h"
-#include "games/controllers/dialogs/GUIDialogButtonCapture.h"
+#include "games/controllers/dialogs/GUIDialogIgnoreInput.h"
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIMessage.h"
@@ -322,6 +322,6 @@ void CGUIControllerWindow::ShowHelp(void)
 
 void CGUIControllerWindow::ShowButtonCaptureDialog(void)
 {
-  CGUIDialogButtonCapture dialog;
+  CGUIDialogIgnoreInput dialog;
   dialog.Show();
 }

--- a/xbmc/input/joysticks/JoystickTranslator.cpp
+++ b/xbmc/input/joysticks/JoystickTranslator.cpp
@@ -19,6 +19,9 @@
  */
 
 #include "JoystickTranslator.h"
+#include "guilib/LocalizeStrings.h"
+#include "input/joysticks/DriverPrimitive.h"
+#include "utils/StringUtils.h"
 
 using namespace KODI;
 using namespace JOYSTICK;
@@ -59,4 +62,22 @@ ANALOG_STICK_DIRECTION CJoystickTranslator::VectorToAnalogStickDirection(float x
   else if (y >  x && y <= -x) return ANALOG_STICK_DIRECTION::LEFT;
 
   return ANALOG_STICK_DIRECTION::UNKNOWN;
+}
+
+std::string CJoystickTranslator::GetPrimitiveName(const CDriverPrimitive& primitive)
+{
+  std::string primitiveTemplate;
+
+  switch (primitive.Type())
+  {
+    case PRIMITIVE_TYPE::BUTTON:
+      primitiveTemplate = g_localizeStrings.Get(35015); // "Button %d"
+      break;
+    case PRIMITIVE_TYPE::SEMIAXIS:
+      primitiveTemplate = g_localizeStrings.Get(35016); // "Axis %d"
+      break;
+    default: break;
+  }
+
+  return StringUtils::Format(primitiveTemplate.c_str(), primitive.Index());
 }

--- a/xbmc/input/joysticks/JoystickTranslator.h
+++ b/xbmc/input/joysticks/JoystickTranslator.h
@@ -25,6 +25,8 @@ namespace KODI
 {
 namespace JOYSTICK
 {
+  class CDriverPrimitive;
+
   /*!
    * \brief Joystick translation utilities
    */
@@ -62,6 +64,15 @@ namespace JOYSTICK
      *         ANALOG_STICK_DIRECTION::UNKNOWN if x and y are both 0
      */
     static ANALOG_STICK_DIRECTION VectorToAnalogStickDirection(float x, float y);
+
+    /*!
+     * \brief Get the localized name of the primitive
+     *
+     * \param primitive The primitive, currently only buttons and axes are supported
+     *
+     * \return A title for the primitive, e.g. "Button 0" or "Axis 1"
+     */
+    static std::string GetPrimitiveName(const CDriverPrimitive& primitive);
   };
 }
 }


### PR DESCRIPTION
This is a follow-up to #11616.

On some platforms, like OSX, joystick drivers send events instead of polling for the joystick's state. If an axis has sent no events, its value won't be known initially. This breaks button mapping, because we need the initial value to detect the axis's center. For example, if a trigger is pushed really fast before being seen by Kodi, the first value could arrive after the trigger is fully pressed. It would look like the fully-pressed position is the center, and when the trigger is unpressed it seems "stuck".

To solve this, if an axis is discovered by Kodi during button mapping, a dialog is shown to the user. This dialog absorbs all button presses, which allows all axes to be moved so that they are detected by Kodi. In future button mapping sessions, the initial value of the axes will be known.

This dialog only needs to be shown once per restart. I must admit, it is very annoying have this error pop up during button mapping. However, I can't think of any way to detect the center if the axis is discovered in any possible state.

I'm open to suggestions for a better help message.

## Screenshots (if appropriate):
![screen shot 2017-02-06 at 1 57 24 am](https://cloud.githubusercontent.com/assets/531482/22642470/a13e93f8-ec0f-11e6-986b-0a6f88423d90.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
