### PR TITLE
[estuary] Fix channel osd recording indicator visibility.

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -49,7 +49,7 @@
 					<visible>player.chaptercount</visible>
 				</control>
 				<control type="group">
-					<visible>Player.Recording + !PVR.ChannelPreviewActive</visible>
+					<visible>Player.Recording + !Player.ChannelPreviewActive</visible>
 					<control type="image">
 						<top>100</top>
 						<left>20</left>


### PR DESCRIPTION
This fixes a small issue caused by a typo in Estuary's DialogSeekBar.xml - there is no PVR.ChannelPreviewActive info bool, only Player.ChannelPreviewActive.

0) Ensure no recordings are active
1) Use the Guide window to start recording the current show on channel X
2) switch to channel X, fullscreen
3) press pgup => osd for channel X appears, lower left corner has "currently recording" indicator, which is okay
4)  press pgup again => osd for channel Y appears
=> bug: although channel Y does not record anything, lower left corner still has the "currently recording" indicator".

@phil65 @ronie good to go?
