### PR TITLE
[osx][droid] target zlib Makefile modified to ensure correct compiler

### DIFF
--- a/tools/depends/target/zlib/Makefile
+++ b/tools/depends/target/zlib/Makefile
@@ -7,7 +7,8 @@ VERSION=1.2.7
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 # configuration settings
-CONFIGURE= CC="$(CC)" CFLAGS="$(CFLAGS)" ./configure --prefix=$(PREFIX) --static
+CONFIGURE= CHOST="$(TOOLCHAIN)/bin/$(HOST)" CC="$(CC)" CFLAGS="$(CFLAGS)" \
+       ./configure --prefix=$(PREFIX) --static
 
 LIBDYLIB=$(PLATFORM)/$(LIBNAME).a
 


### PR DESCRIPTION
## Description
I submitted this same change on the master branch.   Allowed for full compile of android apk on osx platform.  The zlib library was incorrectly picking up the native archiving tools.  The addition of CHOST to the Makefile configuration command ensuried that the correct target binaries were utilized.  

## Motivation and Context
Allows for android cross compile of OSX

## How Has This Been Tested?
Tested on OSX only, produced a valid an functioning apk.  apk side-loaded to firetv gen1 and operating.

Darwin Kernel Version 16.5.0
NDK 12.1.2977051
SDK 25.2.5
javac 1.8.0_111

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed