### PR TITLE
[xbmc][improvement] Clean up and unify our gui message processing

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -37,6 +37,7 @@
 #include "filesystem/File.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "playlists/PlayList.h"
@@ -56,9 +57,6 @@
 using namespace XFILE;
 using namespace PLAYLIST;
 using namespace MEDIA_DETECT;
-using namespace KODI::MESSAGING;
-
-using KODI::MESSAGING::HELPERS::DialogResponse;
 
 CAutorun::CAutorun()
 {
@@ -93,6 +91,8 @@ void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool
 
 bool CAutorun::PlayDisc(const std::string& path, bool bypassSettings, bool startFromBeginning)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if ( !bypassSettings && CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) != AUTOCD_PLAY && !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_DVDS_AUTORUN))
     return false;
 
@@ -124,7 +124,7 @@ bool CAutorun::PlayDisc(const std::string& path, bool bypassSettings, bool start
   if ( !bPlaying && nAddedToPlaylist > 0 )
   {
     CGUIMessage msg( GUI_MSG_PLAYLIST_CHANGED, 0, 0 );
-    g_windowManager.SendMessage( msg );
+    SendGUIMessage(msg);
     g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
     // Start playing the items we inserted
     return g_playlistPlayer.Play(nSize, "");
@@ -498,8 +498,9 @@ bool CAutorun::IsEnabled() const
 
 bool CAutorun::PlayDiscAskResume(const std::string& path)
 {
+  using namespace KODI::MESSAGING::HELPERS;
   return PlayDisc(path, true, !CanResumePlayDVD(path) ||
-    HELPERS::ShowYesNoDialogText(CVariant{341}, CVariant{""}, CVariant{13404}, CVariant{12021}) == 
+                  ShowYesNoDialogText(CVariant{341}, CVariant{""}, CVariant{13404}, CVariant{12021}) == 
     DialogResponse::YES);
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -75,6 +75,7 @@
 #include "cores/DataCacheCore.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 // stuff for current song
 #include "music/MusicInfoLoader.h"
@@ -5833,6 +5834,8 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const std::string &format)
 
 std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *fallback)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, false);
 
@@ -6646,7 +6649,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case VISUALISATION_PRESET:
     {
       CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
-      g_windowManager.SendMessage(msg);
+      SendGUIMessage(msg);
       if (msg.GetPointer())
       {
         CVisualisation* viz = NULL;
@@ -6864,6 +6867,8 @@ bool CGUIInfoManager::EvaluateBool(const std::string &expression, int contextWin
 // for toggle button controls and visibility of images.
 bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListItem *item)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   bool bReturn = false;
   int condition = abs(condition1);
 
@@ -7311,7 +7316,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     case VISUALISATION_LOCKED:
       {
         CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
-        g_windowManager.SendMessage(msg);
+        SendGUIMessage(msg);
         if (msg.GetPointer())
         {
           CVisualisation *pVis = (CVisualisation *)msg.GetPointer();
@@ -7342,7 +7347,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     case VISUALISATION_HAS_PRESETS:
     {
       CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
-      g_windowManager.SendMessage(msg);
+      SendGUIMessage(msg);
       if (msg.GetPointer())
       {
         CVisualisation* viz = NULL;

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -22,6 +22,7 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "dialogs/GUIDialogGamepad.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogNumeric.h"
@@ -423,6 +424,8 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
 
 bool CGUIPassword::LockSource(const std::string& strType, const std::string& strName, bool bState)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   VECSOURCES* pShares = CMediaSourceSettings::GetInstance().GetSources(strType);
   bool bResult = false;
   for (IVECSOURCES it=pShares->begin();it != pShares->end();++it)
@@ -437,14 +440,15 @@ bool CGUIPassword::LockSource(const std::string& strType, const std::string& str
       break;
     }
   }
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
 
   return bResult;
 }
 
 void CGUIPassword::LockSources(bool lock)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // lock or unlock all sources (those with locks)
   const char* strType[] = {"programs", "music", "video", "pictures", "files", "games"};
   for (unsigned int i = 0; i < sizeof(strType) / sizeof(*strType); ++i)
@@ -454,12 +458,13 @@ void CGUIPassword::LockSources(bool lock)
       if (it->m_iLockMode != LOCK_MODE_EVERYONE)
         it->m_iHasLock = lock ? 2 : 1;
   }
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
 }
 
 void CGUIPassword::RemoveSourceLocks()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // remove lock from all sources
   const char* strType[] = {"programs", "music", "video", "pictures", "files", "games"};
   for (unsigned int i = 0; i < sizeof(strType) / sizeof(*strType); ++i)
@@ -474,8 +479,7 @@ void CGUIPassword::RemoveSourceLocks()
       }
   }
   CMediaSourceSettings::GetInstance().Save();
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0, GUI_MSG_UPDATE_SOURCES);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0, GUI_MSG_UPDATE_SOURCES);
 }
 
 bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources)

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -28,6 +28,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/MusicDatabase.h"
 #include "music/windows/GUIWindowMusicPlaylist.h"
 #include "PlayListPlayer.h"
@@ -501,8 +502,9 @@ bool CPartyModeManager::MovePlaying()
 
 void CPartyModeManager::SendUpdateMessage()
 {
-  CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
-  g_windowManager.SendThreadMessage(msg);
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+  PostGUIMessage(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
 }
 
 void CPartyModeManager::Play(int iPos)

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -34,6 +34,7 @@
 #include "settings/Settings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "FilesystemInstaller.h"
 #include "filesystem/FavouritesDirectory.h"
 #include "utils/JobManager.h"
@@ -79,6 +80,8 @@ CAddonInstaller &CAddonInstaller::GetInstance()
 
 void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CSingleLock lock(m_critSection);
   JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), bind2nd(find_map(), jobID));
   if (i != m_downloadJobs.end())
@@ -89,11 +92,13 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
   PrunePackageCache();
 
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(msg);
 }
 
 void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CSingleLock lock(m_critSection);
   JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), bind2nd(find_map(), jobID));
   if (i != m_downloadJobs.end())
@@ -103,7 +108,7 @@ void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, u
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM);
     msg.SetStringParam(i->first);
     lock.Leave();
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(msg);
   }
 }
 

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -37,6 +37,7 @@
 #include "filesystem/AddonsDirectory.h"
 #include "addons/AddonInstaller.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/Settings.h"
 #include "settings/MediaSourceSettings.h"
 #include "utils/StringUtils.h"
@@ -173,14 +174,16 @@ class UpdateAddons : public IRunnable
 
 void CGUIWindowAddonBrowser::OnEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event)
 {
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  g_windowManager.SendThreadMessage(msg);
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
 }
 
 void CGUIWindowAddonBrowser::OnEvent(const ADDON::AddonEvent& event)
 {
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  g_windowManager.SendThreadMessage(msg);
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
 }
 
 bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -47,6 +47,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #include "DVDDemuxers/DVDDemuxCC.h"
 #include "cores/FFmpeg.h"
@@ -4365,6 +4366,8 @@ bool CVideoPlayer::ShowPVRChannelInfo(void)
 
 bool CVideoPlayer::OnAction(const CAction &action)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
 #define THREAD_ACTION(action) \
   do { \
     if (!IsCurrentThread()) { \
@@ -4430,8 +4433,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
           m_callback.OnPlayBackResumed();
         }
         // send a message to everyone that we've gone to the menu
-        CGUIMessage msg(GUI_MSG_VIDEO_MENU_STARTED, 0, 0);
-        g_windowManager.SendThreadMessage(msg);
+        PostGUIMessage(GUI_MSG_VIDEO_MENU_STARTED, 0, 0);
         return true;
       }
       break;

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -53,6 +53,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/tags/MusicInfoTag.h"
 #include "pictures/Picture.h"
 #include "pvr/channels/PVRChannel.h"
@@ -567,6 +568,8 @@ void CDVDRadioRDSData::CloseStream(bool bWaitForBuffers)
 
 void CDVDRadioRDSData::ResetRDSCache()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CSingleLock lock(m_critSection);
 
   m_currentFileUpdate = false;
@@ -633,8 +636,7 @@ void CDVDRadioRDSData::ResetRDSCache()
   g_infoManager.SetCurrentItem(itemptr);
 
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 void CDVDRadioRDSData::Process()

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -45,6 +45,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "addons/Scraper.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #define BACKGROUND_IMAGE       999
 #define GROUP_LIST             996
@@ -274,6 +275,8 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
 
 bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFileItemPtr& item, CONTEXT_BUTTON button)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // buttons that are available on both sources and autosourced items
   if (!item) return false;
   
@@ -407,8 +410,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
           db.SetTextureForPath(item->GetPath(), "thumb", strThumb);
       }
 
-      CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-      g_windowManager.SendThreadMessage(msg);
+      PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       return true;
     }
 
@@ -429,8 +431,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
 
-      CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-      g_windowManager.SendThreadMessage(msg);
+      PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       return true;
     }
   case CONTEXT_BUTTON_RESET_LOCK:
@@ -441,8 +442,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
-      CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-      g_windowManager.SendThreadMessage(msg);
+      PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       return true;
     }
   case CONTEXT_BUTTON_REMOVE_LOCK:
@@ -458,8 +458,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockcode", "0");
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
-      CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-      g_windowManager.SendThreadMessage(msg);
+      PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       return true;
     }
   case CONTEXT_BUTTON_REACTIVATE_LOCK:
@@ -491,8 +490,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "lockmode", strNewLockMode);
       CMediaSourceSettings::GetInstance().UpdateSource(type, share->strName, "badpwdcount", "0");
       CMediaSourceSettings::GetInstance().Save();
-      CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-      g_windowManager.SendThreadMessage(msg);
+      PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
       return true;
     }
   default:

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -31,6 +31,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
 #include "ContextMenuManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/Variant.h"
 
 using namespace XFILE;
@@ -100,6 +101,8 @@ int CGUIDialogFavourites::GetSelectedItem()
 
 void CGUIDialogFavourites::OnClick(int item)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (item < 0 || item >= m_favourites->Size())
     return;
 
@@ -111,7 +114,7 @@ void CGUIDialogFavourites::OnClick(int item)
 
   CGUIMessage message(GUI_MSG_EXECUTE, 0, GetID());
   message.SetStringParam(execute);
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 }
 
 void CGUIDialogFavourites::OnPopupMenu(int item)

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -25,6 +25,7 @@
 #include "XBDateTime.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicDbUrl.h"
 #include "playlists/SmartPlayList.h"
@@ -211,6 +212,8 @@ void CGUIDialogMediaFilter::OnInitWindow()
 
 void CGUIDialogMediaFilter::OnSettingChanged(const CSetting *setting)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CGUIDialogSettingsManualBase::OnSettingChanged(setting);
 
   std::map<std::string, Filter>::iterator it = m_filters.find(setting->GetId());
@@ -333,7 +336,7 @@ void CGUIDialogMediaFilter::OnSettingChanged(const CSetting *setting)
   }
 
   CGUIMessage msg(GUI_MSG_REFRESH_LIST, GetID(), 0);
-  g_windowManager.SendThreadMessage(msg, WINDOW_DIALOG_MEDIA_FILTER);
+  PostGUIMessage(msg, WINDOW_DIALOG_MEDIA_FILTER);
 }
 
 void CGUIDialogMediaFilter::SetupView()
@@ -601,11 +604,12 @@ void CGUIDialogMediaFilter::UpdateControls()
 
 void CGUIDialogMediaFilter::TriggerFilter() const
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (m_filter == NULL)
     return;
 
-  CGUIMessage message(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_FILTER_ITEMS, 10); // 10 for advanced
-  g_windowManager.SendThreadMessage(message);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_FILTER_ITEMS, 10); // 10 for advanced
 }
 
 void CGUIDialogMediaFilter::Reset(bool filtersOnly /* = false */)

--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -26,6 +26,7 @@
 #include "filesystem/EventsDirectory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
@@ -261,6 +262,8 @@ void CEventLog::OnSettingAction(const CSetting *setting)
 
 void CEventLog::SendMessage(const EventPtr& eventPtr, int message)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, message, 0, XFILE::CEventsDirectory::EventToFileItem(eventPtr));
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(msg);
 }

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -22,7 +22,7 @@
 #include "games/controllers/windows/GUIControllerDefines.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/WindowIDs.h"
-#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "threads/Event.h"
 #include "utils/StringUtils.h"
 
@@ -51,14 +51,15 @@ void CGUIFeatureButton::OnUnFocus(void)
 
 bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt, const std::string& strWarn, const std::string& strFeature, CEvent& waitEvent)
 {
-  using namespace KODI::MESSAGING;
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
 
   bool bInterrupted = false;
 
   if (!HasFocus())
   {
     CGUIMessage msgFocus(GUI_MSG_SETFOCUS, GetID(), GetID());
-    CApplicationMessenger::GetInstance().SendGUIMessage(msgFocus, WINDOW_INVALID, false);
+    PostGUIMessage(msgFocus, WINDOW_INVALID);
   }
 
   CGUIMessage msgLabel(GUI_MSG_LABEL_SET, GetID(), GetID());
@@ -78,7 +79,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt, const std::string
       strLabel = StringUtils::Format(strPrompt.c_str(), strFeature.c_str(), secondsRemaining);
 
     msgLabel.SetLabel(strLabel);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);
+    PostGUIMessage(msgLabel, WINDOW_INVALID);
 
     waitEvent.Reset();
     bInterrupted = waitEvent.WaitMSec(1000); // Wait 1 second
@@ -89,7 +90,7 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt, const std::string
 
   // Reset label
   msgLabel.SetLabel(m_feature.Label());
-  CApplicationMessenger::GetInstance().SendGUIMessage(msgLabel, WINDOW_INVALID, false);
+  PostGUIMessage(msgLabel, WINDOW_INVALID);
 
   return bInterrupted;
 }

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -39,6 +39,7 @@
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/DefaultJoystick.h" // for DEFAULT_CONTROLLER_ID
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "peripherals/Peripherals.h"
 #include "ServiceBroker.h"
 
@@ -149,12 +150,10 @@ void CGUIControllerList::ResetController(void)
 
 void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (typeid(event) == typeid(ADDON::AddonEvents::InstalledChanged))
-  {
-    using namespace KODI::MESSAGING;
-    CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg);
-  }
+    PostGUIMessage(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);
 }
 
 bool CGUIControllerList::RefreshControllers(void)

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -23,6 +23,8 @@
 #include "GUIWindowManager.h"
 #include "GUIControl.h"
 #include "GUIInfoManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
+#include "messaging/helpers/DialogHelper.h"
 
 CGUIAction::CGUIAction()
 {
@@ -37,6 +39,8 @@ CGUIAction::CGUIAction(int controlID)
 
 bool CGUIAction::ExecuteActions(int controlID, int parentID, const CGUIListItemPtr &item /* = NULL */) const
 {
+  using namespace KODI::MESSAGING::HELPERS;
+
   if (m_actions.empty()) return false;
   // take a copy of actions that satisfy our conditions
   std::vector<std::string> actions;
@@ -55,9 +59,9 @@ bool CGUIAction::ExecuteActions(int controlID, int parentID, const CGUIListItemP
     CGUIMessage msg(GUI_MSG_EXECUTE, controlID, parentID, 0, 0, item);
     msg.SetStringParam(*i);
     if (m_sendThreadMessages)
-      g_windowManager.SendThreadMessage(msg);
+      PostGUIMessage(msg);
     else
-      g_windowManager.SendMessage(msg);
+      SendGUIMessage(msg);
     retval = true;
   }
   return retval;

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -28,6 +28,7 @@
 #include "input/MouseStat.h"
 #include "input/InputManager.h"
 #include "input/Key.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 CGUIControl::CGUIControl() :
   m_hitColor(0xffffffff),
@@ -303,10 +304,12 @@ void CGUIControl::OnPrevControl()
 
 bool CGUIControl::SendWindowMessage(CGUIMessage &message) const
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIWindow *pWindow = g_windowManager.GetWindow(GetParentID());
   if (pWindow)
     return pWindow->OnMessage(message);
-  return g_windowManager.SendMessage(message);
+  return SendGUIMessage(message);
 }
 
 int CGUIControl::GetID(void) const

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -28,6 +28,7 @@
 #include "GUIControlFactory.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/lib/Setting.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -170,6 +171,8 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName, const std::str
 
 bool GUIFontManager::OnMessage(CGUIMessage &message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (message.GetMessage() != GUI_MSG_NOTIFY_ALL)
     return false;
 
@@ -183,7 +186,7 @@ bool GUIFontManager::OnMessage(CGUIMessage &message)
   { // our device has been reset - we have to reload our ttf fonts, and send
     // a message to controls that we have done so
     ReloadTTFFonts();
-    g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
+    SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
     m_canReload = true;
     return true;
   }

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -21,6 +21,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "LocalizeStrings.h"
 #include "GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogOK.h"
@@ -50,6 +51,8 @@ CGUIKeyboardFactory::~CGUIKeyboardFactory(void)
 
 void CGUIKeyboardFactory::keyTypedCB(CGUIKeyboard *ref, const std::string &typedString)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if(ref)
   {
     // send our search message in safe way (only the active window needs it)
@@ -59,12 +62,12 @@ void CGUIKeyboardFactory::keyTypedCB(CGUIKeyboard *ref, const std::string &typed
       case FILTERING_SEARCH:
         message.SetParam1(GUI_MSG_SEARCH_UPDATE);
         message.SetStringParam(typedString);
-        CApplicationMessenger::GetInstance().SendGUIMessage(message, g_windowManager.GetActiveWindow());
+        PostGUIMessage(message, g_windowManager.GetActiveWindow());
         break;
       case FILTERING_CURRENT:
         message.SetParam1(GUI_MSG_FILTER_ITEMS);
         message.SetStringParam(typedString);
-        CApplicationMessenger::GetInstance().SendGUIMessage(message);
+        PostGUIMessage(message);
         break;
       case FILTERING_NONE:
         break;

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -25,6 +25,7 @@
 #include "utils/StringUtils.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 static const SliderAction actions[] = {
   {"seek",    "PlayerControl(SeekPercentage(%2f))", PLAYER_PROGRESS, false},
@@ -301,6 +302,8 @@ void CGUISliderControl::Move(int iNumSteps)
 
 void CGUISliderControl::SendClick()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   float percent = 100*GetProportion();
   SEND_CLICK_MESSAGE(GetID(), GetParentID(), MathUtils::round_int(percent));
   if (m_action && (!m_dragging || m_action->fireOnDrag))
@@ -308,7 +311,7 @@ void CGUISliderControl::SendClick()
     std::string action = StringUtils::Format(m_action->formatString, percent);
     CGUIMessage message(GUI_MSG_EXECUTE, m_controlID, m_parentID);
     message.SetStringParam(action);
-    g_windowManager.SendMessage(message);    
+    SendGUIMessage(message);    
   }
 }
 

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -24,6 +24,7 @@
 #include "Application.h"
 #include "input/Key.h"
 #include "WindowIDs.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 CGUIVideoControl::CGUIVideoControl(int parentID, int controlID, float posX, float posY, float width, float height)
     : CGUIControl(parentID, controlID, posX, posY, width, height)
@@ -88,11 +89,13 @@ void CGUIVideoControl::RenderEx()
 
 EVENT_RESULT CGUIVideoControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (!g_application.m_pPlayer->IsPlayingVideo()) return EVENT_RESULT_UNHANDLED;
   if (event.m_id == ACTION_MOUSE_LEFT_CLICK)
   { // switch to fullscreen
     CGUIMessage message(GUI_MSG_FULLSCREEN, GetID(), GetParentID());
-    g_windowManager.SendMessage(message);
+    SendGUIMessage(message);
     return EVENT_RESULT_HANDLED;
   }
   return EVENT_RESULT_UNHANDLED;

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -25,6 +25,7 @@
 #include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/Visualisation.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/log.h"
 #include "input/Key.h"
 
@@ -117,13 +118,15 @@ void CGUIVisualisationControl::Process(unsigned int currentTime, CDirtyRegionLis
 
 void CGUIVisualisationControl::FreeResources(bool immediately)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   m_bAttemptedLoad = false;
   // tell our app that we're going
   if (!m_addon)
     return;
 
   CGUIMessage msg(GUI_MSG_VISUALISATION_UNLOADING, m_controlID, 0);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
   CLog::Log(LOGDEBUG, "FreeVisualisation() started");
   CGUIRenderingControl::FreeResources(immediately);
   m_addon.reset();

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -36,6 +36,7 @@
 #include "GUIAudioManager.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
 
@@ -824,6 +825,8 @@ void CGUIWindow::ClearAll()
 
 bool CGUIWindow::Initialize()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (!g_windowManager.Initialized())
     return false;     // can't load if we have no skin yet
   if(!NeedXMLReload())
@@ -835,7 +838,7 @@ bool CGUIWindow::Initialize()
     // if not app thread, send gui msg via app messenger
     // and wait for results, so windowLoaded flag would be updated
     CGUIMessage msg(GUI_MSG_WINDOW_LOAD, 0, 0);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, GetID(), true);
+    SendGUIMessage(msg, GetID());
   }
   return m_windowLoaded;
 }

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -66,9 +66,6 @@ class CGUIWindowManager : public KODI::MESSAGING::IMessageTarget
 public:
   CGUIWindowManager(void);
   virtual ~CGUIWindowManager(void);
-  bool SendMessage(CGUIMessage& message);
-  bool SendMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
-  bool SendMessage(CGUIMessage& message, int window);
   void Initialize();
   void Add(CGUIWindow* pWindow);
   void AddUniqueInstance(CGUIWindow *window);
@@ -156,11 +153,7 @@ public:
   void RemoveDialog(int id);
   int GetTopMostModalDialogID(bool ignoreClosing = false) const;
 
-  void SendThreadMessage(CGUIMessage& message, int window = 0);
-  void DispatchThreadMessages();
-  // method to removed queued messages with message id in the requested message id list.
-  // pMessageIDList: point to first integer of a 0 ends integer array.
-  int RemoveThreadMessageByMessageIds(int *pMessageIDList);
+  void DispatchThreadMessages() const;
   void AddMsgTarget( IMsgTargetCallback* pMsgTarget );
   int GetActiveWindow() const;
   int GetActiveWindowID();
@@ -190,6 +183,10 @@ public:
 #endif
 private:
   void RenderPass() const;
+
+  bool SendMessage(CGUIMessage& message);
+  bool SendMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
+  bool SendMessage(CGUIMessage& message, int window);
 
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();
@@ -224,7 +221,6 @@ private:
   std::stack<int> m_windowHistory;
 
   IWindowManagerCallback* m_pCallback;
-  std::list < std::pair<CGUIMessage*,int> > m_vecThreadMessages;
   CCriticalSection m_critSection;
   std::vector <IMsgTargetCallback*> m_vecMsgTargets;
 

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -24,6 +24,7 @@
 #include "ServiceBroker.h"
 #include "cores/DataCacheCore.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/lib/Setting.h"
@@ -32,6 +33,7 @@
 #include "TextureManager.h"
 #include "input/InputManager.h"
 #include "GUIWindowManager.h"
+#include "messaging/helpers/DialogHelper.h"
 
 using namespace KODI::MESSAGING;
 
@@ -384,6 +386,8 @@ void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
 
 void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdate)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   RESOLUTION lastRes = m_Resolution;
 
   // If the user asked us to guess, go with desktop
@@ -441,7 +445,7 @@ void CGraphicContext::SetVideoResolutionInternal(RESOLUTION res, bool forceUpdat
 
   // update anyone that relies on sizing information
   CInputManager::GetInstance().SetMouseResolution(info_org.iWidth, info_org.iHeight, 1, 1);
-  g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
+  SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
 
   Unlock();
 }
@@ -979,13 +983,15 @@ void CGraphicContext::SetMediaDir(const std::string &strMediaDir)
 
 void CGraphicContext::Flip(bool rendered, bool videoLayer)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   g_Windowing.PresentRender(rendered, videoLayer);
 
   if(m_stereoMode != m_nextStereoMode)
   {
     m_stereoMode = m_nextStereoMode;
     SetVideoResolution(GetVideoResolution(), true);
-    g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_RENDERER_RESET);
+    SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_RENDERER_RESET);
   }
 }
 

--- a/xbmc/input/InertialScrollingHandler.cpp
+++ b/xbmc/input/InertialScrollingHandler.cpp
@@ -24,6 +24,7 @@
 #include "utils/TimeUtils.h"
 #include "input/Key.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "windowing/WindowingFactory.h"
 
 #include <cmath>
@@ -49,6 +50,8 @@ CInertialScrollingHandler::CInertialScrollingHandler()
 
 bool CInertialScrollingHandler::CheckForInertialScrolling(const CAction* action)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   bool ret = false;//return value - false no inertial scrolling - true - inertial scrolling
 
   if(g_Windowing.HasInertialGestures())
@@ -77,7 +80,7 @@ bool CInertialScrollingHandler::CheckForInertialScrolling(const CAction* action)
     //for making switching between multiple lists
     //possible
     CGUIMessage message(GUI_MSG_EXCLUSIVE_MOUSE, 0, 0);
-    g_windowManager.SendMessage(message);     
+    SendGUIMessage(message);     
     m_bScrolling = false;
     //wakeup screensaver on pan begin
     g_application.ResetScreenSaver();    
@@ -91,7 +94,7 @@ bool CInertialScrollingHandler::CheckForInertialScrolling(const CAction* action)
       CGUIMessage message(GUI_MSG_GESTURE_NOTIFY, 0, 0, (int)action->GetAmount(2), (int)action->GetAmount(3));
 
       //ask if the control wants inertial scrolling
-      if(g_windowManager.SendMessage(message))
+      if(SendGUIMessage(message))
       {
         int result = 0;
         if (message.GetPointer())

--- a/xbmc/input/InputCodingTableBaiduPY.cpp
+++ b/xbmc/input/InputCodingTableBaiduPY.cpp
@@ -28,6 +28,7 @@
 #include "utils/RegExp.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 CInputCodingTableBaiduPY::CInputCodingTableBaiduPY(const std::string& strUrl) :
   CThread("BaiduPYApi"),
@@ -71,6 +72,8 @@ void CInputCodingTableBaiduPY::Process()
 
 void CInputCodingTableBaiduPY::HandleResponse(const std::string& strCode, const std::string& response)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (strCode != m_code) // don't handle obsolete response
     return;
 
@@ -99,7 +102,7 @@ void CInputCodingTableBaiduPY::HandleResponse(const std::string& strCode, const 
   CGUIMessage msg(GUI_MSG_CODINGTABLE_LOOKUP_COMPLETED, 0, 0, m_messageCounter);
   msg.SetStringParam(strCode);
   lock.Leave();
-  g_windowManager.SendThreadMessage(msg, g_windowManager.GetActiveWindowID());
+  PostGUIMessage(msg, g_windowManager.GetActiveWindowID());
 }
 
 std::wstring CInputCodingTableBaiduPY::UnicodeToWString(const std::string& unicode)

--- a/xbmc/input/InputCodingTableBasePY.cpp
+++ b/xbmc/input/InputCodingTableBasePY.cpp
@@ -23,6 +23,7 @@
 #include "utils/CharsetConverter.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 static std::map<std::string, std::wstring> codemap =
 {
@@ -448,6 +449,8 @@ std::vector<std::wstring> CInputCodingTableBasePY::GetResponse(int)
 
 bool CInputCodingTableBasePY::GetWordListPage(const std::string& strCode, bool isFirstPage)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (!isFirstPage)
     return false;
 
@@ -462,6 +465,6 @@ bool CInputCodingTableBasePY::GetWordListPage(const std::string& strCode, bool i
   }
   CGUIMessage msg(GUI_MSG_CODINGTABLE_LOOKUP_COMPLETED, 0, 0, 0);
   msg.SetStringParam(strCode);
-  g_windowManager.SendThreadMessage(msg, g_windowManager.GetActiveWindowID());
+  PostGUIMessage(msg, g_windowManager.GetActiveWindowID());
   return true;
 }

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -30,6 +30,7 @@
 #include "input/keyboard/KeyboardEasterEgg.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "guilib/Geometry.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIControl.h"
@@ -357,6 +358,8 @@ bool CInputManager::Process(int windowId, float frameTime)
 
 bool CInputManager::OnEvent(XBMC_Event& newEvent)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   switch (newEvent.type)
   {
   case XBMC_KEYDOWN:
@@ -470,7 +473,7 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
     if (newEvent.touch.action == ACTION_GESTURE_END || newEvent.touch.action == ACTION_TOUCH_TAP)
     {
       CGUIMessage msg(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
-      CApplicationMessenger::GetInstance().SendGUIMessage(msg);
+      PostGUIMessage(msg);
     }
     break;
   } //case

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -19,12 +19,10 @@
  */
 
 #include "GenericTouchActionHandler.h"
-#include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "windowing/WinEvents.h"
-
-using namespace KODI::MESSAGING;
 
 CGenericTouchActionHandler &CGenericTouchActionHandler::GetInstance()
 {
@@ -146,8 +144,10 @@ void CGenericTouchActionHandler::OnRotate(float centerX, float centerY, float an
 
 int CGenericTouchActionHandler::QuerySupportedGestures(float x, float y)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_GESTURE_NOTIFY, 0, 0, (int)x, (int)y);
-  if (!g_windowManager.SendMessage(msg))
+  if (!SendGUIMessage(msg))
     return 0;
 
   int result = 0;

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -40,6 +40,7 @@
 #include "utils/URIUtils.h"
 #include "Application.h"
 #include "PlayListPlayer.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #if defined(TARGET_DARWIN)
 #include "filesystem/SpecialProtocol.h"
@@ -243,13 +244,14 @@ static int RunScript(const std::vector<std::string>& params)
  */
 static int OpenDefaultSettings(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
   AddonPtr addon;
   ADDON::TYPE type = TranslateType(params[0]);
   if (CAddonSystemSettings::GetInstance().GetActive(type, addon))
   {
     bool changed = CGUIDialogAddonSettings::ShowAndGetInput(addon);
     if (type == ADDON_VIZ && changed)
-      g_windowManager.SendMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
+      SendGUIMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
   }
 
   return 0;
@@ -261,6 +263,7 @@ static int OpenDefaultSettings(const std::vector<std::string>& params)
  */
 static int SetDefaultAddon(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
   std::string addonID;
   TYPE type = TranslateType(params[0]);
   bool allowNone = false;
@@ -272,7 +275,7 @@ static int SetDefaultAddon(const std::vector<std::string>& params)
   {
     CAddonSystemSettings::GetInstance().SetActive(type, addonID);
     if (type == ADDON_VIZ)
-      g_windowManager.SendMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
+      SendGUIMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
   }
 
   return 0;

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -22,6 +22,7 @@
 
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
@@ -40,8 +41,7 @@
 #include "utils/RssManager.h"
 #include "utils/AlarmClock.h"
 #include "windows/GUIMediaWindow.h"
-
-using namespace KODI::MESSAGING;
+#include "messaging/helpers/DialogHelper.h"
 
 /*! \brief Execute a GUI action.
  *  \param params The parameters.
@@ -50,6 +50,7 @@ using namespace KODI::MESSAGING;
  */
 static int Action(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::CApplicationMessenger;
   // try translating the action from our ButtonTranslator
   int actionID;
   if (CButtonTranslator::TranslateActionString(params[0].c_str(), actionID))
@@ -122,6 +123,8 @@ static int ActivateWindow(const std::vector<std::string>& params2)
   template<bool Replace>
 static int ActivateAndFocus(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   std::string strWindow = params[0];
 
   // confirm the window destination is valid prior to switching
@@ -140,7 +143,7 @@ static int ActivateAndFocus(const std::vector<std::string>& params)
         CGUIMessage msg(GUI_MSG_SETFOCUS, g_windowManager.GetFocusedWindow(),
                         atol(params[iPtr].c_str()),
                         (params.size() >= iPtr + 2) ? atol(params[iPtr + 1].c_str())+1 : 0);
-        g_windowManager.SendMessage(msg);
+        SendGUIMessage(msg);
         iPtr += 2;
       }
       return 0;
@@ -336,7 +339,7 @@ static int Screenshot(const std::vector<std::string>& params)
  */
 static int SetLanguage(const std::vector<std::string>& params)
 {
-  CApplicationMessenger::GetInstance().PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, params[0]);
+  KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, params[0]);
 
   return 0;
 }
@@ -390,6 +393,8 @@ static int SetProperty(const std::vector<std::string>& params)
  */
 static int SetStereoMode(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::CApplicationMessenger;
+
   CAction action = CStereoscopicsManager::GetInstance().ConvertActionCommandToAction("SetStereoMode", params[0]);
   if (action.GetID() != ACTION_NONE)
     CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(action)));

--- a/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIContainerBuiltins.cpp
@@ -22,6 +22,7 @@
 
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/StringUtils.h"
 
 /*! \brief Change sort method.
@@ -33,8 +34,9 @@
   template<int Dir>
 static int ChangeSortMethod(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
   CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, g_windowManager.GetActiveWindow(), 0, 0, Dir);
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -48,8 +50,9 @@ static int ChangeSortMethod(const std::vector<std::string>& params)
   template<int Dir>
 static int ChangeViewMode(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
   CGUIMessage message(GUI_MSG_CHANGE_VIEW_MODE, g_windowManager.GetActiveWindow(), 0, 0, Dir);
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -59,11 +62,13 @@ static int ChangeViewMode(const std::vector<std::string>& params)
  *  \details params[0] = The URL to refresh window at.
  */
 static int Refresh(const std::vector<std::string>& params)
-{ // NOTE: These messages require a media window, thus they're sent to the current activewindow.
+{ 
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+  // NOTE: These messages require a media window, thus they're sent to the current activewindow.
   //       This shouldn't stop a dialog intercepting it though.
   CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE, 1); // 1 to reset the history
   message.SetStringParam(!params.empty() ? params[0] : "");
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -74,8 +79,10 @@ static int Refresh(const std::vector<std::string>& params)
  */
 static int SetSortMethod(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage message(GUI_MSG_CHANGE_SORT_METHOD, g_windowManager.GetActiveWindow(), 0, atoi(params[0].c_str()));
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -86,8 +93,10 @@ static int SetSortMethod(const std::vector<std::string>& params)
  */
 static int SetViewMode(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage message(GUI_MSG_CHANGE_VIEW_MODE, g_windowManager.GetActiveWindow(), 0, atoi(params[0].c_str()));
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -97,8 +106,10 @@ static int SetViewMode(const std::vector<std::string>& params)
  */
 static int ToggleSortDirection(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage message(GUI_MSG_CHANGE_SORT_DIRECTION, g_windowManager.GetActiveWindow(), 0, 0);
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -110,11 +121,13 @@ static int ToggleSortDirection(const std::vector<std::string>& params)
  */
 static int Update(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE, 0);
   message.SetStringParam(params[0]);
   if (params.size() > 1 && StringUtils::EqualsNoCase(params[1], "replace"))
     message.SetParam2(1); // reset the history
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
@@ -22,6 +22,7 @@
 
 #include "guilib/GUIWindowManager.h"
 #include "input/ButtonTranslator.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/StringUtils.h"
 
 /*! \brief Send a move event to a GUI control.
@@ -31,9 +32,11 @@
  */
 static int ControlMove(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage message(GUI_MSG_MOVE_OFFSET, g_windowManager.GetFocusedWindow(),
                       atoi(params[0].c_str()), atoi(params[1].c_str()));
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }
@@ -45,17 +48,19 @@ static int ControlMove(const std::vector<std::string>& params)
  */
 static int SendClick(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (params.size() == 2)
   {
     // have a window - convert it
     int windowID = CButtonTranslator::TranslateWindow(params[0]);
     CGUIMessage message(GUI_MSG_CLICKED, atoi(params[1].c_str()), windowID);
-    g_windowManager.SendMessage(message);
+    SendGUIMessage(message);
   }
   else
   { // single param - assume you meant the focused window
     CGUIMessage message(GUI_MSG_CLICKED, atoi(params[0].c_str()), g_windowManager.GetFocusedWindow());
-    g_windowManager.SendMessage(message);
+    SendGUIMessage(message);
   }
 
   return 0;
@@ -69,18 +74,20 @@ static int SendClick(const std::vector<std::string>& params)
  */
 static int SendMessage(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   int controlID = atoi(params[0].c_str());
   int windowID = (params.size() == 3) ? CButtonTranslator::TranslateWindow(params[2]) : g_windowManager.GetActiveWindow();
   if (params[1] == "moveup")
-    g_windowManager.SendMessage(GUI_MSG_MOVE_OFFSET, windowID, controlID, 1);
+    SendGUIMessage(GUI_MSG_MOVE_OFFSET, windowID, controlID, 1);
   else if (params[1] == "movedown")
-    g_windowManager.SendMessage(GUI_MSG_MOVE_OFFSET, windowID, controlID, -1);
+    SendGUIMessage(GUI_MSG_MOVE_OFFSET, windowID, controlID, -1);
   else if (params[1] == "pageup")
-    g_windowManager.SendMessage(GUI_MSG_PAGE_UP, windowID, controlID);
+    SendGUIMessage(GUI_MSG_PAGE_UP, windowID, controlID);
   else if (params[1] == "pagedown")
-    g_windowManager.SendMessage(GUI_MSG_PAGE_DOWN, windowID, controlID);
+    SendGUIMessage(GUI_MSG_PAGE_DOWN, windowID, controlID);
   else if (params[1] == "click")
-    g_windowManager.SendMessage(GUI_MSG_CLICKED, controlID, windowID);
+    SendGUIMessage(GUI_MSG_CLICKED, controlID, windowID);
 
   return 0;
 }
@@ -93,13 +100,15 @@ static int SendMessage(const std::vector<std::string>& params)
  */
 static int SetFocus(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   int controlID = atol(params[0].c_str());
   int subItem = (params.size() > 1) ? atol(params[1].c_str())+1 : 0;
   int absID = 0;
   if (params.size() > 2 && StringUtils::EqualsNoCase(params[2].c_str(), "absolute"))
     absID = 1;
   CGUIMessage msg(GUI_MSG_SETFOCUS, g_windowManager.GetFocusedWindow(), controlID, subItem, absID);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   return 0;
 }
@@ -113,9 +122,11 @@ static int SetFocus(const std::vector<std::string>& params)
   template<int Message>
 static int ShiftPage(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   int id = atoi(params[0].c_str());
   CGUIMessage message(Message, g_windowManager.GetFocusedWindow(), id);
-  g_windowManager.SendMessage(message);
+  SendGUIMessage(message);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -28,6 +28,7 @@
 #include "GUIUserMessages.h"
 #include "MediaSource.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/MusicDatabase.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
@@ -205,8 +206,10 @@ static int UpdateLibrary(const std::vector<std::string>& params)
  */
 static int SearchVideoLibrary(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_SEARCH, 0, 0, 0);
-  g_windowManager.SendMessage(msg, WINDOW_VIDEO_NAV);
+  SendGUIMessage(msg, WINDOW_VIDEO_NAV);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -26,6 +26,7 @@
 #include "filesystem/Directory.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "PartyModeManager.h"
 #include "PlayListPlayer.h"
 #include "settings/AdvancedSettings.h"
@@ -116,6 +117,8 @@ static int PlayOffset(const std::vector<std::string>& params)
  */
 static int PlayerControl(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   g_application.ResetScreenSaver();
   g_application.WakeUpScreenSaverAndDPMS();
 
@@ -290,7 +293,7 @@ static int PlayerControl(const std::vector<std::string>& params)
 
     // send message
     CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_RANDOM, 0, 0, iPlaylist, g_playlistPlayer.IsShuffled(iPlaylist));
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(msg);
   }
   else if (StringUtils::StartsWithNoCase(params[0], "repeat"))
   {
@@ -335,8 +338,8 @@ static int PlayerControl(const std::vector<std::string>& params)
     }
 
     // send messages so now playing window can get updated
-    CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_REPEAT, 0, 0, iPlaylist, (int)state);
-    g_windowManager.SendThreadMessage(msg);
+    CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_REPEAT, 0, 0, iPlaylist, static_cast<int>(state));
+    PostGUIMessage(msg);
   }
   else if (StringUtils::StartsWithNoCase(params[0], "resumelivetv"))
   {

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -30,6 +30,7 @@
 #include "GUIUserMessages.h"
 #include "network/Network.h"
 #include "network/NetworkServices.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
@@ -95,6 +96,8 @@ static int LogOff(const std::vector<std::string>& params)
  */
 static int MasterMode(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (g_passwordManager.bMasterUser)
   {
     g_passwordManager.bMasterUser = false;
@@ -110,7 +113,7 @@ static int MasterMode(const std::vector<std::string>& params)
 
   CUtil::DeleteVideoDatabaseDirectoryCache();
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/WeatherBuiltins.cpp
+++ b/xbmc/interfaces/builtins/WeatherBuiltins.cpp
@@ -21,6 +21,7 @@
 #include "WeatherBuiltins.h"
 
 #include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 /*! \brief Switch to a given weather location.
  *  \param params The parameters.
@@ -28,9 +29,11 @@
  */
 static int SetLocation(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   int loc = atoi(params[0].c_str());
   CGUIMessage msg(GUI_MSG_ITEM_SELECT, 0, 0, loc);
-  g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  SendGUIMessage(msg, WINDOW_WEATHER);
 
   return 0;
 }
@@ -44,8 +47,10 @@ static int SetLocation(const std::vector<std::string>& params)
   template<int Direction>
 static int SwitchLocation(const std::vector<std::string>& params)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_MOVE_OFFSET, 0, 0, Direction);
-  g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  SendGUIMessage(msg, WINDOW_WEATHER);
 
   return 0;
 }

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -21,6 +21,7 @@
 #include "InputOperations.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
@@ -71,6 +72,8 @@ JSONRPC_STATUS CInputOperations::activateWindow(int windowID)
 
 JSONRPC_STATUS CInputOperations::SendText(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (CGUIKeyboardFactory::SendTextToActiveKeyboard(parameterObject["text"].asString(), parameterObject["done"].asBoolean()))
     return ACK;
 
@@ -81,7 +84,7 @@ JSONRPC_STATUS CInputOperations::SendText(const std::string &method, ITransportL
   CGUIMessage msg(GUI_MSG_SET_TEXT, 0, window->GetFocusedControlID());
   msg.SetLabel(parameterObject["text"].asString());
   msg.SetParam1(parameterObject["done"].asBoolean() ? 1 : 0);
-  CApplicationMessenger::GetInstance().SendGUIMessage(msg, window->GetID());
+  SendGUIMessage(msg, window->GetID());
 
   return ACK;
 }

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -24,6 +24,7 @@
 #include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 class CVariant;
 
@@ -168,14 +169,17 @@ namespace JSONRPC
   public:
     static inline void NotifyItemUpdated()
     {
-      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE, g_windowManager.GetActiveWindow());
-      g_windowManager.SendThreadMessage(message);
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+      PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE, g_windowManager.GetActiveWindow());
     }
     static inline void NotifyItemUpdated(const CVideoInfoTag &info)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       CFileItemPtr msgItem(new CFileItem(info));
       CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
-      g_windowManager.SendThreadMessage(message);
+      PostGUIMessage(message);
     }
   };
 }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -28,6 +28,7 @@
 #include "interfaces/builtins/Builtins.h"
 #include "PartyModeManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "FileItem.h"
 #include "VideoLibrary.h"
 #include "video/VideoDatabase.h"
@@ -1138,6 +1139,8 @@ int CPlayerOperations::GetPlaylist(PlayerType player)
 
 JSONRPC_STATUS CPlayerOperations::StartSlideshow(const std::string& path, bool recursive, bool random, const std::string &firstPicturePath /* = "" */)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   int flags = 0;
   if (recursive)
     flags |= 1;
@@ -1156,7 +1159,7 @@ JSONRPC_STATUS CPlayerOperations::StartSlideshow(const std::string& path, bool r
   g_application.WakeUpScreenSaverAndDPMS();
   CGUIMessage msg(GUI_MSG_START_SLIDESHOW, 0, 0, flags);
   msg.SetStringParams(params);
-  CApplicationMessenger::GetInstance().SendGUIMessage(msg, WINDOW_SLIDESHOW);
+  SendGUIMessage(msg, WINDOW_SLIDESHOW);
 
   return ACK;
 }
@@ -1168,8 +1171,9 @@ void CPlayerOperations::SendSlideshowAction(int actionID)
 
 void CPlayerOperations::OnPlaylistChanged()
 {
-  CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
-  g_windowManager.SendThreadMessage(msg);
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+  PostGUIMessage(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
 }
 
 JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std::string &property, CVariant &result)

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -24,6 +24,7 @@
 #include "input/Key.h"
 #include "GUIUserMessages.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
 #include "utils/Variant.h"
@@ -239,8 +240,9 @@ int CPlaylistOperations::GetPlaylist(const CVariant &playlist)
 
 void CPlaylistOperations::NotifyAll()
 {
-  CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
-  g_windowManager.SendThreadMessage(msg);
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+  PostGUIMessage(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
 }
 
 JSONRPC_STATUS CPlaylistOperations::GetPropertyValue(int playlist, const std::string &property, CVariant &result)

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -25,6 +25,7 @@
 #include "addons/GUIDialogAddonSettings.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/StringUtils.h"
 
 using namespace ADDON;
@@ -73,6 +74,8 @@ namespace XBMCAddon
 
     void Addon::setSetting(const char* id, const String& value)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       DelayedCallGuard dcguard(languageHook);
       ADDON::AddonPtr addon(pAddon);
       bool save=true;
@@ -86,7 +89,7 @@ namespace XBMCAddon
           params.push_back(id);
           params.push_back(value);
           message.SetStringParams(params);
-          g_windowManager.SendThreadMessage(message,WINDOW_DIALOG_ADDON_SETTINGS);
+          PostGUIMessage(message,WINDOW_DIALOG_ADDON_SETTINGS);
           save=false;
         }
       }

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -37,10 +37,12 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIControlFactory.h"
 #include "listproviders/StaticProvider.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #include "utils/XBMCTinyXML.h"
 #include "utils/StringUtils.h"
 #include "WindowException.h"
+#include "messaging/helpers/DialogHelper.h"
 
 namespace XBMCAddon
 {
@@ -72,18 +74,21 @@ namespace XBMCAddon
 
     void ControlFadeLabel::addLabel(const String& label)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
       CGUIMessage msg(GUI_MSG_LABEL_ADD, iParentId, iControlId);
       msg.SetLabel(label);
 
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     void ControlFadeLabel::reset()
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
 
       vecLabels.clear();
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     CGUIControl* ControlFadeLabel::Create()
@@ -138,12 +143,14 @@ namespace XBMCAddon
 
     void ControlTextBox::setText(const String& text)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       // create message
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
       msg.SetLabel(text);
 
       // send message
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     String ControlTextBox::getText()
@@ -156,9 +163,11 @@ namespace XBMCAddon
 
     void ControlTextBox::reset()
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       // create message
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     void ControlTextBox::scroll(long position)
@@ -962,10 +971,12 @@ namespace XBMCAddon
                                 const char* shadowColor, const char* focusedColor,
                                 const String& label2)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       strText = label;
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
       msg.SetLabel(strText);
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     String ControlLabel::getLabel()
@@ -1028,10 +1039,12 @@ namespace XBMCAddon
                                 const char* shadowColor, const char* focusedColor,
                                 const String& label2)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       strText = label;
       CGUIMessage msg(GUI_MSG_LABEL_SET, iParentId, iControlId);
       msg.SetLabel(strText);
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     String ControlEdit::getLabel()
@@ -1043,18 +1056,21 @@ namespace XBMCAddon
 
     void ControlEdit::setText(const String& text)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       // create message
       CGUIMessage msg(GUI_MSG_LABEL2_SET, iParentId, iControlId);
       msg.SetLabel(text);
 
       // send message
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     String ControlEdit::getText()
     {
+      using KODI::MESSAGING::HELPERS::SendGUIMessage;
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, iParentId, iControlId);
-      g_windowManager.SendMessage(msg, iParentId);
+      SendGUIMessage(msg, iParentId);
 
       return msg.GetLabel();
     }
@@ -1173,6 +1189,8 @@ namespace XBMCAddon
 
     void ControlList::sendLabelBind(int tail)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       // construct a CFileItemList to pass 'em on to the list
       CGUIListItemPtr items(new CFileItemList());
       for (unsigned int i = vecItems.size() - tail; i < vecItems.size(); i++)
@@ -1180,16 +1198,18 @@ namespace XBMCAddon
 
       CGUIMessage msg(GUI_MSG_LABEL_BIND, iParentId, iControlId, 0, 0, items);
       msg.SetPointer(items.get());
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     void ControlList::selectItem(long item)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       // create message
       CGUIMessage msg(GUI_MSG_ITEM_SELECT, iParentId, iControlId, item);
 
       // send message
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
     }
 
     void ControlList::removeItem(int index)
@@ -1204,9 +1224,11 @@ namespace XBMCAddon
 
     void ControlList::reset()
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       CGUIMessage msg(GUI_MSG_LABEL_RESET, iParentId, iControlId);
 
-      g_windowManager.SendThreadMessage(msg, iParentId);
+      PostGUIMessage(msg, iParentId);
 
       // delete all items from vector
       // delete all ListItem from vector

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -26,8 +26,10 @@
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/Variant.h"
 #include "WindowException.h"
+#include "messaging/helpers/DialogHelper.h"
 
 using namespace KODI::MESSAGING;
 
@@ -504,19 +506,24 @@ namespace XBMCAddon
 
     void Window::setFocus(Control* pControl)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       XBMC_TRACE;
+
       if(pControl == NULL)
         throw WindowException("Object should be of type Control");
 
       CGUIMessage msg = CGUIMessage(GUI_MSG_SETFOCUS,pControl->iParentId, pControl->iControlId);
-      g_windowManager.SendThreadMessage(msg, pControl->iParentId);
+      PostGUIMessage(msg, pControl->iParentId);
     }
 
     void Window::setFocusId(int iControlId)
     {
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
       XBMC_TRACE;
       CGUIMessage msg = CGUIMessage(GUI_MSG_SETFOCUS,iWindowId,iControlId);
-      g_windowManager.SendThreadMessage(msg, iWindowId);
+      PostGUIMessage(msg, iWindowId);
     }
 
     Control* Window::getFocus()
@@ -550,6 +557,8 @@ namespace XBMCAddon
 
     void Window::doRemoveControl(Control* pControl, CCriticalSection* gcontext, bool wait)
     {
+      using namespace KODI::MESSAGING::HELPERS;
+
       XBMC_TRACE;
       // type checking, object should be of type Control
       if(pControl == NULL)
@@ -574,7 +583,10 @@ namespace XBMCAddon
 
       CGUIMessage msg(GUI_MSG_REMOVE_CONTROL, 0, 0);
       msg.SetPointer(pControl->pGUIControl);
-      CApplicationMessenger::GetInstance().SendGUIMessage(msg, iWindowId, wait);
+      if (wait)
+        SendGUIMessage(msg, iWindowId);
+      else
+        PostGUIMessage(msg, iWindowId);
 
       // initialize control to zero
       pControl->pGUIControl = NULL;
@@ -719,6 +731,8 @@ namespace XBMCAddon
 
     void Window::doAddControl(Control* pControl, CCriticalSection* gcontext, bool wait)
     {
+      using namespace KODI::MESSAGING::HELPERS;
+
       XBMC_TRACE;
       if(pControl == NULL)
         throw WindowException("NULL Control passed to WindowBase::addControl");
@@ -756,7 +770,10 @@ namespace XBMCAddon
       // This calls the CGUIWindow parent class to do the final add
       CGUIMessage msg(GUI_MSG_ADD_CONTROL, 0, 0);
       msg.SetPointer(pControl->pGUIControl);
-      CApplicationMessenger::GetInstance().SendGUIMessage(msg, iWindowId, wait);
+      if (wait)
+        SendGUIMessage(msg, iWindowId);
+      else
+        PostGUIMessage(msg, iWindowId);
     }
 
     void Window::addControls(std::vector<Control*> pControls)

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "music/MusicThumbLoader.h"
 #include "pictures/PictureThumbLoader.h"
@@ -47,10 +48,10 @@
 #include "video/VideoThumbLoader.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoBase.h"
+#include "messaging/helpers/DialogHelper.h"
 
 using namespace XFILE;
 using namespace ANNOUNCEMENT;
-using namespace KODI::MESSAGING;
 using namespace PVR;
 
 class CDirectoryJob : public CJob
@@ -356,6 +357,8 @@ void CDirectoryProvider::OnJobComplete(unsigned int jobID, bool success, CJob *j
 
 bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CFileItem fileItem(*std::static_pointer_cast<CFileItem>(item));
 
   if (fileItem.HasVideoInfoTag()
@@ -379,7 +382,7 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
   {
     CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);
     message.SetStringParam(execute);
-    g_windowManager.SendMessage(message);
+    SendGUIMessage(message);
     return true;
   }
   return false;

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -137,9 +137,6 @@
 #define TMSG_CALLBACK                     800
 
 
-
-class CGUIMessage;
-
 namespace KODI
 {
 namespace MESSAGING
@@ -385,20 +382,15 @@ public:
    */
   void ProcessWindowMessages();
 
-  /*! \brief Send a GUIMessage, optionally waiting before it's processed to return.
-   * This is kept for backward compat and is just a convenience wrapper for for SendMsg and PostMsg
-   * specifically for UI messages
-   * \param msg the GUIMessage to send.
-   * \param windowID optional window to send the message to (defaults to no specified window).
-   * \param waitResult whether to wait for the result (defaults to false).
-   */
-  void SendGUIMessage(const CGUIMessage &msg, int windowID = WINDOW_INVALID, bool waitResult=false);
-
   /*!
    * \brief This should be called any class implementing \sa IMessageTarget before it
    * can receive any messages
    */
   void RegisterReceiver(IMessageTarget* target);
+
+  // method to removed queued messages with message id in the requested message id list.
+  // pMessageIDList: point to first integer of a 0 ends integer array.
+  int RemoveThreadMessageByMessageIds(std::vector<int>& pMessageIDList);
 
 private:
   // private construction, and no assignments; use the provided singleton methods
@@ -410,9 +402,9 @@ private:
   int SendMsg(ThreadMessage&& msg, bool wait);
   void ProcessMessage(ThreadMessage *pMsg);
 
-  std::queue<ThreadMessage*> m_vecMessages; /*!< queue for regular messages */
-  std::queue<ThreadMessage*> m_vecWindowMessages; /*!< queue for UI messages */
-  std::map<int, IMessageTarget*> m_mapTargets; /*!< a map of registered receivers indexed on the message mask*/
+  std::deque<ThreadMessage*> m_vecMessages;
+  std::deque<ThreadMessage*> m_vecWindowMessages;
+  std::map<int, IMessageTarget*> m_mapTargets;
   CCriticalSection m_critSection;
 };
 }

--- a/xbmc/messaging/helpers/CMakeLists.txt
+++ b/xbmc/messaging/helpers/CMakeLists.txt
@@ -1,5 +1,9 @@
-set(SOURCES DialogHelper.cpp)
+set(SOURCES DialogHelper.cpp
+            GUIMessageHelper.cpp
+)
 
-set(HEADERS DialogHelper.h)
+set(HEADERS DialogHelper.h
+            GUIMessageHelper.h
+)
 
 core_add_library(messagingHelpers)

--- a/xbmc/messaging/helpers/GUIMessageHelper.cpp
+++ b/xbmc/messaging/helpers/GUIMessageHelper.cpp
@@ -1,0 +1,75 @@
+/*
+*      Copyright (C) 2005-2017 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "GUIMessageHelper.h"
+#include "messaging/ApplicationMessenger.h"
+#include "guilib/GUIMessage.h"
+
+
+namespace KODI
+{
+namespace MESSAGING
+{
+namespace HELPERS
+{
+bool SendGUIMessage(CGUIMessage& message)
+{
+  auto result = CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_MESSAGE, 0, -1,
+    static_cast<void*>(new CGUIMessage(message)));
+
+  return result == 1;
+}
+
+bool SendGUIMessage(int message, int senderID, int destID, int param1, int param2)
+{
+  auto result = CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_MESSAGE, 0, -1,
+    static_cast<void*>(new CGUIMessage(message, senderID, destID, param1, param2)));
+
+  return result == 1;
+}
+
+bool SendGUIMessage(CGUIMessage& message, int window)
+{
+  auto result = CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_MESSAGE, window, -1,
+    static_cast<void*>(new CGUIMessage(message)));
+
+  return result == 1;
+}
+
+void PostGUIMessage(CGUIMessage& message)
+{
+  CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_MESSAGE, 0, -1,
+    static_cast<void*>(new CGUIMessage(message)));
+}
+
+void PostGUIMessage(int message, int senderID, int destID, int param1, int param2)
+{
+  CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_MESSAGE, 0, -1,
+    static_cast<void*>(new CGUIMessage(message, senderID, destID, param1, param2)));
+}
+
+void PostGUIMessage(CGUIMessage& message, int window)
+{
+  CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_MESSAGE, window, -1,
+    static_cast<void*>(new CGUIMessage(message)));
+}
+}
+}
+}

--- a/xbmc/messaging/helpers/GUIMessageHelper.h
+++ b/xbmc/messaging/helpers/GUIMessageHelper.h
@@ -27,11 +27,86 @@ namespace MESSAGING
 {
 namespace HELPERS
 {
+  /**
+   * \brief SendGUIMessage sends a message to the UI thread and wait's for completion
+   * 
+   * Senders SHOULD NOT hold a lock when sending a message as it may easily cause deadlocks.
+   * Prefer to use \sa PostGUIMessage unless requiring a result back or wanting to make sure
+   * message is processed before proceeding.
+   * 
+   * \param [in] message \sa CGUIMessage to send
+   * \return true for success, false for failure
+   * \sa PostGUIMessage
+   */
   bool SendGUIMessage(CGUIMessage& message);
+
+  /**
+   * \brief SendGUIMessage sends a message to the UI thread and wait's for completion
+   * 
+   * Senders SHOULD NOT hold a lock when sending a message as it may easily cause deadlocks.
+   * Prefer to use \sa PostGUIMessage unless requiring a result back or wanting to make sure
+   * message is processed before proceeding.
+   * 
+   * \param [in] message message id defined in GUIMessage.h 
+   * \param [in] senderID window id of the sender, if it's from a window or control
+   * \param [in] destID window/control id the message is intended for
+   * \param [in] param1 optional value, meaning is defined by the message
+   * \param [in] param2 optional value, meaning is defined by the message
+   * \return true for success, false for failure
+   * \sa PostGUIMessage
+   */
   bool SendGUIMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
+
+  /**
+   * \brief SendGUIMessage sends a message to the UI thread and wait's for completion
+   * 
+   * Senders SHOULD NOT hold a lock when sending a message as it may easily cause deadlocks.
+   * Prefer to use \sa PostGUIMessage unless requiring a result back or wanting to make sure
+   * message is processed before proceeding.
+   * 
+   * \param [in] message message id defined in GUIMessage.h 
+   * \param [in] window window/control id the message is intended for
+   * \return true for success, false for failure
+   * \sa PostGUIMessage
+   */
   bool SendGUIMessage(CGUIMessage& message, int window);
+
+  /**
+   * \brief PostGUIMessage adds a GUI message to the message queue and returns directly
+   * 
+   * No return values are available, if synchronicity or a return value is required, see
+   * \sa SendGUIMessage
+   * 
+   * \param [in] message \sa CGUIMessage to post
+   * \sa SendGUIMessage
+   */
   void PostGUIMessage(CGUIMessage& message);
+
+  /**
+   * \brief PostGUIMessage adds a GUI message to the message queue and returns directly
+   * 
+   * No return values are available, if synchronicity or a return value is required, see
+   * \sa SendGUIMessage
+   * 
+   * \param [in] message message id defined in GUIMessage.h 
+   * \param [in] senderID window id of the sender, if it's from a window or control
+   * \param [in] destID window/control id the message is intended for
+   * \param [in] param1 optional value, meaning is defined by the message
+   * \param [in] param2 optional value, meaning is defined by the message
+   * \sa SendGUIMessage
+   */
   void PostGUIMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
+
+  /**
+   * \brief PostGUIMessage adds a GUI message to the message queue and returns directly
+   * 
+   * No return values are available, if synchronicity or a return value is required, see
+   * \sa SendGUIMessage
+   * 
+   * \param [in] message \sa CGUIMessage to post
+   * \param [in] window the window id to post the message to
+   * \sa SendGUIMessage
+   */
   void PostGUIMessage(CGUIMessage& message, int window);
 }
 }

--- a/xbmc/messaging/helpers/GUIMessageHelper.h
+++ b/xbmc/messaging/helpers/GUIMessageHelper.h
@@ -1,0 +1,38 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2017 Team Kodi
+*      http://kodi.tv
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with Kodi; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+class CGUIMessage;
+
+namespace KODI
+{
+namespace MESSAGING
+{
+namespace HELPERS
+{
+  bool SendGUIMessage(CGUIMessage& message);
+  bool SendGUIMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
+  bool SendGUIMessage(CGUIMessage& message, int window);
+  void PostGUIMessage(CGUIMessage& message);
+  void PostGUIMessage(int message, int senderID, int destID, int param1 = 0, int param2 = 0);
+  void PostGUIMessage(CGUIMessage& message, int window);
+}
+}
+}

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -39,6 +39,7 @@
 #include "music/MusicThumbLoader.h"
 #include "music/windows/GUIWindowMusicNav.h"
 #include "filesystem/Directory.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 using namespace XFILE;
 
@@ -70,6 +71,8 @@ CGUIDialogMusicInfo::~CGUIDialogMusicInfo(void)
 
 bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch ( message.GetMessage() )
   {
   case GUI_MSG_WINDOW_DEINIT:
@@ -125,7 +128,7 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
         if (m_bArtistInfo && (ACTION_SELECT_ITEM == iAction || ACTION_MOUSE_LEFT_CLICK == iAction))
         {
           CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
-          g_windowManager.SendMessage(msg);
+          SendGUIMessage(msg);
           int iItem = msg.GetParam1();
           if (iItem < 0 || iItem >= static_cast<int>(m_albumSongs->Size()))
             break;
@@ -324,6 +327,8 @@ void CGUIDialogMusicInfo::OnInitWindow()
 
 void CGUIDialogMusicInfo::SetUserrating(int userrating) const
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (userrating < 0) userrating = 0;
   if (userrating > 10) userrating = 10;
   if (userrating != m_albumItem->GetMusicInfoTag()->GetUserrating())
@@ -331,7 +336,7 @@ void CGUIDialogMusicInfo::SetUserrating(int userrating) const
     m_albumItem->GetMusicInfoTag()->SetUserrating(userrating);
     // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_albumItem);
-    g_windowManager.SendMessage(msg);
+    SendGUIMessage(msg);
   }
 }
 
@@ -346,6 +351,8 @@ void CGUIDialogMusicInfo::SetUserrating(int userrating) const
 //!       without sending a file that has this as it's album to this class
 void CGUIDialogMusicInfo::OnGetThumb()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CFileItemList items;
 
   // Current thumb
@@ -446,7 +453,7 @@ void CGUIDialogMusicInfo::OnGetThumb()
   // tell our GUI to completely reload all controls (as some of them
   // are likely to have had this image in use so will need refreshing)
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
   // Update our screen
   Update();
 }
@@ -455,6 +462,8 @@ void CGUIDialogMusicInfo::OnGetThumb()
 // Allow user to select a Fanart
 void CGUIDialogMusicInfo::OnGetFanart()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CFileItemList items;
 
   if (m_albumItem->HasArt("fanart"))
@@ -545,7 +554,7 @@ void CGUIDialogMusicInfo::OnGetFanart()
   // tell our GUI to completely reload all controls (as some of them
   // are likely to have had this image in use so will need refreshing)
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
   // Update our screen
   Update();
 }

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -26,11 +26,12 @@
 #include "GUIUserMessages.h"
 #include "settings/Settings.h"
 #include "addons/GUIWindowAddonBrowser.h"
-#include "xbmc/dialogs/GUIDialogSelect.h"
-#include "xbmc/Application.h"
-#include "xbmc/FileItem.h"
-#include "xbmc/music/tags/MusicInfoTag.h"
-#include "xbmc/music/MusicDatabase.h"
+#include "dialogs/GUIDialogSelect.h"
+#include "Application.h"
+#include "FileItem.h"
+#include "music/tags/MusicInfoTag.h"
+#include "music/MusicDatabase.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #define CONTROL_VIS_BUTTON       500
 #define CONTROL_LOCK_BUTTON      501
@@ -47,6 +48,8 @@ CGUIDialogMusicOSD::~CGUIDialogMusicOSD(void)
 
 bool CGUIDialogMusicOSD::OnMessage(CGUIMessage &message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch (message.GetMessage())
   {
   case GUI_MSG_CLICKED:
@@ -59,13 +62,13 @@ bool CGUIDialogMusicOSD::OnMessage(CGUIMessage &message)
         {
           CServiceBroker::GetSettings().SetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION, addonID);
           CServiceBroker::GetSettings().Save();
-          g_windowManager.SendMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
+          SendGUIMessage(GUI_MSG_VISUALISATION_RELOAD, 0, 0);
         }
       }
       else if (iControl == CONTROL_LOCK_BUTTON)
       {
         CGUIMessage msg(GUI_MSG_VISUALISATION_ACTION, 0, 0, ACTION_VIS_PRESET_LOCK);
-        g_windowManager.SendMessage(msg);
+        SendGUIMessage(msg);
       }
       return true;
     }
@@ -76,6 +79,8 @@ bool CGUIDialogMusicOSD::OnMessage(CGUIMessage &message)
 
 bool CGUIDialogMusicOSD::OnAction(const CAction &action)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch (action.GetID())
   {
     case ACTION_SHOW_OSD:
@@ -106,7 +111,7 @@ bool CGUIDialogMusicOSD::OnAction(const CAction &action)
           track->GetMusicInfoTag()->SetUserrating(userrating);
           // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
           CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, track);
-          g_windowManager.SendMessage(msg);
+          SendGUIMessage(msg);
 
           CMusicDatabase db;
           if (db.Open())

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -39,6 +39,7 @@
 #include "music/Album.h"
 #include "storage/MediaManager.h"
 #include "GUIDialogMusicInfo.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 using namespace XFILE;
 
@@ -66,6 +67,8 @@ CGUIDialogSongInfo::~CGUIDialogSongInfo(void)
 
 bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch (message.GetMessage())
   {
   case GUI_MSG_WINDOW_DEINIT:
@@ -121,7 +124,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
         if ((ACTION_SELECT_ITEM == iAction || ACTION_MOUSE_LEFT_CLICK == iAction))
         {
           CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
-          g_windowManager.SendMessage(msg);
+          SendGUIMessage(msg);
           int iItem = msg.GetParam1();
           if (iItem < 0 || iItem >= static_cast<int>(m_song->GetMusicInfoTag()->GetContributors().size()))
             break;
@@ -229,6 +232,8 @@ void CGUIDialogSongInfo::Update()
 
 void CGUIDialogSongInfo::SetUserrating(int userrating)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (userrating < 0) userrating = 0;
   if (userrating > 10) userrating = 10;
   if (userrating != m_song->GetMusicInfoTag()->GetUserrating())
@@ -236,7 +241,7 @@ void CGUIDialogSongInfo::SetUserrating(int userrating)
     m_song->GetMusicInfoTag()->SetUserrating(userrating);
     // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_song);
-    g_windowManager.SendMessage(msg);
+    SendGUIMessage(msg);
   }
 }
 
@@ -301,6 +306,8 @@ bool CGUIDialogSongInfo::DownloadThumbnail(const std::string &thumbFile)
 //!       without sending a file that has this as it's album to this class
 void CGUIDialogSongInfo::OnGetThumb()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CFileItemList items;
 
 
@@ -386,7 +393,7 @@ void CGUIDialogSongInfo::OnGetThumb()
   // tell our GUI to completely reload all controls (as some of them
   // are likely to have had this image in use so will need refreshing)
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
 //  m_hasUpdatedThumb = true;
 }

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -79,8 +80,10 @@ void CGUIDialogVisualisationPresetList::SetVisualisation(CVisualisation* vis)
 
 void CGUIDialogVisualisationPresetList::OnInitWindow()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
   if (msg.GetPointer())
     SetVisualisation(static_cast<CVisualisation*>(msg.GetPointer()));
   CGUIDialogSelect::OnInitWindow();

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -44,6 +44,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "GUIUserMessages.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/MusicThumbLoader.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
@@ -89,6 +90,8 @@ CMusicInfoScanner::~CMusicInfoScanner()
 
 void CMusicInfoScanner::Process()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanStarted");
   try
   {
@@ -262,8 +265,7 @@ void CMusicInfoScanner::Process()
   
   // we need to clear the musicdb cache and update any active lists
   CUtil::DeleteMusicDatabaseDirectoryCache();
-  CGUIMessage msg(GUI_MSG_SCAN_FINISHED, 0, 0, 0);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_SCAN_FINISHED, 0, 0, 0);
   
   if (m_handle)
     m_handle->MarkFinished();
@@ -435,9 +437,11 @@ void CMusicInfoScanner::CleanDatabase(bool showProgress /* = true */)
 
 static void OnDirectoryScanned(const std::string& strDirectory)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CGUIMessage msg(GUI_MSG_DIRECTORY_SCANNED, 0, 0, 0);
   msg.SetStringParam(strDirectory);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(msg);
 }
 
 static std::string Prettify(const std::string& strDirectory)

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -41,6 +41,7 @@
 #include "input/Key.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/dacp/dacp.h"
 #include "network/Network.h"
@@ -139,6 +140,8 @@ void CAirTunesServer::RefreshMetadata()
 
 void CAirTunesServer::RefreshCoverArt(const char *outputFilename/* = NULL*/)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   static std::string coverArtFile = TMP_COVERART_PATH_JPG;
 
   if (outputFilename != NULL)
@@ -152,7 +155,7 @@ void CAirTunesServer::RefreshCoverArt(const char *outputFilename/* = NULL*/)
   g_infoManager.SetCurrentAlbumThumb(coverArtFile);
   //update the ui
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_REFRESH_THUMBS);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(msg);
 }
 
 void CAirTunesServer::SetMetadataFromBuffer(const char *buffer, unsigned int size)

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -26,6 +26,7 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "network/DNSNameCache.h"
 #include "system.h"
 #include "threads/SingleLock.h"
@@ -68,6 +69,7 @@ void DNSSD_API CZeroconfBrowserMDNS::BrowserCallback(DNSServiceRef browser,
                                                     const char *replyDomain,
                                                     void *context)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
 
   if (errorCode == kDNSServiceErr_NoError)
   {
@@ -90,7 +92,7 @@ void DNSSD_API CZeroconfBrowserMDNS::BrowserCallback(DNSServiceRef browser,
     {
       CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
       message.SetStringParam("zeroconf://");
-      g_windowManager.SendThreadMessage(message);
+      PostGUIMessage(message);
       CLog::Log(LOGDEBUG, "ZeroconfBrowserMDNS::BrowserCallback sent gui update for path zeroconf://");
     }
   }

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -35,6 +35,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "network/Network.h"
 #include "utils/log.h"
 #include "URL.h"
@@ -186,21 +187,25 @@ public:
     // PLT_MediaBrowser methods
     virtual bool OnMSAdded(PLT_DeviceDataReference& device)
     {
-        CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-        message.SetStringParam("upnp://");
-        g_windowManager.SendThreadMessage(message);
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
 
-        return PLT_SyncMediaBrowser::OnMSAdded(device);
+      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
+      message.SetStringParam("upnp://");
+      PostGUIMessage(message);
+
+      return PLT_SyncMediaBrowser::OnMSAdded(device);
     }
     virtual void OnMSRemoved(PLT_DeviceDataReference& device)
     {
-        PLT_SyncMediaBrowser::OnMSRemoved(device);
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
 
-        CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-        message.SetStringParam("upnp://");
-        g_windowManager.SendThreadMessage(message);
+      PLT_SyncMediaBrowser::OnMSRemoved(device);
 
-        PLT_SyncMediaBrowser::OnMSRemoved(device);
+      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
+      message.SetStringParam("upnp://");
+      PostGUIMessage(message);
+
+      PLT_SyncMediaBrowser::OnMSRemoved(device);
     }
 
     // PLT_MediaContainerChangesListener methods
@@ -208,17 +213,19 @@ public:
                                     const char*              item_id,
                                     const char*              update_id)
     {
-        NPT_String path = "upnp://"+device->GetUUID()+"/";
-        if (!NPT_StringsEqual(item_id, "0")) {
-            std::string id(CURL::Encode(item_id));
-            URIUtils::AddSlashAtEnd(id);
-            path += id.c_str();
-        }
+      using KODI::MESSAGING::HELPERS::PostGUIMessage;
 
-        CLog::Log(LOGDEBUG, "UPNP: notified container update %s", (const char*)path);
-        CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
-        message.SetStringParam(path.GetChars());
-        g_windowManager.SendThreadMessage(message);
+      NPT_String path = "upnp://"+device->GetUUID()+"/";
+      if (!NPT_StringsEqual(item_id, "0")) {
+          std::string id(CURL::Encode(item_id));
+          URIUtils::AddSlashAtEnd(id);
+          path += id.c_str();
+      }
+
+      CLog::Log(LOGDEBUG, "UPNP: notified container update %s", (const char*)path);
+      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);
+      message.SetStringParam(path.GetChars());
+      PostGUIMessage(message);
     }
 
     bool MarkWatched(const CFileItem& item, const bool watched)

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -56,6 +56,7 @@
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
@@ -402,9 +403,11 @@ void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral 
 
 void CPeripherals::OnDeviceChanged()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // refresh settings (peripherals manager could be enabled/disabled now)
   CGUIMessage msgSettings(GUI_MSG_UPDATE, WINDOW_SETTINGS_SYSTEM, 0);
-  g_windowManager.SendThreadMessage(msgSettings, WINDOW_SETTINGS_SYSTEM);
+  PostGUIMessage(msgSettings, WINDOW_SETTINGS_SYSTEM);
 
   SetChanged();
 }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -28,6 +28,7 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/URIUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -121,13 +122,15 @@ bool CPictureThumbLoader::LoadItemLookup(CFileItem* pItem)
 
 void CPictureThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (success)
   {
     CThumbExtractor* loader = (CThumbExtractor*)job;
     loader->m_item.SetPath(loader->m_listpath);
     CFileItemPtr pItem(new CFileItem(loader->m_item));
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, pItem);
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(msg);
   }
   CJobQueue::OnJobComplete(jobID, success, job);
 }

--- a/xbmc/powermanagement/DPMSSupport.cpp
+++ b/xbmc/powermanagement/DPMSSupport.cpp
@@ -22,6 +22,7 @@
 #include "DPMSSupport.h"
 #include "utils/log.h"
 #include "windowing/WindowingFactory.h"
+
 #include <assert.h>
 #include <string>
 #ifdef TARGET_WINDOWS

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -42,6 +42,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/ButtonTranslator.h"
 #include "input/InputManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/Settings.h"
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
 #include "storage/DetectDVDType.h"
@@ -235,6 +236,8 @@ void CProfilesManager::Clear()
 
 bool CProfilesManager::LoadProfile(size_t index)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CSingleLock lock(m_critical);
   // check if the index is valid or not
   if (index >= m_profiles.size())
@@ -292,7 +295,7 @@ bool CProfilesManager::LoadProfile(size_t index)
 
   // init windows
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESET);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   CUtil::DeleteDirectoryCache();
   g_directoryCache.Clear();

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -36,6 +36,7 @@
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/Variant.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 using namespace XFILE;
 
@@ -57,14 +58,18 @@ CGUIWindowSettingsProfile::~CGUIWindowSettingsProfile(void)
 
 int CGUIWindowSettingsProfile::GetSelectedItem()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PROFILES);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   return msg.GetParam1();
 }
 
 void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (iItem == (int)CProfilesManager::GetInstance().GetNumberOfProfiles())
     return;
 
@@ -80,7 +85,7 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
     unsigned iCtrlID = GetFocusedControlID();
     g_application.StopPlaying();
     CGUIMessage msg2(GUI_MSG_ITEM_SELECTED, g_windowManager.GetActiveWindow(), iCtrlID);
-    g_windowManager.SendMessage(msg2);
+    SendGUIMessage(msg2);
     g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
     CProfilesManager::GetInstance().LoadMasterProfileForLogin();
     CGUIWindowLoginScreen::LoadProfile(iItem);
@@ -100,6 +105,8 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 
 bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch ( message.GetMessage() )
   {
   case GUI_MSG_WINDOW_DEINIT:
@@ -124,7 +131,7 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
         )
         {
           CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PROFILES);
-          g_windowManager.SendMessage(msg);
+          SendGUIMessage(msg);
           int iItem = msg.GetParam1();
           if (iAction == ACTION_CONTEXT_MENU || iAction == ACTION_MOUSE_RIGHT_CLICK)
           {
@@ -141,7 +148,7 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
             {
               LoadList();
               CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), 2,iItem);
-              g_windowManager.SendMessage(msg);
+              SendGUIMessage(msg);
 
               return true;
             }
@@ -155,7 +162,7 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
             {
               LoadList();
               CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), 2,iItem);
-              g_windowManager.SendMessage(msg);
+              SendGUIMessage(msg);
               return true;
             }
 
@@ -219,8 +226,10 @@ void CGUIWindowSettingsProfile::LoadList()
 
 void CGUIWindowSettingsProfile::ClearListItems()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_PROFILES);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   m_listItems->Clear();
 }

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -31,6 +31,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRGuideInfo.h"
 #include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
@@ -536,13 +537,15 @@ namespace PVR
 
   void CPVRGUIActions::CheckAndSwitchToFullscreen() const
   {
+    using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
     const bool bFullscreen(CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN));
     CMediaSettings::GetInstance().SetVideoStartWindowed(!bFullscreen);
 
     if (bFullscreen)
     {
       CGUIMessage msg(GUI_MSG_FULLSCREEN, 0, g_windowManager.GetActiveWindow());
-      g_windowManager.SendMessage(msg);
+      SendGUIMessage(msg);
     }
   }
 
@@ -571,6 +574,8 @@ namespace PVR
 
   bool CPVRGUIActions::PlayRecording(const CFileItemPtr &item, bool bCheckResume) const
   {
+    using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
     const CPVRRecordingPtr recording(CPVRItem(item).GetRecording());
     if (!recording)
       return false;
@@ -578,7 +583,7 @@ namespace PVR
     if (g_PVRManager.IsPlayingRecording(recording))
     {
       CGUIMessage msg(GUI_MSG_FULLSCREEN, 0, g_windowManager.GetActiveWindow());
-      g_windowManager.SendMessage(msg);
+      SendGUIMessage(msg);
       return true;
     }
 
@@ -648,6 +653,8 @@ namespace PVR
 
   bool CPVRGUIActions::SwitchToChannel(const CFileItemPtr &item, bool bCheckResume) const
   {
+    using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
     if (item->m_bIsFolder)
       return false;
 
@@ -656,7 +663,7 @@ namespace PVR
         (channel && channel->HasRecording() && g_PVRManager.IsPlayingRecording(channel->GetRecording())))
     {
       CGUIMessage msg(GUI_MSG_FULLSCREEN, 0, g_windowManager.GetActiveWindow());
-      g_windowManager.SendMessage(msg);
+      SendGUIMessage(msg);
       return true;
     }
 

--- a/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
+++ b/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp
@@ -22,6 +22,7 @@
 #include "GUIUserMessages.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/Archive.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
@@ -328,6 +329,8 @@ const std::string& CPVRRadioRDSInfoTag::GetComment() const
 
 void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strNews);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -343,8 +346,7 @@ void CPVRRadioRDSInfoTag::SetInfoNews(const std::string& strNews)
   m_strInfoNews.emplace_back(std::move(tmpStr));
 
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
@@ -362,6 +364,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoNews() const
 
 void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strNews);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -377,8 +381,7 @@ void CPVRRadioRDSInfoTag::SetInfoNewsLocal(const std::string& strNews)
   m_strInfoNewsLocal.emplace_front(std::move(tmpStr));
 
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
@@ -396,6 +399,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoNewsLocal() const
 
 void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strSport);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -411,8 +416,7 @@ void CPVRRadioRDSInfoTag::SetInfoSport(const std::string& strSport)
   m_strInfoSport.emplace_front(std::move(tmpStr));
 
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
@@ -430,6 +434,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoSport() const
 
 void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strStock);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -445,8 +451,7 @@ void CPVRRadioRDSInfoTag::SetInfoStock(const std::string& strStock)
   m_strInfoStock.emplace_front(std::move(tmpStr));
 
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
@@ -464,6 +469,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoStock() const
 
 void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strWeather);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -478,8 +485,7 @@ void CPVRRadioRDSInfoTag::SetInfoWeather(const std::string& strWeather)
 
   m_strInfoWeather.emplace_front(std::move(tmpStr));
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
@@ -497,6 +503,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoWeather() const
 
 void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strLottery);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -511,8 +519,7 @@ void CPVRRadioRDSInfoTag::SetInfoLottery(const std::string& strLottery)
 
   m_strInfoLottery.emplace_front(std::move(tmpStr));
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
@@ -530,6 +537,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoLottery() const
 
 void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strEditorialStaff);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -544,8 +553,7 @@ void CPVRRadioRDSInfoTag::SetEditorialStaff(const std::string& strEditorialStaff
 
   m_strEditorialStaff.push_front(tmpStr);
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
@@ -563,6 +571,8 @@ const std::string CPVRRadioRDSInfoTag::GetEditorialStaff() const
 
 void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strHoroscope);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -577,8 +587,7 @@ void CPVRRadioRDSInfoTag::SetInfoHoroscope(const std::string& strHoroscope)
 
   m_strInfoHoroscope.emplace_front(std::move(tmpStr));
   // send a message to all windows to tell them to update the radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
@@ -596,6 +605,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoHoroscope() const
 
 void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strCinema);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -610,8 +621,7 @@ void CPVRRadioRDSInfoTag::SetInfoCinema(const std::string& strCinema)
 
   m_strInfoCinema.emplace_front(std::move(tmpStr));
   // send a message to all windows to tell them to update the fileitem radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
@@ -629,6 +639,8 @@ const std::string CPVRRadioRDSInfoTag::GetInfoCinema() const
 
 void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string tmpStr = Trim(strOther);
   g_charsetConverter.unknownToUTF8(tmpStr);
 
@@ -643,8 +655,7 @@ void CPVRRadioRDSInfoTag::SetInfoOther(const std::string& strOther)
 
   m_strInfoOther.emplace_front(std::move(tmpStr));
   // send a message to all windows to tell them to update the fileitem radiotext
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
 }
 
 const std::string CPVRRadioRDSInfoTag::GetInfoOther() const

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -24,6 +24,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "view/ViewState.h"
 
 #include "pvr/PVRGUIActions.h"
@@ -306,8 +307,9 @@ CGUIControl *CGUIDialogPVRChannelsOSD::GetFirstFocusableControl(int id)
 
 void CGUIDialogPVRChannelsOSD::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
-  CApplicationMessenger::GetInstance().SendGUIMessage(m);
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
+  PostGUIMessage(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
 }
 
 void CGUIDialogPVRChannelsOSD::SaveSelectedItemPath(int iGroupID)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -109,13 +110,14 @@ void CGUIWindowPVRBase::UnregisterObservers(void)
 
 void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (msg == ObservableMessageManagerStopped)
     ClearData();
 
   if (IsActive())
   {
-    CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
-    CApplicationMessenger::GetInstance().SendGUIMessage(m);
+    PostGUIMessage(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
   }
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -26,6 +26,7 @@
 #include "view/GUIViewState.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
@@ -509,6 +510,8 @@ CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuid
 
 void CPVRRefreshTimelineItemsThread::Process()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   static const int BOOSTED_SLEEPS_THRESHOLD = 4;
 
   int iLastEpgItemsCount = 0;
@@ -518,8 +521,7 @@ void CPVRRefreshTimelineItemsThread::Process()
   {
     if (m_pGuideWindow->RefreshTimelineItems() && !m_bStop)
     {
-      CGUIMessage m(GUI_MSG_REFRESH_LIST, m_pGuideWindow->GetID(), 0, ObservableMessageEpg);
-      KODI::MESSAGING::CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      PostGUIMessage(GUI_MSG_REFRESH_LIST, m_pGuideWindow->GetID(), 0, ObservableMessageEpg);
     }
 
     // in order to fill the guide window asap, use a short update interval until we the

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -30,6 +30,7 @@
 #include "guilib/GUITextureD3D.h"
 #include "guilib/GUIWindowManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
@@ -470,8 +471,10 @@ void CRenderSystemDX::DeleteDevice()
 
 void CRenderSystemDX::OnDeviceLost()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CSingleLock lock(m_resourceSection);
-  g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_RENDERER_LOST);
+  SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_RENDERER_LOST);
 
   OnDisplayLost();
 
@@ -487,6 +490,8 @@ void CRenderSystemDX::OnDeviceLost()
 
 void CRenderSystemDX::OnDeviceReset()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CSingleLock lock(m_resourceSection);
 
   if (m_needNewDevice)
@@ -498,7 +503,7 @@ void CRenderSystemDX::OnDeviceReset()
     for (std::vector<ID3DResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDevice();
 
-    g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_RENDERER_RESET);
+    SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_RENDERER_RESET);
   }
 
   OnDisplayReset();

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -34,8 +34,9 @@
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIToggleButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "input/Key.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/SettingControl.h"
 #include "settings/lib/SettingSection.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -87,6 +88,8 @@ CGUIDialogSettingsBase::~CGUIDialogSettingsBase()
 
 bool CGUIDialogSettingsBase::OnMessage(CGUIMessage &message)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   switch (message.GetMessage())
   {
     case GUI_MSG_WINDOW_INIT:
@@ -138,7 +141,7 @@ bool CGUIDialogSettingsBase::OnMessage(CGUIMessage &message)
       {
         m_delayedTimer.Stop();
         CGUIMessage message(GUI_MSG_UPDATE_ITEM, GetID(), m_delayedSetting->GetID(), 1); // param1 = 1 for "reset the control if it's invalid"
-        g_windowManager.SendThreadMessage(message, GetID());
+        PostGUIMessage(message, GetID());
       }
       // update the value of the previous setting (in case it was invalid)
       else if (m_iSetting >= CONTROL_SETTINGS_START_CONTROL && m_iSetting < (int)(CONTROL_SETTINGS_START_CONTROL + m_settingControls.size()))
@@ -147,7 +150,7 @@ bool CGUIDialogSettingsBase::OnMessage(CGUIMessage &message)
         if (control != NULL && control->GetSetting() != NULL && !control->IsValid())
         {
           CGUIMessage message(GUI_MSG_UPDATE_ITEM, GetID(), m_iSetting, 1); // param1 = 1 for "reset the control if it's invalid"
-          g_windowManager.SendThreadMessage(message, GetID());
+          PostGUIMessage(message, GetID());
         }
       }
 
@@ -814,13 +817,15 @@ void CGUIDialogSettingsBase::UpdateSettingControl(const std::string &settingId)
 
 void CGUIDialogSettingsBase::UpdateSettingControl(BaseSettingControlPtr pSettingControl)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (pSettingControl == NULL)
     return;
 
   // we send a thread message so that it's processed the following frame (some settings won't
   // like being changed during Render())
   CGUIMessage message(GUI_MSG_UPDATE_ITEM, GetID(), pSettingControl->GetID());
-  g_windowManager.SendThreadMessage(message, GetID());
+  PostGUIMessage(message, GetID());
 }
 
 void CGUIDialogSettingsBase::SetControlLabel(int controlId, const CVariant &label)

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -30,6 +30,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -133,6 +134,8 @@ void CGUIWindowSettingsScreenCalibration::FreeResources(bool forceUnload)
 
 bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch ( message.GetMessage() )
   {
   case GUI_MSG_WINDOW_DEINIT:
@@ -142,7 +145,7 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
       g_graphicsContext.SetCalibrating(false);
       // reset our screen resolution to what it was initially
       g_graphicsContext.SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution());
-      g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
+      SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
     }
     break;
 

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -29,6 +29,7 @@
 #include "cdioSupport.h"
 #include "filesystem/iso9660.h"
 #include "filesystem/File.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "threads/SingleLock.h"
 #ifdef TARGET_POSIX
 #include <sys/types.h>
@@ -124,6 +125,8 @@ void CDetectDVDMedia::OnExit()
 // Gets state of the DVD drive
 VOID CDetectDVDMedia::UpdateDvdrom()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // Signal for WaitMediaReady()
   // that we are busy detecting the
   // newly inserted media.
@@ -140,8 +143,7 @@ VOID CDetectDVDMedia::UpdateDvdrom()
           // Send Message to GUI that disc been ejected
           SetNewDVDShareUrl("D:\\", false, g_localizeStrings.Get(502));
           m_isoReader.Reset();
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REMOVED_MEDIA);
-          g_windowManager.SendThreadMessage( msg );
+          PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REMOVED_MEDIA);
           waitLock.Leave();
           m_DriveState = DRIVE_OPEN;
           return;
@@ -162,8 +164,7 @@ VOID CDetectDVDMedia::UpdateDvdrom()
             m_pCdInfo = NULL;
           }
           waitLock.Leave();
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-          g_windowManager.SendThreadMessage( msg );
+          PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
           // Do we really need sleep here? This will fix: [ 1530771 ] "Open tray" problem
           // Sleep(6000);
           return ;
@@ -177,9 +178,8 @@ VOID CDetectDVDMedia::UpdateDvdrom()
           SetNewDVDShareUrl("D:\\", false, g_localizeStrings.Get(504));
           m_DriveState = DRIVE_CLOSED_NO_MEDIA;
           // Send Message to GUI that disc has changed
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
           waitLock.Leave();
-          g_windowManager.SendThreadMessage( msg );
+          PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
           return ;
         }
         break;
@@ -194,9 +194,8 @@ VOID CDetectDVDMedia::UpdateDvdrom()
             m_DriveState = DRIVE_CLOSED_MEDIA_PRESENT;
             // Detect ISO9660(mode1/mode2) or CDDA filesystem
             DetectMediaType();
-            CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
             waitLock.Leave();
-            g_windowManager.SendThreadMessage( msg );
+            PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
             // Tell the application object that a new Cd is inserted
             // So autorun can be started.
             if ( !m_bStartup )

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -49,6 +49,7 @@
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"
 #include "AutorunMediaJob.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #include "filesystem/File.h"
 
@@ -283,13 +284,14 @@ bool CMediaManager::SetLocationPath(const std::string& oldPath, const std::strin
 
 void CMediaManager::AddAutoSource(const CMediaSource &share, bool bAutorun)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CMediaSourceSettings::GetInstance().AddShare("files", share);
   CMediaSourceSettings::GetInstance().AddShare("video", share);
   CMediaSourceSettings::GetInstance().AddShare("pictures", share);
   CMediaSourceSettings::GetInstance().AddShare("music", share);
   CMediaSourceSettings::GetInstance().AddShare("programs", share);
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-  g_windowManager.SendThreadMessage( msg );
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
 
 #ifdef HAS_DVD_DRIVE
   if(bAutorun)
@@ -299,13 +301,14 @@ void CMediaManager::AddAutoSource(const CMediaSource &share, bool bAutorun)
 
 void CMediaManager::RemoveAutoSource(const CMediaSource &share)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CMediaSourceSettings::GetInstance().DeleteSource("files", share.strName, share.strPath, true);
   CMediaSourceSettings::GetInstance().DeleteSource("video", share.strName, share.strPath, true);
   CMediaSourceSettings::GetInstance().DeleteSource("pictures", share.strName, share.strPath, true);
   CMediaSourceSettings::GetInstance().DeleteSource("music", share.strName, share.strPath, true);
   CMediaSourceSettings::GetInstance().DeleteSource("programs", share.strName, share.strPath, true);
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-  g_windowManager.SendThreadMessage( msg );
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
 
 #ifdef HAS_DVD_DRIVE
   // delete cached CdInfo if any
@@ -654,6 +657,8 @@ void CMediaManager::ToggleTray(const char cDriveLetter)
 
 void CMediaManager::ProcessEvents()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CSingleLock lock(m_CritSecStorageProvider);
   if (m_platformStorage->PumpDriveChangeEvents(this))
   {
@@ -666,8 +671,7 @@ void CMediaManager::ProcessEvents()
     m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
 #endif
     
-    CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
   }
 }
 

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -35,10 +35,13 @@
 #include "GUIUserMessages.h"
 #include "music/MusicDatabase.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
-#include "xbmc/music/tags/MusicInfoTag.h"
+#include "music/tags/MusicInfoTag.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 bool CSaveFileStateJob::DoWork()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   std::string progressTrackingFile = m_item.GetPath();
 
   if (m_item.HasVideoInfoTag() && StringUtils::StartsWith(m_item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
@@ -153,7 +156,7 @@ bool CSaveFileStateJob::DoWork()
           if (m_item.HasProperty("original_listitem_url"))
             msgItem->SetPath(m_item.GetProperty("original_listitem_url").asString());
           CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 1, msgItem); // 1 to update the listing as well
-          g_windowManager.SendThreadMessage(message);
+          PostGUIMessage(message);
         }
       }
     }

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -35,6 +35,7 @@
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "LangInfo.h"
 #include "log.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "network/Network.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -74,6 +75,8 @@ CWeatherJob::CWeatherJob(int location)
 
 bool CWeatherJob::DoWork()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // wait for the network
   if (!g_application.getNetwork().IsAvailable())
     return false;
@@ -105,8 +108,7 @@ bool CWeatherJob::DoWork()
     SetFromProperties();
 
     // and send a message that we're done
-    CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_WEATHER_FETCHED);
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_WEATHER_FETCHED);
   }
   else
     CLog::Log(LOGERROR, "WEATHER: Weather download failed!");

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -40,6 +40,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "NfoFile.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -236,9 +237,11 @@ namespace VIDEO
 
   static void OnDirectoryScanned(const std::string& strDirectory)
   {
+    using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
     CGUIMessage msg(GUI_MSG_DIRECTORY_SCANNED, 0, 0, 0);
     msg.SetStringParam(strDirectory);
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(msg);
   }
 
   bool CVideoInfoScanner::DoScan(const std::string& strDirectory)

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -26,6 +26,7 @@
 #include "GUIUserMessages.h"
 #include "threads/SingleLock.h"
 #include "Util.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "video/jobs/VideoLibraryCleaningJob.h"
 #include "video/jobs/VideoLibraryJob.h"
 #include "video/jobs/VideoLibraryMarkWatchedJob.h"
@@ -216,9 +217,10 @@ bool CVideoLibraryQueue::IsRunning() const
 
 void CVideoLibraryQueue::Refresh()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CUtil::DeleteVideoDatabaseDirectoryCache();
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
 }
 
 void CVideoLibraryQueue::OnJobComplete(unsigned int jobID, bool success, CJob *job)

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "GUIUserMessages.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "music/MusicDatabase.h"
 #include "rendering/RenderSystem.h"
 #include "settings/AdvancedSettings.h"
@@ -568,6 +569,8 @@ std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
 
 void CVideoThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if (success)
   {
     CThumbExtractor* loader = (CThumbExtractor*)job;
@@ -577,7 +580,7 @@ void CVideoThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* jo
       m_pObserver->OnItemLoaded(&loader->m_item);
     CFileItemPtr pItem(new CFileItem(loader->m_item));
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, pItem);
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(msg);
   }
   CJobQueue::OnJobComplete(jobID, success, job);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -578,6 +578,8 @@ bool CGUIDialogVideoBookmarks::OnAddEpisodeBookmark()
 void CGUIDialogVideoBookmarks::OnJobComplete(unsigned int jobID,
                                              bool success, CJob* job)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (success && IsActive())
   {
     MAPJOBSCHAPS::iterator iter = m_mapJobsChapter.find(job);
@@ -585,7 +587,7 @@ void CGUIDialogVideoBookmarks::OnJobComplete(unsigned int jobID,
     {
       unsigned int chapterIdx = (*iter).second;
       CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, 1, chapterIdx);
-      CApplicationMessenger::GetInstance().SendGUIMessage(m);
+      SendGUIMessage(m);
       m_mapJobsChapter.erase(iter);
     }
   }

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -44,6 +44,7 @@
 #include "filesystem/File.h"
 #include "TextureCache.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "settings/Settings.h"
 #include <string>
 #include <vector>
@@ -530,12 +531,14 @@ bool CGUIDialogVideoBookmarks::AddEpisodeBookmark()
 
 bool CGUIDialogVideoBookmarks::OnAddBookmark()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (!g_application.CurrentFileItem().IsVideo())
     return false;
   
   if (CGUIDialogVideoBookmarks::AddBookmark()) 
   {
-    g_windowManager.SendMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
+    SendGUIMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
                                           g_localizeStrings.Get(298),   // "Bookmarks"
                                           g_localizeStrings.Get(21362));// "Bookmark created"
@@ -546,6 +549,8 @@ bool CGUIDialogVideoBookmarks::OnAddBookmark()
 
 bool CGUIDialogVideoBookmarks::OnAddEpisodeBookmark()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   bool bReturn = false;
   if (g_application.CurrentFileItem().HasVideoInfoTag() && g_application.CurrentFileItem().GetVideoInfoTag()->m_iEpisode > -1)
   {
@@ -558,7 +563,7 @@ bool CGUIDialogVideoBookmarks::OnAddEpisodeBookmark()
       bReturn = CGUIDialogVideoBookmarks::AddEpisodeBookmark();
       if(bReturn)
       {
-        g_windowManager.SendMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
+        SendGUIMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, 
                                               g_localizeStrings.Get(298),   // "Bookmarks"
                                               g_localizeStrings.Get(21363));// "Episode Bookmark created"

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -31,6 +31,7 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "video/VideoInfoScanner.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "video/VideoInfoTag.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -285,6 +286,8 @@ bool CGUIDialogVideoInfo::OnAction(const CAction &action)
 
 void CGUIDialogVideoInfo::SetUserrating(int userrating) const
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   userrating = std::max(userrating, 0);
   userrating = std::min(userrating, 10);
   if (userrating != m_movieItem->GetVideoInfoTag()->m_iUserRating)
@@ -293,7 +296,7 @@ void CGUIDialogVideoInfo::SetUserrating(int userrating) const
     
     // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_movieItem);
-    g_windowManager.SendMessage(msg);
+    SendGUIMessage(msg);
   }
 }
 
@@ -378,6 +381,8 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
 
 void CGUIDialogVideoInfo::Update()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   // setup plot text area
   std::string strTmp = m_movieItem->GetVideoInfoTag()->m_strPlot;
   if (m_movieItem->GetVideoInfoTag()->m_type != MediaTypeTvShow)
@@ -436,7 +441,7 @@ void CGUIDialogVideoInfo::Update()
   if (m_hasUpdatedThumb)
   {
     CGUIMessage reload(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-    g_windowManager.SendMessage(reload);
+    SendGUIMessage(reload);
   }
 }
 
@@ -1683,6 +1688,8 @@ bool CGUIDialogVideoInfo::RemoveItemsFromTag(const CFileItemPtr &tagItem)
 
 bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const MediaType &type)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (item == nullptr || !item->HasVideoInfoTag() || type.empty())
     return false;
 
@@ -1853,7 +1860,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
 
   CUtil::DeleteVideoDatabaseDirectoryCache();
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   return true;
 }

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -28,6 +28,7 @@
 #include "guilib/IGUIContainer.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -67,6 +68,8 @@ void CGUIViewControl::SetParentWindow(int window)
 
 void CGUIViewControl::SetCurrentView(int viewMode, bool bRefresh /* = false */)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   // grab the previous control
   CGUIControl *previousView = NULL;
   if (m_currentView >= 0 && m_currentView < (int)m_visibleViews.size())
@@ -124,7 +127,7 @@ void CGUIViewControl::SetCurrentView(int viewMode, bool bRefresh /* = false */)
   if (hasFocus)
   {
     CGUIMessage msg(GUI_MSG_SETFOCUS, m_parentWindow, pNewView->GetID(), 0);
-    g_windowManager.SendMessage(msg, m_parentWindow);
+    SendGUIMessage(msg, m_parentWindow);
   }
 
   UpdateViewAsControl(((IGUIContainer *)pNewView)->GetLabel());
@@ -140,9 +143,11 @@ void CGUIViewControl::SetItems(CFileItemList &items)
 
 void CGUIViewControl::UpdateContents(const CGUIControl *control, int currentItem)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (!control || !m_fileItems) return;
   CGUIMessage msg(GUI_MSG_LABEL_BIND, m_parentWindow, control->GetID(), currentItem, 0, m_fileItems);
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  SendGUIMessage(msg, m_parentWindow);
 }
 
 void CGUIViewControl::UpdateView()
@@ -159,11 +164,13 @@ void CGUIViewControl::UpdateView()
 
 int CGUIViewControl::GetSelectedItem(const CGUIControl *control) const
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (!control || !m_fileItems)
     return -1;
 
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, m_parentWindow, control->GetID());
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  SendGUIMessage(msg, m_parentWindow);
 
   int iItem = msg.GetParam1();
   if (iItem >= m_fileItems->Size())
@@ -198,6 +205,8 @@ std::string CGUIViewControl::GetSelectedItemPath() const
 
 void CGUIViewControl::SetSelectedItem(int item)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (!m_fileItems || item < 0 || item >= m_fileItems->Size())
     return;
 
@@ -205,7 +214,7 @@ void CGUIViewControl::SetSelectedItem(int item)
     return; // no valid current view!
 
   CGUIMessage msg(GUI_MSG_ITEM_SELECT, m_parentWindow, m_visibleViews[m_currentView]->GetID(), item);
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  SendGUIMessage(msg, m_parentWindow);
 }
 
 void CGUIViewControl::SetSelectedItem(const std::string &itemPath)
@@ -232,11 +241,13 @@ void CGUIViewControl::SetSelectedItem(const std::string &itemPath)
 
 void CGUIViewControl::SetFocused()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (m_currentView < 0 || m_currentView >= (int)m_visibleViews.size())
     return; // no valid current view!
 
   CGUIMessage msg(GUI_MSG_SETFOCUS, m_parentWindow, m_visibleViews[m_currentView]->GetID(), 0);
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  SendGUIMessage(msg, m_parentWindow);
 }
 
 bool CGUIViewControl::HasControl(int viewControlID) const
@@ -302,11 +313,13 @@ int CGUIViewControl::GetNextViewMode(int direction) const
 
 void CGUIViewControl::Clear()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   if (m_currentView < 0 || m_currentView >= (int)m_visibleViews.size())
     return; // no valid current view!
 
   CGUIMessage msg(GUI_MSG_LABEL_RESET, m_parentWindow, m_visibleViews[m_currentView]->GetID(), 0);
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  SendGUIMessage(msg, m_parentWindow);
 }
 
 int CGUIViewControl::GetView(VIEW_TYPE type, int id) const
@@ -322,6 +335,8 @@ int CGUIViewControl::GetView(VIEW_TYPE type, int id) const
 
 void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   // the view as control could be a select/spin/dropdown button
   std::vector< std::pair<std::string, int> > labels;
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
@@ -332,13 +347,13 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   }
   CGUIMessage msg(GUI_MSG_SET_LABELS, m_parentWindow, m_viewAsControl, m_currentView);
   msg.SetPointer(&labels);
-  g_windowManager.SendMessage(msg, m_parentWindow);
+  SendGUIMessage(msg, m_parentWindow);
 
   // otherwise it's just a normal button
   std::string label = StringUtils::Format(g_localizeStrings.Get(534).c_str(), viewLabel.c_str()); // View: %s
   CGUIMessage msgSet(GUI_MSG_LABEL_SET, m_parentWindow, m_viewAsControl);
   msgSet.SetLabel(label);
-  g_windowManager.SendMessage(msgSet, m_parentWindow);
+  SendGUIMessage(msgSet, m_parentWindow);
 }
 
 void CGUIViewControl::UpdateViewVisibility()

--- a/xbmc/windowing/android/WinEventsAndroid.cpp
+++ b/xbmc/windowing/android/WinEventsAndroid.cpp
@@ -28,6 +28,7 @@
 #include "input/XBMC_vkeys.h"
 #include "utils/log.h"
 #include "windowing/WindowingFactory.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 #define ALMOST_ZERO 0.125f
 enum {
@@ -90,6 +91,8 @@ void CWinEventsAndroid::MessagePushRepeat(XBMC_Event *repeatEvent)
 
 bool CWinEventsAndroid::MessagePump()
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   bool ret = false;
 
   // Do not always loop, only pump the initial queued count events. else if ui keep pushing
@@ -110,7 +113,7 @@ bool CWinEventsAndroid::MessagePump()
     ret |= g_application.OnEvent(pumpEvent);
 
     if (pumpEvent.type == XBMC_MOUSEBUTTONUP)
-      g_windowManager.SendMessage(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
+      SendGUIMessage(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);
   }
 
   return ret;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -22,6 +22,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "ContextMenuManager.h"
 #include "FileItemListModification.h"
 #include "GUIPassword.h"
@@ -1474,6 +1475,8 @@ void CGUIMediaWindow::OnRenameItem(int iItem)
 
 void CGUIMediaWindow::OnInitWindow()
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   // initial fetch is done unthreaded to ensure the items are setup prior to skin animations kicking off
   m_rootDir.SetAllowThreads(false);
 
@@ -1491,7 +1494,7 @@ void CGUIMediaWindow::OnInitWindow()
   else
   {
     CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, 0, PLUGIN_REFRESH_DELAY);
-    g_windowManager.SendThreadMessage(msg, m_controlID);
+    PostGUIMessage(msg, m_controlID);
   }
 
   if (updateStartDirectory)

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
 #include "filesystem/ZipManager.h"
@@ -195,6 +196,8 @@ bool CGUIWindowFileManager::OnBack(int actionID)
 
 bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   switch ( message.GetMessage() )
   {
   case GUI_MSG_NOTIFY_ALL:
@@ -297,7 +300,7 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
           {
             //move to next item
             CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), iControl, iItem + 1);
-            g_windowManager.SendMessage(msg);
+            SendGUIMessage(msg);
           }
         }
         else if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_DOUBLE_CLICK)
@@ -360,8 +363,10 @@ void CGUIWindowFileManager::OnSort(int iList)
 
 void CGUIWindowFileManager::ClearFileItems(int iList)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), iList + CONTROL_LEFT_LIST);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 
   m_vecItems[iList]->Clear(); // will clean up everything
 }
@@ -676,8 +681,10 @@ bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDri
 
 void CGUIWindowFileManager::UpdateControl(int iList, int item)
 {
+  using KODI::MESSAGING::HELPERS::SendGUIMessage;
+
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), iList + CONTROL_LEFT_LIST, item, 0, m_vecItems[iList]);
-  g_windowManager.SendMessage(msg);
+  SendGUIMessage(msg);
 }
 
 void CGUIWindowFileManager::OnMark(int iList, int iItem)
@@ -1150,6 +1157,8 @@ int64_t CGUIWindowFileManager::CalculateFolderSize(const std::string &strDirecto
 
 void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob *job)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   if(!success)
   {
     CFileOperationJob* fileJob = (CFileOperationJob*)job;
@@ -1160,7 +1169,7 @@ void CGUIWindowFileManager::OnJobComplete(unsigned int jobID, bool success, CJob
   if (IsActive())
   {
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_UPDATE);
-    CApplicationMessenger::GetInstance().SendGUIMessage(msg, GetID(), false);
+    PostGUIMessage(msg, GetID());
   }
 
   CJobQueue::OnJobComplete(jobID, success, job);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -30,6 +30,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
 #include "utils/StringUtils.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 using namespace ANNOUNCEMENT;
 
@@ -75,6 +76,8 @@ void CGUIWindowHome::OnInitWindow()
 
 void CGUIWindowHome::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   int ra_flag = 0;
 
   CLog::Log(LOGDEBUG, "GOT ANNOUNCEMENT, type: %i, from %s, message %s",(int)flag, sender, message);
@@ -105,7 +108,7 @@ void CGUIWindowHome::Announce(AnnouncementFlag flag, const char *sender, const c
   }
 
   CGUIMessage reload(GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_REFRESH_THUMBS, ra_flag);
-  g_windowManager.SendThreadMessage(reload, GetID());
+  PostGUIMessage(reload, GetID());
 }
 
 void CGUIWindowHome::AddRecentlyAddedJobs(int flag)

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -42,6 +42,7 @@
 #include "interfaces/json-rpc/JSONRPC.h"
 #endif
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 #include "network/Network.h"
 #include "PlayListPlayer.h"
 #include "profiles/Profile.h"
@@ -273,6 +274,8 @@ CFileItemPtr CGUIWindowLoginScreen::GetCurrentListItem(int offset)
 
 void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CServiceBroker::GetContextMenuManager().Deinit();
 
   // stop service addons and give it some time before we start it again
@@ -346,7 +349,6 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // if the user interfaces has been fully initialized let everyone know
   if (uiInitializationFinished)
   {
-    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
-    g_windowManager.SendThreadMessage(msg);
+    PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
   }
 }

--- a/xbmc/windows/GUIWindowStartup.cpp
+++ b/xbmc/windows/GUIWindowStartup.cpp
@@ -22,6 +22,7 @@
 #include "input/Key.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/helpers/GUIMessageHelper.h"
 
 CGUIWindowStartup::CGUIWindowStartup(void)
     : CGUIWindow(WINDOW_STARTUP_ANIM, "Startup.xml")
@@ -41,9 +42,10 @@ bool CGUIWindowStartup::OnAction(const CAction &action)
 
 void CGUIWindowStartup::OnDeinitWindow(int nextWindowID)
 {
+  using KODI::MESSAGING::HELPERS::PostGUIMessage;
+
   CGUIWindow::OnDeinitWindow(nextWindowID);
 
   // let everyone know that the user interface is now ready for usage
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
-  g_windowManager.SendThreadMessage(msg);
+  PostGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UI_READY);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This is a continuation of the work started with the great refactoring of CApplicationMessenger of 2016. Scrapping the message queue that exists in CGUIWindowManager in favor of the one in CApplicationMessenger.

Moving the SendMessage methods out of CGUIWindowManager and moving SendGUIMessage out of CApplicationMessenger and into their own helper methods. Also added Post* versions to match non-GUI message behaviour.

Moving this into helpers removes a bit of dependencies on CGUIWindowManager and circular depends on some places, still lots more work to do in this area.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
