### PR TITLE
Fix FreeBSD build.

### DIFF
--- a/cmake/scripts/freebsd/ExtraTargets.cmake
+++ b/cmake/scripts/freebsd/ExtraTargets.cmake
@@ -1,0 +1,15 @@
+# xrandr
+if(ENABLE_X11 AND X_FOUND AND XRANDR_FOUND)
+  find_package(X QUIET)
+  find_package(XRandR QUIET)
+  add_executable(${APP_NAME_LC}-xrandr ${CMAKE_SOURCE_DIR}/xbmc-xrandr.c)
+  target_link_libraries(${APP_NAME_LC}-xrandr ${SYSTEM_LDFLAGS} ${X_LIBRARIES} m ${XRANDR_LIBRARIES})
+endif()
+
+# WiiRemote
+if(ENABLE_EVENTCLIENTS AND BLUETOOTH_FOUND)
+  find_package(CWiid QUIET)
+  if(CWIID_FOUND)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/WiiRemote build/WiiRemote)
+  endif()
+endif()


### PR DESCRIPTION
## Description
This provides the extra targets for FreeBSD that fixes the build.

## Motivation and Context
This fixes the FreeBSD build that ended with kodi-xrandr not being a known target.

## How Has This Been Tested?
I tested this on FreeBSD 11.0-STABLE and ran cmake to see that it succeeded this time

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
