### PR TITLE
[Krypton] [Android] Fix broken buttons on controllers

### DIFF
--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -458,11 +458,13 @@ bool CPeripheralAddon::ProcessEvents(void)
           case PERIPHERAL_EVENT_TYPE_DRIVER_BUTTON:
           {
             const bool bPressed = (event.ButtonState() == JOYSTICK_STATE_BUTTON_PRESSED);
+            joystickDevice->OnButtonMotion(event.DriverIndex(), bPressed);
             break;
           }
           case PERIPHERAL_EVENT_TYPE_DRIVER_HAT:
           {
             const HAT_STATE state = CPeripheralAddonTranslator::TranslateHatState(event.HatState());
+            joystickDevice->OnHatMotion(event.DriverIndex(), state);
             break;
           }
           case PERIPHERAL_EVENT_TYPE_DRIVER_AXIS:

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
@@ -138,11 +138,13 @@ void CPeripheralBusAndroid::ProcessEvents()
       case PERIPHERAL_EVENT_TYPE_DRIVER_BUTTON:
       {
         const bool bPressed = (event.ButtonState() == JOYSTICK_STATE_BUTTON_PRESSED);
+        joystick->OnButtonMotion(event.DriverIndex(), bPressed);
         break;
       }
       case PERIPHERAL_EVENT_TYPE_DRIVER_HAT:
       {
         const JOYSTICK::HAT_STATE state = CPeripheralAddonTranslator::TranslateHatState(event.HatState());
+        joystick->OnHatMotion(event.DriverIndex(), state);
         break;
       }
       case PERIPHERAL_EVENT_TYPE_DRIVER_AXIS:


### PR DESCRIPTION
A rebase error led to some overzealous removal of code, breaking buttons on Android. This fixes that.