### PR TITLE
[guilib] Isolate included expressions $EXP

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -211,7 +211,7 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
     if (node->Attribute("name") && node->FirstChild())
     {
       std::string tagName = node->Attribute("name");
-      m_expressions.insert(make_pair(tagName, node->FirstChild()->ValueStr()));
+      m_expressions.insert(make_pair(tagName, "[" + node->FirstChild()->ValueStr() + "]"));
     }
     node = node->NextSiblingElement("expression");
   }


### PR DESCRIPTION
## Description
Isolate skin included expressions so that when their including condition is evaluated the order of operations matches expected behavior.

## Motivation and Context
The current behavior just replaces expressions inline, which can have unexpected results if it contains an or "|" not inside brackets. Pretty sure I'm missing some words, so an example is in order.

Imagine an expression such as:

    <expression name="ListItemHas3D">String.Contains(ListItem.Filename, MVC 3D) | ListItem.IsStereoscopic</expression>

Used in a visible condition with another condition like so:

    <visible>$EXP[ListItemHas3D] + Skin.HasSetting(Blurry3D)</visible>

The expected behavior would match `[String.Contains(ListItem.Filename, MVC 3D) | ListItem.IsStereoscopic] + Skin.HasSetting(Blurry3D)`, but it is currently evaluated as `String.Contains(ListItem.Filename, MVC 3D) | ListItem.IsStereoscopic + Skin.HasSetting(Blurry3D)`, which ignores the skin setting if "MVC 3D" matched.

This change just wraps all expressions in brackets when they are first loaded so they behave as expected. I considered some smarts to only wrap expressions with "|" not inside brackets, but this is simpler and I don't figure the conditional evaluator will have a problem with some redundant brackets. I can rework it if I figured wrong, though.

## How Has This Been Tested?
Fired up Kodi with a skin I'm familiar with, checked that the above and a couple of other instances worked with the new behavior, and verified that other conditions behavior did not change.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

This is technically a breaking change because someone could have designed their skin to take advantage of this behavior, but most likely they are just wrapping the condition in brackets themselves to work around it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
