### PR TITLE
[windows] use wmic qfe instead of powershell to check if hotfix is installed

### DIFF
--- a/project/Win32BuildSetup/genNsisInstaller.nsi
+++ b/project/Win32BuildSetup/genNsisInstaller.nsi
@@ -353,14 +353,17 @@ Function .onInit
     StrCpy $HotFixID ""
   ${Endif}
   ${If} $HotFixID != ""
-    SetOutPath "$TEMP\PS"
-    FileOpen $0 ps.ps1 w
-    FileWrite $0 "Get-HotFix -Id KB$HotFixID -ea SilentlyContinue"
-    FileClose $0
-    nsExec::ExecToStack 'powershell -noprofile -inputformat none -ExecutionPolicy RemoteSigned -File "$TEMP\PS\ps.ps1"'
+    nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\wbem\wmic.exe /?"'
     Pop $0 ; return value (it always 0 even if an error occured)
     Pop $1 ; command output
-    RMDir /r "$TEMP\PS"
+    ${If} $0 != 0
+    ${OrIf} $1 == ""
+      MessageBox MB_OK|MB_ICONSTOP|MB_TOPMOST|MB_SETFOREGROUND "Unable to run the Windows program wmic.exe to verify that Windows Update KB$HotFixID is installed.$\nWmic is not installed correctly.$\nPlease fix this issue and try again to install Kodi."
+      Quit
+    ${EndIf}  
+    nsExec::ExecToStack 'cmd /Q /C "%SYSTEMROOT%\System32\wbem\wmic.exe qfe get hotfixid | findstr "^KB$HotFixID[^0-9]""'
+    Pop $0 ; return value (it always 0 even if an error occured)
+    Pop $1 ; command output
     ${If} $0 != 0
     ${OrIf} $1 == ""
       MessageBox MB_OK|MB_ICONSTOP|MB_TOPMOST|MB_SETFOREGROUND "Platform Update for Windows (KB$HotFixID) is required.$\nDownload and install Platform Update for Windows then run setup again."


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Backport of #11893.
Use `wmic qfe` instead of trying to execute a similar command with powershell to check if hotfix is installed.
Also add a check if `wimic` can be executed and show a different error message if it can't be executed.
<!--- Describe your change in detail -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
