### PR TITLE
[windows] use wmic qfe instead of powershell to check if hotfix is installed

### DIFF
--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -354,14 +354,17 @@ Function .onInit
     StrCpy $HotFixID ""
   ${Endif}
   ${If} $HotFixID != ""
-    SetOutPath "$TEMP\PS"
-    FileOpen $0 ps.ps1 w
-    FileWrite $0 "Get-HotFix -Id KB$HotFixID -ea SilentlyContinue"
-    FileClose $0
-    nsExec::ExecToStack 'powershell -noprofile -inputformat none -ExecutionPolicy RemoteSigned -File "$TEMP\PS\ps.ps1"'
+    nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\wbem\wmic.exe /?"'
     Pop $0 ; return value (it always 0 even if an error occured)
     Pop $1 ; command output
-    RMDir /r "$TEMP\PS"
+    ${If} $0 != 0
+    ${OrIf} $1 == ""
+      MessageBox MB_OK|MB_ICONSTOP|MB_TOPMOST|MB_SETFOREGROUND "Unable to run the Windows program wmic.exe to verify that Windows Update KB$HotFixID is installed.$\nWmic is not installed correctly.$\nPlease fix this issue and try again to install Kodi."
+      Quit
+    ${EndIf}  
+    nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\wbem\wmic.exe qfe get hotfixid | findstr "^KB$HotFixID[^0-9]""'
+    Pop $0 ; return value (it always 0 even if an error occured)
+    Pop $1 ; command output
     ${If} $0 != 0
     ${OrIf} $1 == ""
       MessageBox MB_OK|MB_ICONSTOP|MB_TOPMOST|MB_SETFOREGROUND "Platform Update for Windows (KB$HotFixID) is required.$\nDownload and install Platform Update for Windows then run setup again."


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use `wmic qfe` instead of trying to execute a similar command with powershell to check if hotfix is installed.
<!--- Describe your change in detail -->

## Motivation and Context
Some users didn't have the powershell directory in PATH and therefore weren't able to install Kodi, although they have the required hotfix installed.
Not having it in PATH seems strange, but they haven't removed it themself.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Running the installer
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
