### PR TITLE
[buildsteps][windows] adapt run-tests to cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ cmake_install.cmake
 /libtool
 /*.patch
 /kodi-build/
+/gtestresults.xml
 
 # /addons/
 /addons/packages


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Adapt run-tests to cmake that it is working again.
<!--- Describe your change in detail -->

## Motivation and Context
Testsuite currently isn't executed on windows because the script is broken.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
run the script
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
