### PR TITLE
[buildsteps][windows] run-tests: use 64-bit toolset if available

### DIFF
--- a/tools/buildsteps/windows/run-tests.bat
+++ b/tools/buildsteps/windows/run-tests.bat
@@ -25,6 +25,7 @@ SET exitcode=0
 SET useshell=sh
 SET BRANCH=na
 SET buildconfig=Release
+SET PreferredToolArchitecture=x64
 
 
   :: sets the BRANCH env var


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use the 64-bit (crosscompiler) toolset on a 64-Bit OS if it is available, otherwise fall back to the 32-Bit toolset for run-test.
<!--- Describe your change in detail -->

## Motivation and Context
For compiling kodi 64-bit toolset is already used (#11845). If not using the same toolset for kodi-test as for kodi the whole Visual Studio Solution get recompiled which increases build time unnecessary.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
