### PR TITLE
Update SSE3 check to match with the others

### DIFF
--- a/cmake/modules/FindSSE.cmake
+++ b/cmake/modules/FindSSE.cmake
@@ -14,13 +14,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
      string(COMPARE EQUAL "sse2" "${_SSE_THERE}" _SSE2_TRUE)
      CHECK_CXX_ACCEPTS_FLAG("-msse2" _SSE2_OK)
 
-     # /proc/cpuinfo apparently omits sse3 :(
-     string(REGEX REPLACE "^.*[^s](sse3).*$" "\\1" _SSE_THERE ${CPUINFO})
-     string(COMPARE EQUAL "sse3" "${_SSE_THERE}" _SSE3_TRUE)
-     if(NOT _SSE3_TRUE)
-        string(REGEX REPLACE "^.*(T2300).*$" "\\1" _SSE_THERE ${CPUINFO})
-        string(COMPARE EQUAL "T2300" "${_SSE_THERE}" _SSE3_TRUE)
-     endif()
+     # SSE3 is also known as the Prescott New Instructions (PNI)
+     # it's labeled as pni in /proc/cpuinfo
+     string(REGEX REPLACE "^.*(pni).*$" "\\1" _SSE_THERE ${CPUINFO})
+     string(COMPARE EQUAL "pni" "${_SSE_THERE}" _SSE3_TRUE)
      CHECK_CXX_ACCEPTS_FLAG("-msse3" _SSE3_OK)
 
      string(REGEX REPLACE "^.*(ssse3).*$" "\\1" _SSE_THERE ${CPUINFO})


### PR DESCRIPTION
SSE3 is in /proc/cpuinfo, but under an alternative name

## Description
One of the comments in FindSSE was incorrect, this corrects it and explains why it's unusual.

## Motivation and Context
This doesn't change anything meaningful. Some systems (including my own) will now have SSE3 properly enabled in the build system when it was disabled previously. This is mostly to correct a
misconception within the code.

## How Has This Been Tested?
Ran cmake to confirm that SSE3 was still properly enabled on my Linux based system while previously it was not. Ensured kodi built and ran properly in 2 unique configurations and systems.

## Screenshots (if appropriate):

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
