### PR TITLE
[guilib] Evaluate skin expressions everywhere

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -367,7 +367,7 @@ void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, b
     const char *condition = include->Attribute("condition");
     if (condition)
     {
-      INFO::InfoPtr conditionID = g_infoManager.Register(condition);
+      INFO::InfoPtr conditionID = g_infoManager.Register(ResolveExpressions(condition));
       bool value = conditionID->Get();
 
       if (xmlIncludeConditions)

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -106,7 +106,15 @@ void CGUIIncludes::Clear()
   m_expressions.clear();
 }
 
-bool CGUIIncludes::Load(const std::string &file)
+void CGUIIncludes::Load(const std::string &file)
+{
+  if (!Load_Internal(file))
+    return;
+  FlattenExpressions();
+  FlattenSkinVariableConditions();
+}
+
+bool CGUIIncludes::Load_Internal(const std::string &file)
 {
   // check to see if we already have this loaded
   if (HasLoaded(file))
@@ -235,12 +243,59 @@ void CGUIIncludes::LoadIncludes(const TiXmlElement *node)
       if (condition)
       { // load include file if condition evals to true
         if (g_infoManager.Register(condition)->Get())
-          Load(file);
+          Load_Internal(file);
       }
       else
-        Load(file);
+        Load_Internal(file);
     }
     child = child->NextSiblingElement("include");
+  }
+}
+
+void CGUIIncludes::FlattenExpressions()
+{
+  for (auto& expression : m_expressions)
+  {
+    std::vector<std::string> resolved = std::vector<std::string>();
+    resolved.push_back(expression.first);
+    FlattenExpression(expression.second, resolved);
+  }
+}
+
+void CGUIIncludes::FlattenExpression(std::string &expression, const std::vector<std::string> &resolved)
+{
+  std::string original(expression);
+  CGUIInfoLabel::ReplaceSpecialKeywordReferences(expression, "EXP", [&](const std::string &expressionName) -> std::string {
+    if (std::find(resolved.begin(), resolved.end(), expressionName) != resolved.end())
+    {
+      CLog::Log(LOGERROR, "Skin has a circular expression \"%s\": %s", resolved.back().c_str(), original.c_str());
+      return std::string();
+    }
+    auto it = m_expressions.find(expressionName);
+    if (it == m_expressions.end())
+      return std::string();
+
+    std::vector<std::string> rescopy = resolved;
+    rescopy.push_back(expressionName);
+    FlattenExpression(it->second, rescopy);
+
+    return it->second;
+  });
+}
+
+void CGUIIncludes::FlattenSkinVariableConditions()
+{
+  for (auto& variable : m_skinvariables)
+  {
+    TiXmlElement* valueNode = variable.second.FirstChildElement("value");
+    while (valueNode)
+    {
+      const char *condition = valueNode->Attribute("condition");
+      if (condition)
+        valueNode->SetAttribute("condition", ResolveExpressions(condition));
+
+      valueNode = valueNode->NextSiblingElement("value");
+    }
   }
 }
 

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -47,13 +47,13 @@ public:
   void Clear();
 
   /*!
-   \brief Load all include components (defaults, constants, variables, expressions and includes)
-    from the given \code{file}.
-   
+   \brief Load all include components(defaults, constants, variables, expressions and includes)
+   from the main entrypoint \code{file}. Flattens nested expressions and expressions in variable
+   conditions after loading all other included files.
+
    \param file the file to load
-   \return true if the file was loaded otherwise false
-   */
-  bool Load(const std::string &file);
+  */
+  void Load(const std::string &file);
 
   /*!
    \brief Resolve all include components (defaults, constants, variables, expressions and includes)
@@ -81,6 +81,15 @@ private:
     SINGLE_UNDEFINED_PARAM_RESOLVED
   };
 
+  /*!
+   \brief Load all include components (defaults, constants, variables, expressions and includes)
+   from the given \code{file}.
+
+   \param file the file to load
+   \return true if the file was loaded otherwise false
+  */
+  bool Load_Internal(const std::string &file);
+
   bool HasLoaded(const std::string &file) const;
 
   void LoadDefaults(const TiXmlElement *node);
@@ -88,6 +97,24 @@ private:
   void LoadVariables(const TiXmlElement *node);
   void LoadConstants(const TiXmlElement *node);
   void LoadExpressions(const TiXmlElement *node);
+
+  /*!
+   \brief Resolve all expressions containing other expressions to a single evaluatable expression.
+  */
+  void FlattenExpressions();
+
+  /*!
+   \brief Expand any expressions nested in this expression.
+
+   \param expression the expression to flatten
+   \param resolved list of already evaluated expression names, to avoid expanding circular references
+  */
+  void FlattenExpression(std::string &expression, const std::vector<std::string> &resolved);
+
+  /*!
+   \brief Resolve all variable conditions containing expressions to a single evaluatable condition.
+  */
+  void FlattenSkinVariableConditions();
 
   void SetDefaults(TiXmlElement *node);
   void ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, bool>* xmlIncludeConditions = NULL);


### PR DESCRIPTION
## Description
Skin expressions $EXP are now evaluated for skin variable conditions, expressions inside of other expressions, and include conditions __*__. #12096 refactors custom window handling so their visible conditions can include skin expressions as well. Now expressions work everywhere you want them!

__*__ This works for conditions for the prolific named includes that are used in windows, but not conditions for nameless whole-file includes that can be used only in the main _includes.xml_ file. Allowing expressions there doesn't seem worth the hassle of all the code required to get that behavior just right.

## Motivation and Context
Even skinners deserve to be DRY.

http://forum.kodi.tv/showthread.php?tid=308385
http://forum.kodi.tv/showthread.php?tid=300636

## How Has This Been Tested?
Manually, by putting expressions in these newly supported places and ensure they do what I expect, and roll through all sorts of other windows checking that nothing else was affected.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue), or, depending on how you want to look at it,
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
