### PR TITLE
CMake: kodi-eventclients-wiiremote depends on cwiid

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -277,7 +277,7 @@ if(ENABLE_EVENTCLIENTS)
           DESTINATION ${bindir}
           COMPONENT kodi-eventclients-ps3)
 
-  if(BLUETOOTH_FOUND)
+  if(BLUETOOTH_FOUND AND CWIID_FOUND)
     # Install kodi-eventclients-wiiremote
     install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/WiiRemote/${APP_NAME_LC}-wiiremote
             DESTINATION ${bindir}


### PR DESCRIPTION
Fixes
CMake Error at cmake_install.cmake:15930 (file):
  file INSTALL cannot find
  "/home/buildroot/br/output/build/kodi-07daa5578e1d20eb056ce064baa42dbd47c86be2/project/cmake/build/WiiRemote/kodi-wiiremote".

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
