### PR TITLE
AMLCodec: fix 720p -> 1080p switching

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2161,10 +2161,11 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   }
 
   CRect gui, display;
-  gui = CRect(0, 0, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().iWidth, CDisplaySettings::GetInstance().GetCurrentResolutionInfo().iHeight);
 
   const RESOLUTION_INFO& video_res_info = CDisplaySettings::GetInstance().GetResolutionInfo(video_res);
   display = m_display_rect = CRect(0, 0, video_res_info.iScreenWidth, video_res_info.iScreenHeight);
+  gui = CRect(0, 0, video_res_info.iWidth, video_res_info.iHeight);
+
   if (gui != display)
   {
     float xscale = display.Width() / gui.Width();


### PR DESCRIPTION
When user-selected resolution is different to resolution chosen during automatic frame rate and resolution adjustment process, video rect is calculated using user resolution, not current one. This results in video occupying rect larger than screen size.

When recalculating scale we should always consider dimensions from actual screen resolution.

## How Has This Been Tested?
Tested in LE community builds with this fix applied.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
