### PR TITLE
Settings: Disable dithering by default - cause 100% load on old rigs

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2079,7 +2079,7 @@
         <setting id="videoscreen.dither" type="boolean" label="36099" help="36598">
           <requirement>HAS_GL</requirement>
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
         </setting>
         <setting id="videoscreen.ditherdepth" type="integer" label="36100" help="36599">


### PR DESCRIPTION
Backport of:  https://github.com/xbmc/xbmc/pull/11685
