### PR TITLE
[cmake][windows] use precompiled JsonSchemaBuilder if cross compiling

### DIFF
--- a/cmake/modules/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/FindJsonSchemaBuilder.cmake
@@ -10,8 +10,13 @@
 if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
   if(KODI_DEPENDSBUILD OR CMAKE_CROSSCOMPILING)
     add_executable(JsonSchemaBuilder::JsonSchemaBuilder IMPORTED GLOBAL)
-    set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
-                                                               IMPORTED_LOCATION "${NATIVEPREFIX}/bin/JsonSchemaBuilder")
+    if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
+      set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
+                                                                 IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/project/BuildDependencies/bin/json-rpc/JsonSchemaBuilder")
+    else()
+      set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
+                                                                 IMPORTED_LOCATION "${NATIVEPREFIX}/bin/JsonSchemaBuilder")
+    endif()
     set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES FOLDER Tools)
   else()
     add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/JsonSchemaBuilder build/jsonschemabuilder)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
If windows is cross compiling the path to precompiled JsonSchemaBuilder is incorrect.
<!--- Describe your change in detail -->

## Motivation and Context
Don't fail on generate_json_header.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
