### PR TITLE
[Backport] VideoPlayer: fix edl skipping

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -87,10 +87,6 @@ public:
     VIDEO_SET_ASPECT,               // set aspectratio of video
     VIDEO_DRAIN,                    // wait for decoder to output last frame
 
-    // audio related messages
-
-    AUDIO_SILENCE,
-
     // subtitle related messages
     SUBTITLE_CLUTCHANGE,
     SUBTITLE_ADDFILE
@@ -221,7 +217,6 @@ public:
     int time = 0;
     bool relative = false;
     bool backward = false;
-    bool flush = true;
     bool accurate = true;
     bool sync = true;
     bool restore = true;
@@ -234,7 +229,6 @@ public:
   int GetTime() { return m_mode.time; }
   bool GetRelative() { return m_mode.relative; }
   bool GetBackward() { return m_mode.backward; }
-  bool GetFlush() { return m_mode.flush; }
   bool GetAccurate() { return m_mode.accurate; }
   bool GetRestore() { return m_mode.restore; }
   bool GetTrickPlay() { return m_mode.trickplay; }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -46,6 +46,7 @@ void CEdl::Clear()
   m_vecCuts.clear();
   m_vecSceneMarkers.clear();
   m_iTotalCutTime = 0;
+  m_lastQueryTime = 0;
 }
 
 bool CEdl::ReadEditDecisionLists(const std::string& strMovie, const float fFrameRate, const int iHeight)
@@ -822,8 +823,10 @@ std::string CEdl::GetInfo() const
   return strInfo.empty() ? "-" : strInfo;
 }
 
-bool CEdl::InCut(const int iSeek, Cut *pCut) const
+bool CEdl::InCut(const int iSeek, Cut *pCut)
 {
+  m_lastQueryTime = iSeek;
+
   for (int i = 0; i < (int)m_vecCuts.size(); i++)
   {
     if (iSeek < m_vecCuts[i].start) // Early exit if not even up to the cut start time.
@@ -838,6 +841,11 @@ bool CEdl::InCut(const int iSeek, Cut *pCut) const
   }
 
   return false;
+}
+
+int CEdl::GetLastQueryTime() const
+{
+  return m_lastQueryTime;
 }
 
 bool CEdl::GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const
@@ -885,7 +893,7 @@ bool CEdl::GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const
   }
 }
 
-bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const
+bool CEdl::GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker)
 {
   if (!HasSceneMarker())
     return false;

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -53,18 +53,19 @@ public:
   int RemoveCutTime(int iSeek) const;
   int RestoreCutTime(int iClock) const;
 
-  bool InCut(int iSeek, Cut *pCut = NULL) const;
+  bool InCut(int iSeek, Cut *pCut = NULL);
   bool GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const;
+  int GetLastQueryTime() const;
 
-  bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker) const;
+  bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
 
   static std::string MillisecondsToTimeString(const int iMilliseconds);
 
-protected:
 private:
   int m_iTotalCutTime; // ms
   std::vector<Cut> m_vecCuts;
   std::vector<int> m_vecSceneMarkers;
+  int m_lastQueryTime;
 
   bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
   bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1362,7 +1362,6 @@ void CVideoPlayer::Process()
         CDVDMsgPlayerSeek::CMode mode;
         mode.time = (int)GetTime();
         mode.backward = true;
-        mode.flush = true;
         mode.accurate = true;
         mode.sync = true;
         m_messenger.Put(new CDVDMsgPlayerSeek(mode));

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2054,6 +2054,7 @@ void CVideoPlayer::HandlePlaySpeed()
       m_VideoPlayerAudio->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, clock), 1);
       m_VideoPlayerVideo->SendMessage(new CDVDMsgDouble(CDVDMsg::GENERAL_RESYNC, clock), 1);
       SetCaching(CACHESTATE_DONE);
+      UpdatePlayState(0);
 
       m_syncTimer.Set(3000);
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -633,7 +633,6 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
 
   m_dvd.Clear();
   m_State.Clear();
-  m_EdlAutoSkipMarkers.Clear();
   m_UpdateApplication = 0;
 
   m_bAbortRequest = false;
@@ -745,7 +744,6 @@ bool CVideoPlayer::CloseFile(bool reopen)
   StopThread();
 
   m_Edl.Clear();
-  m_EdlAutoSkipMarkers.Clear();
 
   m_HasVideo = false;
   m_HasAudio = false;
@@ -1272,7 +1270,6 @@ void CVideoPlayer::Process()
 
   // look for any EDL files
   m_Edl.Clear();
-  m_EdlAutoSkipMarkers.Clear();
   if (m_CurrentVideo.id >= 0 && m_CurrentVideo.hint.fpsrate > 0 && m_CurrentVideo.hint.fpsscale > 0)
   {
     float fFramesPerSecond = (float)m_CurrentVideo.hint.fpsrate / (float)m_CurrentVideo.hint.fpsscale;
@@ -1286,7 +1283,7 @@ void CVideoPlayer::Process()
    */
   CEdl::Cut cut;
   int starttime = 0;
-  if(m_PlayerOptions.starttime > 0 || m_PlayerOptions.startpercent > 0)
+  if (m_PlayerOptions.starttime > 0 || m_PlayerOptions.startpercent > 0)
   {
     if (m_PlayerOptions.startpercent > 0 && m_pDemuxer)
     {
@@ -1299,7 +1296,7 @@ void CVideoPlayer::Process()
     }
     CLog::Log(LOGDEBUG, "%s - Start position set to last stopped position: %d", __FUNCTION__, starttime);
   }
-  else if(m_Edl.InCut(0, &cut))
+  else if (m_Edl.InCut(starttime, &cut))
   {
     if (cut.action == CEdl::CUT)
     {
@@ -1316,20 +1313,13 @@ void CVideoPlayer::Process()
 
       std::string strTimeString = StringUtils::SecondsToTimeString(cut.end / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
-
-      /*
-       * Setup auto skip markers as if the commercial break had been skipped using standard
-       * detection.
-       */
-      m_EdlAutoSkipMarkers.commbreak_start = cut.start;
-      m_EdlAutoSkipMarkers.commbreak_end   = cut.end;
-      m_EdlAutoSkipMarkers.seek_to_start   = true;
     }
   }
-  if(starttime > 0)
+
+  if (starttime > 0)
   {
     double startpts = DVD_NOPTS_VALUE;
-    if(m_pDemuxer)
+    if (m_pDemuxer)
     {
       if (m_pDemuxer->SeekTime(starttime, false, &startpts))
         CLog::Log(LOGDEBUG, "%s - starting demuxer from: %d", __FUNCTION__, starttime);
@@ -1337,13 +1327,15 @@ void CVideoPlayer::Process()
         CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %d", __FUNCTION__, starttime);
     }
 
-    if(m_pSubtitleDemuxer)
+    if (m_pSubtitleDemuxer)
     {
       if(m_pSubtitleDemuxer->SeekTime(starttime, false, &startpts))
         CLog::Log(LOGDEBUG, "%s - starting subtitle demuxer from: %d", __FUNCTION__, starttime);
       else
         CLog::Log(LOGDEBUG, "%s - failed to start subtitle demuxing from: %d", __FUNCTION__, starttime);
     }
+
+    m_clock.Discontinuity(DVD_MSEC_TO_TIME(starttime));
   }
 
   // make sure application know our info
@@ -1725,24 +1717,13 @@ void CVideoPlayer::ProcessAudioData(CDemuxStream* pStream, DemuxPacket* pPacket)
 
   /*
    * If CheckSceneSkip() returns true then demux point is inside an EDL cut and the packets are dropped.
-   * If not inside a hard cut, but the demux point has reached an EDL mute section then trigger the
-   * AUDIO_SILENCE state. The AUDIO_SILENCE state is reverted as soon as the demux point is outside
-   * of any EDL section while EDL mute is still active.
    */
   CEdl::Cut cut;
   if (CheckSceneSkip(m_CurrentAudio))
     drop = true;
-  else if (m_Edl.InCut(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &cut) && cut.action == CEdl::MUTE // Inside EDL mute
-  &&      !m_EdlAutoSkipMarkers.mute) // Mute not already triggered
+  else if (m_Edl.InCut(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &cut) && cut.action == CEdl::MUTE)
   {
-    m_VideoPlayerAudio->SendMessage(new CDVDMsgBool(CDVDMsg::AUDIO_SILENCE, true));
-    m_EdlAutoSkipMarkers.mute = true;
-  }
-  else if (!m_Edl.InCut(DVD_TIME_TO_MSEC(m_CurrentAudio.dts + m_offset_pts), &cut) // Outside of any EDL
-  &&        m_EdlAutoSkipMarkers.mute) // But the mute hasn't been removed yet
-  {
-    m_VideoPlayerAudio->SendMessage(new CDVDMsgBool(CDVDMsg::AUDIO_SILENCE, false));
-    m_EdlAutoSkipMarkers.mute = false;
+    drop = true;
   }
 
   m_VideoPlayerAudio->SendMessage(new CDVDMsgDemuxerPacket(pPacket, drop));
@@ -1949,7 +1930,7 @@ void CVideoPlayer::HandlePlaySpeed()
           {
             CLog::Log(LOGDEBUG, "Stream stalled, start buffering. Audio: %d - Video: %d",
                                  m_VideoPlayerAudio->GetLevel(),m_VideoPlayerVideo->GetLevel());
-            FlushBuffers(false);
+            FlushBuffers(DVD_NOPTS_VALUE, true, true);
           }
         }
         else
@@ -1965,11 +1946,10 @@ void CVideoPlayer::HandlePlaySpeed()
                    m_VideoPlayerAudio->GetLevel() == 0)
           {
             CLog::Log(LOGDEBUG,"CVideoPlayer::HandlePlaySpeed - audio stream stalled, triggering re-sync");
-            FlushBuffers(false);
+            FlushBuffers(DVD_NOPTS_VALUE, true, true);
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = (int)GetTime();
             mode.backward = false;
-            mode.flush = true;
             mode.accurate = true;
             mode.sync = true;
             m_messenger.Put(new CDVDMsgPlayerSeek(mode));
@@ -2087,7 +2067,7 @@ void CVideoPlayer::HandlePlaySpeed()
           m_VideoPlayerVideo->IsStalled())
       {
         CLog::Log(LOGWARNING, "VideoPlayer::Sync - stream player video does not start, flushing buffers");
-        FlushBuffers(false);
+        FlushBuffers(DVD_NOPTS_VALUE, true, true);
       }
     }
   }
@@ -2162,7 +2142,6 @@ void CVideoPlayer::HandlePlaySpeed()
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = iTime;
             mode.backward = (GetPlaySpeed() < 0);
-            mode.flush = true;
             mode.accurate = false;
             mode.restore = false;
             mode.trickplay = true;
@@ -2345,86 +2324,69 @@ void CVideoPlayer::CheckAutoSceneSkip()
   if (!m_Edl.HasCut())
     return;
 
-
   // Check that there is an audio and video stream.
-  if(m_CurrentAudio.id < 0 ||
-     m_CurrentVideo.id < 0)
+  if((m_CurrentAudio.id < 0 || m_CurrentAudio.syncState != IDVDStreamPlayer::SYNC_INSYNC) ||
+     (m_CurrentVideo.id < 0 || m_CurrentVideo.syncState != IDVDStreamPlayer::SYNC_INSYNC))
     return;
-
 
   // If there is a startpts defined for either the audio or video stream then VideoPlayer is still
   // still decoding frames to get to the previously requested seek point.
-
   if (m_CurrentAudio.inited == false ||
       m_CurrentVideo.inited == false)
     return;
 
-  if (m_CurrentAudio.dts == DVD_NOPTS_VALUE ||
-      m_CurrentVideo.dts == DVD_NOPTS_VALUE)
-    return;
-
-  const int64_t clock = m_omxplayer_mode ? GetTime() : DVD_TIME_TO_MSEC(std::min(m_CurrentAudio.dts, m_CurrentVideo.dts) + m_offset_pts);
+  const int64_t clock = GetTime();
 
   CEdl::Cut cut;
   if (!m_Edl.InCut(clock, &cut))
     return;
 
-  if (cut.action == CEdl::CUT &&
-      !(cut.end == m_EdlAutoSkipMarkers.cut || cut.start == m_EdlAutoSkipMarkers.cut)) // To prevent looping if same cut again
+  if (cut.action == CEdl::CUT)
   {
-    CLog::Log(LOGDEBUG, "%s - Clock in EDL cut [%s - %s]: %s. Automatically skipping over.",
-              __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(),
-              CEdl::MillisecondsToTimeString(cut.end).c_str(), CEdl::MillisecondsToTimeString(clock).c_str());
-
-    //Seeking either goes to the start or the end of the cut depending on the play direction.
-    int seek = GetPlaySpeed() >= 0 ? cut.end : cut.start;
-
-    // Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
-    CDVDMsgPlayerSeek::CMode mode;
-    mode.time = seek;
-    mode.backward = true;
-    mode.flush = false;
-    mode.accurate = false;
-    mode.restore = true;
-    mode.trickplay = false;
-    mode.sync = true;
-    m_messenger.Put(new CDVDMsgPlayerSeek(mode));
-
-    // Seek doesn't always work reliably. Last physical seek time is recorded to prevent looping
-    // if there was an error with seeking and it landed somewhere unexpected, perhaps back in the
-    // cut. The cut automatic skip marker is reset every 500ms allowing another attempt at the seek.
-    m_EdlAutoSkipMarkers.cut = GetPlaySpeed() >= 0 ? cut.end : cut.start;
-  }
-  else if (cut.action == CEdl::COMM_BREAK && GetPlaySpeed() >= 0 &&
-           cut.start > m_EdlAutoSkipMarkers.commbreak_end)
-  {
-    std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
-
-    if (m_SkipCommercials)
+    if ((GetPlaySpeed() > 0 && clock < cut.end - 1000) ||
+        (GetPlaySpeed() < 0 && clock < cut.start + 1000))
     {
-      CLog::Log(LOGDEBUG, "%s - Clock in commercial break [%s - %s]: %s. Automatically skipping to end of commercial break (only done once per break)",
-                __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(), CEdl::MillisecondsToTimeString(cut.end).c_str(),
-                CEdl::MillisecondsToTimeString(clock).c_str());
+      CLog::Log(LOGDEBUG, "%s - Clock in EDL cut [%s - %s]: %s. Automatically skipping over.",
+                __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(),
+                CEdl::MillisecondsToTimeString(cut.end).c_str(), CEdl::MillisecondsToTimeString(clock).c_str());
 
-      // Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
+      //Seeking either goes to the start or the end of the cut depending on the play direction.
+      int seek = GetPlaySpeed() >= 0 ? cut.end : cut.start;
+
       CDVDMsgPlayerSeek::CMode mode;
-      mode.time = cut.end + 1;
+      mode.time = seek;
       mode.backward = true;
-      mode.flush = false;
-      mode.accurate = false;
+      mode.accurate = true;
       mode.restore = true;
       mode.trickplay = false;
       mode.sync = true;
       m_messenger.Put(new CDVDMsgPlayerSeek(mode));
     }
+  }
+  else if (cut.action == CEdl::COMM_BREAK)
+  {
+    if (GetPlaySpeed() > 0 && clock < cut.end - 1000)
+    {
+      std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
+      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
 
-    // Each commercial break is only skipped once so poorly detected commercial breaks can be
-    // manually re-entered. Start and end are recorded to prevent looping and to allow seeking back
-    // to the start of the commercial break if incorrectly flagged.
-    m_EdlAutoSkipMarkers.commbreak_start = cut.start;
-    m_EdlAutoSkipMarkers.commbreak_end   = cut.end;
-    m_EdlAutoSkipMarkers.seek_to_start   = true; // Allow backwards Seek() to go directly to the start
+      if (m_SkipCommercials)
+      {
+        CLog::Log(LOGDEBUG, "%s - Clock in commercial break [%s - %s]: %s. Automatically skipping to end of commercial break",
+                  __FUNCTION__, CEdl::MillisecondsToTimeString(cut.start).c_str(),
+                  CEdl::MillisecondsToTimeString(cut.end).c_str(),
+                  CEdl::MillisecondsToTimeString(clock).c_str());
+
+        CDVDMsgPlayerSeek::CMode mode;
+        mode.time = cut.end;
+        mode.backward = true;
+        mode.accurate = true;
+        mode.restore = false;
+        mode.trickplay = false;
+        mode.sync = true;
+        m_messenger.Put(new CDVDMsgPlayerSeek(mode));
+      }
+    }
   }
 }
 
@@ -2557,8 +2519,7 @@ void CVideoPlayer::HandleMessages()
       if (!msg.GetTrickPlay())
       {
         g_infoManager.SetDisplayAfterSeek(100000);
-        if(msg.GetFlush())
-          SetCaching(CACHESTATE_FLUSH);
+        SetCaching(CACHESTATE_FLUSH);
       }
 
       double start = DVD_NOPTS_VALUE;
@@ -2594,7 +2555,7 @@ void CVideoPlayer::HandleMessages()
         m_State.dts = start;
         m_State.lastSeek = m_clock.GetAbsoluteClock();
 
-        FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate(), msg.GetSync());
+        FlushBuffers(start, msg.GetAccurate(), msg.GetSync());
       }
       else if (m_pDemuxer)
       {
@@ -2605,7 +2566,7 @@ void CVideoPlayer::HandleMessages()
 
         m_State.dts = start;
 
-        FlushBuffers(false, start, false, true);
+        FlushBuffers(start, false, true);
         if (m_playSpeed != DVD_PLAYSPEED_PAUSE)
         {
           SetPlaySpeed(DVD_PLAYSPEED_NORMAL);
@@ -2637,7 +2598,7 @@ void CVideoPlayer::HandleMessages()
       // This should always be the case.
       if(m_pDemuxer && m_pDemuxer->SeekChapter(msg.GetChapter(), &start))
       {
-        FlushBuffers(false, start, true);
+        FlushBuffers(start, true, true);
         offset = DVD_TIME_TO_MSEC(start) - beforeSeek;
         m_callback.OnPlayBackSeekChapter(msg.GetChapter());
       }
@@ -2673,7 +2634,6 @@ void CVideoPlayer::HandleMessages()
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = (int)GetTime();
             mode.backward = true;
-            mode.flush = true;
             mode.accurate = true;
             mode.trickplay = true;
             mode.sync = true;
@@ -2689,7 +2649,6 @@ void CVideoPlayer::HandleMessages()
           CDVDMsgPlayerSeek::CMode mode;
           mode.time = (int)GetTime();
           mode.backward = true;
-          mode.flush = true;
           mode.accurate = true;
           mode.trickplay = true;
           mode.sync = true;
@@ -2714,7 +2673,6 @@ void CVideoPlayer::HandleMessages()
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = (int)GetTime();
             mode.backward = true;
-            mode.flush = true;
             mode.accurate = true;
             mode.trickplay = true;
             mode.sync = true;
@@ -2728,7 +2686,6 @@ void CVideoPlayer::HandleMessages()
           CDVDMsgPlayerSeek::CMode mode;
           mode.time = (int)GetTime();
           mode.backward = true;
-          mode.flush = true;
           mode.accurate = true;
           mode.trickplay = true;
           mode.sync = true;
@@ -2791,7 +2748,7 @@ void CVideoPlayer::HandleMessages()
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
     {
-      FlushBuffers(false);
+      FlushBuffers(DVD_NOPTS_VALUE, true, true);
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
@@ -2837,7 +2794,6 @@ void CVideoPlayer::HandleMessages()
         CDVDMsgPlayerSeek::CMode mode;
         mode.time = iTime;
         mode.backward = m_playSpeed < 0;
-        mode.flush = true;
         mode.accurate = false;
         mode.trickplay = true;
         mode.sync = true;
@@ -2856,7 +2812,6 @@ void CVideoPlayer::HandleMessages()
           CDVDMsgPlayerSeek::CMode mode;
           mode.time = (int)GetTime();
           mode.backward = (speed < 0);
-          mode.flush = true;
           mode.accurate = true;
           mode.restore = false;
           mode.trickplay = true;
@@ -2885,7 +2840,7 @@ void CVideoPlayer::HandleMessages()
     else if (pMsg->IsType(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER) &&
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER) == 0)
     {
-      FlushBuffers(false);
+      FlushBuffers(DVD_NOPTS_VALUE, true, true);
       CDVDInputStreamPVRManager* input = dynamic_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
       //! @todo find a better solution for the "otherStreaHack"
       //! a stream is not sopposed to be terminated before demuxer
@@ -2912,7 +2867,7 @@ void CVideoPlayer::HandleMessages()
     else if (pMsg->IsType(CDVDMsg::PLAYER_CHANNEL_SELECT) &&
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_CHANNEL_SELECT) == 0)
     {
-      FlushBuffers(false);
+      FlushBuffers(DVD_NOPTS_VALUE, true, true);
       CDVDInputStreamPVRManager* input = dynamic_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
       if (input && input->IsOtherStreamHack())
       {
@@ -2945,7 +2900,7 @@ void CVideoPlayer::HandleMessages()
         if (!bShowPreview)
         {
           g_infoManager.SetDisplayAfterSeek(100000);
-          FlushBuffers(false);
+          FlushBuffers(DVD_NOPTS_VALUE, true, true);
           if (input->IsOtherStreamHack())
           {
             CloseDemuxer();
@@ -3183,52 +3138,6 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   }
 
   bool restore = true;
-  if (m_Edl.HasCut())
-  {
-    /*
-     * Alter the standard seek position based on whether any commercial breaks have been
-     * automatically skipped.
-     */
-    const int clock = DVD_TIME_TO_MSEC(m_clock.GetClock());
-    /*
-     * If a large backwards seek occurs within 10 seconds of the end of the last automated
-     * commercial skip, then seek back to the start of the commercial break under the assumption
-     * it was flagged incorrectly. 10 seconds grace period is allowed in case the watcher has to
-     * fumble around finding the remote. Only happens once per commercial break.
-     *
-     * Small skip does not trigger this in case the start of the commercial break was in fact fine
-     * but it skipped too far into the program. In that case small skip backwards behaves as normal.
-     */
-    if (!bPlus && bLargeStep &&
-        m_EdlAutoSkipMarkers.seek_to_start &&
-        clock >= m_EdlAutoSkipMarkers.commbreak_end &&
-        clock <= m_EdlAutoSkipMarkers.commbreak_end + 10*1000) // Only if within 10 seconds of the end (in msec)
-    {
-      CLog::Log(LOGDEBUG, "%s - Seeking back to start of commercial break [%s - %s] as large backwards skip activated within 10 seconds of the automatic commercial skip (only done once per break).",
-                __FUNCTION__, CEdl::MillisecondsToTimeString(m_EdlAutoSkipMarkers.commbreak_start).c_str(),
-                CEdl::MillisecondsToTimeString(m_EdlAutoSkipMarkers.commbreak_end).c_str());
-      seekTarget = m_EdlAutoSkipMarkers.commbreak_start;
-      restore = false;
-      m_EdlAutoSkipMarkers.seek_to_start = false; // So this will only happen within the 10 second grace period once.
-    }
-    /*
-     * If big skip forward within the last "reverted" commercial break, seek to the end of the
-     * commercial break under the assumption that the break was incorrectly flagged and playback has
-     * now reached the actual start of the commercial break. Assume that the end is flagged more
-     * correctly than the landing point for a standard big skip (ends seem to be flagged more
-     * accurately than the start).
-     */
-    else if (bPlus && bLargeStep &&
-             clock >= m_EdlAutoSkipMarkers.commbreak_start &&
-             clock <= m_EdlAutoSkipMarkers.commbreak_end)
-    {
-      CLog::Log(LOGDEBUG, "%s - Seeking to end of previously skipped commercial break [%s - %s] as big forwards skip activated within the break.",
-                __FUNCTION__, CEdl::MillisecondsToTimeString(m_EdlAutoSkipMarkers.commbreak_start).c_str(),
-                CEdl::MillisecondsToTimeString(m_EdlAutoSkipMarkers.commbreak_end).c_str());
-      seekTarget = m_EdlAutoSkipMarkers.commbreak_end;
-      restore = false;
-    }
-  }
 
   int64_t time = GetTime();
   if(g_application.CurrentFileItem().IsStack() &&
@@ -3243,7 +3152,6 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   CDVDMsgPlayerSeek::CMode mode;
   mode.time = (int)seekTarget;
   mode.backward = !bPlus;
-  mode.flush = true;
   mode.accurate = false;
   mode.restore = restore;
   mode.trickplay = false;
@@ -3278,7 +3186,6 @@ bool CVideoPlayer::SeekScene(bool bPlus)
     CDVDMsgPlayerSeek::CMode mode;
     mode.time = iScenemarker;
     mode.backward = !bPlus;
-    mode.flush = true;
     mode.accurate = false;
     mode.restore = false;
     mode.trickplay = false;
@@ -3576,7 +3483,6 @@ void CVideoPlayer::SeekTime(int64_t iTime)
   CDVDMsgPlayerSeek::CMode mode;
   mode.time = (int)iTime;
   mode.backward = true;
-  mode.flush = true;
   mode.accurate = true;
   mode.trickplay = false;
   mode.sync = true;
@@ -3594,7 +3500,6 @@ bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
   mode.time = (int)iTime;
   mode.relative = true;
   mode.backward = (iTime < 0) ? true : false;
-  mode.flush = true;
   mode.accurate = false;
   mode.trickplay = false;
   mode.sync = true;
@@ -4026,7 +3931,7 @@ bool CVideoPlayer::CloseStream(CCurrentStream& current, bool bWaitForBuffers)
   return true;
 }
 
-void CVideoPlayer::FlushBuffers(bool queued, double pts, bool accurate, bool sync)
+void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
 {
   CLog::Log(LOGDEBUG, "CVideoPlayer::FlushBuffers - flushing buffers");
 
@@ -4067,63 +3972,45 @@ void CVideoPlayer::FlushBuffers(bool queued, double pts, bool accurate, bool syn
   m_CurrentRadioRDS.startpts = startpts;
   m_CurrentRadioRDS.packets = 0;
 
-  if (queued)
-  {
-    m_VideoPlayerAudio->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_VideoPlayerVideo->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_VideoPlayerSubtitle->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_VideoPlayerTeletext->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    m_VideoPlayerRadioRDS->SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+  m_VideoPlayerAudio->Flush(sync);
+  m_VideoPlayerVideo->Flush(sync);
+  m_VideoPlayerSubtitle->Flush();
+  m_VideoPlayerTeletext->Flush();
+  m_VideoPlayerRadioRDS->Flush();
 
-    CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(10*1000, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
+  // clear subtitle and menu overlays
+  m_overlayContainer.Clear();
+
+  if(m_playSpeed == DVD_PLAYSPEED_NORMAL ||
+     m_playSpeed == DVD_PLAYSPEED_PAUSE)
+  {
+    // make sure players are properly flushed, should put them in stalled state
+    CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(1000, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
     m_VideoPlayerAudio->SendMessage(msg->Acquire(), 1);
     m_VideoPlayerVideo->SendMessage(msg->Acquire(), 1);
     msg->Wait(m_bStop, 0);
     msg->Release();
-  }
-  else
-  {
-    m_VideoPlayerAudio->Flush(sync);
-    m_VideoPlayerVideo->Flush(sync);
-    m_VideoPlayerSubtitle->Flush();
-    m_VideoPlayerTeletext->Flush();
-    m_VideoPlayerRadioRDS->Flush();
 
-    // clear subtitle and menu overlays
-    m_overlayContainer.Clear();
+    // purge any pending PLAYER_STARTED messages
+    m_messenger.Flush(CDVDMsg::PLAYER_STARTED);
 
-    if(m_playSpeed == DVD_PLAYSPEED_NORMAL
-    || m_playSpeed == DVD_PLAYSPEED_PAUSE)
+    // we should now wait for init cache
+    SetCaching(CACHESTATE_FLUSH);
+    if (sync)
     {
-      // make sure players are properly flushed, should put them in stalled state
-      CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(1000, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);
-      m_VideoPlayerAudio->SendMessage(msg->Acquire(), 1);
-      m_VideoPlayerVideo->SendMessage(msg->Acquire(), 1);
-      msg->Wait(m_bStop, 0);
-      msg->Release();
-
-      // purge any pending PLAYER_STARTED messages
-      m_messenger.Flush(CDVDMsg::PLAYER_STARTED);
-
-      // we should now wait for init cache
-      SetCaching(CACHESTATE_FLUSH);
-      if (sync)
-      {
-        m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_STARTING;
-        m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_STARTING;
-      }
+      m_CurrentAudio.syncState = IDVDStreamPlayer::SYNC_STARTING;
+      m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_STARTING;
     }
-
-    if(pts != DVD_NOPTS_VALUE && sync)
-      m_clock.Discontinuity(pts);
-    UpdatePlayState(0);
   }
+
+  if(pts != DVD_NOPTS_VALUE && sync)
+    m_clock.Discontinuity(pts);
+  UpdatePlayState(0);
 
   if (m_omxplayer_mode)
   {
     m_OmxPlayerState.av_clock.OMXFlush();
-    if (!queued)
-      m_OmxPlayerState.av_clock.OMXStop();
+    m_OmxPlayerState.av_clock.OMXStop();
     m_OmxPlayerState.av_clock.OMXPause();
     m_OmxPlayerState.av_clock.OMXMediaTime(0.0);
   }
@@ -4314,7 +4201,7 @@ int CVideoPlayer::OnDVDNavResult(void* pData, int iMessage)
         else
         {
           bool sync = !IsInMenuInternal();
-          FlushBuffers(false, DVD_NOPTS_VALUE, false, sync);
+          FlushBuffers(DVD_NOPTS_VALUE, false, sync);
           m_dvd.syncClock = true;
           m_dvd.state = DVDSTATE_NORMAL;
           if (m_pDemuxer)
@@ -4571,7 +4458,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = cut.end + 1;
             mode.backward = false;
-            mode.flush = true;
             mode.accurate = false;
             mode.restore = true;
             mode.trickplay = false;
@@ -4611,7 +4497,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = cut.start - 1;
             mode.backward = true;
-            mode.flush = true;
             mode.accurate = false;
             mode.restore = true;
             mode.trickplay = false;
@@ -4626,7 +4511,6 @@ bool CVideoPlayer::OnAction(const CAction &action)
             CDVDMsgPlayerSeek::CMode mode;
             mode.time = 0;
             mode.backward = true;
-            mode.flush = true;
             mode.accurate = false;
             mode.restore = true;
             mode.trickplay = false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -463,8 +463,7 @@ protected:
   double GetQueueTime();
   bool GetCachingTimes(double& play_left, double& cache_left, double& file_offset);
 
-
-  void FlushBuffers(bool queued, double pts = DVD_NOPTS_VALUE, bool accurate = true, bool sync = true);
+  void FlushBuffers(double pts, bool accurate, bool sync);
 
   void HandleMessages();
   void HandlePlaySpeed();
@@ -585,25 +584,6 @@ protected:
 
   CEdl m_Edl;
   bool m_SkipCommercials;
-
-  struct SEdlAutoSkipMarkers {
-
-    void Clear()
-    {
-      cut = -1;
-      commbreak_start = -1;
-      commbreak_end = -1;
-      seek_to_start = false;
-      mute = false;
-    }
-
-    int cut;              // last automatically skipped EDL cut seek position
-    int commbreak_start;  // start time of the last commercial break automatically skipped
-    int commbreak_end;    // end time of the last commercial break automatically skipped
-    bool seek_to_start;   // whether seeking can go back to the start of a previously skipped break
-    bool mute;            // whether EDL mute is on
-
-  } m_EdlAutoSkipMarkers;
 
   CPlayerOptions m_PlayerOptions;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -69,7 +69,6 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent
   m_stalled = true;
   m_paused = false;
   m_syncState = IDVDStreamPlayer::SYNC_STARTING;
-  m_silence = false;
   m_synctype = SYNC_DISCON;
   m_setsynctype = SYNC_DISCON;
   m_prevsynctype = -1;
@@ -150,7 +149,6 @@ void CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints, CDVDAudioCodec* codec)
   m_prevsynctype = -1;
 
   m_prevskipped = false;
-  m_silence = false;
 
   m_maxspeedadjust = 5.0;
 
@@ -345,12 +343,6 @@ void CVideoPlayerAudio::Process()
       }
       m_speed = speed;
     }
-    else if (pMsg->IsType(CDVDMsg::AUDIO_SILENCE))
-    {
-      m_silence = static_cast<CDVDMsgBool*>(pMsg)->m_value;
-      CLog::Log(LOGDEBUG, "CVideoPlayerAudio - CDVDMsg::AUDIO_SILENCE(%f, %d)"
-                , m_audioClock, m_silence);
-    }
     else if (pMsg->IsType(CDVDMsg::GENERAL_STREAMCHANGE))
     {
       CDVDMsgAudioCodecChange* msg(static_cast<CDVDMsgAudioCodecChange*>(pMsg));
@@ -455,14 +447,6 @@ void CVideoPlayerAudio::Process()
           m_processInfo.SetAudioBitsPerSample(audioframe.bits_per_sample);
 
           m_messageParent.Put(new CDVDMsg(CDVDMsg::PLAYER_AVCHANGE));
-        }
-
-        // Zero out the frame data if we are supposed to silence the audio
-        if (m_silence)
-        {
-          int size = audioframe.nb_frames * audioframe.framesize / audioframe.planes;
-          for (unsigned int i=0; i<audioframe.planes; i++)
-            memset(audioframe.data[i], 0, size);
         }
 
         SetSyncType(audioframe.passthrough);

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -96,7 +96,6 @@ protected:
 
   int m_speed;
   bool m_stalled;
-  bool m_silence;
   bool m_paused;
   IDVDStreamPlayer::ESyncState m_syncState;
   XbmcThreads::EndTime m_syncTimer;

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -87,7 +87,6 @@ OMXPlayerAudio::OMXPlayerAudio(OMXClock *av_clock, CDVDMessageQueue& parent, CPr
 
   m_messageQueue.SetMaxTimeSize(8.0);
   m_passthrough = false;
-  m_silence = false;
   m_flush = false;  
 }
 
@@ -136,7 +135,6 @@ void OMXPlayerAudio::OpenStream(CDVDStreamInfo &hints, COMXAudioCodecOMX *codec)
 
   m_speed           = DVD_PLAYSPEED_NORMAL;
   m_audioClock      = DVD_NOPTS_VALUE;
-  m_silence         = false;
   m_syncState = IDVDStreamPlayer::SYNC_STARTING;
   m_flush           = false;
   m_stalled         = m_messageQueue.GetPacketCount(CDVDMsg::DEMUXER_PACKET) == 0;
@@ -279,12 +277,7 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket, bool bTrickPlay)
         
         if(!bDropPacket)
         {
-          // Zero out the frame data if we are supposed to silence the audio
-          if(m_silence)
-            memset(decoded, 0x0, decoded_size);
-
           ret = m_omxAudio.AddPackets(decoded, decoded_size, dts, pts, m_pAudioCodec->GetFrameSize(), settings_changed);
-
           if(ret != decoded_size)
           {
             CLog::Log(LOGERROR, "error ret %d decoded_size %d\n", ret, decoded_size);
@@ -318,9 +311,6 @@ bool OMXPlayerAudio::Decode(DemuxPacket *pkt, bool bDropPacket, bool bTrickPlay)
         
       if(!bDropPacket)
       {
-        if(m_silence)
-          memset(pkt->pData, 0x0, pkt->iSize);
-
         m_omxAudio.AddPackets(pkt->pData, pkt->iSize, m_audioClock, m_audioClock, 0, settings_changed);
       }
 
@@ -457,14 +447,6 @@ void OMXPlayerAudio::Process()
         m_speed = static_cast<CDVDMsgInt*>(pMsg)->m_value;
         CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::PLAYER_SETSPEED %d", m_speed);
       }
-    }
-    else if (pMsg->IsType(CDVDMsg::AUDIO_SILENCE))
-    {
-      m_silence = static_cast<CDVDMsgBool*>(pMsg)->m_value;
-      if (m_silence)
-        CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::AUDIO_SILENCE(%f, 1)", m_audioClock);
-      else
-        CLog::Log(LOGDEBUG, "COMXPlayerAudio - CDVDMsg::AUDIO_SILENCE(%f, 0)", m_audioClock);
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_STREAMCHANGE))
     {


### PR DESCRIPTION
This is a backport of https://github.com/xbmc/xbmc/pull/11646 and https://github.com/xbmc/xbmc/pull/11666.

Confirmed by user to fix EDL skipping in Krypton, no side effects seen in my community builds for Amlogic S805 and S905.