### PR TITLE
[settings] revert default of epg.selectaction back to show info

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1325,7 +1325,7 @@
         </setting>
         <setting id="epg.selectaction" type="integer" label="22079" help="36424">
           <level>1</level>
-          <default>5</default> <!-- EPG_SELECT_ACTION_SMART_SELECT -->
+          <default>2</default> <!-- EPG_SELECT_ACTION_INFO -->
           <constraints>
             <options>
               <option label="36425">0</option> <!-- EPG_SELECT_ACTION_CONTEXT_MENU -->


### PR DESCRIPTION
@ksooo as discussed at #11782 this PR reverts the default of `epg.selectaction`