### PR TITLE
[depends] fix taglib after boost removal

### DIFF
--- a/tools/depends/target/taglib/Makefile
+++ b/tools/depends/target/taglib/Makefile
@@ -17,6 +17,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); rm -rf build; mkdir -p build
 	cd $(PLATFORM); patch -p1 -i ../ID3v2Lookup.patch
+	cd $(PLATFORM); patch -p1 -i ../remove-boost.patch
 	cd $(PLATFORM)/build; $(CMAKE) -DCMAKE_LIBRARY_PATH=$(TOOLCHAIN)/lib/$(HOST) -DBUILD_SHARED_LIBS=OFF ..
 
 $(LIBDYLIB): $(PLATFORM)

--- a/tools/depends/target/taglib/remove-boost.patch
+++ b/tools/depends/target/taglib/remove-boost.patch
@@ -1,0 +1,27 @@
+From de87cd7736d52302db330c830adae50b1e667954 Mon Sep 17 00:00:00 2001
+From: Tsuda Kageyu <tsuda.kageyu@gmail.com>
+Date: Tue, 20 Dec 2016 12:06:21 +0900
+Subject: [PATCH] Remove the CMake check for Boost I missed out on.
+
+---
+ ConfigureChecks.cmake | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/ConfigureChecks.cmake b/ConfigureChecks.cmake
+index f69b438..e39d97b 100644
+--- a/ConfigureChecks.cmake
++++ b/ConfigureChecks.cmake
+@@ -34,13 +34,6 @@ if(NOT ${SIZEOF_DOUBLE} EQUAL 8)
+   message(FATAL_ERROR "TagLib requires that double is 64-bit wide.")
+ endif()
+ 
+-# Enable check_cxx_source_compiles() to work with Boost "header-only" libraries.
+-
+-find_package(Boost)
+-if(Boost_FOUND)
+-  set(CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES};${Boost_INCLUDE_DIRS}")
+-endif()
+-
+ # Determine which kind of atomic operations your compiler supports.
+ 
+ check_cxx_source_compiles("


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
fix building taglib after ee20b03787082db43776b73ffa5f1ff9d6d8a3ad

backport upstream patch not yet in any tagged release.
the patch can be removed once we bump to the next taglib release.