### PR TITLE
Change SetShellVarContext from current to all

### DIFF
--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -163,7 +163,7 @@ InstType "Minimal" ; 3.
 ;Installer Sections
 
 Section "${APP_NAME}" SecAPP
-  SetShellVarContext current
+  SetShellVarContext all
   SectionIn RO
   SectionIn 1 2 3 #section is in install type Normal/Full/Minimal
 
@@ -285,7 +285,7 @@ FunctionEnd
 
 Section "Uninstall"
 
-  SetShellVarContext current
+  SetShellVarContext all
 
   ;ADD YOUR OWN FILES HERE...
   RMDir /r "$INSTDIR\addons"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Changed SetShellVarContext setting from current to all in Installer section and Uninstaller section

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This command sets the context of the installer. Setting to 'all' causes shortcuts and uninstall registry entries to be made in the respective 'All Users' areas of Windows. Setting to 'current' causes those items to be written to the current user space only. Since we require admin privileges to install it makes sense to set this to the all users context. This also fits with Windows app convention.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
No testing. A very simple NSIS installer directive.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
