### PR TITLE
[depends] use ccache for binary add-ons

### DIFF
--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -50,10 +50,7 @@ set(CMAKE_STRIP @STRIP@ CACHE PATH "strip binary" FORCE)
 
 if(PROJECT_SOURCE_DIR MATCHES "tools/depends")
   if(@use_ccache@ STREQUAL "yes")
-    find_program(CCACHE_PROGRAM ccache)
-    if(CCACHE_PROGRAM)
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-    endif()
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "@CCACHE@")
   endif()
 endif()
 

--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -36,6 +36,10 @@ set(CMAKE_CXX_COMPILER @CXX@)
 set(CMAKE_AR @AR@ CACHE FILEPATH "Archiver")
 set(CMAKE_LINKER @LD@ CACHE FILEPATH "Linker")
 
+if(@use_ccache@ STREQUAL "yes")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "@CCACHE@")
+endif()
+
 # where is the target environment
 if(NOT "@use_toolchain@" STREQUAL "")
   list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@/sysroot/usr)

--- a/tools/depends/target/config-binaddons.site.in
+++ b/tools/depends/target/config-binaddons.site.in
@@ -5,9 +5,9 @@ host_alias=@use_host@
 fi
 
 LD="@LD@"
-CC="@CC@"
-CXX="@CXX@"
-CPP="@CPP@"
+CC="@CCACHE@ @CC@"
+CXX="@CCACHE@ @CXX@"
+CPP="@CCACHE@ @CPP@"
 AR="@AR@"
 AS="@AS@"
 NM="@NM@"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use ccache also for binary add-ons, like it is done for depends at #11529.
<!--- Describe your change in detail -->

## Motivation and Context
This will speed up the build of binary add-ons after you have done it once.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Build binary add-ons and checked ccache stats.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
