### PR TITLE
Krypton: Fix compilation on sh4/sparc/arc/xtensa

### DIFF
--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -29,7 +29,8 @@
     !defined(__aarch64__) && \
     !defined(__mips__) && \
     !defined(__SH4__) && \
-    !defined(__sparc__)
+    !defined(__sparc__) && \
+    !defined(__arc__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -23,7 +23,12 @@
 #include "coffldr.h"
 #include "LibraryLoader.h"
 
-#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__aarch64__) && !defined(__mips__)
+#if defined(__linux__) && \
+    !defined(__powerpc__) && \
+    !defined(__arm__) && \
+    !defined(__aarch64__) && \
+    !defined(__mips__) && \
+    !defined(__SH4__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -28,7 +28,8 @@
     !defined(__arm__) && \
     !defined(__aarch64__) && \
     !defined(__mips__) && \
-    !defined(__SH4__)
+    !defined(__SH4__) && \
+    !defined(__sparc__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -30,7 +30,8 @@
     !defined(__mips__) && \
     !defined(__SH4__) && \
     !defined(__sparc__) && \
-    !defined(__arc__)
+    !defined(__arc__) && \
+    !defined(__xtensa__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -24,7 +24,8 @@
     !defined(__arm__) && \
     !defined(__aarch64__) && \
     !defined(__mips__) && \
-    !defined(__SH4__)
+    !defined(__SH4__) && \
+    !defined(__sparc__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -26,7 +26,8 @@
     !defined(__mips__) && \
     !defined(__SH4__) && \
     !defined(__sparc__) && \
-    !defined(__arc__)
+    !defined(__arc__) && \
+    !defined(__xtensa__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -19,7 +19,12 @@
  */
 
 //#ifndef __powerpc__
-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__aarch64__) && !defined(__mips__)
+#if !defined(__powerpc__) && \
+    !defined(__ppc__) && \
+    !defined(__arm__) && \
+    !defined(__aarch64__) && \
+    !defined(__mips__) && \
+    !defined(__SH4__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -25,7 +25,8 @@
     !defined(__aarch64__) && \
     !defined(__mips__) && \
     !defined(__SH4__) && \
-    !defined(__sparc__)
+    !defined(__sparc__) && \
+    !defined(__arc__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -293,7 +293,13 @@ protected:
 
 
 inline int NP2( unsigned x ) {
-#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__) && !defined(__aarch64__) && !defined(__mips__)
+#if defined(TARGET_POSIX) && \
+    !defined(__POWERPC__) && \
+    !defined(__PPC__) && \
+    !defined(__arm__) && \
+    !defined(__aarch64__) && \
+    !defined(__mips__) && \
+    !defined(__SH4__)
   // If there are any issues compiling this, just append a ' && 0'
   // to the above to make it '#if defined(TARGET_POSIX) && 0'
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -300,7 +300,8 @@ inline int NP2( unsigned x ) {
     !defined(__aarch64__) && \
     !defined(__mips__) && \
     !defined(__SH4__) && \
-    !defined(__sparc__)
+    !defined(__sparc__) && \
+    !defined(__arc__)
   // If there are any issues compiling this, just append a ' && 0'
   // to the above to make it '#if defined(TARGET_POSIX) && 0'
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -299,7 +299,8 @@ inline int NP2( unsigned x ) {
     !defined(__arm__) && \
     !defined(__aarch64__) && \
     !defined(__mips__) && \
-    !defined(__SH4__)
+    !defined(__SH4__) && \
+    !defined(__sparc__)
   // If there are any issues compiling this, just append a ' && 0'
   // to the above to make it '#if defined(TARGET_POSIX) && 0'
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -301,7 +301,8 @@ inline int NP2( unsigned x ) {
     !defined(__mips__) && \
     !defined(__SH4__) && \
     !defined(__sparc__) && \
-    !defined(__arc__)
+    !defined(__arc__) && \
+    !defined(__xtensa__)
   // If there are any issues compiling this, just append a ' && 0'
   // to the above to make it '#if defined(TARGET_POSIX) && 0'
 

--- a/xbmc/threads/Atomics.cpp
+++ b/xbmc/threads/Atomics.cpp
@@ -110,7 +110,8 @@ long long cas2(volatile long long* pAddr, long long expectedVal, long long swapV
     defined(__powerpc__) || \
     defined(__arm__) || \
     defined(__aarch64__) || \
-    defined(__SH4__)
+    defined(__SH4__) || \
+    defined(__sparc__)
 // Not available/required
 // Hack to allow compilation
   throw "cas2 is not implemented";

--- a/xbmc/threads/Atomics.cpp
+++ b/xbmc/threads/Atomics.cpp
@@ -106,7 +106,11 @@ long cas(volatile long *pAddr, long expectedVal, long swapVal)
 ///////////////////////////////////////////////////////////////////////////
 long long cas2(volatile long long* pAddr, long long expectedVal, long long swapVal)
 {
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__aarch64__)// PowerPC and ARM
+#if defined(__ppc__) || \
+    defined(__powerpc__) || \
+    defined(__arm__) || \
+    defined(__aarch64__) || \
+    defined(__SH4__)
 // Not available/required
 // Hack to allow compilation
   throw "cas2 is not implemented";

--- a/xbmc/threads/Atomics.cpp
+++ b/xbmc/threads/Atomics.cpp
@@ -112,7 +112,8 @@ long long cas2(volatile long long* pAddr, long long expectedVal, long long swapV
     defined(__aarch64__) || \
     defined(__SH4__) || \
     defined(__sparc__) || \
-    defined(__arc__)
+    defined(__arc__) || \
+    defined(__xtensa__)
 // Not available/required
 // Hack to allow compilation
   throw "cas2 is not implemented";

--- a/xbmc/threads/Atomics.cpp
+++ b/xbmc/threads/Atomics.cpp
@@ -111,7 +111,8 @@ long long cas2(volatile long long* pAddr, long long expectedVal, long long swapV
     defined(__arm__) || \
     defined(__aarch64__) || \
     defined(__SH4__) || \
-    defined(__sparc__)
+    defined(__sparc__) || \
+    defined(__arc__)
 // Not available/required
 // Hack to allow compilation
   throw "cas2 is not implemented";

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -39,7 +39,8 @@
     defined(__aarch64__) || \
     defined(__SH4__) || \
     defined(__sparc__) || \
-    defined(__arc__)
+    defined(__arc__) || \
+    defined(__xtensa__)
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -36,7 +36,8 @@
     defined(__powerpc__) || \
     defined(__mips__) || \
     defined(__arm__) || \
-    defined(__aarch64__)
+    defined(__aarch64__) || \
+    defined(__SH4__)
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -38,7 +38,8 @@
     defined(__arm__) || \
     defined(__aarch64__) || \
     defined(__SH4__) || \
-    defined(__sparc__)
+    defined(__sparc__) || \
+    defined(__arc__)
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -37,7 +37,8 @@
     defined(__mips__) || \
     defined(__arm__) || \
     defined(__aarch64__) || \
-    defined(__SH4__)
+    defined(__SH4__) || \
+    defined(__sparc__)
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 


### PR DESCRIPTION
backport of https://github.com/xbmc/xbmc/pull/12014 with additional patch for xbmc/threads/Atomics.cpp which is not needed for master branch, compile-tested using buildroot toolchains