### PR TITLE
[travis] use precompiled FFmpeg to reduce job time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
       gettext git-core gperf libasound2-dev libass-dev libbz2-dev libcap-dev libcdio-dev libcec4-dev libcrossguid-dev libcurl3
       libcurl4-openssl-dev libdbus-1-dev libfmt3-dev libfontconfig-dev libegl1-mesa-dev libfreetype6-dev libfribidi-dev libgif-dev
       libiso9660-dev libjpeg-dev liblcms2-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmysqlclient-dev libnfs-dev
-      libpcre3-dev libplist-dev libpng-dev libpulse-dev libsmbclient-dev libsqlite3-dev libssh-dev
+      libpcre3-dev libplist-dev libpng-dev libpulse-dev libsmbclient-dev libsox-dev libsqlite3-dev libssh-dev
       libssl-dev libtag1-dev libtinyxml-dev libtool libudev-dev libusb-dev libva-dev libvdpau-dev
       libxml2-dev libxmu-dev libxrandr-dev libxrender-dev libxslt1-dev libxt-dev libyajl-dev mesa-utils
       nasm pmount python-dev python-imaging python-sqlite rapidjson-dev swig unzip uuid-dev yasm zip zlib1g-dev;

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_install:
       sudo add-apt-repository -y ppa:wsnipex/vaapi &&
       sudo add-apt-repository -y ppa:george-edison55/cmake-3.x &&
       sudo add-apt-repository -y ppa:pulse-eight/libcec &&
+      sudo add-apt-repository -y ppa:mc3man/trusty-media &&
       sudo apt-get update -qq;
     fi
 
@@ -69,7 +70,7 @@ install:
 # Linux dependencies
 #
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" ]]; then
-      sudo apt-get install -qq automake autopoint build-essential cmake curl default-jre gawk gdb gdc
+      sudo apt-get install -qq automake autopoint build-essential cmake curl default-jre ffmpeg gawk gdb gdc
       gettext git-core gperf libasound2-dev libass-dev libbz2-dev libcap-dev libcdio-dev libcec4-dev libcrossguid-dev libcurl3
       libcurl4-openssl-dev libdbus-1-dev libfmt3-dev libfontconfig-dev libegl1-mesa-dev libfreetype6-dev libfribidi-dev libgif-dev
       libiso9660-dev libjpeg-dev liblcms2-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmysqlclient-dev libnfs-dev
@@ -91,10 +92,10 @@ before_script:
       cd $TRAVIS_BUILD_DIR/build;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" && "$CXX" == "g++" ]]; then
-      cmake -DCMAKE_BUILD_TYPE=Debug ..;
+      cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_INTERNAL_FFMPEG:BOOL=OFF -DFFMPEG_PATH:PATH=/opt/ffmpeg ..;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$BUILD" == "Kodi" && "$CXX" == "clang++" ]]; then
-      cmake -DCMAKE_CXX_FLAGS="-Qunused-arguments" ..;
+      cmake -DCMAKE_CXX_FLAGS="-Qunused-arguments" -DENABLE_INTERNAL_FFMPEG:BOOL=OFF -DFFMPEG_PATH:PATH=/opt/ffmpeg ..;
     fi
   - if [[ "$BUILD" != "Kodi" ]] && [[ "$ADDONS" == "adsp" || "$ADDONS" == "audiodecoder" || "$ADDONS" == "audioencoder" ||
           "$ADDONS" == "pvr" || "$ADDONS" == "screensaver" || "$ADDONS" == "visualization" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use precompiled FFmpeg on travis to reduce the execution time of a job.
<!--- Describe your change in detail -->

## Motivation and Context
Jobs get killed, because they exceeded the maximum time limit for jobs.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):--

<!--## Types of change-->
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
