### PR TITLE
Disable gcc printf verifier for logging function

### DIFF
--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -318,7 +318,7 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
 
 unsigned int CGUIEPGGridContainerModel::GetGridStartPadding() const
 {
-  int iEpgLingerTime = g_advancedSettings.m_iEpgLingerTime;
+  unsigned int iEpgLingerTime = g_advancedSettings.m_iEpgLingerTime;
 
   if (iEpgLingerTime < GRID_START_PADDING)
     return iEpgLingerTime;

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -42,7 +42,7 @@ public:
   CLog();
   ~CLog(void);
   static void Close();
-  static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...) PARAM2_PRINTF_FORMAT;
+  static void Log(int loglevel, PRINTF_FORMAT_STRING const char *format, ...);
   static void LogFunction(int loglevel, IN_OPT_STRING const char* functionName, PRINTF_FORMAT_STRING const char* format, ...) PARAM3_PRINTF_FORMAT;
 #define LogF(loglevel,format,...) LogFunction((loglevel),__FUNCTION__,(format),##__VA_ARGS__)
   static void MemDump(char *pData, int length);


### PR DESCRIPTION
Now that the newfangled libfmt stuff is used, we get a warning from the verifier and it causes more harm than good.