### PR TITLE
logging: always log skin name and version when loading

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1640,7 +1640,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
     return false;
   }
 
-  CLog::Log(LOGINFO, "  load skin from: %s (version: %s)", skin->Path().c_str(), skin->Version().asString().c_str());
+  CLog::Log(LOGNOTICE, "  load skin from: %s (version: %s)", skin->Path().c_str(), skin->Version().asString().c_str());
   g_SkinInfo = skin;
 
   CLog::Log(LOGINFO, "  load fonts for skin...");


### PR DESCRIPTION
Always log skin details on load.

## Description
Change log level from INFO to NOTICE.

## Motivation and Context
Users post Kodi logs, often without enabling debug.  The reason for posting the log is sometimes due to a skin related issue (particularly when testing nightly builds) and you're forced to go back and ask which skin and/or request debug logging (only to find out it's an incompatible third-party skin). Logging the skin details every time just avoids this delay.

## How Has This Been Tested?
On Linux. The following is a snippet from kodi.log when debug logging is not enabled:
```
14:00:01.677 T:1855976352  NOTICE: Running database version Epg11
14:00:01.682 T:1943198160  NOTICE: start dvd mediatype detection
14:00:01.763 T:1943198160  NOTICE:   load skin from: /usr/share/kodi/addons/skin.estuary (version: 2.0.0)
14:00:02.356 T:1943198160 WARNING: JSONRPC: Could not parse type "Setting.Details.SettingList"
14:00:02.977 T:1943198160  NOTICE: Register - new joystickemulation device registered on application->1: Keyboard player (0000:0000)
```
## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
