### PR TITLE
[PVR] Search window: Fix very first search after kodi start not working.

### DIFF
--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -48,8 +48,6 @@ void CPVREpgSearchFilter::Reset()
   m_iGenreSubType            = EPG_SEARCH_UNSET;
   m_iMinimumDuration         = EPG_SEARCH_UNSET;
   m_iMaximumDuration         = EPG_SEARCH_UNSET;
-  m_startDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate());
-  m_endDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate());
   m_bIncludeUnknownGenres    = false;
   m_bRemoveDuplicates        = false;
 
@@ -61,6 +59,30 @@ void CPVREpgSearchFilter::Reset()
   m_bIgnorePresentTimers     = true;
   m_bIgnorePresentRecordings = true;
   m_iUniqueBroadcastId       = EPG_TAG_INVALID_UID;
+}
+
+void CPVREpgSearchFilter::ValidateStartAndEndDate()
+{
+  const CDateTime start = CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate();
+  const CDateTime end = CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate();
+
+  if (m_startDateTime < start || m_startDateTime > end)
+    m_startDateTime.SetFromUTCDateTime(start);
+
+  if (m_endDateTime > end || m_endDateTime < start)
+    m_endDateTime.SetFromUTCDateTime(end);
+}
+
+const CDateTime& CPVREpgSearchFilter::GetStartDateTime()
+{
+  ValidateStartAndEndDate();
+  return m_startDateTime;
+}
+
+const CDateTime& CPVREpgSearchFilter::GetEndDateTime()
+{
+  ValidateStartAndEndDate();
+  return m_endDateTime;
 }
 
 bool CPVREpgSearchFilter::MatchGenre(const CPVREpgInfoTagPtr &tag) const

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -76,10 +76,10 @@ namespace PVR
     int GetMaximumDuration() const { return m_iMaximumDuration; }
     void SetMaximumDuration(int iMaximumDuration) { m_iMaximumDuration = iMaximumDuration; }
 
-    const CDateTime &GetStartDateTime() const { return m_startDateTime; }
+    const CDateTime &GetStartDateTime();
     void SetStartDateTime(const CDateTime &startDateTime) { m_startDateTime = startDateTime; }
 
-    const CDateTime &GetEndDateTime() const { return m_endDateTime; }
+    const CDateTime &GetEndDateTime();
     void SetEndDateTime(const CDateTime &endDateTime) { m_endDateTime = endDateTime; }
 
     bool ShouldIncludeUnknownGenres() const { return m_bIncludeUnknownGenres; }
@@ -110,6 +110,11 @@ namespace PVR
     void SetUniqueBroadcastId(unsigned int iUniqueBroadcastId) { m_iUniqueBroadcastId = iUniqueBroadcastId; }
 
   private:
+    /*!
+     * @brief Make sure that start and end time match current epg data boundaries.
+     */
+    void ValidateStartAndEndDate();
+
     bool MatchGenre(const CPVREpgInfoTagPtr &tag) const;
     bool MatchDuration(const CPVREpgInfoTagPtr &tag) const;
     bool MatchStartAndEndTimes(const CPVREpgInfoTagPtr &tag) const;


### PR DESCRIPTION
This fixes a very special case with PVR search window:

1) Start Kodi
2) Open the PVR TV (or Radio, doesn't make a difference) window
3) Select "Search..." => Search dialog opens
==> bug: start and end date time both display 01/01/1970, 00:00:00
4)  do not change anything in the dialog; enter a search string - ideally a title of a show you know is in your current epg data
==> because of the nonsense start and end time (not matching epg data boundaries) nothing will be found.

This PR fixes start and end time mismatch by validating data against current epg data before opening the search dialog.

I runtime tested the changes on macOS, latest Kodi master.

@Jalle19 for review?