### PR TITLE
[Fix] Songs smart playlists 3 x slower than similar library node

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1413,7 +1413,7 @@ void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
 {
   CGUIMediaWindow::OnPrepareFileItems(items);
 
-  if (!items.IsMusicDb())
+  if (!items.IsMusicDb() && !items.IsSmartPlayList())
     RetrieveMusicInfo();
 }
 


### PR DESCRIPTION
While investigating ways to reduce the slowness of the songs node on large music libraries, I discovered that smart playlists were actually 3 times slower!!!

`CGUIWindowMusicBase::RetrieveMusicInfo()` was being called unnecessarily as for smart playlists, like music library nodes,  we already have the info from the database. This did not actually scan any tags but waited around as if it was doing something.

To see the problem on a large music library (12000 songs was sufficient on my NUC in debug, but it will vary with CPU) , create a songs type smart playlist without rules (so all songs are in it) and compare how long it takes to display compared to the songs node.

Definitely one to backport.