### PR TITLE
[depends] libfmt: remove BASE_URL pointing to github

### DIFF
--- a/tools/depends/target/libfmt/Makefile
+++ b/tools/depends/target/libfmt/Makefile
@@ -22,7 +22,7 @@ else
     TARBALLS_LOCATION = $(ROOT_DIR)
     RETRIEVE_TOOL := curl
     ARCHIVE_TOOL := tar --strip-components=1 -xf
-    CMAKE := cmake
+    CMAKE := cmake -DCMAKE_INSTALL_PREFIX=$(PREFIX)
   endif
 endif
 

--- a/tools/depends/target/libfmt/Makefile
+++ b/tools/depends/target/libfmt/Makefile
@@ -4,7 +4,6 @@ DEPS = Makefile
 # lib name, version
 LIBNAME=fmt
 VERSION=3.0.1
-BASE_URL=https://github.com/fmtlib/fmt/archive
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
I just realized that I uploaded the win32 deps archive but not the one for depends builds and that the `Makefile` still pointed to github. I have uploaded `fmt-3.0.1.tar.gz` to our mirrors.