### PR TITLE
[PVR] Search window improvements and fixes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -854,7 +854,6 @@ msgstr ""
 
 
 #. label for "searching" message box heading
-#: xbmc/pvr/windows/GUIWindowPVRSearch.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#194"

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -48,6 +48,15 @@ void CPVREpgSearchFilter::Reset()
   m_iGenreSubType            = EPG_SEARCH_UNSET;
   m_iMinimumDuration         = EPG_SEARCH_UNSET;
   m_iMaximumDuration         = EPG_SEARCH_UNSET;
+
+  m_startDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate());
+  if (!m_startDateTime.IsValid())
+    m_startDateTime.SetFromUTCDateTime(CDateTime::GetUTCDateTime()); // default to 'now'
+
+  m_endDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate());
+  if (!m_endDateTime.IsValid())
+    m_endDateTime.SetFromUTCDateTime(m_startDateTime + CDateTimeSpan(10, 0, 0, 0)); // default to start + 10 days
+
   m_bIncludeUnknownGenres    = false;
   m_bRemoveDuplicates        = false;
 
@@ -59,30 +68,6 @@ void CPVREpgSearchFilter::Reset()
   m_bIgnorePresentTimers     = true;
   m_bIgnorePresentRecordings = true;
   m_iUniqueBroadcastId       = EPG_TAG_INVALID_UID;
-}
-
-void CPVREpgSearchFilter::ValidateStartAndEndDate()
-{
-  const CDateTime start = CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate();
-  const CDateTime end = CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate();
-
-  if (m_startDateTime < start || m_startDateTime > end)
-    m_startDateTime.SetFromUTCDateTime(start);
-
-  if (m_endDateTime > end || m_endDateTime < start)
-    m_endDateTime.SetFromUTCDateTime(end);
-}
-
-const CDateTime& CPVREpgSearchFilter::GetStartDateTime()
-{
-  ValidateStartAndEndDate();
-  return m_startDateTime;
-}
-
-const CDateTime& CPVREpgSearchFilter::GetEndDateTime()
-{
-  ValidateStartAndEndDate();
-  return m_endDateTime;
 }
 
 bool CPVREpgSearchFilter::MatchGenre(const CPVREpgInfoTagPtr &tag) const

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -76,10 +76,10 @@ namespace PVR
     int GetMaximumDuration() const { return m_iMaximumDuration; }
     void SetMaximumDuration(int iMaximumDuration) { m_iMaximumDuration = iMaximumDuration; }
 
-    const CDateTime &GetStartDateTime();
+    const CDateTime &GetStartDateTime() const { return m_startDateTime; }
     void SetStartDateTime(const CDateTime &startDateTime) { m_startDateTime = startDateTime; }
 
-    const CDateTime &GetEndDateTime();
+    const CDateTime &GetEndDateTime() const  { return m_endDateTime; }
     void SetEndDateTime(const CDateTime &endDateTime) { m_endDateTime = endDateTime; }
 
     bool ShouldIncludeUnknownGenres() const { return m_bIncludeUnknownGenres; }
@@ -110,11 +110,6 @@ namespace PVR
     void SetUniqueBroadcastId(unsigned int iUniqueBroadcastId) { m_iUniqueBroadcastId = iUniqueBroadcastId; }
 
   private:
-    /*!
-     * @brief Make sure that start and end time match current epg data boundaries.
-     */
-    void ValidateStartAndEndDate();
-
     bool MatchGenre(const CPVREpgInfoTagPtr &tag) const;
     bool MatchDuration(const CPVREpgInfoTagPtr &tag) const;
     bool MatchStartAndEndTimes(const CPVREpgInfoTagPtr &tag) const;


### PR DESCRIPTION
Two changes related to the PVR search window :

1) Improvement: While searching epg events display standard "busy" dialog instaead of ugly modal dialog showing "searching..."

2) Fix: regression introduced with #11992. "Find similar" (triggers epg search from other pvr windows) did not work anymore.

The changes have been runtime tested on macOS, latest kodi master

@Jallle19 for code review?