### PR TITLE
changed: disable hardcoded musicbrainz rate limiting for python scrapers

### DIFF
--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -122,6 +122,7 @@ public:
 
   bool IsInUse() const;
   bool IsNoop();
+  bool IsPython() const { return m_isPython; }
 
   // scraper media functions
   CScraperUrl NfoUrl(const std::string &sNfoContent);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1477,7 +1477,7 @@ bool CMusicInfoScanner::ResolveMusicBrainz(const std::string &strMusicBrainzID, 
       return false;
   }
 
-  if (!musicBrainzURL.m_url.empty())
+  if (!musicBrainzURL.m_url.empty() && !preferredScraper->IsPython())
   {
     Sleep(2000); // MusicBrainz rate-limits queries to 1 p.s - once we hit the rate-limiter
                  // they start serving up the 'you hit the rate-limiter' page fast - meaning


### PR DESCRIPTION
Python scrapers should handle this on their own.

@ronie 