### PR TITLE
[cmake] change RapidJSON_INCLUDE_DIRS to capital letters to get added to SYSTEM_INCLUDES

### DIFF
--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -19,12 +19,12 @@ find_path(RapidJSON_INCLUDE_DIR NAMES rapidjson/rapidjson.h
 set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RapidJSON
+find_package_handle_standard_args(RAPIDJSON
                                   REQUIRED_VARS RapidJSON_INCLUDE_DIR
                                   VERSION_VAR RapidJSON_VERSION)
 
-if(RapidJSON_FOUND)
-  set(RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR})
+if(RAPIDJSON_FOUND)
+  set(RAPIDJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR})
 endif()
 
 mark_as_advanced(RapidJSON_INCLUDE_DIR)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
The lib name for `<lib>_INCLUDE_DIRS` must always be written in upper case otherwise it won't get added to SYSTEM_INCLUDES.
<!--- Describe your change in detail -->

## Motivation and Context
RapidJSON_INCLUDE_DIRS wasn't added to the search path for includes.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiling
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
