### PR TITLE
JSON: Handle option "resume" when opening playlists

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3093,6 +3093,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     if(item.GetProperty("StartPercent").isString())
       fallback = (double)atof(item.GetProperty("StartPercent").asString().c_str());
     options.startpercent = item.GetProperty("StartPercent").asDouble(fallback);
+    // Clear the property from m_itemCurrentFile so that it doesn't get set
+    // again on the original FileItem when the playback ends
+    m_itemCurrentFile->ClearProperty("StartPercent");
   }
 
   options.starttime = CUtil::ConvertMilliSecsToSecs(item.m_lStartOffset);


### PR DESCRIPTION
The issue I'm trying to fix here is that when you send a JSON query of type "Player.Open", using playlistid and position as parameters, the option "resume" gets silently ignored. To reproduce it, send these queries (with a loaded video playlist):

`{"params": {"item": {"position": 0, "playlistid": 1}, "options": {"resume": false}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`

`{"params": {"item": {"position": 0, "playlistid": 1}, "options": {"resume": 50.0}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`

`{"params": {"item": {"position": 0, "playlistid": 1}, "options": {"resume": {"hours": 0, "seconds": 10, "minutes": 10, "milliseconds": 10}}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`


The changes I implemented are:
xbmc/interfaces/json-rpc/PlayerOperations.cpp:
In CPlayerOperations::Open when opening a playlist by id and position, it doesn't send message TMSG_MEDIA_PLAY anymore but TMSG_PLAYLISTPLAYER_PLAY, attaching as payload a pointer to a CVariant containing either a double (percentage) or an int (-1 for STARTOFFSET_RESUME or number of seconds offset).

xbmc/PlayListPlayer.cpp:
PLAYLIST::CPlayListPlayer::OnApplicationMessage, handling the message TMSG_PLAYLISTPLAYER_PLAY, now reads param2 as the playlistid and the payload pointer as the pointer to the CVariant instance containing the resume value. It will set the current playlist, if needed. Before this patch, this was done in TMSG_MEDIA_PLAY. I removed that part from the handler of the latter message since the only occurrence in the code base of using TMSG_MEDIA_PLAY to open a specific playlist at a specific position was in the JSON handler that I changed above.
Also, in CPlayListPlayer::Play the start offset and percentage both always get reset.

xbmc/Application.cpp:
Reset the property "StartPercent" from m_itemCurrentFile as otherwise the property will be set again on the original item in the playlist, once the playback ends.


With these changes resume works as expected on videos. With music it works when you supply a specific time (but the display will act as if the file is being played from the beginning), percentage and STARTOFFSET_RESUME currently get ignored by the music player, which is outside of the scope of this PR.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
