### PR TITLE
Fix allocation of 0-length array

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -147,7 +147,12 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
 
   // copy the arguments into a local buffer
   m_argc = arguments.size();
-  m_argv = new char*[m_argc];
+  
+  if(m_argc > 0)
+  {
+    m_argv = new char*[m_argc];
+  }
+
   for (unsigned int i = 0; i < m_argc; i++)
   {
     m_argv[i] = new char[arguments.at(i).length() + 1];

--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -59,8 +59,6 @@ protected:
   virtual void onError(const std::string &exceptionType = "", const std::string &exceptionValue = "", const std::string &exceptionTraceback = "");
 
   std::string m_sourceFile;
-  unsigned int  m_argc;
-  char **m_argv;
   CCriticalSection m_critical;
 
 private:


### PR DESCRIPTION
## Description
Using Valgrind to troubleshoot a crash, came across this. Not the crash I was looking for but interesting nonetheless. If we're called with argc=0, we allocate a 0-length array, pass it to Python then we get a memory error as Python tries to access member 0 of the 0-length array.

## Motivation and Context
Fixes an invalid memory read.

## How Has This Been Tested?
I clicked around a bunch and didn't manage to get it to crash. Re-ran in valgrind and the invalid memory read is no longer there. Ran all existing tests.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
