### PR TITLE
Fix rumble always enabled

### DIFF
--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.3.0" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.3.0"/>
+<addon id="kodi.peripheral" version="1.3.1" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.3.1"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16511,7 +16511,17 @@ msgctxt "#35052"
 msgid "Activate the rumble motors of all controllers."
 msgstr ""
 
-#empty strings from id 35053 to 35054
+#. Setting to enable rumble for GUI notifications
+#: system/settings/settings.xml
+msgctxt "#35053"
+msgid "Enable rumble for notifications"
+msgstr ""
+
+#. Description of setting to enable rumble for GUI notifications
+#: system/settings/settings.xml
+msgctxt "#35054"
+msgid "Activates controller rumble motors when a notification occurs."
+msgstr ""
 
 #. Help text for controller window
 #: xbmc/games/controllers/windows/GUIControllerWindow.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2757,12 +2757,16 @@
         <setting id="input.testrumble" type="action" label="35051" help="35052">
           <level>2</level>
           <dependencies>
-            <dependency type="enable" on="property" name="HasRumbleFeature" />
+            <dependency type="visible" on="property" name="HasRumbleFeature" />
+            <dependency type="enable" on="property" name="HasRumbleController" />
           </dependencies>
           <control type="button" format="action" />
         </setting>
         <setting id="input.controllerpoweroff" type="boolean" label="35088" help="35089">
-          <level>0</level>
+          <level>1</level>
+          <dependencies>
+            <dependency type="visible" on="property" name="HasPowerOffFeature" />
+          </dependencies>
           <default>false</default>
           <control type="toggle" />
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2754,6 +2754,14 @@
           <level>0</level>
           <control type="button" format="action" />
         </setting>
+        <setting id="input.rumblenotify" type="boolean" label="35053" help="35054">
+          <level>1</level>
+          <dependencies>
+            <dependency type="visible" on="property" name="HasRumbleFeature" />
+          </dependencies>
+          <control type="toggle" />
+          <default>false</default>
+        </setting>
         <setting id="input.testrumble" type="action" label="35051" help="35052">
           <level>2</level>
           <dependencies>

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -50,10 +50,10 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.3.0"
+#define PERIPHERAL_API_VERSION "1.3.1"
 
 /* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.3.0"
+#define PERIPHERAL_MIN_API_VERSION "1.3.1"
 
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
@@ -112,6 +112,8 @@ extern "C"
   typedef struct PERIPHERAL_CAPABILITIES
   {
     bool provides_joysticks;            /*!< @brief true if the add-on provides joysticks */
+    bool provides_joystick_rumble;
+    bool provides_joystick_power_off;
     bool provides_buttonmaps;           /*!< @brief true if the add-on provides button maps */
   } ATTRIBUTE_PACKED PERIPHERAL_CAPABILITIES;
   ///}

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_cpp_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_cpp_dll.h
@@ -101,7 +101,7 @@ class DllUtils
 {
 public:
 
-  static unsigned int VecToStruct(std::vector<DllSetting> &vecSet, ADDON_StructSetting*** sSet) 
+  static unsigned int VecToStruct(const std::vector<DllSetting> &vecSet, ADDON_StructSetting*** sSet)
   {
     *sSet = NULL;
     if (vecSet.empty())
@@ -143,7 +143,7 @@ public:
     return uiElements;
   }
 
-  static void StructToVec(unsigned int iElements, ADDON_StructSetting*** sSet, std::vector<DllSetting> *vecSet) 
+  static void StructToVec(unsigned int iElements, ADDON_StructSetting*** sSet, std::vector<DllSetting> *vecSet)
   {
     if(iElements == 0)
       return;

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -62,6 +62,7 @@ namespace PERIPHERALS
     FEATURE_IMON,
     FEATURE_JOYSTICK,
     FEATURE_RUMBLE,
+    FEATURE_POWER_OFF,
   };
 
   enum PeripheralType

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -64,6 +64,7 @@
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
+#include "ServiceBroker.h"
 
 #if defined(HAVE_LIBCEC)
 #include "bus/virtual/PeripheralBusCEC.h"
@@ -777,6 +778,9 @@ bool CPeripherals::GetNextKeypress(float frameTime, CKey &key)
 
 void CPeripherals::OnUserNotification()
 {
+  if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_INPUT_RUMBLENOTIFY))
+    return;
+
   PeripheralVector peripherals;
   GetPeripheralsWithFeature(peripherals, FEATURE_RUMBLE);
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -251,6 +251,17 @@ PeripheralBusPtr CPeripherals::GetBusWithDevice(const std::string &strLocation) 
   return nullptr;
 }
 
+bool CPeripherals::SupportsFeature(PeripheralFeature feature) const
+{
+  bool bSupportsFeature = false;
+
+  CSingleLock lock(m_critSectionBusses);
+  for (const auto& bus : m_busses)
+    bSupportsFeature |= bus->SupportsFeature(feature);
+
+  return bSupportsFeature;
+}
+
 int CPeripherals::GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature, PeripheralBusType busType /* = PERIPHERAL_BUS_UNKNOWN */) const
 {
   CSingleLock lock(m_critSectionBusses);

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -94,6 +94,13 @@ namespace PERIPHERALS
     PeripheralBusPtr GetBusWithDevice(const std::string &strLocation) const;
 
     /*!
+     * @brief Check if any busses support the given feature
+     * @param feature The feature to check for
+     * @return True if a bus supports the feature, false otherwise
+     */
+    bool SupportsFeature(PeripheralFeature feature) const;
+
+    /*!
      * @brief Get all peripheral instances that have the given feature.
      * @param results The list of results.
      * @param feature The feature to search for.

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -70,6 +70,8 @@ CPeripheralAddon::CPeripheralAddon(ADDON::AddonProps props, bool bProvidesJoysti
   CAddonDll(std::move(props)),
   m_apiVersion("0.0.0"),
   m_bProvidesJoysticks(bProvidesJoysticks),
+  m_bSupportsJoystickRumble(false),
+  m_bSupportsJoystickPowerOff(false),
   m_bProvidesButtonMaps(bProvidesButtonMaps)
 {
   ResetProperties();
@@ -175,6 +177,10 @@ bool CPeripheralAddon::GetAddonProperties(void)
         m_bProvidesButtonMaps ? "true" : "false", Author().c_str());
     return false;
   }
+
+  // Read properties that depend on underlying driver
+  m_bSupportsJoystickRumble = addonCapabilities.provides_joystick_rumble;
+  m_bSupportsJoystickPowerOff = addonCapabilities.provides_joystick_power_off;
 
   return true;
 }
@@ -293,6 +299,21 @@ PeripheralPtr CPeripheralAddon::GetByPath(const std::string &strPath) const
   }
 
   return result;
+}
+
+bool CPeripheralAddon::SupportsFeature(PeripheralFeature feature) const
+{
+  switch (feature)
+  {
+    case FEATURE_RUMBLE:
+      return m_bSupportsJoystickRumble;
+    case FEATURE_POWER_OFF:
+      return m_bSupportsJoystickPowerOff;
+    default:
+      break;
+  }
+
+  return false;
 }
 
 int CPeripheralAddon::GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -70,6 +70,7 @@ namespace PERIPHERALS
     bool         HasFeature(const PeripheralFeature feature) const;
     PeripheralPtr GetPeripheral(unsigned int index) const;
     PeripheralPtr GetByPath(const std::string &strPath) const;
+    bool         SupportsFeature(PeripheralFeature feature) const;
     int          GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const;
     size_t       GetNumberOfPeripherals(void) const;
     size_t       GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const;
@@ -146,6 +147,8 @@ namespace PERIPHERALS
     /* @brief Add-on properties */
     ADDON::AddonVersion m_apiVersion;
     bool                m_bProvidesJoysticks;
+    bool                m_bSupportsJoystickRumble;
+    bool                m_bSupportsJoystickPowerOff;
     bool                m_bProvidesButtonMaps;
 
     /* @brief Map of peripherals belonging to the add-on */

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -76,6 +76,13 @@ namespace PERIPHERALS
     virtual bool HasPeripheral(const std::string &strLocation) const;
 
     /*!
+     * @brief Check if the bus supports the given feature
+     * @param feature The feature to check for
+     * @return True if the bus supports the feature, false otherwise
+     */
+    virtual bool SupportsFeature(PeripheralFeature feature) const { return false; }
+
+    /*!
      * @brief Get all peripheral instances that have the given feature.
      * @param results The list of results.
      * @param feature The feature to search for.

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -301,6 +301,17 @@ PeripheralPtr CPeripheralBusAddon::GetByPath(const std::string &strPath) const
   return result;
 }
 
+bool CPeripheralBusAddon::SupportsFeature(PeripheralFeature feature) const
+{
+  bool bSupportsFeature = false;
+
+  CSingleLock lock(m_critSection);
+  for (const auto& addon : m_addons)
+    bSupportsFeature |= addon->SupportsFeature(feature);
+
+  return bSupportsFeature;
+}
+
 int CPeripheralBusAddon::GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const
 {
   int iReturn(0);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -77,6 +77,7 @@ namespace PERIPHERALS
     virtual bool         HasFeature(const PeripheralFeature feature) const override;
     virtual PeripheralPtr GetPeripheral(const std::string &strLocation) const override;
     virtual PeripheralPtr GetByPath(const std::string &strPath) const override;
+    virtual bool         SupportsFeature(PeripheralFeature feature) const override;
     virtual int          GetPeripheralsWithFeature(PeripheralVector &results, const PeripheralFeature feature) const override;
     virtual size_t       GetNumberOfPeripherals(void) const override;
     virtual size_t       GetNumberOfPeripheralsWithId(const int iVendorId, const int iProductId) const override;

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -81,6 +81,10 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
     {
       bSuccess = true; // Nothing to do
     }
+    else if (feature == FEATURE_POWER_OFF)
+    {
+      bSuccess = true; // Nothing to do
+    }
   }
 
   return bSuccess;
@@ -291,5 +295,15 @@ void CPeripheralJoystick::SetMotorCount(unsigned int motorCount)
   if (m_motorCount == 0)
     m_features.erase(std::remove(m_features.begin(), m_features.end(), FEATURE_RUMBLE), m_features.end());
   else if (std::find(m_features.begin(), m_features.end(), FEATURE_RUMBLE) == m_features.end())
+    m_features.push_back(FEATURE_RUMBLE);
+}
+
+void CPeripheralJoystick::SetSupportsPowerOff(bool bSupportsPowerOff)
+{
+  m_supportsPowerOff = bSupportsPowerOff;
+
+  if (!m_supportsPowerOff)
+    m_features.erase(std::remove(m_features.begin(), m_features.end(), FEATURE_POWER_OFF), m_features.end());
+  else if (std::find(m_features.begin(), m_features.end(), FEATURE_POWER_OFF) == m_features.end())
     m_features.push_back(FEATURE_RUMBLE);
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -103,7 +103,7 @@ namespace PERIPHERALS
     void SetHatCount(unsigned int hatCount)       { m_hatCount      = hatCount; }
     void SetAxisCount(unsigned int axisCount)     { m_axisCount     = axisCount; }
     void SetMotorCount(unsigned int motorCount); // specialized to update m_features
-    void SetSupportsPowerOff(bool supportsPowerOff) { m_supportsPowerOff = supportsPowerOff; }
+    void SetSupportsPowerOff(bool bSupportsPowerOff); // specialized to update m_features
 
   protected:
     void InitializeDeadzoneFiltering();

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -84,9 +84,21 @@ bool HasRumbleFeature(const std::string &condition, const std::string &value, co
 {
   using namespace PERIPHERALS;
 
-  PeripheralVector results;
-  g_peripherals.GetPeripheralsWithFeature(results, FEATURE_RUMBLE);
-  return !results.empty();
+  return g_peripherals.SupportsFeature(FEATURE_RUMBLE);
+}
+
+bool HasRumbleController(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
+{
+  using namespace PERIPHERALS;
+
+  return g_peripherals.HasPeripheralWithFeature(FEATURE_RUMBLE);
+}
+
+bool HasPowerOffFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
+{
+  using namespace PERIPHERALS;
+
+  return g_peripherals.SupportsFeature(FEATURE_POWER_OFF);
 }
 
 bool IsFullscreen(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
@@ -347,6 +359,8 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("checkpvrparentalpin",           CheckPVRParentalPin));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasperipherals",                HasPeripherals));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblefeature",              HasRumbleFeature));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblecontroller",           HasRumbleController));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("haspowerofffeature",            HasPowerOffFeature));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isfullscreen",                  IsFullscreen));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("ismasteruser",                  IsMasterUser));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("isusingttfsubtitles",           IsUsingTTFSubtitles));

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -376,6 +376,7 @@ const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
 const std::string CSettings::SETTING_INPUT_ASKNEWCONTROLLERS = "input.asknewcontrollers";
 const std::string CSettings::SETTING_INPUT_CONTROLLERCONFIG = "input.controllerconfig";
+const std::string CSettings::SETTING_INPUT_RUMBLENOTIFY = "input.rumblenotify";
 const std::string CSettings::SETTING_INPUT_TESTRUMBLE = "input.testrumble";
 const std::string CSettings::SETTING_INPUT_CONTROLLERPOWEROFF = "input.controllerpoweroff";
 const std::string CSettings::SETTING_INPUT_APPLEREMOTEMODE = "input.appleremotemode";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -332,6 +332,7 @@ public:
   static const std::string SETTING_INPUT_ENABLEMOUSE;
   static const std::string SETTING_INPUT_ASKNEWCONTROLLERS;
   static const std::string SETTING_INPUT_CONTROLLERCONFIG;
+  static const std::string SETTING_INPUT_RUMBLENOTIFY;
   static const std::string SETTING_INPUT_TESTRUMBLE;
   static const std::string SETTING_INPUT_CONTROLLERPOWEROFF;
   static const std::string SETTING_INPUT_APPLEREMOTEMODE;


### PR DESCRIPTION
This adds a setting to disable rumble for notifications. The default is to not rumble.

Reported here: http://forum.kodi.tv/showthread.php?tid=296564

This also improves the visibility conditions for rumble and power-off settings. Now, they are only shown if the underlying joystick driver supports each.

The corresponding peripheral.joystick commit is https://github.com/xbmc/peripheral.joystick/pull/86

## Screenshots (if appropriate):
<img width="1340" alt="screen shot 2017-02-19 at 12 09 03 pm" src="https://cloud.githubusercontent.com/assets/531482/23106397/d0ed5d5e-f6a1-11e6-9e9e-d0c5f16347c1.png">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
