### PR TITLE
[fix] minor keymap fix

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -457,8 +457,6 @@
       <o>PlayerProcessInfo</o>
       <l>LockPreset</l>
       <escape>FullScreen</escape>
-      <g>ActivateWindow(PVROSDGuide)</g>
-      <c>ActivateWindow(PVROSDChannels)</c>
     </keyboard>
   </Visualisation>
   <MusicOSD>
@@ -663,6 +661,8 @@
       <down>Down</down>
       <return>OSD</return>
       <enter>OSD</enter>
+      <g>ActivateWindow(PVRChannelGuide)</g>
+      <c>ActivateWindow(PVROSDChannels)</c>
       <return mod="longpress">ActivateWindow(PVROSDChannels)</return>
       <enter mod="longpress">ActivateWindow(PVROSDChannels)</enter>
       <pageup>ChannelUp</pageup>
@@ -677,6 +677,8 @@
       <down>Down</down>
       <return>OSD</return>
       <enter>OSD</enter>
+      <g>ActivateWindow(PVRChannelGuide)</g>
+      <c>ActivateWindow(PVROSDChannels)</c>
       <return mod="longpress">ActivateWindow(PVROSDChannels)</return>
       <enter mod="longpress">ActivateWindow(PVROSDChannels)</enter>
       <pageup>ChannelUp</pageup>
@@ -691,13 +693,13 @@
       <c>Close</c>
     </keyboard>
   </PVROSDChannels>
-  <PVROSDGuide>
+  <PVRChannelGuide>
     <keyboard>
       <backspace>Close</backspace>
       <escape>Close</escape>
       <browser_back>Close</browser_back>
     </keyboard>
-  </PVROSDGuide>
+  </PVRChannelGuide>
   <PVRSettings>
     <keyboard>
       <backspace>PreviousMenu</backspace>


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

ActivateWindow(PVROSDGuide) / ActivateWindow(PVROSDChannels) do not make sense in Visualisation. move them to FullscreenLiveTV / FullscreenRadio

also rename PVROSDGuide to PVRChannelGuide ref: #11554

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

EDIT: this is a valid fix for Krypton as well and can be partialy backported if wanted.