### PR TITLE
[PVR] Cleanup: Get rid of raw pointer in signature of CPVRTimers::GetTimerRule

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -349,7 +349,7 @@ namespace PVR
 
     bool DeleteTimerRule::Execute(const CFileItemPtr &item) const
     {
-      CFileItemPtr parentTimer(g_PVRTimers->GetTimerRule(item.get()));
+      const CFileItemPtr parentTimer(g_PVRTimers->GetTimerRule(item));
       if (parentTimer)
         return CPVRGUIActions::GetInstance().DeleteTimerRule(parentTimer);
 

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -551,7 +551,7 @@ namespace PVR
 
   bool CPVRGUIActions::EditTimerRule(const CFileItemPtr &item) const
   {
-    CFileItemPtr parentTimer(g_PVRTimers->GetTimerRule(item.get()));
+    const CFileItemPtr parentTimer(g_PVRTimers->GetTimerRule(item));
     if (parentTimer)
       return EditTimer(parentTimer);
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -866,7 +866,7 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerRule(const CPVRTimerInfoTagPtr &timer) c
   return CPVRTimerInfoTagPtr();
 }
 
-CFileItemPtr CPVRTimers::GetTimerRule(const CFileItem *item) const
+CFileItemPtr CPVRTimers::GetTimerRule(const CFileItemPtr &item) const
 {
   CPVRTimerInfoTagPtr timer;
   if (item && item->HasEPGInfoTag())

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -232,7 +232,7 @@ namespace PVR
      * @param item The timer to query the timer rule for
      * @return The timer rule, or an empty fileitemptr if none was found.
      */
-    CFileItemPtr GetTimerRule(const CFileItem *item) const;
+    CFileItemPtr GetTimerRule(const CFileItemPtr &item) const;
 
     /*!
      * @brief Update the channel pointers.


### PR DESCRIPTION
Just a little code cleanup, no functional changes.

@Jalle19 good to go?