### PR TITLE
[estuary] Krypton: Fix regression in WallWatchedIconVar. Recent recordings hom…

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -331,6 +331,7 @@
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.IsCollection">overlays/set.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
+		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
 		<value condition="Integer.IsGreater(ListItem.Playcount,0)">$INFO[ListItem.Overlay]</value>
 	</variable>
 	<!-- Breadcrumbs -->


### PR DESCRIPTION
Fix regression in WallWatchedIconVar. Recent recordings home screen widget did not display 'resumable' bitmap anymore.

The line in question is present on xbmc master, but was removed for Krypton with one of the recent estuary skin resyncs. I guess it was a mistake.

@phil65 good to go?