### PR TITLE
PVR: never cache pvr directories

### DIFF
--- a/xbmc/filesystem/PVRDirectory.h
+++ b/xbmc/filesystem/PVRDirectory.h
@@ -32,8 +32,10 @@ public:
   CPVRDirectory();
   virtual ~CPVRDirectory();
 
-  virtual bool GetDirectory(const CURL& url, CFileItemList &items);
-  virtual bool AllowAll() const { return true; }
+  virtual bool GetDirectory(const CURL& url, CFileItemList &items) override;
+  virtual bool AllowAll() const override { return true; }
+  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const override { return DIR_CACHE_NEVER; };
+  virtual bool Exists(const CURL& url) override;
 
   static bool SupportsWriteFileOperations(const std::string& strPath);
   static bool IsLiveTV(const std::string& strPath);
@@ -41,10 +43,6 @@ public:
   static bool HasDeletedTVRecordings();
   static bool HasRadioRecordings();
   static bool HasDeletedRadioRecordings();
-
-  virtual bool Exists(const CURL& url);
-
-private:
 };
 
 }


### PR DESCRIPTION
pvr items are not cached, hence the directory must be be cached either. currently calling Exists on pvr recordings always fails because the cached dir is empty.

@ksooo I am investigating an issue with scanning pvr recordings to tv shows. there is more broken.