### PR TITLE
Krypton: add replaygain to dsf files

### DIFF
--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -71,6 +71,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Base64.h"
 #include "settings/AdvancedSettings.h"
+#include "MusicInfoTagLoaderFFmpeg.h"
 
 using namespace TagLib;
 using namespace MUSIC_INFO;
@@ -1123,6 +1124,12 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
         file = oggVorbisFile = new Ogg::Vorbis::File(stream);
       }
     }
+    else if (strExtension == "dsf" || strExtension == "mka")
+    {
+		  CMusicInfoTagLoaderFFmpeg dsf;
+		  if (dsf.Load(strFileName, tag, art))
+			  CLog::Log(LOGDEBUG, "reading dsf tags");
+    }
   }
   catch (const std::exception& ex)
   {
@@ -1133,7 +1140,8 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
   {
     delete file;
     delete stream;
-    CLog::Log(LOGDEBUG, "file %s could not be opened for tag reading", strFileName.c_str());
+    if (strExtension != "dsf" && strExtension != "mka")
+      CLog::Log(LOGDEBUG, "file could not be opened for tag reading");
     return false;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Add parsing of replaygain info from dsf file when reading those files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Up to now replaygain is never applied when you read a dsf file. With this patch replaygain is parsed and correctly applied.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested with my own dsf files, checking the logs to verify the correct replaygain was applied on my files when reading them.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
