### PR TITLE
[Fix]Music cleanup hanging on large MySQL databases

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3059,8 +3059,14 @@ bool CMusicDatabase::CleanupArtists()
     m_pDS->exec("INSERT INTO tmp_delartists select idArtist from song_artist");
     m_pDS->exec("INSERT INTO tmp_delartists select idArtist from album_artist");
     m_pDS->exec(PrepareSQL("INSERT INTO tmp_delartists VALUES(%i)", BLANKARTIST_ID));
-    m_pDS->exec("delete from artist where idArtist not in (select idArtist from tmp_delartists)");
+    // tmp_delartists contains duplicate ids, and on a large library with small changes can be very large.
+    // To avoid MySQL hanging or timeout create a table of unique ids with primary key
+    m_pDS->exec("CREATE TEMPORARY TABLE tmp_keep (idArtist INTEGER PRIMARY KEY)");
+    m_pDS->exec("INSERT INTO tmp_keep SELECT DISTINCT idArtist from tmp_delartists");
+    m_pDS->exec("DELETE FROM artist WHERE idArtist NOT IN (SELECT idArtist FROM tmp_keep)");
+    // Tidy up temp tables
     m_pDS->exec("DROP TABLE tmp_delartists");
+    m_pDS->exec("DROP TABLE tmp_keep");
 
     return true;
   }


### PR DESCRIPTION
Music library cleanup, both on library update, and the overall facility avilable from settings menu, is hanging on very large MySQL (or MariaDB) databases. Smaller db can benefit for a more efficient process too.

The issue is `CMusicDatabase::CleanupArtists` which creates a temp table tmp_delartists of artist ids to keep, but this table contains duplicates and does not have an index. If few artists need removing then on a large collection, tmp_delartists can be very large (e.g. ~12 x number of artists). The query
DELETE FROM artist WHERE idArtist NOT IN (SELECT idArtist FROM tmp_delartists)
then hangs.

It is unsurprizing that doing a "NOT IN" on an non-indexed table with 370k rows is unsuccessful!

In comparison testing has proven that an additional step of creating a temp table of unique artist ids to keep with an index (primary key), and using that in the "NOT IN" works reasonably with both few and many records on both MySQL and SQLite.

Backported as #11801