### PR TITLE
explicitly pass rrefs for move semantics

### DIFF
--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -29,7 +29,7 @@ namespace ADDON
 {
 
 std::unique_ptr<CImageDecoder>
-CImageDecoder::FromExtension(AddonProps props, const cp_extension_t* ext)
+CImageDecoder::FromExtension(AddonProps&& props, const cp_extension_t* ext)
 {
   std::string mime = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@mimetype");
   std::string extension = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@extension");
@@ -38,7 +38,7 @@ CImageDecoder::FromExtension(AddonProps props, const cp_extension_t* ext)
                                                           std::move(extension)));
 }
 
-CImageDecoder::CImageDecoder(AddonProps props, std::string mime, std::string extension) :
+CImageDecoder::CImageDecoder(AddonProps&& props, std::string mime, std::string extension) :
   CAddonDll(std::move(props)),
   m_mimetype(std::move(mime)),
   m_extension(std::move(extension))

--- a/xbmc/addons/ImageDecoder.h
+++ b/xbmc/addons/ImageDecoder.h
@@ -28,13 +28,13 @@ namespace ADDON
                         public IImage
   {
   public:
-    static std::unique_ptr<CImageDecoder> FromExtension(AddonProps,
+    static std::unique_ptr<CImageDecoder> FromExtension(AddonProps&&,
                                                         const cp_extension_t* ext);
     explicit CImageDecoder(AddonProps props) :
       CAddonDll(std::move(props))
     {}
 
-    CImageDecoder(AddonProps props, std::string mimetypes, std::string extensions);
+    CImageDecoder(AddonProps&& props, std::string mimetypes, std::string extensions);
     virtual ~CImageDecoder();
 
     bool Create(const std::string& mimetype);
@@ -56,7 +56,7 @@ namespace ADDON
     std::string m_mimetype;
     std::string m_extension;
     IMAGEDEC_PROPS m_info;
-    KodiToAddonFuncTable_ImageDecoder m_struct;
+    KodiToAddonFuncTable_ImageDecoder m_struct = {};
   };
 
 } /*namespace ADDON*/


### PR DESCRIPTION
should quell PASS_BY_VALUE warnings from coverity

also zero initialize member struct to quell a (harmless) UNINIT_CTOR warning
requested by @fritsch. note that these issues exist in every other add-on class as well.