### PR TITLE
drop support for 'old' static listitem format

### DIFF
--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -31,58 +31,38 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
 
   assert(item);
 
-  // check whether we're using the more verbose method...
-  const TiXmlNode *click = item->FirstChild("onclick");
-  if (click && click->FirstChild())
+  CGUIInfoLabel label, label2, thumb, icon;
+  CGUIControlFactory::GetInfoLabel(item, "label", label, parentID);
+  CGUIControlFactory::GetInfoLabel(item, "label2", label2, parentID);
+  CGUIControlFactory::GetInfoLabel(item, "thumb", thumb, parentID);
+  CGUIControlFactory::GetInfoLabel(item, "icon", icon, parentID);
+  const char *id = item->Attribute("id");
+  std::string condition;
+  CGUIControlFactory::GetConditionalVisibility(item, condition);
+  SetVisibleCondition(condition, parentID);
+  CGUIControlFactory::GetActions(item, "onclick", m_clickActions);
+  SetLabel(label.GetLabel(parentID));
+  SetLabel2(label2.GetLabel(parentID));
+  SetArt("thumb", thumb.GetLabel(parentID, true));
+  SetIconImage(icon.GetLabel(parentID, true));
+  if (!label.IsConstant())  m_info.push_back(std::make_pair(label, "label"));
+  if (!label2.IsConstant()) m_info.push_back(std::make_pair(label2, "label2"));
+  if (!thumb.IsConstant())  m_info.push_back(std::make_pair(thumb, "thumb"));
+  if (!icon.IsConstant())   m_info.push_back(std::make_pair(icon, "icon"));
+  m_iprogramCount = id ? atoi(id) : 0;
+  // add any properties
+  const TiXmlElement *property = item->FirstChildElement("property");
+  while (property)
   {
-    CGUIInfoLabel label, label2, thumb, icon;
-    CGUIControlFactory::GetInfoLabel(item, "label", label, parentID);
-    CGUIControlFactory::GetInfoLabel(item, "label2", label2, parentID);
-    CGUIControlFactory::GetInfoLabel(item, "thumb", thumb, parentID);
-    CGUIControlFactory::GetInfoLabel(item, "icon", icon, parentID);
-    const char *id = item->Attribute("id");
-    std::string condition;
-    CGUIControlFactory::GetConditionalVisibility(item, condition);
-    SetVisibleCondition(condition, parentID);
-    CGUIControlFactory::GetActions(item, "onclick", m_clickActions);
-    SetLabel(label.GetLabel(parentID));
-    SetLabel2(label2.GetLabel(parentID));
-    SetArt("thumb", thumb.GetLabel(parentID, true));
-    SetIconImage(icon.GetLabel(parentID, true));
-    if (!label.IsConstant())  m_info.push_back(std::make_pair(label, "label"));
-    if (!label2.IsConstant()) m_info.push_back(std::make_pair(label2, "label2"));
-    if (!thumb.IsConstant())  m_info.push_back(std::make_pair(thumb, "thumb"));
-    if (!icon.IsConstant())   m_info.push_back(std::make_pair(icon, "icon"));
-    m_iprogramCount = id ? atoi(id) : 0;
-    // add any properties
-    const TiXmlElement *property = item->FirstChildElement("property");
-    while (property)
+    std::string name = XMLUtils::GetAttribute(property, "name");
+    CGUIInfoLabel prop;
+    if (!name.empty() && CGUIControlFactory::GetInfoLabelFromElement(property, prop, parentID))
     {
-      std::string name = XMLUtils::GetAttribute(property, "name");
-      CGUIInfoLabel prop;
-      if (!name.empty() && CGUIControlFactory::GetInfoLabelFromElement(property, prop, parentID))
-      {
-        SetProperty(name, prop.GetLabel(parentID, true).c_str());
-        if (!prop.IsConstant())
-          m_info.push_back(std::make_pair(prop, name));
-      }
-      property = property->NextSiblingElement("property");
+      SetProperty(name, prop.GetLabel(parentID, true).c_str());
+      if (!prop.IsConstant())
+        m_info.push_back(std::make_pair(prop, name));
     }
-  }
-  else
-  {
-    std::string label, label2, thumb, icon;
-    label  = XMLUtils::GetAttribute(item, "label");  label  = CGUIControlFactory::FilterLabel(label);
-    label2 = XMLUtils::GetAttribute(item, "label2"); label2 = CGUIControlFactory::FilterLabel(label2);
-    thumb  = XMLUtils::GetAttribute(item, "thumb");  thumb  = CGUIControlFactory::FilterLabel(thumb);
-    icon   = XMLUtils::GetAttribute(item, "icon");   icon   = CGUIControlFactory::FilterLabel(icon);
-    const char *id = item->Attribute("id");
-    SetLabel(CGUIInfoLabel::GetLabel(label, parentID));
-    SetPath(item->FirstChild()->Value());
-    SetLabel2(CGUIInfoLabel::GetLabel(label2, parentID));
-    SetArt("thumb", CGUIInfoLabel::GetLabel(thumb, parentID, true));
-    SetIconImage(CGUIInfoLabel::GetLabel(icon, parentID, true));
-    m_iprogramCount = id ? atoi(id) : 0;
+    property = property->NextSiblingElement("property");
   }
 }
 


### PR DESCRIPTION
there are two possible formats to define a static listitem, but i've never seen any skin using this format:
https://github.com/xbmc/xbmc/blame/a005e3f5e68d07f28d642bbc2e988ace72499a9e/guilib/GUIBaseContainer.cpp#L886-L889

the main purpose of this pr is to get rid of the requirement to define `<onclick>noop</onclick` for static listitems that have no action.
the presence of an  'onclick' tag is currently used to differentiate between the two formats.


ping @HitcherUK @BigNoid @phil65 