### PR TITLE
Fix memory and resource leak

### DIFF
--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -295,31 +295,34 @@ bool CGUIConfigurationWizard::OnKeyPress(const CKey& key)
 
   bool bHandled = false;
 
-  switch (m_actionMap->GetActionID(key))
+  if (!m_bStop)
   {
-  case ACTION_MOVE_LEFT:
-  case ACTION_MOVE_RIGHT:
-  case ACTION_MOVE_UP:
-  case ACTION_MOVE_DOWN:
-  case ACTION_PAGE_UP:
-  case ACTION_PAGE_DOWN:
-    // Abort and allow motion
-    Abort(false);
-    bHandled = false;
-    break;
+    switch (m_actionMap->GetActionID(key))
+    {
+    case ACTION_MOVE_LEFT:
+    case ACTION_MOVE_RIGHT:
+    case ACTION_MOVE_UP:
+    case ACTION_MOVE_DOWN:
+    case ACTION_PAGE_UP:
+    case ACTION_PAGE_DOWN:
+      // Abort and allow motion
+      Abort(false);
+      bHandled = false;
+      break;
 
-  case ACTION_PARENT_DIR:
-  case ACTION_PREVIOUS_MENU:
-  case ACTION_STOP:
-    // Abort and prevent action
-    Abort(false);
-    bHandled = true;
-    break;
+    case ACTION_PARENT_DIR:
+    case ACTION_PREVIOUS_MENU:
+    case ACTION_STOP:
+      // Abort and prevent action
+      Abort(false);
+      bHandled = true;
+      break;
 
-  default:
-    // Absorb keypress
-    bHandled = true;
-    break;
+    default:
+      // Absorb keypress
+      bHandled = true;
+      break;
+    }
   }
 
   return bHandled;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -525,6 +525,9 @@ bool CPeripheralAddon::GetFeatures(const CPeripheral* device,
 
   LogError(retVal = m_struct.GetFeatures(&joystickStruct, strControllerId.c_str(),
                                            &featureCount, &pFeatures), "GetFeatures()");
+
+  ADDON::Joystick::FreeStruct(joystickStruct);
+
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     for (unsigned int i = 0; i < featureCount; i++)
@@ -562,6 +565,10 @@ bool CPeripheralAddon::MapFeature(const CPeripheral* device,
 
   LogError(retVal = m_struct.MapFeatures(&joystickStruct, strControllerId.c_str(),
                                                  1, &addonFeature), "MapFeatures()");
+
+  ADDON::Joystick::FreeStruct(joystickStruct);
+  ADDON::JoystickFeature::FreeStruct(addonFeature);
+
   return retVal == PERIPHERAL_NO_ERROR;
 }
 
@@ -583,6 +590,9 @@ bool CPeripheralAddon::GetIgnoredPrimitives(const CPeripheral* device, Primitive
 
   LogError(retVal = m_struct.GetIgnoredPrimitives(&joystickStruct, &primitiveCount,
                                                       &pPrimitives), "GetIgnoredPrimitives()");
+
+  ADDON::Joystick::FreeStruct(joystickStruct);
+
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     for (unsigned int i = 0; i < primitiveCount; i++)
@@ -616,6 +626,7 @@ bool CPeripheralAddon::SetIgnoredPrimitives(const CPeripheral* device, const Pri
   LogError(retVal = m_struct.SetIgnoredPrimitives(&joystickStruct,
         primitives.size(), addonPrimitives), "SetIgnoredPrimitives()");
 
+  ADDON::Joystick::FreeStruct(joystickStruct);
   ADDON::DriverPrimitives::FreeStructs(primitives.size(), addonPrimitives);
 
   return retVal == PERIPHERAL_NO_ERROR;
@@ -634,6 +645,8 @@ void CPeripheralAddon::SaveButtonMap(const CPeripheral* device)
 
   m_struct.SaveButtonMap(&joystickStruct);
 
+  ADDON::Joystick::FreeStruct(joystickStruct);
+
   // Notify observing button maps
   RefreshButtonMaps(device->DeviceName());
 }
@@ -650,6 +663,8 @@ void CPeripheralAddon::RevertButtonMap(const CPeripheral* device)
   joystickInfo.ToStruct(joystickStruct);
 
   m_struct.RevertButtonMap(&joystickStruct);
+
+  ADDON::Joystick::FreeStruct(joystickStruct);
 }
 
 void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::string& strControllerId)
@@ -664,6 +679,8 @@ void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::stri
   joystickInfo.ToStruct(joystickStruct);
 
   m_struct.ResetButtonMap(&joystickStruct, strControllerId.c_str());
+
+  ADDON::Joystick::FreeStruct(joystickStruct);
 
   // Notify observing button maps
   RefreshButtonMaps(device->DeviceName());

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -56,6 +56,9 @@ CPeripheralBusAddon::~CPeripheralBusAddon()
   Clear();
 
   // destroy any (loaded) addons
+  for (const auto& addon : m_addons)
+    addon->Destroy();
+
   m_failedAddons.clear();
   m_addons.clear();
 }


### PR DESCRIPTION
This PR fixes a memory leak when mapping buttons with peripheral add-ons, and an error where peripheral add-on DLLs aren't unloaded upon shutdown.

Also included is a possible fix for the controller dialog.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
