### PR TITLE
Use invoke-id instead addon-id for selecting the monitor for abortrequest

### DIFF
--- a/xbmc/interfaces/legacy/LanguageHook.h
+++ b/xbmc/interfaces/legacy/LanguageHook.h
@@ -111,6 +111,7 @@ namespace XBMCAddon
      */
     virtual String GetAddonId() { return emptyString; }
     virtual String GetAddonVersion() { return emptyString; }
+    virtual long GetInvokerId() { return -1; }
 
     virtual void RegisterPlayerCallback(IPlayerCallback* player) = 0;
     virtual void UnregisterPlayerCallback(IPlayerCallback* player) = 0;

--- a/xbmc/interfaces/legacy/Monitor.cpp
+++ b/xbmc/interfaces/legacy/Monitor.cpp
@@ -32,6 +32,7 @@ namespace XBMCAddon
       if (languageHook)
       {
         Id = languageHook->GetAddonId();
+        invokerId = languageHook->GetInvokerId();
         languageHook->RegisterMonitorCallback(this);
       }
     }

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -41,6 +41,7 @@ namespace XBMCAddon
     class Monitor : public AddonCallback
     {
       String Id;
+      long invokerId;
       CEvent abortEvent;
     public:
       Monitor();
@@ -68,6 +69,7 @@ namespace XBMCAddon
       inline void    OnNotification(const String &sender, const String &method, const String &data) { XBMC_TRACE; invokeCallback(new CallbackFunction<Monitor,const String,const String,const String>(this,&Monitor::onNotification,sender,method,data)); }
 
       inline const String& GetId() { return Id; }
+      inline long GetInvokerId() { return invokerId; }
 
       void OnAbortRequested();
 #endif

--- a/xbmc/interfaces/python/LanguageHook.cpp
+++ b/xbmc/interfaces/python/LanguageHook.cpp
@@ -156,6 +156,23 @@ namespace XBMCAddon
       return "";
     }
 
+    long PythonLanguageHook::GetInvokerId()
+    {
+      XBMC_TRACE;
+
+      // Get a reference to the main module
+      // and global dictionary
+      PyObject* main_module = PyImport_AddModule((char*)"__main__");
+      PyObject* global_dict = PyModule_GetDict(main_module);
+      // Extract a reference to the function "func_name"
+      // from the global dictionary
+      PyObject* pyid = PyDict_GetItemString(global_dict, "__xbmcinvokerid__");
+      if (pyid)
+        return PyLong_AsLong(pyid);
+      return -1;
+    }
+
+
     void PythonLanguageHook::RegisterPlayerCallback(IPlayerCallback* player) { XBMC_TRACE; g_pythonParser.RegisterPythonPlayerCallBack(player); }
     void PythonLanguageHook::UnregisterPlayerCallback(IPlayerCallback* player) { XBMC_TRACE; g_pythonParser.UnregisterPythonPlayerCallBack(player); }
     void PythonLanguageHook::RegisterMonitorCallback(XBMCAddon::xbmc::Monitor* monitor) { XBMC_TRACE; g_pythonParser.RegisterPythonMonitorCallBack(monitor); }

--- a/xbmc/interfaces/python/LanguageHook.h
+++ b/xbmc/interfaces/python/LanguageHook.h
@@ -73,6 +73,7 @@ namespace XBMCAddon
 
       virtual String GetAddonId();
       virtual String GetAddonVersion();
+      virtual long GetInvokerId();
 
       virtual void RegisterPlayerCallback(IPlayerCallback* player);
       virtual void UnregisterPlayerCallback(IPlayerCallback* player);

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -569,6 +569,9 @@ void CPythonInvoker::onPythonModuleInitialization(void* moduleDict)
   PyObject *pyxbmcapiversion = PyString_FromString(version.asString().c_str());
   PyDict_SetItemString(moduleDictionary, "__xbmcapiversion__", pyxbmcapiversion);
 
+  PyObject *pyinvokerid = PyLong_FromLong(GetId());
+  PyDict_SetItemString(moduleDictionary, "__xbmcinvokerid__", pyinvokerid);
+
   CLog::Log(LOGDEBUG, "CPythonInvoker(%d, %s): instantiating addon using automatically obtained id of \"%s\" dependent on version %s of the xbmc.python api",
             GetId(), m_sourceFile.c_str(), m_addon->ID().c_str(), version.asString().c_str());
 }

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -636,22 +636,16 @@ void XBPython::OnScriptAbortRequested(ILanguageInvoker *invoker)
 {
   XBMC_TRACE;
 
-  std::string addonId;
+  long invokerId(-1);
   if (invoker != NULL)
-  {
-    const ADDON::AddonPtr& addon = invoker->GetAddon();
-    if (addon != NULL)
-      addonId = addon->ID();
-  }
+    invokerId = invoker->GetId();
 
   LOCK_AND_COPY(std::vector<XBMCAddon::xbmc::Monitor*>, tmp, m_vecMonitorCallbackList);
   for (MonitorCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
   {
     if (CHECK_FOR_ENTRY(m_vecMonitorCallbackList, (*it)))
     {
-      if (addonId.empty())
-        (*it)->OnAbortRequested();
-      else if ((*it)->GetId() == addonId)
+      if (invokerId < 0 || (*it)->GetInvokerId() == invokerId)
         (*it)->OnAbortRequested();
     }
   }


### PR DESCRIPTION
Use invoker id instead addon-id for signaling python monitor

## Description
For addons wich come together with a service-addon the services are stopped if the main addon script is cancelled e.g. by using [ESC] or double [Baclspace].
Cancelling is done through Monitor::abortrequest signal.

Reason is that the Monitor to signal is selected by addon-id (plugin.video.netflix) which is shared for normal addon and service addon.
This PR selects the Monitor to signal by the invoker id wich is different for service-addon and normal addon.

## Motivation and Context
netflix addon service gets killed on ESC or fast double backspace

## How Has This Been Tested?
[Win32 / Linux / Mac] 
- install netflix addon
- start netflix addon
- press ESC
- look in the kodi log for canceled services.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
