### PR TITLE
[gui] include now supports nested element processing

### DIFF
--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -122,6 +122,7 @@ private:
   void ResolveExpressions(TiXmlElement *node);
 
   typedef std::map<std::string, std::string> Params;
+  static void InsertNested(TiXmlElement *controls, TiXmlElement *node, TiXmlElement *include);
   static bool GetParameters(const TiXmlElement *include, const char *valueAttribute, Params& params);
   static void ResolveParametersForNode(TiXmlElement *node, const Params& params);
   static ResolveParamsResult ResolveParameters(const std::string& strInput, std::string& strOutput, const Params& params);


### PR DESCRIPTION
Extends our GUI lib and adds support to use a `nested` element to include a XML fragment which is defined between the start-tag and end-tag of an include element. The nested part can contain anything what is valid in our skin language. Using parameters for the nested XML fragment is also supported.

This is really handy if you want to re-use XML fragments before and after some variable XML nested fragment e.g. a menu with variable items. Currently you need to specify a `menu_top` and `menu_bottom` include definition and include it before and after your variable XML fragment.

```xml
<!-- define a nested include -->
<include name="nested_include">
  <control type="group">
    <include>OtherInclude</include>
    <!-- nested element, used to indicate where to place the nested elements of include body -->
    <nested />
  </control>
</include>

<!-- use the nested include -->
<include content="nested_include">
  <param name="x" value="v1" />
  <param name="y" value="v2" />
  <!-- nested elements -->
  <control type="label">..</control> 
  <control type="group">
    <control type="label">..</control> 
  </control> 
</include>
```