### PR TITLE
[PVR] Reintroduce 'Delete' context menu entry for recording folders.

### DIFF
--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -248,6 +248,13 @@ namespace PVR
       if (item.GetPVRRecordingInfoTag())
         return true;
 
+      // recordings folder?
+      if (item.m_bIsFolder)
+      {
+        const CPVRRecordingsPath path(item.GetPath());
+        return path.IsValid();
+      }
+
       return false;
     }
 


### PR DESCRIPTION
Fixes a small regression introduced with https://github.com/xbmc/xbmc/pull/10870

Reported here: http://forum.kodi.tv/showthread.php?tid=311828

This change has been runtime tested on macOS, latest kodi master.

@metaron-uk fyi
@Jalle19 are the code changes okay?