### PR TITLE
[linux] systemd service support for add-ons and timedated support for timezone

### DIFF
--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -33,10 +33,12 @@ endif()
 if(DBUS_FOUND)
   list(APPEND SOURCES DBusMessage.cpp
                       DBusReserve.cpp
-                      DBusUtil.cpp)
+                      DBusUtil.cpp
+                      SystemdUtils.cpp)
   list(APPEND HEADERS DBusMessage.h
                       DBusReserve.h
-                      DBusUtil.h)
+                      DBusUtil.h
+                      SystemdUtils.h)
 endif()
 
 if(CORE_PLATFORM_NAME_LC STREQUAL rbpi)

--- a/xbmc/platform/linux/LinuxTimezone.cpp
+++ b/xbmc/platform/linux/LinuxTimezone.cpp
@@ -13,6 +13,9 @@
 #include "PlatformDefs.h"
 #include "LinuxTimezone.h"
 #include "utils/SystemInfo.h"
+#ifdef HAS_DBUS
+#include "SystemdUtils.h"
+#endif
 
 #include "ServiceBroker.h"
 #include "Util.h"
@@ -141,6 +144,9 @@ void CLinuxTimezone::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   const std::string &settingId = setting->GetId();
   if (settingId == CSettings::SETTING_LOCALE_TIMEZONE)
   {
+#ifdef HAS_DBUS
+    CSystemdUtils::SetTimezone(std::static_pointer_cast<const CSettingString>(setting)->GetValue());
+#endif
     SetTimezone(std::static_pointer_cast<const CSettingString>(setting)->GetValue());
 
     CDateTime::ResetTimezoneBias();

--- a/xbmc/platform/linux/SystemdUtils.cpp
+++ b/xbmc/platform/linux/SystemdUtils.cpp
@@ -1,0 +1,82 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "SystemdUtils.h"
+
+#include "DBusUtil.h"
+#include "utils/log.h"
+
+// systemd DBus interface specification:
+// https://www.freedesktop.org/wiki/Software/systemd/dbus
+
+static const std::string SYSTEMD_DEST = "org.freedesktop.systemd1";
+static const std::string SYSTEMD_PATH = "/org/freedesktop/systemd1";
+static const std::string SYSTEMD_IFACE = "org.freedesktop.systemd1.Manager";
+
+bool CSystemdUtils::EnableUnit(const char **units, unsigned int length)
+{
+  CDBusMessage message(SYSTEMD_DEST, SYSTEMD_PATH, SYSTEMD_IFACE, "EnableUnitFiles");
+
+  // It takes a list of unit files to enable (either just file names or full absolute paths)
+  message.AppendArgument(units, length);
+
+  // The first controls whether the unit shall be enabled for runtime only (true, /run), or persistently (false, /etc)
+  message.AppendArgument(false);
+
+  // The second one controls whether symlinks pointing to other units shall be replaced if necessary
+  message.AppendArgument(false);
+  return message.SendSystem() != NULL;
+}
+
+bool CSystemdUtils::DisableUnit(const char **units, unsigned int length)
+{
+  CDBusMessage message(SYSTEMD_DEST, SYSTEMD_PATH, SYSTEMD_IFACE, "DisableUnitFiles");
+
+  // It takes a list of unit files to enable (either just file names or full absolute paths)
+  message.AppendArgument(units, length);
+
+  // The first controls whether the unit shall be enabled for runtime only (true, /run), or persistently (false, /etc)
+  message.AppendArgument(false);
+
+  return message.SendSystem() != NULL;
+}
+
+bool CSystemdUtils::StartUnit(const std::string& unit)
+{
+  CDBusMessage message(SYSTEMD_DEST, SYSTEMD_PATH, SYSTEMD_IFACE, "StartUnit");
+
+  // Takes the unit to activate, plus a mode string
+  message.AppendArgument(unit.c_str());
+  message.AppendArgument("replace");
+
+  return message.SendSystem() != NULL;
+}
+
+bool CSystemdUtils::StopUnit(const std::string& unit)
+{
+  CDBusMessage message(SYSTEMD_DEST, SYSTEMD_PATH, SYSTEMD_IFACE, "StopUnit");
+
+  // Takes the unit to activate, plus a mode string
+  message.AppendArgument(unit.c_str());
+  message.AppendArgument("replace");
+
+  return message.SendSystem() != NULL;
+}

--- a/xbmc/platform/linux/SystemdUtils.cpp
+++ b/xbmc/platform/linux/SystemdUtils.cpp
@@ -80,3 +80,23 @@ bool CSystemdUtils::StopUnit(const std::string& unit)
 
   return message.SendSystem() != NULL;
 }
+
+// timedated DBus interface specification:
+// https://www.freedesktop.org/wiki/Software/systemd/timedated
+
+static const std::string TIMEDATED_DEST = "org.freedesktop.timedate1";
+static const std::string TIMEDATED_PATH = "/org/freedesktop/timedate1";
+static const std::string TIMEDATED_IFACE = "org.freedesktop.timedate1";
+
+bool CSystemdUtils::SetTimezone(const std::string& timezone)
+{
+  CDBusMessage message(TIMEDATED_DEST, TIMEDATED_PATH, TIMEDATED_IFACE, "SetTimezone");
+
+  // Pass a value like "Europe/Berlin" to set the timezone
+  message.AppendArgument(timezone.c_str());
+
+  // The user_interaction boolean parameters can be used to control whether PolicyKit should interactively ask the user for authentication credentials if it needs to.
+  message.AppendArgument(false);
+
+  return message.SendSystem() != NULL;
+}

--- a/xbmc/platform/linux/SystemdUtils.h
+++ b/xbmc/platform/linux/SystemdUtils.h
@@ -1,0 +1,31 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+class CSystemdUtils
+{
+public:
+  static bool EnableUnit(const char **arrayString, unsigned int length);
+  static bool DisableUnit(const char **arrayString, unsigned int length);
+  static bool StartUnit(const std::string& unit);
+  static bool StopUnit(const std::string& unit);
+};

--- a/xbmc/platform/linux/SystemdUtils.h
+++ b/xbmc/platform/linux/SystemdUtils.h
@@ -28,4 +28,5 @@ public:
   static bool DisableUnit(const char **arrayString, unsigned int length);
   static bool StartUnit(const std::string& unit);
   static bool StopUnit(const std::string& unit);
+  static bool SetTimezone(const std::string& timezone);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

This change is pretty specific to LibreELEC however it may be something that upstream is interested so I am making a PR. This will probably replace our current patches in LibreELEC regardless of if they are accepted here or not. If this isn't something that we want in Kodi then it would still be nice to get some comments about the code quality (I'm no c++ dev). 

This allows running systemd services that are inside the add-on. On LibreELEC because we use Kodi's add-on system as the package manager. We provide binary add-ons that can contain services (like tvheadend, docker, etc). These services are started via systemd service files. We previously maintained an ugly patch to start these services. see, https://github.com/xbmc/xbmc/commit/aadeef8bdff40ae19cb61f1206ff30ebbaebb8bb and [here](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/mediacenter/kodi/scripts/systemd-addon-wrapper)

I wanted to make something that is cleaner and using proper methods. Since Kodi has a DBus method already it was rather simple to use that. So when add-ons are enabled/disabled dbus calls the systemd manager to enable/disable and start/stop service units.

The second commit extends this to add timedated support to allow setting the host OS timezone from within kodi. LibreELEC again maintained a patch for this. see, https://github.com/xbmc/xbmc/commit/fb5c7a43280419bfa464b945da3b46f74782f0ad

I decided to only depend on dbus because that's what is done in [LogindUPowerSyscall.cpp](https://github.com/xbmc/xbmc/blob/master/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp) as it doesn't look for systemd or upower.

I'll probably add some logging to SystemdUtils.cpp eventually.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

see description above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

I tested this in LibreELEC. It works just like before with the old patches.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
