### PR TITLE
[Fix]Skip trying to use TagLib to read tags from Shoutcasts

### DIFF
--- a/xbmc/music/tags/TagLibVFSStream.cpp
+++ b/xbmc/music/tags/TagLibVFSStream.cpp
@@ -20,6 +20,8 @@
 #include "limits.h"
 #include "TagLibVFSStream.h"
 #include "filesystem/File.h"
+#include "filesystem/FileCache.h"
+#include "filesystem/ShoutcastFile.h"
 #include <taglib/tiostream.h>
 
 using namespace XFILE;
@@ -37,6 +39,17 @@ TagLibVFSStream::TagLibVFSStream(const std::string& strFileName, bool readOnly)
   {
     if (!m_file.Open(strFileName))
       m_bIsOpen = false;
+    else
+    { // Check if this stream is a Shoutcast, and skip scanning tags if it is.
+      // Shoutcast has its own metadata format that TagLib does not read
+      CFileCache* fileCacheItem = dynamic_cast<CFileCache*>(m_file.GetImplementation());
+      if (fileCacheItem)
+      {
+        CShoutcastFile* item = dynamic_cast<CShoutcastFile*>(fileCacheItem->GetFileImp());
+        if (item)
+          m_bIsOpen = false;
+      }
+    }
   }
   else
   {


### PR DESCRIPTION
Stop trying to get TabLib to read metadata from Shoutcasts, but not excluding other internet streams.
An alternative to #11759 

TabLib is not designed to cope with Shoutcasts, which while being an MPEG audio stream have a bespoke header and metadata format, and some streams cause TabLib to hang (or actually search indefinitely).

@fritsch @arnova @phate89 @wsnipex 

I realise that a future refactoring wants to make TagLibVFSStream more controlled, and protect from unlimited reading. This is not an attempt at that, just a modest change that could be backported, that will avoid hangups caused by passing tagLib streams that we know do not contain tags it can read.

