### PR TITLE
store arbitrary artist art in art table

### DIFF
--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -49,6 +49,11 @@ void CArtist::MergeScrapedArtist(const CArtist& source, bool override /* = true 
   thumbURL = source.thumbURL;
   fanart = source.fanart;
   discography = source.discography;
+  for (std::map<std::string, std::string>::const_iterator i = source.art.begin(); i != source.art.end(); ++i)
+  {
+    if (override || art.find(i->first) == art.end())
+      art[i->first] = i->second;
+  }
 }
 
 

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -62,6 +62,7 @@ public:
     styles.clear();
     moods.clear();
     instruments.clear();
+    art.clear();
     strBorn.clear();
     strFormed.clear();
     strDied.clear();
@@ -93,6 +94,7 @@ public:
   std::vector<std::string> styles;
   std::vector<std::string> moods;
   std::vector<std::string> instruments;
+  std::map<std::string, std::string> art;
   std::string strBorn;
   std::string strFormed;
   std::string strDied;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1191,6 +1191,9 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
     AddArtistDiscography(artist.idArtist, disc.first, disc.second);
   }
 
+  if (!artist.art.empty())
+    SetArtForItem(artist.idArtist, MediaTypeArtist, artist.art);
+
   return true;
 }
 


### PR DESCRIPTION
store artist artwork (artist logo, artist banner, etc..) in the art table.
skins will be able to display this artwork using ListItem.Art()

we already have this functionality for all other media types (movies, tvshows, albums, etc..)
but it was never hooked up to artists.

@DaveTBlake 