### PR TITLE
[MediaCodec] Fix videoBuffer video dimensions

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1392,14 +1392,14 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat* med
     }
   }
 
-  if (width)
-    m_videobuffer.iWidth  = width;
-  if (height)
-    m_videobuffer.iHeight = height;
+  if (crop_right)
+    width = crop_right  + 1 - crop_left;
+  if (crop_bottom)
+    height = crop_bottom + 1 - crop_top;
 
-  // picture display width/height include the cropping.
-  m_videobuffer.iDisplayWidth  = crop_right  + 1 - crop_left;
-  m_videobuffer.iDisplayHeight = crop_bottom + 1 - crop_top;
+  m_videobuffer.iDisplayWidth  = m_videobuffer.iWidth  = width;
+  m_videobuffer.iDisplayHeight = m_videobuffer.iHeight = height;
+
   if (m_hints.aspect > 1.0 && !m_hints.forced_aspect)
   {
     m_videobuffer.iDisplayWidth  = ((int)lrint(m_videobuffer.iHeight * m_hints.aspect)) & ~3;


### PR DESCRIPTION
[MediaCodec] Fix videoBuffer video dimensions

## Description
Refering to the mediacodec API documentation the size of a frame is computed by:
1.) Retrieve mediaFormat wich / height
2.) Check if crop rect is given and overwrite values in 1.)

## Motivation and Context
http://trac.kodi.tv/ticket/17390

## How Has This Been Tested?
provided an apk including the change to the trac poster

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
