### PR TITLE
[Fix]Speedup Songs node by skipping pointless fetch of cuesheet data

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -400,7 +400,7 @@ public:
   bool GetSongsNav(const std::string& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription = SortDescription());
   bool GetSongsByYear(const std::string& baseDir, CFileItemList& items, int year);
   bool GetSongsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
-  bool GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), bool artistData = false, bool cueSheetData = true);
+  bool GetSongsFullByWhere(const std::string &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), bool artistData = false, bool cueSheetData = false);
   bool GetAlbumsByWhere(const std::string &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
   bool GetAlbumsByWhere(const std::string &baseDir, const Filter &filter, VECALBUMS& albums, int& total, const SortDescription &sortDescription = SortDescription(), bool countOnly = false);
   bool GetArtistsByWhere(const std::string& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription(), bool countOnly = false);


### PR DESCRIPTION
Chipping away at what makes songs node on large library so slow. 

The way embedded cueshseets are implemented is taking *7%* of the total time taken to process the songs node, even when there are no embedded cuesheets in the music collection. Even worse the cuesheet processing in `GetSongsFullByWhere()` is only to get replay gain data for any embedded cuesheets, yet other design flaws means that this replay gain is not actually applied on playback. Not only is the way the data is fetched inefficient, but it is totally pointless!

It is a minor change to stop fetching embedded cuesheet replay gain data by default, and I suggest we backport it for an immediate performance gain.

I am looking at fixing the cuesheet data design and replaygain issues for Leia in a separate PR.