### PR TITLE
Joysticks: Fix iMON conflicts by allowing users to enable/disable interfaces

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16513,7 +16513,19 @@ msgctxt "#35020"
 msgid "Press all analog buttons now to detect them:[CR][CR]{0:s}"
 msgstr ""
 
-#empty strings from id 35021 to 35048
+#empty strings from id 35022 to 35046
+
+#. Name of setting to configure peripheral add-ons
+#: system/settings/settings.xml
+msgctxt "#35047"
+msgid "Driver settings"
+msgstr ""
+
+#. Description of setting with label #35047 "Driver settings"
+#: system/settings/settings.xml
+msgctxt "#35048"
+msgid "View and configure peripheral add-ons."
+msgstr ""
 
 #. Name of game add-ons category
 #: xbmc/addons/Addon.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2676,6 +2676,13 @@
           </dependencies>
           <control type="button" format="action" />
         </setting>
+        <setting id="input.peripherallibraries" type="action" label="35047" help="35048">
+          <level>1</level>
+          <dependencies>
+            <dependency type="enable" on="property" name="HasPeripheralLibraries" />
+          </dependencies>
+          <control type="button" format="action" />
+        </setting>
       </group>
       <group id="2" label="14094">
         <setting id="input.enablemouse" type="boolean" label="21369" help="36377">

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -187,6 +187,12 @@ public:
   void OnPreUnInstall() override {};
   void OnPostUnInstall() override {};
 
+  /*! \brief Utility function to get the default value of a given setting
+   \param setting The XML setting
+   \return The default value for the setting, or empty if no default / unknown
+   */
+  virtual std::string GetDefaultValue(const TiXmlElement *setting) const override;
+
 protected:
   /*! \brief Load the default settings and override these with any previously configured user settings
    \param bForce force the load of settings even if they are already loaded (reload)

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -38,7 +38,8 @@ void CBinaryAddonCache::Init()
     ADDON_INPUTSTREAM,
     ADDON_PVRDLL,
     ADDON_GAMEDLL,
-    ADDON_VFS
+    ADDON_VFS,
+    ADDON_PERIPHERALDLL,
   };
   CAddonMgr::GetInstance().Events().Subscribe(this, &CBinaryAddonCache::OnEvent);
   Update();
@@ -52,18 +53,33 @@ void CBinaryAddonCache::Deinit()
 void CBinaryAddonCache::GetAddons(VECADDONS& addons, const TYPE& type)
 {
   VECADDONS myAddons;
-  {
-    CSingleLock lock(m_critSection);
-    auto it = m_addons.find(type);
-    if (it != m_addons.end())
-      myAddons = it->second;
-  }
+  GetInstalledAddons(myAddons, type);
 
   for (auto &addon : myAddons)
   {
     if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
       addons.emplace_back(std::move(addon));
   }
+}
+
+void CBinaryAddonCache::GetDisabledAddons(VECADDONS& addons, const TYPE& type)
+{
+  VECADDONS myAddons;
+  GetInstalledAddons(myAddons, type);
+
+  for (auto &addon : myAddons)
+  {
+    if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
+      addons.emplace_back(std::move(addon));
+  }
+}
+
+void CBinaryAddonCache::GetInstalledAddons(VECADDONS& addons, const TYPE& type)
+{
+  CSingleLock lock(m_critSection);
+  auto it = m_addons.find(type);
+  if (it != m_addons.end())
+    addons = it->second;
 }
 
 AddonPtr CBinaryAddonCache::GetAddonInstance(const std::string& strId, TYPE type)

--- a/xbmc/addons/BinaryAddonCache.h
+++ b/xbmc/addons/BinaryAddonCache.h
@@ -36,6 +36,8 @@ public:
   void Init();
   void Deinit();
   void GetAddons(VECADDONS& addons, const TYPE& type);
+  void GetDisabledAddons(VECADDONS& addons, const TYPE& type);
+  void GetInstalledAddons(VECADDONS& addons, const TYPE& type);
   AddonPtr GetAddonInstance(const std::string& strId, TYPE type);
 
 protected:

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -1135,18 +1135,9 @@ void CGUIDialogAddonSettings::SetDefaultSettings()
     {
       const std::string   id = XMLUtils::GetAttribute(setting, "id");
       const std::string type = XMLUtils::GetAttribute(setting, "type");
-      const char *value = setting->Attribute("default");
       if (!id.empty())
-      {
-        if (value)
-          m_settings[id] = value;
-        else if (type == "bool")
-          m_settings[id] = "false";
-        else if (type == "slider" || type == "enum")
-          m_settings[id] = "0";
-        else
-          m_settings[id] = "";
-      }
+        m_settings[id] = m_addon->GetDefaultValue(setting);
+
       setting = setting->NextSiblingElement("setting");
     }
     category = category->NextSiblingElement("category");

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -139,6 +139,7 @@ namespace ADDON
     virtual void OnPostInstall(bool update, bool modal) =0;
     virtual void OnPreUnInstall() =0;
     virtual void OnPostUnInstall() =0;
+    virtual std::string GetDefaultValue(const TiXmlElement *setting) const = 0;
   };
 };
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -24,6 +24,9 @@
 
 #include "addons/PeripheralAddon.h"
 #include "addons/AddonButtonMap.h"
+#include "addons/AddonManager.h"
+#include "addons/GUIDialogAddonSettings.h"
+#include "addons/GUIWindowAddonBrowser.h"
 #include "bus/PeripheralBus.h"
 #include "bus/PeripheralBusUSB.h"
 #if defined(TARGET_ANDROID)
@@ -980,6 +983,17 @@ void CPeripherals::OnSettingAction(const CSetting *setting)
     g_windowManager.ActivateWindow(WINDOW_DIALOG_GAME_CONTROLLERS);
   else if (settingId == CSettings::SETTING_INPUT_TESTRUMBLE)
     TestFeature(FEATURE_RUMBLE);
+  else if (settingId == CSettings::SETTING_INPUT_PERIPHERALLIBRARIES)
+  {
+    std::string strAddonId;
+    CGUIWindowAddonBrowser::SelectAddonID(ADDON::ADDON_PERIPHERALDLL, strAddonId, false, true, true, false, true);
+    if (!strAddonId.empty())
+    {
+      ADDON::AddonPtr addon;
+      if (ADDON::CAddonMgr::GetInstance().GetAddon(strAddonId, addon))
+        CGUIDialogAddonSettings::ShowAndGetInput(addon);
+    }
+  }
 }
 
 void CPeripherals::OnApplicationMessage(MESSAGING::ThreadMessage* pMsg)

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -21,12 +21,14 @@
 #include "PeripheralBusAddon.h"
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
+#include "addons/BinaryAddonCache.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/addons/PeripheralAddon.h"
 #include "peripherals/devices/PeripheralJoystick.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "ServiceBroker.h"
 
 #include <algorithm>
 #include <memory>
@@ -144,7 +146,7 @@ bool CPeripheralBusAddon::PerformDeviceScan(PeripheralScanResults &results)
     CSingleLock lock(m_critSection);
     addons = m_addons;
   }
-  
+
   for (const auto& addon : addons)
     addon->PerformDeviceScan(results);
 
@@ -214,7 +216,9 @@ void CPeripheralBusAddon::EnableButtonMapping()
   if (!GetAddonWithButtonMap(dummy))
   {
     VECADDONS disabledAddons;
-    if (CAddonMgr::GetInstance().GetDisabledAddons(disabledAddons, ADDON_PERIPHERALDLL))
+    CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
+    addonCache.GetDisabledAddons(disabledAddons, ADDON_PERIPHERALDLL);
+    if (!disabledAddons.empty())
       PromptEnableAddons(disabledAddons);
   }
 }
@@ -426,10 +430,7 @@ bool CPeripheralBusAddon::SplitLocation(const std::string& strLocation, Peripher
 
 void CPeripheralBusAddon::UpdateAddons(void)
 {
-  using namespace ADDON;
-
   auto GetPeripheralAddonID = [](const PeripheralAddonPtr& addon) { return addon->ID(); };
-  auto GetAddonID = [](const AddonPtr& addon) { return addon->ID(); };
 
   std::set<std::string> currentIds;
   std::set<std::string> newIds;
@@ -438,9 +439,8 @@ void CPeripheralBusAddon::UpdateAddons(void)
   std::set<std::string> removed;
 
   // Get new add-ons
-  VECADDONS newAddons;
-  CAddonMgr::GetInstance().GetAddons(newAddons, ADDON_PERIPHERALDLL);
-  std::transform(newAddons.begin(), newAddons.end(), std::inserter(newIds, newIds.end()), GetAddonID);
+  PeripheralAddonVector newAddons = GetEnabledAddons();
+  std::transform(newAddons.begin(), newAddons.end(), std::inserter(newIds, newIds.end()), GetPeripheralAddonID);
 
   CSingleLock lock(m_critSection);
 
@@ -457,26 +457,23 @@ void CPeripheralBusAddon::UpdateAddons(void)
   {
     CLog::Log(LOGDEBUG, "Add-on bus: Registering add-on %s", addonId.c_str());
 
-    auto GetAddon = [addonId](const AddonPtr& addon) { return addon->ID() == addonId; };
+    auto GetAddon = [&addonId](const PeripheralAddonPtr& addon) { return addon->ID() == addonId; };
 
-    VECADDONS::iterator it = std::find_if(newAddons.begin(), newAddons.end(), GetAddon);
+    PeripheralAddonVector::iterator it = std::find_if(newAddons.begin(), newAddons.end(), GetAddon);
     if (it != newAddons.end())
     {
-      PeripheralAddonPtr newAddon = std::dynamic_pointer_cast<CPeripheralAddon>(*it);
-      if (newAddon)
+      PeripheralAddonPtr& newAddon = *it;
+
+      bool bCreated;
       {
-        bool bCreated;
-
-        {
-          CSingleExit exit(m_critSection);
-          bCreated = (newAddon->CreateAddon() == ADDON_STATUS_OK);
-        }
-
-        if (bCreated)
-          m_addons.push_back(newAddon);
-        else
-          m_failedAddons.push_back(newAddon);
+        CSingleExit exit(m_critSection);
+        bCreated = (newAddon->CreateAddon() == ADDON_STATUS_OK);
       }
+
+      if (bCreated)
+        m_addons.emplace_back(std::move(newAddon));
+      else
+        m_failedAddons.emplace_back(std::move(newAddon));
     }
   }
 
@@ -537,4 +534,25 @@ void CPeripheralBusAddon::PromptEnableAddons(const ADDON::VECADDONS& disabledAdd
         CAddonMgr::GetInstance().EnableAddon(addon->ID());
     }
   }
+}
+
+PeripheralAddonVector CPeripheralBusAddon::GetEnabledAddons()
+{
+  using namespace ADDON;
+
+  PeripheralAddonVector result;
+
+  // Get enabled add-ons
+  VECADDONS tempAddons;
+  CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
+  addonCache.GetAddons(tempAddons, ADDON_PERIPHERALDLL);
+
+  // Downcast pointers
+  for (const auto& addon : tempAddons)
+  {
+    PeripheralAddonPtr peripheralAddon = std::static_pointer_cast<CPeripheralAddon>(addon);
+    result.emplace_back(std::move(peripheralAddon));
+  }
+
+  return result;
 }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -102,6 +102,9 @@ namespace PERIPHERALS
 
     void PromptEnableAddons(const ADDON::VECADDONS& disabledAddons);
 
+    // Helper function
+    static PeripheralAddonVector GetEnabledAddons();
+
     PeripheralAddonVector m_addons;
     PeripheralAddonVector m_failedAddons;
     CCriticalSection      m_critSection;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -24,6 +24,7 @@
 #include "GUIPassword.h"
 #include "Util.h"
 #include "addons/AddonManager.h"
+#include "addons/BinaryAddonCache.h"
 #include "addons/Skin.h"
 #if defined(TARGET_ANDROID)
 #include "platform/android/activity/AndroidFeatures.h"
@@ -81,6 +82,18 @@ bool CheckPVRParentalPin(const std::string &condition, const std::string &value,
 bool HasPeripherals(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
   return CServiceBroker::GetPeripherals().GetNumberOfPeripherals() > 0;
+}
+
+bool HasPeripheralLibraries(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
+{
+  using namespace ADDON;
+
+  VECADDONS peripheralAddons;
+
+  CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
+  addonCache.GetInstalledAddons(peripheralAddons, ADDON_PERIPHERALDLL);
+
+  return !peripheralAddons.empty();
 }
 
 bool HasRumbleFeature(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
@@ -355,6 +368,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("checkmasterlock",               CheckMasterLock));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("checkpvrparentalpin",           CheckPVRParentalPin));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasperipherals",                HasPeripherals));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasperipherallibraries",        HasPeripheralLibraries));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblefeature",              HasRumbleFeature));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("hasrumblecontroller",           HasRumbleController));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("haspowerofffeature",            HasPowerOffFeature));

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -373,6 +373,7 @@ const std::string CSettings::SETTING_AUDIOOUTPUT_TRUEHDPASSTHROUGH = "audiooutpu
 const std::string CSettings::SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH = "audiooutput.dtshdpassthrough";
 const std::string CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS = "audiooutput.volumesteps";
 const std::string CSettings::SETTING_INPUT_PERIPHERALS = "input.peripherals";
+const std::string CSettings::SETTING_INPUT_PERIPHERALLIBRARIES = "input.peripherallibraries";
 const std::string CSettings::SETTING_INPUT_ENABLEMOUSE = "input.enablemouse";
 const std::string CSettings::SETTING_INPUT_ASKNEWCONTROLLERS = "input.asknewcontrollers";
 const std::string CSettings::SETTING_INPUT_CONTROLLERCONFIG = "input.controllerconfig";
@@ -1184,6 +1185,7 @@ void CSettings::InitializeISettingCallbacks()
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALS);
+  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALLIBRARIES);
   settingSet.insert(CSettings::SETTING_INPUT_CONTROLLERCONFIG);
   settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
   settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -327,6 +327,7 @@ public:
   static const std::string SETTING_AUDIOOUTPUT_DTSHDPASSTHROUGH;
   static const std::string SETTING_AUDIOOUTPUT_VOLUMESTEPS;
   static const std::string SETTING_INPUT_PERIPHERALS;
+  static const std::string SETTING_INPUT_PERIPHERALLIBRARIES;
   static const std::string SETTING_INPUT_ENABLEMOUSE;
   static const std::string SETTING_INPUT_ASKNEWCONTROLLERS;
   static const std::string SETTING_INPUT_CONTROLLERCONFIG;


### PR DESCRIPTION
This includes the fixes and improvements necessary for https://github.com/xbmc/peripheral.joystick/pull/98. 

The iMON failures result from scanning for DirectInput devices. With this fix, the user can selectively disable the DirectInput interface while keeping XInput controllers working.

![screenshot001](https://cloud.githubusercontent.com/assets/531482/24831216/a7733bb4-1c4a-11e7-85c4-b26e4a64de23.png)

Also, on linux, where we have three interfaces (Linux joystick api, udev and SDL 2) the user can select which interface to use. This will allow more testing for the udev switch.

![screenshot from 2017-04-08 11-05-18](https://cloud.githubusercontent.com/assets/531482/24831276/cdf80a66-1c4b-11e7-8aee-5102c87d447b.png)

A setting action has been added to allow the joystick add-on to be configured from within settings (instead of having to access joystick settings through the add-on manager).

![screenshot000](https://cloud.githubusercontent.com/assets/531482/24831217/aeaefa80-1c4a-11e7-8252-02a0157c6fd9.png)

Also included are three fixes for "select" controls in add-on settings.

## Screenshots
Coming soon

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
