### PR TITLE
[Fix][Backport]Skip TagLib trying to read tags from internet streams

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1040,6 +1040,10 @@ void CTagLoaderTagLib::AddArtistInstrument(CMusicInfoTag &tag, const std::vector
 
 bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, const std::string& fallbackFileExtension, MUSIC_INFO::EmbeddedArt *art /* = NULL */)
 {
+  // Dont try to read the tags for streams & shoutcast
+  if (URIUtils::IsInternetStream(strFileName))
+    return false;
+
   std::string strExtension = URIUtils::GetExtension(strFileName);
   StringUtils::TrimLeft(strExtension, ".");
 


### PR DESCRIPTION
Backport of #11759 

Kodi is still hanging on playback of some internet streams because of unnecessary calls to TagLib to scan metadata that hang. Solution is to do as  `CMusicInfoTagLoaderFactory` does and skip attempting to read tags from internet streams.