### PR TITLE
FIX: [droid] remove dependency on android-support-v4.jar

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -140,7 +140,6 @@ libs: $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so
 	cd xbmc/obj/local/$(CPU)/; find . -name "*.so" -not -name "lib*.so" | sed "s/\.\///" | xargs -I@ mv @ lib@
 	cp -fp xbmc/obj/local/$(CPU)/*.so xbmc/lib/$(CPU)/
 	$(STRIP) --strip-unneeded xbmc/lib/$(CPU)/*.so
-	cp -fp $(SDKROOT)/extras/android/support/v4/android-support-v4.jar xbmc/libs
 	install -p $(GDBPATH) ./xbmc/libs/$(CPU)/gdbserver
 	echo "set solib-search-path ./obj/local/$(CPU)" > ./xbmc/libs/$(CPU)/gdb.setup
 	echo "directory $(TOOLCHAIN)/sysroot/usr/include $(NDKROOT)/sources/android/native_app_glue" \
@@ -149,8 +148,8 @@ libs: $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so
 
 xbmc/classes.dex: res
 	mkdir -p xbmc/obj
-	@javac -classpath $(SDKROOT)/platforms/$(SDK_PLATFORM)/android.jar:$(SDKROOT)/extras/android/support/v4/android-support-v4.jar:xbmc/obj -d xbmc/obj -sourcepath xbmc/src xbmc/src/*.java $(JAVAC_EXTRA_ARGS)
-	@javac -classpath $(SDKROOT)/platforms/$(SDK_PLATFORM)/android.jar:$(SDKROOT)/extras/android/support/v4/android-support-v4.jar:xbmc/obj -d xbmc/obj -sourcepath xbmc/src xbmc/src/org/xbmc/kodi/*.java $(JAVAC_EXTRA_ARGS)
+	@javac -classpath $(SDKROOT)/platforms/$(SDK_PLATFORM)/android.jar:xbmc/obj -d xbmc/obj -sourcepath xbmc/src xbmc/src/*.java $(JAVAC_EXTRA_ARGS)
+	@javac -classpath $(SDKROOT)/platforms/$(SDK_PLATFORM)/android.jar:xbmc/obj -d xbmc/obj -sourcepath xbmc/src xbmc/src/org/xbmc/kodi/*.java $(JAVAC_EXTRA_ARGS)
 	@$(DX) --dex --output=xbmc/classes.dex xbmc/obj xbmc/libs
 
 package: libs python xbmc/classes.dex

--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCRecommendationBuilder.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCRecommendationBuilder.java.in
@@ -5,7 +5,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import @APP_PACKAGE@.R;
@@ -102,8 +101,8 @@ public class XBMCRecommendationBuilder
       extras.putString(API_NOTIFICATION_EXTRA_BACKGROUND_IMAGE_URI, mBackgroundUri);
     }
 
-    Notification notification = new NotificationCompat.BigPictureStyle(
-        new NotificationCompat.Builder(mContext)
+    Notification notification = new Notification.BigPictureStyle(
+        new Notification.Builder(mContext)
             .setContentTitle(mTitle)
             .setContentText(mDescription)
             .setPriority(mPriority)

--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCSearchableActivity.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCSearchableActivity.java.in
@@ -6,7 +6,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.app.Activity;
 import android.app.SearchManager;
-import android.support.v4.widget.SimpleCursorAdapter;
+import android.widget.SimpleCursorAdapter;
 import android.util.Log;
 import android.widget.ListView;
 


### PR DESCRIPTION
The lib is not needed with a min api of 21.