### PR TITLE
[Fix][Backport]Default music artist separators remove colon and "|" (ticket 17401)

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -279,7 +279,7 @@ void CAdvancedSettings::Initialize()
   m_strMusicLibraryAlbumFormat = "";
   m_prioritiseAPEv2tags = false;
   m_musicItemSeparator = " / ";
-  m_musicArtistSeparators = { ";", ":", "|", " feat. ", " ft. " };
+  m_musicArtistSeparators = { ";", " feat. ", " ft. " };
   m_videoItemSeparator = " / ";
   m_iMusicLibraryDateAdded = 1; // prefer mtime over ctime and current time
 


### PR DESCRIPTION
Simple modification that fixes Ticket http://trac.kodi.tv/ticket/17401

Both ":" and "|" appear in artist names, so having them as defualt can cause artists to be misidentified. Users can always configure these to be separators if they have used them in their tagging (and do not have any in the artist names)

Backport of #11873 .