### PR TITLE
[filesystem][dialogs] Add context menus for favourites home screen widget

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -522,7 +522,6 @@
 						<onright>9000</onright>
 						<onup>14100</onup>
 						<ondown>14100</ondown>
-						<onclick>$INFO[ListItem.FileNameAndPath]</onclick>
 						<preloaditems>2</preloaditems>
 						<scrolltime tween="cubic" easing="out">500</scrolltime>
 						<orientation>vertical</orientation>

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -83,6 +83,9 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CMarkUnWatched>(),
       std::make_shared<CONTEXTMENU::CEjectDisk>(),
       std::make_shared<CONTEXTMENU::CEjectDrive>(),
+      std::make_shared<CONTEXTMENU::CRemoveFavourite>(),
+      std::make_shared<CONTEXTMENU::CRenameFavourite>(),
+      std::make_shared<CONTEXTMENU::CChooseThumbnailForFavourite>(),
   };
 
   ReloadAddonItems();

--- a/xbmc/ContextMenus.h
+++ b/xbmc/ContextMenus.h
@@ -39,4 +39,39 @@ struct CEjectDrive : CStaticContextMenuAction
   bool Execute(const CFileItemPtr& item) const override;
 };
 
+class CFavouriteContextMenuAction : public CStaticContextMenuAction
+{
+public:
+  explicit CFavouriteContextMenuAction(uint32_t label) : CStaticContextMenuAction(label) {}
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+protected:
+  virtual ~CFavouriteContextMenuAction() = default;
+  virtual bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const = 0;
+};
+
+class CRemoveFavourite : public CFavouriteContextMenuAction
+{
+public:
+  CRemoveFavourite() : CFavouriteContextMenuAction(15015) {} // Remove
+protected:
+  bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const override;
+};
+
+class CRenameFavourite : public CFavouriteContextMenuAction
+{
+public:
+  CRenameFavourite() : CFavouriteContextMenuAction(118) {} // Rename
+protected:
+  bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const override;
+};
+
+class CChooseThumbnailForFavourite : public CFavouriteContextMenuAction
+{
+public:
+  CChooseThumbnailForFavourite() : CFavouriteContextMenuAction(20019) {} // Choose thumbnail
+protected:
+  bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const override;
+};
+
 }

--- a/xbmc/dialogs/GUIDialogFavourites.h
+++ b/xbmc/dialogs/GUIDialogFavourites.h
@@ -36,7 +36,10 @@ public:
 
   virtual CFileItemPtr GetCurrentListItem(int offset = 0);
 
-  virtual bool HasListItems() const { return true; };
+  virtual bool HasListItems() const { return true; }
+
+  static bool ChooseAndSetNewName(const CFileItemPtr &item);
+  static bool ChooseAndSetNewThumbnail(const CFileItemPtr &item);
 
 protected:
   int GetSelectedItem();


### PR DESCRIPTION
Subject says it all - this PR adds context menus to the favorite home screen widget items.

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/24587833/b0143674-17bd-11e7-82ea-e61ea5e5e999.png)

This change has been tested on macOS, latest kodi master.

@phil65 fyi, iirc you are in favor for this feature...

@Jalle19 @tamland mind doing the review.