### PR TITLE
[PVR] Trac 17359: Fix crash in CPVRTimers::GetTimerRule(const CFileItem *item).

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -875,8 +875,11 @@ CFileItemPtr CPVRTimers::GetTimerRule(const CFileItem *item) const
     timer = item->GetPVRTimerInfoTag();
 
   if (timer)
-    return CFileItemPtr(new CFileItem(GetTimerRule(timer)));
-
+  {
+    timer = GetTimerRule(timer);
+    if (timer)
+      return CFileItemPtr(new CFileItem(timer));
+  }
   return CFileItemPtr();
 }
 


### PR DESCRIPTION
Fixes a crash related to timer rule creation : http://trac.kodi.tv/ticket/17359

This was runtime-tested by me on latest kodi master on macOS and by the trac ticket submitter using a test build on Windows.

Needs backport.

@Jalle19 for review?