### PR TITLE
[PVR] Timer settings dialog: Prefill recordings folder with timer title

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -149,7 +149,12 @@ void CGUIDialogPVRTimerSettings::SetTimer(const CPVRTimerInfoTagPtr &timer)
   m_iPriority           = m_timerInfoTag->m_iPriority;
   m_iLifetime           = m_timerInfoTag->m_iLifetime;
   m_iMaxRecordings      = m_timerInfoTag->m_iMaxRecordings;
-  m_strDirectory        = m_timerInfoTag->m_strDirectory;
+
+  if (m_bIsNewTimer && m_timerInfoTag->m_strDirectory.empty() && m_timerType->SupportsRecordingFolders())
+    m_strDirectory = m_strTitle;
+  else
+    m_strDirectory = m_timerInfoTag->m_strDirectory;
+
   m_iRecordingGroup     = m_timerInfoTag->m_iRecordingGroup;
 
   InitializeChannelsList();


### PR DESCRIPTION
This is a small change that imo significantly improves user experience. 

For example, when creating an epg based timer rule, which shall put recordings in a certain directory (recording folder setting), in most cases the user wants to use the name of epg event for the recording folder name. With this change the user must no longer type in that name as it is prefilled by the timers settings dialog.

Runtime tested on latest master.

@Jalle19 for review?