### PR TITLE
Simplify new controller dialog text

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16754,13 +16754,13 @@ msgstr ""
 #. Title of dialog to ask users if they would like to configure a new controller
 #: xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
 msgctxt "#35011"
-msgid "New controller detected"
+msgid "Unknown controller detected"
 msgstr ""
 
-#. Text of dialog to ask users if they would like to configure a new controller
+#. Text of dialog for new controllers. %s - controller name
 #: xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
 msgctxt "#35012"
-msgid "A new controller has been detected. Configuration can be done at any time in \"Settings -> System Settings -> Input\". Would you like to configure it now?"
+msgid "Would you like to setup \"%s\"?"
 msgstr ""
 
 #empty string with id 35013

--- a/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
+++ b/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.cpp
@@ -22,9 +22,11 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
+#include "utils/StringUtils.h"
 
 using namespace KODI;
 using namespace JOYSTICK;
@@ -34,7 +36,7 @@ CGUIDialogNewJoystick::CGUIDialogNewJoystick() :
 {
 }
 
-void CGUIDialogNewJoystick::ShowAsync()
+void CGUIDialogNewJoystick::ShowAsync(const std::string& deviceName)
 {
   bool bShow = true;
 
@@ -46,16 +48,20 @@ void CGUIDialogNewJoystick::ShowAsync()
     bShow = false;
 
   if (bShow)
+  {
+    m_strDeviceName = deviceName;
     Create();
+  }
 }
 
 void CGUIDialogNewJoystick::Process()
 {
   using namespace MESSAGING::HELPERS;
 
-  // "New controller detected"
-  // "A new controller has been detected. Configuration can be done at any time in "Settings -> System Settings -> Input". Would you like to configure it now?"
-  if (ShowYesNoDialogText(CVariant{ 35011 }, CVariant{ 35012 }) == DialogResponse::YES)
+  // "Unknown controller detected"
+  // "Would you like to setup \"%s\"?"
+  std::string dialogText = StringUtils::Format(g_localizeStrings.Get(35012).c_str(), m_strDeviceName.c_str());
+  if (ShowYesNoDialogText(CVariant{ 35011 }, CVariant{ std::move(dialogText) }) == DialogResponse::YES)
   {
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_DIALOG_GAME_CONTROLLERS);
   }

--- a/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.h
+++ b/xbmc/input/joysticks/dialogs/GUIDialogNewJoystick.h
@@ -22,6 +22,8 @@
 
 #include "threads/Thread.h"
 
+#include <string>
+
 namespace KODI
 {
 namespace JOYSTICK
@@ -32,11 +34,14 @@ namespace JOYSTICK
     CGUIDialogNewJoystick();
     virtual ~CGUIDialogNewJoystick() = default;
 
-    void ShowAsync();
+    void ShowAsync(const std::string& deviceName);
 
   protected:
     // implementation of CThread
     virtual void Process() override;
+
+  private:
+    std::string m_strDeviceName;
   };
 }
 }

--- a/xbmc/input/joysticks/generic/InputHandling.cpp
+++ b/xbmc/input/joysticks/generic/InputHandling.cpp
@@ -117,7 +117,7 @@ bool CInputHandling::OnDigitalMotion(const CDriverPrimitive& source, bool bPress
     if (m_buttonMap->IsEmpty())
     {
       CLog::Log(LOGDEBUG, "Empty button map detected for %s", m_buttonMap->ControllerID().c_str());
-      m_dialog->ShowAsync();
+      m_dialog->ShowAsync(m_buttonMap->DeviceName());
     }
   }
 


### PR DESCRIPTION
## Description

When an unknown controller is first detected, a dialog is shown. ATM this dialog is an ugly wall of text. This PR simplifies the dialog and adds useful information - the controller name.

## Screenshots (if appropriate):

Before:

![new controller - complicated](https://cloud.githubusercontent.com/assets/531482/22805976/bc46d742-eed4-11e6-8676-fdcd14cce6aa.png)

The "No" button is highlighted because I just want the ugly text to go away.

After:

![new controller - simple](https://cloud.githubusercontent.com/assets/531482/22805996/caac4470-eed4-11e6-8a41-775eb6a8b436.png)

The "Yes" button is highlighted because yes, I do want to setup my controller.

## Motivation and Context
Observation of a non technical user.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
