### PR TITLE
PlayListPlayer: New function the ensure items are played with a playlist

### DIFF
--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -72,6 +72,11 @@ public:
   bool PlaySongId(int songId);
   bool Play();
 
+  /*! \brief Creates a new playlist for an item and starts playing it
+   \param pItem The item to play.
+   */
+  bool Play(const CFileItemPtr &pItem, std::string player);
+
   /*! \brief Start playing a particular entry in the current playlist
    \param index the index of the item to play. This value is modified to ensure it lies within the current playlist.
    \param replace whether this item should replace the currently playing item. See CApplication::PlayFile (defaults to false).

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -470,28 +470,10 @@ static int PlayMedia(const std::vector<std::string>& params)
     g_playlistPlayer.SetCurrentPlaylist(playlist);
     g_playlistPlayer.Play(playOffset, "");
   }
+  else if (item.IsAudio() || item.IsVideo())
+    g_playlistPlayer.Play(std::make_shared<CFileItem>(item), "");
   else
-  {
-    int playlist = PLAYLIST_NONE;
-
-    if (item.IsAudio())
-      playlist = PLAYLIST_MUSIC;
-    else if (item.IsVideo())
-      playlist = PLAYLIST_VIDEO;
-
-    if (playlist != PLAYLIST_NONE)
-    {
-      g_playlistPlayer.ClearPlaylist(playlist);
-      g_playlistPlayer.SetCurrentPlaylist(playlist);
-    }
-
-    // play media
-    if (!g_application.PlayMedia(item, "", playlist))
-    {
-      CLog::Log(LOGERROR, "PlayMedia could not play media: %s", params[0].c_str());
-      return false;
-    }
-  }
+    g_application.PlayMedia(item, "", PLAYLIST_NONE);
 
   return 0;
 }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1102,11 +1102,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
       OnQueueItem(iItem);
       return true;
     }
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.ClearPlaylist(PLAYLIST_MUSIC);
-    g_playlistPlayer.Add(PLAYLIST_MUSIC, pItem);
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
-    g_playlistPlayer.Play();
+    g_playlistPlayer.Play(pItem, player);
     return true;
   }
   return CGUIMediaWindow::OnPlayMedia(iItem, player);

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -21,7 +21,6 @@
 #include "ContextMenus.h"
 #include "Application.h"
 #include "Autorun.h"
-#include "playlists/PlayList.h"
 #include "Util.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoBase.h"
@@ -121,16 +120,7 @@ static void SetPathAndPlay(CFileItem& item)
   }
   item.SetProperty("check_resume", false);
 
-  CFileItemPtr movieItem((std::make_shared<CFileItem>(item)));
-
-  g_playlistPlayer.Reset();
-  g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-  PLAYLIST::CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO);
-  playlist.Clear();
-  playlist.Add(movieItem);
-
-  // play movie...
-  g_playlistPlayer.Play(0, "");
+  g_playlistPlayer.Play(std::make_shared<CFileItem>(item), "");
 }
 
 bool CResume::Execute(const CFileItemPtr& itemIn) const

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1179,19 +1179,10 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr &item, std::str
 
 void CGUIWindowVideoBase::PlayMovie(const CFileItem *item, const std::string &player)
 {
-  CFileItemPtr movieItem(new CFileItem(*item));
-
-  g_playlistPlayer.Reset();
-  g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO);
-  playlist.Clear();
-  playlist.Add(movieItem);
-
   if(m_thumbLoader.IsLoading())
     m_thumbLoader.StopAsync();
 
-  // play movie...
-  g_playlistPlayer.Play(0, player);
+  g_playlistPlayer.Play(std::make_shared<CFileItem>(*item), player);
 
   if(!g_application.m_pPlayer->IsPlayingVideo())
     m_thumbLoader.Load(*m_vecItems);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -622,7 +622,12 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
     g_application.ProcessAndStartPlaylist(strPlayList, *pPlayList, PLAYLIST_MUSIC);
     return;
   }
-  if (pItem->IsAudio() || pItem->IsVideo() || pItem->IsGame())
+  if (pItem->IsAudio() || pItem->IsVideo())
+  {
+    g_playlistPlayer.Play(std::make_shared<CFileItem>(*pItem), player);
+    return;
+  }
+  if (pItem->IsGame())
   {
     g_application.PlayFile(*pItem, player);
     return ;


### PR DESCRIPTION
There are cases where playback of files doesn't create a playlist. @Montellese made a comment about that here: https://github.com/xbmc/xbmc/pull/5958#issuecomment-67295177

One of those cases is when you start playback of an item over JSON like this:
`{"params": {"item": {"file": "/videos/video.mp4"}}, "jsonrpc": "2.0", "id": 1, "method": "Player.Open"}`
(Or, more generally, every time TMSG_MEDIA_PLAY gets sent with a single item attached)

Another is where you start playback of a file over the Kodi file manager. What's worse here is that the old playlist doesn't get deleted before playback.

To take care of that I added a new overloaded function Play() to the PlayListPlayer that takes an item as argument, creates a new playlist for it and starts the playback.

For the second commit I found two instances that can use the new function:
1) In CGUIWindowVideoBase::PlayMovie(), when opening a file from the video browser
2) In CGUIWindowMusicBase::OnPlayMedia(), when opening a file from the music browser while the setting to automatically queue the next item is disabled

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
