### PR TITLE
AMLCodec: do not set blackout policy

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1701,11 +1701,6 @@ void CAMLCodec::Reset()
 
   SetPollDevice(-1);
 
-  // set the system blackout_policy to leave the last frame showing
-  int blackout_policy;
-  SysfsUtils::GetInt("/sys/class/video/blackout_policy", blackout_policy);
-  SysfsUtils::SetInt("/sys/class/video/blackout_policy", 0);
-
   // restore the speed (some amcodec versions require this)
   if (m_speed != DVD_PLAYSPEED_NORMAL)
   {
@@ -1725,9 +1720,6 @@ void CAMLCodec::Reset()
   am_packet_init(&am_private->am_pkt);
   am_private->am_pkt.codec = &am_private->vcodec;
   pre_header_feeding(am_private, &am_private->am_pkt);
-
-  // restore the saved system blackout_policy value
-  SysfsUtils::SetInt("/sys/class/video/blackout_policy", blackout_policy);
 
   // reset some interal vars
   m_cur_pts = INT64_0;


### PR DESCRIPTION
Hardware decoders that use CMA decide on whether to release memory depending
on blackout policy. If we change the policy when resetting decoder CMA is
sometimes not released which leads to OOM. Although it's a kernel bug it would
be nice if Kodi did not trigger it.

<!--- Provide a general summary of your change in the Title above -->

## How Has This Been Tested?
Tested in my community S805 and S905(X) builds with Kodi Krypton.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
