### PR TITLE
display revision num. when building

### DIFF
--- a/tools/Linux/packaging/mk-debian-package.sh
+++ b/tools/Linux/packaging/mk-debian-package.sh
@@ -46,6 +46,7 @@ function checkEnv {
     echo "REPO_DIR: $REPO_DIR"
     getVersion
     echo "RELEASEV: $RELEASEV"
+    echo "REVISION: $TAGREV"
     [[ -n $TAG ]] && echo "TAG: $TAG"
     echo "DISTS: $DISTS"
     echo "ARCHS: $ARCHS"


### PR DESCRIPTION
## Description
Display TAGREV when building (for review purposes)

## Motivation and Context
Added so it is known before package kicks off.

## How Has This Been Tested?
Tested with new build of Kodi in master

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
