### PR TITLE
[PVR] Fix 'Switch to channel' context menu action after #11747#.

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -261,7 +261,7 @@ bool CPlayListPlayer::Play(const CFileItemPtr &pItem, std::string player)
   int playlist;
   if (pItem->IsAudio())
     playlist = PLAYLIST_MUSIC;
-  else if (pItem->IsVideo())
+  else if (pItem->IsVideo() || pItem->IsLiveTV())
     playlist = PLAYLIST_VIDEO;
   else
     return false;


### PR DESCRIPTION
Fix regression introduced by #11747. PVR context menu action "Switch to channel" did not work any longer.

I runtime tested this fix an macOS, latest Kodi master.

@dgam1 @Razzeee fyi