### PR TITLE
[interfaces] legacy: fix format error when building with -Werror=form…

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -857,7 +857,7 @@ namespace XBMCAddon
       for (const auto& el : alt.later())
       {
         if (el.which() == second)
-          throw WrongTypeException(StringUtils::Format("When using \"%s\" you need to supply a string or list of strings for the value in the dictionary", tag.c_str()).c_str());
+          throw WrongTypeException("When using \"%s\" you need to supply a string or list of strings for the value in the dictionary", tag.c_str());
         els.emplace_back(el.former());
       }
       return els;


### PR DESCRIPTION
…at-security

<!--- Provide a general summary of your change in the Title above -->
fixes PPA builds. which use -Werror=format-security by default

>‘std::vector<std::__cxx11::basic_string<char> > XBMCAddon::xbmcgui::ListItem::getStringArray(const InfoLabelValue&, const string&, std::__cxx11::string)’:
/data/src/xbmc/xbmc/interfaces/legacy/ListItem.cpp:860:176: error: format not a string literal and no format arguments [-Werror=format-security]
           throw WrongTypeException(StringUtils::Format("When using \"%s\" you need to supply a string or list of strings for the value in the dictionary", tag.c_str()).c_str());
                                                                                                                                                                                ^
cc1plus: some warnings being treated as errors

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
