### PR TITLE
[xbmc] General cleanup of ApplicationMessenger

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -425,6 +425,9 @@ bool CApplication::SetupNetwork()
 
 bool CApplication::Create()
 {
+  // Grab a handle to our thread to be used later in identifying the render thread.
+  m_threadID = CThread::GetCurrentThreadId();
+
   m_ServiceManager.reset(new CServiceManager());
   if (!m_ServiceManager->Init1())
   {
@@ -439,6 +442,7 @@ bool CApplication::Create()
   CApplicationMessenger::GetInstance().RegisterReceiver(this);
   CApplicationMessenger::GetInstance().RegisterReceiver(&g_playlistPlayer);
   CApplicationMessenger::GetInstance().RegisterReceiver(&g_infoManager);
+  CApplicationMessenger::GetInstance().SetGUIThread(m_threadID);
 
   for (int i = RES_HDTV_1080i; i <= RES_PAL60_16x9; i++)
   {
@@ -451,8 +455,6 @@ bool CApplication::Create()
   tzset();   // Initialize timezone information variables
 #endif
 
-  // Grab a handle to our thread to be used later in identifying the render thread.
-  m_threadID = CThread::GetCurrentThreadId();
 
   //! @todo - move to CPlatformXXX
   #if defined(TARGET_POSIX)
@@ -2899,6 +2901,9 @@ void CApplication::Stop(int exitCode)
       g_SkinInfo->SaveSettings();
 
     m_bStop = true;
+    // Add this here to keep the same ordering behaviour for now
+    // Needs cleaning up
+    CApplicationMessenger::GetInstance().Stop();
     m_AppFocused = false;
     m_ExitCode = exitCode;
     CLog::Log(LOGNOTICE, "stop all");

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -23,14 +23,26 @@
 #include <memory>
 #include <utility>
 
-#include "Application.h"
 #include "guilib/GraphicContext.h"
+#include "guilib/GUIMessage.h"
+#include "messaging/IMessageTarget.h"
 #include "threads/SingleLock.h"
 
 namespace KODI
 {
 namespace MESSAGING
 {
+
+class CDelayedMessage : public CThread
+{
+  public:
+    CDelayedMessage(ThreadMessage& msg, unsigned int delay);
+    virtual void Process() override;
+
+  private:
+    unsigned int   m_delay;
+    ThreadMessage  m_msg;
+};
 
 CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay) : CThread("DelayedMessage")
 {
@@ -101,7 +113,7 @@ int CApplicationMessenger::SendMsg(ThreadMessage&& message, bool wait)
     message.result = std::make_shared<int>(-1);
     // check that we're not being called from our application thread, else we'll be waiting
     // forever!
-    if (!g_application.IsCurrentThread())
+    if (!CThread::IsCurrentThread(m_guiThreadId))
     {
       message.waitEvent.reset(new CEvent(true));
       waitEvent = message.waitEvent;
@@ -117,7 +129,7 @@ int CApplicationMessenger::SendMsg(ThreadMessage&& message, bool wait)
   }
 
 
-  if (g_application.m_bStop)
+  if (m_bStop)
     return -1;
 
   ThreadMessage* msg = new ThreadMessage(std::move(message));

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -144,25 +144,13 @@ namespace KODI
 {
 namespace MESSAGING
 {
-
-class CDelayedMessage : public CThread
-{
-  public:
-    CDelayedMessage(ThreadMessage& msg, unsigned int delay);
-    virtual void Process() override;
-
-  private:
-    unsigned int   m_delay;
-    ThreadMessage  m_msg;
-};
+class IMessageTarget;
 
 struct ThreadMessageCallback
 {
   void (*callback)(void *userptr);
   void *userptr;
 };
-
-class IMessageTarget;
 
 /*!
  * \class CApplicationMessenger ApplicationMessenger.h "messaging/ApplicationMessenger.h"
@@ -400,6 +388,18 @@ public:
    */
   void RegisterReceiver(IMessageTarget* target);
 
+  /*!
+   * \brief Set the UI thread id to avoid messenger being dependent on
+   * CApplication to determine if marshaling is required
+   * \param thread The UI thread ID
+   */
+  void SetGUIThread(ThreadIdentifier thread) { m_guiThreadId = thread; }
+
+  /*
+   * \brief Signals the shutdown of the application and message processing
+   */
+  void Stop() { m_bStop = true; }
+
 private:
   // private construction, and no assignments; use the provided singleton methods
   CApplicationMessenger();
@@ -414,6 +414,8 @@ private:
   std::queue<ThreadMessage*> m_vecWindowMessages; /*!< queue for UI messages */
   std::map<int, IMessageTarget*> m_mapTargets; /*!< a map of registered receivers indexed on the message mask*/
   CCriticalSection m_critSection;
+  ThreadIdentifier m_guiThreadId{0};
+  bool m_bStop{ false };
 };
 }
 }


### PR DESCRIPTION
Remove the circular dependency with CApplication
Move the DelayedThreadMessage to the cpp file as it's an implementation detail.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
