### PR TITLE
Set Param1 to WINDOW_INVALID for plugins when Init is called

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1490,8 +1490,8 @@ void CGUIMediaWindow::OnInitWindow()
   }
   else
   {
-    CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, 0, PLUGIN_REFRESH_DELAY);
-    g_windowManager.SendThreadMessage(msg, m_controlID);
+    CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, PLUGIN_REFRESH_DELAY);
+    g_windowManager.SendThreadMessage(msg, GetID());
   }
 
   if (updateStartDirectory)


### PR DESCRIPTION

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Small fix to send the correct WINDOW_INVALID in Param1 of the window init message that is send if the window is showing the content from a plugin.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
For opening addons with ActivateWindow the return param was being ignored, this was a bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Run all built time tests and built in tests.
Tested that when ActivateWindow is called with return the history is correctly set to just the root entry point.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
