### PR TITLE
[Darwin] Separate Apple Remote settings into new group

### DIFF
--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -23,7 +23,7 @@
       </group>
     </category>
     <category id="input">
-      <group id="2">
+      <group id="3">
         <setting id="input.appleremotemode" type="integer" label="13600" help="36416">
           <level>1</level>
           <default>1</default> <!-- APPLE_REMOTE_STANDARD -->
@@ -35,7 +35,7 @@
               <option label="13613">3</option> <!-- APPLE_REMOTE_MULTIREMOTE -->
             </options>
           </constraints>
-          <control type="spinner" format="string"/>
+          <control type="list" format="string"/>
         </setting>
         <setting id="input.appleremotealwayson" type="boolean" label="13602" help="36417">
           <level>4</level>

--- a/system/settings/darwin_ios.xml
+++ b/system/settings/darwin_ios.xml
@@ -54,13 +54,15 @@
         </setting>
       </group>
       <group id="2">
+        <setting id="input.enablemouse">
+          <visible>false</visible>
+        </setting>
+      </group>
+      <group id="3">
         <setting id="input.appleremotemode" type="integer" label="13600" help="36416">
           <visible>false</visible>
         </setting>
         <setting id="input.appleremotesequencetime" type="integer" label="13603" help="36418">
-          <visible>false</visible>
-        </setting>
-        <setting id="input.enablemouse">
           <visible>false</visible>
         </setting>
       </group>

--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -9,7 +9,7 @@
       </group>
     </category>
     <category id="input">
-      <group id="2">
+      <group id="3">
         <setting id="input.appleremotealwayson">
           <level>1</level>
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2767,6 +2767,8 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="3" label="13600">
+      </group>
     </category>
     <category id="network" label="798" help="36379">
       <group id="1" label="16000">


### PR DESCRIPTION
This places the Apple Remote settings into a new group named "Apple Remote".

Previously, they were part of the Devices group, which led to poor UX by having 7 mostly unrelated settings in the same group.

ping @jjd-uk, this is your territory

## Screenshots (if appropriate):
Before:
<img width="1340" alt="screen shot 2017-02-18 at 10 59 08 pm" src="https://cloud.githubusercontent.com/assets/531482/23100123/7c0046ae-f62d-11e6-88eb-696d057ea9d8.png">

After:
<img width="1341" alt="screen shot 2017-02-18 at 10 36 11 pm" src="https://cloud.githubusercontent.com/assets/531482/23100036/78afbb4a-f62a-11e6-842a-1ae519e032c1.png">
