### PR TITLE
[depends] bump rapidjson to 1.1.0

### DIFF
--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -14,7 +14,7 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
-  set(RapidJSON_VERSION 1.0.2)
+  set(RapidJSON_VERSION 1.1.0)
 else()
   set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
 endif()

--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -39,7 +39,7 @@ pcre-8.37-win32-vc140-v3.7z
 pillow-3.1.0-win32-vc140.7z
 pycryptodome-3.4.3-win32.7z
 python-2.7.11-win32-vc140-v2.7z
-rapidjson-1.0.2-win32.7z
+rapidjson-1.1.0-win32.7z
 shairplay-0.9.0-win32-vc140-v2.7z
 sqlite-3.10.2-win32-vc140.7z
 swig-3.0.10-win32.7z

--- a/tools/depends/target/rapidjson/0001-remove_custom_cxx_flags.patch
+++ b/tools/depends/target/rapidjson/0001-remove_custom_cxx_flags.patch
@@ -1,18 +1,29 @@
-diff -rupN a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	2015-09-10 18:33:21.048580591 +0200
-+++ b/CMakeLists.txt	2015-09-10 18:34:19.136579486 +0200
-@@ -25,14 +25,6 @@ if(RAPIDJSON_HAS_STDSTRING)
-     add_definitions(-DRAPIDJSON_HAS_STDSTRING)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ceda71b..efb259e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,7 +50,6 @@ if(CCACHE_FOUND)
+ endif(CCACHE_FOUND)
+ 
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror")
+     if (RAPIDJSON_BUILD_CXX11)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+@@ -73,7 +72,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+         endif()
+     endif()
+ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra -Werror -Wno-missing-field-initializers")
+     if (RAPIDJSON_BUILD_CXX11)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+     endif()
+@@ -88,7 +86,6 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+         endif()
+     endif()
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-    add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
  endif()
  
--if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra")
--elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wall -Wextra")
--elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
--    add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
--endif()
--
- #add extra search paths for libraries and includes
- SET(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")
- SET(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE STRING "Directory where lib will install")
+

--- a/tools/depends/target/rapidjson/Makefile
+++ b/tools/depends/target/rapidjson/Makefile
@@ -3,7 +3,7 @@ DEPS = Makefile 0001-remove_custom_cxx_flags.patch
 
 # lib name, version
 LIBNAME=rapidjson
-VERSION=1.0.2
+VERSION=1.1.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/utils/JSONVariantParser.cpp
+++ b/xbmc/utils/JSONVariantParser.cpp
@@ -34,6 +34,7 @@ public:
   bool Int64(int64_t i);
   bool Uint64(uint64_t u);
   bool Double(double d);
+  bool RawNumber(const char* str, rapidjson::SizeType length, bool copy);
   bool String(const char* str, rapidjson::SizeType length, bool copy);
   bool StartObject();
   bool Key(const char* str, rapidjson::SizeType length, bool copy);
@@ -110,6 +111,11 @@ bool CJSONVariantParserHandler::Uint64(uint64_t u)
 bool CJSONVariantParserHandler::Double(double d)
 {
   return Primitive(d);
+}
+
+bool CJSONVariantParserHandler::RawNumber(const char* str, rapidjson::SizeType length, bool copy)
+{
+  return Primitive(str, length);
 }
 
 bool CJSONVariantParserHandler::String(const char* str, rapidjson::SizeType length, bool copy)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

build and runtime tested on linux with both rapidjson 1.0.2 and 1.1.0. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

cc @Montellese 