### PR TITLE
changed: always expand iso images in music window

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -373,12 +373,14 @@ bool CDirectory::RemoveRecursive(const CURL& url)
   return false;
 }
 
-void CDirectory::FilterFileDirectories(CFileItemList &items, const std::string &mask)
+void CDirectory::FilterFileDirectories(CFileItemList &items, const std::string &mask,
+                                       bool expandImages)
 {
   for (int i=0; i< items.Size(); ++i)
   {
     CFileItemPtr pItem=items[i];
-    if (!pItem->m_bIsFolder && pItem->IsFileFolder(EFILEFOLDER_TYPE_ALWAYS))
+    auto mode = expandImages ? EFILEFOLDER_TYPE_ONBROWSE : EFILEFOLDER_TYPE_ALWAYS;
+    if (!pItem->m_bIsFolder && pItem->IsFileFolder(mode))
     {
       std::unique_ptr<IFileDirectory> pDirectory(CFileDirectoryFactory::Create(pItem->GetURL(),pItem.get(),mask));
       if (pDirectory.get())

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -78,7 +78,10 @@ public:
 
   /*! \brief Filter files that act like directories from the list, replacing them with their directory counterparts
    \param items The item list to filter
-   \param mask  The mask to apply when filtering files */
-  static void FilterFileDirectories(CFileItemList &items, const std::string &mask);
+   \param mask  The mask to apply when filtering files
+   \param expandImages True to include disc images in file directory expansion
+  */
+  static void FilterFileDirectories(CFileItemList &items, const std::string &mask,
+                                    bool expandImages=false);
 };
 }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -36,6 +36,7 @@
 #include "GUIPassword.h"
 #include "PartyModeManager.h"
 #include "GUIInfoManager.h"
+#include "filesystem/Directory.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "music/dialogs/GUIDialogSongInfo.h"
 #include "addons/GUIDialogAddonInfo.h"
@@ -1233,6 +1234,9 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
   bool bResult = CGUIMediaWindow::GetDirectory(strDirectory, items);
   if (bResult)
   {
+    // We always want to expand disc images in music windows.
+    CDirectory::FilterFileDirectories(items, ".iso", true);
+
     CMusicThumbLoader loader;
     loader.FillThumb(items);
 


### PR DESCRIPTION
This makes iso images into filedirectories in the music window.

Currently, there has been no iso support for music (although we can do audio cd iso in the code i believe). Anyways, I want to add an add-on for SACD iso support. That requires this change.

It should do no harm, and by default .iso is not a music extension anyways.