### PR TITLE
[PVR] Fix inconsistent TimerSettings 'Enable/Disable'

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -119,7 +119,7 @@ void CGUIDialogPVRTimerSettings::SetTimer(const CPVRTimerInfoTagPtr &timer)
   m_timerType     = m_timerInfoTag->GetTimerType();
   m_bIsRadio      = m_timerInfoTag->m_bIsRadio;
   m_bIsNewTimer   = m_timerInfoTag->m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX;
-  m_bTimerActive  = m_bIsNewTimer || !m_timerType->SupportsEnableDisable() || m_timerInfoTag->IsActive();
+  m_bTimerActive  = m_bIsNewTimer || !m_timerType->SupportsEnableDisable() || !(m_timerInfoTag->m_state == PVR_TIMER_STATE_DISABLED);
   m_bStartAnyTime = m_bIsNewTimer || !m_timerType->SupportsStartAnyTime() || m_timerInfoTag->m_bStartAnyTime;
   m_bEndAnyTime   = m_bIsNewTimer || !m_timerType->SupportsEndAnyTime() || m_timerInfoTag->m_bEndAnyTime;
   m_strTitle      = m_timerInfoTag->m_strTitle;


### PR DESCRIPTION
'Completed' rule timers currently show as 'Enabled = false' in the timer settings dialog, but if you bring up the timer list context menu, they show the option 'Deactivate'. 
This PR fixes the inconsistency by showing rules as 'Enabled' in the Timer Settings dialog unless they are specifically reported as status 'Disabled'.

Strictly the context menu should say 'Enable/Disable' not 'Activate/Deactivate' as the backend decides which timers are active, kodi can only 'Enable' or 'Disable' them. (Change this as well in separate commit?)

## Description
CPVRGUIActions::ToggleTimerState uses timer->m_state ==
PVR_TIMER_STATE_DISABLED to set Activate or Deactivate option

GUIDialogPVRTimerSettings was using timer->isActive() to set Enabled in
in the TimerSettings dialog which is inconsistent.

Update to use timer->m_state == PVR_TIMER_STATE_DISABLED for both

## Motivation and Context
Fix an inconsistency in the GUI.

## How Has This Been Tested?
Tested on x86 using latest master against pvr.mythtv

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@ksooo for comment and initial review