### PR TITLE
[addons][windows] replaced replace inline assembler with intrinsics

### DIFF
--- a/cmake/addons/depends/common/p8-platform/p8-platform.txt
+++ b/cmake/addons/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,1 @@
-p8-platform https://github.com/xbmc/platform.git 81c38cd885f822983dbf27b198239729bae13786
+p8-platform https://github.com/xbmc/platform.git 32190045c7eb6883c0662db2f91b4ceeab904fc2


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Bump p8-platform to include a change that replaces inline assembler with intrinsics for windows.
https://github.com/xbmc/platform/pull/2
<!--- Describe your change in detail -->

## Motivation and Context
Windows x64 doesn't allow inline assembler.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
