### PR TITLE
[Fix] [Backport]Songs smart playlists 3 x slower than similar library node

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1394,7 +1394,7 @@ void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
 {
   CGUIMediaWindow::OnPrepareFileItems(items);
 
-  if (!items.IsMusicDb())
+  if (!items.IsMusicDb() && !items.IsSmartPlayList())
     RetrieveMusicInfo();
 }
 


### PR DESCRIPTION
Backport of #11702 

While investigating ways to reduce the slowness of the songs node on large music libraries, I discovered that smart playlists were actually 3 times slower!!!

CGUIWindowMusicBase::RetrieveMusicInfo() was being called unnecessarily as for smart playlists, like music library nodes, we already have the info from the database. This did not actually scan any tags but waited around as if it was doing something.

Wish it was as simple to speed up the songs node itself.