### PR TITLE
[Estuary] [PVR] Add Season/Episode to recordings

### DIFF
--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -169,7 +169,7 @@
 	<include name="WidgetListEpisodes">
 		<param name="main_label">$INFO[ListItem.Title]</param>
 		<param name="sub_label">$INFO[ListItem.TVShowTitle]</param>
-		<param name="thumb_label">$INFO[ListItem.Season,,x]$INFO[ListItem.Episode]</param>
+		<param name="thumb_label">$VAR[SeasonEpisode]</param>
 		<param name="sortby"></param>
 		<param name="visible">True</param>
 		<param name="sortorder">ascending</param>

--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -46,7 +46,7 @@
 							<right>30</right>
 							<aligny>center</aligny>
 							<scroll>true</scroll>
-							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]$VAR[SeasonEpisode, ,]</label>
 						</control>
 						<control type="label">
 							<left>15</left>
@@ -72,7 +72,7 @@
 							<height>80</height>
 							<right>30</right>
 							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]</label>
+							<label>$INFO[ListItem.Label]$INFO[ListItem.EpisodeName, (,)]$VAR[SeasonEpisode, ,]</label>
 						</control>
 						<control type="label">
 							<left>15</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
+        <variable name="SeasonEpisode">
+	        <value>$INFO[ListItem.Season,,[COLOR grey]x[/COLOR]]$INFO[ListItem.Episode]</value>
+	</variable>
 	<variable name="PVRStatusImageVar">
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.HasTimer | ListItem.HasTimerSchedule">windows/pvr/timer.png</value>
@@ -8,7 +11,7 @@
 		<value condition="System.HasAddon(plugin.program.autocompletion) + !System.HasHiddenInput">plugin://plugin.program.autocompletion?info=autocomplete&amp;&amp;id=$INFO[Control.GetLabel(312).index(1)]&amp;&amp;limit=9</value>
 	</variable>
 	<variable name="PlaylistLabelVar">
-		<value condition="String.IsEqual(ListItem.DbType,episode)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode)">$INFO[ListItem.TVShowtitle,,: ]$VAR[SeasonEpisode,,. ]$INFO[ListItem.Title]</value>
 		<value condition="String.IsEqual(ListItem.DbType,musicvideo)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>
 		<value>$INFO[ListItem.Label]</value>
 	</variable>
@@ -250,7 +253,7 @@
 		<value>$INFO[ListItem.Label]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 	</variable>
 	<variable name="VideoInfoSubLabelVar">
-		<value condition="String.IsEqual(ListItem.DBType,episode)">$INFO[ListItem.Season]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR],: ]$INFO[ListItem.TVShowTitle]</value>
+		<value condition="String.IsEqual(ListItem.DBType,episode)">$VAR[SeasonEpisode,: ]$INFO[ListItem.TVShowTitle]</value>
 		<value condition="String.IsEqual(ListItem.DBType,movie)">$INFO[ListItem.Tagline,[I],[/I]]</value>
 		<value>$INFO[ListItem.Genre]</value>
 	</variable>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -122,7 +122,7 @@
 	<include name="InfoWallEpisodeLayout">
 		<param name="main_label">$INFO[ListItem.Title]</param>
 		<param name="sub_label">$INFO[ListItem.TVShowTitle]</param>
-		<param name="thumb_label">$INFO[ListItem.Season,,x]$INFO[ListItem.Episode]</param>
+		<param name="thumb_label">$VAR[SeasonEpisode]</param>
 		<param name="fallback_image">DefaultTVShows.png</param>
 		<param name="focused">false</param>
 		<definition>


### PR DESCRIPTION
Adds season/episode display to Estuary skin for PVR recordings.
Scaled back version of a more ambitious change in https://github.com/xbmc/xbmc/pull/11783 which started to look like a step too far.

## Description
Adds season/episode display to Estuary skin in the \<season\>x\<episode\> format for recordings when provided by the PVR backend (or Videos database) and the previous behaviour when it doesn't.

Coded as a single $VAR so the format is consistent across all applications and easier to maintain/change

## Motivation and Context
Allows you to see at a glance if you have recorded all the episodes in a series, or if you are missing some.
(Sort your recordings by 'File' to see them in season/episode order)

## How Has This Been Tested?
Tested using current master on RPi (LibreElec Millhouse test builds) and on x86 against my mythtv backend.

## Screenshots (if appropriate):
Example recorded Series folder
![screenshot070](https://cloud.githubusercontent.com/assets/12870817/25048470/8c265fd2-2134-11e7-937d-daf74dc90d8b.png)

Example recorded Series folder without episode names
![screenshot071](https://cloud.githubusercontent.com/assets/12870817/25048486/9ff13078-2134-11e7-8413-2395c923ee90.png)

Example movies (no episode name or season/episode information)
![screenshot072](https://cloud.githubusercontent.com/assets/12870817/25048491/ad59115e-2134-11e7-8041-634d5dbcddca.png)

Example showing a mixture
![screenshot073](https://cloud.githubusercontent.com/assets/12870817/25048519/daf22a60-2134-11e7-9ab6-fa56af7a15da.png)

Example showing 'recently added episodes' using the standard season/episode format
![screenshot074](https://cloud.githubusercontent.com/assets/12870817/25048525/e41dc8f6-2134-11e7-95dc-b21684d9a8b7.png)

Similar format is used in the TV Series section, but this is hard coded (I haven't worked out where yet!)
![screenshot075](https://cloud.githubusercontent.com/assets/12870817/25048538/f096f116-2134-11e7-9152-fc75a22e82b2.png)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

pings: @ksooo, @ronie @phil65