### PR TITLE
[Fix]paplayer: replaygain regression

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AELimiter.h
+++ b/xbmc/cores/AudioEngine/Utils/AELimiter.h
@@ -36,7 +36,7 @@ class CAELimiter
 
     void SetAmplification(float amplify)
     {
-      m_amplify = std::max(std::min(amplify, 1000.0f), 1.0f);
+      m_amplify = std::max(std::min(amplify, 1000.0f), 0.0f);
     }
 
     float GetAmplification()

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -495,9 +495,11 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
   si->m_stream->SetVolume    (si->m_volume);
   float peak = 1.0;
   float gain = si->m_decoder.GetReplayGain(peak);
-  if (peak == 1.0)
+  if (peak * gain <= 1.0)
+    // No clipping protection needed
     si->m_stream->SetReplayGain(gain);
   else
+    // Clipping protecton provided as audio limiting
     si->m_stream->SetAmplification(gain);
 
   /* if its not the first stream and crossfade is not enabled */


### PR DESCRIPTION
There have been a number of user reports of replaygain not working since #10924 that fixed the issue of replay gain not being applied if peak value was missing, and also removed the avoid clipping setting. See http://forum.kodi.tv/showthread.php?tid=296751&pid=2517978#pid2517978

Fixed by using peak * gain > 1.0 as the clipping protection check .

@FernetMenta we agree this is the immediate fix, nice and simple for backport as #11864