### PR TITLE
Fix missing xbmcgui.ACTION_ values

### DIFF
--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -28,6 +28,7 @@
 #include "interfaces/legacy/WindowDialog.h"
 #include "interfaces/legacy/Dialog.h"
 #include "interfaces/legacy/WindowXML.h"
+#include "input/ActionIDs.h"
 #include "input/Key.h"
 
 using namespace XBMCAddon;
@@ -116,4 +117,5 @@ using namespace xbmcgui;
 
 %include "interfaces/legacy/WindowXML.h"
 
+%include "input/ActionIDs.h"
 %include "input/Key.h"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Adds an include of `input/ActionIDs.h` which was recently introduced in https://github.com/xbmc/xbmc/pull/11645 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Navigation is broken in some addons due to `xbmcgui` missing all the `ACTION_` IDs such as `ACTION_MOVE_DOWN`. The log shows errors such as
```
 Error Type: <type 'exceptions.AttributeError'>
 Error Contents: 'module' object has no attribute 'ACTION_MOVE_DOWN'
```
I have no idea if this actually fixes the problem as I have been unable to compile with the new cmake system.
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Not tested as I have been unable to compile with cmake.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
