### PR TITLE
[EPG] Guide window: fix progress indicator rendering.

### DIFF
--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -292,7 +292,9 @@ float CGUIEPGGridContainer::GetCurrentTimePositionOnPage() const
   if (!m_gridModel->GetGridStart().IsValid())
     return -1.0f;
 
-  return ((CDateTime::GetUTCDateTime() - m_gridModel->GetGridStart()).GetSecondsTotal() * m_blockSize) / (CGUIEPGGridContainerModel::MINSPERBLOCK * 60) - m_programmeScrollOffset;
+  const CDateTimeSpan startDelta(CDateTime::GetUTCDateTime() - m_gridModel->GetGridStart());
+  float fPos = (startDelta.GetSecondsTotal() * m_blockSize) / (CGUIEPGGridContainerModel::MINSPERBLOCK * 60) - m_programmeScrollOffset;
+  return std::min(fPos, m_orientation == VERTICAL ? m_gridWidth : m_gridHeight);
 }
 
 float CGUIEPGGridContainer::GetProgressIndicatorWidth() const


### PR DESCRIPTION
Spotted this after merging new horizontal epg grid layout (#11958), but this bug was there forever - just not as easy to spot with the vertical grid layout.

Pictures to illustrate the problem:

![screenshot000](https://cloud.githubusercontent.com/assets/3226626/25063428/702ea3c4-21e4-11e7-946e-6c311535b635.png)
![screenshot001](https://cloud.githubusercontent.com/assets/3226626/25063429/7030a91c-21e4-11e7-9932-a3549c22a1f9.png)

The change was runtime-tested on macOS, latest Kodi master.

@Jalle19 for code review?