### PR TITLE
Added option to disable OS screensaver in windowed mode

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4620,7 +4620,12 @@ msgctxt "#1450"
 msgid "Put display to sleep when idle"
 msgstr ""
 
-#empty strings from id 1451 to 2049
+#: system/settings/settings.xml
+msgctxt "#1451"
+msgid "Disable OS Screensaver"
+msgstr ""
+
+#empty strings from id 1452 to 2049
 #strings through to 1470 reserved for power-saving
 
 msgctxt "#2050"
@@ -18989,7 +18994,11 @@ msgctxt "#36422"
 msgid "Enable hardware video decode using Amlogic decoder."
 msgstr ""
 
-#empty string with id 36423
+#. Description of setting with label #1451 "Disable OS screensaver"
+#: system/settings/settings.xml
+msgctxt "#36423"
+msgid "Prevents the operating system from starting the screensaver while Kodi is in in windowed mode."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36424"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2850,6 +2850,11 @@
             <formatlabel>14044</formatlabel>
           </control>
         </setting>
+        <setting id="powermanagement.screensaveroff" type="boolean" label="1451" help="36423">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="powermanagement.shutdowntime" type="integer" label="357" help="36389">
           <level>2</level>
           <default>0</default>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -387,6 +387,7 @@ const std::string CSettings::SETTING_NETWORK_HTTPPROXYUSERNAME = "network.httppr
 const std::string CSettings::SETTING_NETWORK_HTTPPROXYPASSWORD = "network.httpproxypassword";
 const std::string CSettings::SETTING_NETWORK_BANDWIDTH = "network.bandwidth";
 const std::string CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF = "powermanagement.displaysoff";
+const std::string CSettings::SETTING_POWERMANAGEMENT_SCREENSAVEROFF = "powermanagement.screensaveroff";
 const std::string CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNTIME = "powermanagement.shutdowntime";
 const std::string CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE = "powermanagement.shutdownstate";
 const std::string CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS = "powermanagement.wakeonaccess";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -343,6 +343,7 @@ public:
   static const std::string SETTING_NETWORK_HTTPPROXYPASSWORD;
   static const std::string SETTING_NETWORK_BANDWIDTH;
   static const std::string SETTING_POWERMANAGEMENT_DISPLAYSOFF;
+  static const std::string SETTING_POWERMANAGEMENT_SCREENSAVEROFF;
   static const std::string SETTING_POWERMANAGEMENT_SHUTDOWNTIME;
   static const std::string SETTING_POWERMANAGEMENT_SHUTDOWNSTATE;
   static const std::string SETTING_POWERMANAGEMENT_WAKEONACCESS;

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -454,7 +454,7 @@ void CWinSystemX11::ShowOSMouse(bool show)
 
 void CWinSystemX11::ResetOSScreensaver()
 {
-  if (m_bFullScreen)
+  if (m_bFullScreen || CServiceBroker::GetSettings().GetBool(CSettings::SETTING_POWERMANAGEMENT_SCREENSAVEROFF))
   {
     //disallow the screensaver when we're fullscreen by periodically calling XResetScreenSaver(),
     //normally SDL does this but we disable that in CApplication::Create()

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1611,8 +1611,11 @@ bool CWinSystemOSX::IsSystemScreenSaverEnabled()
 
 void CWinSystemOSX::ResetOSScreensaver()
 {
-  // allow os screensaver only if we are fullscreen
-  EnableSystemScreenSaver(!m_bFullScreen);
+  // allow os screensaver only if we are not fullscreen or the screensaver is disabled in Kodi settings
+  if (m_bFullScreen || CServiceBroker::GetSettings().GetBool(CSettings::SETTING_POWERMANAGEMENT_SCREENSAVEROFF))
+    EnableSystemScreenSaver(false);
+  else
+    EnableSystemScreenSaver(true);
 }
 
 void CWinSystemOSX::EnableTextInput(bool bEnable)


### PR DESCRIPTION
## Description
I added an option in the `System` -> `Power Saving` menu to disable initialization of the operating system's screen saver while Kodi is running.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I often run Kodi in Windowed mode and have the system screensaver interrupt my viewing. This has been complained about several times on the forums and issues on trac (now all closed because they're obsolete/invalid/needs more info), dating back several years.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
OS: Linux Mint 18.1 x64, Cinnamon 3.2.7
ScreenSaver: cinnamon-screensaver 3.2.13
Kernel: 4.4.0-64-generic
CPU: i7-3770k 4.20GHz
RAM: 22.5 GiB
GPU: Nvidia GTX 970 - Driver version 378.13

I'm only able to test this on Linux, though I think the changes I made will work on OSX as well. Regarding Windows, I don't think my changes will do anything and have no clue how to go about implementing this functionality on Windows.

I didn't run into any errors, either in building or while testing. I tested by:

- setting my screensaver initialization time down to 1 minute
- running Kodi windowed
- leaving the option disabled at first
- playing a video for 1 minute until the screensaver started
- exiting the video
- enabling the option
- playing a video for 2 minutes to confirm screensaver wouldn't start

I did not run into any errors or issues either in building or testing.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
