### PR TITLE
Amltiming fr3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,6 +309,7 @@ lib/cpluff/stamp-h1
 
 #/tools/depends
 /tools/depends/native/*/*native/
+/tools/depends/target/*/aarch64-linux-gnu/
 /tools/depends/native/JsonSchemaBuilder/bin/
 /tools/depends/native/TexturePacker/bin/
 /tools/depends/target/ffmpeg/.ffmpeg-installed

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -26,35 +26,38 @@
 #include "cores/VideoPlayer/DVDClock.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
+#include "settings/AdvancedSettings.h"
 #include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
+#include "threads/Atomics.h"
 #include "utils/AMLUtils.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/SysfsUtils.h"
 #include "utils/TimeUtils.h"
 
-extern "C" {
-#include "libavutil/avutil.h"
-}  // extern "C"
-
 #include <unistd.h>
 #include <queue>
 #include <vector>
 #include <signal.h>
-#include <semaphore.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
+#include <sys/utsname.h>
 #include <linux/videodev2.h>
+#include <sys/poll.h>
+#include <chrono>
+#include <thread>
 
 // amcodec include
 extern "C" {
 #include <amcodec/codec.h>
 }  // extern "C"
+
+CEvent g_aml_sync_event;
 
 class PosixFile
 {
@@ -128,6 +131,11 @@ public:
   virtual int codec_set_cntl_mode(codec_para_t *pcodec, unsigned int mode)=0;
   virtual int codec_set_cntl_avthresh(codec_para_t *pcodec, unsigned int avthresh)=0;
   virtual int codec_set_cntl_syncthresh(codec_para_t *pcodec, unsigned int syncthresh)=0;
+
+  virtual int codec_set_av_threshold(codec_para_t *pcodec, int threshold)=0;
+  virtual int codec_set_video_delay_limited_ms(codec_para_t *pcodec,int delay_ms)=0;
+  virtual int codec_get_video_delay_limited_ms(codec_para_t *pcodec,int *delay_ms)=0;
+  virtual int codec_get_video_cur_delay_ms(codec_para_t *pcodec,int *delay_ms)=0;
 };
 
 class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
@@ -151,6 +159,11 @@ class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
   DEFINE_METHOD2(int, codec_set_cntl_avthresh,  (codec_para_t *p1, unsigned int p2))
   DEFINE_METHOD2(int, codec_set_cntl_syncthresh,(codec_para_t *p1, unsigned int p2))
 
+  DEFINE_METHOD2(int, codec_set_av_threshold,   (codec_para_t *p1, int p2))
+  DEFINE_METHOD2(int, codec_set_video_delay_limited_ms, (codec_para_t *p1, int p2))
+  DEFINE_METHOD2(int, codec_get_video_delay_limited_ms, (codec_para_t *p1, int *p2))
+  DEFINE_METHOD2(int, codec_get_video_cur_delay_ms, (codec_para_t *p1, int *p2))
+
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(codec_init)
     RESOLVE_METHOD(codec_close)
@@ -167,6 +180,11 @@ class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
     RESOLVE_METHOD(codec_set_cntl_mode)
     RESOLVE_METHOD(codec_set_cntl_avthresh)
     RESOLVE_METHOD(codec_set_cntl_syncthresh)
+
+    RESOLVE_METHOD(codec_set_av_threshold)
+    RESOLVE_METHOD(codec_set_video_delay_limited_ms)
+    RESOLVE_METHOD(codec_get_video_delay_limited_ms)
+    RESOLVE_METHOD(codec_get_video_cur_delay_ms)
   END_METHOD_RESOLVE()
 
 public:
@@ -218,14 +236,17 @@ public:
 #define TRICKMODE_I     0x01
 #define TRICKMODE_FFFB  0x02
 
-// same as AV_NOPTS_VALUE
-#define INT64_0         INT64_C(0x8000000000000000)
+static const int64_t INT64_0 = 0x8000000000000000ULL;
 
 #define EXTERNAL_PTS    (1)
 #define SYNC_OUTSIDE    (2)
+#define KEYFRAME_PTS_ONLY 0x100
 
 // missing tags
+#ifndef CODEC_TAG_VC_1
 #define CODEC_TAG_VC_1  (0x312D4356)
+#endif
+
 #define CODEC_TAG_RV30  (0x30335652)
 #define CODEC_TAG_RV40  (0x30345652)
 #define CODEC_TAG_MJPEG (0x47504a4d)
@@ -309,6 +330,19 @@ typedef struct am_private_t
   int               dumpfile;
   bool              dumpdemux;
 } am_private_t;
+
+typedef struct vframe_states
+{
+  int vf_pool_size;
+  int buf_free_num;
+  int buf_recycle_num;
+  int buf_avail_num;
+} vframe_states_t;
+
+#ifndef AMSTREAM_IOC_VF_STATUS
+#define AMSTREAM_IOC_MAGIC  'S'
+#define AMSTREAM_IOC_VF_STATUS  _IOR(AMSTREAM_IOC_MAGIC, 0x60, unsigned long)
+#endif
 
 /*************************************************************************/
 /*************************************************************************/
@@ -518,7 +552,7 @@ static void am_packet_init(am_packet_t *pkt)
   pkt->avduration = 0;
   pkt->isvalid    = 0;
   pkt->newflag    = 0;
-  pkt->lastpts    = 0;
+  pkt->lastpts    = INT64_0;
   pkt->data       = NULL;
   pkt->buf        = NULL;
   pkt->data_size  = 0;
@@ -543,46 +577,14 @@ void am_packet_release(am_packet_t *pkt)
 
 int check_in_pts(am_private_t *para, am_packet_t *pkt)
 {
-    int last_duration = 0;
-    static int last_v_duration = 0;
-    int64_t pts = 0;
-
-    last_duration = last_v_duration;
-
-    if (para->stream_type == AM_STREAM_ES) {
-        if ((int64_t)INT64_0 != pkt->avpts) {
-            pts = pkt->avpts;
-
-            if (para->m_dll->codec_checkin_pts(pkt->codec, pts) != 0) {
-                CLog::Log(LOGDEBUG, "ERROR check in pts error!");
-                return PLAYER_PTS_ERROR;
-            }
-
-        } else if ((int64_t)INT64_0 != pkt->avdts) {
-            pts = pkt->avdts * last_duration;
-
-            if (para->m_dll->codec_checkin_pts(pkt->codec, pts) != 0) {
-                CLog::Log(LOGDEBUG, "ERROR check in dts error!");
-                return PLAYER_PTS_ERROR;
-            }
-
-            last_v_duration = pkt->avduration ? pkt->avduration : 1;
-        } else {
-            if (!para->check_first_pts) {
-                if (para->m_dll->codec_checkin_pts(pkt->codec, 0) != 0) {
-                    CLog::Log(LOGDEBUG, "ERROR check in 0 to video pts error!");
-                    return PLAYER_PTS_ERROR;
-                }
-            }
-        }
-        if (!para->check_first_pts) {
-            para->check_first_pts = 1;
-        }
-    }
-    if (pts > 0)
-      pkt->lastpts = pts;
-
-    return PLAYER_SUCCESS;
+  if (para->stream_type == AM_STREAM_ES
+    && INT64_0 != pkt->avpts
+    && para->m_dll->codec_checkin_pts(pkt->codec, pkt->avpts) != 0)
+  {
+    CLog::Log(LOGDEBUG, "ERROR check in pts error!");
+    return PLAYER_PTS_ERROR;
+  }
+  return PLAYER_SUCCESS;
 }
 
 static int write_header(am_private_t *para, am_packet_t *pkt)
@@ -652,7 +654,7 @@ int write_av_packet(am_private_t *para, am_packet_t *pkt)
         }
         pkt->newflag = 0;
     }
-	
+
     buf = pkt->data;
     size = pkt->data_size ;
     if (size == 0 && pkt->isvalid) {
@@ -1319,9 +1321,14 @@ int set_header_info(am_private_t *para)
 
 /*************************************************************************/
 CAMLCodec::CAMLCodec()
-  : CThread("CAMLCodec")
+  : m_opened(false)
+  , m_ptsIs64us(false)
+  , m_cur_pts(INT64_0)
+  , m_last_pts(0)
+  , m_bufferIndex(-1)
+  , m_state(0)
+  , m_frameSizeSum(0)
 {
-  m_opened = false;
   am_private = new am_private_t;
   memset(am_private, 0, sizeof(am_private_t));
   m_dll = new DllLibAmCodec;
@@ -1337,25 +1344,39 @@ CAMLCodec::CAMLCodec()
 
 CAMLCodec::~CAMLCodec()
 {
-  StopThread();
   delete am_private;
   am_private = NULL;
   delete m_dll, m_dll = NULL;
 }
 
+float CAMLCodec::OMXPtsToSeconds(int omxpts)
+{
+  return static_cast<float>(omxpts) / PTS_FREQ;
+}
+
+int CAMLCodec::OMXDurationToNs(int duration)
+{
+  return static_cast<int>(static_cast<float>(duration) / PTS_FREQ * 1000000 );
+}
+
+int CAMLCodec::GetAmlDuration() const
+{
+  return am_private ? (am_private->video_rate * PTS_FREQ) / UNIT_FREQ : 0;
+};
+
 bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
 {
   m_speed = DVD_PLAYSPEED_NORMAL;
-  m_1st_pts = 0;
-  m_cur_pts = 0;
+  m_cur_pts = INT64_0;
   m_dst_rect.SetRect(0, 0, 0, 0);
   m_zoom = -1;
   m_contrast = -1;
   m_brightness = -1;
-  m_vbufsize = 500000 * 2;
-  m_start_dts = 0;
-  m_start_pts = 0;
+  m_start_adj = 0;
   m_hints = hints;
+  m_state = 0;
+  m_frameSizes.clear();
+  m_frameSizeSum = 0;
 
   if (!OpenAmlVideo(hints))
   {
@@ -1480,6 +1501,8 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
       break;
     case VFORMAT_MPEG4:
       am_private->gcodec.param = (void*)EXTERNAL_PTS;
+      if (m_hints.ptsinvalid)
+        am_private->gcodec.param = (void*)(EXTERNAL_PTS | KEYFRAME_PTS_ONLY);
       break;
     case VFORMAT_H264:
     case VFORMAT_H264MVC:
@@ -1522,7 +1545,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
     case VFORMAT_VC1:
       // vc1 in an avi file
       if (m_hints.ptsinvalid)
-        am_private->gcodec.param = (void*)EXTERNAL_PTS;
+        am_private->gcodec.param = (void*)KEYFRAME_PTS_ONLY;
       break;
     case VFORMAT_HEVC:
       am_private->gcodec.format = VIDEO_DEC_FORMAT_HEVC;
@@ -1546,9 +1569,10 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   am_private->dumpdemux = false;
   dumpfile_open(am_private);
 
-  //! @bug make sure we are not stuck in pause (amcodec bug)
-  m_dll->codec_resume(&am_private->vcodec);
+  m_dll->codec_pause(&am_private->vcodec);
+
   m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
+  m_dll->codec_set_video_delay_limited_ms(&am_private->vcodec, 1000);
 
   m_dll->codec_set_cntl_avthresh(&am_private->vcodec, AV_SYNC_THRESH);
   m_dll->codec_set_cntl_syncthresh(&am_private->vcodec, 0);
@@ -1558,8 +1582,6 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   am_private->am_pkt.codec = &am_private->vcodec;
   pre_header_feeding(am_private, &am_private->am_pkt);
 
-  Create();
-
   m_display_rect = CRect(0, 0, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().iWidth, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().iHeight);
 
   std::string strScaler;
@@ -1567,21 +1589,25 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   if (strScaler.find("enabled") == std::string::npos)     // Scaler not enabled, use screen size
     m_display_rect = CRect(0, 0, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().iScreenWidth, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().iScreenHeight);
 
-/*
-  // if display is set to 1080xxx, then disable deinterlacer for HD content
-  // else bandwidth usage is too heavy and it will slow down video decoder.
-  char display_mode[256] = {0};
-  SysfsUtils::GetString("/sys/class/display/mode", display_mode, 255);
-  if (strstr(display_mode,"1080"))
-    SysfsUtils::SetInt("/sys/module/di/parameters/bypass_all", 1);
-  else
-    SysfsUtils::SetInt("/sys/module/di/parameters/bypass_all", 0);
-*/
+  SysfsUtils::SetInt("/sys/class/video/freerun_mode", 1);
+
+
+  struct utsname un;
+  if (uname(&un) == 0)
+  {
+    int linuxversion[2];
+    sscanf(un.release,"%d.%d", &linuxversion[0], &linuxversion[1]);
+    if (linuxversion[0] > 3 || (linuxversion[0] == 3 && linuxversion[1] >= 14))
+      m_ptsIs64us = true;
+  }
+
+  CLog::Log(LOGNOTICE, "CAMLCodec::OpenDecoder - using V4L2 pts format: %s", m_ptsIs64us ? "64Bit":"32Bit");
 
   m_opened = true;
   // vcodec is open, update speed if it was
   // changed before VideoPlayer called OpenDecoder.
   SetSpeed(m_speed);
+  SetPollDevice(am_private->vcodec.cntl_handle);
 
   return true;
 }
@@ -1600,7 +1626,7 @@ bool CAMLCodec::OpenAmlVideo(const CDVDStreamInfo &hints)
   m_defaultVfmMap = GetVfmMap("default");
   SetVfmMap("default", "decoder ppmgr deinterlace amlvideo amvideo");
 
-  SysfsUtils::SetInt("/sys/module/amlvideodri/parameters/freerun_mode", 1);
+  SysfsUtils::SetInt("/sys/module/amlvideodri/parameters/freerun_mode", 3);
 
   return true;
 }
@@ -1636,12 +1662,13 @@ void CAMLCodec::SetVfmMap(const std::string &name, const std::string &map)
 void CAMLCodec::CloseDecoder()
 {
   CLog::Log(LOGDEBUG, "CAMLCodec::CloseDecoder");
-  StopThread();
+
+  SetPollDevice(-1);
 
   // never leave vcodec ff/rw or paused.
   if (m_speed != DVD_PLAYSPEED_NORMAL)
   {
-    m_dll->codec_resume(&am_private->vcodec);
+    //m_dll->codec_resume(&am_private->vcodec);
     m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
   }
   m_dll->codec_close(&am_private->vcodec);
@@ -1672,6 +1699,8 @@ void CAMLCodec::Reset()
   if (!m_opened)
     return;
 
+  SetPollDevice(-1);
+
   // set the system blackout_policy to leave the last frame showing
   int blackout_policy;
   SysfsUtils::GetInt("/sys/class/video/blackout_policy", blackout_policy);
@@ -1680,11 +1709,14 @@ void CAMLCodec::Reset()
   // restore the speed (some amcodec versions require this)
   if (m_speed != DVD_PLAYSPEED_NORMAL)
   {
-    m_dll->codec_resume(&am_private->vcodec);
     m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
   }
+  m_dll->codec_pause(&am_private->vcodec);
+
   // reset the decoder
   m_dll->codec_reset(&am_private->vcodec);
+  m_dll->codec_set_video_delay_limited_ms(&am_private->vcodec, 1000);
+
   dumpfile_close(am_private);
   dumpfile_open(am_private);
 
@@ -1697,20 +1729,31 @@ void CAMLCodec::Reset()
   // restore the saved system blackout_policy value
   SysfsUtils::SetInt("/sys/class/video/blackout_policy", blackout_policy);
 
-  // reset some internal vars
-  m_1st_pts = 0;
-  m_cur_pts = 0;
-  m_ptsQueue.clear();
+  // reset some interal vars
+  m_cur_pts = INT64_0;
+  m_state = 0;
+  m_start_adj = 0;
+  m_frameSizes.clear();
+  m_frameSizeSum = 0;
+
   SetSpeed(m_speed);
+
+  SetPollDevice(am_private->vcodec.cntl_handle);
 }
 
 int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
 {
   if (!m_opened)
-    return VC_BUFFER;
+    return VC_ERROR;
 
+  int rtn(0);
+
+  float timesize(GetTimeSize());
   if (pData)
   {
+    m_frameSizes.push_back(iSize);
+    m_frameSizeSum += iSize;
+
     am_private->am_pkt.data = pData;
     am_private->am_pkt.data_size = iSize;
 
@@ -1721,31 +1764,39 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
     // handle pts, including 31bit wrap, aml can only handle 31
     // bit pts as it uses an int in kernel.
     if (m_hints.ptsinvalid || pts == DVD_NOPTS_VALUE)
-      am_private->am_pkt.avpts = AV_NOPTS_VALUE;
+      am_private->am_pkt.avpts = INT64_0;
     else
     {
       am_private->am_pkt.avpts = 0.5 + (pts * PTS_FREQ) / DVD_TIME_BASE;\
-      if (!m_start_pts && am_private->am_pkt.avpts >= 0x7fffffff)
-        m_start_pts = am_private->am_pkt.avpts & ~0x0000ffff;
+      if (!m_start_adj && am_private->am_pkt.avpts >= 0x7fffffff)
+        m_start_adj = am_private->am_pkt.avpts & ~0x0000ffff;
+      am_private->am_pkt.avpts -= m_start_adj;
+      m_state |= STATE_HASPTS;
     }
-    if (am_private->am_pkt.avpts != (int64_t)AV_NOPTS_VALUE)
-      am_private->am_pkt.avpts -= m_start_pts;
 
     // handle dts, including 31bit wrap, aml can only handle 31
     // bit dts as it uses an int in kernel.
     if (dts == DVD_NOPTS_VALUE)
-      am_private->am_pkt.avdts = AV_NOPTS_VALUE;
+      am_private->am_pkt.avdts = am_private->am_pkt.avpts;
     else
     {
       am_private->am_pkt.avdts = 0.5 + (dts * PTS_FREQ) / DVD_TIME_BASE;
-      if (!m_start_dts && am_private->am_pkt.avdts >= 0x7fffffff)
-        m_start_dts = am_private->am_pkt.avdts & ~0x0000ffff;
-    }
-    if (am_private->am_pkt.avdts != (int64_t)AV_NOPTS_VALUE)
-      am_private->am_pkt.avdts -= m_start_dts;
+      if (!m_start_adj && am_private->am_pkt.avdts >= 0x7fffffff)
+        m_start_adj = am_private->am_pkt.avdts & ~0x0000ffff;
+      am_private->am_pkt.avdts -= m_start_adj;
 
-    //CLog::Log(LOGDEBUG, "CAMLCodec::Decode: iSize(%d), dts(%f), pts(%f), avdts(%llx), avpts(%llx)",
-    //  iSize, dts, pts, am_private->am_pkt.avdts, am_private->am_pkt.avpts);
+      // For VC1 AML decoder uses PTS only on I-Frames
+      if (am_private->am_pkt.avpts == INT64_0 && (((size_t)am_private->gcodec.param) & KEYFRAME_PTS_ONLY))
+        am_private->am_pkt.avpts = am_private->am_pkt.avdts;
+    }
+    // We use this to determine the fill state if no PTS is given
+    if (m_cur_pts == INT64_0)
+    {
+      m_cur_pts = am_private->am_pkt.avdts;
+      // No PTS given -> use first DTS for AML ptsserver initialization
+      if ((m_state & STATE_HASPTS) == 0)
+         am_private->am_pkt.avpts = am_private->am_pkt.avdts;
+    }
 
     // some formats need header/data tweaks.
     // the actual write occurs once in write_av_packet
@@ -1767,78 +1818,140 @@ int CAMLCodec::Decode(uint8_t *pData, size_t iSize, double dts, double pts)
       loop++;
     }
     if (loop == 100)
-    {
       // Decoder got stuck; Reset
       Reset();
-    }
 
-    // if we seek, then GetTimeSize is wrong as
-    // reports lastpts - cur_pts and hw decoder has
-    // not started outputing new pts values yet.
-    // so we grab the 1st pts sent into driver and
-    // use that to calc GetTimeSize.
-    if (m_1st_pts == 0)
-      m_1st_pts = am_private->am_pkt.lastpts;
+    if ((m_state & STATE_PREFILLED) == 0 && timesize >= 1.0)
+       m_state |= STATE_PREFILLED;
   }
 
-  // if we have still frames, demux size will be small
-  // and we need to pre-buffer more.
-  double target_timesize = 1.0;
-  if (iSize < 20)
-    target_timesize = 2.0;
+  if ((m_state & STATE_PREFILLED) != 0 && timesize > 0.5 &&  DequeueBuffer() == 0)
+    rtn |= VC_PICTURE;
 
-  int rtn = 0;
-
-  // keep hw buffered demux above 1 second
-  if (GetTimeSize() < target_timesize)
+  if (((rtn & VC_PICTURE) == 0 && timesize < 2.0) || timesize < 1.0)
     rtn |= VC_BUFFER;
 
-  // wait until we get a new frame or 25ms,
-  if (m_ptsQueue.size() == 0)
-    m_ready_event.WaitMSec(25);
 
-  if (m_ptsQueue.size() > 0)
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
   {
-    CSingleLock lock(m_ptsQueueMutex);
-    m_cur_pts = m_ptsQueue.front();
-    m_ptsQueue.pop_front();
-    rtn |= VC_PICTURE;
+    CLog::Log(LOGDEBUG, "CAMLCodec::Decode: ret: %d, sz: %u, dts_in: %0.4lf[%llX], pts_in: %0.4lf[%llX], adj:%llu, ptsOut:%0.4f, amlpts:%d, idx:%u, timesize:%0.4f",
+      rtn,
+      static_cast<unsigned int>(iSize),
+      dts / DVD_TIME_BASE, am_private->am_pkt.avdts,
+      pts / DVD_TIME_BASE, am_private->am_pkt.avpts,
+      m_start_adj,
+      static_cast<float>(m_cur_pts)/PTS_FREQ,
+      static_cast<int>(m_cur_pts),
+      m_bufferIndex,
+      timesize
+    );
   }
-/*
-  CLog::Log(LOGDEBUG, "CAMLCodec::Decode: "
-    "rtn(%d), m_cur_pictcnt(%lld), m_cur_pts(%f), lastpts(%f), GetTimeSize(%f), GetDataSize(%d)",
-    rtn, m_cur_pictcnt, (float)m_cur_pts/PTS_FREQ, (float)am_private->am_pkt.lastpts/PTS_FREQ, GetTimeSize(), GetDataSize());
-*/
+
   return rtn;
 }
 
-int CAMLCodec::DequeueBuffer(int64_t &pts)
+std::atomic_flag CAMLCodec::m_pollSync = ATOMIC_FLAG_INIT;
+int CAMLCodec::m_pollDevice;
+
+int CAMLCodec::PollFrame()
+{
+  CAtomicSpinLock lock(m_pollSync);
+  if (m_pollDevice < 0)
+    return 0;
+
+  struct pollfd codec_poll_fd[1];
+
+  codec_poll_fd[0].fd = m_pollDevice;
+  codec_poll_fd[0].events = POLLOUT;
+
+  if (poll(codec_poll_fd, 1, 100) > 0)
+  {
+    g_aml_sync_event.Set();
+    return 1;
+  }
+  return 0;
+}
+
+void CAMLCodec::SetPollDevice(int dev)
+{
+  CAtomicSpinLock lock(m_pollSync);
+  m_pollDevice = dev;
+}
+
+int CAMLCodec::ReleaseFrame(const uint32_t index, bool drop)
+{
+  int ret;
+  v4l2_buffer vbuf = { 0 };
+  vbuf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  vbuf.index = index;
+
+  if (drop)
+    vbuf.flags |= V4L2_BUF_FLAG_DONE;
+
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "CAMLCodec::ReleaseFrame idx:%u", index);
+
+  if ((ret = m_amlVideoFile->IOControl(VIDIOC_QBUF, &vbuf)) < 0)
+    CLog::Log(LOGERROR, "CAMLCodec::ReleaseFrame - VIDIOC_QBUF failed: %s", strerror(errno));
+  return ret;
+}
+
+int CAMLCodec::DequeueBuffer()
 {
   v4l2_buffer vbuf = { 0 };
   vbuf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
+  //Driver change from 10 to 0ms latency, throttle here
+  std::chrono::time_point<std::chrono::system_clock> now(std::chrono::system_clock::now());
 
   if (m_amlVideoFile->IOControl(VIDIOC_DQBUF, &vbuf) < 0)
   {
     if (errno != EAGAIN)
       CLog::Log(LOGERROR, "CAMLCodec::DequeueBuffer - VIDIOC_DQBUF failed: %s", strerror(errno));
+
+    std::chrono::milliseconds elapsed(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - now).count());
+
+    if (elapsed < std::chrono::milliseconds(10))
+      std::this_thread::sleep_for(std::chrono::milliseconds(10) - elapsed);
+
     return -errno;
   }
 
   // Since kernel 3.14 Amlogic changed length and units of PTS values reported here.
   // To differentiate such PTS values we check for existence of omx_pts_interval_lower
   // parameter, because it was introduced since kernel 3.14.
-  if (access("/sys/module/amvideo/parameters/omx_pts_interval_lower", F_OK) != -1)
+  m_last_pts = m_cur_pts;
+
+  if (m_ptsIs64us)
   {
-    pts = vbuf.timestamp.tv_sec & 0xFFFFFFFF;
-    pts <<= 32;
-    pts += vbuf.timestamp.tv_usec & 0xFFFFFFFF;
-    pts = (pts * PTS_FREQ) / DVD_TIME_BASE;
+    m_cur_pts = vbuf.timestamp.tv_sec & 0xFFFFFFFF;
+    m_cur_pts <<= 32;
+    m_cur_pts += vbuf.timestamp.tv_usec & 0xFFFFFFFF;
+    m_cur_pts = (m_cur_pts * PTS_FREQ) / DVD_TIME_BASE;
   }
   else
   {
-    pts = vbuf.timestamp.tv_usec;
+    m_cur_pts = vbuf.timestamp.tv_usec;
   }
+  m_bufferIndex = vbuf.index;
   return 0;
+}
+
+float CAMLCodec::GetTimeSize()
+{
+  struct buf_status bs;
+  m_dll->codec_get_vbuf_state(&am_private->vcodec, &bs);
+
+  //CLog::Log(LOGDEBUG, "CAMLCodec::Decode: buf status: s:%d dl:%d fl:%d rp:%u wp:%u",bs.size, bs.data_len, bs.free_len, bs.read_pointer, bs.write_pointer);  
+  while (m_frameSizeSum >  (unsigned int)bs.data_len)
+  {
+    m_frameSizeSum -= m_frameSizes.front();
+    m_frameSizes.pop_front();
+  }
+  if (bs.free_len < bs.data_len)
+    return 7.0;
+
+  return (float)(m_frameSizes.size() * am_private->video_rate) / UNIT_FREQ;
 }
 
 bool CAMLCodec::GetPicture(DVDVideoPicture *pDvdVideoPicture)
@@ -1848,24 +1961,23 @@ bool CAMLCodec::GetPicture(DVDVideoPicture *pDvdVideoPicture)
 
   pDvdVideoPicture->iFlags = DVP_FLAG_ALLOCATED;
   pDvdVideoPicture->format = RENDER_FMT_AML;
-  pDvdVideoPicture->iDuration = (double)(am_private->video_rate * DVD_TIME_BASE) / UNIT_FREQ;
+
+  if (m_last_pts <= 0)
+    pDvdVideoPicture->iDuration = (double)(am_private->video_rate * DVD_TIME_BASE) / UNIT_FREQ;
+  else
+    pDvdVideoPicture->iDuration = (double)((m_cur_pts - m_last_pts) * DVD_TIME_BASE) / PTS_FREQ;
 
   pDvdVideoPicture->dts = DVD_NOPTS_VALUE;
-  if (m_speed == DVD_PLAYSPEED_NORMAL)
-    pDvdVideoPicture->pts = (double)m_cur_pts / PTS_FREQ * DVD_TIME_BASE;
-  else
-  {
-    if (m_cur_pts == 0)
-      pDvdVideoPicture->pts = (double)m_1st_pts / PTS_FREQ * DVD_TIME_BASE;
-    else
-      pDvdVideoPicture->pts = (double)m_cur_pts / PTS_FREQ * DVD_TIME_BASE;
-  }
+  pDvdVideoPicture->pts = (double)GetCurPts() / PTS_FREQ * DVD_TIME_BASE;
 
   return true;
 }
 
 void CAMLCodec::SetSpeed(int speed)
 {
+  if (m_speed == speed)
+    return;
+
   CLog::Log(LOGDEBUG, "CAMLCodec::SetSpeed, speed(%d)", speed);
 
   // update internal vars regardless
@@ -1878,83 +1990,21 @@ void CAMLCodec::SetSpeed(int speed)
   switch(speed)
   {
     case DVD_PLAYSPEED_PAUSE:
-      m_dll->codec_pause(&am_private->vcodec);
+      //m_dll->codec_pause(&am_private->vcodec);
       m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
       break;
     case DVD_PLAYSPEED_NORMAL:
-      m_dll->codec_resume(&am_private->vcodec);
+      //m_dll->codec_resume(&am_private->vcodec);
       m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_NONE);
       break;
     default:
-      m_dll->codec_resume(&am_private->vcodec);
+      //m_dll->codec_resume(&am_private->vcodec);
       if ((am_private->video_format == VFORMAT_H264) || (am_private->video_format == VFORMAT_H264_4K2K))
         m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_FFFB);
       else
         m_dll->codec_set_cntl_mode(&am_private->vcodec, TRICKMODE_I);
       break;
   }
-}
-
-int CAMLCodec::GetDataSize()
-{
-  if (!m_opened)
-    return 0;
-
-  struct buf_status vbuf ={0};
-  if (m_dll->codec_get_vbuf_state(&am_private->vcodec, &vbuf) >= 0)
-    m_vbufsize = vbuf.size;
-
-  return vbuf.data_len;
-}
-
-double CAMLCodec::GetTimeSize()
-{
-  if (!m_opened)
-    return 0;
-
-  // if m_cur_pts is zero, hw decoder was not started yet
-  // so we use the pts of the 1st demux packet that was send
-  // to hw decoder to calc timesize.
-  if (m_cur_pts == 0)
-    m_timesize = (double)(am_private->am_pkt.lastpts - m_1st_pts) / PTS_FREQ;
-  else
-    m_timesize = (double)(am_private->am_pkt.lastpts - GetOMXPts()) / PTS_FREQ;
-
-  // lie to VideoPlayer, it is hardcoded to a max of 8 seconds,
-  // if you buffer more than 8 seconds, it goes nuts.
-  double timesize = m_timesize;
-  if (timesize < 0.0)
-    timesize = 0.0;
-  else if (timesize > 7.0)
-    timesize = 7.0;
-
-  return timesize;
-}
-
-void CAMLCodec::Process()
-{
-  CLog::Log(LOGDEBUG, "CAMLCodec::Process Started");
-
-  while (!m_bStop)
-  {
-    if (m_dll->codec_poll_cntl(&am_private->vcodec) < 0)
-    {
-      CLog::Log(LOGDEBUG, "CAMLCodec::Process: codec_poll_cntl failed");
-      Sleep(10);
-    }
-
-    {
-      CSingleLock lock(m_ptsQueueMutex);
-      int64_t pts = 0;
-      if (DequeueBuffer(pts) == 0)
-      {
-        m_ptsQueue.push_back(pts + m_start_pts);
-        m_ready_event.Set();
-      }
-    }
-  }
-
-  CLog::Log(LOGDEBUG, "CAMLCodec::Process Stopped");
 }
 
 void CAMLCodec::ShowMainVideo(const bool show)
@@ -2083,7 +2133,8 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
     case 1:
     case 3:
       {
-        int diff = (int) ((dst_rect.Height() - dst_rect.Width()) / 2);
+        double scale = (double)dst_rect.Height() / dst_rect.Width();
+        int diff = (int) ((dst_rect.Height()*scale - dst_rect.Width()) / 2);
         dst_rect = CRect(DestRect.x1 - diff, DestRect.y1, DestRect.x2 + diff, DestRect.y2);
       }
 
@@ -2207,4 +2258,10 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   // we only get called once gui has changed to something
   // that would show video playback, so show it.
   ShowMainVideo(true);
+}
+
+void CAMLCodec::SetVideoRate(int videoRate)
+{
+  if (am_private)
+    am_private->video_rate = videoRate;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -24,8 +24,9 @@
 #include "cores/IPlayer.h"
 #include "guilib/Geometry.h"
 #include "rendering/RenderSystem.h"
-#include "threads/Thread.h"
+
 #include <deque>
+#include <atomic>
 
 typedef struct am_private_t am_private_t;
 
@@ -34,7 +35,7 @@ class DllLibAmCodec;
 class PosixFile;
 typedef std::shared_ptr<PosixFile> PosixFilePtr;
 
-class CAMLCodec : public CThread
+class CAMLCodec
 {
 public:
   CAMLCodec();
@@ -48,14 +49,18 @@ public:
 
   bool          GetPicture(DVDVideoPicture* pDvdVideoPicture);
   void          SetSpeed(int speed);
-  int           GetDataSize();
-  double        GetTimeSize();
   void          SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
-  int64_t       GetCurPts() const { return m_cur_pts; }
-  int       	GetOMXPts() const { return static_cast<int>(m_cur_pts - m_start_pts); }
+  void          SetVideoRate(int videoRate);
+  int64_t       GetCurPts() const { return m_cur_pts + m_start_adj; }
+  int           GetOMXPts() const { return static_cast<int>(m_cur_pts); }
+  uint32_t      GetBufferIndex() const { return m_bufferIndex; };
+  static float  OMXPtsToSeconds(int omxpts);
+  static int    OMXDurationToNs(int duration);
+  int           GetAmlDuration() const;
+  int           ReleaseFrame(const uint32_t index, bool bDrop = false);
 
-protected:
-  virtual void  Process();
+  static int    PollFrame();
+  static void   SetPollDevice(int device);
 
 private:
   void          ShowMainVideo(const bool show);
@@ -69,20 +74,20 @@ private:
   void          CloseAmlVideo();
   std::string   GetVfmMap(const std::string &name);
   void          SetVfmMap(const std::string &name, const std::string &map);
-  int           DequeueBuffer(int64_t &pts);
+  int           DequeueBuffer();
+  float         GetTimeSize();
 
   DllLibAmCodec   *m_dll;
   bool             m_opened;
+  bool             m_ptsIs64us;
   am_private_t    *am_private;
   CDVDStreamInfo   m_hints;
-  volatile int     m_speed;
-  volatile int64_t m_1st_pts;
-  volatile int64_t m_cur_pts;
-  volatile double  m_timesize;
-  volatile int64_t m_vbufsize;
-  int64_t          m_start_dts;
-  int64_t          m_start_pts;
-  CEvent           m_ready_event;
+  int              m_speed;
+  int64_t          m_cur_pts;
+  uint32_t         m_max_frame_size;
+  int64_t          m_start_adj;
+  int64_t          m_last_pts;
+  uint32_t         m_bufferIndex;
 
   CRect            m_dst_rect;
   CRect            m_display_rect;
@@ -95,8 +100,17 @@ private:
   int              m_brightness;
   RESOLUTION       m_video_res;
 
+  static const unsigned int STATE_PREFILLED  = 1;
+  static const unsigned int STATE_HASPTS     = 2;
+
+  unsigned int m_state;
+
   PosixFilePtr     m_amlVideoFile;
   std::string      m_defaultVfmMap;
-  std::deque<int64_t>  m_ptsQueue;
-  CCriticalSection m_ptsQueueMutex;
+
+  std::deque<uint32_t> m_frameSizes;
+  std::uint32_t m_frameSizeSum;
+
+  static std::atomic_flag  m_pollSync;
+  static int m_pollDevice;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "utils/SysfsUtils.h"
 #include "settings/Settings.h"
+#include "threads/Thread.h"
 
 #define __MODULE_NAME__ "DVDVideoCodecAmlogic"
 
@@ -43,16 +44,17 @@ typedef struct frame_queue {
 CDVDVideoCodecAmlogic::CDVDVideoCodecAmlogic(CProcessInfo &processInfo) : CDVDVideoCodec(processInfo),
   m_Codec(NULL),
   m_pFormatName("amcodec"),
+  m_opened(false),
   m_last_pts(0.0),
   m_frame_queue(NULL),
   m_queue_depth(0),
   m_framerate(0.0),
   m_video_rate(0),
   m_mpeg2_sequence(NULL),
+  m_drop(false),
+  m_has_keyframe(false),
   m_bitparser(NULL),
-  m_bitstream(NULL),
-  m_opened(false),
-  m_drop(false)
+  m_bitstream(NULL)
 {
   pthread_mutex_init(&m_queue_mutex, NULL);
 }
@@ -125,14 +127,18 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       {
         m_bitstream = new CBitstreamConverter;
         m_bitstream->Open(m_hints.codec, (uint8_t*)m_hints.extradata, m_hints.extrasize, true);
+        m_bitstream->ResetKeyframe();
         // make sure we do not leak the existing m_hints.extradata
         free(m_hints.extradata);
         m_hints.extrasize = m_bitstream->GetExtraSize();
         m_hints.extradata = malloc(m_hints.extrasize);
         memcpy(m_hints.extradata, m_bitstream->GetExtraData(), m_hints.extrasize);
       }
-      //m_bitparser = new CBitstreamParser();
-      //m_bitparser->Open();
+      else
+      {
+        m_bitparser = new CBitstreamParser();
+        m_bitparser->Open();
+      }
       break;
     case AV_CODEC_ID_MPEG4:
     case AV_CODEC_ID_MSMPEG4V2:
@@ -147,9 +153,9 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
       // amcodec can't handle h263
       return false;
       break;
-    case AV_CODEC_ID_FLV1:
-      m_pFormatName = "am-flv1";
-      break;
+//    case AV_CODEC_ID_FLV1:
+//      m_pFormatName = "am-flv1";
+//      break;
     case AV_CODEC_ID_RV10:
     case AV_CODEC_ID_RV20:
     case AV_CODEC_ID_RV30:
@@ -236,6 +242,9 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
   m_processInfo.SetVideoDecoderName(m_pFormatName, true);
   m_processInfo.SetVideoDimensions(m_hints.width, m_hints.height);
   m_processInfo.SetVideoDeintMethod("hardware");
+  m_processInfo.SetVideoDAR(m_hints.aspect);
+
+  m_has_keyframe = false;
 
   CLog::Log(LOGINFO, "%s: Opened Amlogic Codec", __MODULE_NAME__);
   return true;
@@ -277,21 +286,35 @@ int CDVDVideoCodecAmlogic::Decode(uint8_t *pData, int iSize, double dts, double 
       if (!m_bitstream->Convert(pData, iSize))
         return VC_ERROR;
 
+      if (!m_bitstream->HasKeyframe())
+      {
+        CLog::Log(LOGDEBUG, "%s::Decode waiting for keyframe (bitstream)", __MODULE_NAME__);
+        return VC_BUFFER;
+      }
       pData = m_bitstream->GetConvertBuffer();
       iSize = m_bitstream->GetConvertSize();
     }
-
-    if (m_bitparser)
-      m_bitparser->FindIdrSlice(pData, iSize);
-
+    else if (!m_has_keyframe && m_bitparser)
+    {
+      if (!m_bitparser->HasKeyframe(pData, iSize))
+      {
+        CLog::Log(LOGDEBUG, "%s::Decode waiting for keyframe (bitparser)", __MODULE_NAME__);
+        return VC_BUFFER;
+      }
+      else
+        m_has_keyframe = true;
+    }
     FrameRateTracking( pData, iSize, dts, pts);
-  }
 
-  if (!m_opened)
-  {
-    if (m_Codec && !m_Codec->OpenDecoder(m_hints))
-      CLog::Log(LOGERROR, "%s: Failed to open Amlogic Codec", __MODULE_NAME__);
-    m_opened = true;
+    if (!m_opened)
+    {
+      if (pts == DVD_NOPTS_VALUE)
+        m_hints.ptsinvalid = true;
+
+      if (m_Codec && !m_Codec->OpenDecoder(m_hints))
+        CLog::Log(LOGERROR, "%s: Failed to open Amlogic Codec", __MODULE_NAME__);
+      m_opened = true;
+    }
   }
 
   if (m_hints.ptsinvalid)
@@ -307,6 +330,9 @@ void CDVDVideoCodecAmlogic::Reset(void)
 
   m_Codec->Reset();
   m_mpeg2_sequence_pts = 0;
+  m_has_keyframe = false;
+  if (m_bitstream && m_hints.codec == AV_CODEC_ID_H264)
+    m_bitstream->ResetKeyframe();
 }
 
 bool CDVDVideoCodecAmlogic::GetPicture(DVDVideoPicture* pDvdVideoPicture)
@@ -315,7 +341,8 @@ bool CDVDVideoCodecAmlogic::GetPicture(DVDVideoPicture* pDvdVideoPicture)
     m_Codec->GetPicture(&m_videobuffer);
   *pDvdVideoPicture = m_videobuffer;
 
-  CDVDAmlogicInfo* info = new CDVDAmlogicInfo(this, m_Codec, m_Codec->GetOMXPts());
+  CDVDAmlogicInfo* info = new CDVDAmlogicInfo(this, m_Codec, 
+   m_Codec->GetOMXPts(), m_Codec->GetAmlDuration(), m_Codec->GetBufferIndex());
 
   {
     CSingleLock lock(m_secure);
@@ -363,29 +390,13 @@ void CDVDVideoCodecAmlogic::SetDropState(bool bDrop)
   // Freerun mode causes amvideo driver to ignore timing and process frames
   // as quickly as they are coming from decoder. By enabling freerun mode we can
   // skip rendering of the frames that are requested to be dropped by VideoPlayer.
-  SysfsUtils::SetInt("/sys/class/video/freerun_mode", bDrop ? 1 : 0);
+  //SysfsUtils::SetInt("/sys/class/video/freerun_mode", bDrop ? 1 : 0);
 }
 
 void CDVDVideoCodecAmlogic::SetSpeed(int iSpeed)
 {
   if (m_Codec)
     m_Codec->SetSpeed(iSpeed);
-}
-
-int CDVDVideoCodecAmlogic::GetDataSize(void)
-{
-  if (m_Codec)
-    return m_Codec->GetDataSize();
-
-  return 0;
-}
-
-double CDVDVideoCodecAmlogic::GetTimeSize(void)
-{
-  if (m_Codec)
-    return m_Codec->GetTimeSize();
-
-  return 0.0;
 }
 
 void CDVDVideoCodecAmlogic::FrameQueuePop(void)
@@ -466,8 +477,7 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
       m_framerate = m_mpeg2_sequence->rate;
       m_video_rate = (int)(0.5 + (96000.0 / m_framerate));
 
-      CLog::Log(LOGDEBUG, "%s: detected mpeg2 aspect ratio(%f), framerate(%f), video_rate(%d)",
-        __MODULE_NAME__, m_mpeg2_sequence->ratio, m_framerate, m_video_rate);
+      m_processInfo.SetVideoFps(m_framerate);
 
       // update m_hints for 1st frame fixup.
       switch(m_mpeg2_sequence->rate_info)
@@ -526,7 +536,7 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
     if (cur_pts == DVD_NOPTS_VALUE)
       cur_pts = m_frame_queue->dts;
 
-    pthread_mutex_unlock(&m_queue_mutex);	
+    pthread_mutex_unlock(&m_queue_mutex);
 
     float duration = cur_pts - m_last_pts;
     m_last_pts = cur_pts;
@@ -559,21 +569,9 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
           break;
 
         // 25.000 (40000.000000)
-        case 40000:
+        case 39900 ... 40100:
           framerate = 25000.0 / 1000.0;
           break;
-
-        // 24.975 (40040.000000)
-        case 40040:
-          framerate = 25000.0 / 1001.0;
-          break;
-
-        /*
-        // 24.000 (41666.666666)
-        case 41667:
-          framerate = 24000.0 / 1000.0;
-          break;
-        */
 
         // 23.976 (41708.33333)
         case 40200 ... 43200:
@@ -592,6 +590,12 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
       {
         m_framerate = framerate;
         m_video_rate = (int)(0.5 + (96000.0 / framerate));
+
+        if (m_Codec)
+          m_Codec->SetVideoRate(m_video_rate);
+
+        m_processInfo.SetVideoFps(m_framerate);
+
         CLog::Log(LOGDEBUG, "%s: detected new framerate(%f), video_rate(%d)",
           __MODULE_NAME__, m_framerate, m_video_rate);
       }
@@ -607,11 +611,14 @@ void CDVDVideoCodecAmlogic::RemoveInfo(CDVDAmlogicInfo *info)
   m_inflight.erase(m_inflight.find(info));
 }
 
-CDVDAmlogicInfo::CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts)
+CDVDAmlogicInfo::CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts, int amlDuration, uint32_t bufferIndex)
   : m_refs(0)
   , m_codec(codec)
   , m_amlCodec(amlcodec)
   , m_omxPts(omxPts)
+  , m_amlDuration(amlDuration)
+  , m_bufferIndex(bufferIndex)
+  , m_rendered(false)
 {
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -36,7 +36,7 @@ class CDVDVideoCodecAmlogic;
 class CDVDAmlogicInfo
 {
 public:
-  CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts);
+  CDVDAmlogicInfo(CDVDVideoCodecAmlogic *codec, CAMLCodec *amlcodec, int omxPts, int amlDuration, uint32_t bufferIndex);
 
   // reference counting
   CDVDAmlogicInfo* Retain();
@@ -44,7 +44,11 @@ public:
 
   CAMLCodec *getAmlCodec() const;
   int GetOmxPts() const { return m_omxPts; }
+  int GetAmlDuration() const { return m_amlDuration; }
+  uint32_t GetBufferIndex() const { return m_bufferIndex; };
   void invalidate();
+  void SetRendered() { m_rendered = true; };
+  bool IsRendered() { return m_rendered; };
 
 protected:
   long m_refs;
@@ -52,7 +56,9 @@ protected:
 
   CDVDVideoCodecAmlogic* m_codec;
   CAMLCodec* m_amlCodec;
-  int m_omxPts;
+  int m_omxPts, m_amlDuration;
+  uint32_t m_bufferIndex;
+  bool m_rendered;
 };
 
 class CDVDVideoCodecAmlogic : public CDVDVideoCodec
@@ -71,8 +77,6 @@ public:
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual void SetSpeed(int iSpeed);
   virtual void SetDropState(bool bDrop);
-  virtual int  GetDataSize(void);
-  virtual double GetTimeSize(void);
   virtual const char* GetName(void) { return (const char*)m_pFormatName; }
 
 protected:
@@ -98,6 +102,7 @@ protected:
   mpeg2_sequence *m_mpeg2_sequence;
   double          m_mpeg2_sequence_pts;
   bool            m_drop;
+  bool            m_has_keyframe;
 
   CBitstreamParser *m_bitparser;
   CBitstreamConverter *m_bitstream;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -24,17 +24,29 @@
 
 #if defined(HAS_LIBAMCODEC)
 
-#include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+#include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 
-class CRendererAML : public CLinuxRendererGLES
+class CRendererAML : public CBaseRenderer
 {
 public:
   CRendererAML();
   virtual ~CRendererAML();
-  
+
   virtual bool RenderCapture(CRenderCapture* capture);
   virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index);
   virtual void ReleaseBuffer(int idx);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_formatl, unsigned int orientation);
+  virtual bool IsConfigured(){ return m_bConfigured; };
+  virtual CRenderInfo GetRenderInfo();
+  virtual int GetImage(YV12Image *image, int source = -1, bool readonly = false);
+  virtual void ReleaseImage(int source, bool preserve = false){};
+  virtual void FlipPage(int source);
+  virtual void PreInit(){};
+  virtual void UnInit(){};
+  virtual void Reset();
+  virtual void Update(){};
+  virtual void RenderUpdate(bool clear, unsigned int flags = 0, unsigned int alpha = 255);
+  virtual bool SupportsMultiPassRendering(){ return false; };
 
   // Player functions
   virtual bool IsGuiLayer();
@@ -47,16 +59,19 @@ public:
 
   virtual EINTERLACEMETHOD AutoInterlaceMethod();
 
-protected:
-
-  // hooks for hw dec renderer
-  virtual bool LoadShadersHook();
-  virtual bool RenderHook(int index);  
-  virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
-  virtual bool RenderUpdateVideoHook(bool clear, DWORD flags = 0, DWORD alpha = 255);
-
 private:
-  int m_prevPts;
+
+  int m_iRenderBuffer;
+  static const int m_numRenderBuffers = 4;
+
+  struct BUFFER
+  {
+    void *hwDec;
+    int duration;
+  } m_buffers[m_numRenderBuffers];
+
+  int m_prevVPts;
+  bool m_bConfigured;
 };
 
 #endif

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -88,6 +88,12 @@ public:
   ~CBitstreamParser();
 
   static bool FindIdrSlice(const uint8_t *buf, int buf_size);
+  static bool Open();
+  static void Close();
+  static bool HasKeyframe(const uint8_t *buf, int buf_size);
+
+protected:
+  static const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);
 };
 
 class CBitstreamConverter
@@ -104,6 +110,8 @@ public:
   int               GetConvertSize() const;
   uint8_t*          GetExtraData(void) const;
   int               GetExtraSize() const;
+  void              ResetKeyframe(void);
+  bool              HasKeyframe() const;
 
   static void       parseh264_sps(const uint8_t *sps, const uint32_t sps_size, bool *interlaced, int32_t *max_ref_frames);
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
@@ -144,4 +152,5 @@ protected:
   bool              m_convert_3byteTo4byteNALSize;
   bool              m_convert_bytestream;
   AVCodecID         m_codec;
+  bool              m_has_keyframe;
 };

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -87,13 +87,9 @@ public:
   CBitstreamParser();
   ~CBitstreamParser();
 
-  static bool FindIdrSlice(const uint8_t *buf, int buf_size);
   static bool Open();
   static void Close();
   static bool HasKeyframe(const uint8_t *buf, int buf_size);
-
-protected:
-  static const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);
 };
 
 class CBitstreamConverter

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -50,6 +50,9 @@
 #if defined(TARGET_ANDROID)
 #include "video/videosync/VideoSyncAndroid.h"
 #endif
+#if defined(HAS_LIBAMCODEC)
+#include "video/videosync/VideoSyncAML.h"
+#endif
 
 #ifdef TARGET_POSIX
 #include "linux/XTimeUtils.h"
@@ -126,6 +129,8 @@ void CVideoReferenceClock::Process()
     m_pVideoSync = new CVideoSyncIMX(this);
 #elif defined(TARGET_ANDROID)
     m_pVideoSync = new CVideoSyncAndroid(this);
+#elif defined(HAS_LIBAMCODEC)
+    m_pVideoSync = new CVideoSyncAML(this);
 #endif
 
     if (m_pVideoSync)

--- a/xbmc/video/videosync/CMakeLists.txt
+++ b/xbmc/video/videosync/CMakeLists.txt
@@ -40,6 +40,11 @@ if(IMX_FOUND)
   list(APPEND HEADERS VideoSyncIMX.h)
 endif()
 
+if(AML_FOUND)
+  list(APPEND SOURCES VideoSyncAML.cpp)
+  list(APPEND HEADERS VideoSyncAML.h)
+endif()
+
 if(SOURCES AND HEADERS)
   core_add_library(video_sync)
 endif()

--- a/xbmc/video/videosync/VideoSyncAML.cpp
+++ b/xbmc/video/videosync/VideoSyncAML.cpp
@@ -1,0 +1,110 @@
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "system.h"
+
+#if defined(HAS_LIBAMCODEC)
+
+#include "video/videosync/VideoSyncAML.h"
+#include "guilib/GraphicContext.h"
+#include "windowing/WindowingFactory.h"
+#include "utils/TimeUtils.h"
+#include "utils/log.h"
+#include "threads/Thread.h"
+#include <sys/poll.h>
+
+#include <chrono>
+#include <thread>
+
+extern CEvent g_aml_sync_event;
+
+CVideoSyncAML::CVideoSyncAML(CVideoReferenceClock *clock)
+: CVideoSync(clock)
+, m_abort(false)
+{
+}
+
+CVideoSyncAML::~CVideoSyncAML()
+{
+}
+
+bool CVideoSyncAML::Setup(PUPDATECLOCK func)
+{
+  UpdateClock = func;
+
+  m_abort = false;
+
+  g_Windowing.Register(this);
+  CLog::Log(LOGDEBUG, "CVideoReferenceClock: setting up AML");
+
+  return true;
+}
+
+void CVideoSyncAML::Run(std::atomic<bool>& stop)
+{
+  // We use the wall clock for timout handling (no AML h/w, startup)
+  std::chrono::time_point<std::chrono::system_clock> now(std::chrono::system_clock::now());
+  unsigned int waittime (3000 / m_fps);
+  uint64_t numVBlanks (0);
+
+  while (!stop && !m_abort)
+  {
+    int countVSyncs(1);
+    if( !g_aml_sync_event.WaitMSec(waittime))
+    {
+      std::chrono::milliseconds elapsed(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - now).count());
+      uint64_t curVBlanks = (m_fps * elapsed.count()) / 1000;
+      int64_t lastVBlankTime((curVBlanks * 1000) / m_fps);
+      if (elapsed.count() > lastVBlankTime)
+      {
+        lastVBlankTime = (++curVBlanks * 1000) / m_fps;
+        std::this_thread::sleep_for(std::chrono::milliseconds(lastVBlankTime - elapsed.count()));
+      }
+      countVSyncs = curVBlanks - numVBlanks;
+      numVBlanks = curVBlanks;
+    }
+    else
+      ++numVBlanks;
+
+    uint64_t now = CurrentHostCounter();
+
+    UpdateClock(countVSyncs, now, m_refClock);
+  }
+}
+
+void CVideoSyncAML::Cleanup()
+{
+  CLog::Log(LOGDEBUG, "CVideoReferenceClock: cleaning up AML");
+  g_Windowing.Unregister(this);
+}
+
+float CVideoSyncAML::GetFps()
+{
+  m_fps = g_graphicsContext.GetFPS();
+  CLog::Log(LOGDEBUG, "CVideoReferenceClock: fps: %.3f", m_fps);
+  return m_fps;
+}
+
+void CVideoSyncAML::OnResetDisplay()
+{
+  m_abort = true;
+}
+
+#endif

--- a/xbmc/video/videosync/VideoSyncAML.cpp
+++ b/xbmc/video/videosync/VideoSyncAML.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2014 Team XBMC
+ *      Copyright (C) 2017 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/xbmc/video/videosync/VideoSyncAML.h
+++ b/xbmc/video/videosync/VideoSyncAML.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2016 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(HAS_LIBAMCODEC)
+
+#include "video/videosync/VideoSync.h"
+#include "guilib/DispResource.h"
+
+class CVideoSyncAML : public CVideoSync, IDispResource
+{
+public:
+  CVideoSyncAML(CVideoReferenceClock *clock);
+  virtual ~CVideoSyncAML();
+  virtual bool Setup(PUPDATECLOCK func);
+  virtual void Run(std::atomic<bool>& stop);
+  virtual void Cleanup();
+  virtual float GetFps();
+  virtual void OnResetDisplay();
+private:
+  volatile bool m_abort;
+};
+
+#endif

--- a/xbmc/video/videosync/VideoSyncAML.h
+++ b/xbmc/video/videosync/VideoSyncAML.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2016 Team XBMC
+ *      Copyright (C) 2017 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
AMLDecode / Rendering rework

## Description
This PR solves all known issues wich arrived through reference clock changes starting with K17.
Goal of the implementation was to use only the kodi clock for timing and to avoid use of the aml internal clock.
Decoded Frames are now kept back in the AML video driver and are "released" at the time kodi renderer gives the flip signal for displaying decoded those frames.

**There are some linux driver changes needed to be able to get it run, these changes are already agreed by AML and will be porten into their device tree soon.**
The changes in linux kernel can be found at https://github.com/peak3d/linux, branch c1_qbuf (for kernel 3.10 / S805) and branch c2_qbuf (for kernel 3.14 / S905) 

## Motivation and Context
H/W videoplayback was completely broken / out of audio sync before.
Most users only played a subset of video codecs using h/w rendering.

## How Has This Been Tested?
LE usergroup is using this patch now for several month.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
