### PR TITLE
[EPG] Guide window: Fix deadlock when switching grid views.

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -584,6 +584,14 @@ CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuid
 {
 }
 
+CPVRRefreshTimelineItemsThread::~CPVRRefreshTimelineItemsThread()
+{
+  // Note: CThread dtor will also call StopThread(true), but if thread worker function exits that
+  //       late, it might access member variables of this which are already destroyed. Thus, stop
+  //       the thread worker here and synchronously, while all members of this are still alive.
+  StopThread(true);
+}
+
 void CPVRRefreshTimelineItemsThread::Stop()
 {
   StopThread(false);

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -93,7 +93,7 @@ namespace PVR
   {
   public:
     CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuide *pGuideWindow);
-    virtual ~CPVRRefreshTimelineItemsThread() {}
+    virtual ~CPVRRefreshTimelineItemsThread();
 
     virtual void Process();
 


### PR DESCRIPTION
A very special case, described in the forum: http://forum.kodi.tv/showthread.php?tid=298462&pid=2570347#pid2570347 ff.

Interesting parts if the call stacks supplied by the problem reporter:

<pre>
Thread 44 (Thread 0x7f0631625700 (LWP 8209)):
#0  __lll_lock_wait () at ../sysdeps/unix/sysv/linux/x86_64/lowlevellock.S:135
#1  0x00007f06e3aa9910 in pthread_cond_broadcast@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_broadcast.S:133
#2  0x0000000000aaac87 in CEvent::Set() ()
===> accesses PVR::CPVRRefreshTimelineItemsThread::m_done, which is 
  already destroyed at this point (~PVR::CPVRRefreshTimelineItemsThread 
  already left it's dtor body, destructed own members (!) and is in dtor of the 
  base class - see thread 1 stack). behavior is undefined. seems CEvent::Set()
  never returns for the problem reporter. 
#3  0x0000000000cafe45 in PVR::CPVRRefreshTimelineItemsThread::Process() ()
#4  0x0000000000aab8ef in CThread::Action() ()
#5  0x0000000000aabf9b in CThread::staticThread(void*) ()
#6  0x00007f06e3aa3444 in start_thread (arg=0x7f0631625700) at pthread_create.c:333
#7  0x00007f06df2fb86f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105


Thread 1 (Thread 0x7f06d3d76840 (LWP 785)):
#0  pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:180
#1  0x0000000000828081 in XbmcThreads::ConditionVariable::wait(CCriticalSection&, unsigned long) ()
#2  0x00000000008283fc in CEvent::WaitMSec(unsigned int) ()
#3  0x0000000000aabe64 in CThread::StopThread(bool) ()
#4  0x0000000000aabe8f in CThread::~CThread() ()
#5  0x0000000000cb07ff in PVR::CPVRRefreshTimelineItemsThread::~CPVRRefreshTimelineItemsThread() ()
===> dtor's body left, own members destroyed, calling dtor of base class
#6  0x0000000000caefd4 in PVR::CGUIWindowPVRGuide::StartRefreshTimelineItemsThread() ()
#7  0x0000000000caf0b0 in PVR::CGUIWindowPVRGuide::Init() ()
#8  0x0000000000cb004b in PVR::CGUIWindowPVRGuide::OnMessage(CGUIMessage&) ()
#9  0x0000000000b4acbf in CGUIWindowManager::SendMessage(CGUIMessage&) ()
#10 0x0000000000e0029d in ?? ()
#11 0x0000000000dfcf43 in CBuiltins::Execute(std::string const&) ()
#12 0x0000000000c13ec5 in CApplication::ExecuteXBMCAction(std::string, std::shared_ptr<CGUIListItem> const&) ()
#13 0x0000000000c14926 in CApplication::OnMessage(CGUIMessage&) ()
#14 0x0000000000b4aae3 in CGUIWindowManager::SendMessage(CGUIMessage&) ()
#15 0x0000000000afb9bd in CGUIAction::ExecuteActions(int, int, std::shared_ptr<CGUIListItem> const&) const ()
#16 0x0000000000b0311a in CGUIButtonControl::OnClick() ()
#17 0x0000000000b02769 in CGUIButtonControl::OnAction(CAction const&) ()
#18 0x0000000000b471ce in CGUIWindow::OnAction(CAction const&) ()
#19 0x0000000000a28e6b in CGUIMediaWindow::OnAction(CAction const&) ()
#20 0x0000000000cad3a9 in PVR::CGUIWindowPVRBase::OnAction(CAction const&) ()
#21 0x0000000000b4af6c in CGUIWindowManager::OnAction(CAction const&) const ()
#22 0x0000000000c11367 in CApplication::OnAction(CAction const&) ()
#23 0x0000000000aee608 in CInputManager::OnKey(CKey const&) ()
#24 0x0000000000aeef63 in CInputManager::ProcessRemote(int) ()
#25 0x0000000000aefae5 in CInputManager::Process(int, float) ()
#26 0x0000000000c06fe8 in CApplication::FrameMove(bool, bool) ()
#27 0x0000000000c726b6 in CXBApplicationEx::Run(CFileItemList&) ()
#28 0x0000000000ac6141 in XBMC_Run ()
#29 0x00000000007caf98 in main ()
</pre>

The gist of the fix is that thread worker function must have exited when dtor of <code>CPVRRefreshTimelineItemsThread</code> gets called. This is guaranteed if <code>CPVRRefreshTimelineItemsThread::Stop()</code> stops the worker and waits (!) for it to exit - it did not wait before this PR.

To my best knowledge, this should not have any side effects, but you never know. :-/

@MilhouseVH as I cannot reproduce myself, could you please include this PR in your next build and ask the reporter for feedback?
@Jalle19 mind doing the review?