### PR TITLE
fixed: install into system-expected python library path

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -203,11 +203,13 @@ install(FILES ${CMAKE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/ko
         COMPONENT kodi-image-dev)
 
 if(ENABLE_EVENTCLIENTS)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(prefix='')"
+                  OUTPUT_VARIABLE PYTHON_LIB_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
   # Install kodi-eventclients-common BT python files
   install(PROGRAMS ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/bt/__init__.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/bt/bt.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/bt/hid.py
-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}/bt
+          DESTINATION ${PYTHON_LIB_PATH}/${APP_NAME_LC}/bt
           COMPONENT kodi-eventclients-common)
 
   # Install kodi-eventclients-common PS3 python files
@@ -216,7 +218,7 @@ if(ENABLE_EVENTCLIENTS)
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixaxis.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixpair.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/ps3/sixwatch.py
-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}/ps3
+          DESTINATION ${PYTHON_LIB_PATH}/${APP_NAME_LC}/ps3
           COMPONENT kodi-eventclients-common)
 
   # Install kodi-eventclients-common python files
@@ -226,7 +228,7 @@ if(ENABLE_EVENTCLIENTS)
                    "${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/PS3 BD Remote/ps3_remote.py"
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/xbmcclient.py
                    ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/zeroconf.py
-          DESTINATION lib/python2.7/dist-packages/${APP_NAME_LC}
+          DESTINATION ${PYTHON_LIB_PATH}/${APP_NAME_LC}
           COMPONENT kodi-eventclients-common)
 
   # Install kodi-eventclients-common icons


### PR DESCRIPTION
dist-packages is a debian-ism and does not play well on distros with other origins. ref http://forum.kodi.tv/showthread.php?tid=309969