### PR TITLE
[PVR][Esturay] Channelgroup manager dialog: Add support for radio channel groups

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9957,7 +9957,19 @@ msgctxt "#19172"
 msgid "Instant recording duration"
 msgstr ""
 
-#empty strings from id 19173 to 19174
+#. generic label for 'Live TV channel groups' used in different places
+#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
+#: addons/skin.estuary/xml/Variables.xml
+msgctxt "#19173"
+msgid "TV channel groups"
+msgstr ""
+
+#. generic label for pvr-provided 'Radio channel groups' used in different places
+#: addons/skin.estuary/xml/DialogPVRGroupManager.xml
+#: addons/skin.estuary/xml/Variables.xml
+msgctxt "#19174"
+msgid "Radio channel groups"
+msgstr ""
 
 #. pvr settings "default time to add before the start of an event to record (according to its epg data)" setting label
 #: system/settings/settings.xml

--- a/addons/skin.estuary/xml/DialogPVRGroupManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRGroupManager.xml
@@ -11,7 +11,7 @@
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1720" />
 				<param name="height" value="880" />
-				<param name="header_label" value="$LOCALIZE[19143]" />
+				<param name="header_label" value="$VAR[PVRGroupMgrHeader]$INFO[Container(13).NumItems, (,)]" />
 				<param name="header_id" value="1" />
 			</include>
 			<control type="grouplist" id="9000">
@@ -55,6 +55,15 @@
 					<include>SettingsItemCommon</include>
 					<font>font25_title</font>
 					<label>$LOCALIZE[31046]</label>
+				</control>
+				<control type="togglebutton" id="34">
+					<description>TV/Radio toggle</description>
+					<width>370</width>
+					<include>SettingsItemCommon</include>
+					<font>font25_title</font>
+					<label>$LOCALIZE[19174]</label>
+					<altlabel>$LOCALIZE[19173]</altlabel>
+					<usealttexture>!String.IsEmpty(Window.Property(IsRadio))</usealttexture>
 				</control>
 				<control type="button" id="29">
 					<description>OK</description>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -354,6 +354,10 @@
 		<value condition="!String.IsEmpty(Window.Property(IsRadio))">$LOCALIZE[19199] - $LOCALIZE[19024]</value>
 		<value>$LOCALIZE[19199] - $LOCALIZE[19023]</value>
 	</variable>
+	<variable name="PVRGroupMgrHeader">
+		<value condition="!String.IsEmpty(Window.Property(IsRadio))">$LOCALIZE[19048] - $LOCALIZE[19174]</value>
+		<value>$LOCALIZE[19048] - $LOCALIZE[19173]</value>
+	</variable>
 	<variable name="PVRAreaVar">
 		<value condition="Control.HasFocus(100)">$LOCALIZE[19019]</value>
 		<value condition="Control.HasFocus(101)">$LOCALIZE[19069]</value>

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -47,17 +47,19 @@ using namespace PVR;
 #define BUTTON_RENAMEGROUP            27
 #define BUTTON_DELGROUP               28
 #define BUTTON_OK                     29
+#define BUTTON_TOGGLE_RADIO_TV        34
 
 CGUIDialogPVRGroupManager::CGUIDialogPVRGroupManager() :
     CGUIDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER, "DialogPVRGroupManager.xml")
 {
-  m_bIsRadio = 0;
   m_iSelectedUngroupedChannel = 0;
   m_iSelectedGroupMember = 0;
   m_iSelectedChannelGroup = 0;
   m_ungroupedChannels = new CFileItemList;
   m_groupMembers      = new CFileItemList;
   m_channelGroups     = new CFileItemList;
+
+  SetRadio(false);
 }
 
 CGUIDialogPVRGroupManager::~CGUIDialogPVRGroupManager()
@@ -65,6 +67,12 @@ CGUIDialogPVRGroupManager::~CGUIDialogPVRGroupManager()
   delete m_ungroupedChannels;
   delete m_groupMembers;
   delete m_channelGroups;
+}
+
+void CGUIDialogPVRGroupManager::SetRadio(bool bIsRadio)
+{
+  m_bIsRadio = bIsRadio;
+  SetProperty("IsRadio", m_bIsRadio ? "true" : "");
 }
 
 bool CGUIDialogPVRGroupManager::PersistChanges(void)
@@ -273,6 +281,21 @@ bool CGUIDialogPVRGroupManager::ActionButtonHideGroup(CGUIMessage &message)
   return bReturn;
 }
 
+bool CGUIDialogPVRGroupManager::ActionButtonToggleRadioTV(CGUIMessage &message)
+{
+  bool bReturn = false;
+
+  if (message.GetSenderId() == BUTTON_TOGGLE_RADIO_TV)
+  {
+    PersistChanges();
+    SetRadio(!m_bIsRadio);
+    Update();
+    bReturn = true;
+  }
+
+  return bReturn;
+}
+
 bool CGUIDialogPVRGroupManager::OnMessageClick(CGUIMessage &message)
 {
   return ActionButtonOk(message) ||
@@ -282,7 +305,8 @@ bool CGUIDialogPVRGroupManager::OnMessageClick(CGUIMessage &message)
       ActionButtonUngroupedChannels(message) ||
       ActionButtonGroupMembers(message) ||
       ActionButtonChannelGroups(message) ||
-      ActionButtonHideGroup(message);
+      ActionButtonHideGroup(message) ||
+      ActionButtonToggleRadioTV(message);
 }
 
 bool CGUIDialogPVRGroupManager::OnMessage(CGUIMessage& message)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.h
@@ -36,7 +36,7 @@ namespace PVR
     virtual bool OnMessage(CGUIMessage& message);
     virtual void OnWindowLoaded();
     virtual void OnWindowUnload();
-    void SetRadio(bool IsRadio) { m_bIsRadio = IsRadio; }
+    void SetRadio(bool bIsRadio);
 
   protected:
     virtual void OnInitWindow();
@@ -56,6 +56,7 @@ namespace PVR
     bool ActionButtonGroupMembers(CGUIMessage &message);
     bool ActionButtonChannelGroups(CGUIMessage &message);
     bool ActionButtonHideGroup(CGUIMessage &message);
+    bool ActionButtonToggleRadioTV(CGUIMessage &message);
     bool OnMessageClick(CGUIMessage &message);
 
     CPVRChannelGroupPtr m_selectedGroup;


### PR DESCRIPTION
This PR adds support for radio channel groups to the PVR Channelgroups manager dialog. Stumbled over this missing feature today - could not believe that this was missing! ;-)

![screenshot001](https://cloud.githubusercontent.com/assets/3226626/24083641/1be0c0ae-0cdb-11e7-8688-0c1eade40abb.png)
![screenshot000](https://cloud.githubusercontent.com/assets/3226626/24083645/1f5df8e6-0cdb-11e7-975e-396308b62bb9.png)

The changes were runtime tested an macOS on latest Kodi master.

@Jalle19 @xhaggi for core code review?
@phil65 @ronie for review of the skin changes?