### PR TITLE
[PVR] CPVRTimers fixes and optimization

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -987,7 +987,7 @@ int CPVRClient::GetTimersAmount(void)
   return m_struct.GetTimersAmount();
 }
 
-PVR_ERROR CPVRClient::GetTimers(CPVRTimers *results)
+PVR_ERROR CPVRClient::GetTimers(CPVRTimersContainer *results)
 {
   if (!m_bReadyToUse)
     return PVR_ERROR_SERVER_ERROR;
@@ -997,7 +997,7 @@ PVR_ERROR CPVRClient::GetTimers(CPVRTimers *results)
 
   ADDON_HANDLE_STRUCT handle;
   handle.callerAddress = this;
-  handle.dataAddress = (CPVRTimers*) results;
+  handle.dataAddress = results;
   PVR_ERROR retVal = m_struct.GetTimers(&handle);
 
   LogError(retVal, __FUNCTION__);

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -41,7 +41,7 @@ namespace PVR
   class CPVRChannelGroup;
   class CPVRChannelGroupInternal;
   class CPVRChannelGroups;
-  class CPVRTimers;
+  class CPVRTimersContainer;
   class CPVRTimerInfoTag;
   class CPVRRecordings;
   class CPVREpgContainer;
@@ -387,7 +387,7 @@ namespace PVR
      * @param results The container to store the result in.
      * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
      */
-    PVR_ERROR GetTimers(CPVRTimers *results);
+    PVR_ERROR GetTimers(CPVRTimersContainer *results);
 
     /*!
      * @brief Add a timer on the backend.

--- a/xbmc/addons/interfaces/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/interfaces/PVR/AddonCallbacksPVR.cpp
@@ -213,8 +213,8 @@ void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HAND
     return;
   }
 
-  CPVRClient *client     = GetPVRClient(addonData);
-  CPVRTimers *xbmcTimers = static_cast<CPVRTimers *>(handle->dataAddress);
+  CPVRClient *client = GetPVRClient(addonData);
+  CPVRTimersContainer *xbmcTimers = static_cast<CPVRTimersContainer *>(handle->dataAddress);
   if (!timer || !client || !xbmcTimers)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -461,7 +461,7 @@ bool CPVRClients::HasTimerSupport(int iClientId)
   return false;
 }
 
-bool CPVRClients::GetTimers(CPVRTimers *timers, std::vector<int> &failedClients)
+bool CPVRClients::GetTimers(CPVRTimersContainer *timers, std::vector<int> &failedClients)
 {
   bool bSuccess(true);
   PVR_CLIENTMAP clients;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -353,7 +353,7 @@ namespace PVR
      * @param failedClients in case of errors will contain the ids of the clients for which the timers could not be obtained.
      * @return true on success for all clients, false in case of error for at least one client.
      */
-    bool GetTimers(CPVRTimers *timers, std::vector<int> &failedClients);
+    bool GetTimers(CPVRTimersContainer *timers, std::vector<int> &failedClients);
 
     /*!
      * @brief Add a new timer to a backend.

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -42,7 +42,42 @@ namespace PVR
   class CPVRRecording;
   class CPVRTimersPath;
 
-  class CPVRTimers : public Observer
+  class CPVRTimersContainer
+  {
+  public:
+    CPVRTimersContainer() : m_iLastId(0) {}
+
+    /*!
+     * @brief Add a timer tag to this container or update the tag if already present in this container.
+     * @param The timer tag
+     * @return True, if the update was successful. False, otherwise.
+     */
+    bool UpdateFromClient(const CPVRTimerInfoTagPtr &timer);
+
+    /*!
+     * @brief Get the timer tag denoted by given client id and timer id.
+     * @param iClientId The client id.
+     * @param iClientTimerId The timer id.
+     * @return the timer tag if found, null otherwise.
+     */
+    CPVRTimerInfoTagPtr GetByClient(int iClientId, unsigned int iClientTimerId) const;
+
+    typedef std::vector<CPVRTimerInfoTagPtr> VecTimerInfoTag;
+    typedef std::map<CDateTime, VecTimerInfoTag*> MapTags;
+
+    /*!
+     * @brief Get the timertags map.
+     * @return The map.
+     */
+    const MapTags& GetTags() const { return m_tags; }
+
+  protected:
+    CCriticalSection m_critSection;
+    unsigned int m_iLastId;
+    MapTags m_tags;
+  };
+
+  class CPVRTimers : public CPVRTimersContainer, public Observer
   {
   public:
     CPVRTimers(void);
@@ -58,11 +93,6 @@ namespace PVR
      * @brief refresh the channel list from the clients.
      */
     bool Update(void);
-
-    /**
-     * Add a timer entry to this container, called by the client callback.
-     */
-    bool UpdateFromClient(const CPVRTimerInfoTagPtr &timer);
 
     /*!
      * @return The tv or radio timer that will be active next (state scheduled), or an empty fileitemptr if none.
@@ -249,12 +279,8 @@ namespace PVR
     CPVRTimerInfoTagPtr GetById(unsigned int iTimerId) const;
 
   private:
-    typedef std::map<CDateTime, std::vector<CPVRTimerInfoTagPtr>* > MapTags;
-    typedef std::vector<CPVRTimerInfoTagPtr> VecTimerInfoTag;
-
     void Unload(void);
-    bool UpdateEntries(const CPVRTimers &timers, const std::vector<int> &failedClients);
-    CPVRTimerInfoTagPtr GetByClient(int iClientId, unsigned int iClientTimerId) const;
+    bool UpdateEntries(const CPVRTimersContainer &timers, const std::vector<int> &failedClients);
     bool GetRootDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
     bool GetSubDirectory(const CPVRTimersPath &path, CFileItemList &items) const;
     bool SetEpgTagTimer(const CPVRTimerInfoTagPtr &timer);
@@ -274,10 +300,7 @@ namespace PVR
     std::vector<CFileItemPtr> GetActiveRecordings(const TimerKind &eKind) const;
     int AmountActiveRecordings(const TimerKind &eKind) const;
 
-    CCriticalSection  m_critSection;
-    bool              m_bIsUpdating;
-    MapTags           m_tags;
-    unsigned int      m_iLastId;
+    bool m_bIsUpdating;
   };
 
   class CPVRTimersPath

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -63,7 +63,7 @@ namespace PVR
     CPVRTimerInfoTagPtr GetByClient(int iClientId, unsigned int iClientTimerId) const;
 
     typedef std::vector<CPVRTimerInfoTagPtr> VecTimerInfoTag;
-    typedef std::map<CDateTime, VecTimerInfoTag*> MapTags;
+    typedef std::map<CDateTime, VecTimerInfoTag> MapTags;
 
     /*!
      * @brief Get the timertags map.


### PR DESCRIPTION
Well, this one fixes a memory leak and optimizes resource consumption and performance when updating timers.

I runtime-tested this on macOS, latest kodi master.

@Jalle19 mind taking a look.