### PR TITLE
allow tag rev to be defined for rebuilds

### DIFF
--- a/tools/Linux/packaging/mk-debian-package.sh
+++ b/tools/Linux/packaging/mk-debian-package.sh
@@ -22,6 +22,7 @@
 RELEASEV=${RELEASEV:-"auto"}
 VERSION_PREFIX=${VERSION_PREFIX:-""}
 TAG=${TAG}
+TAGREV=${TAGREV:-""}
 REPO_DIR=${WORKSPACE:-$(cd "$(dirname $0)/../../../" ; pwd)}
 [[ $(which lsb_release) ]] && DISTS=${DISTS:-$(lsb_release -cs)} || DISTS=${DISTS:-"stable"}
 ARCHS=${ARCHS:-$(dpkg --print-architecture)}


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
allow tag rev to be defined for rebuilds

## Motivation and Context
If someone packaging Kodi makes a change in their debian packaging, the pkg rev always stays 0. The build script checks if TAGREV is set, but if you use:

```
PKGREV="2"
...
RELEASEV="${KODI_TAG}" \
TAGREV="${PKGREV}"
DISTS="${DIST}" \
ARCHS="${ARCH}" \
BUILDER="${BUILDER}" \
PDEBUILD_OPTS="${BUILDOPTS}" \
PBUILDER_BASE="${PBUILDER_BASE}" \
tools/Linux/packaging/mk-debian-package.sh
```
...Tag rev is not picked up. The current workaround for me, it to export TAGREV above this piece.

## How Has This Been Tested?
Tested on Arch Linux and SteamOS. Took the existing xbmc-packaging tarball, made the change and repacked it. Did an ls of the build directly as it began to build to see that the full pkg text was "kodi_17.0-Krypton~git20170211.1829-a10c5048f2-2"

## Checklist:

- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
