### PR TITLE
Revert "Moved party mode, set default and clear default to new contextmenu

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -87,9 +87,6 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CRemoveFavourite>(),
       std::make_shared<CONTEXTMENU::CRenameFavourite>(),
       std::make_shared<CONTEXTMENU::CChooseThumbnailForFavourite>(),
-      std::make_shared<CONTEXTMENU::CPlayPartymode>(),
-      std::make_shared<CONTEXTMENU::CSetDefault>(),
-      std::make_shared<CONTEXTMENU::CClearDefault>(),
   };
 
   ReloadAddonItems();

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -22,14 +22,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "tags/MusicInfoTag.h"
-#include "PartyModeManager.h"
-#include "settings/Settings.h"
-#include "utils/LegacyPathTranslation.h"
-#include "utils/log.h"
-#include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
-#include "Util.h"
-#include "filesystem/MusicDatabaseDirectory.h"
-#include "ServiceBroker.h"
 
 
 namespace CONTEXTMENU
@@ -46,108 +38,6 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
 bool CMusicInfo::Execute(const CFileItemPtr& item) const
 {
   CGUIDialogMusicInfo::ShowFor(*item);
-  return true;
-}
-
-bool CPlayPartymode::IsVisible(const CFileItem& item) const
-{
-  return !item.IsParentFolder() && item.CanQueue() && !item.IsAddonsPath() && !item.IsScript() && item.IsSmartPlayList();
-}
-
-bool CPlayPartymode::Execute(const CFileItemPtr& item) const
-{
-  g_partyModeManager.Enable(PARTYMODECONTEXT_MUSIC, item->GetPath());
-  return true;
-}
-
-bool CSetDefault::IsVisible(const CFileItem& item) const
-{
-  if (!item.IsPath("sources://music/"))
-  {
-    // are we in the playlists location?
-    bool inPlaylists = item.IsPath(CUtil::MusicPlaylistsLocation()) || item.IsPath("special://musicplaylists/");
-    //Set default or clear default
-    XFILE::CMusicDatabaseDirectory dir;
-    XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE nodetype = dir.GetDirectoryType(item.GetPath());
-    if (!item.IsParentFolder() && !inPlaylists &&
-      (nodetype == XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE_ROOT ||
-        nodetype == XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE_OVERVIEW ||
-        nodetype == XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE_TOP100))
-    {
-      return !item.IsPath(CServiceBroker::GetSettings().GetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW));
-    }
-  }
-  return false;
-}
-
-std::string CSetDefault::GetQuickpathName(const std::string& strPath) const
-{
-  std::string path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
-  StringUtils::ToLower(path);
-  if (path == "musicdb://genres/")
-    return "Genres";
-  else if (path == "musicdb://artists/")
-    return "Artists";
-  else if (path == "musicdb://albums/")
-    return "Albums";
-  else if (path == "musicdb://songs/")
-    return "Songs";
-  else if (path == "musicdb://top100/")
-    return "Top100";
-  else if (path == "musicdb://top100/songs/")
-    return "Top100Songs";
-  else if (path == "musicdb://top100/albums/")
-    return "Top100Albums";
-  else if (path == "musicdb://recentlyaddedalbums/")
-    return "RecentlyAddedAlbums";
-  else if (path == "musicdb://recentlyplayedalbums/")
-    return "RecentlyPlayedAlbums";
-  else if (path == "musicdb://compilations/")
-    return "Compilations";
-  else if (path == "musicdb://years/")
-    return "Years";
-  else if (path == "musicdb://singles/")
-    return "Singles";
-  else if (path == "special://musicplaylists/")
-    return "Playlists";
-  else
-  {
-    CLog::Log(LOGERROR, "CSetDefault::GetQuickpathName: Unknown parameter (%s)", strPath.c_str());
-    return strPath;
-  }
-}
-
-bool CSetDefault::Execute(const CFileItemPtr& item) const
-{
-  CServiceBroker::GetSettings().SetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW, GetQuickpathName(item->GetPath()));
-  CServiceBroker::GetSettings().Save();
-  return true;
-}
-
-bool CClearDefault::IsVisible(const CFileItem& item) const
-{
-  if (!item.IsPath("sources://music/"))
-  {
-    // are we in the playlists location?
-    bool inPlaylists = item.IsPath(CUtil::MusicPlaylistsLocation()) || item.IsPath("special://musicplaylists/");
-    //Set default or clear default
-    XFILE::CMusicDatabaseDirectory dir;
-    XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE nodetype = dir.GetDirectoryType(item.GetPath());
-    if (!item.IsParentFolder() && !inPlaylists &&
-      (nodetype == XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE_ROOT ||
-        nodetype == XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE_OVERVIEW ||
-        nodetype == XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE_TOP100))
-    {
-      return !CServiceBroker::GetSettings().GetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW).empty();
-    }
-  }
-  return false;
-}
-
-bool CClearDefault::Execute(const CFileItemPtr& item) const
-{
-  CServiceBroker::GetSettings().SetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW, "");
-  CServiceBroker::GetSettings().Save();
   return true;
 }
 

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -49,26 +49,4 @@ struct CSongInfo : CMusicInfo
   CSongInfo() : CMusicInfo(MediaTypeSong) {}
 };
 
-struct CPlayPartymode : CStaticContextMenuAction
-{
-  CPlayPartymode() : CStaticContextMenuAction(15216) {} // Play in Partymode
-  bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
-};
-
-struct CSetDefault : CStaticContextMenuAction
-{
-  CSetDefault() : CStaticContextMenuAction(13335) {} // set default
-  bool IsVisible(const CFileItem& item) const override;
-  std::string GetQuickpathName(const std::string& strPath) const;
-  bool Execute(const CFileItemPtr& item) const override;
-};
-
-struct CClearDefault : CStaticContextMenuAction
-{
-  CClearDefault() : CStaticContextMenuAction(13403) {} // clear default
-  bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
-};
-
 }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -802,6 +802,10 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
           if (players.size() >= 1)
             buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...
         }
+        if (item->IsSmartPlayList())
+        {
+            buttons.Add(CONTEXT_BUTTON_PLAY_PARTYMODE, 15216); // Play in Partymode
+        }
         if (item->IsAudioBook())
         {
           int bookmark;
@@ -904,6 +908,10 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         OnClick(itemNumber, player);
       return true;
     }
+
+  case CONTEXT_BUTTON_PLAY_PARTYMODE:
+    g_partyModeManager.Enable(PARTYMODECONTEXT_MUSIC, item->GetPath());
+    return true;
 
   case CONTEXT_BUTTON_RIP_CD:
     OnRipCD();

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -218,6 +218,43 @@ bool CGUIWindowMusicNav::OnAction(const CAction& action)
   return CGUIWindowMusicBase::OnAction(action);
 }
 
+std::string CGUIWindowMusicNav::GetQuickpathName(const std::string& strPath) const
+{
+  std::string path = CLegacyPathTranslation::TranslateMusicDbPath(strPath);
+  StringUtils::ToLower(path);
+  if (path == "musicdb://genres/")
+    return "Genres";
+  else if (path == "musicdb://artists/")
+    return "Artists";
+  else if (path == "musicdb://albums/")
+    return "Albums";
+  else if (path == "musicdb://songs/")
+    return "Songs";
+  else if (path == "musicdb://top100/")
+    return "Top100";
+  else if (path == "musicdb://top100/songs/")
+    return "Top100Songs";
+  else if (path == "musicdb://top100/albums/")
+    return "Top100Albums";
+  else if (path == "musicdb://recentlyaddedalbums/")
+    return "RecentlyAddedAlbums";
+  else if (path == "musicdb://recentlyplayedalbums/")
+    return "RecentlyPlayedAlbums";
+  else if (path == "musicdb://compilations/")
+    return "Compilations";
+  else if (path == "musicdb://years/")
+    return "Years";
+  else if (path == "musicdb://singles/")
+    return "Singles";
+  else if (path == "special://musicplaylists/")
+    return "Playlists";
+  else
+  {
+    CLog::Log(LOGERROR, "  CGUIWindowMusicNav::GetQuickpathName: Unknown parameter (%s)", strPath.c_str());
+    return strPath;
+  }
+}
+
 bool CGUIWindowMusicNav::OnClick(int iItem, const std::string &player /* = "" */)
 {
   if (iItem < 0 || iItem >= m_vecItems->Size()) return false;
@@ -485,7 +522,18 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
+      //Set default or clear default
       NODE_TYPE nodetype = dir.GetDirectoryType(item->GetPath());
+      if (!item->IsParentFolder() && !inPlaylists &&
+         (nodetype == NODE_TYPE_ROOT ||
+          nodetype == NODE_TYPE_OVERVIEW ||
+          nodetype == NODE_TYPE_TOP100))
+      {
+        if (!item->IsPath(CServiceBroker::GetSettings().GetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW)))
+          buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 13335); // set default
+        if (!CServiceBroker::GetSettings().GetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW).empty())
+          buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // clear default
+      }
       NODE_TYPE childtype = dir.GetDirectoryChildType(item->GetPath());
       if (childtype == NODE_TYPE_ALBUM ||
           childtype == NODE_TYPE_ARTIST ||
@@ -598,6 +646,16 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_INFO_ALL:
     OnItemInfoAll(itemNumber);
+    return true;
+
+  case CONTEXT_BUTTON_SET_DEFAULT:
+    CServiceBroker::GetSettings().SetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW, GetQuickpathName(item->GetPath()));
+    CServiceBroker::GetSettings().Save();
+    return true;
+
+  case CONTEXT_BUTTON_CLEAR_DEFAULT:
+    CServiceBroker::GetSettings().SetString(CSettings::SETTING_MYMUSIC_DEFAULTLIBVIEW, "");
+    CServiceBroker::GetSettings().Save();
     return true;
 
   case CONTEXT_BUTTON_GO_TO_ARTIST:

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -50,6 +50,7 @@ protected:
   virtual std::string GetStartFolder(const std::string &url) override;
 
   bool GetSongsFromPlayList(const std::string& strPlayList, CFileItemList &items);
+  std::string GetQuickpathName(const std::string& strPath) const;
 
   VECSOURCES m_shares;
 


### PR DESCRIPTION
This reverts commit 0c70c21c7f77acce0f9dd0c93506b816cee9abf4.

@Razzeee as we discussed on Slack, we want to revert this for now. The problem is more complex than simply copy & past over old code and logic. ;-)