### PR TITLE
[backport] CMake: kodi-eventclients-wiiremote depends on cwiid

### DIFF
--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -264,7 +264,7 @@ if(ENABLE_EVENTCLIENTS)
           DESTINATION ${bindir}
           COMPONENT kodi-eventclients-ps3)
 
-  if(BLUETOOTH_FOUND)
+  if(BLUETOOTH_FOUND AND CWIID_FOUND)
     # Install kodi-eventclients-wiiremote
     install(PROGRAMS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/WiiRemote/${APP_NAME_LC}-wiiremote
             DESTINATION ${bindir}


### PR DESCRIPTION
backport of #11698 

Fixes
CMake Error at cmake_install.cmake:15930 (file):
  file INSTALL cannot find
  "/home/buildroot/br/output/build/kodi-07daa5578e1d20eb056ce064baa42dbd47c86be2/project/cmake/build/WiiRemote/kodi-wiiremote".
