### PR TITLE
[osx] - add the minimum required osx version to the info.plist - this…

### DIFF
--- a/xbmc/platform/darwin/osx/Info.plist.in
+++ b/xbmc/platform/darwin/osx/Info.plist.in
@@ -22,6 +22,8 @@
 	<string>@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@.@APP_VERSION_TAG_LC@</string>
 	<key>CFBundleVersion</key>
 	<string>r####</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>@CMAKE_OSX_DEPLOYMENT_TARGET@</string>
 	<key>CFBundleSignature</key>
 	<string>@APP_NAME@</string>
 </dict>


### PR DESCRIPTION
… will show a message box on startup when minimum osx version is not installed (also mentioning the needed minimum osx version)


## Description
Ensure that the bundle can't be started on to old osx versions

## Motivation and Context
To many users post crash reports due to unsupported osx versions. Its much better to use the osx feature here which will present the user with a message box that the minimum osx version is not present

## How Has This Been Tested?
This simply sets the osx deployment target as minimum osx version in the info.plist. Tested via generating the info.plist and adding it to a kodi bundle (editing to some very high osx version that is newer then the one i have installed). Results as expected in a dialog telling me i need a newer version for running Kodi.

## Screenshot
https://www.dropbox.com/s/fdgnxsbbtv4ln3a/osxminversion_dialog.png?dl=0

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
