### PR TITLE
[win] use users profile folder as home folder

### DIFF
--- a/xbmc/storage/windows/Win32StorageProvider.cpp
+++ b/xbmc/storage/windows/Win32StorageProvider.cpp
@@ -21,9 +21,12 @@
 #include "WIN32Util.h"
 #include "guilib/LocalizeStrings.h"
 #include "filesystem/SpecialProtocol.h"
+#include "platform/win32/CharsetConverter.h"
 #include "storage/MediaManager.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
+
+#include <ShlObj.h>
 
 bool CWin32StorageProvider::xbevent = false;
 
@@ -49,8 +52,14 @@ void CWin32StorageProvider::Initialize()
 
 void CWin32StorageProvider::GetLocalDrives(VECSOURCES &localDrives)
 {
+  using namespace KODI::PLATFORM::WINDOWS;
   CMediaSource share;
-  share.strPath = CSpecialProtocol::TranslatePath("special://home");
+  wchar_t profilePath[MAX_PATH];
+  if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_PROFILE, nullptr, 0, profilePath)) ||
+      GetEnvironmentVariable(L"USERPROFILE", profilePath, MAX_PATH) > 0)
+    share.strPath = FromW(profilePath);
+  else
+    share.strPath = CSpecialProtocol::TranslatePath("special://home");
   share.strName = g_localizeStrings.Get(21440);
   share.m_ignore = true;
   share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use the users profile folder (normaly `C:\Users\<username>`) as home folder in the file browser.
Currently `special://home` is used which maps to `C:\Users\<username>\AppData\Roaming\Kodi`.
<!--- Describe your change in detail -->

## Motivation and Context
Current mapping isn't useful if you want to add a source which is located in the profile folder.
Other platforms already behave like it is with this change on windows.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
runtime tested
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
