### PR TITLE
properly exclude musicbrainz timeout for python scrapers

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1476,12 +1476,15 @@ bool CMusicInfoScanner::ResolveMusicBrainz(const std::string &strMusicBrainzID, 
       return false;
   }
 
-  if (!musicBrainzURL.m_url.empty() && !preferredScraper->IsPython())
+  if (!musicBrainzURL.m_url.empty())
   {
-    Sleep(2000); // MusicBrainz rate-limits queries to 1 p.s - once we hit the rate-limiter
-                 // they start serving up the 'you hit the rate-limiter' page fast - meaning
-                 // we will never get below the rate-limit threshold again in a specific run.
-                 // This helps us to avoid the rate-limiter as far as possible.
+    if (!preferredScraper->IsPython())
+    {
+      Sleep(2000); // MusicBrainz rate-limits queries to 1 p.s - once we hit the rate-limiter
+                   // they start serving up the 'you hit the rate-limiter' page fast - meaning
+                   // we will never get below the rate-limit threshold again in a specific run.
+                   // This helps us to avoid the rate-limiter as far as possible.
+    }
     CLog::Log(LOGDEBUG,"-- nfo-scraper: %s",preferredScraper->Name().c_str());
     CLog::Log(LOGDEBUG,"-- nfo url: %s", musicBrainzURL.m_url[0].m_url.c_str());
     bMusicBrainz = true;


### PR DESCRIPTION
due to the change in https://github.com/xbmc/xbmc/pull/11678, bMusicBrainz now always returns false.

the issue i see with this is that kodi now ignores the scraper response to the 'resolveid' call
and continues with a 'find' call instead of 'getdetails'.

i think we only need to exclude the sleep timeout here.

@notspiff  