### PR TITLE
[PVR] fix timer type display for 'invalid' types

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -735,7 +735,8 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     return;
   }
 
-  int idx = 0;
+  bool bFoundThisType(false);
+  int idx(0);
   const std::vector<CPVRTimerTypePtr> types(CPVRTimerType::GetAllTypes());
   for (const auto &type : types)
   {
@@ -750,11 +751,11 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       continue;
 
     // Drop TimerTypes that require EPGInfo, if none is populated
-    if (m_bIsNewTimer && type->RequiresEpgTagOnCreate() && !m_timerInfoTag->GetEpgInfoTag())
+    if (type->RequiresEpgTagOnCreate() && !m_timerInfoTag->GetEpgInfoTag())
       continue;
 
     // Drop TimerTypes without 'Series' EPG attributes if none are set
-    if (m_bIsNewTimer && type->RequiresEpgSeriesOnCreate())
+    if (type->RequiresEpgSeriesOnCreate())
     {
       const EPG::CEpgInfoTagPtr epgTag(m_timerInfoTag->GetEpgInfoTag());
       if (epgTag && !epgTag->IsSeries())
@@ -762,15 +763,21 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     }
 
     // Drop TimerTypes that forbid EPGInfo, if it is populated
-    if (m_bIsNewTimer && type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
+    if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
       continue;
 
     // Drop TimerTypes that aren't rules if end time is in the past
     if (!type->IsTimerRule() && m_timerInfoTag->EndAsLocalTime() < CDateTime::GetCurrentDateTime())
       continue;
 
+    if (!bFoundThisType && *type == *m_timerType)
+      bFoundThisType = true;
+
     m_typeEntries.insert(std::make_pair(idx++, type));
   }
+
+  if (!bFoundThisType)
+    m_typeEntries.insert(std::make_pair(idx++, m_timerType));
 }
 
 void CGUIDialogPVRTimerSettings::InitializeChannelsList()


### PR DESCRIPTION
Allows 'invalid' timer types to be correctly displayed in the Timer Settings dialog
(See forum http://forum.kodi.tv/showthread.php?tid=307538)

## Description
Currently a timer type can be 'skipped' when building the list of valid timer types to present in the Timer Settings dialog. The result is that not all timer types are displayed properly.
This change adds the current type to the list if it would otherwise be skipped so the settings can be displayed correctly.

## Motivation and Context
Ensures timers are always displayed correctly.

## How Has This Been Tested?
On x86 (linux) with pvr.mythtv client.

## Screenshots:
Display of an 'Unhandled' timer type
![screenshot062](https://cloud.githubusercontent.com/assets/12870817/23335295/73d4da58-fbaa-11e6-8a75-a691ddd29877.png)
After (How this type should be presented):
![screenshot063](https://cloud.githubusercontent.com/assets/12870817/23335296/7ff1640a-fbaa-11e6-9911-daedc0b86f71.png)
![screenshot064](https://cloud.githubusercontent.com/assets/12870817/23335297/84e0b402-fbaa-11e6-9274-285bc29bc55b.png)
Before (How this type was previously presented):
![screenshot065](https://cloud.githubusercontent.com/assets/12870817/23335317/093bc21e-fbab-11e6-8db0-07a07be42bef.png)
![screenshot066](https://cloud.githubusercontent.com/assets/12870817/23335319/0f467550-fbab-11e6-96d6-0f356ffbf6ec.png)

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed