### PR TITLE
[PVR] CPVRActionListener: Fix direct number input handling

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -120,8 +120,8 @@ bool CPVRActionListener::OnAction(const CAction &action)
 
         int iRemote = bIsJumpSMS ? action.GetID() - (ACTION_JUMP_SMS2 - REMOTE_2) : action.GetID();
         CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().AppendChannelNumberDigit(iRemote - REMOTE_0);
+        return true;
       }
-      return true;
     }
     break;
   }


### PR DESCRIPTION
Fixes a regression introduced by #11919 which killed direct number input while playing a video => http://forum.kodi.tv/showthread.php?tid=298462&pid=2565415#pid2565415

CPVRActionListener logic relied on the fact that it would not get called for the video input number scenario. By chance it earlier was registered always after the video action listener, I guess, which has changed with #11919.

@Jalle19 mind taking a look.

@MilhouseVH fyi