### PR TITLE
CHG: [droid;amc] Dynamic surface view instances

### DIFF
--- a/tools/android/packaging/xbmc/activity_main.xml.in
+++ b/tools/android/packaging/xbmc/activity_main.xml.in
@@ -4,11 +4,5 @@
   android:layout_height="match_parent"
   android:background="@android:color/transparent" >
 
-  <@APP_PACKAGE@.XBMCVideoView
-    android:id="@+id/VideoView1"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:background="@android:color/transparent" />
-
 </RelativeLayout>
 

--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/Main.java.in
@@ -9,23 +9,21 @@ import android.media.AudioManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Choreographer;
+import android.view.Gravity;
 import android.view.View;
-import android.view.Surface;
-import android.widget.RelativeLayout;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.os.Handler;
-import @APP_PACKAGE@.XBMCVideoView;
 
 public class Main extends NativeActivity implements Choreographer.FrameCallback
 {
   private static final String TAG = "@APP_NAME_LC@";
 
+  public static Main MainActivity = null;
+
   private XBMCSettingsContentObserver mSettingsContentObserver;
   private XBMCInputDeviceListener mInputDeviceListener;
-  private XBMCVideoView mVideoView = null;
   private XBMCJsonRPC mJsonRPC = null;
-  private RelativeLayout mVideoLayout = null;
   private View thisView = null;
   private Handler handler = new Handler();
   private Intent mNewIntent = null;
@@ -54,51 +52,27 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   public Main()
   {
     super();
+    MainActivity = this;
   }
 
-  public Surface getVideoViewSurface()
-  {
-    return mVideoView.getSurface();
-  }
-
-  public Rect getVideoViewSurfaceRect()
+  public Rect getDisplayRect()
   {
     Rect ret = new Rect();
     ret.top = 0;
     ret.left = 0;
-    ret.right = mVideoView.mWidth;
-    ret.bottom = mVideoView.mHeight;
+    ret.right = 0;
+    ret.bottom = 0;
+
+    try
+    {
+      ret.right = thisView.getRootView().getWidth();
+      ret.bottom = thisView.getRootView().getHeight();
+    }
+    catch (Exception e) {}
 
     return ret;
   }
 
-  public void setVideoViewSurfaceRect(final int left, final int top, final int right, final int bottom)
-  {
-    runOnUiThread(new Runnable()
-    {
-      @Override
-      public void run()
-      {
-        android.widget.RelativeLayout.LayoutParams mp = new android.widget.RelativeLayout.LayoutParams(mVideoView.getLayoutParams());
-        mp.setMargins(left, top, mVideoLayout.getWidth() - right, mVideoLayout.getHeight() - bottom);
-        mVideoView.setLayoutParams(mp);
-        mVideoView.requestLayout();
-      }
-    });
-  }
-
-  public void clearVideoView()
-  {
-    runOnUiThread(new Runnable()
-    {
-      @Override
-      public void run()
-      {
-        mVideoView.clearSurface();
-      }
-    });
-  }
-  
   public void registerMediaButtonEventReceiver()
   {
     AudioManager manager = (AudioManager) getSystemService(AUDIO_SERVICE);
@@ -128,10 +102,6 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     getWindow().setFormat(PixelFormat.TRANSPARENT);
 
     setContentView(R.layout.activity_main);
-    mVideoView = (XBMCVideoView)findViewById(R.id.VideoView1);
-    mVideoView.getHolder().setFormat(PixelFormat.TRANSPARENT);
-    mVideoLayout = (RelativeLayout) findViewById(R.id.VideoLayout);
-
     setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
     mSettingsContentObserver = new XBMCSettingsContentObserver(this, handler);

--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCVideoView.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCVideoView.java.in
@@ -1,14 +1,8 @@
 package @APP_PACKAGE@;
 
-import javax.microedition.khronos.egl.EGL10;
-import javax.microedition.khronos.egl.EGLConfig;
-import javax.microedition.khronos.egl.EGLContext;
-import javax.microedition.khronos.egl.EGLDisplay;
-import javax.microedition.khronos.egl.EGLSurface;
-
-import android.R.bool;
-import android.opengl.GLES20;
-import android.util.AttributeSet;
+import android.graphics.Color;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
 import android.util.Log;
 import android.view.Surface;
 import android.view.SurfaceHolder;
@@ -17,83 +11,86 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.view.View;
+import android.widget.RelativeLayout;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
 
 public class XBMCVideoView extends SurfaceView implements
     SurfaceHolder.Callback
 {
+  native void _OnSurfaceChanged(SurfaceHolder holder, int format, int width, int height);
+  native void _OnSurfaceCreated(SurfaceHolder holder);
+  native void _OnSurfaceDestroyed(SurfaceHolder holder);
+
   private static final String TAG = "XBMCVideoPlayView";
 
-  public boolean mHasHolder = false;
-  public int mWidth = -1;
-  public int mHeight = -1;
+  public boolean mIsCreated = false;
+  private RelativeLayout mVideoLayout = null;
+
+  public static XBMCVideoView createVideoView()
+  {
+    FutureTask<XBMCVideoView> futureResult = new FutureTask<XBMCVideoView>(new Callable<XBMCVideoView>() {
+      @Override
+      public XBMCVideoView call() throws Exception
+      {
+        return new XBMCVideoView(Main.MainActivity);
+      }
+    });
+
+    try
+    {
+      Main.MainActivity.runOnUiThread(futureResult);
+      XBMCVideoView vw = futureResult.get();
+      return vw;
+    }
+    catch (Exception e)
+    {
+      e.printStackTrace();
+      return null;
+    }
+  }
 
   public XBMCVideoView(Context context)
   {
     super(context);
     getHolder().addCallback(this);
+    getHolder().setFormat(PixelFormat.TRANSPARENT);
+    setZOrderMediaOverlay(true);
+    mVideoLayout = (RelativeLayout) Main.MainActivity.findViewById(R.id.VideoLayout);
   }
 
-  public XBMCVideoView(Context context, AttributeSet attrs)
+  public void add()
   {
-    this(context, attrs, 0);
-    getHolder().addCallback(this);
+    Main.MainActivity.runOnUiThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        mVideoLayout.addView(XBMCVideoView.this);
+
+        RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+        setLayoutParams(layoutParams);
+        setBackgroundColor(Color.TRANSPARENT);
+      }
+    });
   }
 
-  public XBMCVideoView(Context context, AttributeSet attrs, int defStyle)
+  public void release()
   {
-    super(context, attrs, defStyle);
-    getHolder().addCallback(this);
-  }
-
-  /**
-   * Clears the playback surface to black.
-   */
-  public void clearSurface()
-  {
-    if (!mHasHolder)
-      return;
-
-    // Have to go EGL to allow reuse of surface
-
-    final int EGL_OPENGL_ES2_BIT = 4;
-    final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
-
-    EGL10 egl = (EGL10) EGLContext.getEGL();
-    EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
-    egl.eglInitialize(display, null);
-
-    int[] attribList =
-    { EGL10.EGL_RED_SIZE, 8, EGL10.EGL_GREEN_SIZE, 8, EGL10.EGL_BLUE_SIZE, 8,
-        EGL10.EGL_ALPHA_SIZE, 8, EGL10.EGL_RENDERABLE_TYPE,
-        EGL_OPENGL_ES2_BIT, EGL10.EGL_NONE, 0, // placeholder for
-                                                     // recordable [@-3]
-        EGL10.EGL_NONE };
-    EGLConfig[] configs = new EGLConfig[1];
-    int[] numConfigs = new int[1];
-    egl.eglChooseConfig(display, attribList, configs, configs.length,
-        numConfigs);
-    EGLConfig config = configs[0];
-    EGLContext context = egl.eglCreateContext(display, config,
-        EGL10.EGL_NO_CONTEXT, new int[]
-        { EGL_CONTEXT_CLIENT_VERSION, 2, EGL10.EGL_NONE });
-    EGLSurface eglSurface = egl.eglCreateWindowSurface(display, config,
-        this, new int[]
-        { EGL10.EGL_NONE });
-
-    egl.eglMakeCurrent(display, eglSurface, eglSurface, context);
-    GLES20.glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-    GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
-    egl.eglSwapBuffers(display, eglSurface);
-    egl.eglDestroySurface(display, eglSurface);
-    egl.eglMakeCurrent(display, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE,
-        EGL10.EGL_NO_CONTEXT);
-    egl.eglDestroyContext(display, context);
-    egl.eglTerminate(display);
+    Main.MainActivity.runOnUiThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        mVideoLayout.removeView(XBMCVideoView.this);
+      }
+    });
   }
 
   public Surface getSurface()
   {
-    if (!mHasHolder)
+    if (!mIsCreated)
     {
       return null;
     } else
@@ -103,33 +100,56 @@ public class XBMCVideoView extends SurfaceView implements
     }
   }
 
+  public void setSurfaceRect(final int left, final int top, final int right, final int bottom)
+  {
+    Main.MainActivity.runOnUiThread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try
+        {
+          // Android does not allow to adjust AR and/or size of a frame on a Surface.
+          // Instead, we render fullscreen on the surface and adjust the size of the surface for AR
+          // For zoom, we adjust the margins of the layout containing the surface to achieve the desired result
+          // Note: This assume margins can be negative for positive zoom levels. This doesn't work on Philips/Sony TV's
+          RelativeLayout.LayoutParams mp = new RelativeLayout.LayoutParams(getLayoutParams());
+          mp.setMargins(left, top, mVideoLayout.getWidth() - right, mVideoLayout.getHeight() - bottom);
+          setLayoutParams(mp);
+          requestLayout();
+        }
+        catch (Exception e)
+        {
+          e.printStackTrace();
+        }
+      }
+    });
+  }
+
+
   @Override
   public void surfaceCreated(SurfaceHolder holder)
   {
     Log.d(TAG, "Created");
-    mHasHolder = true;
-
-    View v = getRootView();
-    mWidth = v.getWidth();
-    mHeight = v.getHeight();
+    mIsCreated = true;
+    _OnSurfaceCreated(holder);
   }
 
   @Override
   public void surfaceChanged(SurfaceHolder holder, int format, int width,
       int height)
   {
+    _OnSurfaceChanged(holder, format, width, height);
+
     Log.d(TAG, "Changed, format:" + format + ", width:" + width
         + ", height:" + height);
-
-    View v = getRootView();
-    mWidth = v.getWidth();
-    mHeight = v.getHeight();
   }
 
   @Override
   public void surfaceDestroyed(SurfaceHolder holder)
   {
     Log.d(TAG, "Destroyed");
-    mHasHolder = false;
+    mIsCreated = false;
+    _OnSurfaceDestroyed(holder);
   }
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -333,15 +333,21 @@ void CDVDMediaCodecInfo::RenderUpdate(const CRect &SrcRect, const CRect &DestRec
   if (!m_valid)
     return;
 
-  if (DestRect != m_videoview->getSurfaceRect())
+  CRect surfRect = m_videoview->getSurfaceRect();
+  if (DestRect != surfRect)
   {
     CRect adjRect = CXBMCApp::MapRenderToDroid(DestRect);
-    m_videoview->setSurfaceRect(adjRect);
-    CLog::Log(LOGDEBUG, "RenderUpdate: Dest - %f+%f-%fx%f", DestRect.x1, DestRect.y1, DestRect.Width(), DestRect.Height());
-    CLog::Log(LOGDEBUG, "RenderUpdate: Adj  - %f+%f-%fx%f", adjRect.x1, adjRect.y1, adjRect.Width(), adjRect.Height());
+    if (adjRect != surfRect)
+    {
+      m_videoview->setSurfaceRect(adjRect);
+      CLog::Log(LOGDEBUG, "RenderUpdate: Dest - %f+%f-%fx%f", DestRect.x1, DestRect.y1, DestRect.Width(), DestRect.Height());
+      CLog::Log(LOGDEBUG, "RenderUpdate: Adj  - %f+%f-%fx%f", adjRect.x1, adjRect.y1, adjRect.Width(), adjRect.Height());
 
-    // setVideoViewSurfaceRect is async, so skip rendering this frame
-    ReleaseOutputBuffer(false);
+      // setVideoViewSurfaceRect is async, so skip rendering this frame
+      ReleaseOutputBuffer(false);
+    }
+    else
+      ReleaseOutputBuffer(true);
   }
   else
     ReleaseOutputBuffer(true);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -326,7 +326,7 @@ void CDVDMediaCodecInfo::UpdateTexImage()
   }
 }
 
-void CDVDMediaCodecInfo::RenderUpdate(const CRect &SrcRect, const CRect &DestRect)
+void CDVDMediaCodecInfo::RenderUpdate(const CRect &DestRect)
 {
   CSingleLock lock(m_section);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -85,7 +85,7 @@ public:
   int                 GetTextureID() const;
   void                GetTransformMatrix(float *textureMatrix);
   void                UpdateTexImage();
-  void                RenderUpdate(const CRect &SrcRect, const CRect &DestRect);
+  void                RenderUpdate(const CRect &DestRect);
 
 private:
   // private because we are reference counted

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -31,6 +31,7 @@
 
 #include "DVDVideoCodec.h"
 #include "DVDStreamInfo.h"
+#include "platform/android/activity/JNIXBMCVideoView.h"
 #include "threads/Thread.h"
 #include "threads/SingleLock.h"
 #include "guilib/Geometry.h"
@@ -66,7 +67,8 @@ public:
                       unsigned int texture,
                       AMediaCodec* codec,
                       std::shared_ptr<CJNISurfaceTexture> &surfacetexture,
-                      std::shared_ptr<CDVDMediaCodecOnFrameAvailable> &frameready);
+                      std::shared_ptr<CDVDMediaCodecOnFrameAvailable> &frameready,
+                      std::shared_ptr<CJNIXBMCVideoView> &videoview);
 
   // reference counting
   CDVDMediaCodecInfo* Retain();
@@ -101,9 +103,10 @@ private:
   AMediaCodec* m_codec;
   std::shared_ptr<CJNISurfaceTexture> m_surfacetexture;
   std::shared_ptr<CDVDMediaCodecOnFrameAvailable> m_frameready;
+  std::shared_ptr<CJNIXBMCVideoView> m_videoview;
 };
 
-class CDVDVideoCodecAndroidMediaCodec : public CDVDVideoCodec
+class CDVDVideoCodecAndroidMediaCodec : public CDVDVideoCodec, public CJNISurfaceHolderCallback
 {
 public:
   CDVDVideoCodecAndroidMediaCodec(CProcessInfo &processInfo, bool surface_render = false);
@@ -143,6 +146,7 @@ protected:
   int             m_state;
   int             m_noPictureLoop;
 
+  std::shared_ptr<CJNIXBMCVideoView> m_jnivideoview;
   CJNISurface*    m_jnisurface;
   CJNISurface     m_jnivideosurface;
   AMediaCrypto   *m_crypto;
@@ -170,4 +174,10 @@ protected:
   unsigned int    m_lastInflight;
   int             m_src_offset[4];
   int             m_src_stride[4];
+  
+  // CJNISurfaceHolderCallback interface
+public:
+  virtual void surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height) override;
+  virtual void surfaceCreated(CJNISurfaceHolder holder) override;
+  virtual void surfaceDestroyed(CJNISurfaceHolder holder) override;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -129,7 +129,7 @@ void CRendererMediaCodecSurface::FlipPage(int source)
   // Benefit of this place is that it is called from render-thread and not
   // affected by gui stalls when opening overlay dialogs
   if (mci)
-    mci->ReleaseOutputBuffer(true);
+    mci->RenderUpdate(m_surfDestRect);
 }
 
 bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
@@ -178,16 +178,16 @@ void CRendererMediaCodecSurface::ReorderDrawPoints()
   if (stereo_mode)
     g_graphicsContext.SetStereoView(RENDER_STEREO_VIEW_OFF);
 
-  CRect dstRect(m_destRect);
+  m_surfDestRect = m_destRect;
   CRect srcRect(m_sourceRect);
   switch (stereo_mode)
   {
     case RENDER_STEREO_MODE_SPLIT_HORIZONTAL:
-      dstRect.y2 *= 2.0;
+      m_surfDestRect.y2 *= 2.0;
       srcRect.y2 *= 2.0;
       break;
     case RENDER_STEREO_MODE_SPLIT_VERTICAL:
-      dstRect.x2 *= 2.0;
+      m_surfDestRect.x2 *= 2.0;
       srcRect.x2 *= 2.0;
       break;
     default:
@@ -200,20 +200,13 @@ void CRendererMediaCodecSurface::ReorderDrawPoints()
     case 90:
     case 270:
     {
-        double scale = (double)dstRect.Height() / dstRect.Width();
-        int diff = (int) ((dstRect.Height()*scale - dstRect.Width()) / 2);
-        dstRect = CRect(dstRect.x1 - diff, dstRect.y1, dstRect.x2 + diff, dstRect.y2);
+      double scale = (double)m_surfDestRect.Height() / m_surfDestRect.Width();
+      int diff = (int) ((m_surfDestRect.Height()*scale - m_surfDestRect.Width()) / 2);
+      m_surfDestRect = CRect(m_surfDestRect.x1 - diff, m_surfDestRect.y1, m_surfDestRect.x2 + diff, m_surfDestRect.y2);
     }
     default:
       break;
   }
-
-  CRect adjRect = CXBMCApp::MapRenderToDroid(dstRect);
-  CXBMCApp::get()->setVideoViewSurfaceRect(adjRect.x1, adjRect.y1, adjRect.x2, adjRect.y2);
-
-  CLog::Log(LOGDEBUG, "CRendererMediaCodecSurface::ReorderDrawPoints: dst: %0.1f+%0.1f-%0.1fx%0.1f, adj: %0.1f+%0.1f-%0.1fx%0.1f",
-    dstRect.x1, dstRect.y1, dstRect.Width(), dstRect.Height(),
-    adjRect.x1, adjRect.y1, adjRect.Width(), adjRect.Height());
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -75,6 +75,7 @@ private:
   std::chrono::time_point<std::chrono::system_clock> m_prevTime;
   bool m_bConfigured;
   unsigned int m_updateCount;
+  CRect m_surfDestRect;
 };
 
 #endif

--- a/xbmc/platform/android/activity/CMakeLists.txt
+++ b/xbmc/platform/android/activity/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES android_main.cpp
             EventLoop.cpp
             GraphicBuffer.cpp
             JNIMainActivity.cpp
+            JNIXBMCVideoView.cpp
             XBMCApp.cpp
             ${NDKROOT}/sources/android/native_app_glue/android_native_app_glue.c
             ${NDKROOT}/sources/android/cpufeatures/cpu-features.c)
@@ -22,6 +23,7 @@ set(HEADERS AndroidExtra.h
             GraphicBuffer.h
             IActivityHandler.h
             JNIMainActivity.h
+            JNIXBMCVideoView.h
             XBMCApp.h)
 
 core_add_library(platform_android_activity)

--- a/xbmc/platform/android/activity/JNIMainActivity.cpp
+++ b/xbmc/platform/android/activity/JNIMainActivity.cpp
@@ -119,28 +119,10 @@ void CJNIMainActivity::_doFrame(JNIEnv *env, jobject context, jlong frameTimeNan
     m_appInstance->doFrame(frameTimeNanos);
 }
 
-CJNISurface CJNIMainActivity::getVideoViewSurface()
+CJNIRect CJNIMainActivity::getDisplayRect()
 {
   return call_method<jhobject>(m_context,
-                               "getVideoViewSurface", "()Landroid/view/Surface;");
-}
-
-void CJNIMainActivity::clearVideoView()
-{
-  call_method<void>(m_context,
-                    "clearVideoView", "()V");
-}
-
-CJNIRect CJNIMainActivity::getVideoViewSurfaceRect()
-{
-  return call_method<jhobject>(m_context,
-                               "getVideoViewSurfaceRect", "()Landroid/graphics/Rect;");
-}
-
-void CJNIMainActivity::setVideoViewSurfaceRect(int l, int t, int r, int b)
-{
-  call_method<void>(m_context,
-                    "setVideoViewSurfaceRect", "(IIII)V", l, t, r, b);
+                               "getDisplayRect", "()Landroid/graphics/Rect;");
 }
 
 void CJNIMainActivity::registerMediaButtonEventReceiver()

--- a/xbmc/platform/android/activity/JNIMainActivity.h
+++ b/xbmc/platform/android/activity/JNIMainActivity.h
@@ -22,7 +22,6 @@
 #include <androidjni/Activity.h>
 #include <androidjni/InputManager.h>
 #include <androidjni/Rect.h>
-#include <androidjni/Surface.h>
 
 class CJNIMainActivity : public CJNIActivity, public CJNIInputManagerInputDeviceListener
 {
@@ -46,11 +45,8 @@ public:
   static void registerMediaButtonEventReceiver();
   static void unregisterMediaButtonEventReceiver();
 
-  CJNISurface getVideoViewSurface();
-  void clearVideoView();
-  CJNIRect getVideoViewSurfaceRect();
-  void setVideoViewSurfaceRect(int l, int t, int r, int b);
-
+  CJNIRect getDisplayRect();
+  
 private:
   static CJNIMainActivity *m_appInstance;
 

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -1,0 +1,189 @@
+/*
+ *      Copyright (C) 2016 Christian Browet
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "JNIXBMCVideoView.h"
+
+#include <androidjni/jutils-details.hpp>
+#include <androidjni/ClassLoader.h>
+
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <list>
+#include <algorithm>
+#include <cassert>
+
+using namespace jni;
+
+// Map java object instances to C++ instances
+std::list<std::pair<jhobject, CJNIXBMCVideoView*>> s_videoview_map;
+
+CJNIXBMCVideoView* find_videoview(const jhobject& o)
+{
+  for( auto it = s_videoview_map.begin(); it != s_videoview_map.end(); ++it )
+  {
+    if (it->first == o)
+      return it->second;
+  }
+  return nullptr;
+}
+
+CJNIXBMCVideoView::CJNIXBMCVideoView()
+  : m_callback(nullptr)
+  , m_surfaceCreated(nullptr)
+{
+}
+
+CJNIXBMCVideoView::CJNIXBMCVideoView(const jni::jhobject &object)
+  : CJNIBase(object)
+  , m_callback(nullptr)
+  , m_surfaceCreated(nullptr)
+{
+}
+
+CJNIXBMCVideoView::~CJNIXBMCVideoView()
+{
+  delete m_surfaceCreated;
+}
+
+CJNIXBMCVideoView* CJNIXBMCVideoView::createVideoView(CJNISurfaceHolderCallback* callback)
+{
+  std::string dotClassName = CJNIContext::getPackageName() + ".XBMCVideoView";
+  std::string slashClassName = dotClassName;
+  std::replace(slashClassName.begin(), slashClassName.end(), '.', '/');
+  std::string signature = "()L" + slashClassName + ";";
+
+  CJNIXBMCVideoView* pvw = new CJNIXBMCVideoView(call_static_method<jhobject>(xbmc_jnienv(), CJNIContext::getClassLoader().loadClass(dotClassName),
+                                                                              "createVideoView", signature.c_str()));
+  if (!*pvw)
+  {
+    CLog::Log(LOGERROR, "Cannot instantiate VideoView!!");
+    delete pvw;
+    return nullptr;
+  }
+
+  s_videoview_map.push_back(std::pair<jhobject, CJNIXBMCVideoView*>(pvw->get_raw(), pvw));
+  pvw->m_callback = callback;
+  pvw->m_surfaceCreated = new CEvent;
+  if (pvw->isCreated())
+    pvw->m_surfaceCreated->Set();
+  pvw->add();
+
+  return pvw;
+}
+
+void CJNIXBMCVideoView::_OnSurfaceChanged(JNIEnv *env, jobject thiz, jobject holder, jint format, jint width, jint height )
+{
+  (void)env;
+
+  CJNIXBMCVideoView *inst = find_videoview(jhobject(thiz));
+  if (inst)
+    inst->OnSurfaceChanged(CJNISurfaceHolder(jhobject(holder)), format, width, height);
+}
+
+void CJNIXBMCVideoView::_OnSurfaceCreated(JNIEnv* env, jobject thiz, jobject holder)
+{
+  (void)env;
+
+  CJNIXBMCVideoView *inst = find_videoview(jhobject(thiz));
+  if (inst)
+    inst->OnSurfaceCreated(CJNISurfaceHolder(jhobject(holder)));
+}
+
+void CJNIXBMCVideoView::_OnSurfaceDestroyed(JNIEnv* env, jobject thiz, jobject holder)
+{
+  (void)env;
+
+  CJNIXBMCVideoView *inst = find_videoview(jhobject(thiz));
+  if (inst)
+    inst->OnSurfaceDestroyed(CJNISurfaceHolder(jhobject(holder)));
+}
+
+void CJNIXBMCVideoView::OnSurfaceChanged(CJNISurfaceHolder holder, int format, int width, int height)
+{
+  if (m_callback)
+    m_callback->surfaceChanged(holder, format, width, height);
+}
+
+void CJNIXBMCVideoView::OnSurfaceCreated(CJNISurfaceHolder holder)
+{
+  if (m_surfaceCreated)
+    m_surfaceCreated->Set();
+  if (m_callback)
+    m_callback->surfaceCreated(holder);
+}
+
+void CJNIXBMCVideoView::OnSurfaceDestroyed(CJNISurfaceHolder holder)
+{
+  if (m_surfaceCreated)
+    m_surfaceCreated->Reset();
+  if (m_callback)
+    m_callback->surfaceDestroyed(holder);
+}
+
+bool CJNIXBMCVideoView::waitForSurface(unsigned int millis)
+{
+  return m_surfaceCreated->WaitMSec(millis);
+}
+
+void CJNIXBMCVideoView::add()
+{
+  call_method<void>(m_object,
+                    "add", "()V");
+}
+
+void CJNIXBMCVideoView::release()
+{
+  for( auto it = s_videoview_map.begin(); it != s_videoview_map.end(); ++it )
+  {
+    if (it->second == this)
+    {
+      s_videoview_map.erase(it);
+      break;
+    }
+  }
+
+  call_method<void>(m_object,
+                    "release", "()V");
+}
+
+CJNISurface CJNIXBMCVideoView::getSurface()
+{
+  return call_method<jhobject>(m_object,
+                               "getSurface", "()Landroid/view/Surface;");
+}
+
+const CRect& CJNIXBMCVideoView::getSurfaceRect()
+{
+  return m_surfaceRect;
+}
+
+void CJNIXBMCVideoView::setSurfaceRect(const CRect& rect)
+{
+  call_method<void>(m_object,
+                    "setSurfaceRect", "(IIII)V", int(rect.x1), int(rect.y1), int(rect.x2), int(rect.y2));
+  m_surfaceRect = rect;
+}
+
+bool CJNIXBMCVideoView::isCreated() const
+{
+  return get_field<jboolean>(m_object, "mIsCreated");
+}
+

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.h
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.h
@@ -1,0 +1,66 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Christian Browet
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <androidjni/JNIBase.h>
+
+#include <androidjni/Context.h>
+#include <androidjni/Rect.h>
+#include <androidjni/Surface.h>
+#include <androidjni/SurfaceHolder.h>
+
+#include "guilib/Geometry.h"
+#include "threads/Event.h"
+
+class CJNIXBMCVideoView : public CJNIBase
+{
+public:
+  CJNIXBMCVideoView(const jni::jhobject &object);
+  ~CJNIXBMCVideoView();
+
+  static CJNIXBMCVideoView* createVideoView(CJNISurfaceHolderCallback* callback);
+
+  static void _OnSurfaceChanged(JNIEnv* env, jobject thiz, jobject holder, jint format, jint width, jint height);
+  static void _OnSurfaceCreated(JNIEnv* env, jobject thiz, jobject holder);
+  static void _OnSurfaceDestroyed(JNIEnv* env, jobject thiz, jobject holder);
+
+  bool waitForSurface(unsigned int millis);
+  bool isActive() { return m_surfaceCreated->Signaled(); }
+  CJNISurface getSurface();
+  const CRect& getSurfaceRect();
+  void setSurfaceRect(const CRect& rect);
+  void add();
+  void release();
+  int ID() const;
+  bool isCreated() const;
+
+protected:
+  CJNISurfaceHolderCallback* m_callback;
+  CEvent* m_surfaceCreated;
+
+  void OnSurfaceChanged(CJNISurfaceHolder holder, int format, int width, int height);
+  void OnSurfaceCreated(CJNISurfaceHolder holder);
+  void OnSurfaceDestroyed(CJNISurfaceHolder holder);
+
+  CRect m_surfaceRect;
+
+private:
+  CJNIXBMCVideoView();
+};

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -121,6 +121,7 @@ std::vector<CActivityResultEvent*> CXBMCApp::m_activityResultEvents;
 CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
   : CJNIMainActivity(nativeActivity)
   , CJNIBroadcastReceiver(CJNIContext::getPackageName() + ".XBMCBroadcastReceiver")
+  , m_videosurfaceInUse(false)
 {
   m_xbmcappinstance = this;
   m_activity = nativeActivity;
@@ -200,13 +201,14 @@ void CXBMCApp::onResume()
 void CXBMCApp::onPause()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
-  
+
   if (g_application.m_pPlayer->IsPlaying())
   {
-    if (g_application.m_pPlayer->IsPlayingVideo())
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_STOP)));
-    else
-      registerMediaButtonEventReceiver();
+    if (g_application.m_pPlayer->HasVideo())
+    {
+      if (!g_application.m_pPlayer->IsPaused())
+        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(ACTION_PAUSE)));
+    }
   }
 
   EnableWakeLock(false);
@@ -546,10 +548,13 @@ CRect CXBMCApp::MapRenderToDroid(const CRect& srcRect)
   float scaleX = 1.0;
   float scaleY = 1.0;
 
-  CJNIRect r = m_xbmcappinstance->getVideoViewSurfaceRect();
-  RESOLUTION_INFO renderRes = CDisplaySettings::GetInstance().GetResolutionInfo(g_graphicsContext.GetVideoResolution());
-  scaleX = (double)r.width() / renderRes.iWidth;
-  scaleY = (double)r.height() / renderRes.iHeight;
+  CJNIRect r = m_xbmcappinstance->getDisplayRect();
+  if (r.width() && r.height())
+  {
+    RESOLUTION_INFO renderRes = CDisplaySettings::GetInstance().GetResolutionInfo(g_graphicsContext.GetVideoResolution());
+    scaleX = (double)r.width() / renderRes.iWidth;
+    scaleY = (double)r.height() / renderRes.iHeight;
+  }
 
   return CRect(srcRect.x1 * scaleX, srcRect.y1 * scaleY, srcRect.x2 * scaleX, srcRect.y2 * scaleY);
 }

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -94,6 +94,7 @@ class CXBMCApp
 public:
   CXBMCApp(ANativeActivity *nativeActivity);
   virtual ~CXBMCApp();
+  static CXBMCApp* get() { return m_xbmcappinstance; }
 
   // IAnnouncer IF
   virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
@@ -186,7 +187,8 @@ public:
 
   static bool WaitVSync(unsigned int milliSeconds);
 
-  static CXBMCApp* get() { return m_xbmcappinstance; }
+  bool getVideosurfaceInUse();
+  void setVideosurfaceInUse(bool videosurfaceInUse);
 
 protected:
   // limit who can access Volume
@@ -212,6 +214,7 @@ private:
   static bool m_headsetPlugged;
   static IInputDeviceCallbacks* m_inputDeviceCallbacks;
   static IInputDeviceEventHandler* m_inputDeviceEventHandler;
+  bool m_videosurfaceInUse;
   bool m_firstrun;
   bool m_exiting;
   pthread_t m_thread;

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -30,6 +30,7 @@
 #include "CompileInfo.h"
 #include "EventLoop.h"
 #include "platform/android/activity/JNIMainActivity.h"
+#include "platform/android/activity/JNIXBMCVideoView.h"
 #include "utils/StringUtils.h"
 #include "XBMCApp.h"
 
@@ -142,6 +143,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   std::string settingsObserver = pkgRoot + "/XBMCSettingsContentObserver";
   std::string audioFocusChangeListener = pkgRoot + "/XBMCOnAudioFocusChangeListener";
   std::string inputDeviceListener = pkgRoot + "/XBMCInputDeviceListener";
+  std::string videoView = pkgRoot + "/XBMCVideoView";
 
   jclass cMain = env->FindClass(mainClass.c_str());
   if(cMain)
@@ -228,6 +230,31 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
       { "_onInputDeviceRemoved", "(I)V", (void*)&CJNIMainActivity::_onInputDeviceRemoved }
     };
     env->RegisterNatives(cInputDeviceListener, mInputDeviceCallbacks, 3);
+  }
+
+  jclass cVideoView = env->FindClass(videoView.c_str());
+  if(cVideoView)
+  {
+    JNINativeMethod mOnSurfaceChanged = {
+      "_OnSurfaceChanged",
+      "(Landroid/view/SurfaceHolder;III)V",
+      (void*)&CJNIXBMCVideoView::_OnSurfaceChanged
+    };
+    env->RegisterNatives(cVideoView, &mOnSurfaceChanged, 1);
+
+    JNINativeMethod mOnSurfaceCreated = {
+      "_OnSurfaceCreated",
+      "(Landroid/view/SurfaceHolder;)V",
+      (void*)&CJNIXBMCVideoView::_OnSurfaceCreated
+    };
+    env->RegisterNatives(cVideoView, &mOnSurfaceCreated, 1);
+
+    JNINativeMethod mOnSurfaceDestroyed = {
+      "_OnSurfaceDestroyed",
+      "(Landroid/view/SurfaceHolder;)V",
+      (void*)&CJNIXBMCVideoView::_OnSurfaceDestroyed
+    };
+    env->RegisterNatives(cVideoView, &mOnSurfaceDestroyed, 1);
   }
 
   return version;


### PR DESCRIPTION
Refactor of Mediacodec Surface to have dynamic SurfaceView's rather than a single static one.

Benefits:
1) Allows multiple parallel amc + surface instances
2) Get rid of the ugly clear() method
3) Save resources by not having a permanent SurfaceView

No functional changes