### PR TITLE
AESinkPULSE: Return to PA's delay infrastructure

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -70,8 +70,6 @@ private:
   pa_cvolume m_Volume;
   bool m_volume_needs_update;
   uint32_t m_periodSize;
-  uint64_t m_lastPackageStamp;
-  uint64_t m_filled_bytes;
 
   pa_context *m_Context;
   pa_threaded_mainloop *m_MainLoop;


### PR DESCRIPTION
After several years I tested again with PA 8.0 - delay looks very fine. No need to manually workaround it anymore.