### PR TITLE
[Krypton] libdvd: fix setting compiler when cross-compiling, backport 11185

### DIFF
--- a/project/cmake/modules/FindLibDvd.cmake
+++ b/project/cmake/modules/FindLibDvd.cmake
@@ -76,7 +76,7 @@ if(NOT WIN32)
     endforeach()
 
     set(DVDREAD_CFLAGS "${DVDREAD_CFLAGS} -I${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include")
-    if(KODI_DEPENDSBUILD)
+    if(CMAKE_CROSSCOMPILING)
       set(EXTRA_FLAGS "CC=${CMAKE_C_COMPILER}")
     endif()
 


### PR DESCRIPTION
backport of https://github.com/xbmc/xbmc/pull/11185