### PR TITLE
[windows] split dependencies directory for different architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,10 +246,12 @@ lib/cpluff/stamp-h1
 /project/BuildDependencies/bin/swig
 /project/BuildDependencies/bin/doxygen
 /project/BuildDependencies/bin/json-rpc
+/project/BuildDependencies/x64
 
 # /system
 /system/cpluff.dll
 /system/EasyHook32.dll
+/system/EasyHook64.dll
 /system/libcurl.dll
 /system/libeay32.dll
 /system/libexif.dll

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -20,9 +20,14 @@ set(CMAKE_SYSTEM_NAME Windows)
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/lib/win32)
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg)
 list(APPEND CMAKE_SYSTEM_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg/bin)
+list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH})
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependencies)
 
-set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/python)
+if(${ARCH} STREQUAL win32)
+  set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/python)
+else()
+  set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH}/include/python)
+endif()
 
 
 # -------- Compiler options ---------
@@ -51,8 +56,13 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
 
 # For #pragma comment(lib X)
 # TODO: It would certainly be better to handle these libraries via CMake modules.
-link_directories(${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg/bin
-                 ${CMAKE_SOURCE_DIR}/project/BuildDependencies/lib)
+if(${ARCH} STREQUAL win32)
+  link_directories(${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg/bin
+                   ${CMAKE_SOURCE_DIR}/project/BuildDependencies/lib)
+else()
+  link_directories(${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg/bin
+                   ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH}/lib)
+endif()
 
 # Additional libraries
 list(APPEND DEPLIBS d3d11.lib DInput8.lib DSound.lib winmm.lib Mpr.lib Iphlpapi.lib WS2_32.lib


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
- split dependencies directory to `project/BuildDependencies/${ARCH}`
- keep `project/BuildDependencies` as dependencies fallback (mostly for win32)
- gitignore x64 directories/files
<!--- Describe your change in detail -->

## Motivation and Context
Some changes which are need to get windows x64 compiled.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled on win32 and x64
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
