### PR TITLE
[cmake] [backport #11585] Tidy up ffmpeg in order to be more flexible and versatile. 

### DIFF
--- a/project/cmake/modules/FindFFMPEG.cmake
+++ b/project/cmake/modules/FindFFMPEG.cmake
@@ -235,14 +235,10 @@ if(NOT FFMPEG_FOUND)
                    -DPKG_CONFIG_EXECUTABLE=${PKG_CONFIG_EXECUTABLE}
                    -DCROSSCOMPILING=${CMAKE_CROSSCOMPILING}
                    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-                   -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
-                   -DCPU=${WITH_CPU}
                    -DOS=${OS}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_AR=${CMAKE_AR}
-                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                   -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS})
+                   -DCMAKE_AR=${CMAKE_AR})
   endif()
 
   externalproject_add(ffmpeg
@@ -254,6 +250,11 @@ if(NOT FFMPEG_FOUND)
                                  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                                  -DFFMPEG_VER=${FFMPEG_VER}
                                  -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
+                                 -DCPU=${CPU}
+                                 -DENABLE_NEON=${ENABLE_NEON}
+                                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                                 -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                                 -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
                                  ${CROSS_ARGS}
                       PATCH_COMMAND ${CMAKE_COMMAND} -E copy
                                     ${CORE_SOURCE_DIR}/tools/depends/target/ffmpeg/CMakeLists.txt

--- a/project/cmake/scripts/android/ArchSetup.cmake
+++ b/project/cmake/scripts/android/ArchSetup.cmake
@@ -25,9 +25,6 @@ else()
   endif()
 endif()
 
-set(FFMPEG_OPTS --enable-cross-compile --cpu=cortex-a9 --arch=arm --target-os=linux --enable-neon
-                --disable-vdpau --cc=${CMAKE_C_COMPILER} --host-cc=${CMAKE_C_COMPILER}
-                --strip=${CMAKE_STRIP})
 set(ENABLE_SDL OFF CACHE BOOL "" FORCE)
 set(ENABLE_X11 OFF CACHE BOOL "" FORCE)
 set(ENABLE_AML OFF CACHE BOOL "" FORCE)

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -11,8 +11,27 @@ if(CROSSCOMPILING)
   list(APPEND ffmpeg_conf --pkg-config=${PKG_CONFIG_EXECUTABLE} --pkg-config-flags=--static)
   list(APPEND ffmpeg_conf --enable-cross-compile --cpu=${CPU} --arch=${CPU} --target-os=${OS})
   list(APPEND ffmpeg_conf --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER} --ar=${CMAKE_AR})
-  list(APPEND ffmpeg_conf --extra-cflags=${CMAKE_C_FLAGS} --extra-cxxflags=${CMAKE_CXX_FLAGS} --extra-ldflags=${CMAKE_EXE_LINKER_FLAGS})
   message(STATUS "CROSS: ${ffmpeg_conf}")
+endif()
+
+if(CMAKE_C_FLAGS)
+  list(APPEND ffmpeg_conf --extra-cflags=${CMAKE_C_FLAGS})
+endif()
+
+if(CMAKE_CXX_FLAGS)
+  list(APPEND ffmpeg_conf --extra-cxxflags=${CMAKE_CXX_FLAGS})
+endif()
+
+if(CMAKE_EXE_LINKER_FLAGS)
+  list(APPEND ffmpeg_conf --extra-ldflags=${CMAKE_EXE_LINKER_FLAGS})
+endif()
+
+if(ENABLE_NEON)
+  list(APPEND ffmpeg_conf --enable-neon)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL Release)
+  list(APPEND ffmpeg_conf --disable-debug)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd)
@@ -37,9 +56,11 @@ elseif(CORE_SYSTEM_NAME STREQUAL osx)
                           --disable-decoder=mpeg_xvmc --disable-vda --disable-crystalhd --enable-videotoolbox
                           --target-os=darwin
                           --disable-securetransport)
+elseif(CORE_SYSTEM_NAME STREQUAL rbpi)
+  list(APPEND ffmpeg_conf --cpu=${CPU} --disable-vaapi --disable-vdpau)
 endif()
 
-if(CPU MATCHES arm)
+if(CPU MATCHES arm OR CORE_SYSTEM_NAME STREQUAL rbpi)
   list(APPEND ffmpeg_conf --enable-pic --disable-armv5te --disable-armv6t2)
 elseif(CPU MATCHES mips)
   list(APPEND ffmpeg_conf --disable-mips32r2 --disable-mipsdspr1 --disable-mipsdspr2)
@@ -49,6 +70,8 @@ find_package(GnuTls)
 if(GNUTLS_FOUND)
   list(APPEND ffmpeg_conf --enable-gnutls)
 endif()
+
+message(STATUS "FFMPEG_CONF: ${ffmpeg_conf}")
 
 include(ExternalProject)
 externalproject_add(ffmpeg


### PR DESCRIPTION
Backport of #11585 