### PR TITLE
[estuary] re-add PVRChannelNumberInput to fullscreenvideo

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -7,6 +7,7 @@
 	<depth>DepthOSD</depth>
 	<zorder>0</zorder>
 	<controls>
+		<include>PVRChannelNumberInput</include>
 		<control type="group">
 			<bottom>0</bottom>
 			<height>190</height>
@@ -197,17 +198,6 @@
 				<height>200</height>
 				<aspectratio aligny="center">keep</aspectratio>
 				<texture>$INFO[Player.Art(thumb)]</texture>
-			</control>
-			<control type="label">
-				<left>20</left>
-				<width>220</width>
-				<top>-80</top>
-				<height>25</height>
-				<label>$INFO[VideoPlayer.ChannelNumberLabel]</label>
-				<shadowcolor>black</shadowcolor>
-				<align>center</align>
-				<font>WeatherTemp</font>
-				<aligny>center</aligny>
 			</control>
 			<control type="label">
 				<right>20</right>


### PR DESCRIPTION
fix regression introduced by https://github.com/xbmc/xbmc/pull/11734
