### PR TITLE
Fix compilation error: ‘sprintf’ is not a member of ‘fmt’

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -37,6 +37,7 @@
 #include <locale>
 
 #include <fmt/format.h>
+#include <fmt/printf.h>
 
 #include "LangInfo.h"
 #include "XBDateTime.h"


### PR DESCRIPTION
In order to use fmt::sprintf, fmt/printf.h must be included. See http://fmtlib.net/dev/api.html#printf-formatting

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Currently, compilation fails with this error:
```
xbmc/utils/StringUtils.h:73:16: error: ‘sprintf’ is not a member of ‘fmt’
        result = fmt::sprintf(fmt, std::forward<Args>(args)...);
```
I'm using fmt 3.0.1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
There's a compilation failure :-)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Compiled, and this failure doesn't occur.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
