### PR TITLE
[PVR] Fix trac17374: Settings deinitialized too early on app exit.

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -52,7 +52,6 @@ void CPVRActionListener::Init()
   settingSet.insert(CSettings::SETTING_PVRMANAGER_CHANNELSCAN);
   settingSet.insert(CSettings::SETTING_PVRMENU_SEARCHICONS);
   settingSet.insert(CSettings::SETTING_PVRCLIENT_MENUHOOK);
-  settingSet.insert(CSettings::SETTING_EPG_DAYSTODISPLAY);
   CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
 }
 
@@ -196,10 +195,6 @@ void CPVRActionListener::OnSettingAction(const CSetting *setting)
   else if (settingId == CSettings::SETTING_PVRCLIENT_MENUHOOK)
   {
     CPVRGUIActions::GetInstance().ProcessMenuHooks(CFileItemPtr());
-  }
-  else if (settingId == CSettings::SETTING_EPG_DAYSTODISPLAY)
-  {
-    g_PVRClients->SetEPGTimeFrame(static_cast<const CSettingInt*>(setting)->GetValue());
   }
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -94,7 +94,7 @@ namespace PVR
     bool m_bStopped;
   };
 
-  class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer
+  class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer, public ISettingCallback
   {
     friend class CPVRClients;
 
@@ -130,6 +130,9 @@ namespace PVR
      * @return The PVRManager instance.
      */
     static CPVRManager &GetInstance();
+
+    // ISettingCallback implementation
+    void OnSettingChanged(const CSetting *setting) override;
 
     /*!
      * @brief Get the channel groups container.
@@ -647,6 +650,10 @@ namespace PVR
 
     std::atomic_bool m_isChannelPreview;
     CEventSource<PVREvent> m_events;
+
+    // settings cache
+    bool m_bSettingPowerManagementEnabled; // SETTING_PVRPOWERMANAGEMENT_ENABLED
+    std::string m_strSettingWakeupCommand; // SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD
   };
 
   class CPVRStartupJob : public CJob


### PR DESCRIPTION
This fixes http://trac.kodi.tv/ticket/17374

Settings are cleared too early on app exit => https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/PVRManager.cpp#L531 does not get the right settings values on app shutdown => wake up command gets not executed.

Bug was introduced by a fix I did some time ago, to only call wake up command on app exit, not on every pvr manager restart (which can happen quite some time during app lifetime).

@Montellese @FernetMenta I moved deinit of settings in CApplication::Cleanup() to a later point in time, namely to CServiceManager::Deinit(), after PVR mananger shutdown. Is this okay? Runtime test went fine.