### PR TITLE
[cmake][windows] use correct d3dcompiler depending on target architecture

### DIFF
--- a/cmake/modules/FindD3DX11Effects.cmake
+++ b/cmake/modules/FindD3DX11Effects.cmake
@@ -7,10 +7,10 @@
 find_file(D3DCOMPILER_DLL
           NAMES d3dcompiler_47.dll d3dcompiler_46.dll
           PATHS
-            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0;InstallationFolder]/Redist/D3D/x86"
-            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.1;InstallationFolder]/Redist/D3D/x86"
-            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.0;InstallationFolder]/Redist/D3D/x86"
-            "$ENV{WindowsSdkDir}Redist/d3d/x86"
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0;InstallationFolder]/Redist/D3D/${SDK_TARGET_ARCH}"
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.1;InstallationFolder]/Redist/D3D/${SDK_TARGET_ARCH}"
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v8.0;InstallationFolder]/Redist/D3D/${SDK_TARGET_ARCH}"
+            "$ENV{WindowsSdkDir}Redist/d3d/${SDK_TARGET_ARCH}"
           NO_DEFAULT_PATH)
 if(NOT D3DCOMPILER_DLL)
   message(WARNING "Could NOT find Direct3D Compiler")

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -1,6 +1,12 @@
 # -------- Architecture settings ---------
 
-set(ARCH win32)
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set(ARCH win32)
+  set(SDK_TARGET_ARCH x86)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(ARCH x64)
+  set(SDK_TARGET_ARCH x64)
+endif()
 
 
 # -------- Paths (mainly for find_package) ---------


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use the correct d3dcompiler depending on the target architecture.
<!--- Describe your change in detail -->

## Motivation and Context
Without this change win32 version of d3dcompiler is also packed in x64 and therefore Kodi can't start.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested on win32 and x64.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
