### PR TITLE
[PVR] Rework CPVRActionListener and CPVRGUIActions lifecycle

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3043,7 +3043,7 @@ bool CApplication::PlayMedia(const CFileItem& item, const std::string &player, i
   }
   else if (item.IsPVR())
   {
-    return CPVRGUIActions::GetInstance().PlayMedia(CFileItemPtr(new CFileItem(item)));
+    return CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(CFileItemPtr(new CFileItem(item)));
   }
 
   CURL path(item.GetPath());
@@ -4093,7 +4093,7 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     // set to Dim in the case of a dialog on screen or playing video
     if (g_windowManager.HasModalDialog() ||
         (m_pPlayer->IsPlayingVideo() && m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE)) ||
-        CPVRGUIActions::GetInstance().IsRunningChannelScan())
+        CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan())
     {
       if (!CAddonMgr::GetInstance().GetAddon("screensaver.xbmc.builtin.dim", m_screenSaver))
         m_screenSaver.reset(new CScreenSaver(""));

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5937,7 +5937,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     CServiceBroker::GetPVRManager().TranslateCharInfo(info, strLabel);
     break;
   case PVR_CHANNEL_NUMBER_INPUT:
-    strLabel = CPVRGUIActions::GetInstance().GetChannelNumberInputHandler().GetChannelNumberAsString();
+    strLabel = CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().GetChannelNumberAsString();
     break;
   case ADSP_ACTIVE_STREAM_TYPE:
   case ADSP_DETECTED_STREAM_TYPE:

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -230,7 +230,7 @@ JSONRPC_STATUS CPVROperations::Record(const std::string &method, ITransportLayer
 
   if (toggle)
   {
-    if (!CPVRGUIActions::GetInstance().SetRecordingOnChannel(pChannel, pChannel->IsRecording()))
+    if (!CServiceBroker::GetPVRManager().GUIActions()->SetRecordingOnChannel(pChannel, pChannel->IsRecording()))
       return FailedToExecute;
   }
 
@@ -242,7 +242,7 @@ JSONRPC_STATUS CPVROperations::Scan(const std::string &method, ITransportLayer *
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  CPVRGUIActions::GetInstance().StartChannelScan();
+  CServiceBroker::GetPVRManager().GUIActions()->StartChannelScan();
   return ACK;
 }
 
@@ -262,7 +262,7 @@ JSONRPC_STATUS CPVROperations::GetPropertyValue(const std::string &property, CVa
   else if (property == "scanning")
   {
     if (started)
-      result = CPVRGUIActions::GetInstance().IsRunningChannelScan();
+      result = CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan();
     else
       result = false;
   }
@@ -346,7 +346,7 @@ JSONRPC_STATUS CPVROperations::AddTimer(const std::string &method, ITransportLay
   CPVRTimerInfoTagPtr newTimer = CPVRTimerInfoTag::CreateFromEpg(epgTag, parameterObject["timerrule"].asBoolean(false));
   if (newTimer)
   {
-    if (CPVRGUIActions::GetInstance().AddTimer(newTimer))
+    if (CServiceBroker::GetPVRManager().GUIActions()->AddTimer(newTimer))
       return ACK;
   }
   return FailedToExecute;
@@ -399,7 +399,7 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
     if (!timer)
       return InvalidParams;
 
-    sentOkay = CPVRGUIActions::GetInstance().AddTimer(timer);
+    sentOkay = CServiceBroker::GetPVRManager().GUIActions()->AddTimer(timer);
   }
 
   if (sentOkay)

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -35,29 +35,25 @@
 namespace PVR
 {
 
-CPVRActionListener &CPVRActionListener::GetInstance()
+CPVRActionListener::CPVRActionListener()
 {
-  static CPVRActionListener instance;
-  return instance;
+  g_application.RegisterActionListener(this);
+  CServiceBroker::GetSettings().RegisterCallback(this, {
+    CSettings::SETTING_PVRPARENTAL_ENABLED,
+    CSettings::SETTING_PVRMANAGER_RESETDB,
+    CSettings::SETTING_EPG_RESETEPG,
+    CSettings::SETTING_PVRMANAGER_CHANNELMANAGER,
+    CSettings::SETTING_PVRMANAGER_GROUPMANAGER,
+    CSettings::SETTING_PVRMANAGER_CHANNELSCAN,
+    CSettings::SETTING_PVRMENU_SEARCHICONS,
+    CSettings::SETTING_PVRCLIENT_MENUHOOK,
+  });
 }
 
-void CPVRActionListener::Init()
-{
-  std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_PVRPARENTAL_ENABLED);
-  settingSet.insert(CSettings::SETTING_PVRMANAGER_RESETDB);
-  settingSet.insert(CSettings::SETTING_EPG_RESETEPG);
-  settingSet.insert(CSettings::SETTING_PVRMANAGER_CHANNELMANAGER);
-  settingSet.insert(CSettings::SETTING_PVRMANAGER_GROUPMANAGER);
-  settingSet.insert(CSettings::SETTING_PVRMANAGER_CHANNELSCAN);
-  settingSet.insert(CSettings::SETTING_PVRMENU_SEARCHICONS);
-  settingSet.insert(CSettings::SETTING_PVRCLIENT_MENUHOOK);
-  CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
-}
-
-void CPVRActionListener::Deinit()
+CPVRActionListener::~CPVRActionListener()
 {
   CServiceBroker::GetSettings().UnregisterCallback(this);
+  g_application.UnregisterActionListener(this);
 }
 
 bool CPVRActionListener::OnAction(const CAction &action)
@@ -77,15 +73,15 @@ bool CPVRActionListener::OnAction(const CAction &action)
       {
         case ACTION_PVR_PLAY:
           if (!isPlayingPvr)
-            CPVRGUIActions::GetInstance().SwitchToChannel(PlaybackTypeAny);
+            CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(PlaybackTypeAny);
           break;
         case ACTION_PVR_PLAY_TV:
           if (!isPlayingPvr || g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
-            CPVRGUIActions::GetInstance().SwitchToChannel(PlaybackTypeTV);
+            CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(PlaybackTypeTV);
           break;
         case ACTION_PVR_PLAY_RADIO:
           if (!isPlayingPvr || !g_application.CurrentFileItem().GetPVRChannelInfoTag()->IsRadio())
-            CPVRGUIActions::GetInstance().SwitchToChannel(PlaybackTypeRadio);
+            CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(PlaybackTypeRadio);
           break;
       }
       return true;
@@ -122,7 +118,7 @@ bool CPVRActionListener::OnAction(const CAction &action)
           return false;
 
         int iRemote = bIsJumpSMS ? action.GetID() - (ACTION_JUMP_SMS2 - REMOTE_2) : action.GetID();
-        CPVRGUIActions::GetInstance().GetChannelNumberInputHandler().AppendChannelNumberDigit(iRemote - REMOTE_0);
+        CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().AppendChannelNumberDigit(iRemote - REMOTE_0);
       }
       return true;
     }
@@ -160,11 +156,11 @@ void CPVRActionListener::OnSettingAction(const CSetting *setting)
   const std::string &settingId = setting->GetId();
   if (settingId == CSettings::SETTING_PVRMANAGER_RESETDB)
   {
-    CPVRGUIActions::GetInstance().ResetPVRDatabase(false);
+    CServiceBroker::GetPVRManager().GUIActions()->ResetPVRDatabase(false);
   }
   else if (settingId == CSettings::SETTING_EPG_RESETEPG)
   {
-    CPVRGUIActions::GetInstance().ResetPVRDatabase(true);
+    CServiceBroker::GetPVRManager().GUIActions()->ResetPVRDatabase(true);
   }
   else if (settingId == CSettings::SETTING_PVRMANAGER_CHANNELMANAGER)
   {
@@ -186,7 +182,7 @@ void CPVRActionListener::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_PVRMANAGER_CHANNELSCAN)
   {
-    CPVRGUIActions::GetInstance().StartChannelScan();
+    CServiceBroker::GetPVRManager().GUIActions()->StartChannelScan();
   }
   else if (settingId == CSettings::SETTING_PVRMENU_SEARCHICONS)
   {
@@ -194,7 +190,7 @@ void CPVRActionListener::OnSettingAction(const CSetting *setting)
   }
   else if (settingId == CSettings::SETTING_PVRCLIENT_MENUHOOK)
   {
-    CPVRGUIActions::GetInstance().ProcessMenuHooks(CFileItemPtr());
+    CServiceBroker::GetPVRManager().GUIActions()->ProcessMenuHooks(CFileItemPtr());
   }
 }
 

--- a/xbmc/pvr/PVRActionListener.h
+++ b/xbmc/pvr/PVRActionListener.h
@@ -29,11 +29,8 @@ namespace PVR
 class CPVRActionListener : public IActionListener, public ISettingCallback
 {
 public:
-
-  void Init();
-  void Deinit();
-
-  static CPVRActionListener &GetInstance();
+  CPVRActionListener();
+  virtual ~CPVRActionListener();
 
   // IActionListener implementation
   bool OnAction(const CAction &action) override;
@@ -43,8 +40,6 @@ public:
   void OnSettingAction(const CSetting *setting) override;
 
 private:
-  CPVRActionListener() = default;
-  ~CPVRActionListener() = default;
   CPVRActionListener(const CPVRActionListener&) = delete;
   CPVRActionListener& operator=(const CPVRActionListener&) = delete;
 };

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -122,9 +122,9 @@ namespace PVR
     bool ShowInformation::Execute(const CFileItemPtr &item) const
     {
       if (item->GetPVRRecordingInfoTag())
-        return CPVRGUIActions::GetInstance().ShowRecordingInfo(item);
+        return CServiceBroker::GetPVRManager().GUIActions()->ShowRecordingInfo(item);
 
-      return CPVRGUIActions::GetInstance().ShowEPGInfo(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -148,7 +148,7 @@ namespace PVR
 
     bool FindSimilar::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().FindSimilar(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->FindSimilar(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -170,7 +170,7 @@ namespace PVR
 
     bool PlayRecording::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().PlayRecording(item, true /* bCheckResume */);
+      return CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(item, true /* bCheckResume */);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -191,7 +191,7 @@ namespace PVR
 
     bool StartRecording::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().AddTimer(item, false);
+      return CServiceBroker::GetPVRManager().GUIActions()->AddTimer(item, false);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -212,7 +212,7 @@ namespace PVR
 
     bool StopRecording::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().StopRecording(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->StopRecording(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -229,7 +229,7 @@ namespace PVR
 
     bool RenameRecording::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().RenameRecording(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->RenameRecording(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -254,7 +254,7 @@ namespace PVR
 
     bool DeleteRecording::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().DeleteRecording(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->DeleteRecording(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -271,7 +271,7 @@ namespace PVR
 
     bool UndeleteRecording::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().UndeleteRecording(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->UndeleteRecording(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -298,7 +298,7 @@ namespace PVR
 
     bool ToggleTimerState::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().ToggleTimerState(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->ToggleTimerState(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -315,7 +315,7 @@ namespace PVR
 
     bool AddTimerRule::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().AddTimerRule(item, true);
+      return CServiceBroker::GetPVRManager().GUIActions()->AddTimerRule(item, true);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -332,7 +332,7 @@ namespace PVR
 
     bool EditTimerRule::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().EditTimerRule(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->EditTimerRule(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -351,7 +351,7 @@ namespace PVR
     {
       const CFileItemPtr parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(item));
       if (parentTimer)
-        return CPVRGUIActions::GetInstance().DeleteTimerRule(parentTimer);
+        return CServiceBroker::GetPVRManager().GUIActions()->DeleteTimerRule(parentTimer);
 
       return false;
     }
@@ -392,7 +392,7 @@ namespace PVR
 
     bool EditTimer::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().EditTimer(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->EditTimer(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -417,7 +417,7 @@ namespace PVR
 
     bool RenameTimer::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().RenameTimer(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->RenameTimer(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -445,7 +445,7 @@ namespace PVR
 
     bool DeleteTimer::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().DeleteTimer(item);
+      return CServiceBroker::GetPVRManager().GUIActions()->DeleteTimer(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -499,7 +499,7 @@ namespace PVR
 
     bool PVRClientMenuHook::Execute(const CFileItemPtr &item) const
     {
-      return CPVRGUIActions::GetInstance().ProcessMenuHooks(item);;
+      return CServiceBroker::GetPVRManager().GUIActions()->ProcessMenuHooks(item);;
     }
 
   } // namespace CONEXTMENUITEM

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -127,12 +127,6 @@ namespace PVR
     bool DoRun(const CFileItemPtr &item) override { return CServiceBroker::GetPVRManager().Recordings()->Undelete(*item); }
   };
 
-  CPVRGUIActions& CPVRGUIActions::GetInstance()
-  {
-    static CPVRGUIActions instance;
-    return instance;
-  }
-
   CPVRGUIActions::CPVRGUIActions()
   : m_bChannelScanRunning(false)
   {

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -61,11 +61,8 @@ namespace PVR
   class CPVRGUIActions
   {
   public:
-    /*!
-     * @brief Request an instance of class CPVRGUIActions.
-     * @return the instance.
-     */
-    static CPVRGUIActions& GetInstance();
+    CPVRGUIActions();
+    virtual ~CPVRGUIActions() = default;
 
     /*!
      * @brief Open a dialog with epg information for a given item.
@@ -319,10 +316,8 @@ namespace PVR
     CPVRChannelNumberInputHandler &GetChannelNumberInputHandler();
 
   private:
-    CPVRGUIActions();
     CPVRGUIActions(const CPVRGUIActions&) = delete;
     CPVRGUIActions const& operator=(CPVRGUIActions const&) = delete;
-    virtual ~CPVRGUIActions() {}
 
     /*!
      * @brief Open the timer settings dialog.

--- a/xbmc/pvr/PVRJobs.cpp
+++ b/xbmc/pvr/PVRJobs.cpp
@@ -39,12 +39,12 @@ namespace PVR
 
 bool CPVRSetRecordingOnChannelJob::DoWork()
 {
-  return CPVRGUIActions::GetInstance().SetRecordingOnChannel(m_channel, m_bOnOff);
+  return CServiceBroker::GetPVRManager().GUIActions()->SetRecordingOnChannel(m_channel, m_bOnOff);
 }
 
 bool CPVRContinueLastChannelJob::DoWork()
 {
-  return CPVRGUIActions::GetInstance().ContinueLastPlayedChannel();
+  return CServiceBroker::GetPVRManager().GUIActions()->ContinueLastPlayedChannel();
 }
 
 CPVREventlogJob::CPVREventlogJob(bool bNotifyUser, bool bError, const std::string &label, const std::string &msg, const std::string &icon)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -28,6 +28,7 @@
 #include "utils/JobManager.h"
 #include "utils/Observer.h"
 
+#include "pvr/PVRActionListener.h"
 #include "pvr/PVREvent.h"
 #include "pvr/PVRTypes.h"
 #include "pvr/recordings/PVRRecording.h"
@@ -145,6 +146,12 @@ namespace PVR
      * @return The timers container.
      */
     CPVRClientsPtr Clients(void) const;
+
+    /*!
+     * @brief Get access to the pvr gui actions.
+     * @return The gui actions.
+     */
+    CPVRGUIActionsPtr GUIActions(void) const;
 
     /*!
      * @brief Init PVRManager.
@@ -622,6 +629,7 @@ namespace PVR
     CPVRTimersPtr                  m_timers;                      /*!< pointer to the timers container */
     CPVRClientsPtr                 m_addons;                      /*!< pointer to the pvr addon container */
     std::unique_ptr<CPVRGUIInfo>   m_guiInfo;                     /*!< pointer to the guiinfo data */
+    CPVRGUIActionsPtr              m_guiActions;                  /*!< pointer to the pvr gui actions */
     //@}
 
     CPVRManagerJobQueue             m_pendingUpdates;              /*!< vector of pending pvr updates */
@@ -647,5 +655,6 @@ namespace PVR
     // settings cache
     bool m_bSettingPowerManagementEnabled; // SETTING_PVRPOWERMANAGEMENT_ENABLED
     std::string m_strSettingWakeupCommand; // SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD
+    CPVRActionListener m_actionListener;
   };
 }

--- a/xbmc/pvr/PVRTypes.h
+++ b/xbmc/pvr/PVRTypes.h
@@ -56,5 +56,8 @@ namespace PVR
   class CPVRTimers;
   typedef std::shared_ptr<CPVRTimers> CPVRTimersPtr;
 
+  class CPVRGUIActions;
+  typedef std::shared_ptr<CPVRGUIActions> CPVRGUIActionsPtr;
+
 } // namespace PVR
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
@@ -136,7 +136,7 @@ void CGUIDialogPVRChannelGuide::ShowInfo(int item)
   if (item < 0 || item >= (int)m_vecItems->Size())
     return;
 
-  CPVRGUIActions::GetInstance().ShowEPGInfo(m_vecItems->Get(item));
+  CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(m_vecItems->Get(item));
 }
 
 void CGUIDialogPVRChannelGuide::OnWindowLoaded()

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -292,7 +292,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioParentalLocked(CGUIMessage &
   bool selected(msg.GetParam1() == 1);
 
   // ask for PIN first
-  if (!CPVRGUIActions::GetInstance().CheckParentalPIN())
+  if (!CServiceBroker::GetPVRManager().GUIActions()->CheckParentalPIN())
   { // failed - reset to previous
     SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_PARENTAL_LOCK, !selected);
     return false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -271,7 +271,7 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
     return;
 
   Close();
-  CPVRGUIActions::GetInstance().SwitchToChannel(m_vecItems->Get(item), true /* bCheckResume */);
+  CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(m_vecItems->Get(item), true /* bCheckResume */);
   m_group = GetPlayingGroup();
 }
 
@@ -280,7 +280,7 @@ void CGUIDialogPVRChannelsOSD::ShowInfo(int item)
   if (item < 0 || item >= (int)m_vecItems->Size())
     return;
 
-  CPVRGUIActions::GetInstance().ShowEPGInfo(m_vecItems->Get(item));
+  CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(m_vecItems->Get(item));
 }
 
 void CGUIDialogPVRChannelsOSD::OnWindowLoaded()

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -88,7 +88,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonChannelGuide(CGUIMessage &message)
       return bReturn;
     }
 
-    bReturn = CPVRGUIActions::GetInstance().ShowChannelEPG(CFileItemPtr(new CFileItem(m_progItem)));
+    bReturn = CServiceBroker::GetPVRManager().GUIActions()->ShowChannelEPG(CFileItemPtr(new CFileItem(m_progItem)));
   }
 
   return bReturn;
@@ -115,14 +115,14 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
     {
       const CFileItemPtr item(new CFileItem(timerTag));
       if (timerTag->IsRecording())
-        bReturn = CPVRGUIActions::GetInstance().StopRecording(item);
+        bReturn = CServiceBroker::GetPVRManager().GUIActions()->StopRecording(item);
       else
-        bReturn = CPVRGUIActions::GetInstance().DeleteTimer(item);
+        bReturn = CServiceBroker::GetPVRManager().GUIActions()->DeleteTimer(item);
     }
     else
     {
       const CFileItemPtr item(new CFileItem(m_progItem));
-      bReturn = CPVRGUIActions::GetInstance().AddTimer(item, false);
+      bReturn = CServiceBroker::GetPVRManager().GUIActions()->AddTimer(item, false);
     }
   }
 
@@ -141,7 +141,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonAddTimer(CGUIMessage &message)
     if (m_progItem && !m_progItem->Timer())
     {
       const CFileItemPtr item(new CFileItem(m_progItem));
-      bReturn = CPVRGUIActions::GetInstance().AddTimerRule(item, true);
+      bReturn = CServiceBroker::GetPVRManager().GUIActions()->AddTimerRule(item, true);
     }
   }
 
@@ -161,9 +161,9 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(CGUIMessage &message)
 
     const CFileItemPtr item(new CFileItem(m_progItem));
     if (message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
-      CPVRGUIActions::GetInstance().PlayRecording(item, true /* bCheckResume */);
+      CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(item, true /* bCheckResume */);
     else
-      CPVRGUIActions::GetInstance().SwitchToChannel(item, true /* bCheckResume */);
+      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, true /* bCheckResume */);
 
     bReturn = true;
   }
@@ -176,7 +176,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonFind(CGUIMessage &message)
   bool bReturn = false;
 
   if (message.GetSenderId() == CONTROL_BTN_FIND)
-    return CPVRGUIActions::GetInstance().FindSimilar(CFileItemPtr(new CFileItem(m_progItem)), this);
+    return CServiceBroker::GetPVRManager().GUIActions()->FindSimilar(CFileItemPtr(new CFileItem(m_progItem)), this);
 
   return bReturn;
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -19,7 +19,9 @@
  */
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "pvr/PVRGUIActions.h"
+#include "pvr/PVRManager.h"
 
 #include "GUIDialogPVRRecordingInfo.h"
 
@@ -67,7 +69,7 @@ bool CGUIDialogPVRRecordingInfo::OnClickButtonPlay(CGUIMessage &message)
     Close();
 
     if (m_recordItem)
-      CPVRGUIActions::GetInstance().PlayRecording(m_recordItem, true /* check resume */);
+      CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(m_recordItem, true /* check resume */);
 
     bReturn = true;
   }
@@ -93,6 +95,6 @@ CFileItemPtr CGUIDialogPVRRecordingInfo::GetCurrentListItem(int offset)
 
 void CGUIDialogPVRRecordingInfo::ShowFor(const CFileItemPtr& item)
 {
-  CPVRGUIActions::GetInstance().ShowRecordingInfo(item);
+  CServiceBroker::GetPVRManager().GUIActions()->ShowRecordingInfo(item);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -154,13 +154,13 @@ bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
            case ACTION_SELECT_ITEM:
            case ACTION_MOUSE_LEFT_CLICK:
            case ACTION_PLAY:
-             CPVRGUIActions::GetInstance().SwitchToChannel(m_vecItems->Get(iItem), true);
+             CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(m_vecItems->Get(iItem), true);
              break;
            case ACTION_SHOW_INFO:
-             CPVRGUIActions::GetInstance().ShowEPGInfo(m_vecItems->Get(iItem));
+             CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(m_vecItems->Get(iItem));
              break;
            case ACTION_DELETE_ITEM:
-             CPVRGUIActions::GetInstance().HideChannel(m_vecItems->Get(iItem));
+             CServiceBroker::GetPVRManager().GUIActions()->HideChannel(m_vecItems->Get(iItem));
              break;
            case ACTION_CONTEXT_MENU:
            case ACTION_MOUSE_RIGHT_CLICK:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -292,19 +292,19 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_SWITCH:
-                  CPVRGUIActions::GetInstance().SwitchToChannel(pItem, true);
+                  CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(pItem, true);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_PLAY_RECORDING:
-                  CPVRGUIActions::GetInstance().PlayRecording(pItem, true);
+                  CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(pItem, true);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_INFO:
-                  CPVRGUIActions::GetInstance().ShowEPGInfo(pItem);
+                  CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(pItem);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_RECORD:
-                  CPVRGUIActions::GetInstance().ToggleTimer(pItem);
+                  CServiceBroker::GetPVRManager().GUIActions()->ToggleTimer(pItem);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_SMART_SELECT:
@@ -319,23 +319,23 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
                     if (start <= now && now <= end)
                     {
                       // current event
-                      CPVRGUIActions::GetInstance().SwitchToChannel(pItem, true);
+                      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(pItem, true);
                     }
                     else if (now < start)
                     {
                       // future event
                       if (tag->HasTimer())
-                        CPVRGUIActions::GetInstance().EditTimer(pItem);
+                        CServiceBroker::GetPVRManager().GUIActions()->EditTimer(pItem);
                       else
-                        CPVRGUIActions::GetInstance().AddTimer(pItem, false);
+                        CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
                     }
                     else
                     {
                       // past event
                       if (tag->HasRecording())
-                        CPVRGUIActions::GetInstance().PlayRecording(pItem, true);
+                        CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(pItem, true);
                       else
-                        CPVRGUIActions::GetInstance().ShowEPGInfo(pItem);
+                        CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(pItem);
                     }
                     bReturn = true;
                   }
@@ -344,19 +344,19 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
               }
               break;
             case ACTION_SHOW_INFO:
-              CPVRGUIActions::GetInstance().ShowEPGInfo(pItem);
+              CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(pItem);
               bReturn = true;
               break;
             case ACTION_PLAY:
-              CPVRGUIActions::GetInstance().PlayRecording(pItem, true);
+              CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(pItem, true);
               bReturn = true;
               break;
             case ACTION_RECORD:
-              CPVRGUIActions::GetInstance().ToggleTimer(pItem);
+              CServiceBroker::GetPVRManager().GUIActions()->ToggleTimer(pItem);
               bReturn = true;
               break;
             case ACTION_PVR_SHOW_TIMER_RULE:
-              CPVRGUIActions::GetInstance().AddTimerRule(pItem, true);
+              CServiceBroker::GetPVRManager().GUIActions()->AddTimerRule(pItem, true);
               bReturn = true;
               break;
             case ACTION_CONTEXT_MENU:
@@ -382,7 +382,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
                 const CFileItemPtr item(epgGridContainer->GetSelectedChannelItem());
                 if (item)
                 {
-                  CPVRGUIActions::GetInstance().SwitchToChannel(item, true);
+                  CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, true);
                   bReturn = true;
                 }
               }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -222,7 +222,7 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
 
               if (message.GetParam1() == ACTION_PLAY)
               {
-                CPVRGUIActions::GetInstance().PlayRecording(item, true /* check resume */);
+                CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(item, true /* check resume */);
                 bReturn = true;
               }
               else
@@ -234,15 +234,15 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
                     bReturn = true;
                     break;
                   case SELECT_ACTION_PLAY_OR_RESUME:
-                    CPVRGUIActions::GetInstance().PlayRecording(item, true /* check resume */);
+                    CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(item, true /* check resume */);
                     bReturn = true;
                     break;
                   case SELECT_ACTION_RESUME:
-                    CPVRGUIActions::GetInstance().ResumePlayRecording(item, true /* fall back to play if no resume possible */);
+                    CServiceBroker::GetPVRManager().GUIActions()->ResumePlayRecording(item, true /* fall back to play if no resume possible */);
                     bReturn = true;
                     break;
                   case SELECT_ACTION_INFO:
-                    CPVRGUIActions::GetInstance().ShowRecordingInfo(item);
+                    CServiceBroker::GetPVRManager().GUIActions()->ShowRecordingInfo(item);
                     bReturn = true;
                     break;
                   default:
@@ -258,11 +258,11 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
               bReturn = true;
               break;
             case ACTION_SHOW_INFO:
-              CPVRGUIActions::GetInstance().ShowRecordingInfo(item);
+              CServiceBroker::GetPVRManager().GUIActions()->ShowRecordingInfo(item);
               bReturn = true;
               break;
             case ACTION_DELETE_ITEM:
-              CPVRGUIActions::GetInstance().DeleteRecording(item);
+              CServiceBroker::GetPVRManager().GUIActions()->DeleteRecording(item);
               bReturn = true;
               break;
             default:
@@ -325,7 +325,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_
 {
   if (button == CONTEXT_BUTTON_DELETE_ALL)
   {
-    CPVRGUIActions::GetInstance().DeleteAllRecordingsFromTrash();
+    CServiceBroker::GetPVRManager().GUIActions()->DeleteAllRecordingsFromTrash();
     return true;
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "ServiceBroker.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "epg/EpgContainer.h"
@@ -145,7 +146,7 @@ bool CGUIWindowPVRSearch::OnMessage(CGUIMessage &message)
             if (URIUtils::PathEquals(pItem->GetPath(), "pvr://guide/searchresults/search/"))
               OpenDialogSearch();
             else
-               CPVRGUIActions::GetInstance().ShowEPGInfo(pItem);
+               CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(pItem);
             return true;
           }
 
@@ -155,7 +156,7 @@ bool CGUIWindowPVRSearch::OnMessage(CGUIMessage &message)
             return true;
 
           case ACTION_RECORD:
-            CPVRGUIActions::GetInstance().ToggleTimer(pItem);
+            CServiceBroker::GetPVRManager().GUIActions()->ToggleTimer(pItem);
             return true;
         }
       }

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -136,7 +136,7 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage &message)
               OnPopupMenu(iItem);
               break;
             case ACTION_DELETE_ITEM:
-              CPVRGUIActions::GetInstance().DeleteTimer(m_vecItems->Get(iItem));
+              CServiceBroker::GetPVRManager().GUIActions()->DeleteTimer(m_vecItems->Get(iItem));
               break;
             default:
               bReturn = false;
@@ -189,9 +189,9 @@ bool CGUIWindowPVRTimersBase::ActionShowTimer(const CFileItemPtr &item)
      create a new timer and open settings dialog, otherwise
      open settings for selected timer entry */
   if (URIUtils::PathEquals(item->GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-    bReturn = CPVRGUIActions::GetInstance().AddTimer(m_bRadio);
+    bReturn = CServiceBroker::GetPVRManager().GUIActions()->AddTimer(m_bRadio);
   else
-    bReturn = CPVRGUIActions::GetInstance().EditTimer(item);
+    bReturn = CServiceBroker::GetPVRManager().GUIActions()->EditTimer(item);
 
   return bReturn;
 }

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -34,6 +34,7 @@
 #include "peripherals/Peripherals.h"
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRGUIActions.h"
+#include "pvr/PVRManager.h"
 #include "settings/SettingAddon.h"
 #if defined(HAS_LIBAMCODEC)
 #include "utils/AMLUtils.h"
@@ -72,7 +73,7 @@ bool CheckMasterLock(const std::string &condition, const std::string &value, con
 
 bool CheckPVRParentalPin(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
-  return PVR::CPVRGUIActions::GetInstance().CheckParentalPIN();
+  return CServiceBroker::GetPVRManager().GUIActions()->CheckParentalPIN();
 }
 
 bool HasPeripherals(const std::string &condition, const std::string &value, const CSetting *setting, void *data)


### PR DESCRIPTION
This PR reworks CPVRActionListener and CPVRGUIActions lifecycle (no more static instances).

This change was runtime-tested on macOS, latest Kodi master.

@Jalle19 for review?