### PR TITLE
[linuxinput] map KEY_SLEEP to power

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -228,6 +228,7 @@ KeyMap keyMap[] = {
   { KEY_VOLUMEDOWN    , XBMCK_VOLUME_DOWN },
   { KEY_VOLUMEUP      , XBMCK_VOLUME_UP   },
   { KEY_POWER         , XBMCK_POWER       },
+  { KEY_SLEEP         , XBMCK_POWER       },
   { KEY_KPEQUAL       , XBMCK_KP_EQUALS   },
   { KEY_PAUSE         , XBMCK_PAUSE       },
   { KEY_PAUSECD       , XBMCK_PAUSE       },


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
on some remotes there is a power button that sends KEY_SLEEP instead of KEY_POWER. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
this trivial change makes this key work ootb

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

runtime tested with Rii i25 mini remote.

before this PR:
```
DEBUG: CLinuxInputDevice::KeyEvent: TranslateKey returned XBMCK_UNKNOWN from code(142)
```
after this PR:
```
DEBUG: Keyboard: scancode: 0x8e, sym: 0x0140, unicode: 0x0000, modifier: 0x0
DEBUG: OnKey: power (0xf0de) pressed, action is ActivateWindow(ShutdownMenu)
DEBUG: Activating window ID: 10111
```
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
