### PR TITLE
[xbmc] Start work on getting rid of our emulated GetDiskFreeSpaceEx method

### DIFF
--- a/xbmc/platform/CMakeLists.txt
+++ b/xbmc/platform/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCES Platform.cpp
             xbmc.cpp
             ${OVERRIDES_CPP})
 
-set(HEADERS MessagePrinter.h
+set(HEADERS Filesystem.h
+            MessagePrinter.h
             Platform.h
             xbmc.h
             XbmcContext.h

--- a/xbmc/platform/Filesystem.h
+++ b/xbmc/platform/Filesystem.h
@@ -1,0 +1,39 @@
+#pragma once
+/*
+*      Copyright (C) 2005-2017 Team Kodi
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <string>
+#include <system_error>
+namespace KODI
+{
+namespace PLATFORM
+{
+namespace FILESYSTEM
+{
+struct space_info {
+  std::uintmax_t capacity;
+  std::uintmax_t free;
+  std::uintmax_t available;
+};
+
+space_info space(const std::string& path, std::error_code& ec);
+}
+}
+}

--- a/xbmc/platform/posix/CMakeLists.txt
+++ b/xbmc/platform/posix/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES MessagePrinter.cpp)
+set(SOURCES Filesystem.cpp
+            MessagePrinter.cpp)
 
 core_add_library(platform_posix)

--- a/xbmc/platform/posix/Filesystem.cpp
+++ b/xbmc/platform/posix/Filesystem.cpp
@@ -1,0 +1,75 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Filesystem.h"
+#include "system.h"
+#include "filesystem/SpecialProtocol.h"
+
+#ifdef TARGET_POSIX
+#include <sys/stat.h>
+#endif
+#if !defined(TARGET_DARWIN) && !defined(TARGET_FREEBSD) && !defined(TARGET_ANDROID)
+#include <sys/vfs.h>
+#else
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
+
+#if defined(TARGET_ANDROID)
+#include <sys/statfs.h>
+#endif
+
+namespace KODI
+{
+namespace PLATFORM
+{
+namespace FILESYSTEM
+{
+
+space_info space(const std::string& path, std::error_code& ec)
+{
+  ec.clear();
+  space_info sp;
+#if defined(TARGET_ANDROID) || defined(TARGET_DARWIN)
+  struct statfs fsInfo;
+  // is 64-bit on android and darwin (10.6SDK + any iOS)
+  auto result = statfs(CSpecialProtocol::TranslatePath(path).c_str(), &fsInfo);
+#else
+  struct statfs64 fsInfo;
+  auto result = statfs64(CSpecialProtocol::TranslatePath(path).c_str(), &fsInfo);
+#endif
+
+  if (result != 0)
+  {
+    ec.assign(result, std::system_category());
+    sp.available = static_cast<uintmax_t>(-1);
+    sp.capacity = static_cast<uintmax_t>(-1);
+    sp.free = static_cast<uintmax_t>(-1);
+    return sp;
+  }
+  sp.available = static_cast<uintmax_t>(fsInfo.f_bavail * fsInfo.f_bsize);
+  sp.capacity = static_cast<uintmax_t>(fsInfo.f_blocks * fsInfo.f_bsize);
+  sp.free = static_cast<uintmax_t>(fsInfo.f_bfree * fsInfo.f_bsize);
+
+  return sp;
+}
+}
+}
+}

--- a/xbmc/platform/win32/CMakeLists.txt
+++ b/xbmc/platform/win32/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES CharsetConverter.cpp
             WinMain.cpp
             crts_caller.cpp
             dxerr.cpp
+            Filesystem.cpp
             pch.cpp
             stat_utf8.cpp
             stdio_utf8.cpp

--- a/xbmc/platform/win32/Filesystem.cpp
+++ b/xbmc/platform/win32/Filesystem.cpp
@@ -1,0 +1,65 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "platform/Filesystem.h"
+#include "platform/win32/CharsetConverter.h"
+
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+
+namespace KODI
+{
+namespace PLATFORM
+{
+namespace FILESYSTEM
+{
+space_info space(const std::string& path, std::error_code& ec)
+{
+  using WINDOWS::ToW;
+
+  ec.clear();
+  space_info sp;
+  auto pathW = ToW(path);
+
+  ULARGE_INTEGER capacity;
+  ULARGE_INTEGER available;
+  ULARGE_INTEGER free;
+  auto result = GetDiskFreeSpaceExW(pathW.c_str(), &available, &capacity, &free);
+
+  if (result == FALSE)
+  {
+    ec.assign(GetLastError(), std::system_category());
+    sp.available = static_cast<uintmax_t>(-1);
+    sp.capacity = static_cast<uintmax_t>(-1);
+    sp.free = static_cast<uintmax_t>(-1);
+    return sp;
+  }
+
+  sp.available = static_cast<uintmax_t>(available.QuadPart);
+  sp.capacity = static_cast<uintmax_t>(capacity.QuadPart);
+  sp.free = static_cast<uintmax_t>(free.QuadPart);
+
+  return sp;
+}
+}
+}
+}

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -131,7 +131,7 @@ public:
   std::string GetCPUSerial();
   static std::string GetManufacturerName(void);
   static std::string GetModelName(void);
-  bool GetDiskSpace(const std::string& drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed);
+  bool GetDiskSpace(std::string drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed);
   std::string GetHddSpaceInfo(int& percent, int drive, bool shortText=false);
   std::string GetHddSpaceInfo(int drive, bool shortText=false);
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -59,6 +59,7 @@
 #include "utils/Variant.h"
 #include "Autorun.h"
 #include "URL.h"
+#include "platform/Filesystem.h"
 #ifdef TARGET_POSIX
 #include "linux/XFileUtils.h"
 #endif
@@ -321,6 +322,7 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
 
 void CGUIWindowFileManager::OnSort(int iList)
 {
+  using namespace KODI::PLATFORM::FILESYSTEM;
   // always sort the list by label in ascending order
   for (int i = 0; i < m_vecItems[iList]->Size(); i++)
   {
@@ -335,19 +337,21 @@ void CGUIWindowFileManager::OnSort(int iList)
     {
       if (pItem->IsHD())
       {
-        ULARGE_INTEGER ulBytesFree;
-        if (GetDiskFreeSpaceEx(pItem->GetPath().c_str(), &ulBytesFree, NULL, NULL))
+        std::error_code ec;
+        auto freeSpace = space(pItem->GetPath(), ec);
+        if (ec.value() == 0)
         {
-          pItem->m_dwSize = ulBytesFree.QuadPart;
+          pItem->m_dwSize = freeSpace.free;
           pItem->SetFileSizeLabel();
         }
       }
       else if (pItem->IsDVD() && g_mediaManager.IsDiscInDrive())
       {
-        ULARGE_INTEGER ulBytesTotal;
-        if (GetDiskFreeSpaceEx(pItem->GetPath().c_str(), NULL, &ulBytesTotal, NULL))
+        std::error_code ec;
+        auto freeSpace = space(pItem->GetPath(), ec);
+        if (ec.value() == 0)
         {
-          pItem->m_dwSize = ulBytesTotal.QuadPart;
+          pItem->m_dwSize = freeSpace.capacity;
           pItem->SetFileSizeLabel();
         }
       }


### PR DESCRIPTION
Decided to unify some of our low level file handling
methods on the std::filesystem idea. As it's not standardized
yet and implementations are experimental this is a simple
version that suits our current needs. The idea is that once platforms
start offering non-experimental versions of std::filesytem we can
easily move over to using them.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
runtime tested on windows

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
