### PR TITLE
AE: use iec pause bursts only for audio sync

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -960,8 +960,9 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
       }
       else if (samples->pkt->pause_burst_ms > 0)
       {
-        // construct a pause burst
-        m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms);
+        // construct a pause burst if we have already output valid audio
+        bool burst = m_extStreaming && (m_packer->GetBuffer()[0] != 0);
+        m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms, burst);
       }
       else
         m_packer->Reset();

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -44,6 +44,7 @@ CAEBitstreamPacker::CAEBitstreamPacker() :
   m_dataSize (0),
   m_pauseDuration(0)
 {
+  Reset();
 }
 
 CAEBitstreamPacker::~CAEBitstreamPacker()
@@ -92,7 +93,7 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
   }
 }
 
-void CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis)
+void CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts)
 {
   // re-use last buffer
   if (m_pauseDuration == millis)
@@ -119,6 +120,11 @@ void CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis)
     default:
       CLog::Log(LOGERROR, "CAEBitstreamPacker::Pack - no pack function");
   }
+
+  if (!iecBursts)
+  {
+    memset(m_packedBuffer, 0, m_dataSize);
+  }
 }
 
 unsigned int CAEBitstreamPacker::GetSize()
@@ -135,6 +141,8 @@ void CAEBitstreamPacker::Reset()
 {
   m_dataSize = 0;
   m_trueHDPos = 0;
+  m_pauseDuration = 0;
+  m_packedBuffer[0] = 0;
 }
 
 /* we need to pack 24 TrueHD audio units into the unknown MAT format before packing into IEC61937 */

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -33,7 +33,7 @@ public:
   ~CAEBitstreamPacker();
 
   void Pack(CAEStreamInfo &info, uint8_t* data, int size);
-  void PackPause(CAEStreamInfo &info, unsigned int millis);
+  void PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts);
   void Reset();
   uint8_t* GetBuffer();
   unsigned int GetSize();


### PR DESCRIPTION
fixes passthrough issues with some AVRs:

http://forum.kodi.tv/showthread.php?tid=307243