### PR TITLE
Fix EGLNativeTypeAmlogic for probing resolutions

### DIFF
--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -171,8 +171,11 @@ bool CEGLNativeTypeAmlogic::ProbeResolutions(std::vector<RESOLUTION_INFO> &resol
   RESOLUTION_INFO res;
   for (std::vector<std::string>::const_iterator i = probe_str.begin(); i != probe_str.end(); ++i)
   {
-    if(aml_mode_to_resolution(i->c_str(), &res))
-      resolutions.push_back(res);
+    if (((StringUtils::StartsWith(i->c_str(), "4k2k")) && (aml_support_h264_4k2k() > AML_NO_H264_4K2K)) || !(StringUtils::StartsWith(i->c_str(), "4k2k")))
+    {
+      if (aml_mode_to_resolution(i->c_str(), &res))
+        resolutions.push_back(res);
+    }
   }
   return resolutions.size() > 0;
 


### PR DESCRIPTION
I noticed issue with latest official Amlogic kernel releases (3.10.33)
where /sys/class/amhdmitx/amhdmitx0/disp_cap reports also 4k2k resolutions
on S805 boards which results in 4K resolutions showing as available.

That makes 4K resolutions available to be set which is misleading and in the
end user may actually select unsupported resolution.

Also my suggestion is to merge it to Krypton too.