### PR TITLE
[filesystem] ZipManager: skip path traversal

### DIFF
--- a/xbmc/filesystem/ZipManager.cpp
+++ b/xbmc/filesystem/ZipManager.cpp
@@ -21,6 +21,7 @@
 #include "ZipManager.h"
 
 #include <algorithm>
+#include <regex>
 #include <utility>
 
 #include "File.h"
@@ -205,7 +206,8 @@ bool CZipManager::GetZipList(const CURL& url, std::vector<SZipEntry>& items)
     // Jump after central file header extra field and file comment
     mFile.Seek(ze.eclength + ze.clength,SEEK_CUR);
 
-    items.push_back(ze);
+    if (!std::regex_search(strName, PATH_TRAVERSAL))
+      items.push_back(ze);
   }
 
   /* go through list and figure out file header lengths */

--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -32,11 +32,14 @@
 #define ECDREC_SIZE 22
 
 #include <memory.h>
+#include <regex>
 #include <string>
 #include <vector>
 #include <map>
 
 class CURL;
+
+static const std::regex PATH_TRAVERSAL(R"_((^|\/|\\)\.{2}($|\/|\\))_");
 
 struct SZipEntry {
   unsigned int header;

--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestDirectory.cpp 
             TestFile.cpp
             TestFileFactory.cpp
-            TestZipFile.cpp)
+            TestZipFile.cpp
+            TestZipManager.cpp)
 
 core_add_test_library(filesystem_test)

--- a/xbmc/filesystem/test/TestZipManager.cpp
+++ b/xbmc/filesystem/test/TestZipManager.cpp
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "filesystem/ZipManager.h"
+
+#include "gtest/gtest.h"
+
+TEST(TestZipManager, PathTraversal)
+{
+  ASSERT_TRUE(std::regex_search("..", PATH_TRAVERSAL));
+  ASSERT_TRUE(std::regex_search("../test.txt", PATH_TRAVERSAL));
+  ASSERT_TRUE(std::regex_search("..\\test.txt", PATH_TRAVERSAL));
+  ASSERT_TRUE(std::regex_search("test/../test.txt", PATH_TRAVERSAL));
+  ASSERT_TRUE(std::regex_search("test\\../test.txt", PATH_TRAVERSAL));
+  ASSERT_TRUE(std::regex_search("test\\..\\test.txt", PATH_TRAVERSAL));
+  
+  ASSERT_FALSE(std::regex_search("...", PATH_TRAVERSAL));
+  ASSERT_FALSE(std::regex_search("..test.txt", PATH_TRAVERSAL));
+  ASSERT_FALSE(std::regex_search("test.txt..", PATH_TRAVERSAL));
+  ASSERT_FALSE(std::regex_search("test..test.txt", PATH_TRAVERSAL));
+}


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Skip items in a zip file, which try to traverse to a parent directory.
<!--- Describe your change in detail -->

## Motivation and Context
Without this a zip file can override every file the current user has write permission.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested with a malicious zip file.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@ace20022 @MartijnKaijser @wsnipex FYI