### PR TITLE
[PVR] Krypton: Trac 17359: Fix crash in CPVRTimers::GetTimerRule(const CFileItem *item).

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -888,8 +888,11 @@ CFileItemPtr CPVRTimers::GetTimerRule(const CFileItem *item) const
     timer = item->GetPVRTimerInfoTag();
 
   if (timer)
-    return CFileItemPtr(new CFileItem(GetTimerRule(timer)));
-
+  {
+    timer = GetTimerRule(timer);
+    if (timer)
+      return CFileItemPtr(new CFileItem(timer));
+  }
   return CFileItemPtr();
 }
 


### PR DESCRIPTION
Backport of #11748 

@Jalle19 for review?