### PR TITLE
Revert "[bluray] Early return if requested "dir" is in fact a file."

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -156,9 +156,6 @@ int DllLibbluray::dir_read(BD_DIR_H *dir, BD_DIRENT *entry)
 
 BD_DIR_H *DllLibbluray::dir_open(const char* dirname)
 {
-  if (CFile::Exists(dirname))
-    return NULL;
-
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - Opening dir %s\n", dirname);
     SDirState *st = new SDirState();
 


### PR DESCRIPTION
This reverts commit 462d64d9bbac5cde36c5e52efabe78e77260c2ac.

Our udf implementation does not distinguish between dirs and files inside an iso file.