### PR TITLE
pvr: fix playing items from library

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -751,7 +751,8 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
    || IsInternetStream()
    || IsParentFolder()
    || IsVirtualDirectoryRoot()
-   || IsPlugin())
+   || IsPlugin()
+   || IsPVR())
     return true;
 
   if (IsVideoDb() && HasVideoInfoTag())


### PR DESCRIPTION
see title

this broke with removal of needless loader for pvr. makes no sense checking for existing recordings at this point. backend might not be running and showing a dialog asking the user for removal of item is only confusing.