### PR TITLE
[PVR] Trac #17374: enabled "PVR -> Power saving -> Wakeup command" setting is not called

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -47,6 +47,7 @@ CPVRActionListener::CPVRActionListener()
     CSettings::SETTING_PVRMANAGER_CHANNELSCAN,
     CSettings::SETTING_PVRMENU_SEARCHICONS,
     CSettings::SETTING_PVRCLIENT_MENUHOOK,
+    CSettings::SETTING_EPG_DAYSTODISPLAY
   });
 }
 
@@ -145,6 +146,10 @@ void CPVRActionListener::OnSettingChanged(const CSetting *setting)
       else
         dynamic_cast<CSettingBool*>(const_cast<CSetting*>(setting))->SetValue(false);
     }
+  }
+  else if (settingId == CSettings::SETTING_EPG_DAYSTODISPLAY)
+  {
+    CServiceBroker::GetPVRManager().Clients()->SetEPGTimeFrame(static_cast<const CSettingInt*>(setting)->GetValue());
   }
 }
 

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include "pvr/PVRSettings.h"
 #include "pvr/PVRTypes.h"
 #include "pvr/PVRChannelNumberInputHandler.h"
 
@@ -415,6 +416,7 @@ namespace PVR
   private:
     CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
     bool m_bChannelScanRunning;
+    CPVRSettings m_settings;
 
   };
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -30,6 +30,7 @@
 
 #include "pvr/PVRActionListener.h"
 #include "pvr/PVREvent.h"
+#include "pvr/PVRSettings.h"
 #include "pvr/PVRTypes.h"
 #include "pvr/recordings/PVRRecording.h"
 
@@ -89,7 +90,7 @@ namespace PVR
     bool m_bStopped;
   };
 
-  class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer, public ISettingCallback
+  class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer
   {
     friend class CPVRClients;
 
@@ -119,9 +120,6 @@ namespace PVR
     virtual ~CPVRManager(void);
 
     virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
-
-    // ISettingCallback implementation
-    void OnSettingChanged(const CSetting *setting) override;
 
     /*!
      * @brief Get the channel groups container.
@@ -652,9 +650,7 @@ namespace PVR
     std::atomic_bool m_isChannelPreview;
     CEventSource<PVREvent> m_events;
 
-    // settings cache
-    bool m_bSettingPowerManagementEnabled; // SETTING_PVRPOWERMANAGEMENT_ENABLED
-    std::string m_strSettingWakeupCommand; // SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD
     CPVRActionListener m_actionListener;
+    CPVRSettings m_settings;
   };
 }

--- a/xbmc/pvr/PVRSettings.h
+++ b/xbmc/pvr/PVRSettings.h
@@ -19,24 +19,39 @@
  *
  */
 
+#include <map>
 #include <string>
 #include <utility>
-#include <vector>
 
-class CSetting;
+#include "settings/lib/ISettingCallback.h"
+#include "settings/lib/Setting.h"
 
 namespace PVR
 {
-  class CPVRSettings
+  class CPVRSettings : private ISettingCallback
   {
   public:
+    CPVRSettings(const std::set<std::string> & settingNames);
+    virtual ~CPVRSettings();
+
+    // ISettingCallback implementation
+    void OnSettingChanged(const CSetting *setting) override;
+
+    bool GetBoolValue(const std::string &settingName) const;
+    int GetIntValue(const std::string &settingName) const;
+    std::string GetStringValue(const std::string &settingName) const;
+
     // settings value filler for start/end recording margin time for PVR timers.
     static void MarginTimeFiller(
       const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 
   private:
-    CPVRSettings() = delete;
     CPVRSettings(const CPVRSettings&) = delete;
     CPVRSettings& operator=(CPVRSettings const&) = delete;
+
+    void Init(const std::set<std::string> &settingNames);
+
+    CCriticalSection m_critSection;
+    std::map<std::string, SettingPtr> m_settings;
   };
 }

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h"
+#include "pvr/PVRSettings.h"
 #include "PVRTimerInfoTag.h"
 #include "utils/Observer.h"
 #include "XBDateTime.h"
@@ -301,6 +302,7 @@ namespace PVR
     int AmountActiveRecordings(const TimerKind &eKind) const;
 
     bool m_bIsUpdating;
+    CPVRSettings m_settings;
   };
 
   class CPVRTimersPath

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -41,7 +41,11 @@ using namespace PVR;
 
 CGUIWindowPVRRecordings::CGUIWindowPVRRecordings(bool bRadio) :
   CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_RECORDINGS : WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml") ,
-  m_bShowDeletedRecordings(false)
+  m_bShowDeletedRecordings(false),
+  m_settings({
+    CSettings::SETTING_PVRRECORD_GROUPRECORDINGS,
+    CSettings::SETTING_MYVIDEOS_SELECTACTION
+  })
 {
   g_infoManager.RegisterObserver(this);
 }
@@ -169,7 +173,7 @@ void CGUIWindowPVRRecordings::UpdateButtons(void)
 
   SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE, g_localizeStrings.Get(iStringId));
 
-  bool bGroupRecordings = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
+  bool bGroupRecordings = m_settings.GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTNGROUPITEMS, bGroupRecordings);
 
   CGUIRadioButtonControl *btnShowDeleted = (CGUIRadioButtonControl*) GetControl(CONTROL_BTNSHOWDELETED);
@@ -227,7 +231,7 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
               }
               else
               {
-                switch (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MYVIDEOS_SELECTACTION))
+                switch (m_settings.GetIntValue(CSettings::SETTING_MYVIDEOS_SELECTACTION))
                 {
                   case SELECT_ACTION_CHOOSE:
                     OnPopupMenu(iItem);

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -22,6 +22,8 @@
 #include "video/VideoThumbLoader.h"
 #include "video/VideoDatabase.h"
 
+#include "pvr/PVRSettings.h"
+
 #include "GUIWindowPVRBase.h"
 
 namespace PVR
@@ -51,5 +53,6 @@ namespace PVR
     CVideoThumbLoader m_thumbLoader;
     CVideoDatabase m_database;
     bool m_bShowDeletedRecordings;
+    CPVRSettings m_settings;
   };
 }


### PR DESCRIPTION
This should finally fix http://trac.kodi.tv/ticket/17374. First fix attempt (#11849) was incomplete.

This is a more complete approach, which introduces a self contained auto updating settings container for PVR settings.

@FernetMenta for review, please.