### PR TITLE
erase unsupport tags in TX3G subtitle

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -29,6 +29,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/auto_buffer.h"
+#include "utils/RegExp.h"
 
 // 3GPP/TX3G (aka MPEG-4 Timed Text) Subtitle support
 // 3GPP -> 3rd Generation Partnership Program
@@ -247,6 +248,18 @@ int CDVDOverlayCodecTX3G::Decode(DemuxPacket *pPacket)
 
   if (strUTF8[strUTF8.size()-1] == '\n')
     strUTF8.erase(strUTF8.size()-1);
+
+  // erase unsupport tags
+  CRegExp tags;
+  if (tags.RegComp("(\\{[^\\}]*\\})"))
+  {
+    int pos = 0;
+    while ((pos = tags.RegFind(strUTF8.c_str(), pos)) >= 0)
+    {
+      std::string tag = tags.GetMatch(0);
+      strUTF8.erase(pos, tag.length());
+    }
+  }
 
   // add a new text element to our container
   m_pOverlay->AddElement(new CDVDOverlayText::CElementText(strUTF8.c_str()));


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
erase not supported {} tags in TX3G subtitles like we do with subrip subtitles in mkv and external.

## Motivation and Context
see http://trac.kodi.tv/ticket/17214

## How Has This Been Tested?
tested under win10

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
