### PR TITLE
Add trailer to UPNP and fix so video information dialog is displayed for UPNP video items.

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
@@ -179,6 +179,8 @@ PLT_Didl::ConvertFilterToMask(const NPT_String& filter)
           mask |= PLT_FILTER_MASK_XBMC_COUNTRY;
         } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_USERRATING, len, true) == 0) {
           mask |= PLT_FILTER_MASK_XBMC_USERRATING;
+        } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_TRAILER, len, true) == 0) {
+          mask |= PLT_FILTER_MASK_XBMC_TRAILER;
         }
 
         if (next_comma < 0) {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
@@ -103,6 +103,7 @@
 #define PLT_FILTER_MASK_XBMC_COUNTRY                NPT_UINT64_C(0x0002000000000000)
 #define PLT_FILTER_MASK_XBMC_USERRATING             NPT_UINT64_C(0x0004000000000000)
 #define PLT_FILTER_MASK_XBMC_LASTPLAYERSTATE        NPT_UINT64_C(0x0008000000000000)
+#define PLT_FILTER_MASK_XBMC_TRAILER                NPT_UINT64_C(0x0010000000000000)
 
 #define PLT_FILTER_FIELD_TITLE                      "dc:title"
 #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
@@ -156,6 +157,7 @@
 #define PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER     "xbmc:uniqueidentifier"
 #define PLT_FILTER_FIELD_XBMC_COUNTRY               "xbmc:country"
 #define PLT_FILTER_FIELD_XBMC_USERRATING            "xbmc:userrating"
+#define PLT_FILTER_FIELD_XBMC_TRAILER               "xbmc:trailer"
 
 extern const char* didl_header;
 extern const char* didl_footer;

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -873,6 +873,11 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
 
     PLT_XmlHelper::GetChildText(entry, "uniqueidentifier", m_XbmcInfo.unique_identifier, didl_namespace_xbmc, 256);
 
+    PLT_XmlHelper::GetChildText(entry, "userrating", str, didl_namespace_xbmc, 256);
+    NPT_Int32 iuser_rating;
+    if (NPT_FAILED(str.ToInteger(iuser_rating))) iuser_rating = 0;
+    m_XbmcInfo.user_rating = iuser_rating;
+
     PLT_XmlHelper::GetChildText(entry, "trailer", m_XbmcInfo.trailer, didl_namespace_xbmc, 256);
 
     // re serialize the entry didl as a we might need to pass it to a renderer

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -264,6 +264,7 @@ PLT_MediaObject::Reset()
     m_XbmcInfo.unique_identifier = "";
     m_XbmcInfo.countries.Clear();
     m_XbmcInfo.user_rating = 0;
+    m_XbmcInfo.trailer = "";
 
     m_Didl = "";
 
@@ -633,6 +634,13 @@ PLT_MediaObject::ToDidl(NPT_UInt64 mask, NPT_String& didl)
       didl += "</xbmc:lastPlayerState>";
     }
 
+    // trailer
+    if ((mask & PLT_FILTER_MASK_XBMC_TRAILER) && !m_XbmcInfo.trailer.IsEmpty()) {
+      didl += "<xbmc:trailer>";
+      PLT_Didl::AppendXmlEscape(didl, m_XbmcInfo.trailer);
+      didl += "</xbmc:trailer>";
+    }
+
     // class is required
     didl += "<upnp:class";
 	if (!m_ObjectClass.friendly_name.IsEmpty()) {
@@ -864,6 +872,8 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     m_XbmcInfo.artwork.FromDidl(children);
 
     PLT_XmlHelper::GetChildText(entry, "uniqueidentifier", m_XbmcInfo.unique_identifier, didl_namespace_xbmc, 256);
+
+    PLT_XmlHelper::GetChildText(entry, "trailer", m_XbmcInfo.trailer, didl_namespace_xbmc, 256);
 
     // re serialize the entry didl as a we might need to pass it to a renderer
     // we may have modified the tree to "fix" issues, so as not to break a renderer

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
@@ -173,6 +173,7 @@ typedef struct {
   NPT_String unique_identifier;
   NPT_List<NPT_String> countries;
   NPT_Int32 user_rating;
+  NPT_String trailer;
 } PLT_XbmcInfo;
 
 typedef struct {

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
@@ -70,7 +70,7 @@ typedef struct PLT_CapabilitiesData {
 typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
 
 // explicitely specify res otherwise WMP won't return a URL!
-#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:lastPlayerState,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country,xbmc:userrating"
+#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:lastPlayerState,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country,xbmc:userrating,xbmc:trailer"
 
 /*----------------------------------------------------------------------
 |   PLT_MediaContainerListener

--- a/lib/libUPnP/patches/0048-platinum-add-xbmc-trailer-for-movie-trailers.patch
+++ b/lib/libUPnP/patches/0048-platinum-add-xbmc-trailer-for-movie-trailers.patch
@@ -1,0 +1,96 @@
+From c8c9c30735f2ffaf3fd3c9f1f5d24a094a0e1aaf Mon Sep 17 00:00:00 2001
+From: Jeff Grieger <jeff@griegers.com>
+Date: Tue, 25 Sep 2018 11:00:00 +0200
+Subject: [PATCH] platinum: add xbmc:trailer for movie trailers
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp           |  2 ++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h             |  2 ++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp      | 10 ++++++++++
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h        |  1 +
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h |  2 +-
+ 5 files changed, 16 insertions(+), 1 deletion(-)
+
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.cpp
+@@ -179,6 +179,8 @@
+           mask |= PLT_FILTER_MASK_XBMC_COUNTRY;
+         } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_USERRATING, len, true) == 0) {
+           mask |= PLT_FILTER_MASK_XBMC_USERRATING;
++        } else if (NPT_String::CompareN(s + i, PLT_FILTER_FIELD_XBMC_TRAILER, len, true) == 0) {
++          mask |= PLT_FILTER_MASK_XBMC_TRAILER;
+         }
+ 
+         if (next_comma < 0) {
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltDidl.h
+@@ -103,6 +103,7 @@
+ #define PLT_FILTER_MASK_XBMC_COUNTRY                NPT_UINT64_C(0x0002000000000000)
+ #define PLT_FILTER_MASK_XBMC_USERRATING             NPT_UINT64_C(0x0004000000000000)
+ #define PLT_FILTER_MASK_XBMC_LASTPLAYERSTATE        NPT_UINT64_C(0x0008000000000000)
++#define PLT_FILTER_MASK_XBMC_TRAILER                NPT_UINT64_C(0x0010000000000000)
+ 
+ #define PLT_FILTER_FIELD_TITLE                      "dc:title"
+ #define PLT_FILTER_FIELD_CREATOR                    "dc:creator"
+@@ -156,6 +157,7 @@
+ #define PLT_FILTER_FIELD_XBMC_UNIQUE_IDENTIFIER     "xbmc:uniqueidentifier"
+ #define PLT_FILTER_FIELD_XBMC_COUNTRY               "xbmc:country"
+ #define PLT_FILTER_FIELD_XBMC_USERRATING            "xbmc:userrating"
++#define PLT_FILTER_FIELD_XBMC_TRAILER               "xbmc:trailer"
+ 
+ extern const char* didl_header;
+ extern const char* didl_footer;
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -264,6 +264,7 @@
+     m_XbmcInfo.unique_identifier = "";
+     m_XbmcInfo.countries.Clear();
+     m_XbmcInfo.user_rating = 0;
++    m_XbmcInfo.trailer = "";
+ 
+     m_Didl = "";
+ 
+@@ -633,6 +634,13 @@
+       didl += "</xbmc:lastPlayerState>";
+     }
+ 
++    // trailer
++    if ((mask & PLT_FILTER_MASK_XBMC_TRAILER) && !m_XbmcInfo.trailer.IsEmpty()) {
++      didl += "<xbmc:trailer>";
++      PLT_Didl::AppendXmlEscape(didl, m_XbmcInfo.trailer);
++      didl += "</xbmc:trailer>";
++    }
++
+     // class is required
+     didl += "<upnp:class";
+ 	if (!m_ObjectClass.friendly_name.IsEmpty()) {
+@@ -865,6 +873,8 @@
+ 
+     PLT_XmlHelper::GetChildText(entry, "uniqueidentifier", m_XbmcInfo.unique_identifier, didl_namespace_xbmc, 256);
+ 
++    PLT_XmlHelper::GetChildText(entry, "trailer", m_XbmcInfo.trailer, didl_namespace_xbmc, 256);
++
+     // re serialize the entry didl as a we might need to pass it to a renderer
+     // we may have modified the tree to "fix" issues, so as not to break a renderer
+     // (don't write xml prefix as this didl could be part of a larger document)
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.h
+@@ -173,6 +173,7 @@
+   NPT_String unique_identifier;
+   NPT_List<NPT_String> countries;
+   NPT_Int32 user_rating;
++  NPT_String trailer;
+ } PLT_XbmcInfo;
+ 
+ typedef struct {
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.h
+@@ -70,7 +70,7 @@
+ typedef NPT_Reference<PLT_CapabilitiesData> PLT_CapabilitiesDataReference;
+ 
+ // explicitely specify res otherwise WMP won't return a URL!
+-#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:lastPlayerState,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country,xbmc:userrating"
++#define PLT_DEFAULT_FILTER  "dc:date,dc:description,upnp:longDescription,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:rating,upnp:lastPlaybackPosition,upnp:lastPlaybackTime,upnp:playbackCount,upnp:originalTrackNumber,upnp:episodeNumber,upnp:programTitle,upnp:seriesTitle,upnp:album,upnp:artist,upnp:author,upnp:director,dc:publisher,searchable,childCount,dc:title,dc:creator,upnp:actor,res@resolution,upnp:episodeCount,upnp:episodeSeason,xbmc:lastPlayerState,xbmc:dateadded,xbmc:rating,xbmc:votes,xbmc:artwork,xbmc:uniqueidentifier,xbmc:country,xbmc:userrating,xbmc:trailer"
+ 
+ /*----------------------------------------------------------------------
+ |   PLT_MediaContainerListener

--- a/lib/libUPnP/patches/0049-platinum-parse-userrating.patch
+++ b/lib/libUPnP/patches/0049-platinum-parse-userrating.patch
@@ -1,0 +1,23 @@
+From 4ef31402024662a24c47ef26e518069b3f6cf415 Mon Sep 17 00:00:00 2001
+From: Jeff Grieger <jeff@griegers.com>
+Date: Tue, 25 Sep 2018 11:00:00 +0200
+Subject: [PATCH] platinum: parse userrating
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -873,6 +873,11 @@
+ 
+     PLT_XmlHelper::GetChildText(entry, "uniqueidentifier", m_XbmcInfo.unique_identifier, didl_namespace_xbmc, 256);
+ 
++    PLT_XmlHelper::GetChildText(entry, "userrating", str, didl_namespace_xbmc, 256);
++    NPT_Int32 iuser_rating;
++    if (NPT_FAILED(str.ToInteger(iuser_rating))) iuser_rating = 0;
++    m_XbmcInfo.user_rating = iuser_rating;
++
+     PLT_XmlHelper::GetChildText(entry, "trailer", m_XbmcInfo.trailer, didl_namespace_xbmc, 256);
+ 
+     // re serialize the entry didl as a we might need to pass it to a renderer

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -251,6 +251,22 @@ public:
         return InvokeUpdateObject(path.c_str(), (const char*)curr_value, (const char*)new_value);
     }
 
+    bool SetUserRating(const CFileItem& item, const int old_rating)
+    {
+      if (!item.HasVideoInfoTag() || item.GetPath().empty())
+      {
+        return false;
+      }
+
+      NPT_String curr_value;
+      NPT_String new_value;
+
+      curr_value.Append(NPT_String::Format("<xbmc:userrating>%d</xbmc:userrating>", old_rating));
+      new_value.Append(NPT_String::Format("<xbmc:userrating>%d</xbmc:userrating>", item.GetVideoInfoTag()->m_iUserRating));
+
+      return InvokeUpdateObject(item.GetPath().c_str(), static_cast<const char*>(curr_value), static_cast<const char*>(new_value));
+    }
+
     bool InvokeUpdateObject(const char* id, const char* curr_value, const char* new_value)
     {
         CURL url(id);
@@ -522,6 +538,21 @@ CUPnP::SaveFileState(const CFileItem& item, const CBookmark& bookmark, const boo
         return browser->SaveFileState(item, bookmark, updatePlayCount);
     }
     return false;
+}
+
+/*----------------------------------------------------------------------
+|   CUPnP::SetUserRating
++---------------------------------------------------------------------*/
+bool
+CUPnP::SetUserRating(const CFileItem& item, const int old_rating)
+{
+  if (upnp && upnp->m_MediaBrowser)
+  {
+    // dynamic_cast is safe here, avoids polluting CUPnP.h header file
+    CMediaBrowser* browser = dynamic_cast<CMediaBrowser*>(upnp->m_MediaBrowser);
+    return browser->SetUserRating(item, old_rating);
+  }
+  return false;
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnP.h
+++ b/xbmc/network/upnp/UPnP.h
@@ -70,6 +70,9 @@ public:
                               const CBookmark& bookmark,
                               const bool updatePlayCount);
 
+    static bool SetUserRating(const CFileItem& item,
+                              const int old_rating);
+
     static void RegisterUserdata(void* ptr);
     static void UnregisterUserdata(void* ptr);
 private:

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -307,6 +307,7 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
     for (const auto& country : tag.m_country)
       object.m_XbmcInfo.countries.Add(country.c_str());
     object.m_XbmcInfo.user_rating = tag.m_iUserRating;
+    object.m_XbmcInfo.trailer = tag.m_strTrailer.c_str();
 
     for (unsigned int index = 0; index < tag.m_genre.size(); index++)
       object.m_Affiliation.genres.Add(tag.m_genre.at(index).c_str());
@@ -812,6 +813,7 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     for (unsigned int index = 0; index < object.m_XbmcInfo.countries.GetItemCount(); index++)
       tag.m_country.push_back(object.m_XbmcInfo.countries.GetItem(index)->GetChars());
     tag.m_iUserRating = object.m_XbmcInfo.user_rating;
+    tag.SetTrailer(object.m_XbmcInfo.trailer.GetChars());
 
     for (unsigned int index = 0; index < object.m_Affiliation.genres.GetItemCount(); index++)
     {

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -45,6 +45,9 @@
 #include "filesystem/Directory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
+#if defined(HAS_UPNP)
+#include "network/upnp/UPnP.h"
+#endif
 #include "utils/FileUtils.h"
 #include "utils/Variant.h"
 #include "messaging/helpers/DialogOKHelper.h"
@@ -98,6 +101,12 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
 
       if (m_startUserrating != m_movieItem->GetVideoInfoTag()->m_iUserRating)
       {
+#if defined(HAS_UPNP)
+        if (URIUtils::IsUPnP(m_movieItem->GetPath()))
+        {
+          UPNP::CUPnP::SetUserRating(*m_movieItem, m_startUserrating);
+        }
+#endif
         CVideoDatabase db;
         if (db.Open())
         {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -712,7 +712,8 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
     if (!scraper &&
         !(m_database.HasMovieInfo(item->GetPath()) ||
           m_database.HasTvShowInfo(strDir)           ||
-          m_database.HasEpisodeInfo(item->GetPath())))
+          m_database.HasEpisodeInfo(item->GetPath())) &&
+        !URIUtils::IsUPnP(strDir))
     {
       return false;
     }


### PR DESCRIPTION
-Add movie trailers to UPNP.
-Enable 'Show Information' for UPNP videos to show video information instead of playing the video.

## Description
-The attribute xbmc:trailer is added to UPNP.
-When 'Show Information' is selected as the Videos 'Default Select Action' UPNP videos would start playing instead of the show information dialog displaying.  This patch will show the information dialog instead of playing the video and also enables the information dialog when 'i' is pressed on a selected UPNP video.

## Motivation and Context
-Movie trailers can now be played when Kodi is pulling meta data from another UPNP server that provides the xbmc:trailer attribute (such as a Kodi UPNP server).
-When Videos 'Default Select Action' is set to 'Show Information' the information dialog is displayed instead of the video playing and when a user presses 'i' for information on a selected UPNP video, the information dialog is displayed.

## How Has This Been Tested?
Compiled and tested on Windows and Linux.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
