### PR TITLE
[PVR] Krypton: fix timer type display for 'invalid' types

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -744,11 +744,11 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
       continue;
 
     // Drop TimerTypes that require EPGInfo, if none is populated
-    if (m_bIsNewTimer && type->RequiresEpgTagOnCreate() && !m_timerInfoTag->GetEpgInfoTag())
+    if (type->RequiresEpgTagOnCreate() && !m_timerInfoTag->GetEpgInfoTag())
       continue;
 
     // Drop TimerTypes without 'Series' EPG attributes if none are set
-    if (m_bIsNewTimer && type->RequiresEpgSeriesOnCreate())
+    if (type->RequiresEpgSeriesOnCreate())
     {
       const EPG::CEpgInfoTagPtr epgTag(m_timerInfoTag->GetEpgInfoTag());
       if (epgTag && !epgTag->IsSeries())
@@ -756,7 +756,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     }
 
     // Drop TimerTypes that forbid EPGInfo, if it is populated
-    if (m_bIsNewTimer && type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
+    if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
       continue;
 
     // Drop TimerTypes that aren't rules if end time is in the past

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -729,7 +729,8 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     return;
   }
 
-  int idx = 0;
+  bool bFoundThisType(false);
+  int idx(0);
   const std::vector<CPVRTimerTypePtr> types(CPVRTimerType::GetAllTypes());
   for (const auto &type : types)
   {
@@ -763,8 +764,14 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     if (!type->IsTimerRule() && m_timerInfoTag->EndAsLocalTime() < CDateTime::GetCurrentDateTime())
       continue;
 
+    if (!bFoundThisType && *type == *m_timerType)
+      bFoundThisType = true;
+
     m_typeEntries.insert(std::make_pair(idx++, type));
   }
+
+  if (!bFoundThisType)
+    m_typeEntries.insert(std::make_pair(idx++, m_timerType));
 }
 
 void CGUIDialogPVRTimerSettings::InitializeChannelsList()


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/11753

Tested on x86 with pvr.mythtv