### PR TITLE
[linux] prevent wasting RAM due to memory fragmentation

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -32,6 +32,9 @@ USERDATA_DIR="${HOME}/.${bin_name}"
 # Workaround for high CPU load with nvidia GFX
 export __GL_YIELD=USLEEP
 
+# Fix wasting RAM due to fragmentation
+export MALLOC_MMAP_THRESHOLD_=131072
+
 
 # Check for some options used by this script
 while [ "$#" -gt "0" ]


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
As discussed previously we "seem to leak RAM" due to fragmentation, setting this env var has been reported to fix it.

https://www.gnu.org/software/libc/manual/html_node/Malloc-Tunable-Parameters.html
>All chunks larger than this value are allocated outside the normal heap, using the mmap system call. This way it is guaranteed that the memory for these chunks can be returned to the system on free. Note that requests smaller than this threshold might still be allocated via mmap.
If this parameter is not set, the default value is set as 128 KiB and the threshold is adjusted dynamically to suit the allocation patterns of the program. If the parameter is set, the dynamic adjustment is disabled and the value is set statically to the input value. 

If no regressions are found, we should probably backport this to Krypton
@fritsch @popcornmix ping