### PR TITLE
spelling: [API] GetMininumGameAPIVersion

### DIFF
--- a/addons/kodi.game/addon.xml
+++ b/addons/kodi.game/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.game" version="1.0.29" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.29"/>
+<addon id="kodi.game" version="1.0.30" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.0.30"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -46,7 +46,7 @@ const char* GetGameAPIVersion(void);
  *
  * \return Must be GAME_MIN_API_VERSION_STRING
  */
-const char* GetMininumGameAPIVersion(void);
+const char* GetMinimumGameAPIVersion(void);
 
 // --- Game operations ---------------------------------------------------------
 
@@ -259,7 +259,7 @@ void __declspec(dllexport) get_addon(void* ptr)
   KodiToAddonFuncTable_Game* pClient = static_cast<KodiToAddonFuncTable_Game*>(ptr);
 
   pClient->GetGameAPIVersion        = GetGameAPIVersion;
-  pClient->GetMininumGameAPIVersion = GetMininumGameAPIVersion;
+  pClient->GetMinimumGameAPIVersion = GetMinimumGameAPIVersion;
   pClient->LoadGame                 = LoadGame;
   pClient->LoadGameSpecial          = LoadGameSpecial;
   pClient->LoadStandalone           = LoadStandalone;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -457,7 +457,7 @@ typedef struct game_client_properties
 typedef struct KodiToAddonFuncTable_Game
 {
   const char* (__cdecl* GetGameAPIVersion)(void);
-  const char* (__cdecl* GetMininumGameAPIVersion)(void);
+  const char* (__cdecl* GetMinimumGameAPIVersion)(void);
   GAME_ERROR  (__cdecl* LoadGame)(const char*);
   GAME_ERROR  (__cdecl* LoadGameSpecial)(SPECIAL_GAME_TYPE, const char**, size_t);
   GAME_ERROR  (__cdecl* LoadStandalone)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -45,7 +45,7 @@
 #define ADDON_INSTANCE_VERSION_ADSP                   "0.1.8"
 #define ADDON_INSTANCE_VERSION_AUDIODECODER           "1.0.0"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER           "1.0.0"
-#define ADDON_INSTANCE_VERSION_GAME                   "1.0.29"
+#define ADDON_INSTANCE_VERSION_GAME                   "1.0.30"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER           "1.0.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM            "1.0.6"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL             "1.3.1"


### PR DESCRIPTION
Spelling fixes

## Description
Semi-automated spelling review of codebase (includes comments, code, public apis, documentation, etc)

## Motivation and Context
I have a toolchain which I've been evolving for a while, and I like to test it on projects, especially as a way to give a little in appreciation of projects that I may be using/have used/plan to use.

## How Has This Been Tested?
- [x] This has not been tested.

## Types of change
- [x] Breaking change
- - [x] Public APIs - I'm pretty sure I've renamed some public APIs. I'm happy to split such items out (either including backwards compat or dropping them entirely), but I'd rather have a conversation about which those things are before I eagerly split.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
