### PR TITLE
Encasulate all the is playcount set functionality in CVideoInfoTag

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -64,7 +64,7 @@ namespace XBMCAddon
       if (!path.empty())
         item->SetPath(path);
 
-      item->GetVideoInfoTag()->SetPlayCount(-1);
+      item->GetVideoInfoTag()->ResetPlayCount();
     }
 
     ListItem::~ListItem()

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5255,7 +5255,7 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       CFileItemPtr item = items.Get(path);
       if (item)
       {
-        if (!items.IsPlugin() || item->GetVideoInfoTag()->GetPlayCount() == -1)
+        if (!items.IsPlugin() || !item->GetVideoInfoTag()->IsPlayCountSet())
           item->GetVideoInfoTag()->SetPlayCount(m_pDS->fv(1).get_asInt());
 
         if (!item->GetVideoInfoTag()->GetResumePoint().IsSet())

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -87,7 +87,7 @@ void CVideoInfoTag::Reset()
   m_showLink.clear();
   m_namedSeasons.clear();
   m_streamDetails.Reset();
-  m_playCount = 0;
+  m_playCount = PLAYCOUNT_NOT_SET;
   m_EpBookmark.Reset();
   m_EpBookmark.type = CBookmark::EPISODE;
   m_basePath.clear();
@@ -1538,7 +1538,7 @@ std::vector<std::string> CVideoInfoTag::Trim(std::vector<std::string>&& items)
 
 int CVideoInfoTag::GetPlayCount() const
 {
-  return m_playCount;
+  return IsPlayCountSet() ? m_playCount : 0;
 }
 
 bool CVideoInfoTag::SetPlayCount(int count)
@@ -1549,8 +1549,21 @@ bool CVideoInfoTag::SetPlayCount(int count)
 
 bool CVideoInfoTag::IncrementPlayCount()
 {
+  if (!IsPlayCountSet())
+    m_playCount = 0;
+
   m_playCount++;
   return true;
+}
+
+void CVideoInfoTag::ResetPlayCount()
+{
+  m_playCount = PLAYCOUNT_NOT_SET;
+}
+
+bool CVideoInfoTag::IsPlayCountSet() const
+{
+  return m_playCount != PLAYCOUNT_NOT_SET;
 }
 
 CBookmark CVideoInfoTag::GetResumePoint() const

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -189,6 +189,17 @@ public:
   virtual bool IncrementPlayCount();
 
   /*!
+  * @brief Reset playcount
+  */
+  virtual void ResetPlayCount();
+
+  /*!
+  * @brief Check if the playcount is set
+  * @return True if play count value is set
+  */
+  virtual bool IsPlayCountSet() const;
+
+  /*!
    * @brief Get this videos's resume point.
    * @return the resume point.
    */
@@ -291,6 +302,7 @@ private:
 
   int m_playCount;
   CBookmark m_resumePoint;
+  static const int PLAYCOUNT_NOT_SET = -1;
 };
 
 typedef std::vector<CVideoInfoTag> VECMOVIES;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -642,15 +642,6 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
       if (!pItem->m_bIsFolder && !fetchedPlayCounts)
       {
         database.GetPlayCounts(items.GetPath(), items);
-        // for addons if playcount is still -1 set it to zero
-        if (items.IsPlugin())
-        {
-          for (auto pFI : items)
-          {
-            if (pFI->GetVideoInfoTag()->GetPlayCount() == -1)
-              pFI->GetVideoInfoTag()->SetPlayCount(0);
-          }
-        }
         fetchedPlayCounts = true;
       }
       


### PR DESCRIPTION
Don't use a magic number of -1 of video playcount not set value

## Description
Small change to not use magic numbers

## Motivation and Context
magic numbers are bad

## How Has This Been Tested?
Built and tested use cases are still valid.
Run the build tests.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
