### PR TITLE
zlib configure modification to address cross-compile for android on OS X

### DIFF
--- a/tools/depends/target/zlib/Makefile
+++ b/tools/depends/target/zlib/Makefile
@@ -7,7 +7,8 @@ VERSION=1.2.7
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 # configuration settings
-CONFIGURE= CC="$(CC)" CFLAGS="$(CFLAGS)" ./configure --prefix=$(PREFIX) --static
+CONFIGURE= CHOST="$(TOOLCHAIN)/bin/$(HOST)" CC="$(CC)" CFLAGS="$(CFLAGS)" \
+	./configure --prefix=$(PREFIX) --static
 
 LIBDYLIB=$(PLATFORM)/$(LIBNAME).a
 


### PR DESCRIPTION
## Description
Added CHOST environment variable to ./configure  to ensure correct cross-compiler picked up during target compilation.

## Motivation and Context
This was necessary when compiling depends library on OS X using NDK 12b.

## How Has This Been Tested?
tested on only one platform
OSX 
uname -a
16.5.0 Darwin Kernel Version 16.5.0: Fri Mar  3 16:52:33 PST 2017; root:xnu-3789.51.2~3/RELEASE_X86_64 x86_64

sdk
grep "Revision" source.properties 
Pkg.Revision=25.2.5

ndk
grep "Revision" source.properties 
Pkg.Revision = 12.1.2977051

## Screenshots (if appropriate):

## Types of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed