### PR TITLE
[osx] - add the minimum required osx version to the info.plist

### DIFF
--- a/project/cmake/scripts/osx/ArchSetup.cmake
+++ b/project/cmake/scripts/osx/ArchSetup.cmake
@@ -32,3 +32,5 @@ list(APPEND DEPLIBS "-framework DiskArbitration" "-framework IOKit"
                     "-framework CoreAudio" "-framework AudioToolbox"
                     "-framework CoreGraphics" "-framework CoreMedia"
                     "-framework VideoToolbox")
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.8)

--- a/xbmc/platform/darwin/osx/Info.plist.in
+++ b/xbmc/platform/darwin/osx/Info.plist.in
@@ -22,6 +22,8 @@
 	<string>@APP_VERSION_MAJOR@.@APP_VERSION_MINOR@.@APP_VERSION_TAG_LC@</string>
 	<key>CFBundleVersion</key>
 	<string>r####</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>@CMAKE_OSX_DEPLOYMENT_TARGET@</string>
 	<key>CFBundleSignature</key>
 	<string>@APP_NAME@</string>
 </dict>


### PR DESCRIPTION
backport of #11932

@fetzerch do you see a problem with adding the deployment target in the ArchSetup? (i need it else the configure command won't replace the variable in Info.plist.in). Any side effects you can think of?