### PR TITLE
Get ready for Mir 1.0 by removing deprecations

### DIFF
--- a/cmake/modules/FindMir.cmake
+++ b/cmake/modules/FindMir.cmake
@@ -11,7 +11,7 @@
 
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (PC_MIR mirclient QUIET)
+  pkg_check_modules (PC_MIR mirclient>=0.26.2 QUIET)
 endif()
 
 find_path(MIR_INCLUDE_DIR NAMES mir_toolkit/mir_client_library.h

--- a/xbmc/windowing/mir/GLContextEGL.cpp
+++ b/xbmc/windowing/mir/GLContextEGL.cpp
@@ -117,11 +117,11 @@ bool CGLContextEGL::CreateContext()
   return true;
 }
 
-bool CGLContextEGL::CreateSurface(MirWindow* surface)
+bool CGLContextEGL::CreateSurface(MirWindow* window)
 {
   EGLNativeWindowType egl_nwin = (EGLNativeWindowType)
                                  mir_buffer_stream_get_egl_native_window(
-                                 mir_window_get_buffer_stream(surface));
+                                 mir_window_get_buffer_stream(window));
 
   m_eglSurface = eglCreateWindowSurface(m_eglDisplay,
                                         m_eglConfig,

--- a/xbmc/windowing/mir/GLContextEGL.cpp
+++ b/xbmc/windowing/mir/GLContextEGL.cpp
@@ -117,11 +117,11 @@ bool CGLContextEGL::CreateContext()
   return true;
 }
 
-bool CGLContextEGL::CreateSurface(MirSurface* surface)
+bool CGLContextEGL::CreateSurface(MirWindow* surface)
 {
   EGLNativeWindowType egl_nwin = (EGLNativeWindowType)
                                  mir_buffer_stream_get_egl_native_window(
-                                 mir_surface_get_buffer_stream(surface));
+                                 mir_window_get_buffer_stream(surface));
 
   m_eglSurface = eglCreateWindowSurface(m_eglDisplay,
                                         m_eglConfig,

--- a/xbmc/windowing/mir/GLContextEGL.h
+++ b/xbmc/windowing/mir/GLContextEGL.h
@@ -34,7 +34,7 @@ public:
                      EGLint renderable_type,
                      EGLint rendering_api);
 
-  bool CreateSurface(MirWindow* surface);
+  bool CreateSurface(MirWindow* window);
   bool CreateContext();
   void Destroy();
   void Detach();

--- a/xbmc/windowing/mir/GLContextEGL.h
+++ b/xbmc/windowing/mir/GLContextEGL.h
@@ -34,7 +34,7 @@ public:
                      EGLint renderable_type,
                      EGLint rendering_api);
 
-  bool CreateSurface(MirSurface* surface);
+  bool CreateSurface(MirWindow* surface);
   bool CreateContext();
   void Destroy();
   void Detach();

--- a/xbmc/windowing/mir/WinEventsMir.cpp
+++ b/xbmc/windowing/mir/WinEventsMir.cpp
@@ -327,7 +327,7 @@ void MirHandleInput(MirInputEvent const* iev)
 }
 }
 
-void MirHandleEvent(MirSurface* surface, MirEvent const* ev, void* context)
+void MirHandleEvent(MirWindow* surface, MirEvent const* ev, void* context)
 {
   MirEventType event_type = mir_event_get_type(ev);
   switch (event_type)

--- a/xbmc/windowing/mir/WinEventsMir.cpp
+++ b/xbmc/windowing/mir/WinEventsMir.cpp
@@ -327,7 +327,7 @@ void MirHandleInput(MirInputEvent const* iev)
 }
 }
 
-void MirHandleEvent(MirWindow* surface, MirEvent const* ev, void* context)
+void MirHandleEvent(MirWindow* window, MirEvent const* ev, void* context)
 {
   MirEventType event_type = mir_event_get_type(ev);
   switch (event_type)

--- a/xbmc/windowing/mir/WinEventsMir.h
+++ b/xbmc/windowing/mir/WinEventsMir.h
@@ -27,7 +27,7 @@
 
 #include "../WinEvents.h"
 
-extern void MirHandleEvent(MirSurface* surface, MirEvent const* ev, void* context);
+extern void MirHandleEvent(MirWindow* surface, MirEvent const* ev, void* context);
 
 class CWinEventsMir : public IWinEvents
 {

--- a/xbmc/windowing/mir/WinEventsMir.h
+++ b/xbmc/windowing/mir/WinEventsMir.h
@@ -27,7 +27,7 @@
 
 #include "../WinEvents.h"
 
-extern void MirHandleEvent(MirWindow* surface, MirEvent const* ev, void* context);
+extern void MirHandleEvent(MirWindow* window, MirEvent const* ev, void* context);
 
 class CWinEventsMir : public IWinEvents
 {

--- a/xbmc/windowing/mir/WinSystemMir.h
+++ b/xbmc/windowing/mir/WinSystemMir.h
@@ -56,6 +56,6 @@ public:
 
 protected:
   MirConnection* m_connection;
-  MirSurface* m_surface;
+  MirWindow* m_window;
   MirPixelFormat m_pixel_format;
 };

--- a/xbmc/windowing/mir/WinSystemMirGLContext.cpp
+++ b/xbmc/windowing/mir/WinSystemMirGLContext.cpp
@@ -41,7 +41,7 @@ bool CWinSystemMirGLContext::CreateNewWindow(const std::string& name,
 
   CWinSystemMir::CreateNewWindow(name, fullScreen, res, userFunction);
 
-  if (!m_pGLContext.CreateSurface(m_surface))
+  if (!m_pGLContext.CreateSurface(m_window))
   {
     return false;
   }


### PR DESCRIPTION
## Description
Remove all deprecations and replace them with the new way to do it. Though the main diff change is the rename of surface --> window.

## Motivation and Context
So kodi can render on mir 1.0 once released.

## How Has This Been Tested?
Tested on ubuntu 17.04 working. This new change will require mir 0.26.2

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
