### PR TITLE
[jenkins][windows] don't remove previous compiled version of ffmpeg & libdvd if nothing changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ testMain
 config.cache
 config.status
 config.log
+.last_success_revision
 *.d
 *.depend
 *.pc

--- a/tools/buildsteps/win32/buildffmpeg.sh
+++ b/tools/buildsteps/win32/buildffmpeg.sh
@@ -12,6 +12,17 @@ FFMPEG_TARGET_OS=mingw32
 do_loaddeps $FFMPEG_VERSION_FILE
 FFMPEGDESTDIR=/xbmc/lib/win32/$LIBNAME
 
+if [ "$(pathChanged $FFMPEGDESTDIR $FFMPEG_VERSION_FILE /xbmc/project/BuildDependencies/DownloadMingwBuildEnv.bat /xbmc/tools/buildsteps/win32)" == "0" ]
+then
+  cp $FFMPEGDESTDIR/bin/*.dll /xbmc/system/
+  if [ -f $BGPROCESSFILE ]; then
+    rm $BGPROCESSFILE
+  fi
+  exit
+else
+  git clean -dffx $FFMPEGDESTDIR
+fi
+
 do_getFFmpegConfig() {
   if [[ -f "$FFMPEG_CONFIG_FILE" ]]; then
     FFMPEG_OPTS_SHARED="$FFMPEG_BASE_OPTS $(cat "$FFMPEG_CONFIG_FILE" | sed -e 's:\\::g' -e 's/#.*//')"
@@ -148,7 +159,8 @@ do_print_status "$LIBNAME-$VERSION (${BITS})" "$blue_color" "Configuring"
   --extra-cflags="$extra_cflags" --extra-ldflags="$extra_ldflags"
 
 do_makelib &&
-cp $FFMPEGDESTDIR/bin/*.dll /xbmc/system/
+cp $FFMPEGDESTDIR/bin/*.dll /xbmc/system/ &&
+tagSuccessFulBuild $FFMPEGDESTDIR $FFMPEG_VERSION_FILE /xbmc/project/BuildDependencies/DownloadMingwBuildEnv.bat /xbmc/tools/buildsteps/win32
 
 #remove the bgprocessfile for signaling the process end
 if [ -f $BGPROCESSFILE ]; then

--- a/tools/buildsteps/win32/buildlibdvd.sh
+++ b/tools/buildsteps/win32/buildlibdvd.sh
@@ -7,6 +7,18 @@ LIBDVDPREFIX=/xbmc/lib/libdvd
 PKG_CONFIG_PATH=$LIBDVDPREFIX/lib/pkgconfig
 export PKG_CONFIG_PATH
 
+if [ "$(pathChanged $LIBDVDPREFIX /xbmc/tools/depends/target/libdvdcss/DVDCSS-VERSION /xbmc/tools/depends/target/libdvdread/DVDREAD-VERSION /xbmc/tools/depends/target/libdvdnav/DVDNAV-VERSION /xbmc/project/BuildDependencies/DownloadMingwBuildEnv.bat /xbmc/tools/buildsteps/win32)" == "0" ]
+then
+  cp "$LIBDVDPREFIX/bin/libdvdcss-2.dll" /xbmc/system/
+  cp $LIBDVDPREFIX/bin/libdvdnav.dll /xbmc/system/
+  if [ -f $BGPROCESSFILE ]; then
+    rm $BGPROCESSFILE
+  fi
+  exit
+else
+  git clean -dffx $LIBDVDPREFIX
+fi
+
 do_load_autoconf() {
   do_loaddeps $1
   do_clean_get $MAKEFLAGS
@@ -62,7 +74,8 @@ gcc \
    -static-libgcc
 
 strip -S $LIBDVDPREFIX/bin/libdvdnav.dll &&
-cp $LIBDVDPREFIX/bin/libdvdnav.dll /xbmc/system/
+cp $LIBDVDPREFIX/bin/libdvdnav.dll /xbmc/system/ &&
+tagSuccessFulBuild $LIBDVDPREFIX /xbmc/tools/depends/target/libdvdcss/DVDCSS-VERSION /xbmc/tools/depends/target/libdvdread/DVDREAD-VERSION /xbmc/tools/depends/target/libdvdnav/DVDNAV-VERSION /xbmc/project/BuildDependencies/DownloadMingwBuildEnv.bat /xbmc/tools/buildsteps/win32
 do_print_status "libdvd (${BITS})" "$green_color" "Done"
 
 #remove the bgprocessfile for signaling the process end

--- a/tools/buildsteps/win32/prepare-env.bat
+++ b/tools/buildsteps/win32/prepare-env.bat
@@ -9,8 +9,8 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
-ECHO running git clean -xfd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
-git clean -xfd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
+ECHO running git clean -xfd -e "lib/libdvd" -e "lib/win32/ffmpeg" -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
+git clean -xfd -e "lib/libdvd" -e "lib/win32/ffmpeg" -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
 
 rem cleaning additional directories
 ECHO delete build directories


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Copy the behaviour for depends on other platform for ffmpeg and libdvd.
They are treated independent so it could happen that non, only one or both are compiled.
If Configuration is set to Release they always get rebuild.
<!--- Describe your change in detail -->

## Motivation and Context
speed up compile time on jenkins for windows
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
locally tested with different parameters
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
