### PR TITLE
[Peripherals] Fix segfault by adding some synchronization to peripheral add-ons

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -653,8 +653,7 @@ bool CApplication::Create()
   m_replayGainSettings.iPreAmp = m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINPREAMP);
   m_replayGainSettings.iNoGainPreAmp = m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_MUSICPLAYER_REPLAYGAINNOGAINPREAMP);
 
-  // Create the Mouse, Keyboard, Remote, and Joystick devices
-  // Initialize after loading settings to get joystick deadzone setting
+  // Create the Mouse, Keyboard and Remote
   CInputManager::GetInstance().InitializeInputs();
 
   // load the keyboard layouts

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1093,10 +1093,6 @@ bool CApplication::Initialize()
     StringUtils::Format(g_localizeStrings.Get(178).c_str(), g_sysinfo.GetAppName().c_str()),
     "special://xbmc/media/icon256x256.png", EventLevel::Basic)));
 
-#if !defined(TARGET_DARWIN_IOS)
-  g_peripherals.Initialise();
-#endif
-
   getNetwork().WaitForNet();
 
   // Load curl so curl_global_init gets called before any service threads
@@ -1340,8 +1336,6 @@ void CApplication::StopServices()
   CLog::Log(LOGNOTICE, "stop dvd detect media");
   m_DetectDVDType.StopThread();
 #endif
-
-  g_peripherals.Clear();
 }
 
 void CApplication::OnSettingChanged(const CSetting *setting)
@@ -2315,7 +2309,7 @@ bool CApplication::OnAction(const CAction &action)
     }
   }
 
-  if (g_peripherals.OnAction(action))
+  if (CServiceBroker::GetPeripherals().OnAction(action))
     return true;
 
   if (action.GetID() == ACTION_MUTE)
@@ -4720,7 +4714,7 @@ void CApplication::ShowVolumeBar(const CAction *action)
 
 bool CApplication::IsMuted() const
 {
-  if (g_peripherals.IsMuted())
+  if (CServiceBroker::GetPeripherals().IsMuted())
     return true;
   return CAEFactory::IsMuted();
 }
@@ -4744,7 +4738,7 @@ void CApplication::SetMute(bool mute)
 
 void CApplication::Mute()
 {
-  if (g_peripherals.Mute())
+  if (CServiceBroker::GetPeripherals().Mute())
     return;
 
   CAEFactory::SetMute(true);
@@ -4754,7 +4748,7 @@ void CApplication::Mute()
 
 void CApplication::UnMute()
 {
-  if (g_peripherals.UnMute())
+  if (CServiceBroker::GetPeripherals().UnMute())
     return;
 
   CAEFactory::SetMute(false);

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -78,6 +78,11 @@ GAME::CGameServices& CServiceBroker::GetGameServices()
   return g_application.m_ServiceManager->GetGameServices();
 }
 
+PERIPHERALS::CPeripherals& CServiceBroker::GetPeripherals()
+{
+  return g_application.m_ServiceManager->GetPeripherals();
+}
+
 bool CServiceBroker::IsBinaryAddonCacheUp()
 {
   return g_application.m_ServiceManager->init_level > 1;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -54,6 +54,11 @@ namespace GAME
   class CGameServices;
 }
 
+namespace PERIPHERALS
+{
+  class CPeripherals;
+}
+
 class CServiceBroker
 {
 public:
@@ -68,5 +73,6 @@ public:
   static PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
   static CSettings& GetSettings();
   static GAME::CGameServices& GetGameServices();
+  static PERIPHERALS::CPeripherals& GetPeripherals();
   static bool IsBinaryAddonCacheUp();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -24,6 +24,7 @@
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "cores/DataCacheCore.h"
 #include "games/GameServices.h"
+#include "peripherals/Peripherals.h"
 #include "PlayListPlayer.h"
 #include "utils/log.h"
 #include "interfaces/AnnouncementManager.h"
@@ -33,7 +34,8 @@
 #include "settings/Settings.h"
 
 CServiceManager::CServiceManager() :
-  m_gameServices(new GAME::CGameServices)
+  m_gameServices(new GAME::CGameServices),
+  m_peripherals(new PERIPHERALS::CPeripherals)
 {
 }
 
@@ -87,6 +89,7 @@ bool CServiceManager::Init2()
 
 bool CServiceManager::Init3()
 {
+  m_peripherals->Initialise();
   m_ADSPManager->Init();
   m_PVRManager->Init();
   m_contextMenuManager->Init();
@@ -99,6 +102,7 @@ bool CServiceManager::Init3()
 void CServiceManager::Deinit()
 {
   m_gameServices->Deinit();
+  m_peripherals.reset();
   m_contextMenuManager.reset();
   m_binaryAddonCache.reset();
   if (m_PVRManager)
@@ -174,6 +178,11 @@ CSettings& CServiceManager::GetSettings()
 GAME::CGameServices& CServiceManager::GetGameServices()
 {
   return *m_gameServices;
+}
+
+PERIPHERALS::CPeripherals& CServiceManager::GetPeripherals()
+{
+  return *m_peripherals;
 }
 
 // deleters for unique_ptr

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -59,6 +59,11 @@ namespace GAME
   class CGameServices;
 }
 
+namespace PERIPHERALS
+{
+  class CPeripherals;
+}
+
 class CServiceManager
 {
 public:
@@ -83,6 +88,7 @@ public:
    */
   CPlatform& GetPlatform();
   GAME::CGameServices& GetGameServices();
+  PERIPHERALS::CPeripherals& GetPeripherals();
 
   PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
   int init_level = 0;
@@ -114,4 +120,5 @@ protected:
   std::unique_ptr<PLAYLIST::CPlayListPlayer> m_playlistPlayer;
   std::unique_ptr<CSettings> m_settings;
   std::unique_ptr<GAME::CGameServices> m_gameServices;
+  std::unique_ptr<PERIPHERALS::CPeripherals> m_peripherals;
 };

--- a/xbmc/addons/interfaces/Peripheral/AddonCallbacksPeripheral.cpp
+++ b/xbmc/addons/interfaces/Peripheral/AddonCallbacksPeripheral.cpp
@@ -66,7 +66,7 @@ CPeripheralAddon* CAddonCallbacksPeripheral::GetPeripheralAddon(void* addonData,
 
 void CAddonCallbacksPeripheral::TriggerScan(void* addonData)
 {
-  g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_ADDON);
+  CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERAL_BUS_ADDON);
 }
 
 void CAddonCallbacksPeripheral::RefreshButtonMaps(void* addonData, const char* deviceName, const char* controllerId)

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -22,6 +22,7 @@
 #include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
+#include "ServiceBroker.h"
 
 #define POPUP_ICON                400
 #define POPUP_CAPTION_TEXT        401
@@ -136,7 +137,7 @@ bool CGUIDialogKaiToast::DoWork()
     SetSound(toast.withSound);
 
     // Activate haptics for this notification
-    PERIPHERALS::g_peripherals.OnUserNotification();
+    CServiceBroker::GetPeripherals().OnUserNotification();
 
     ResetTimer();
     return true;

--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -25,6 +25,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
+#include "ServiceBroker.h"
 
 #include <cstring>
 
@@ -46,7 +47,7 @@ void CGameSettings::OnSettingChanged(const CSetting *setting)
   const std::string& settingId = setting->GetId();
   if (settingId == CSettings::SETTING_GAMES_KEYBOARD_PLAYERS)
   {
-    PERIPHERALS::g_peripherals.TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_APPLICATION);
+    CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_APPLICATION);
   }
   else if (settingId == CSettings::SETTING_GAMES_ENABLEREWIND ||
            settingId == CSettings::SETTING_GAMES_REWINDTIME)

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -321,7 +321,7 @@ bool CGameClient::InitializeGameplay(const std::string& gamePath, IGameAudioCall
     m_serializeSize   = GetSerializeSize();
     m_audio           = audio;
     m_video           = video;
-    m_inputRateHandle = PERIPHERALS::g_peripherals.SetEventScanRate(INPUT_SCAN_RATE);
+    m_inputRateHandle = CServiceBroker::GetPeripherals().SetEventScanRate(INPUT_SCAN_RATE);
 
     if (m_bSupportsKeyboard)
       OpenKeyboard();

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -30,6 +30,7 @@
 #include "input/ActionIDs.h"
 #include "peripherals/Peripherals.h"
 #include "utils/Variant.h"
+#include "ServiceBroker.h"
 
 #include <algorithm>
 #include <iterator>
@@ -115,30 +116,24 @@ bool CGUIDialogButtonCapture::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
 
 void CGUIDialogButtonCapture::InstallHooks(void)
 {
-  using namespace PERIPHERALS;
-
-  g_peripherals.RegisterJoystickButtonMapper(this);
-  g_peripherals.RegisterObserver(this);
+  CServiceBroker::GetPeripherals().RegisterJoystickButtonMapper(this);
+  CServiceBroker::GetPeripherals().RegisterObserver(this);
 }
 
 void CGUIDialogButtonCapture::RemoveHooks(void)
 {
-  using namespace PERIPHERALS;
-
-  g_peripherals.UnregisterObserver(this);
-  g_peripherals.UnregisterJoystickButtonMapper(this);
+  CServiceBroker::GetPeripherals().UnregisterObserver(this);
+  CServiceBroker::GetPeripherals().UnregisterJoystickButtonMapper(this);
 }
 
 void CGUIDialogButtonCapture::Notify(const Observable& obs, const ObservableMessage msg)
 {
-  using namespace PERIPHERALS;
-
   switch (msg)
   {
   case ObservableMessagePeripheralsChanged:
   {
-    g_peripherals.UnregisterJoystickButtonMapper(this);
-    g_peripherals.RegisterJoystickButtonMapper(this);
+    CServiceBroker::GetPeripherals().UnregisterJoystickButtonMapper(this);
+    CServiceBroker::GetPeripherals().RegisterJoystickButtonMapper(this);
     break;
   }
   default:

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -30,6 +30,7 @@
 #include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "ServiceBroker.h"
 
 using namespace KODI;
 using namespace GAME;
@@ -335,10 +336,8 @@ bool CGUIConfigurationWizard::OnButtonPress(const std::string& button)
 
 void CGUIConfigurationWizard::InstallHooks(void)
 {
-  using namespace PERIPHERALS;
-
-  g_peripherals.RegisterJoystickButtonMapper(this);
-  g_peripherals.RegisterObserver(this);
+  CServiceBroker::GetPeripherals().RegisterJoystickButtonMapper(this);
+  CServiceBroker::GetPeripherals().RegisterObserver(this);
 
   // If we're not using emulation, allow keyboard input to abort prompt
   if (!m_bEmulation)
@@ -349,27 +348,23 @@ void CGUIConfigurationWizard::InstallHooks(void)
 
 void CGUIConfigurationWizard::RemoveHooks(void)
 {
-  using namespace PERIPHERALS;
-
   CInputManager::GetInstance().UnregisterMouseHandler(this);
 
   if (!m_bEmulation)
     CInputManager::GetInstance().UnregisterKeyboardHandler(this);
 
-  g_peripherals.UnregisterObserver(this);
-  g_peripherals.UnregisterJoystickButtonMapper(this);
+  CServiceBroker::GetPeripherals().UnregisterObserver(this);
+  CServiceBroker::GetPeripherals().UnregisterJoystickButtonMapper(this);
 }
 
 void CGUIConfigurationWizard::Notify(const Observable& obs, const ObservableMessage msg)
 {
-  using namespace PERIPHERALS;
-
   switch (msg)
   {
     case ObservableMessagePeripheralsChanged:
     {
-      g_peripherals.UnregisterJoystickButtonMapper(this);
-      g_peripherals.RegisterJoystickButtonMapper(this);
+      CServiceBroker::GetPeripherals().UnregisterJoystickButtonMapper(this);
+      CServiceBroker::GetPeripherals().RegisterJoystickButtonMapper(this);
       break;
     }
     default:

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -143,7 +143,7 @@ void CGUIControllerList::ResetController(void)
     if (!CGUIDialogYesNo::ShowAndGetInput(35060, 35061))
       return;
 
-    PERIPHERALS::g_peripherals.ResetButtonMaps(strControllerId);
+    CServiceBroker::GetPeripherals().ResetButtonMaps(strControllerId);
   }
 }
 

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/WindowIDs.h"
+#include "ServiceBroker.h"
 
 // To check for button mapping support
 #include "dialogs/GUIDialogOK.h"
@@ -204,8 +205,6 @@ void CGUIControllerWindow::OnEvent(const ADDON::CRepositoryUpdater::RepositoryUp
 
 void CGUIControllerWindow::OnInitWindow(void)
 {
-  using namespace PERIPHERALS;
-
   CGUIDialog::OnInitWindow();
 
   if (!m_featureList)
@@ -233,7 +232,7 @@ void CGUIControllerWindow::OnInitWindow(void)
   OnMessage(msgFocus);
 
   // Enable button mapping support
-  if (!g_peripherals.GetInstance().EnableButtonMapping())
+  if (!CServiceBroker::GetPeripherals().EnableButtonMapping())
     CLog::Log(LOGDEBUG, "Joystick support not found");
 
   // FIXME: not thread safe

--- a/xbmc/games/ports/PortMapper.cpp
+++ b/xbmc/games/ports/PortMapper.cpp
@@ -28,7 +28,8 @@ using namespace GAME;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 
-CPortMapper::CPortMapper()
+CPortMapper::CPortMapper(PERIPHERALS::CPeripherals& peripheralManager) :
+  m_peripheralManager(peripheralManager)
 {
   CPortManager::GetInstance().RegisterObserver(this);
 }
@@ -56,7 +57,7 @@ void CPortMapper::ProcessPeripherals()
   auto& oldPortMap = m_portMap;
 
   PeripheralVector devices;
-  g_peripherals.GetPeripheralsWithFeature(devices, FEATURE_JOYSTICK);
+  m_peripheralManager.GetPeripheralsWithFeature(devices, FEATURE_JOYSTICK);
 
   std::map<PeripheralPtr, IInputHandler*> newPortMap;
   CPortManager::GetInstance().MapDevices(devices, newPortMap);

--- a/xbmc/games/ports/PortMapper.h
+++ b/xbmc/games/ports/PortMapper.h
@@ -32,12 +32,17 @@ namespace JOYSTICK
 }
 }
 
+namespace PERIPHERALS
+{
+  class CPeripherals;
+}
+
 namespace GAME
 {
   class CPortMapper : public Observer
   {
   public:
-    CPortMapper();
+    CPortMapper(PERIPHERALS::CPeripherals& peripheralManager);
 
     virtual ~CPortMapper();
 
@@ -46,6 +51,10 @@ namespace GAME
   private:
     void ProcessPeripherals();
 
+    // Construction parameters
+    PERIPHERALS::CPeripherals& m_peripheralManager;
+
+    // Port paremters
     std::map<PERIPHERALS::PeripheralPtr, KODI::JOYSTICK::IInputHandler*>  m_portMap;
   };
 }

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -57,6 +57,7 @@
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "settings/Settings.h"
+#include "ServiceBroker.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
@@ -72,7 +73,6 @@ using EVENTSERVER::CEventServer;
 
 using namespace KODI;
 using namespace MESSAGING;
-using PERIPHERALS::CPeripherals;
 
 CInputManager::CInputManager() :
   m_mouseButtonMap(new MOUSE::CMouseWindowingButtonMap),
@@ -125,7 +125,7 @@ bool CInputManager::ProcessRemote(int windowId)
 bool CInputManager::ProcessPeripherals(float frameTime)
 {
   CKey key;
-  if (g_peripherals.GetNextKeypress(frameTime, key))
+  if (CServiceBroker::GetPeripherals().GetNextKeypress(frameTime, key))
     return OnKey(key);
   return false;
 }

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -31,10 +31,9 @@
 #include "peripherals/devices/PeripheralHID.h"
 #include "threads/SystemClock.h"
 #include "utils/log.h"
+#include "ServiceBroker.h"
 
 #define HOLD_THRESHOLD 250
-
-using namespace PERIPHERALS;
 
 bool operator==(const XBMC_keysym& lhs, const XBMC_keysym& rhs)
 {
@@ -60,8 +59,10 @@ void CKeyboardStat::Initialize()
 
 bool CKeyboardStat::LookupSymAndUnicodePeripherals(XBMC_keysym &keysym, uint8_t *key, char *unicode)
 {
+  using namespace PERIPHERALS;
+
   PeripheralVector hidDevices;
-  if (g_peripherals.GetPeripheralsWithFeature(hidDevices, FEATURE_HID))
+  if (CServiceBroker::GetPeripherals().GetPeripheralsWithFeature(hidDevices, FEATURE_HID))
   {
     for (auto& peripheral : hidDevices)
     {

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -83,7 +83,6 @@ CPeripherals::CPeripherals() :
   m_portMapper(*this)
 {
   RegisterObserver(&m_portMapper);
-  Clear();
 }
 
 CPeripherals::~CPeripherals()

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -79,7 +79,8 @@ using namespace XFILE;
 CPeripherals::CPeripherals() :
   m_bInitialised(false),
   m_bIsStarted(false),
-  m_eventScanner(this)
+  m_eventScanner(this),
+  m_portMapper(*this)
 {
   RegisterObserver(&m_portMapper);
   Clear();
@@ -91,14 +92,9 @@ CPeripherals::~CPeripherals()
   UnregisterObserver(&m_portMapper);
 }
 
-CPeripherals &CPeripherals::GetInstance()
-{
-  static CPeripherals peripheralsInstance;
-  return peripheralsInstance;
-}
-
 void CPeripherals::Initialise()
 {
+#if !defined(TARGET_DARWIN_IOS)
   CSingleLock lock(m_critSection);
   if (m_bIsStarted)
     return;
@@ -113,16 +109,16 @@ void CPeripherals::Initialise()
   std::vector<PeripheralBusPtr> busses;
 
 #if defined(HAVE_PERIPHERAL_BUS_USB)
-  busses.push_back(std::make_shared<CPeripheralBusUSB>(this));
+  busses.push_back(std::make_shared<CPeripheralBusUSB>(*this));
 #endif
 #if defined(HAVE_LIBCEC)
-  busses.push_back(std::make_shared<CPeripheralBusCEC>(this));
+  busses.push_back(std::make_shared<CPeripheralBusCEC>(*this));
 #endif
-  busses.push_back(std::make_shared<CPeripheralBusAddon>(this));
+  busses.push_back(std::make_shared<CPeripheralBusAddon>(*this));
 #if defined(TARGET_ANDROID)
-  busses.push_back(std::make_shared<CPeripheralBusAndroid>(this));
+  busses.push_back(std::make_shared<CPeripheralBusAndroid>(*this));
 #endif
-  busses.push_back(std::make_shared<CPeripheralBusApplication>(this));
+  busses.push_back(std::make_shared<CPeripheralBusApplication>(*this));
 
   {
     CSingleLock bussesLock(m_critSectionBusses);
@@ -138,6 +134,7 @@ void CPeripherals::Initialise()
   m_bInitialised = true;
   MESSAGING::CApplicationMessenger::GetInstance().RegisterReceiver(this);
   ANNOUNCEMENT::CAnnouncementManager::GetInstance().AddAnnouncer(this);
+#endif
 }
 
 void CPeripherals::Clear()
@@ -317,33 +314,33 @@ void CPeripherals::CreatePeripheral(CPeripheralBus &bus, const PeripheralScanRes
   switch(mappedResult.m_mappedType)
   {
   case PERIPHERAL_HID:
-    peripheral = PeripheralPtr(new CPeripheralHID(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralHID(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_NIC:
-    peripheral = PeripheralPtr(new CPeripheralNIC(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralNIC(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_DISK:
-    peripheral = PeripheralPtr(new CPeripheralDisk(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralDisk(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_NYXBOARD:
-    peripheral = PeripheralPtr(new CPeripheralNyxboard(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralNyxboard(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_TUNER:
-    peripheral = PeripheralPtr(new CPeripheralTuner(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralTuner(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_BLUETOOTH:
-    peripheral = PeripheralPtr(new CPeripheralBluetooth(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralBluetooth(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_CEC:
 #if defined(HAVE_LIBCEC)
     if (bus.Type() == PERIPHERAL_BUS_CEC)
-      peripheral = PeripheralPtr(new CPeripheralCecAdapter(mappedResult, &bus));
+      peripheral = PeripheralPtr(new CPeripheralCecAdapter(*this, mappedResult, &bus));
 #else
     if (!m_bMissingLibCecWarningDisplayed)
     {
@@ -355,15 +352,15 @@ void CPeripherals::CreatePeripheral(CPeripheralBus &bus, const PeripheralScanRes
     break;
 
   case PERIPHERAL_IMON:
-    peripheral = PeripheralPtr(new CPeripheralImon(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralImon(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_JOYSTICK:
-    peripheral = PeripheralPtr(new CPeripheralJoystick(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralJoystick(*this, mappedResult, &bus));
     break;
 
   case PERIPHERAL_JOYSTICK_EMULATION:
-    peripheral = PeripheralPtr(new CPeripheralJoystickEmulation(mappedResult, &bus));
+    peripheral = PeripheralPtr(new CPeripheralJoystickEmulation(*this, mappedResult, &bus));
     break;
 
   default:

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -76,6 +76,8 @@ using namespace PERIPHERALS;
 using namespace XFILE;
 
 CPeripherals::CPeripherals() :
+  m_bInitialised(false),
+  m_bIsStarted(false),
   m_eventScanner(this)
 {
   RegisterObserver(&m_portMapper);

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -25,6 +25,7 @@
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
 #include "games/ports/PortMapper.h" //! @todo Find me a better place
+#include "interfaces/IAnnouncer.h"
 #include "messaging/IMessageTarget.h"
 #include "settings/lib/ISettingCallback.h"
 #include "system.h"
@@ -54,7 +55,8 @@ namespace PERIPHERALS
   class CPeripherals :  public ISettingCallback,
                         public Observable,
                         public KODI::MESSAGING::IMessageTarget,
-                        public IEventScannerCallback
+                        public IEventScannerCallback,
+                        public ANNOUNCEMENT::IAnnouncer
   {
   public:
     static CPeripherals &GetInstance();
@@ -237,6 +239,11 @@ namespace PERIPHERALS
      */
     bool TestFeature(PeripheralFeature feature);
 
+    /*!
+     * \brief Request all devices with power-off support to power down
+     */
+    void PowerOffDevices();
+
     bool SupportsCEC() const
     {
 #if defined(HAVE_LIBCEC)
@@ -295,11 +302,16 @@ namespace PERIPHERALS
      */
     void UnregisterJoystickButtonMapper(KODI::JOYSTICK::IButtonMapper* mapper);
 
+    // implementation of ISettingCallback
     virtual void OnSettingChanged(const CSetting *setting) override;
     virtual void OnSettingAction(const CSetting *setting) override;
 
+    // implementation of IMessageTarget
     virtual void OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg) override;
     virtual int GetMessageMask() override;
+
+    // implementation of IAnnouncer
+    virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
 
   private:
     CPeripherals();

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -312,7 +312,7 @@ namespace PERIPHERALS
     bool                                 m_bInitialised;
     bool                                 m_bIsStarted;
 #if !defined(HAVE_LIBCEC)
-    bool                                 m_bMissingLibCecWarningDisplayed;
+    bool                                 m_bMissingLibCecWarningDisplayed = false;
 #endif
     std::vector<PeripheralBusPtr>        m_busses;
     std::vector<PeripheralDeviceMapping> m_mappings;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -50,8 +50,6 @@ namespace JOYSTICK
 
 namespace PERIPHERALS
 {
-  #define g_peripherals CPeripherals::GetInstance()
-
   class CPeripherals :  public ISettingCallback,
                         public Observable,
                         public KODI::MESSAGING::IMessageTarget,
@@ -59,7 +57,8 @@ namespace PERIPHERALS
                         public ANNOUNCEMENT::IAnnouncer
   {
   public:
-    static CPeripherals &GetInstance();
+    CPeripherals();
+
     virtual ~CPeripherals();
 
     /*!
@@ -314,7 +313,6 @@ namespace PERIPHERALS
     virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
 
   private:
-    CPeripherals();
     bool LoadMappings();
     bool GetMappingForDevice(const CPeripheralBus &bus, PeripheralScanResult& result) const;
     static void GetSettingsFromMappingsFile(TiXmlElement *xmlNode, std::map<std::string, PeripheralDeviceSetting> &m_settings);

--- a/xbmc/peripherals/addons/AddonButtonMapping.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMapping.cpp
@@ -29,9 +29,9 @@ using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 
-CAddonButtonMapping::CAddonButtonMapping(CPeripheral* peripheral, IButtonMapper* mapper)
+CAddonButtonMapping::CAddonButtonMapping(CPeripherals& manager, CPeripheral* peripheral, IButtonMapper* mapper)
 {
-  PeripheralAddonPtr addon = g_peripherals.GetAddonWithButtonMap(peripheral);
+  PeripheralAddonPtr addon = manager.GetAddonWithButtonMap(peripheral);
 
   if (!addon)
   {

--- a/xbmc/peripherals/addons/AddonButtonMapping.h
+++ b/xbmc/peripherals/addons/AddonButtonMapping.h
@@ -37,12 +37,13 @@ namespace JOYSTICK
 namespace PERIPHERALS
 {
   class CPeripheral;
+  class CPeripherals;
 
   class CAddonButtonMapping : public KODI::JOYSTICK::IDriverHandler,
                               public KODI::JOYSTICK::IButtonMapCallback
   {
   public:
-    CAddonButtonMapping(CPeripheral* peripheral, KODI::JOYSTICK::IButtonMapper* mapper);
+    CAddonButtonMapping(CPeripherals& manager, CPeripheral* peripheral, KODI::JOYSTICK::IButtonMapper* mapper);
 
     virtual ~CAddonButtonMapping(void);
 

--- a/xbmc/peripherals/addons/AddonInputHandling.cpp
+++ b/xbmc/peripherals/addons/AddonInputHandling.cpp
@@ -32,9 +32,9 @@ using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 
-CAddonInputHandling::CAddonInputHandling(CPeripheral* peripheral, IInputHandler* handler, IDriverReceiver* receiver)
+CAddonInputHandling::CAddonInputHandling(CPeripherals& manager, CPeripheral* peripheral, IInputHandler* handler, IDriverReceiver* receiver)
 {
-  PeripheralAddonPtr addon = g_peripherals.GetAddonWithButtonMap(peripheral);
+  PeripheralAddonPtr addon = manager.GetAddonWithButtonMap(peripheral);
 
   if (!addon)
   {

--- a/xbmc/peripherals/addons/AddonInputHandling.h
+++ b/xbmc/peripherals/addons/AddonInputHandling.h
@@ -37,12 +37,16 @@ namespace JOYSTICK
 namespace PERIPHERALS
 {
   class CPeripheral;
+  class CPeripherals;
 
   class CAddonInputHandling : public KODI::JOYSTICK::IDriverHandler,
                               public KODI::JOYSTICK::IInputReceiver
   {
   public:
-    CAddonInputHandling(CPeripheral* peripheral, KODI::JOYSTICK::IInputHandler* handler, KODI::JOYSTICK::IDriverReceiver* receiver);
+    CAddonInputHandling(CPeripherals& manager,
+                        CPeripheral* peripheral,
+                        KODI::JOYSTICK::IInputHandler* handler,
+                        KODI::JOYSTICK::IDriverReceiver* receiver);
 
     virtual ~CAddonInputHandling(void);
 

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -38,6 +38,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
+#include "ServiceBroker.h"
 
 #include <algorithm>
 #include <string.h>
@@ -96,7 +97,7 @@ void CPeripheralAddon::ResetProperties(void)
 
 ADDON::AddonPtr CPeripheralAddon::GetRunningInstance(void) const
 {
-  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(g_peripherals.GetBusByType(PERIPHERAL_BUS_ADDON));
+  PeripheralBusAddonPtr addonBus = std::static_pointer_cast<CPeripheralBusAddon>(CServiceBroker::GetPeripherals().GetBusByType(PERIPHERAL_BUS_ADDON));
   if (addonBus)
   {
     ADDON::AddonPtr peripheralAddon;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -79,20 +79,6 @@ CPeripheralAddon::CPeripheralAddon(ADDON::AddonProps props, bool bProvidesJoysti
 
 CPeripheralAddon::~CPeripheralAddon(void)
 {
-  // delete all peripherals provided by this addon
-  for (const auto& peripheral : m_peripherals)
-  {
-    if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_INPUT_CONTROLLERPOWEROFF))
-    {
-      // shutdown the joystick if it is supported
-      if (peripheral.second->Type() == PERIPHERAL_JOYSTICK)
-      {
-        std::shared_ptr<CPeripheralJoystick> joystick = std::static_pointer_cast<CPeripheralJoystick>(peripheral.second);
-        if (joystick->SupportsPowerOff())
-          PowerOffJoystick(peripheral.first);
-      }
-    }
-  }
   m_peripherals.clear();
 
   // only clear buttonMaps but don't delete them as they are owned by a CAddonJoystickInputHandling instance
@@ -712,6 +698,9 @@ void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::stri
 void CPeripheralAddon::PowerOffJoystick(unsigned int index)
 {
   if (!HasFeature(FEATURE_JOYSTICK))
+    return;
+
+  if (!SupportsFeature(FEATURE_POWER_OFF))
     return;
 
   m_struct.PowerOffJoystick(index);

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -25,6 +25,7 @@
 #include "input/joysticks/JoystickTypes.h"
 #include "peripherals/PeripheralTypes.h"
 #include "threads/CriticalSection.h"
+#include "threads/SharedSection.h"
 
 #include <map>
 #include <memory>
@@ -63,6 +64,11 @@ namespace PERIPHERALS
      * @brief Initialise the instance of this add-on
      */
     ADDON_STATUS CreateAddon(void);
+
+    /*!
+     * \brief Deinitialize the instance of this add-on
+     */
+    void DestroyAddon();
 
     bool         Register(unsigned int peripheralIndex, const PeripheralPtr& peripheral);
     void         UnregisterRemovedDevices(const PeripheralScanResults &results, PeripheralVector& removedPeripherals);
@@ -166,5 +172,7 @@ namespace PERIPHERALS
     
     PERIPHERAL_PROPERTIES m_info;
     KodiToAddonFuncTable_Peripheral m_struct;
+
+    CSharedSection      m_dllSection;
   };
 }

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -31,7 +31,7 @@ using namespace PERIPHERALS;
 
 #define PERIPHERAL_DEFAULT_RESCAN_INTERVAL 5000
 
-CPeripheralBus::CPeripheralBus(const std::string &threadname, CPeripherals *manager, PeripheralBusType type) :
+CPeripheralBus::CPeripheralBus(const std::string &threadname, CPeripherals& manager, PeripheralBusType type) :
     CThread(threadname.c_str()),
     m_iRescanTime(PERIPHERAL_DEFAULT_RESCAN_INTERVAL),
     m_bInitialised(false),
@@ -48,7 +48,7 @@ bool CPeripheralBus::InitializeProperties(CPeripheral& peripheral)
   if (peripheral.Type() == PERIPHERAL_JOYSTICK)
   {
     // Ensure an add-on is present to translate input
-    if (!g_peripherals.GetInstance().GetAddonWithButtonMap(&peripheral))
+    if (!m_manager.GetAddonWithButtonMap(&peripheral))
     {
       CLog::Log(LOGWARNING, "Button mapping add-on not present for %s (%s), skipping", peripheral.Location().c_str(), peripheral.DeviceName().c_str());
       return false;
@@ -118,7 +118,7 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults &resul
       peripheral->OnDeviceRemoved();
     }
 
-    m_manager->OnDeviceDeleted(*this, *peripheral);
+    m_manager.OnDeviceDeleted(*this, *peripheral);
   }
 }
 
@@ -128,7 +128,7 @@ void CPeripheralBus::RegisterNewDevices(const PeripheralScanResults &results)
   {
     const PeripheralScanResult& result = results.m_results.at(iResultPtr);
     if (!HasPeripheral(result.m_strLocation))
-      g_peripherals.CreatePeripheral(*this, result);
+      m_manager.CreatePeripheral(*this, result);
   }
 }
 
@@ -142,7 +142,7 @@ bool CPeripheralBus::ScanForDevices(void)
     UnregisterRemovedDevices(results);
     RegisterNewDevices(results);
 
-    CPeripherals::GetInstance().NotifyObservers(ObservableMessagePeripheralsChanged);
+    m_manager.NotifyObservers(ObservableMessagePeripheralsChanged);
 
     bReturn = true;
   }
@@ -283,7 +283,7 @@ void CPeripheralBus::Register(const PeripheralPtr& peripheral)
   if (bPeripheralAdded)
   {
     CLog::Log(LOGNOTICE, "%s - new %s device registered on %s->%s: %s (%s:%s)", __FUNCTION__, PeripheralTypeTranslator::TypeToString(peripheral->Type()), PeripheralTypeTranslator::BusTypeToString(m_type), peripheral->Location().c_str(), peripheral->DeviceName().c_str(), peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
-    m_manager->OnDeviceAdded(*this, *peripheral);
+    m_manager.OnDeviceAdded(*this, *peripheral);
   }
 }
 

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -174,6 +174,12 @@ namespace PERIPHERALS
     */
     virtual bool EnableButtonMapping() { return false; }
 
+    /*!
+     * \brief Power off the specified device
+     * \param strLocation The device's location
+     */
+    virtual void PowerOff(const std::string& strLocation) { }
+
   protected:
     virtual void Process(void);
     virtual bool ScanForDevices(void);

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -43,7 +43,7 @@ namespace PERIPHERALS
   class CPeripheralBus : protected CThread
   {
   public:
-    CPeripheralBus(const std::string &threadname, CPeripherals *manager, PeripheralBusType type);
+    CPeripheralBus(const std::string &threadname, CPeripherals& manager, PeripheralBusType type);
     virtual ~CPeripheralBus(void) { Clear(); }
 
     /*!
@@ -198,7 +198,7 @@ namespace PERIPHERALS
     bool                       m_bInitialised;
     bool                       m_bIsStarted;
     bool                       m_bNeedsPolling; /*!< true when this bus needs to be polled for new devices, false when it uses callbacks to notify this bus of changed */
-    CPeripherals *const        m_manager;
+    CPeripherals&              m_manager;
     const PeripheralBusType    m_type;
     CCriticalSection           m_critSection;
     CEvent                     m_triggerEvent;

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.cpp
@@ -36,7 +36,7 @@ using namespace PERIPHERALS;
 
 static const std::string DeviceLocationPrefix = "android/inputdevice/";
 
-CPeripheralBusAndroid::CPeripheralBusAndroid(CPeripherals *manager) :
+CPeripheralBusAndroid::CPeripheralBusAndroid(CPeripherals& manager) :
     CPeripheralBus("PeripBusAndroid", manager, PERIPHERAL_BUS_ANDROID)
 {
   // we don't need polling as we get notified through the IInputDeviceCallbacks interface

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
@@ -38,7 +38,7 @@ namespace PERIPHERALS
                                 public IInputDeviceEventHandler
   {
   public:
-    CPeripheralBusAndroid(CPeripherals *manager);
+    CPeripheralBusAndroid(CPeripherals& manager);
     virtual ~CPeripheralBusAndroid();
 
     // specialisation of CPeripheralBus

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.cpp
@@ -26,7 +26,7 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
+CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
     CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   usb_init();

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.h
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.h
@@ -31,7 +31,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals *manager);
+    CPeripheralBusUSB(CPeripherals& manager);
 
     /*!
      * @see PeripheralBus::PerformDeviceScan()

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
@@ -76,7 +76,7 @@ extern "C" {
 
 using namespace PERIPHERALS;
 
-CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
+CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
     CPeripheralBus("PeripBusUSBUdev", manager, PERIPHERAL_BUS_USB)
 {
   /* the Process() method in this class overrides the one in CPeripheralBus, so leave this set to true */

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.h
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.h
@@ -32,7 +32,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals *manager);
+    CPeripheralBusUSB(CPeripherals& manager);
     virtual ~CPeripheralBusUSB(void);
 
     virtual void Clear(void);

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.cpp
@@ -42,7 +42,7 @@ typedef struct USBDevicePrivateData {
 } USBDevicePrivateData;
 #endif
 
-CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
+CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
     CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   m_bNeedsPolling = false;

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.h
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.h
@@ -34,7 +34,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals *manager);
+    CPeripheralBusUSB(CPeripherals& manager);
     virtual ~CPeripheralBusUSB();
 
     /*!

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -225,6 +225,14 @@ bool CPeripheralBusAddon::EnableButtonMapping()
   return bEnabled;
 }
 
+void CPeripheralBusAddon::PowerOff(const std::string& strLocation)
+{
+  PeripheralAddonPtr addon;
+  unsigned int peripheralIndex;
+  if (SplitLocation(strLocation, addon, peripheralIndex))
+    addon->PowerOffJoystick(peripheralIndex);
+}
+
 void CPeripheralBusAddon::UnregisterRemovedDevices(const PeripheralScanResults &results)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -34,7 +34,7 @@
 using namespace KODI;
 using namespace PERIPHERALS;
 
-CPeripheralBusAddon::CPeripheralBusAddon(CPeripherals *manager) :
+CPeripheralBusAddon::CPeripheralBusAddon(CPeripherals& manager) :
     CPeripheralBus("PeripBusAddon", manager, PERIPHERAL_BUS_ADDON)
 {
   using namespace ADDON;
@@ -243,7 +243,7 @@ void CPeripheralBusAddon::UnregisterRemovedDevices(const PeripheralScanResults &
     addon->UnregisterRemovedDevices(results, removedPeripherals);
 
   for (const auto& peripheral : removedPeripherals)
-    m_manager->OnDeviceDeleted(*this, *peripheral);
+    m_manager.OnDeviceDeleted(*this, *peripheral);
 }
 
 void CPeripheralBusAddon::Register(const PeripheralPtr& peripheral)
@@ -259,7 +259,7 @@ void CPeripheralBusAddon::Register(const PeripheralPtr& peripheral)
   if (SplitLocation(peripheral->Location(), addon, peripheralIndex))
   {
     if (addon->Register(peripheralIndex, peripheral))
-      m_manager->OnDeviceAdded(*this, *peripheral);
+      m_manager.OnDeviceAdded(*this, *peripheral);
   }
 }
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -57,7 +57,7 @@ CPeripheralBusAddon::~CPeripheralBusAddon()
 
   // destroy any (loaded) addons
   for (const auto& addon : m_addons)
-    addon->Destroy();
+    addon->DestroyAddon();
 
   m_failedAddons.clear();
   m_addons.clear();
@@ -509,7 +509,7 @@ void CPeripheralBusAddon::UpdateAddons(void)
     if (erased)
     {
       CSingleExit exit(m_critSection);
-      erased->Destroy();
+      erased->DestroyAddon();
     }
   }
 }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -84,6 +84,7 @@ namespace PERIPHERALS
     virtual void         GetDirectory(const std::string &strPath, CFileItemList &items) const override;
     virtual void         ProcessEvents(void) override;
     virtual bool         EnableButtonMapping() override;
+    virtual void         PowerOff(const std::string& strLocation) override;
 
     // implementation of IAddonMgrCallback
     bool RequestRestart(ADDON::AddonPtr addon, bool datachanged) override;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -37,7 +37,7 @@ namespace PERIPHERALS
                               public ADDON::IAddonMgrCallback
   {
   public:
-    CPeripheralBusAddon(CPeripherals *manager);
+    CPeripheralBusAddon(CPeripherals& manager);
     virtual ~CPeripheralBusAddon(void);
 
     void UpdateAddons(void);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
@@ -26,7 +26,7 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralBusApplication::CPeripheralBusApplication(CPeripherals* manager) :
+CPeripheralBusApplication::CPeripheralBusApplication(CPeripherals& manager) :
     CPeripheralBus("PeripBusApplication", manager, PERIPHERAL_BUS_APPLICATION)
 {
   // Initialize CPeripheralBus

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
@@ -32,7 +32,7 @@ namespace PERIPHERALS
   class CPeripheralBusApplication : public CPeripheralBus
   {
   public:
-    CPeripheralBusApplication(CPeripherals* manager);
+    CPeripheralBusApplication(CPeripherals& manager);
     virtual ~CPeripheralBusApplication(void) { }
 
     // implementation of CPeripheralBus

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -50,7 +50,7 @@ class PERIPHERALS::DllLibCEC : public DllDynamic, DllLibCECInterface
   END_METHOD_RESOLVE()
 };
 
-CPeripheralBusCEC::CPeripheralBusCEC(CPeripherals *manager) :
+CPeripheralBusCEC::CPeripheralBusCEC(CPeripherals& manager) :
     CPeripheralBus("PeripBusCEC", manager, PERIPHERAL_BUS_CEC),
     m_dll(new DllLibCEC),
     m_cecAdapter(NULL)

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.h
@@ -40,7 +40,7 @@ namespace PERIPHERALS
   class CPeripheralBusCEC : public CPeripheralBus
   {
   public:
-    CPeripheralBusCEC(CPeripherals *manager);
+    CPeripheralBusCEC(CPeripherals& manager);
     virtual ~CPeripheralBusCEC(void);
 
     /*!

--- a/xbmc/peripherals/bus/win32/PeripheralBusUSB.cpp
+++ b/xbmc/peripherals/bus/win32/PeripheralBusUSB.cpp
@@ -34,7 +34,7 @@ using namespace PERIPHERALS;
 // Only to avoid endless loops while scanning for devices
 #define MAX_BUS_DEVICES 2000
 
-CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
+CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
     CPeripheralBus("PeripBusUSB", manager, PERIPHERAL_BUS_USB)
 {
   /* device removals aren't always triggering OnDeviceRemoved events, so poll for changes every 5 seconds to be sure we don't miss anything */

--- a/xbmc/peripherals/bus/win32/PeripheralBusUSB.h
+++ b/xbmc/peripherals/bus/win32/PeripheralBusUSB.h
@@ -29,7 +29,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals *manager);
+    CPeripheralBusUSB(CPeripherals& manager);
 
     /*!
      * @see PeripheralBus::PerformDeviceScan()

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -50,7 +50,8 @@ struct SortBySettingsOrder
   }
 };
 
-CPeripheral::CPeripheral(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+CPeripheral::CPeripheral(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  m_manager(manager),
   m_type(scanResult.m_mappedType),
   m_busType(scanResult.m_busType),
   m_mappedBusType(scanResult.m_mappedBusType),
@@ -151,7 +152,7 @@ bool CPeripheral::Initialise(void)
   if (m_bInitialised)
     return bReturn;
 
-  g_peripherals.GetSettingsFromMapping(*this);
+  m_manager.GetSettingsFromMapping(*this);
 
   std::string safeDeviceName = m_strDeviceName;
   StringUtils::Replace(safeDeviceName, ' ', '_');
@@ -543,7 +544,7 @@ void CPeripheral::LoadPersistedSettings(void)
 void CPeripheral::ResetDefaultSettings(void)
 {
   ClearSettings();
-  g_peripherals.GetSettingsFromMapping(*this);
+  m_manager.GetSettingsFromMapping(*this);
 
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.begin();
   while (it != m_settings.end())
@@ -571,7 +572,7 @@ void CPeripheral::RegisterJoystickInputHandler(IInputHandler* handler)
   auto it = m_inputHandlers.find(handler);
   if (it == m_inputHandlers.end())
   {
-    CAddonInputHandling* addonInput = new CAddonInputHandling(this, handler, GetDriverReceiver());
+    CAddonInputHandling* addonInput = new CAddonInputHandling(m_manager, this, handler, GetDriverReceiver());
     RegisterJoystickDriverHandler(addonInput, false);
     m_inputHandlers[handler].reset(addonInput);
   }
@@ -594,7 +595,7 @@ void CPeripheral::RegisterJoystickButtonMapper(IButtonMapper* mapper)
   std::map<IButtonMapper*, IDriverHandler*>::iterator it = m_buttonMappers.find(mapper);
   if (it == m_buttonMappers.end())
   {
-    IDriverHandler* addonMapping = new CAddonButtonMapping(this, mapper);
+    IDriverHandler* addonMapping = new CAddonButtonMapping(m_manager, this, mapper);
     RegisterJoystickDriverHandler(addonMapping, false);
     m_buttonMappers[mapper] = addonMapping;
   }

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -44,6 +44,7 @@ namespace PERIPHERALS
 {
   class CGUIDialogPeripheralSettings;
   class CPeripheralBus;
+  class CPeripherals;
 
   typedef enum
   {
@@ -57,7 +58,7 @@ namespace PERIPHERALS
     friend class CGUIDialogPeripheralSettings;
 
   public:
-    CPeripheral(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheral(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheral(void);
 
     bool operator ==(const CPeripheral &right) const;
@@ -211,6 +212,7 @@ namespace PERIPHERALS
   protected:
     virtual void ClearSettings(void);
 
+    CPeripherals&                    m_manager;
     PeripheralType                   m_type;
     PeripheralBusType                m_busType;
     PeripheralBusType                m_mappedBusType;

--- a/xbmc/peripherals/devices/PeripheralBluetooth.cpp
+++ b/xbmc/peripherals/devices/PeripheralBluetooth.cpp
@@ -22,8 +22,8 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralBluetooth::CPeripheralBluetooth(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus)
+CPeripheralBluetooth::CPeripheralBluetooth(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus)
 {
   m_features.push_back(FEATURE_BLUETOOTH);
 }

--- a/xbmc/peripherals/devices/PeripheralBluetooth.h
+++ b/xbmc/peripherals/devices/PeripheralBluetooth.h
@@ -26,7 +26,7 @@ namespace PERIPHERALS
   class CPeripheralBluetooth : public CPeripheral
   {
   public:
-    CPeripheralBluetooth(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralBluetooth(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralBluetooth(void) {};
   };
 }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -87,8 +87,8 @@ class DllLibCEC : public DllDynamic, DllLibCECInterface
   END_METHOD_RESOLVE()
 };
 
-CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheralHID(scanResult, bus),
+CPeripheralCecAdapter::CPeripheralCecAdapter(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheralHID(manager, scanResult, bus),
   CThread("CECAdapter"),
   m_dll(NULL),
   m_cecAdapter(NULL)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -91,7 +91,7 @@ namespace PERIPHERALS
     friend class CPeripheralCecAdapterReopenJob;
 
   public:
-    CPeripheralCecAdapter(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralCecAdapter(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralCecAdapter(void);
 
     void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);

--- a/xbmc/peripherals/devices/PeripheralDisk.cpp
+++ b/xbmc/peripherals/devices/PeripheralDisk.cpp
@@ -23,8 +23,8 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralDisk::CPeripheralDisk(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus)
+CPeripheralDisk::CPeripheralDisk(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus)
 {
   m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35003) : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_DISK);

--- a/xbmc/peripherals/devices/PeripheralDisk.h
+++ b/xbmc/peripherals/devices/PeripheralDisk.h
@@ -26,7 +26,7 @@ namespace PERIPHERALS
   class CPeripheralDisk : public CPeripheral
   {
   public:
-    CPeripheralDisk(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralDisk(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralDisk(void) {};
   };
 }

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -25,8 +25,8 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralHID::CPeripheralHID(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus)
+CPeripheralHID::CPeripheralHID(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus)
 {
   m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35001) : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_HID);

--- a/xbmc/peripherals/devices/PeripheralHID.h
+++ b/xbmc/peripherals/devices/PeripheralHID.h
@@ -27,7 +27,7 @@ namespace PERIPHERALS
   class CPeripheralHID : public CPeripheral
   {
   public:
-    CPeripheralHID(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralHID(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralHID(void);
     virtual bool InitialiseFeature(const PeripheralFeature feature);
     virtual bool LookupSymAndUnicode(XBMC_keysym &keysym, uint8_t *key, char *unicode) { return false; }

--- a/xbmc/peripherals/devices/PeripheralImon.cpp
+++ b/xbmc/peripherals/devices/PeripheralImon.cpp
@@ -28,8 +28,8 @@ using namespace PERIPHERALS;
 std::atomic<long> CPeripheralImon::m_lCountOfImonsConflictWithDInput(0L);
 
 
-CPeripheralImon::CPeripheralImon(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheralHID(scanResult, bus)
+CPeripheralImon::CPeripheralImon(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheralHID(manager, scanResult, bus)
 {
   m_features.push_back(FEATURE_IMON);
   m_bImonConflictsWithDInput = false;

--- a/xbmc/peripherals/devices/PeripheralImon.h
+++ b/xbmc/peripherals/devices/PeripheralImon.h
@@ -30,7 +30,7 @@ namespace PERIPHERALS
   class CPeripheralImon : public CPeripheralHID
   {
   public:
-    CPeripheralImon(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralImon(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralImon(void) {}
     virtual bool InitialiseFeature(const PeripheralFeature feature);
     virtual void OnSettingChanged(const std::string &strChangedSetting);

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -127,11 +127,23 @@ bool CPeripheralJoystick::TestFeature(PeripheralFeature feature)
   case FEATURE_RUMBLE:
     bSuccess = m_defaultInputHandler.TestRumble();
     break;
+  case FEATURE_POWER_OFF:
+    if (m_supportsPowerOff)
+    {
+      PowerOff();
+      bSuccess = true;
+    }
+    break;
   default:
     break;
   }
 
   return bSuccess;
+}
+
+void CPeripheralJoystick::PowerOff()
+{
+  m_bus->PowerOff(m_strLocation);
 }
 
 void CPeripheralJoystick::RegisterJoystickDriverHandler(IDriverHandler* handler, bool bPromiscuous)

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -33,8 +33,8 @@ using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 
-CPeripheralJoystick::CPeripheralJoystick(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus),
+CPeripheralJoystick::CPeripheralJoystick(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus),
   m_requestedPort(JOYSTICK_PORT_UNKNOWN),
   m_buttonCount(0),
   m_hatCount(0),
@@ -93,7 +93,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralJoystick::InitializeDeadzoneFiltering()
 {
   // Get a button map for deadzone filtering
-  PeripheralAddonPtr addon = g_peripherals.GetAddonWithButtonMap(this);
+  PeripheralAddonPtr addon = m_manager.GetAddonWithButtonMap(this);
   if (addon)
   {
     m_buttonMap.reset(new CAddonButtonMap(this, addon, DEFAULT_CONTROLLER_ID));

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -44,11 +44,13 @@ namespace JOYSTICK
 
 namespace PERIPHERALS
 {
+  class CPeripherals;
+
   class CPeripheralJoystick : public CPeripheral, //! @todo extend CPeripheralHID
                               public KODI::JOYSTICK::IDriverReceiver
   {
   public:
-    CPeripheralJoystick(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralJoystick(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
 
     virtual ~CPeripheralJoystick(void);
 

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -108,6 +108,8 @@ namespace PERIPHERALS
   protected:
     void InitializeDeadzoneFiltering();
 
+    void PowerOff();
+
     struct DriverHandler
     {
       KODI::JOYSTICK::IDriverHandler* handler;

--- a/xbmc/peripherals/devices/PeripheralJoystickEmulation.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystickEmulation.cpp
@@ -28,8 +28,8 @@
 using namespace KODI;
 using namespace PERIPHERALS;
 
-CPeripheralJoystickEmulation::CPeripheralJoystickEmulation(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus)
+CPeripheralJoystickEmulation::CPeripheralJoystickEmulation(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus)
 {
   m_features.push_back(FEATURE_JOYSTICK);
 }

--- a/xbmc/peripherals/devices/PeripheralJoystickEmulation.h
+++ b/xbmc/peripherals/devices/PeripheralJoystickEmulation.h
@@ -29,7 +29,7 @@ namespace PERIPHERALS
                                        public KODI::KEYBOARD::IKeyboardHandler
   {
   public:
-    CPeripheralJoystickEmulation(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralJoystickEmulation(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
 
     virtual ~CPeripheralJoystickEmulation(void);
 

--- a/xbmc/peripherals/devices/PeripheralNIC.cpp
+++ b/xbmc/peripherals/devices/PeripheralNIC.cpp
@@ -23,8 +23,8 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralNIC::CPeripheralNIC(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus)
+CPeripheralNIC::CPeripheralNIC(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus)
 {
   m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35002) : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_NIC);

--- a/xbmc/peripherals/devices/PeripheralNIC.h
+++ b/xbmc/peripherals/devices/PeripheralNIC.h
@@ -26,7 +26,7 @@ namespace PERIPHERALS
   class CPeripheralNIC : public CPeripheral
   {
   public:
-    CPeripheralNIC(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralNIC(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralNIC(void) {};
   };
 }

--- a/xbmc/peripherals/devices/PeripheralNyxboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralNyxboard.cpp
@@ -25,8 +25,8 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralNyxboard::CPeripheralNyxboard(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheralHID(scanResult, bus)
+CPeripheralNyxboard::CPeripheralNyxboard(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheralHID(manager, scanResult, bus)
 {
   m_features.push_back(FEATURE_NYXBOARD);
 }

--- a/xbmc/peripherals/devices/PeripheralNyxboard.h
+++ b/xbmc/peripherals/devices/PeripheralNyxboard.h
@@ -26,7 +26,7 @@ namespace PERIPHERALS
   class CPeripheralNyxboard : public CPeripheralHID
   {
   public:
-    CPeripheralNyxboard(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralNyxboard(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralNyxboard(void) {};
     virtual bool LookupSymAndUnicode(XBMC_keysym &keysym, uint8_t *key, char *unicode);
   };

--- a/xbmc/peripherals/devices/PeripheralTuner.cpp
+++ b/xbmc/peripherals/devices/PeripheralTuner.cpp
@@ -22,8 +22,8 @@
 
 using namespace PERIPHERALS;
 
-CPeripheralTuner::CPeripheralTuner(const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
-  CPeripheral(scanResult, bus)
+CPeripheralTuner::CPeripheralTuner(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus) :
+  CPeripheral(manager, scanResult, bus)
 {
   m_features.push_back(FEATURE_TUNER);
 }

--- a/xbmc/peripherals/devices/PeripheralTuner.h
+++ b/xbmc/peripherals/devices/PeripheralTuner.h
@@ -26,7 +26,7 @@ namespace PERIPHERALS
   class CPeripheralTuner : public CPeripheral
   {
   public:
-    CPeripheralTuner(const PeripheralScanResult& scanResult, CPeripheralBus* bus);
+    CPeripheralTuner(CPeripherals& manager, const PeripheralScanResult& scanResult, CPeripheralBus* bus);
     virtual ~CPeripheralTuner(void) {};
   };
 }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -30,6 +30,7 @@
 #include "settings/lib/SettingSection.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
+#include "ServiceBroker.h"
 
 using namespace PERIPHERALS;
 
@@ -91,7 +92,7 @@ void CGUIDialogPeripheralSettings::Save()
   if (m_item == NULL || m_initialising)
     return;
 
-  PeripheralPtr peripheral = g_peripherals.GetByPath(m_item->GetPath());
+  PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
   if (!peripheral)
     return;
 
@@ -103,7 +104,7 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   if (m_item == NULL)
     return;
 
-  PeripheralPtr peripheral = g_peripherals.GetByPath(m_item->GetPath());
+  PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
   if (!peripheral)
     return;
 
@@ -138,7 +139,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
   m_initialising = true;
   bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
 
-  PeripheralPtr peripheral = g_peripherals.GetByPath(m_item->GetPath());
+  PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
   if (!peripheral)
   {
     CLog::Log(LOGDEBUG, "%s - no peripheral", __FUNCTION__);

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -32,7 +32,6 @@
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "guilib/LocalizeStrings.h"
 #include "peripherals/Peripherals.h"
-#include "peripherals/bus/virtual/PeripheralBusAddon.h"
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRGUIActions.h"
 #include "settings/SettingAddon.h"
@@ -45,6 +44,7 @@
 #if defined(TARGET_DARWIN_OSX)
 #include "platform/darwin/DarwinUtils.h"
 #endif// defined(TARGET_DARWIN_OSX)
+#include "ServiceBroker.h"
 
 bool AddonHasSettings(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
@@ -77,28 +77,22 @@ bool CheckPVRParentalPin(const std::string &condition, const std::string &value,
 
 bool HasPeripherals(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
-  return PERIPHERALS::g_peripherals.GetNumberOfPeripherals() > 0;
+  return CServiceBroker::GetPeripherals().GetNumberOfPeripherals() > 0;
 }
 
 bool HasRumbleFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
-  using namespace PERIPHERALS;
-
-  return g_peripherals.SupportsFeature(FEATURE_RUMBLE);
+  return CServiceBroker::GetPeripherals().SupportsFeature(PERIPHERALS::FEATURE_RUMBLE);
 }
 
 bool HasRumbleController(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
-  using namespace PERIPHERALS;
-
-  return g_peripherals.HasPeripheralWithFeature(FEATURE_RUMBLE);
+  return CServiceBroker::GetPeripherals().HasPeripheralWithFeature(PERIPHERALS::FEATURE_RUMBLE);
 }
 
 bool HasPowerOffFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
-  using namespace PERIPHERALS;
-
-  return g_peripherals.SupportsFeature(FEATURE_POWER_OFF);
+  return CServiceBroker::GetPeripherals().SupportsFeature(PERIPHERALS::FEATURE_POWER_OFF);
 }
 
 bool IsFullscreen(const std::string &condition, const std::string &value, const CSetting *setting, void *data)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -85,6 +85,7 @@
 #include "utils/Variant.h"
 #include "view/ViewStateSettings.h"
 #include "input/InputManager.h"
+#include "ServiceBroker.h"
 
 #define SETTINGS_XML_FOLDER "special://xbmc/system/settings/"
 #define SETTINGS_XML_ROOT   "settings"
@@ -1183,7 +1184,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_INPUT_CONTROLLERCONFIG);
   settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
   settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
-  m_settingsManager->RegisterCallback(&PERIPHERALS::CPeripherals::GetInstance(), settingSet);
+  m_settingsManager->RegisterCallback(&CServiceBroker::GetPeripherals(), settingSet);
 
 #if defined(TARGET_DARWIN_OSX)
   settingSet.clear();
@@ -1244,7 +1245,7 @@ void CSettings::UninitializeISettingCallbacks()
   m_settingsManager->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)
   m_settingsManager->UnregisterCallback(&g_weatherManager);
-  m_settingsManager->UnregisterCallback(&PERIPHERALS::CPeripherals::GetInstance());
+  m_settingsManager->UnregisterCallback(&CServiceBroker::GetPeripherals());
 #if defined(TARGET_DARWIN_OSX)
   m_settingsManager->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif

--- a/xbmc/windowing/WinEvents.cpp
+++ b/xbmc/windowing/WinEvents.cpp
@@ -21,6 +21,7 @@
 #include "WinEvents.h"
 #include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
+#include "ServiceBroker.h"
 
 #if   defined(TARGET_WINDOWS)
 #include "windows/WinEventsWin32.h"
@@ -64,7 +65,7 @@ void Init()
   CSingleLock lock(g_lock);
   if (!g_init)
   {
-    PERIPHERALS::CPeripherals::GetInstance().RegisterObserver(&g_imp);
+    CServiceBroker::GetPeripherals().RegisterObserver(&g_imp);
     g_init = true;
   }
 }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -50,10 +50,10 @@
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "messaging/ApplicationMessenger.h"
+#include "ServiceBroker.h"
 
 #ifdef TARGET_WINDOWS
 
-using namespace PERIPHERALS;
 using namespace KODI::MESSAGING;
 
 HWND g_hWnd = NULL;
@@ -794,13 +794,13 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         switch(wParam)
         {
           case DBT_DEVNODES_CHANGED:
-            g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
+            CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_USB);
             break;
           case DBT_DEVICEARRIVAL:
           case DBT_DEVICEREMOVECOMPLETE:
             if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
             {
-              g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
+              CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_USB);
             }
             // check if an usb or optical media was inserted or removed
             if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_VOLUME)


### PR DESCRIPTION
This fixes a segfault at exit when peripheral add-ons misbehave. In particular, if the add-on hangs in another thread, then it can be destroyed while still in use. This was causing a segfault on exit.

Another segfault (or possibly the same one) has been fixed by moving g_peripherals to ServiceManager. Before, it tried to release resources when the static object was deconstructed after the app shut down.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
