### PR TITLE
[PVR] GUI Actions: Execute recordings actions async

### DIFF
--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -31,12 +31,12 @@ class CBusyWaiter : public CThread
 public:
   CBusyWaiter(IRunnable *runnable) : CThread(runnable, "waiting"), m_done(new CEvent()) {  }
   
-  bool Wait()
+  bool Wait(unsigned int displaytime, bool allowCancel)
   {
     std::shared_ptr<CEvent> e_done(m_done);
 
     Create();
-    return CGUIDialogBusy::WaitOnEvent(*e_done);
+    return CGUIDialogBusy::WaitOnEvent(*e_done, displaytime, allowCancel);
   }
 
   // 'this' is actually deleted from the thread where it's on the stack
@@ -50,12 +50,12 @@ public:
 
 };
 
-bool CGUIDialogBusy::Wait(IRunnable *runnable)
+bool CGUIDialogBusy::Wait(IRunnable *runnable, unsigned int displaytime /* = 100 */, bool allowCancel /* = true */)
 {
   if (!runnable)
     return false;
   CBusyWaiter waiter(runnable);
-  return waiter.Wait();
+  return waiter.Wait(displaytime, allowCancel);
 }
 
 bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 100 */, bool allowCancel /* = true */)

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -44,18 +44,20 @@ public:
    Creates a thread to run the given runnable, and while waiting
    it displays the busy dialog.
    \param runnable the IRunnable to run.
+   \param displaytime the time in ms to wait prior to showing the busy dialog (defaults to 100ms)
+   \param allowCancel whether the user can cancel the wait, defaults to true.
    \return true if the runnable completes, false if the user cancels early.
    */
-  static bool Wait(IRunnable *runnable);
+  static bool Wait(IRunnable *runnable, unsigned int displaytime = 100, bool allowCancel = true);
 
   /*! \brief Wait on an event while displaying the busy dialog.
    Throws up the busy dialog after the given time.
-   \param even the CEvent to wait on.
+   \param event the CEvent to wait on.
    \param displaytime the time in ms to wait prior to showing the busy dialog (defaults to 100ms)
    \param allowCancel whether the user can cancel the wait, defaults to true.
    \return true if the event completed, false if cancelled.
    */
-  static bool WaitOnEvent(CEvent &event, unsigned int timeout = 100, bool allowCancel = true);
+  static bool WaitOnEvent(CEvent &event, unsigned int displaytime = 100, bool allowCancel = true);
 protected:
   virtual void Open_Internal(const std::string &param = "");
   bool m_bCanceled;


### PR DESCRIPTION
My recordings are located on a NAS which automatically spins down disks and falls asleep if NAS gets not accessed for a certain period of time and it automatically gets awakened on demand. The latter can take up to 20 secs.

Visual effect in Kodi is for example, a 20 secs blocking user interface after selecting "delete" on a recording in Kodi's PVR Recordings window.

This PR fixes this gui blocking by executing the functions in question asynchronously (and by giving visual feedback using the Kodi busy dialog).

This has been runtime tested on macOS and Linux on latest Kodi master.

@Jalle19 for review?

