### PR TITLE
[depends] samba-gplv3: add patch to remove deprecated define in perl generator script

### DIFF
--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile configureEndian.patch samba_android.patch samba_off64_t.patch no_fork_and_exec.patch
+DEPS= ../../Makefile.include Makefile configureEndian.patch perlArrayDefinedDeprecated.patch samba_android.patch samba_off64_t.patch no_fork_and_exec.patch
 
 # lib name, version
 LIBNAME=samba
@@ -50,6 +50,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 -i ../configureEndian.patch
+	cd $(PLATFORM); patch -p1 -i ../perlArrayDefinedDeprecated.patch
 	cd $(PLATFORM)/source3; ./autogen.sh
 ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p0 < ../samba_android.patch

--- a/tools/depends/target/samba-gplv3/perlArrayDefinedDeprecated.patch
+++ b/tools/depends/target/samba-gplv3/perlArrayDefinedDeprecated.patch
@@ -1,0 +1,22 @@
+--- a/pidl/lib/Parse/Pidl/ODL.pm
++++ b/pidl/lib/Parse/Pidl/ODL.pm
+@@ -70,7 +70,7 @@
+ 					next;
+ 				}
+ 				my $podl = Parse::Pidl::IDL::parse_file($idl_path, $opt_incdirs);
+-				if (defined(@$podl)) {
++				if (@$podl) {
+ 					require Parse::Pidl::Typelist;
+ 					my $basename = basename($idl_path, ".idl");
+ 
+--- a/pidl/pidl
++++ b/pidl/pidl
+@@ -604,7 +604,7 @@
+ 		require Parse::Pidl::IDL;
+ 
+ 		$pidl = Parse::Pidl::IDL::parse_file($idl_file, \@opt_incdirs);
+-		defined @$pidl || die "Failed to parse $idl_file";
++		@$pidl || die "Failed to parse $idl_file";
+ 	}
+ 
+ 	require Parse::Pidl::Typelist;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Some versions of perl fail with code like `define(@array)`, others only warn that this way is deprecated.
Patch `define` out of the scripts.
<!--- Describe your change in detail -->

## Motivation and Context
Reports of failing to build samba-gplv3 after the version bump.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Confirmed to compile with this patch, with a perl version that wasn't able to generate the files before.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
