### PR TITLE
[PVR] Guide window: Fix selection after channelgroup switching

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -416,14 +416,6 @@ void CGUIEPGGridContainer::RenderItem(float posX, float posY, CGUIListItem *item
   g_graphicsContext.RestoreOrigin();
 }
 
-void CGUIEPGGridContainer::ResetCoordinates()
-{
-  m_channelCursor = 0;
-  m_channelOffset = 0;
-  m_blockCursor = 0;
-  m_blockOffset = 0;
-}
-
 bool CGUIEPGGridContainer::OnAction(const CAction &action)
 {
   switch (action.GetID())
@@ -750,8 +742,22 @@ void CGUIEPGGridContainer::UpdateItems()
 
   if (prevSelectedEpgTag && (oldChannelIndex != 0 || oldBlockIndex != 0))
   {
-    if (m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag() != prevSelectedEpgTag)
+    if (newChannelIndex >= m_gridModel->ChannelItemsSize() ||
+        newBlockIndex >= m_gridModel->GetBlockCount() ||
+        m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag() != prevSelectedEpgTag)
+    {
       m_gridModel->FindChannelAndBlockIndex(channelUid, broadcastUid, eventOffset, newChannelIndex, newBlockIndex);
+
+      if (newChannelIndex == CGUIEPGGridContainerModel::INVALID_INDEX ||
+          newBlockIndex == CGUIEPGGridContainerModel::INVALID_INDEX)
+      {
+        // previous selection is no longer in grid, goto channel 0 and now
+        SetInvalid();
+        GoToChannel(0);
+        GoToNow();
+        return;
+      }
+    }
 
     // restore previous selection.
     if (newChannelIndex == oldChannelIndex && newBlockIndex == oldBlockIndex)
@@ -1665,17 +1671,17 @@ void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList>
 
 void CGUIEPGGridContainer::GoToChannel(int channelIndex)
 {
-  if (channelIndex > m_gridModel->ChannelItemsSize() - m_channelsPerPage)
-  {
-    // last page
-    ScrollToChannelOffset(m_gridModel->ChannelItemsSize() - m_channelsPerPage);
-    SetChannel(channelIndex - (m_gridModel->ChannelItemsSize() - m_channelsPerPage));
-  }
-  else if (channelIndex < m_channelsPerPage)
+  if (channelIndex < m_channelsPerPage)
   {
     // first page
     ScrollToChannelOffset(0);
     SetChannel(channelIndex);
+  }
+  else if (channelIndex > m_gridModel->ChannelItemsSize() - m_channelsPerPage)
+  {
+    // last page
+    ScrollToChannelOffset(m_gridModel->ChannelItemsSize() - m_channelsPerPage);
+    SetChannel(channelIndex - (m_gridModel->ChannelItemsSize() - m_channelsPerPage));
   }
   else
   {
@@ -1686,17 +1692,12 @@ void CGUIEPGGridContainer::GoToChannel(int channelIndex)
 
 void CGUIEPGGridContainer::GoToBlock(int blockIndex)
 {
-  if (blockIndex > m_gridModel->GetBlockCount() - m_blocksPerPage)
+  int lastPage = m_gridModel->GetBlockCount() - m_blocksPerPage;
+  if (blockIndex > lastPage)
   {
-    // last block
-    ScrollToBlockOffset(m_gridModel->GetBlockCount() - m_blocksPerPage);
-    SetBlock(blockIndex - (m_gridModel->GetBlockCount() - m_blocksPerPage));
-  }
-  else if (blockIndex < m_blocksPerPage)
-  {
-    // first block
-    ScrollToBlockOffset(0);
-    SetBlock(blockIndex);
+    // last page
+    ScrollToBlockOffset(lastPage);
+    SetBlock(blockIndex - lastPage);
   }
   else
   {

--- a/xbmc/epg/GUIEPGGridContainer.h
+++ b/xbmc/epg/GUIEPGGridContainer.h
@@ -94,7 +94,6 @@ namespace EPG
      * @return true if the selection was set to the given channel, false otherwise.
      */
     bool SetChannel(const std::string &channel);
-    void ResetCoordinates();
 
   protected:
     bool OnClick(int actionID);

--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -272,6 +272,9 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
   const CDateTimeSpan blockDuration(0, 0, MINSPERBLOCK, 0);
   bool bFoundPrevChannel = false;
 
+  newChannelIndex = INVALID_INDEX;
+  newBlockIndex = INVALID_INDEX;
+
   for (size_t channel = 0; channel < m_channelItems.size(); ++channel)
   {
     CDateTime gridCursor(m_gridStart); //reset cursor for new channel

--- a/xbmc/epg/GUIEPGGridContainerModel.h
+++ b/xbmc/epg/GUIEPGGridContainerModel.h
@@ -53,6 +53,7 @@ namespace EPG
     void Refresh(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd, int iRulerUnit, int iBlocksPerPage, float fBlockSize);
     void SetInvalid();
 
+    static const int INVALID_INDEX = -1;
     void FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int &newChannelIndex, int &newBlockIndex) const;
 
     void FreeChannelMemory(int keepStart, int keepEnd);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -198,14 +198,8 @@ bool CGUIWindowPVRGuide::GetDirectory(const std::string &strDirectory, CFileItem
   {
     CSingleLock lock(m_critSection);
 
-    // group change detected reset grid coordinates and refresh grid items
     if (!m_bRefreshTimelineItems && *m_cachedChannelGroup != *GetChannelGroup())
     {
-      CGUIEPGGridContainer* epgGridContainer = GetGridControl();
-      if (!epgGridContainer)
-        return true;
-
-      epgGridContainer->ResetCoordinates();
       m_bRefreshTimelineItems = true;
       bRefresh = true;
     }
@@ -443,10 +437,16 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
 bool CGUIWindowPVRGuide::RefreshTimelineItems()
 {
-  if (m_bRefreshTimelineItems)
+  bool bRefreshTimelineItems;
   {
-    m_bRefreshTimelineItems = false;
+    CSingleLock lock(m_critSection);
 
+    bRefreshTimelineItems = m_bRefreshTimelineItems;
+    m_bRefreshTimelineItems = false;
+  }
+
+  if (bRefreshTimelineItems)
+  {
     CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (epgGridContainer)
     {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -55,6 +55,8 @@ CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
 CGUIWindowPVRGuide::~CGUIWindowPVRGuide(void)
 {
   g_EpgContainer.UnregisterObserver(this);
+
+  m_bRefreshTimelineItems = false;
   StopRefreshTimelineItemsThread();
 }
 
@@ -72,8 +74,13 @@ void CGUIWindowPVRGuide::Init()
     epgGridContainer->GoToNow();
   }
 
+  if (!m_refreshTimelineItemsThread)
+  {
+    CSingleLock lock(m_critSection);
+    m_bRefreshTimelineItems = true; // force data update on first window open
+  }
+
   StartRefreshTimelineItemsThread();
-  m_bRefreshTimelineItems = true; // force data update on window open/re-open
 }
 
 void CGUIWindowPVRGuide::ClearData()
@@ -104,6 +111,16 @@ void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
 
   m_bChannelSelectionRestored = false;
 
+  {
+    CSingleLock lock(m_critSection);
+    if (m_vecItems && !m_newTimeline)
+    {
+      // speedup: save a copy of current items for reuse when re-opening the window
+      m_newTimeline.reset(new CFileItemList);
+      m_newTimeline->Copy(*m_vecItems);
+    }
+  }
+
   CGUIWindowPVRBase::OnDeinitWindow(nextWindowID);
 }
 
@@ -117,19 +134,15 @@ void CGUIWindowPVRGuide::StartRefreshTimelineItemsThread()
 void CGUIWindowPVRGuide::StopRefreshTimelineItemsThread()
 {
   if (m_refreshTimelineItemsThread)
-  {
-    m_bRefreshTimelineItems = false;
     m_refreshTimelineItemsThread->Stop();
-  }
 }
 
 void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  if (IsActive() &&
-      (msg == ObservableMessageEpg ||
-       msg == ObservableMessageEpgContainer ||
-       msg == ObservableMessageChannelGroupReset ||
-       msg == ObservableMessageChannelGroup))
+  if (msg == ObservableMessageEpg ||
+      msg == ObservableMessageEpgContainer ||
+      msg == ObservableMessageChannelGroupReset ||
+      msg == ObservableMessageChannelGroup)
   {
     CSingleLock lock(m_critSection);
     m_bRefreshTimelineItems = true;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <memory>
+#include "threads/Event.h"
 #include "threads/Thread.h"
 #include "pvr/PVRChannelNumberInputHandler.h"
 #include "GUIWindowPVRBase.h"
@@ -96,7 +97,12 @@ namespace PVR
 
     virtual void Process();
 
+    void DoRefresh();
+    void Stop();
+
   private:
     CGUIWindowPVRGuide *m_pGuideWindow;
+    CEvent m_ready;
+    CEvent m_done;
   };
 }


### PR DESCRIPTION
This PR fixes wrong epg event selection after channel group switching in the PVR Guide window. Expected behavior is that the same event is still selected after a channel group switch, if the previously selected channel is also part of the new channel group. Otherwise, the first channel of the new group is selected.

The second commit introduces asynchrounous channel group switching. The gui render thread is no longer blocked while the epg grid gets refilled. A wait dialog is shown if the refill lasts longer than 100 msecs.

This was runtime tested on macOS and Linux on latest Kodi master.

@Jalle19 for code review?
@xhaggi for runtime testing (you reported the problems ;-)