### PR TITLE
[buildsteps][windows] fix BuildSetup.bat after 0a14316 (#12031)

### DIFF
--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -48,7 +48,7 @@ SET buildbinaryaddons=true
 SET exitcode=0
 SET useshell=rxvt
 SET BRANCH=na
-FOR %%b in (%1, %2, %3, %4) DO (
+FOR %%b in (%1, %2, %3, %4, %5) DO (
   IF %%b==clean SET buildmode=clean
   IF %%b==noclean SET buildmode=noclean
   IF %%b==noprompt SET promptlevel=noprompt
@@ -104,7 +104,7 @@ set WORKSPACE=%base_dir%\kodi-build
 :MAKE_BUILD_EXE
   ECHO Copying files...
   PUSHD %base_dir%\project\Win32BuildSetup
-  IF EXIST BUILD_WIN32 rmdir BUILD_WIN32 /S /Q
+  IF EXIST BUILD_WIN32\application rmdir BUILD_WIN32\application /S /Q
   rem Add files to exclude.txt that should not be included in the installer
   
   Echo Thumbs.db>>exclude.txt


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
- Jenkins passes nobinaryaddons as 5th parameter
- allow to run make-addons before BuildSetup and also keep them
<!--- Describe your change in detail -->

## Motivation and Context
binary addons currently get always build
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
