### PR TITLE
FIX: [python] no abort + droid libs

### DIFF
--- a/tools/depends/target/python27/Makefile
+++ b/tools/depends/target/python27/Makefile
@@ -39,6 +39,8 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../Python-2.7.10-android.patch
 	cd $(PLATFORM); patch -p0 < ../Python-no-export-path.patch
 	cd $(PLATFORM); patch -p0 < ../fix-ffi.patch
+	cd $(PLATFORM); patch -l -p0 < ../python-android-binmodule.patch
+	cd $(PLATFORM); patch -p1 < ../Python-no-abort.patch
 ifeq ($(OS),ios)
 	cd $(PLATFORM); patch -p0 < ../make-fork-optional.patch
 	cd $(PLATFORM); patch -p0 < ../Python-2.6.5-urllib.diff

--- a/tools/depends/target/python27/Python-no-abort.patch
+++ b/tools/depends/target/python27/Python-no-abort.patch
@@ -1,0 +1,24 @@
+diff -ur orig/Modules/posixmodule.c arm-linux-androideabi-21/Modules/posixmodule.c
+--- orig/Modules/posixmodule.c	2016-07-30 22:35:02.016158026 +0200
++++ arm-linux-androideabi-21/Modules/posixmodule.c	2016-08-27 13:02:46.755833610 +0200
+@@ -8632,7 +8632,7 @@
+ static PyObject *
+ posix_abort(PyObject *self, PyObject *noargs)
+ {
+-    abort();
++    // abort();
+     /*NOTREACHED*/
+     Py_FatalError("abort() called from Python code didn't abort!");
+     return NULL;
+diff -ur orig/Python/pythonrun.c arm-linux-androideabi-21/Python/pythonrun.c
+--- orig/Python/pythonrun.c	2009-10-27 13:48:52.000000000 +0100
++++ arm-linux-androideabi-21/Python/pythonrun.c	2016-08-27 13:03:38.051914732 +0200
+@@ -1697,7 +1697,7 @@
+     DebugBreak();
+ #endif
+ #endif /* MS_WINDOWS */
+-    abort();
++	// abort();
+ }
+
+ /* Clean up and exit */

--- a/tools/depends/target/python27/python-android-binmodule.patch
+++ b/tools/depends/target/python27/python-android-binmodule.patch
@@ -1,0 +1,31 @@
+--- Python/dynload_shlib.c	2014-08-13 15:13:49.879675283 +0200
++++ Python/dynload_shlib.c	2014-08-13 19:03:57.456363680 +0200
+@@ -112,10 +112,6 @@
+         dlopenflags = PyThreadState_GET()->interp->dlopenflags;
+ #endif
+ 
+-	if (Py_VerboseFlag)
+-		PySys_WriteStderr("dlopen(\"%s\", %x);\n", pathname, 
+-				  dlopenflags);
+-
+ #ifdef __VMS
+ 	/* VMS currently don't allow a pathname, use a logical name instead */
+ 	/* Concatenate 'python_module_' and shortname */
+@@ -125,8 +121,17 @@
+ 	PyOS_snprintf(pathbuf, sizeof(pathbuf), "python_module_%-.200s", 
+ 		      shortname);
+ 	pathname = pathbuf;
++#elif defined(ANDROID)
++	/* Android does not allow a pathname and wants lib*.so */
++	PyOS_snprintf(pathbuf, sizeof(pathbuf), "lib%-.200s.so", 
++		      shortname);
++	pathname = pathbuf;
+ #endif
+ 
++	if (Py_VerboseFlag)
++		PySys_WriteStderr("dlopen(\"%s\", %x);\n", pathname, 
++				  dlopenflags);
++
+ 	handle = dlopen(pathname, dlopenflags);
+ 
+ 	if (handle == NULL) {


### PR DESCRIPTION
Couple of python patches:

1) Do not allow python to abort Kodi
2) Re-apply 2,6 patch regarding libraries on droid

Not sure if 2) is still needed specifically with pillow, but definitely needed in general