### PR TITLE
VideoPlayer: Fix compiler warnings

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3667,10 +3667,10 @@ void CApplication::OnPlayBackSpeedChanged(int iSpeed)
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnSpeedChanged", m_itemCurrentFile, param);
 }
 
-void CApplication::OnPlayBackSeek(int iTime, int seekOffset)
+void CApplication::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
 {
 #ifdef HAS_PYTHON
-  g_pythonParser.OnPlayBackSeek(iTime, seekOffset);
+  g_pythonParser.OnPlayBackSeek(static_cast<int>(iTime), static_cast<int>(seekOffset));
 #endif
 
   CVariant param;
@@ -3679,7 +3679,7 @@ void CApplication::OnPlayBackSeek(int iTime, int seekOffset)
   param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
   param["player"]["speed"] = (int)m_pPlayer->GetPlaySpeed();
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnSeek", m_itemCurrentFile, param);
-  g_infoManager.SetDisplayAfterSeek(2500, seekOffset);
+  g_infoManager.SetDisplayAfterSeek(2500, static_cast<int>(seekOffset));
 }
 
 void CApplication::OnPlayBackSeekChapter(int iChapter)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -164,7 +164,7 @@ public:
   virtual void OnPlayBackResumed() override;
   virtual void OnPlayBackStopped() override;
   virtual void OnQueueNextItem() override;
-  virtual void OnPlayBackSeek(int iTime, int seekOffset) override;
+  virtual void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) override;
   virtual void OnPlayBackSeekChapter(int iChapter) override;
   virtual void OnPlayBackSpeedChanged(int iSpeed) override;
 

--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -30,7 +30,7 @@ public:
   virtual void OnPlayBackResumed() {};
   virtual void OnPlayBackStopped() = 0;
   virtual void OnQueueNextItem() = 0;
-  virtual void OnPlayBackSeek(int iTime, int seekOffset) {};
+  virtual void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) {};
   virtual void OnPlayBackSeekChapter(int iChapter) {};
   virtual void OnPlayBackSpeedChanged(int iSpeed) {};
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -61,7 +61,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   // set any special options
   for(std::vector<CDVDCodecOption>::iterator it = options.m_keys.begin(); it != options.m_keys.end(); ++it)
     if (it->m_name == "allowdtshddecode")
-      allowdtshddecode = atoi(it->m_value.c_str());
+      allowdtshddecode = atoi(it->m_value.c_str()) != 0;
 
   if (hints.codec == AV_CODEC_ID_DTS && allowdtshddecode)
     pCodec = avcodec_find_decoder_by_name("dcadec");
@@ -151,8 +151,8 @@ bool CDVDAudioCodecFFmpeg::AddData(const DemuxPacket &packet)
   av_init_packet(&avpkt);
   avpkt.data = packet.pData;
   avpkt.size = packet.iSize;
-  avpkt.dts = (packet.dts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : packet.dts / DVD_TIME_BASE * AV_TIME_BASE;
-  avpkt.pts = (packet.pts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : packet.pts / DVD_TIME_BASE * AV_TIME_BASE;
+  avpkt.dts = (packet.dts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.dts / DVD_TIME_BASE) * AV_TIME_BASE;
+  avpkt.pts = (packet.pts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.pts / DVD_TIME_BASE) * AV_TIME_BASE;
   int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
 
   // try again
@@ -286,7 +286,7 @@ enum AEDataFormat CDVDAudioCodecFFmpeg::GetDataFormat()
 int CDVDAudioCodecFFmpeg::GetBitRate()
 {
   if (m_pCodecContext)
-    return m_pCodecContext->bit_rate;
+    return static_cast<int>(m_pCodecContext->bit_rate);
   return 0;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -140,7 +140,7 @@ void CDVDAudioCodecFFmpeg::Dispose()
 bool CDVDAudioCodecFFmpeg::AddData(const DemuxPacket &packet)
 {
   if (!m_pCodecContext)
-    return -1;
+    return false;
 
   if (m_eof)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -31,11 +31,13 @@
 #include "utils/auto_buffer.h"
 #include "utils/RegExp.h"
 
+#include <cstddef>
+
 // 3GPP/TX3G (aka MPEG-4 Timed Text) Subtitle support
 // 3GPP -> 3rd Generation Partnership Program
 // adapted from https://trac.handbrake.fr/browser/trunk/libhb/dectx3gsub.c;
 
-#define LEN_CHECK(x)    do { if((end - pos) < (x)) return OC_ERROR; } while(0)
+#define LEN_CHECK(x)    do { if((end - pos) < static_cast<std::ptrdiff_t>(x)) return OC_ERROR; } while(0)
 
 // NOTE: None of these macros check for buffer overflow
 #define READ_U8()       *pos;                                                     pos += 1;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -342,7 +342,7 @@ bool CDXVAContext::GetInputAndTarget(int codec, bool bHighBitdepth, GUID &inGuid
 
     for (unsigned i = 0; i < m_input_count && outFormat == DXGI_FORMAT_UNKNOWN; i++)
     {
-      bool supported = IsEqualGUID(m_input_list[i], *mode->guid);
+      bool supported = IsEqualGUID(m_input_list[i], *mode->guid) != 0;
       if (codec == AV_CODEC_ID_HEVC)
       {
         if (bHighBitdepth && !IsEqualGUID(m_input_list[i], D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10))

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -169,7 +169,7 @@ public:
   int iFpsRate;
   int iHeight; // height of the stream reported by the demuxer
   int iWidth; // width of the stream reported by the demuxer
-  float fAspect; // display aspect of stream
+  double fAspect; // display aspect of stream
   bool bVFR;  // variable framerate
   bool bPTSInvalid; // pts cannot be trusted (avi's).
   bool bForcedAspect; // aspect is forced from container

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -516,7 +516,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
       CVariant programProp(pInput->GetProperty("program"));
       if (!programProp.isNull())
       {
-        int programNumber = programProp.asInteger();
+        int programNumber = static_cast<int>(programProp.asInteger());
 
         for (unsigned int i = 0; i < m_pFormatContext->nb_programs; ++i)
         {
@@ -1081,7 +1081,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
   CDVDInputStream::IPosTime* ist = m_pInput->GetIPosTime();
   if (ist)
   {
-    if (!ist->PosTime(time))
+    if (!ist->PosTime(static_cast<int>(time)))
       return false;
 
     if(startpts)
@@ -1332,7 +1332,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iChannels = pStream->codecpar->channels;
         st->iSampleRate = pStream->codecpar->sample_rate;
         st->iBlockAlign = pStream->codecpar->block_align;
-        st->iBitRate = pStream->codecpar->bit_rate;
+        st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
         st->iBitsPerSample = pStream->codecpar->bits_per_raw_sample;
         st->iChannelLayout = pStream->codecpar->channel_layout;
         if (st->iBitsPerSample == 0)
@@ -1395,7 +1395,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           st->fAspect *= (double)pStream->codecpar->width / pStream->codecpar->height;
         st->iOrientation = 0;
         st->iBitsPerPixel = pStream->codecpar->bits_per_coded_sample;
-        st->iBitRate = pStream->codecpar->bit_rate;
+        st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
 
         AVDictionaryEntry *rtag = av_dict_get(pStream->metadata, "rotate", NULL, 0);
         if (rtag) 
@@ -1678,7 +1678,7 @@ int64_t CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
   if(ich)  
     return ich->GetChapterPos(chapterIdx);
 
-  return m_pFormatContext->chapters[chapterIdx-1]->start*av_q2d(m_pFormatContext->chapters[chapterIdx-1]->time_base);
+  return static_cast<int64_t>(m_pFormatContext->chapters[chapterIdx-1]->start*av_q2d(m_pFormatContext->chapters[chapterIdx-1]->time_base));
 }
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -80,12 +80,12 @@ int DllLibbluray::file_eof(BD_FILE_H *file)
 
 int64_t DllLibbluray::file_read(BD_FILE_H *file, uint8_t *buf, int64_t size)
 {
-  return static_cast<CFile*>(file->internal)->Read(buf, size); //! @todo fix size cast
+  return static_cast<int64_t>(static_cast<CFile*>(file->internal)->Read(buf, static_cast<size_t>(size)));
 }
 
 int64_t DllLibbluray::file_write(BD_FILE_H *file, const uint8_t *buf, int64_t size)
 {
-  return static_cast<CFile*>(file->internal)->Write(buf, size);
+  return static_cast<int64_t>(static_cast<CFile*>(file->internal)->Write(buf, static_cast<size_t>(size)));
 }
 
 BD_FILE_H * DllLibbluray::file_open(const char* filename, const char *mode)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -115,7 +115,7 @@ std::string CDVDInputStreamFFmpeg::GetProxyHost() const
 uint16_t CDVDInputStreamFFmpeg::GetProxyPort() const
 {
   if (m_item.HasProperty("proxy.port"))
-    return m_item.GetProperty("proxy.port").asInteger();
+    return static_cast<uint16_t>(m_item.GetProperty("proxy.port").asInteger());
 
   // Select the standard port
   const std::string value = GetProxyType();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -228,7 +228,7 @@ bool CInputStreamAddon::SeekTime(double time, bool backward, double* startpts)
 
   if (m_hasPosTime)
   {
-    if (!PosTime(time))
+    if (!PosTime(static_cast<int>(time)))
       return false;
 
     FlushDemux();

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -62,7 +62,7 @@ public:
   int fpsrate;
   int height; // height of the stream reported by the demuxer
   int width; // width of the stream reported by the demuxer
-  float aspect; // display aspect as reported by demuxer
+  double aspect; // display aspect as reported by demuxer
   bool vfr; // variable framerate
   bool stills; // there may be odd still frames in video
   int level; // encoder level of the stream reported by the decoder. used to qualify hw decoders.

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -906,28 +906,28 @@ unsigned int CDVDRadioRDSData::DecodeDI(uint8_t *msgElement)
 {
   bool value;
 
-  value = msgElement[3] & 1;
+  value = (msgElement[3] & 1) != 0;
   if (m_DI_IsStereo != value)
   {
     CLog::Log(LOGDEBUG, "Radio UECP (RDS) Processor - %s - Stream changed over to %s", __FUNCTION__, value ? "Stereo" : "Mono");
     m_DI_IsStereo = value;
   }
 
-  value = msgElement[3] & 2;
+  value = (msgElement[3] & 2) != 0;
   if (m_DI_ArtificialHead != value)
   {
     CLog::Log(LOGDEBUG, "Radio UECP (RDS) Processor - %s - Stream changed over to %sArtificial Head", __FUNCTION__, value ? "" : "Not ");
     m_DI_ArtificialHead = value;
   }
 
-  value = msgElement[3] & 4;
+  value = (msgElement[3] & 4) != 0;
   if (m_DI_ArtificialHead != value)
   {
     CLog::Log(LOGDEBUG, "Radio UECP (RDS) Processor - %s - Stream changed over to %sCompressed Head", __FUNCTION__, value ? "" : "Not ");
     m_DI_ArtificialHead = value;
   }
 
-  value = msgElement[3] & 8;
+  value = (msgElement[3] & 8) != 0;
   if (m_DI_DynamicPTY != value)
   {
     CLog::Log(LOGDEBUG, "Radio UECP (RDS) Processor - %s - Stream changed over to %s PTY", __FUNCTION__, value ? "dynamic" : "static");
@@ -940,8 +940,8 @@ unsigned int CDVDRadioRDSData::DecodeDI(uint8_t *msgElement)
 unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
 {
   uint8_t dsn = msgElement[1];
-  bool traffic_announcement = msgElement[3] & 1;
-  bool traffic_programme    = msgElement[3] & 2;
+  bool traffic_announcement = (msgElement[3] & 1) != 0;
+  bool traffic_programme    = (msgElement[3] & 2) != 0;
 
   if (traffic_announcement && !m_TA_TP_TrafficAdvisory && traffic_programme && dsn == 0 && CServiceBroker::GetSettings().GetBool("pvrplayback.trafficadvisory"))
   {
@@ -1162,7 +1162,7 @@ unsigned int CDVDRadioRDSData::DecodeRTC(uint8_t *msgElement)
 {
   uint8_t hours   = msgElement[UECP_CLOCK_HOURS];
   uint8_t minutes = msgElement[UECP_CLOCK_MINUTES];
-  bool    minus   = msgElement[UECP_CLOCK_LOCALOFFSET] & 0x20;
+  bool    minus   = (msgElement[UECP_CLOCK_LOCALOFFSET] & 0x20) != 0;
   if (minus)
   {
     if (msgElement[UECP_CLOCK_LOCALOFFSET] >> 1)

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -170,7 +170,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
   {
     m_fFrameRate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration((double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
     m_bFpsInvalid = false;
-    m_processInfo.SetVideoFps(m_fFrameRate);
+    m_processInfo.SetVideoFps(static_cast<float>(m_fFrameRate));
   }
   else
   {
@@ -193,9 +193,9 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
 
   // use aspect in stream if available
   if(hint.forced_aspect)
-    m_fForcedAspectRatio = hint.aspect;
+    m_fForcedAspectRatio = static_cast<float>(hint.aspect);
   else
-    m_fForcedAspectRatio = 0.0;
+    m_fForcedAspectRatio = 0.0f;
 
   if (m_pVideoCodec && m_pVideoCodec->Reconfigure(hint))
   {
@@ -376,7 +376,7 @@ void CVideoPlayerVideo::Process()
     else if (pMsg->IsType(CDVDMsg::VIDEO_SET_ASPECT))
     {
       CLog::Log(LOGDEBUG, "CVideoPlayerVideo - CDVDMsg::VIDEO_SET_ASPECT");
-      m_fForcedAspectRatio = *((CDVDMsgDouble*)pMsg);
+      m_fForcedAspectRatio = static_cast<float>(*((CDVDMsgDouble*)pMsg));
     }
     else if (pMsg->IsType(CDVDMsg::GENERAL_RESET))
     {
@@ -786,7 +786,7 @@ int CVideoPlayerVideo::OutputPicture(const VideoPicture* src, double pts)
   flags |= stereo_flags;
 
   if(!m_renderManager.Configure(picture,
-                                config_framerate,
+                                static_cast<float>(config_framerate),
                                 flags,
                                 m_hints.orientation,
                                 m_pVideoCodec->GetAllowedReferences()))
@@ -1021,7 +1021,7 @@ void CVideoPlayerVideo::CalcFrameRate()
         CLog::Log(LOGDEBUG,"%s framerate was:%f calculated:%f", __FUNCTION__, m_fFrameRate, m_fStableFrameRate / m_iFrameRateCount);
         m_fFrameRate = m_fStableFrameRate / m_iFrameRateCount;
         m_bFpsInvalid = false;
-        m_processInfo.SetVideoFps(m_fFrameRate);
+        m_processInfo.SetVideoFps(static_cast<float>(m_fFrameRate));
       }
 
       //reset the stored framerates

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -52,7 +52,7 @@ public:
     double pts;
   };
   std::deque<CGain> m_gain;
-  double m_totalGain;
+  int m_totalGain;
   double m_lastPts;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -110,21 +110,21 @@ inline void CBaseRenderer::ReorderDrawPoints()
   }
 
 
-  int diffX = 0;
-  int diffY = 0;
-  int centerX = 0;
-  int centerY = 0;
+  float diffX = 0.0f;
+  float diffY = 0.0f;
+  float centerX = 0.0f;
+  float centerY = 0.0f;
   
   if (changeAspect)// we are either rotating by 90 or 270 degrees which inverts aspect ratio
   {
-    int newWidth = m_destRect.Height(); // new width is old height
-    int newHeight = m_destRect.Width(); // new height is old width
-    int diffWidth = newWidth - m_destRect.Width(); // difference between old and new width
-    int diffHeight = newHeight - m_destRect.Height(); // difference between old and new height
+    float newWidth = m_destRect.Height(); // new width is old height
+    float newHeight = m_destRect.Width(); // new height is old width
+    float diffWidth = newWidth - m_destRect.Width(); // difference between old and new width
+    float diffHeight = newHeight - m_destRect.Height(); // difference between old and new height
 
     // if the new width is bigger then the old or
     // the new height is bigger then the old - we need to scale down
-    if (diffWidth > 0 || diffHeight > 0 )
+    if (diffWidth > 0.0f || diffHeight > 0.0f)
     {
       float aspectRatio = GetAspectRatio();
       // scale to fit screen width because
@@ -143,8 +143,8 @@ inline void CBaseRenderer::ReorderDrawPoints()
     }
     
     // calculate the center point of the view
-    centerX = m_viewRect.x1 + m_viewRect.Width() / 2;
-    centerY = m_viewRect.y1 + m_viewRect.Height() / 2;
+    centerX = m_viewRect.x1 + m_viewRect.Width() / 2.0f;
+    centerY = m_viewRect.y1 + m_viewRect.Height() / 2.0f;
 
     // calculate the number of pixels we need to go in each
     // x direction from the center point

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -108,7 +108,7 @@ void CDebugRenderer::CRenderer::Render(int idx)
 {
   std::vector<COverlay*> render;
   std::vector<SElement>& list = m_buffers[idx];
-  int posY = 0;
+  float posY = 0.0f;
   for (std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
   {
     COverlay* o = nullptr;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -179,7 +179,9 @@ void COverlayQuadsDX::Render(SRenderState &state)
   {
     CRect rect;
     g_Windowing.GetViewPort(rect);
-    g_Windowing.SetCameraPosition(CPoint(rect.Width()*0.5f, rect.Height()*0.5f), rect.Width(), rect.Height());
+    g_Windowing.SetCameraPosition(CPoint(rect.Width() * 0.5f, rect.Height() * 0.5f),
+                                  static_cast<int>(rect.Width()),
+                                  static_cast<int>(rect.Height()));
   }
 
   XMMATRIX trans = XMMatrixTranslation(state.x, state.y, 0.0f);
@@ -347,7 +349,9 @@ void COverlayImageDX::Render(SRenderState &state)
   {
     CRect rect;
     g_Windowing.GetViewPort(rect);
-    g_Windowing.SetCameraPosition(CPoint(rect.Width()*0.5f, rect.Height()*0.5f), rect.Width(), rect.Height());
+    g_Windowing.SetCameraPosition(CPoint(rect.Width() * 0.5f, rect.Height() * 0.5f),
+                                  static_cast<int>(rect.Width()),
+                                  static_cast<int>(rect.Height()));
   }
 
   XMMATRIX trans = m_pos == POSITION_RELATIVE

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -318,7 +318,7 @@ bool CRenderManager::Configure()
     m_bTriggerUpdateResolution = true;
     m_presentstep = PRESENT_IDLE;
     m_presentpts = DVD_NOPTS_VALUE;
-    m_lateframes = -1.0;
+    m_lateframes = -1;
     m_presentevent.notifyAll();
     m_renderedOverlay = false;
     m_renderDebug = false;
@@ -887,7 +887,7 @@ RESOLUTION CRenderManager::GetResolution()
     return res;
 
   if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
-    res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, CONF_FLAGS_STEREO_MODE_MASK(m_flags));
+    res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, CONF_FLAGS_STEREO_MODE_MASK(m_flags) != 0);
 
   return res;
 }
@@ -1083,7 +1083,7 @@ void CRenderManager::UpdateResolution()
     {
       if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
-        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, CONF_FLAGS_STEREO_MODE_MASK(m_flags));
+        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, CONF_FLAGS_STEREO_MODE_MASK(m_flags) != 0);
         g_graphicsContext.SetVideoResolution(res);
         UpdateDisplayLatency();
       }
@@ -1224,7 +1224,7 @@ int CRenderManager::WaitForBuffer(volatile std::atomic_bool&bStop, int timeout)
     else
       presenttime = clock + 0.02;
 
-    int sleeptime = (presenttime - clock) * 1000;
+    int sleeptime = static_cast<int>((presenttime - clock) * 1000);
     if (sleeptime < 0)
       sleeptime = 0;
     sleeptime = std::min(sleeptime, 20);
@@ -1331,7 +1331,7 @@ void CRenderManager::PrepareNextRender()
       m_QueueSkip++;
     }
 
-    int lateframes = (renderPts - m_Queue[idx].pts) * m_fps / DVD_TIME_BASE;
+    int lateframes = static_cast<int>((renderPts - m_Queue[idx].pts) * m_fps / DVD_TIME_BASE);
     if (lateframes)
       m_lateframes += lateframes;
     else
@@ -1377,7 +1377,7 @@ void CRenderManager::CheckEnableClockSync()
 
   if (m_fps != 0)
   {
-    float fps = m_fps;
+    double fps = m_fps;
     double refreshrate, clockspeed;
     int missedvblanks;
     if (m_dvdClock.GetClockInfo(missedvblanks, clockspeed, refreshrate))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -731,7 +731,7 @@ void CWinRenderer::RenderSW()
     CLog::Log(LOGERROR, __FUNCTION__" - failed to lock swtarget texture into memory");
 
   uint8_t *dst[] = { (uint8_t*)destlr.pData, 0, 0, 0 };
-  int dstStride[] = { destlr.RowPitch, 0, 0, 0 };
+  int dstStride[] = { static_cast<int>(destlr.RowPitch), 0, 0, 0 };
 
   sws_scale(m_sw_scale_ctx, src, srcStride, 0, m_sourceHeight, dst, dstStride);
 
@@ -902,8 +902,8 @@ void CWinRenderer::RenderHW(DWORD flags)
                        static_cast<float>(m_IntermediateTarget.GetHeight()));
   if (m_capture)
   {
-    target.x2 = m_capture->GetWidth();
-    target.y2 = m_capture->GetHeight();
+    target.x2 = static_cast<float>(m_capture->GetWidth());
+    target.y2 = static_cast<float>(m_capture->GetHeight());
   }
   CWIN32Util::CropSource(src, dst, target, m_renderOrientation);
 
@@ -939,7 +939,10 @@ void CWinRenderer::RenderHW(DWORD flags)
 
       g_Windowing.GetViewPort(oldViewPort);
       g_Windowing.SetViewPort(bbSize);
-      g_Windowing.SetCameraPosition(CPoint(bbSize.Width() / 2.f, bbSize.Height() / 2.f), bbSize.Width(), bbSize.Height(), 0.f);
+      g_Windowing.SetCameraPosition(CPoint(bbSize.Width() / 2.f, bbSize.Height() / 2.f),
+                                    static_cast<int>(bbSize.Width()),
+                                    static_cast<int>(bbSize.Height()),
+                                    0.f);
     }
 
     // render frame

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -1112,13 +1112,13 @@ void PAPlayer::SeekTime(int64_t iTime /*=0*/)
   if (!m_currentStream)
     return;
 
-  int seekOffset = (int)(iTime - GetTimeInternal());
+  int64_t seekOffset = iTime - GetTimeInternal();
 
   if (m_playbackSpeed != 1)
     SetSpeed(1);
 
   m_currentStream->m_seekFrame = (int)((float)m_currentStream->m_audioFormat.m_sampleRate * ((float)iTime + (float)m_currentStream->m_startOffset) / 1000.0f);
-  m_callback.OnPlayBackSeek((int)iTime, seekOffset);
+  m_callback.OnPlayBackSeek(iTime, seekOffset);
 }
 
 void PAPlayer::SeekPercentage(float fPercent /*=0*/)


### PR DESCRIPTION
This PR fixes most compiler warnings due to type mismatches. Some type choices may need to be reevaluated.