### PR TITLE
Fix Path Traversal Described In CVE-2017-5982

### DIFF
--- a/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
@@ -61,6 +61,18 @@ void CHTTPFileHandler::SetFile(const std::string& file, int responseStatus)
   if (m_url.empty())
     return;
 
+  if (file.find("image://") == 0)
+  {
+    const CURL pathToUrl(file);
+    if (pathToUrl.GetHostName().find("../") != std::string::npos ||
+        pathToUrl.GetHostName().find("..\\") != std::string::npos)
+    {
+        m_response.type = HTTPError;
+        m_response.status = MHD_HTTP_NOT_FOUND;
+        return;
+    }
+  }
+
   // translate the response status into the response type
   if (m_response.status == MHD_HTTP_OK)
     m_response.type = HTTPFileDownload;

--- a/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
@@ -36,12 +36,6 @@ CHTTPImageHandler::CHTTPImageHandler(const HTTPRequest &request)
 
     XFILE::CImageFile imageFile;
     const CURL pathToUrl(file);
-    if (pathToUrl.GetHostName().find("..") != std::string::npos)
-    {
-        responseStatus = MHD_HTTP_NOT_FOUND;
-        return;
-    }
-
     if (imageFile.Exists(pathToUrl))
     {
       responseStatus = MHD_HTTP_OK;

--- a/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageHandler.cpp
@@ -36,6 +36,12 @@ CHTTPImageHandler::CHTTPImageHandler(const HTTPRequest &request)
 
     XFILE::CImageFile imageFile;
     const CURL pathToUrl(file);
+    if (pathToUrl.GetHostName().find("..") != std::string::npos)
+    {
+        responseStatus = MHD_HTTP_NOT_FOUND;
+        return;
+    }
+
     if (imageFile.Exists(pathToUrl))
     {
       responseStatus = MHD_HTTP_OK;


### PR DESCRIPTION
## Description
I noticed that NVD had assigned [CVE-2017-5982 ](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5982)to Kodi. I also found that there was an [exploid-db entry](https://www.exploit-db.com/exploits/41312/) as well as a [metasploit module](https://github.com/rapid7/metasploit-framework/pull/7980/files). However, I couldn't find a patch in the code base.

After some searching, I found a brief discussion on the [forums](http://forum.kodi.tv/showthread.php?tid=144110&pid=2527773#pid2527773) in which @MartijnKaijser welcomed patches. This pull request introduces a simple fix.

## Motivation and Context
The bug is a local file inclusion due to path traversal when using image:// in conjunction with an HTTP request. The following request command will download /etc/passwd from a remote Kodi web server.

```sh
albinolobster@ubuntu:~$ wget http://192.168.1.40:8080/%69%6d%61%67%65%2f%69%6d%61%67%65%3a%2f%2f%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%32%65%25%32%65%25%32%66%25%36%35%25%37%34%25%36%33%25%32%66%25%37%30%25%36%31%25%37%33%25%37%33%25%37%37%25%36%34
```
The decoded request looks like this: "image/image:/../../../../../../../../../../etc/passwd"

In order to stop this behavior I've dropped a very simple check for ".." in the pathToURL value in CHTTPImageHandler's constructor. This might not be a perfect solution, but it does catch the problem.

As an aside, one might be interested why something like image/image:/etc/passwd doesn't work. This is simply because CTextureCache::IsCachedImage marks "full paths" as a cached image and /etc/passwd eventually fails image decoding.

## How Has This Been Tested?
Ensured that the provided wget no longer downloads /etc/passwd. Browsed around the site at :8080 without issue.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
