### PR TITLE
Fix crash due to exception when entering Games -> Keyboard settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16755,7 +16755,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#35156"
-msgid "{0:i}"
+msgid "{0:d}"
 msgstr ""
 
 #. Name of setting to configure a keyboard player's controller configuration


### PR DESCRIPTION
More concerning is that a typo in strings.po can crash Kodi. We should probably add a try/catch block when calling the new format function.