### PR TITLE
Fix for YouTube Add-On Crash

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -101,6 +101,10 @@ static std::vector<std::vector<char>> storeArgumentsCCompatible(std::vector<std:
   std::vector<std::vector<char>> output;
   std::transform(input.begin(), input.end(), std::back_inserter(output),
                 [](std::string const & i) { return std::vector<char>(i.c_str(), i.c_str() + i.length() + 1); });
+
+  if (output.empty())
+    output.push_back(std::vector<char>(1u, '\0'));
+
   return output;
 }
 
@@ -233,10 +237,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
   Py_DECREF(sysMod); // release ref to sysMod
 
   // set current directory and python's path.
-  if (argc > 0)
-  {
-    PySys_SetArgv(argc, &argv[0]);
-  }
+  PySys_SetArgv(argc, &argv[0]);
 
 #ifdef TARGET_WINDOWS
   std::string pyPathUtf8;


### PR DESCRIPTION
## Description
 #11814 caused crash in Youtube plugin which has 0 argc. Turns out we still need to call PySys_SetArgv but with argc=0 and argv as pointer to empty string.

## Motivation and Context
Youtube crash introduced in #11814 

## How Has This Been Tested?
Tested manually on x86_64 Ubuntu Linux. Tested both Weather and YouTube add-ons. Both load & work now. Also ran under valgrind & confirmed no errors in these cases.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
