### PR TITLE
AESinkPULSE: Avoid deadlock

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -795,8 +795,11 @@ void CAESinkPULSE::Deinitialize()
   if (m_Stream)
     Drain();
 
-  if (m_MainLoop)
-    pa_threaded_mainloop_stop(m_MainLoop);
+  {
+    CSingleExit exit(m_sec);
+    if (m_MainLoop)
+      pa_threaded_mainloop_stop(m_MainLoop);
+  }
 
   if (m_Stream)
   {


### PR DESCRIPTION
Backport of: https://github.com/xbmc/xbmc/pull/11728