### PR TITLE
[cleanup] remove some old xbox references

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1262,7 +1262,6 @@ void CFileItem::FillInDefaultIcon()
   //   default picture for videos
   //   default picture for shortcuts
   //   default picture for playlists
-  //   or the icon embedded in an .xbe
   //
   // for folders
   //   for .. folders the default picture for parent folder

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -180,7 +180,7 @@ namespace XBMCAddon
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
     /// ..
-    /// xbmc.executebuiltin('RunXBE(c:\\avalaunch.xbe)')
+    /// xbmc.executebuiltin('Skin.SetString(abc,def)')
     /// ..
     /// ~~~~~~~~~~~~~
     ///

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -57,7 +57,7 @@ std::string CGUIViewStateWindowPrograms::GetLockType()
 
 std::string CGUIViewStateWindowPrograms::GetExtensions()
 {
-  return ".xbe|.cut";
+  return ".cut";
 }
 
 VECSOURCES& CGUIViewStateWindowPrograms::GetSources()


### PR DESCRIPTION
.xbe was the extension for xbox executables afaik.
This removes some references to this old file type.