### PR TITLE
[network][windows] GetNameServers(): use GetAdaptersAddresses

### DIFF
--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -29,6 +29,11 @@
 #include "utils/StringUtils.h"
 #include "platform/win32/WIN32Util.h"
 
+#include <netinet/in.h>
+#include <Mstcpip.h>
+
+#pragma comment(lib, "Ntdll.lib")
+
 // undefine if you want to build without the wlan stuff
 // might be needed for VS2003
 #define HAS_WIN32_WLAN_API
@@ -216,35 +221,31 @@ std::vector<std::string> CNetworkWin32::GetNameServers(void)
 {
   std::vector<std::string> result;
 
-  FIXED_INFO *pFixedInfo;
+  const ULONG flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_FRIENDLY_NAME;
   ULONG ulOutBufLen;
-  IP_ADDR_STRING *pIPAddr;
 
-  pFixedInfo = (FIXED_INFO *) malloc(sizeof (FIXED_INFO));
-  if (pFixedInfo == NULL)
+  if (GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, nullptr, &ulOutBufLen) != ERROR_BUFFER_OVERFLOW)
     return result;
 
-  ulOutBufLen = sizeof (FIXED_INFO);
-  if (GetNetworkParams(pFixedInfo, &ulOutBufLen) == ERROR_BUFFER_OVERFLOW)
-  {
-    free(pFixedInfo);
-    pFixedInfo = (FIXED_INFO *) malloc(ulOutBufLen);
-    if (pFixedInfo == NULL)
-      return result;
-  }
+  PIP_ADAPTER_ADDRESSES adapterAddresses = static_cast<PIP_ADAPTER_ADDRESSES>(malloc(ulOutBufLen));
+  if (adapterAddresses == nullptr)
+    return result;
 
-  if (GetNetworkParams(pFixedInfo, &ulOutBufLen) == NO_ERROR)
+  if (GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, adapterAddresses, &ulOutBufLen) == NO_ERROR)
   {
-    result.push_back(pFixedInfo->DnsServerList.IpAddress.String);
-    pIPAddr = pFixedInfo->DnsServerList.Next;
-    while(pIPAddr)
+    for (PIP_ADAPTER_ADDRESSES adapter = adapterAddresses; adapter; adapter = adapter->Next)
     {
-      result.push_back(pIPAddr->IpAddress.String);
-      pIPAddr = pIPAddr->Next;
+      if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK || adapter->OperStatus != IF_OPER_STATUS::IfOperStatusUp)
+        continue;
+      for (PIP_ADAPTER_DNS_SERVER_ADDRESS dnsAddress = adapter->FirstDnsServerAddress; dnsAddress; dnsAddress = dnsAddress->Next)
+      {
+        std::string strIp = GetIpStr(dnsAddress->Address.lpSockaddr);
+        if (!strIp.empty())
+          result.push_back(strIp);
+      }
     }
-
   }
-  free(pFixedInfo);
+  free(adapterAddresses);
 
   return result;
 }
@@ -277,6 +278,29 @@ bool CNetworkWin32::PingHost(unsigned long host, unsigned int timeout_ms /* = 20
     return (pEchoReply->Status == IP_SUCCESS);
   }
   return false;
+}
+
+const std::string CNetworkWin32::GetIpStr(const struct sockaddr* sa)
+{
+  std::string result;
+  if (!sa)
+    return result;
+
+  char buffer[INET6_ADDRSTRLEN] = { 0 };
+  switch (sa->sa_family)
+  {
+    case AF_INET:
+      RtlIpv4AddressToStringA(&reinterpret_cast<const struct sockaddr_in *>(sa)->sin_addr, buffer);
+      break;
+    case AF_INET6:
+      RtlIpv6AddressToStringA(&reinterpret_cast<const struct sockaddr_in6 *>(sa)->sin6_addr, buffer);
+      break;
+    default:
+      return result;
+  }
+
+  result = buffer;
+  return result;
 }
 
 bool CNetworkInterfaceWin32::GetHostMacAddress(unsigned long host, std::string& mac)

--- a/xbmc/network/windows/NetworkWin32.h
+++ b/xbmc/network/windows/NetworkWin32.h
@@ -80,6 +80,17 @@ public:
    virtual std::vector<std::string> GetNameServers(void);
    virtual void SetNameServers(const std::vector<std::string>& nameServers);
 
+   /*!
+    \brief  IPv6/IPv4 compatible conversion of host IP address
+    \param  struct sockaddr
+    \return Function converts binary structure sockaddr to std::string.
+            It can read sockaddr_in and sockaddr_in6, cast as (sockaddr*).
+            IPv4 address is returned in the format x.x.x.x (where x is 0-255),
+            IPv6 address is returned in it's canonised form.
+            On error (or no IPv6/v4 valid input) empty string is returned.
+    */
+   const static std::string GetIpStr(const sockaddr* sa);
+
    friend class CNetworkInterfaceWin32;
 
 private:


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use `GetAdaptersAddresses` instead of `GetNetworkParams` to get the list of nameservers on windows
<!--- Describe your change in detail -->

## Motivation and Context
`GetAdaptersAddresses` also returns IPv6 addresses ans is Windows Store compatible.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
runtime tested
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
