### PR TITLE
[Fix]Skip TagLib trying to read tags from internet streams

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1042,6 +1042,10 @@ void CTagLoaderTagLib::AddArtistInstrument(CMusicInfoTag &tag, const std::vector
 
 bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, const std::string& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art /* = NULL */)
 {
+  // Dont try to read the tags for streams & shoutcast  
+  if (URIUtils::IsInternetStream(strFileName))
+    return false;
+
   std::string strExtension = URIUtils::GetExtension(strFileName);
   StringUtils::TrimLeft(strExtension, ".");
 


### PR DESCRIPTION
Stop trying to get TabLib to read metadata from internet streams including (Shoutcasts).

Upgrading to TagLib 1.11.1 introduced issues with Shoutcasts that ended ".mp3" hanging,  http://trac.kodi.tv/ticket/17210, and we attempted to fix that in v17.0 with a patch to TagLib #11543. But OpenElec 7.0.1(Kodi v16) would also had had this issue as it deployed v1.11.1 (unpatched).

However a similar issue has now immerged with internet streams ending .acc
http://forum.kodi.tv/showthread.php?tid=308102
http://forum.kodi.tv/showthread.php?tid=308139&pid=2535623
(and maybe on trac thread too)

Kodi is hanging because TabLib gets indigestion attempting to scan tags from a continuous stream, not a fixed length file. I think we need to stop throwing internet streams at TabLib to scan for metadata. `CMusicInfoTagLoaderFactory` has always avoided this, see https://github.com/xbmc/xbmc/blob/0ce9048fcb99e136634e69f69cf3807781cf6da9/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp#L48
but `VideoPlayerCodec::Init` and `CAudioDecoder::Init` call CTagLoaderTagLib.Load directly

I had an aborted attempt at a fix in #11530 (closed) but was going about it the wrong way. @FernetMenta suggested skipping tag scanning for all internet streams was the better solution, and I agree.

@popcornmix , @Paxxi as discussed on Slack