### PR TITLE
control horizontal sliders by up/down to right/left GUISliderControl.cpp

### DIFF
--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -212,7 +212,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_UP:
-    if (IsActive() && m_orientation == VERTICAL)
+    if (IsActive())
     {
       Move(1);
       return true;
@@ -220,7 +220,7 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_DOWN:
-    if (IsActive() && m_orientation == VERTICAL)
+    if (IsActive())
     {
       Move(-1);
       return true;


### PR DESCRIPTION


<!--- Provide a general summary of your change in the Title above -->
lets control horizontal sliders by up/down to right/left, if itself is active.

## Description
<!--- Describe your change in detail -->
deleted the vertical condition, to control horizontal sliders too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
very helpful for rotary controls.
works as a real active flag.

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
On OSMC from today

<!--- Include details of your testing environment, and the tests you ran to -->
1. activate the horizontal slider with press
2.a) moves left with left
2.b) moves left with down
2.c) moves right with up
2.d) moves right with right
3. deactivate with press

<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
