### PR TITLE
[PVR] pvr windows cleanup and refactoring of class hierarchy

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -257,19 +257,19 @@ void CGUIWindowManager::CreateWindows()
 
   /* Load PVR related Windows and Dialogs */
   Add(new CGUIDialogTeletext);
-  Add(new CGUIWindowPVRChannels(false));
-  Add(new CGUIWindowPVRRecordings(false));
-  Add(new CGUIWindowPVRGuide(false));
-  Add(new CGUIWindowPVRTimers(false));
-  Add(new CGUIWindowPVRTimerRules(false));
-  Add(new CGUIWindowPVRSearch(false));
-  Add(new CGUIWindowPVRChannels(true));
-  Add(new CGUIWindowPVRRecordings(true));
-  Add(new CGUIWindowPVRGuide(true));
-  Add(new CGUIWindowPVRTimers(true));
-  Add(new CGUIWindowPVRTimerRules(true));
+  Add(new CGUIWindowPVRTVChannels);
+  Add(new CGUIWindowPVRTVRecordings);
+  Add(new CGUIWindowPVRTVGuide);
+  Add(new CGUIWindowPVRTVTimers);
+  Add(new CGUIWindowPVRTVTimerRules);
+  Add(new CGUIWindowPVRTVSearch);
+  Add(new CGUIWindowPVRRadioChannels);
+  Add(new CGUIWindowPVRRadioRecordings);
+  Add(new CGUIWindowPVRRadioGuide);
+  Add(new CGUIWindowPVRRadioTimers);
+  Add(new CGUIWindowPVRRadioTimerRules);
+  Add(new CGUIWindowPVRRadioSearch);
   Add(new CGUIDialogPVRRadioRDSInfo);
-  Add(new CGUIWindowPVRSearch(true));
   Add(new CGUIDialogPVRGuideInfo);
   Add(new CGUIDialogPVRRecordingInfo);
   Add(new CGUIDialogPVRTimerSettings);

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -208,7 +208,12 @@ namespace PVR
     const bool bRadio(CPVRItem(item).IsRadio());
 
     int windowSearchId = bRadio ? WINDOW_RADIO_SEARCH : WINDOW_TV_SEARCH;
-    CGUIWindowPVRSearch *windowSearch = g_windowManager.GetWindow<CGUIWindowPVRSearch>(windowSearchId);
+    CGUIWindowPVRSearchBase *windowSearch;
+    if (bRadio)
+      windowSearch = g_windowManager.GetWindow<CGUIWindowPVRRadioSearch>(windowSearchId);
+    else
+      windowSearch = g_windowManager.GetWindow<CGUIWindowPVRTVSearch>(windowSearchId);
+
     if (!windowSearch)
     {
       CLog::Log(LOGERROR, "PVRGUIActions - %s - unable to get %s!", __FUNCTION__, bRadio ? "WINDOW_RADIO_SEARCH" : "WINDOW_TV_SEARCH");

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -114,7 +114,7 @@ namespace PVR
      */
     virtual ~CPVRManager(void);
 
-    virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
 
     /*!
      * @brief Get the channel groups container.
@@ -546,7 +546,7 @@ namespace PVR
     /*!
      * @brief PVR update and control thread.
      */
-    virtual void Process(void) override;
+    void Process(void) override;
 
   private:
     /*!

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -109,14 +109,14 @@ namespace PVR
      * @param bDataChanged True if the client's data changed, false otherwise (unused).
      * @return True if the client was found and restarted, false otherwise.
      */
-    virtual bool RequestRestart(ADDON::AddonPtr addon, bool bDataChanged) override;
+    bool RequestRestart(ADDON::AddonPtr addon, bool bDataChanged) override;
 
     /*!
      * @brief Remove a single client add-on.
      * @param addon The add-on to remove.
      * @return True if the client was found and removed, false otherwise.
      */
-    virtual bool RequestRemoval(ADDON::AddonPtr addon) override;
+    bool RequestRemoval(ADDON::AddonPtr addon) override;
 
     /*!
      * @brief Unload all loaded add-ons and reset all class properties.

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -262,7 +262,7 @@ namespace PVR
 
     //@}
 
-    virtual void OnSettingChanged(const CSetting *setting) override;
+    void OnSettingChanged(const CSetting *setting) override;
 
     /*!
      * @brief Get a channel given it's EPG ID.

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -30,15 +30,15 @@ namespace PVR
   public:
     CGUIDialogPVRGuideInfo(void);
     virtual ~CGUIDialogPVRGuideInfo(void);
-    virtual bool OnMessage(CGUIMessage& message) override;
-    virtual bool OnInfo(int actionID) override;
-    virtual bool HasListItems() const override { return true; };
-    virtual CFileItemPtr GetCurrentListItem(int offset = 0) override;
+    bool OnMessage(CGUIMessage& message) override;
+    bool OnInfo(int actionID) override;
+    bool HasListItems() const override { return true; };
+    CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
     void SetProgInfo(const CPVREpgInfoTagPtr &tag);
 
   protected:
-    virtual void OnInitWindow() override;
+    void OnInitWindow() override;
 
     bool OnClickButtonOK(CGUIMessage &message);
     bool OnClickButtonRecord(CGUIMessage &message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -28,10 +28,10 @@ namespace PVR
   public:
     CGUIDialogPVRRecordingInfo(void);
     virtual ~CGUIDialogPVRRecordingInfo(void) {}
-    virtual bool OnMessage(CGUIMessage& message) override;
-    virtual bool OnInfo(int actionID) override;
-    virtual bool HasListItems() const override { return true; };
-    virtual CFileItemPtr GetCurrentListItem(int offset = 0) override;
+    bool OnMessage(CGUIMessage& message) override;
+    bool OnInfo(int actionID) override;
+    bool HasListItems() const override { return true; };
+    CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
     void SetRecording(const CFileItem *item);
 

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -110,7 +110,7 @@ namespace PVR
      * @param obs The observable that sent the update.
      * @param msg The update message.
      */
-    virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
+    void Notify(const Observable &obs, const ObservableMessage msg) override;
 
     CPVREpgPtr CreateChannelEpg(const PVR::CPVRChannelPtr &channel);
 
@@ -249,7 +249,7 @@ namespace PVR
     /*!
      * @brief EPG update thread
      */
-    virtual void Process(void) override;
+    void Process(void) override;
 
     /*!
      * @brief Load all tables from the database

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -57,17 +57,19 @@ namespace PVR
   {
   public:
     virtual ~CGUIWindowPVRBase(void);
-    virtual void OnInitWindow(void) override;
-    virtual void OnDeinitWindow(int nextWindowID) override;
-    virtual bool OnMessage(CGUIMessage& message) override;
-    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
-    virtual void UpdateButtons(void) override;
-    virtual bool OnAction(const CAction &action) override;
-    virtual bool OnBack(int actionID) override;
+
+    void OnInitWindow(void) override;
+    void OnDeinitWindow(int nextWindowID) override;
+    bool OnMessage(CGUIMessage& message) override;
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+    void UpdateButtons(void) override;
+    bool OnAction(const CAction &action) override;
+    bool OnBack(int actionID) override;
+    void Notify(const Observable &obs, const ObservableMessage msg) override;
+    void SetInvalid() override;
+    bool CanBeActivated() const override;
+
     virtual bool OpenChannelGroupSelectionDialog(void);
-    virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
-    virtual void SetInvalid() override;
-    virtual bool CanBeActivated() const override;
 
     static std::string GetSelectedItemPath(bool bRadio);
     static void SetSelectedItemPath(bool bRadio, const std::string &path);

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -43,8 +43,8 @@
 
 using namespace PVR;
 
-CGUIWindowPVRChannels::CGUIWindowPVRChannels(bool bRadio) :
-  CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_CHANNELS : WINDOW_TV_CHANNELS, "MyPVRChannels.xml"),
+CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string &xmlFile) :
+  CGUIWindowPVRBase(bRadio, id, xmlFile),
   CPVRChannelNumberInputHandler(1000),
   m_bShowHiddenChannels(false)
 {
@@ -52,13 +52,13 @@ CGUIWindowPVRChannels::CGUIWindowPVRChannels(bool bRadio) :
   g_infoManager.RegisterObserver(this);
 }
 
-CGUIWindowPVRChannels::~CGUIWindowPVRChannels()
+CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase()
 {
   g_infoManager.UnregisterObserver(this);
   CServiceBroker::GetPVRManager().EpgContainer().UnregisterObserver(this);
 }
 
-void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &buttons)
+void CGUIWindowPVRChannelsBase::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   // Add parent buttons before the Manage button
   CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
@@ -66,14 +66,7 @@ void CGUIWindowPVRChannels::GetContextButtons(int itemNumber, CContextButtons &b
   buttons.Add(CONTEXT_BUTTON_EDIT, 16106); /* Manage... */
 }
 
-std::string CGUIWindowPVRChannels::GetDirectoryPath(void)
-{
-  return StringUtils::Format("pvr://channels/%s/%s/",
-      m_bRadio ? "radio" : "tv",
-      m_bShowHiddenChannels ? ".hidden" : GetChannelGroup()->GroupName().c_str());
-}
-
-bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
+bool CGUIWindowPVRChannelsBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return false;
@@ -82,7 +75,7 @@ bool CGUIWindowPVRChannels::OnContextButton(int itemNumber, CONTEXT_BUTTON butto
       CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRChannelsBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory);
 
@@ -101,7 +94,7 @@ bool CGUIWindowPVRChannels::Update(const std::string &strDirectory, bool updateF
   return bReturn;
 }
 
-void CGUIWindowPVRChannels::UpdateButtons(void)
+void CGUIWindowPVRChannelsBase::UpdateButtons(void)
 {
   CGUIRadioButtonControl *btnShowHidden = (CGUIRadioButtonControl*) GetControl(CONTROL_BTNSHOWHIDDEN);
   if (btnShowHidden)
@@ -114,7 +107,7 @@ void CGUIWindowPVRChannels::UpdateButtons(void)
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022) : GetChannelGroup()->GroupName());
 }
 
-bool CGUIWindowPVRChannels::OnAction(const CAction &action)
+bool CGUIWindowPVRChannelsBase::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
@@ -135,7 +128,7 @@ bool CGUIWindowPVRChannels::OnAction(const CAction &action)
   return CGUIWindowPVRBase::OnAction(action);
 }
 
-bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
+bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
 {
   bool bReturn = false;
   switch (message.GetMessage())
@@ -217,7 +210,7 @@ bool CGUIWindowPVRChannels::OnMessage(CGUIMessage& message)
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRChannels::OnContextButtonManage(const CFileItemPtr &item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRChannelsBase::OnContextButtonManage(const CFileItemPtr &item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
@@ -258,7 +251,7 @@ bool CGUIWindowPVRChannels::OnContextButtonManage(const CFileItemPtr &item, CONT
   return bReturn;
 }
 
-void CGUIWindowPVRChannels::UpdateEpg(const CFileItemPtr &item)
+void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr &item)
 {
   const CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
 
@@ -291,14 +284,14 @@ void CGUIWindowPVRChannels::UpdateEpg(const CFileItemPtr &item)
   }
 }
 
-void CGUIWindowPVRChannels::ShowChannelManager()
+void CGUIWindowPVRChannelsBase::ShowChannelManager()
 {
   CGUIDialogPVRChannelManager *dialog = g_windowManager.GetWindow<CGUIDialogPVRChannelManager>(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
   if (dialog)
     dialog->Open();
 }
 
-void CGUIWindowPVRChannels::ShowGroupManager(void)
+void CGUIWindowPVRChannelsBase::ShowGroupManager(void)
 {
   /* Load group manager dialog */
   CGUIDialogPVRGroupManager* pDlgInfo = g_windowManager.GetWindow<CGUIDialogPVRGroupManager>(WINDOW_DIALOG_PVR_GROUP_MANAGER);
@@ -311,7 +304,7 @@ void CGUIWindowPVRChannels::ShowGroupManager(void)
   return;
 }
 
-void CGUIWindowPVRChannels::OnInputDone()
+void CGUIWindowPVRChannelsBase::OnInputDone()
 {
   const int iChannelNumber = GetChannelNumber();
   if (iChannelNumber >= 0)
@@ -327,4 +320,26 @@ void CGUIWindowPVRChannels::OnInputDone()
       ++itemIndex;
     }
   }
+}
+
+CGUIWindowPVRTVChannels::CGUIWindowPVRTVChannels()
+  : CGUIWindowPVRChannelsBase(false, WINDOW_TV_CHANNELS, "MyPVRChannels.xml")
+{
+}
+
+std::string CGUIWindowPVRTVChannels::GetDirectoryPath()
+{
+  return StringUtils::Format("pvr://channels/tv/%s/",
+                             m_bShowHiddenChannels ? ".hidden" : GetChannelGroup()->GroupName().c_str());
+}
+
+CGUIWindowPVRRadioChannels::CGUIWindowPVRRadioChannels()
+  : CGUIWindowPVRChannelsBase(true, WINDOW_RADIO_CHANNELS, "MyPVRChannels.xml")
+{
+}
+
+std::string CGUIWindowPVRRadioChannels::GetDirectoryPath()
+{
+  return StringUtils::Format("pvr://channels/radio/%s/",
+                             m_bShowHiddenChannels ? ".hidden" : GetChannelGroup()->GroupName().c_str());
 }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -25,11 +25,11 @@
 
 namespace PVR
 {
-  class CGUIWindowPVRChannels : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
+  class CGUIWindowPVRChannelsBase : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
   {
   public:
-    CGUIWindowPVRChannels(bool bRadio);
-    virtual ~CGUIWindowPVRChannels(void);
+    CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string &xmlFile);
+    virtual ~CGUIWindowPVRChannelsBase();
 
     virtual bool OnMessage(CGUIMessage& message) override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
@@ -41,9 +41,6 @@ namespace PVR
     // CPVRChannelNumberInputHandler implementation
     void OnInputDone() override;
 
-  protected:
-    virtual std::string GetDirectoryPath(void) override;
-
   private:
     bool OnContextButtonManage(const CFileItemPtr &item, CONTEXT_BUTTON button);
 
@@ -51,6 +48,25 @@ namespace PVR
     void ShowGroupManager();
     void UpdateEpg(const CFileItemPtr &item);
 
+  protected:
     bool m_bShowHiddenChannels;
+  };
+
+  class CGUIWindowPVRTVChannels : public CGUIWindowPVRChannelsBase
+  {
+  public:
+    CGUIWindowPVRTVChannels();
+
+  protected:
+    std::string GetDirectoryPath() override;
+  };
+
+  class CGUIWindowPVRRadioChannels : public CGUIWindowPVRChannelsBase
+  {
+  public:
+    CGUIWindowPVRRadioChannels();
+
+  protected:
+    std::string GetDirectoryPath() override;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -31,12 +31,12 @@ namespace PVR
     CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRChannelsBase();
 
-    virtual bool OnMessage(CGUIMessage& message) override;
-    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
-    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
-    virtual void UpdateButtons(void) override;
-    virtual bool OnAction(const CAction &action) override;
+    bool OnMessage(CGUIMessage& message) override;
+    void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+    void UpdateButtons(void) override;
+    bool OnAction(const CAction &action) override;
 
     // CPVRChannelNumberInputHandler implementation
     void OnInputDone() override;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -43,8 +43,8 @@
 
 using namespace PVR;
 
-CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
-  CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_GUIDE : WINDOW_TV_GUIDE, "MyPVRGuide.xml"),
+CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string &xmlFile) :
+  CGUIWindowPVRBase(bRadio, id, xmlFile),
   CPVRChannelNumberInputHandler(1000),
   m_bChannelSelectionRestored(false)
 {
@@ -52,7 +52,7 @@ CGUIWindowPVRGuide::CGUIWindowPVRGuide(bool bRadio) :
   CServiceBroker::GetPVRManager().EpgContainer().RegisterObserver(this);
 }
 
-CGUIWindowPVRGuide::~CGUIWindowPVRGuide(void)
+CGUIWindowPVRGuideBase::~CGUIWindowPVRGuideBase()
 {
   CServiceBroker::GetPVRManager().EpgContainer().UnregisterObserver(this);
 
@@ -60,12 +60,12 @@ CGUIWindowPVRGuide::~CGUIWindowPVRGuide(void)
   StopRefreshTimelineItemsThread();
 }
 
-CGUIEPGGridContainer* CGUIWindowPVRGuide::GetGridControl()
+CGUIEPGGridContainer* CGUIWindowPVRGuideBase::GetGridControl()
 {
   return dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
 }
 
-void CGUIWindowPVRGuide::Init()
+void CGUIWindowPVRGuideBase::Init()
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
@@ -83,7 +83,7 @@ void CGUIWindowPVRGuide::Init()
   StartRefreshTimelineItemsThread();
 }
 
-void CGUIWindowPVRGuide::ClearData()
+void CGUIWindowPVRGuideBase::ClearData()
 {
   {
     CSingleLock lock(m_critSection);
@@ -94,7 +94,7 @@ void CGUIWindowPVRGuide::ClearData()
   CGUIWindowPVRBase::ClearData();
 }
 
-void CGUIWindowPVRGuide::OnInitWindow()
+void CGUIWindowPVRGuideBase::OnInitWindow()
 {
   if (m_guiState.get())
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
@@ -105,7 +105,7 @@ void CGUIWindowPVRGuide::OnInitWindow()
   CGUIWindowPVRBase::OnInitWindow();
 }
 
-void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
+void CGUIWindowPVRGuideBase::OnDeinitWindow(int nextWindowID)
 {
   StopRefreshTimelineItemsThread();
 
@@ -124,20 +124,20 @@ void CGUIWindowPVRGuide::OnDeinitWindow(int nextWindowID)
   CGUIWindowPVRBase::OnDeinitWindow(nextWindowID);
 }
 
-void CGUIWindowPVRGuide::StartRefreshTimelineItemsThread()
+void CGUIWindowPVRGuideBase::StartRefreshTimelineItemsThread()
 {
   StopRefreshTimelineItemsThread();
   m_refreshTimelineItemsThread.reset(new CPVRRefreshTimelineItemsThread(this));
   m_refreshTimelineItemsThread->Create();
 }
 
-void CGUIWindowPVRGuide::StopRefreshTimelineItemsThread()
+void CGUIWindowPVRGuideBase::StopRefreshTimelineItemsThread()
 {
   if (m_refreshTimelineItemsThread)
     m_refreshTimelineItemsThread->Stop();
 }
 
-void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage msg)
+void CGUIWindowPVRGuideBase::Notify(const Observable &obs, const ObservableMessage msg)
 {
   if (msg == ObservableMessageEpg ||
       msg == ObservableMessageEpgContainer ||
@@ -153,7 +153,7 @@ void CGUIWindowPVRGuide::Notify(const Observable &obs, const ObservableMessage m
   }
 }
 
-void CGUIWindowPVRGuide::SetInvalid()
+void CGUIWindowPVRGuideBase::SetInvalid()
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
@@ -162,7 +162,7 @@ void CGUIWindowPVRGuide::SetInvalid()
   CGUIWindowPVRBase::SetInvalid();
 }
 
-void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &buttons)
+void CGUIWindowPVRGuideBase::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return;
@@ -174,7 +174,7 @@ void CGUIWindowPVRGuide::GetContextButtons(int itemNumber, CContextButtons &butt
   CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
-void CGUIWindowPVRGuide::UpdateSelectedItemPath()
+void CGUIWindowPVRGuideBase::UpdateSelectedItemPath()
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
@@ -185,14 +185,14 @@ void CGUIWindowPVRGuide::UpdateSelectedItemPath()
   }
 }
 
-void CGUIWindowPVRGuide::UpdateButtons(void)
+void CGUIWindowPVRGuideBase::UpdateButtons(void)
 {
   CGUIWindowPVRBase::UpdateButtons();
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetChannelGroup()->GroupName());
 }
 
-bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory, updateFilterPath);
 
@@ -206,7 +206,7 @@ bool CGUIWindowPVRGuide::Update(const std::string &strDirectory, bool updateFilt
   return bReturn;
 }
 
-bool CGUIWindowPVRGuide::GetDirectory(const std::string &strDirectory, CFileItemList &items)
+bool CGUIWindowPVRGuideBase::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   bool bRefreshTimelineItems = false;
 
@@ -240,7 +240,7 @@ bool CGUIWindowPVRGuide::GetDirectory(const std::string &strDirectory, CFileItem
   return true;
 }
 
-bool CGUIWindowPVRGuide::OnAction(const CAction &action)
+bool CGUIWindowPVRGuideBase::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
@@ -267,7 +267,7 @@ bool CGUIWindowPVRGuide::OnAction(const CAction &action)
   return CGUIWindowPVRBase::OnAction(action);
 }
 
-bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
+bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
 {
   bool bReturn = false;
   switch (message.GetMessage())
@@ -447,7 +447,7 @@ bool CGUIWindowPVRGuide::OnMessage(CGUIMessage& message)
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
+bool CGUIWindowPVRGuideBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return false;
@@ -459,7 +459,7 @@ bool CGUIWindowPVRGuide::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPVRGuide::RefreshTimelineItems()
+bool CGUIWindowPVRGuideBase::RefreshTimelineItems()
 {
   bool bRefreshTimelineItems;
   {
@@ -513,7 +513,7 @@ bool CGUIWindowPVRGuide::RefreshTimelineItems()
   return false;
 }
 
-bool CGUIWindowPVRGuide::OnContextButtonBegin(CFileItem *item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRGuideBase::OnContextButtonBegin(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
@@ -527,7 +527,7 @@ bool CGUIWindowPVRGuide::OnContextButtonBegin(CFileItem *item, CONTEXT_BUTTON bu
   return bReturn;
 }
 
-bool CGUIWindowPVRGuide::OnContextButtonEnd(CFileItem *item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRGuideBase::OnContextButtonEnd(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
@@ -541,7 +541,7 @@ bool CGUIWindowPVRGuide::OnContextButtonEnd(CFileItem *item, CONTEXT_BUTTON butt
   return bReturn;
 }
 
-bool CGUIWindowPVRGuide::OnContextButtonNow(CFileItem *item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRGuideBase::OnContextButtonNow(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
@@ -555,7 +555,7 @@ bool CGUIWindowPVRGuide::OnContextButtonNow(CFileItem *item, CONTEXT_BUTTON butt
   return bReturn;
 }
 
-void CGUIWindowPVRGuide::OnInputDone()
+void CGUIWindowPVRGuideBase::OnInputDone()
 {
   const int iChannelNumber = GetChannelNumber();
   if (iChannelNumber >= 0)
@@ -576,7 +576,7 @@ void CGUIWindowPVRGuide::OnInputDone()
   }
 }
 
-CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuide *pGuideWindow)
+CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase *pGuideWindow)
 : CThread("epg-grid-refresh-timeline-items"),
   m_pGuideWindow(pGuideWindow),
   m_ready(true),

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -33,11 +33,11 @@ namespace PVR
   class CGUIEPGGridContainer;
   class CPVRRefreshTimelineItemsThread;
 
-  class CGUIWindowPVRGuide : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
+  class CGUIWindowPVRGuideBase : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
   {
   public:
-    CGUIWindowPVRGuide(bool bRadio);
-    virtual ~CGUIWindowPVRGuide(void);
+    CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string &xmlFile);
+    virtual ~CGUIWindowPVRGuideBase();
 
     virtual void OnInitWindow() override;
     virtual void OnDeinitWindow(int nextWindowID) override;
@@ -85,10 +85,22 @@ namespace PVR
     bool m_bChannelSelectionRestored;
   };
 
+  class CGUIWindowPVRTVGuide : public CGUIWindowPVRGuideBase
+  {
+  public:
+    CGUIWindowPVRTVGuide() : CGUIWindowPVRGuideBase(false, WINDOW_TV_GUIDE, "MyPVRGuide.xml") {}
+  };
+
+  class CGUIWindowPVRRadioGuide : public CGUIWindowPVRGuideBase
+  {
+  public:
+    CGUIWindowPVRRadioGuide() : CGUIWindowPVRGuideBase(true, WINDOW_RADIO_GUIDE, "MyPVRGuide.xml") {}
+  };
+
   class CPVRRefreshTimelineItemsThread : public CThread
   {
   public:
-    CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuide *pGuideWindow);
+    CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase *pGuideWindow);
     virtual ~CPVRRefreshTimelineItemsThread();
 
     virtual void Process();
@@ -97,7 +109,7 @@ namespace PVR
     void Stop();
 
   private:
-    CGUIWindowPVRGuide *m_pGuideWindow;
+    CGUIWindowPVRGuideBase *m_pGuideWindow;
     CEvent m_ready;
     CEvent m_done;
   };

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -39,15 +39,15 @@ namespace PVR
     CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRGuideBase();
 
-    virtual void OnInitWindow() override;
-    virtual void OnDeinitWindow(int nextWindowID) override;
-    virtual bool OnMessage(CGUIMessage& message) override;
-    virtual bool OnAction(const CAction &action) override;
-    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
-    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    virtual void UpdateButtons(void) override;
-    virtual void Notify(const Observable &obs, const ObservableMessage msg) override;
-    virtual void SetInvalid() override;
+    void OnInitWindow() override;
+    void OnDeinitWindow(int nextWindowID) override;
+    bool OnMessage(CGUIMessage& message) override;
+    bool OnAction(const CAction &action) override;
+    void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    void UpdateButtons(void) override;
+    void Notify(const Observable &obs, const ObservableMessage msg) override;
+    void SetInvalid() override;
     bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
 
     bool RefreshTimelineItems();
@@ -56,9 +56,9 @@ namespace PVR
     void OnInputDone() override;
 
   protected:
-    virtual void UpdateSelectedItemPath() override;
-    virtual std::string GetDirectoryPath(void) override { return ""; }
-    virtual bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
+    void UpdateSelectedItemPath() override;
+    std::string GetDirectoryPath(void) override { return ""; }
+    bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
 
     void ClearData() override;
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -39,8 +39,8 @@
 
 using namespace PVR;
 
-CGUIWindowPVRRecordings::CGUIWindowPVRRecordings(bool bRadio) :
-  CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_RECORDINGS : WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml") ,
+CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio, int id, const std::string &xmlFile) :
+  CGUIWindowPVRBase(bRadio, id, xmlFile),
   m_bShowDeletedRecordings(false),
   m_settings({
     CSettings::SETTING_PVRRECORD_GROUPRECORDINGS,
@@ -50,23 +50,23 @@ CGUIWindowPVRRecordings::CGUIWindowPVRRecordings(bool bRadio) :
   g_infoManager.RegisterObserver(this);
 }
 
-CGUIWindowPVRRecordings::~CGUIWindowPVRRecordings()
+CGUIWindowPVRRecordingsBase::~CGUIWindowPVRRecordingsBase()
 {
   g_infoManager.UnregisterObserver(this);
 }
 
-void CGUIWindowPVRRecordings::OnWindowLoaded()
+void CGUIWindowPVRRecordingsBase::OnWindowLoaded()
 {
   CONTROL_SELECT(CONTROL_BTNGROUPITEMS);
 }
 
-std::string CGUIWindowPVRRecordings::GetDirectoryPath(void)
+std::string CGUIWindowPVRRecordingsBase::GetDirectoryPath()
 {
   const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings, m_bRadio);
   return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }
 
-void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons &buttons)
+void CGUIWindowPVRRecordingsBase::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return;
@@ -96,7 +96,7 @@ void CGUIWindowPVRRecordings::GetContextButtons(int itemNumber, CContextButtons 
     CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
-bool CGUIWindowPVRRecordings::OnAction(const CAction &action)
+bool CGUIWindowPVRRecordingsBase::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_PARENT_DIR ||
       action.GetID() == ACTION_NAV_BACK)
@@ -111,7 +111,7 @@ bool CGUIWindowPVRRecordings::OnAction(const CAction &action)
   return CGUIWindowPVRBase::OnAction(action);
 }
 
-bool CGUIWindowPVRRecordings::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
+bool CGUIWindowPVRRecordingsBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return false;
@@ -121,7 +121,7 @@ bool CGUIWindowPVRRecordings::OnContextButton(int itemNumber, CONTEXT_BUTTON but
       CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPVRRecordings::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRRecordingsBase::Update(const std::string &strDirectory, bool updateFilterPath /* = true */)
 {
   m_thumbLoader.StopThread();
 
@@ -159,7 +159,7 @@ bool CGUIWindowPVRRecordings::Update(const std::string &strDirectory, bool updat
   return bReturn;
 }
 
-void CGUIWindowPVRRecordings::UpdateButtons(void)
+void CGUIWindowPVRRecordingsBase::UpdateButtons()
 {
   int iWatchMode = CMediaSettings::GetInstance().GetWatchedMode("recordings");
   int iStringId = 257; // "Error"
@@ -190,7 +190,7 @@ void CGUIWindowPVRRecordings::UpdateButtons(void)
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, bGroupRecordings && path.IsValid() ? path.GetUnescapedDirectoryPath() : "");
 }
 
-bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
+bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage &message)
 {
   bool bReturn = false;
   switch (message.GetMessage())
@@ -325,7 +325,7 @@ bool CGUIWindowPVRRecordings::OnMessage(CGUIMessage &message)
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRRecordings::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRRecordingsBase::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_BUTTON button)
 {
   if (button == CONTEXT_BUTTON_DELETE_ALL)
   {
@@ -336,7 +336,7 @@ bool CGUIWindowPVRRecordings::OnContextButtonDeleteAll(CFileItem *item, CONTEXT_
   return false;
 }
 
-void CGUIWindowPVRRecordings::OnPrepareFileItems(CFileItemList& items)
+void CGUIWindowPVRRecordingsBase::OnPrepareFileItems(CFileItemList& items)
 {
   if (items.IsEmpty())
     return;
@@ -362,7 +362,7 @@ void CGUIWindowPVRRecordings::OnPrepareFileItems(CFileItemList& items)
   CGUIWindowPVRBase::OnPrepareFileItems(items);
 }
 
-bool CGUIWindowPVRRecordings::GetFilteredItems(const std::string &filter, CFileItemList &items)
+bool CGUIWindowPVRRecordingsBase::GetFilteredItems(const std::string &filter, CFileItemList &items)
 {
   bool listchanged = CGUIWindowPVRBase::GetFilteredItems(filter, items);
 

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -34,17 +34,17 @@ namespace PVR
     CGUIWindowPVRRecordingsBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRRecordingsBase();
 
-    virtual void OnWindowLoaded() override;
-    virtual bool OnMessage(CGUIMessage& message) override;
-    virtual bool OnAction(const CAction &action) override;
-    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
-    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
-    virtual void UpdateButtons() override;
+    void OnWindowLoaded() override;
+    bool OnMessage(CGUIMessage& message) override;
+    bool OnAction(const CAction &action) override;
+    void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
+    void UpdateButtons() override;
 
   protected:
-    virtual std::string GetDirectoryPath(void) override;
-    virtual void OnPrepareFileItems(CFileItemList &items) override;
+    std::string GetDirectoryPath(void) override;
+    void OnPrepareFileItems(CFileItemList &items) override;
     bool GetFilteredItems(const std::string &filter, CFileItemList &items) override;
 
   private:

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -28,11 +28,11 @@
 
 namespace PVR
 {
-  class CGUIWindowPVRRecordings : public CGUIWindowPVRBase
+  class CGUIWindowPVRRecordingsBase : public CGUIWindowPVRBase
   {
   public:
-    CGUIWindowPVRRecordings(bool bRadio);
-    virtual ~CGUIWindowPVRRecordings(void);
+    CGUIWindowPVRRecordingsBase(bool bRadio, int id, const std::string &xmlFile);
+    virtual ~CGUIWindowPVRRecordingsBase();
 
     virtual void OnWindowLoaded() override;
     virtual bool OnMessage(CGUIMessage& message) override;
@@ -40,7 +40,7 @@ namespace PVR
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
     virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
     virtual bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
-    virtual void UpdateButtons(void) override;
+    virtual void UpdateButtons() override;
 
   protected:
     virtual std::string GetDirectoryPath(void) override;
@@ -54,5 +54,17 @@ namespace PVR
     CVideoDatabase m_database;
     bool m_bShowDeletedRecordings;
     CPVRSettings m_settings;
+  };
+
+  class CGUIWindowPVRTVRecordings : public CGUIWindowPVRRecordingsBase
+  {
+  public:
+    CGUIWindowPVRTVRecordings() : CGUIWindowPVRRecordingsBase(false, WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml") {}
+  };
+
+  class CGUIWindowPVRRadioRecordings : public CGUIWindowPVRRecordingsBase
+  {
+  public:
+    CGUIWindowPVRRadioRecordings() : CGUIWindowPVRRecordingsBase(true, WINDOW_RADIO_RECORDINGS, "MyPVRRecordings.xml") {}
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -67,13 +67,13 @@ namespace
   }
 } // unnamed namespace
 
-CGUIWindowPVRSearch::CGUIWindowPVRSearch(bool bRadio) :
-  CGUIWindowPVRBase(bRadio, bRadio ? WINDOW_RADIO_SEARCH : WINDOW_TV_SEARCH, "MyPVRSearch.xml"),
+CGUIWindowPVRSearchBase::CGUIWindowPVRSearchBase(bool bRadio, int id, const std::string &xmlFile) :
+  CGUIWindowPVRBase(bRadio, id, xmlFile),
   m_bSearchConfirmed(false)
 {
 }
 
-void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &buttons)
+void CGUIWindowPVRSearchBase::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return;
@@ -83,7 +83,7 @@ void CGUIWindowPVRSearch::GetContextButtons(int itemNumber, CContextButtons &but
   CGUIWindowPVRBase::GetContextButtons(itemNumber, buttons);
 }
 
-bool CGUIWindowPVRSearch::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
+bool CGUIWindowPVRSearchBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return false;
@@ -93,7 +93,7 @@ bool CGUIWindowPVRSearch::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-void CGUIWindowPVRSearch::SetItemToSearch(const CFileItemPtr &item)
+void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItemPtr &item)
 {
   m_searchfilter.Reset();
 
@@ -114,7 +114,7 @@ void CGUIWindowPVRSearch::SetItemToSearch(const CFileItemPtr &item)
     Refresh(true);
 }
 
-void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
+void CGUIWindowPVRSearchBase::OnPrepareFileItems(CFileItemList &items)
 {
   bool bAddSpecialSearchItem = items.IsEmpty();
 
@@ -140,7 +140,7 @@ void CGUIWindowPVRSearch::OnPrepareFileItems(CFileItemList &items)
   }
 }
 
-bool CGUIWindowPVRSearch::OnMessage(CGUIMessage &message)
+bool CGUIWindowPVRSearchBase::OnMessage(CGUIMessage &message)
 {
   if (message.GetMessage() == GUI_MSG_CLICKED)
   {
@@ -181,7 +181,7 @@ bool CGUIWindowPVRSearch::OnMessage(CGUIMessage &message)
   return CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRSearch::OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRSearchBase::OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
@@ -198,7 +198,7 @@ bool CGUIWindowPVRSearch::OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON b
   return bReturn;
 }
 
-void CGUIWindowPVRSearch::OpenDialogSearch()
+void CGUIWindowPVRSearchBase::OpenDialogSearch()
 {
   CGUIDialogPVRGuideSearch* dlgSearch = g_windowManager.GetWindow<CGUIDialogPVRGuideSearch>(WINDOW_DIALOG_PVR_GUIDE_SEARCH);
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -24,11 +24,11 @@
 
 namespace PVR
 {
-  class CGUIWindowPVRSearch : public CGUIWindowPVRBase
+  class CGUIWindowPVRSearchBase : public CGUIWindowPVRBase
   {
   public:
-    CGUIWindowPVRSearch(bool bRadio);
-    virtual ~CGUIWindowPVRSearch(void) {};
+    CGUIWindowPVRSearchBase(bool bRadio, int id, const std::string &xmlFile);
+    virtual ~CGUIWindowPVRSearchBase() {};
 
     virtual bool OnMessage(CGUIMessage& message)  override;
     virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
@@ -49,7 +49,19 @@ namespace PVR
 
     void OpenDialogSearch();
 
-    bool                  m_bSearchConfirmed;
+    bool m_bSearchConfirmed;
     CPVREpgSearchFilter m_searchfilter;
+  };
+
+  class CGUIWindowPVRTVSearch : public CGUIWindowPVRSearchBase
+  {
+  public:
+    CGUIWindowPVRTVSearch() : CGUIWindowPVRSearchBase(false, WINDOW_TV_SEARCH, "MyPVRSearch.xml") {}
+  };
+
+  class CGUIWindowPVRRadioSearch : public CGUIWindowPVRSearchBase
+  {
+  public:
+    CGUIWindowPVRRadioSearch() : CGUIWindowPVRSearchBase(true, WINDOW_RADIO_SEARCH, "MyPVRSearch.xml") {}
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -30,9 +30,9 @@ namespace PVR
     CGUIWindowPVRSearchBase(bool bRadio, int id, const std::string &xmlFile);
     virtual ~CGUIWindowPVRSearchBase() {};
 
-    virtual bool OnMessage(CGUIMessage& message)  override;
-    virtual void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
-    virtual bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+    bool OnMessage(CGUIMessage& message)  override;
+    void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
 
     /*!
      * @brief set the item to search similar events for.
@@ -41,8 +41,8 @@ namespace PVR
     void SetItemToSearch(const CFileItemPtr &item);
 
   protected:
-    virtual void OnPrepareFileItems(CFileItemList &items) override;
-    virtual std::string GetDirectoryPath(void) override { return ""; }
+    void OnPrepareFileItems(CFileItemList &items) override;
+    std::string GetDirectoryPath(void) override { return ""; }
 
   private:
     bool OnContextButtonClear(CFileItem *item, CONTEXT_BUTTON button);

--- a/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
@@ -26,13 +26,24 @@
 
 using namespace PVR;
 
-CGUIWindowPVRTimerRules::CGUIWindowPVRTimerRules(bool bRadio) :
-  CGUIWindowPVRTimersBase(bRadio, bRadio ? WINDOW_RADIO_TIMER_RULES : WINDOW_TV_TIMER_RULES, "MyPVRTimers.xml")
+CGUIWindowPVRTVTimerRules::CGUIWindowPVRTVTimerRules() :
+  CGUIWindowPVRTimersBase(false, WINDOW_TV_TIMER_RULES, "MyPVRTimers.xml")
 {
 }
 
-std::string CGUIWindowPVRTimerRules::GetDirectoryPath(void)
+std::string CGUIWindowPVRTVTimerRules::GetDirectoryPath()
 {
-  const std::string basePath(CPVRTimersPath(m_bRadio, true).GetPath());
+  const std::string basePath(CPVRTimersPath(false, true).GetPath());
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
+}
+
+CGUIWindowPVRRadioTimerRules::CGUIWindowPVRRadioTimerRules() :
+CGUIWindowPVRTimersBase(true, WINDOW_RADIO_TIMER_RULES, "MyPVRTimers.xml")
+{
+}
+
+std::string CGUIWindowPVRRadioTimerRules::GetDirectoryPath()
+{
+  const std::string basePath(CPVRTimersPath(true, true).GetPath());
   return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRTimerRules.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimerRules.h
@@ -25,13 +25,23 @@
 
 namespace PVR
 {
-  class CGUIWindowPVRTimerRules : public CGUIWindowPVRTimersBase
+  class CGUIWindowPVRTVTimerRules : public CGUIWindowPVRTimersBase
   {
   public:
-    CGUIWindowPVRTimerRules(bool bRadio);
-    virtual ~CGUIWindowPVRTimerRules(void) {};
+    CGUIWindowPVRTVTimerRules();
+    virtual ~CGUIWindowPVRTVTimerRules() {};
 
   protected:
-    virtual std::string GetDirectoryPath(void) override;
+    std::string GetDirectoryPath() override;
+  };
+
+  class CGUIWindowPVRRadioTimerRules : public CGUIWindowPVRTimersBase
+  {
+  public:
+    CGUIWindowPVRRadioTimerRules();
+    virtual ~CGUIWindowPVRRadioTimerRules() {};
+
+  protected:
+    std::string GetDirectoryPath() override;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -25,13 +25,24 @@
 
 using namespace PVR;
 
-CGUIWindowPVRTimers::CGUIWindowPVRTimers(bool bRadio) :
-  CGUIWindowPVRTimersBase(bRadio, bRadio ? WINDOW_RADIO_TIMERS : WINDOW_TV_TIMERS, "MyPVRTimers.xml")
+CGUIWindowPVRTVTimers::CGUIWindowPVRTVTimers() :
+  CGUIWindowPVRTimersBase(false, WINDOW_TV_TIMERS, "MyPVRTimers.xml")
 {
 }
 
-std::string CGUIWindowPVRTimers::GetDirectoryPath(void)
+std::string CGUIWindowPVRTVTimers::GetDirectoryPath()
 {
-  const std::string basePath(CPVRTimersPath(m_bRadio, false).GetPath());
+  const std::string basePath(CPVRTimersPath(false, false).GetPath());
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
+}
+
+CGUIWindowPVRRadioTimers::CGUIWindowPVRRadioTimers() :
+CGUIWindowPVRTimersBase(true, WINDOW_RADIO_TIMERS, "MyPVRTimers.xml")
+{
+}
+
+std::string CGUIWindowPVRRadioTimers::GetDirectoryPath()
+{
+  const std::string basePath(CPVRTimersPath(true, false).GetPath());
   return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.h
@@ -25,13 +25,21 @@
 
 namespace PVR
 {
-  class CGUIWindowPVRTimers : public CGUIWindowPVRTimersBase
+  class CGUIWindowPVRTVTimers : public CGUIWindowPVRTimersBase
   {
   public:
-    CGUIWindowPVRTimers(bool bRadio);
-    virtual ~CGUIWindowPVRTimers(void) {};
+    CGUIWindowPVRTVTimers();
 
   protected:
-    virtual std::string GetDirectoryPath(void) override;
+    std::string GetDirectoryPath() override;
+  };
+
+  class CGUIWindowPVRRadioTimers : public CGUIWindowPVRTimersBase
+  {
+  public:
+    CGUIWindowPVRRadioTimers();
+
+  protected:
+    std::string GetDirectoryPath() override;
   };
 }


### PR DESCRIPTION
1) Get rid of 'bRadio' parameter to categorize windows: introduce dedicated tv|radio window classes.
2) Remove superfluous 'virtual' from overridden methods.

Runtime-tested on macOS, latest kodi master.
