### PR TITLE
Fix musicbrainz resolution with python based scrapers

### DIFF
--- a/addons/metadata.demo.artists/demo.py
+++ b/addons/metadata.demo.artists/demo.py
@@ -46,6 +46,9 @@ if action == 'find':
     liz.setProperty('artist.genre', 'classical / jazz')
     liz.setProperty('artist.born', '2012')
     xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/artist2", listitem=liz, isFolder=True)
+elif action == 'resolveid':
+    liz=xbmcgui.ListItem(path='/path/to/artist2', offscreen=True)
+    xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
 elif action == 'getdetails':
     url=urllib.unquote_plus(params["url"])
     print 'Artist with url %s' %(url)

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -496,6 +496,20 @@ CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
 {
   CScraperUrl scurlRet;
 
+  if (m_isPython)
+  {
+    std::stringstream str;
+    str << "plugin://" << ID()
+        << "?action=resolveid&key=" << CURL::Encode(externalID);
+
+    CFileItem item("resolve me", false);
+
+    if (XFILE::CPluginDirectory::GetPluginResult(str.str(), item))
+      scurlRet.ParseString(item.GetPath());
+
+    return scurlRet;
+  }
+
   // scraper function takes an external ID, returns XML (see below)
   std::vector<std::string> vcsIn;
   vcsIn.push_back(externalID);

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -62,7 +62,7 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberDigit(int iDigit)
 
   // recalc channel string
   m_strChannel.erase();
-  if (m_digits.size() != m_iMaxDigits || GetChannelNumber() > 0)
+  if (m_digits.size() != (size_t)m_iMaxDigits || GetChannelNumber() > 0)
   {
     for (int digit : m_digits)
       m_strChannel.append(StringUtils::Format("%d", digit));


### PR DESCRIPTION
This fixes mbrainz resolution using python based scrapers. Previously it tried to load the py file as xml, then crashed and burned.

@ronie 