### PR TITLE
[cmake] fix building WiiRemote

### DIFF
--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -7,6 +7,9 @@ if(ENABLE_X11 AND X_FOUND AND XRANDR_FOUND)
 endif()
 
 # WiiRemote
-if(ENABLE_EVENTCLIENTS AND BLUETOOTH_FOUND AND CWIID_FOUND)
-  add_subdirectory(${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/WiiRemote build/WiiRemote)
+if(ENABLE_EVENTCLIENTS AND BLUETOOTH_FOUND)
+  find_package(CWiid QUIET)
+  if(CWIID_FOUND)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/WiiRemote build/WiiRemote)
+  endif()
 endif()


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
fix building WiiRemote after 0e7ddb333b0401e1c4a053036c35c05596601a16


