### PR TITLE
[guilib] Isolate included expressions $EXP

### DIFF
--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -209,7 +209,7 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
     if (node->Attribute("name") && node->FirstChild())
     {
       std::string tagName = node->Attribute("name");
-      m_expressions.insert(make_pair(tagName, node->FirstChild()->ValueStr()));
+      m_expressions.insert(make_pair(tagName, "[" + node->FirstChild()->ValueStr() + "]"));
     }
     node = node->NextSiblingElement("expression");
   }


### PR DESCRIPTION
## Description
Backport of #12012. Isolate skin included expressions so that when their including condition is evaluated the order of operations matches expected behavior.

## Motivation and Context
The current behavior just replaces expressions inline, which can have unexpected results if it contains an or "|" not inside brackets.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is technically a breaking change because someone could have designed their skin to take advantage of this behavior, but most likely they are just wrapping the condition in brackets themselves to work around it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
