### PR TITLE
For addon created ListItems dont overwrite playcount data from DB

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -64,7 +64,7 @@ namespace XBMCAddon
       if (!path.empty())
         item->SetPath(path);
 
-	  item->GetVideoInfoTag()->SetPlayCount(-1);
+      item->GetVideoInfoTag()->SetPlayCount(-1);
     }
 
     ListItem::~ListItem()

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -63,6 +63,8 @@ namespace XBMCAddon
         item->SetArt("thumb",  thumbnailImage );
       if (!path.empty())
         item->SetPath(path);
+
+	  item->GetVideoInfoTag()->SetPlayCount(-1);
     }
 
     ListItem::~ListItem()

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5266,13 +5266,6 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       m_pDS->next();
     }
 
-    // if playcount is still -1 set it to zero
-    for (CFileItemPtr pItem : items)
-    {
-      if (pItem->GetVideoInfoTag()->GetPlayCount() == -1)
-        pItem->GetVideoInfoTag()->SetPlayCount(0);
-    }
-
     return true;
   }
   catch (...)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5255,7 +5255,7 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       CFileItemPtr item = items.Get(path);
       if (item)
       {
-        if (item->GetVideoInfoTag()->GetPlayCount() == -1)
+        if (!items.IsPlugin() || item->GetVideoInfoTag()->GetPlayCount() == -1)
         {
           item->GetVideoInfoTag()->SetPlayCount(m_pDS->fv(1).get_asInt());
         }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5255,7 +5255,10 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       CFileItemPtr item = items.Get(path);
       if (item)
       {
-        item->GetVideoInfoTag()->SetPlayCount(m_pDS->fv(1).get_asInt());
+        if (item->GetVideoInfoTag()->GetPlayCount() == -1)
+        {
+          item->GetVideoInfoTag()->SetPlayCount(m_pDS->fv(1).get_asInt());
+        }
         if (!item->GetVideoInfoTag()->GetResumePoint().IsSet())
         {
           item->GetVideoInfoTag()->SetResumePoint(m_pDS->fv(2).get_asInt(), m_pDS->fv(3).get_asInt());
@@ -5263,6 +5266,17 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       }
       m_pDS->next();
     }
+
+    // if playcount is still -1 set it to zero
+    for (int i = 0; i < items.Size(); i++)
+    {
+      CFileItemPtr pItem = items[i];
+      if (pItem->GetVideoInfoTag()->GetPlayCount() == -1)
+      {
+        pItem->GetVideoInfoTag()->SetPlayCount(0);
+      }
+    }
+	
     return true;
   }
   catch (...)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5256,9 +5256,8 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       if (item)
       {
         if (!items.IsPlugin() || item->GetVideoInfoTag()->GetPlayCount() == -1)
-        {
           item->GetVideoInfoTag()->SetPlayCount(m_pDS->fv(1).get_asInt());
-        }
+
         if (!item->GetVideoInfoTag()->GetResumePoint().IsSet())
         {
           item->GetVideoInfoTag()->SetResumePoint(m_pDS->fv(2).get_asInt(), m_pDS->fv(3).get_asInt());
@@ -5268,15 +5267,12 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
     }
 
     // if playcount is still -1 set it to zero
-    for (int i = 0; i < items.Size(); i++)
+    for (CFileItemPtr pItem : items)
     {
-      CFileItemPtr pItem = items[i];
       if (pItem->GetVideoInfoTag()->GetPlayCount() == -1)
-      {
         pItem->GetVideoInfoTag()->SetPlayCount(0);
-      }
     }
-	
+
     return true;
   }
   catch (...)

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -629,7 +629,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
       /* NOTE: Currently we GetPlayCounts on our items regardless of whether content is set
                 as if content is set, GetItemsForPaths doesn't return anything not in the content tables.
                 This code can be removed once the content tables are always filled */
-      if (!pItem->m_bIsFolder && !fetchedPlayCounts)
+      if (!pItem->m_bIsFolder && !fetchedPlayCounts && !items.IsPlugin())
       {
         database.GetPlayCounts(items.GetPath(), items);
         fetchedPlayCounts = true;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -639,7 +639,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
       /* NOTE: Currently we GetPlayCounts on our items regardless of whether content is set
                 as if content is set, GetItemsForPaths doesn't return anything not in the content tables.
                 This code can be removed once the content tables are always filled */
-      if (!pItem->m_bIsFolder && !fetchedPlayCounts && !items.IsPlugin())
+      if (!pItem->m_bIsFolder && !fetchedPlayCounts)
       {
         database.GetPlayCounts(items.GetPath(), items);
         fetchedPlayCounts = true;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -642,6 +642,15 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
       if (!pItem->m_bIsFolder && !fetchedPlayCounts)
       {
         database.GetPlayCounts(items.GetPath(), items);
+        // for addons if playcount is still -1 set it to zero
+        if(items.IsPlugin())
+        {
+          for (auto pItem : items)
+          {
+            if (pItem->GetVideoInfoTag()->GetPlayCount() == -1)
+              pItem->GetVideoInfoTag()->SetPlayCount(0);
+          }
+        }
         fetchedPlayCounts = true;
       }
       

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -643,12 +643,12 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
       {
         database.GetPlayCounts(items.GetPath(), items);
         // for addons if playcount is still -1 set it to zero
-        if(items.IsPlugin())
+        if (items.IsPlugin())
         {
-          for (auto pItem : items)
+          for (auto pFI : items)
           {
-            if (pItem->GetVideoInfoTag()->GetPlayCount() == -1)
-              pItem->GetVideoInfoTag()->SetPlayCount(0);
+            if (pFI->GetVideoInfoTag()->GetPlayCount() == -1)
+              pFI->GetVideoInfoTag()->SetPlayCount(0);
           }
         }
         fetchedPlayCounts = true;


### PR DESCRIPTION
When displaying ListItems from an addon dont overwite the playcount with the one stored in the DB if the addon has set a playcount in the video info tag data.
The addon should control what its play count is.

## Description
Default playcount in the video info tag data to -1 when creating ListItems
If the playcount is -1 update that with the value from the DB if there is one, otherwise set it to zero.

## Motivation and Context
I have an addon that wants to be able to set its own playcount and resume data and not have this overwritten by any local DB data Kodi has. The addon gets its play count and resume data from a remote source, in this case the www.emby.media server.

## How Has This Been Tested?
Tested with addon to make sure the playcount is no longer overwritten.
Tested:
 - if playcount is set by the addon it is not overwritten.
 - if an addon did not setting the playcount then it is correct set from the DB value.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ X] All new and existing tests passed
