### PR TITLE
[Estuary] PVR Channel list - Fix overlapping text.

### DIFF
--- a/addons/skin.estuary/xml/MyPVRChannels.xml
+++ b/addons/skin.estuary/xml/MyPVRChannels.xml
@@ -12,11 +12,11 @@
 				<include>OpenClose_Left</include>
 				<control type="fixedlist" id="50">
 					<left>0</left>
-					<top>list_y_offset</top>
+					<top>140</top>
 					<right>918</right>
 					<bottom>list_y_offset</bottom>
-					<movement>3</movement>
-					<focusposition>5</focusposition>
+					<movement>5</movement>
+					<focusposition>4</focusposition>
 					<scrolltime tween="cubic" easing="out">500</scrolltime>
 					<orientation>vertical</orientation>
 					<onleft>9000</onleft>


### PR DESCRIPTION
Move the top of the channel list, and adjust the movement and focusposition, so that it's contents don't overlap with the top and bottom breadcrumb trails.  When using PageUp and PageDown controls to scroll through the list, the top and bottom entries were rendered unreadable.

## Description
- Adjust the 'top' property of the PVR Channels List so that it doesn't clash with the upper TopBar.
- Adjust the 'movement' and 'focusposition' properties so that there's no gap at the top of the list when it's first viewed (and the 1st channel is highlighted) and to ensure that the bottom entry isn't fouled by the BottomBar. 

## Motivation and Context
- Unable to read top and bottom channel details when scrolling through list using PageUp and PageDown controls.

## How Has This Been Tested?
- Validated on a Raspberry Pi running OSMC with Kodi 17.1 at 1920 x 1080 resolution.
- Checked list scrolls normally with up/down/pageup/pagedown remote control buttons.
- Checked top and bottom entries aren't obscured by the TopBar and BottomBar.
- Checked top and bottom entries can be selected. 

## Screenshots (if appropriate):
Before:
![before](https://cloud.githubusercontent.com/assets/26748169/24422135/673377ba-13f0-11e7-84ee-34261a205ab9.png)
After:
![after](https://cloud.githubusercontent.com/assets/26748169/24422153/71fdb048-13f0-11e7-80f9-390fc4a500d3.png)

## Types of change
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed