### PR TITLE
[PVR] Trac 17311: timer rules windows/settings dialog fixes

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -750,11 +750,11 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       continue;
 
     // Drop TimerTypes that require EPGInfo, if none is populated
-    if (type->RequiresEpgTagOnCreate() && !m_timerInfoTag->GetEpgInfoTag())
+    if (m_bIsNewTimer && type->RequiresEpgTagOnCreate() && !m_timerInfoTag->GetEpgInfoTag())
       continue;
 
     // Drop TimerTypes without 'Series' EPG attributes if none are set
-    if (type->RequiresEpgSeriesOnCreate())
+    if (m_bIsNewTimer && type->RequiresEpgSeriesOnCreate())
     {
       const EPG::CEpgInfoTagPtr epgTag(m_timerInfoTag->GetEpgInfoTag());
       if (epgTag && !epgTag->IsSeries())
@@ -762,7 +762,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     }
 
     // Drop TimerTypes that forbid EPGInfo, if it is populated
-    if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
+    if (m_bIsNewTimer && type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
       continue;
 
     // Drop TimerTypes that aren't rules if end time is in the past

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -976,12 +976,22 @@ CEpgInfoTagPtr CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) const
           {
             m_epgTag = epg->GetTagByBroadcastId(m_iEpgUid);
           }
-          else if (!m_bStartAnyTime && !m_bEndAnyTime)
+          else
           {
-            // if no epg uid present, try to find a tag according to timer's start/end time
-            m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0));
-            if (m_epgTag)
-              m_iEpgUid = m_epgTag->UniqueBroadcastID();
+            time_t startTime = 0;
+            time_t endTime = 0;
+
+            StartAsUTC().GetAsTime(startTime);
+            if (startTime > 0)
+              EndAsUTC().GetAsTime(endTime);
+
+            if (startTime > 0 && endTime > 0)
+            {
+              // if no epg uid present, try to find a tag according to timer's start/end time
+              m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0));
+              if (m_epgTag)
+                m_iEpgUid = m_epgTag->UniqueBroadcastID();
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes two issues with the PVR timer rules window / timer settings dialog : http://trac.kodi.tv/ticket/17311

This was runtime-tested by me on latest kodi master on macOS and by the trac ticket submitter using a test build on Windows.

Needs backport.

@Jalle19 for review?
