### PR TITLE
[PVR] Standard list items for EPG, timers & recordings [WIP]

### DIFF
--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -46,7 +46,7 @@
 							<right>30</right>
 							<aligny>center</aligny>
 							<scroll>true</scroll>
-							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
 							<left>15</left>
@@ -72,7 +72,7 @@
 							<height>80</height>
 							<right>30</right>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
 							<left>15</left>
@@ -185,7 +185,7 @@
 									<height>90</height>
 									<width>780</width>
 									<aligny>center</aligny>
-									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]</label>
 									<shadowcolor>text_shadow</shadowcolor>
 								</control>
 							</focusedlayout>
@@ -195,7 +195,7 @@
 									<height>90</height>
 									<width>$PARAM[width]</width>
 									<aligny>center</aligny>
-									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+									<label>$INFO[ListItem.Date,[COLOR grey],[/COLOR][CR]]$INFO[ListItem.Label]</label>
 									<shadowcolor>text_shadow</shadowcolor>
 								</control>
 							</itemlayout>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -133,7 +133,34 @@ CFileItem::CFileItem(const CEpgInfoTagPtr& tag)
   m_bIsFolder = false;
   m_epgInfoTag = tag;
   m_strPath = tag->Path();
-  SetLabel(tag->Title());
+
+  std::string strLabel("");
+  std::string strTitleEpisodeName("");
+  //Title and Episode
+  if (tag->EpisodeName().empty())
+    strTitleEpisodeName = tag->Title();
+  else
+    strTitleEpisodeName = StringUtils::Format("%s (%s)", tag->Title().c_str(), tag->EpisodeName().c_str());
+  //Season + Episode
+  int iSeason(-1);
+  int iEpisode(-1);
+  if (tag->SeriesNumber() > 0)
+    iSeason = tag->SeriesNumber();
+  if (tag->EpisodeNumber() > 0)
+    iEpisode = tag->EpisodeNumber();
+  if (iEpisode >= 0)
+  {
+    if (iSeason == 0) // prefix episode with 'S'
+      strLabel = StringUtils::Format("%s S%d", strTitleEpisodeName.c_str(), iEpisode);
+    else
+      strLabel = StringUtils::Format("%s %dx%d", strTitleEpisodeName.c_str(), iSeason, iEpisode);
+  }
+  else
+  {
+    strLabel = StringUtils::Format("%s", strTitleEpisodeName.c_str());
+  }
+  SetLabel(strLabel);
+
   m_strLabel2 = tag->Plot();
   m_dateTime = tag->StartAsLocalTime();
 
@@ -198,7 +225,34 @@ CFileItem::CFileItem(const CPVRRecordingPtr& record)
   m_bIsFolder = false;
   m_pvrRecordingInfoTag = record;
   m_strPath = record->m_strFileNameAndPath;
-  SetLabel(record->m_strTitle);
+
+  std::string strLabel("");
+  std::string strTitleEpisodeName("");
+  //Title and Episode
+  if (record->EpisodeName().empty())
+    strTitleEpisodeName = record->m_strTitle;
+  else
+    strTitleEpisodeName = StringUtils::Format("%s (%s)", record->m_strTitle.c_str(), record->EpisodeName().c_str());
+  //Season + Episode
+  int iSeason(-1);
+  int iEpisode(-1);
+  if (record->m_iSeason > 0)
+    iSeason = record->m_iSeason;
+  if (record->m_iEpisode > 0)
+    iEpisode = record->m_iEpisode;
+  if (iEpisode >= 0)
+  {
+    if (iSeason == 0) // prefix episode with 'S'
+      strLabel = StringUtils::Format("%s S%d", strTitleEpisodeName.c_str(), iEpisode);
+    else
+      strLabel = StringUtils::Format("%s %dx%d", strTitleEpisodeName.c_str(), iSeason, iEpisode);
+  }
+  else
+  {
+    strLabel = StringUtils::Format("%s", strTitleEpisodeName.c_str());
+  }
+  SetLabel(strLabel);
+
   m_strLabel2 = record->m_strPlot;
   FillInMimeType(false);
 }
@@ -212,7 +266,36 @@ CFileItem::CFileItem(const CPVRTimerInfoTagPtr& timer)
   m_bIsFolder = timer->IsTimerRule();
   m_pvrTimerInfoTag = timer;
   m_strPath = timer->Path();
-  SetLabel(timer->Title());
+
+  std::string strLabel("");
+  const CEpgInfoTagPtr tag(timer->GetEpgInfoTag());
+  if (tag)
+  {
+    //Season + Episode
+    int iSeason(-1);
+		int iEpisode(-1);
+    if (tag->SeriesNumber() > 0)
+      iSeason = tag->SeriesNumber();
+    if (tag->EpisodeNumber() > 0)
+      iEpisode = tag->EpisodeNumber();
+    if (iEpisode >= 0)
+    {
+      if (iSeason == 0) // prefix episode with 'S'
+        strLabel = StringUtils::Format("%s S%d", timer->Title().c_str(), iEpisode);
+      else
+        strLabel = StringUtils::Format("%s %dx%d", timer->Title().c_str(), iSeason, iEpisode);
+    }
+    else
+    {
+      strLabel = timer->Title();
+    }
+  }
+  else
+  {
+    strLabel = timer->Title();
+  }
+  SetLabel(strLabel);
+
   m_strLabel2 = timer->Summary();
   m_dateTime = timer->StartAsLocalTime();
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -563,6 +563,12 @@ private:
    */
   CBookmark GetResumePoint() const;
 
+  /*!
+   * brief Return a descriptive list entry in the currently selected format
+   * return a string formated in the currently selected way
+   */
+  std::string FormatListLabel(std::string strTitle, std::string strEpisodeName, int iSeason, int iEpisode, int iYearFirstShown) const;
+
   std::string m_strPath;            ///< complete path to item
 
   SortSpecial m_specialSort;


### PR DESCRIPTION
Adds Title (Subtitle)  SeasonxEpisode to PVR EPG entries, timers and recordings
(As per suggestion in https://github.com/xbmc/xbmc/pull/11000 )

## Description
If a PVR client provides EpisodeName, Season and/or Episode information, display this in lists of EPG entries, timers and recordings:

Format = Standard kodi Season/Episode format as used in Videos section and Estuary skin: 
Title (EpisodeName) 1.2 = Season 1, Episode 2
Title (EpisodeName) S1 = Special 1
Title (EpisodeName) = no Season or Episode, but an EpisodeName
Title = no Season, Episode or EpisodeName

## Motivation and Context
If you record a whole series, you may miss one, or they may be recorded out of order. This allows you to see which episodes you missed. 
Couple this with sort by 'File' (https://github.com/xbmc/xbmc/pull/10999) and you can sort in season/episode order.

## How Has This Been Tested?
Tested in this form using pvr.mythtv with a 0.27 backend on x86 linux using Estury and Confluence

## Screenshots (if appropriate):
As per https://github.com/xbmc/xbmc/pull/11000 but with x instead of .

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

I would say it is non-breaking but skins like confluence and Estuary which use <label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label> will need to change this to
<label>$INFO[ListItem.Label]</label> to avoid getting duplicate 'EpisodeName' entries

Several other non-core skins will just work :)

Let me know if I should include Estuary changes in a separate commit (to be done later) or maybe I should re-purpose https://github.com/xbmc/xbmc/pull/11000 to accompany it. (Failing that, feel free to have a go yourselves!)

@phil65 @ronie - hope you like it
@ksooo - OK, what's wrong with my coding style ;-)