### PR TITLE
Do not invoke UpdateFileList() when calling SaveFileState()

### DIFF
--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -170,7 +170,7 @@ void CSaveFileState::DoWork(CFileItem& item,
           CFileItemPtr msgItem(new CFileItem(item));
           if (item.HasProperty("original_listitem_url"))
             msgItem->SetPath(item.GetProperty("original_listitem_url").asString());
-          CGUIMessage message(GUI_MSG_NOTIFY_ALL, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 1, msgItem); // 1 to update the listing as well
+          CGUIMessage message(GUI_MSG_NOTIFY_ALL, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
         }
       }


### PR DESCRIPTION
There's a bug that will create another playlist after you created and started a playlist with JSON. You can reproduce the bug with the following steps:

1. With the GUI open the Youtube Add-On and go to "Popular right now". Right click an item and select "Play from here".
2. Clear Playlist with JSON: `{"params": {"playlistid": 1}, "jsonrpc": "2.0", "id": 1, "method": "Playlist.Clear"}`
3. Add items to playlist: `{"params": {"item": [{"file": "/movies/movie1.mp4"}, {"file": "/movies/movie2.mp4"}], "playlistid": 1}, "jsonrpc": "2.0", "id": 1, "method": "Playlist.Add"}`
4. Open Playlist: `{"params": {"item": {"position": 0, "playlistid": 1}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`
5. Wait a second
6. Check playlist: `{"params": {"playlistid": 1}, "jsonrpc": "2.0", "id": 1, "method": "Playlist.GetItems"}`
7. In the JSON response you'll see that the playlist has been replaced with the youtube videos, although playback of your first item will have started normally.

What is happening here is that in CApplication::PlayFile() within the first lines CApplication::SaveFileState() will be called, which ends up in CSaveFileStateJob::DoWork(), queuing the GUIMessage that I changed in this PR. Processing that message in CGUIMediaWindow::OnMessage(), after updating the item sent as payload, CGUIMediaWindow::UpdateFileList() will be called, resulting in setting the playlist based on the list of items in that window.

param2 of that GUIMessage is deliberately set to 1 so that CGUIMediaWindow::UpdateFileList() gets called. It appears to me, though, that this is not actually what one wants here. UpdateFileList() seems to be created for cases where the layout of the items changes, through resorting and such. During normal playback of a playlist each of the played items get all the updating they need, don't they?

It seems to boil down to this question: Does anything calling CApplication::SaveFileState() expect CGUIMediaWindow::UpdateFileList() to be run?

Doesn't look like it to me, but I'm not familiar enough with the code to be certain. Here's the commit that introduced this: https://github.com/xbmc/xbmc/commit/0ec8479b64649f6008b90b36846955397319787b

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
