### PR TITLE
add dng to mime types

### DIFF
--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -104,6 +104,7 @@ std::map<std::string, std::string> fillMimeTypes()
   mimeTypes.insert(std::pair<std::string, std::string>("dir",       "application/x-director"));
   mimeTypes.insert(std::pair<std::string, std::string>("dl",        "video/dl"));
   mimeTypes.insert(std::pair<std::string, std::string>("divx",      "video/x-msvideo"));
+  mimeTypes.insert(std::pair<std::string, std::string>("dng",       "image/dng"));
   mimeTypes.insert(std::pair<std::string, std::string>("doc",       "application/msword"));
   mimeTypes.insert(std::pair<std::string, std::string>("docx",      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
   mimeTypes.insert(std::pair<std::string, std::string>("dot",       "application/msword"));


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

Adds image/dng mime type

see, https://github.com/notspiff/imagedecoder.raw/issues/2
and, https://github.com/notspiff/imagedecoder.raw/pull/3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

required for using imagedecoder.raw with dng files

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
