### PR TITLE
[EPG] Fix gap tag update handling.

### DIFF
--- a/xbmc/epg/GUIEPGGridContainerModel.cpp
+++ b/xbmc/epg/GUIEPGGridContainerModel.cpp
@@ -290,6 +290,16 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
       {
         tag = m_programmeItems[progIdx]->GetEPGInfoTag();
 
+        if (!bFoundPrevChannel && channelUid > -1)
+        {
+          chan = tag->ChannelTag();
+          if (chan && chan->UniqueID() == channelUid)
+          {
+            newChannelIndex = channel;
+            bFoundPrevChannel = true;
+          }
+        }
+
         if (tag->EpgID() != iEpgId || gridCursor < tag->StartAsUTC() || m_gridEnd <= tag->StartAsUTC())
           break; // next block
 
@@ -300,15 +310,6 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
             newChannelIndex = channel;
             newBlockIndex   = block + eventOffset;
             return; // both found. done.
-          }
-          if (!bFoundPrevChannel && channelUid > -1)
-          {
-            chan = tag->ChannelTag();
-            if (chan && chan->UniqueID() == channelUid)
-            {
-              newChannelIndex = channel;
-              bFoundPrevChannel = true;
-            }
           }
           break; // next block
         }


### PR DESCRIPTION
This is a followup to #11879, where so called gap tags ('holes' in the epg) were not handled correctly. Effect was 'jumping' epg grid after selecting a gap tag followed by some time of user inactivity (hard to explain, but easy to spot :-).

The changes were runtime tested on macOS, latest Kodi master.

Needs backport.

@Jalle19 mind doing the code review.