### PR TITLE
Settings: Disable dithering by default - cause 100% load on old rigs

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2212,7 +2212,7 @@
         <setting id="videoscreen.dither" type="boolean" label="36099" help="36598">
           <requirement>HAS_GL</requirement>
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
         </setting>
         <setting id="videoscreen.ditherdepth" type="integer" label="36100" help="36599">


### PR DESCRIPTION
See title.

Background: http://forum.kodi.tv/showthread.php?tid=231955&pid=2528669#pid2528669