### PR TITLE
[PVR] Fix 'Switch to channel' context menu action after #11747# - a b…

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -261,7 +261,7 @@ bool CPlayListPlayer::Play(const CFileItemPtr &pItem, std::string player)
   int playlist;
   if (pItem->IsAudio())
     playlist = PLAYLIST_MUSIC;
-  else if (pItem->IsVideo() || pItem->IsLiveTV())
+  else if (pItem->IsVideo())
     playlist = PLAYLIST_VIDEO;
   else
     return false;

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -120,7 +120,10 @@ static void SetPathAndPlay(CFileItem& item)
   }
   item.SetProperty("check_resume", false);
 
-  g_playlistPlayer.Play(std::make_shared<CFileItem>(item), "");
+  if (item.IsLiveTV()) // pvr tv or pvr radio?
+    g_application.PlayMedia(item, "", PLAYLIST_NONE);
+  else
+    g_playlistPlayer.Play(std::make_shared<CFileItem>(item), "");
 }
 
 bool CResume::Execute(const CFileItemPtr& itemIn) const


### PR DESCRIPTION
…etter approach (do not create a playlist for Livr TV).

Better than restoring previous behavior to create a playlist when selecting the "Switch to channel" context menu item is to not create a playlist for Live TV. We do not do this anywhere else.

This change was runtime tested on macOS, latest Kodi master.

@dgam1 fyi.