### PR TITLE
[settings] change spinners to list for media/video

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1053,7 +1053,7 @@
               <option label="20422">2</option> <!-- Always -->
             </options>
           </constraints>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="videolibrary.tvshowsincludeallseasonsandspecials" type="integer" parent="videolibrary.tvshowsselectfirstunwatcheditem" label="21472" help="21473">
           <level>2</level>
@@ -1069,7 +1069,7 @@
           <dependencies>
             <dependency type="enable" setting="videolibrary.tvshowsselectfirstunwatcheditem" operator="!is">0</dependency> <!-- Never -->
           </dependencies>
-          <control type="spinner" format="string" />
+          <control type="list" format="string" />
         </setting>
         <setting id="videolibrary.actorthumbs" type="boolean" label="20402" help="36143">
           <level>2</level>


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Change "Select first unwatched TV show season/episode" from spinner to a list

## Motivation and Context
Spinners are bad m'kay

## How Has This Been Tested?
Runtime tested.
## Screenshots (if appropriate):
Before:
![schermafbeelding 2017-04-30 om 08 59 35](https://cloud.githubusercontent.com/assets/447067/25562318/5da729b0-2d83-11e7-8c61-917f8203a157.png)

After:
![schermafbeelding 2017-04-30 om 09 01 35](https://cloud.githubusercontent.com/assets/447067/25562330/a4775c5c-2d83-11e7-9293-74549a8a290f.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
