### PR TITLE
[PVR] Fix timers map after f47956f9d2dc50ace7b7dc3a529eafc988f4471e

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -72,6 +72,8 @@ namespace PVR
     const MapTags& GetTags() const { return m_tags; }
 
   protected:
+    void InsertTimer(const CPVRTimerInfoTagPtr &newTimer);
+
     CCriticalSection m_critSection;
     unsigned int m_iLastId;
     MapTags m_tags;


### PR DESCRIPTION
Fixes a regression with PVR timers not being recognized any longer by Kodi after https://github.com/xbmc/xbmc/commit/f47956f9d2dc50ace7b7dc3a529eafc988f4471e

Problem was reported in the forum: http://forum.kodi.tv/showthread.php?tid=298461&pid=2562848#pid2562848

@MilhouseVH fyi, maybe you can include this PR into your next build

@Jalle19 mind doing the code review.