### PR TITLE
Fix uninitialised memory read in RenderManager

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -205,9 +205,9 @@ protected:
 
   struct SPresent
   {
-    double         pts;
-    EFIELDSYNC     presentfield;
-    EPRESENTMETHOD presentmethod;
+    double         pts = 0.0;
+    EFIELDSYNC     presentfield = FS_NONE;
+    EPRESENTMETHOD presentmethod = PRESENT_METHOD_SINGLE;
   } m_Queue[NUM_BUFFERS];
 
   std::deque<int> m_free;


### PR DESCRIPTION
## Description
We sometimes read members from SPresent before we've initialised them. Initialise them in a new constructor.

## Motivation and Context
The behaviour here is undefined. From my testing on Linux, it doesn't seem to cause a big problem, but we're not guaranteed good behaviour.

## How Has This Been Tested?
Ran existing unit tests. They passed. Also ran kodi manually on x86_64 Ubuntu Linux to trigger this codepath. Worked fine.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
