### PR TITLE
[depends] install pycryptodome under the alternative Cryptodome names…

### DIFF
--- a/tools/depends/target/pythonmodule-pycryptodome/Makefile
+++ b/tools/depends/target/pythonmodule-pycryptodome/Makefile
@@ -39,7 +39,7 @@ endif
 
 $(LIBDYLIB): $(PLATFORM)
 	mkdir -p $(PLATFORM)/output
-	cd $(PLATFORM); $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py build_ext --plat-name $(OS)-$(TARGET_ARCH)
+	cd $(PLATFORM); touch .separate_namespace && $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py build_ext --plat-name $(OS)-$(TARGET_ARCH)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	cd $(PLATFORM); $(CROSSFLAGS) $(NATIVEPREFIX)/bin/python setup.py install --prefix=$(PREFIX)


### PR DESCRIPTION
…pace instead of Crypto

Under linux the standard python-crypto module is usually already installed as Crypto and must not be overwritten by cryptodome.
Using the alternative namespace Cryptodome avoids clashes with the original module since both are not compatible with each other.

Addons using this module are advised to change their import statements to import Cryptodome

@peak3d  ping