### PR TITLE
GUI: Provide mechanism to disable gui overlay when empty

### DIFF
--- a/xbmc/linux/DllBCM.h
+++ b/xbmc/linux/DllBCM.h
@@ -73,7 +73,18 @@ public:
                                                               VC_DISPMANX_ALPHA_T *alpha,
                                                               DISPMANX_CLAMP_T *clamp, DISPMANX_TRANSFORM_T transform ) = 0;
   virtual int vc_dispmanx_update_submit_sync( DISPMANX_UPDATE_HANDLE_T update ) = 0;
+  virtual int vc_dispmanx_update_submit( DISPMANX_UPDATE_HANDLE_T update, DISPMANX_CALLBACK_FUNC_T cb_func, void *cb_arg ) = 0;
+
   virtual int vc_dispmanx_element_remove( DISPMANX_UPDATE_HANDLE_T update, DISPMANX_ELEMENT_HANDLE_T element ) = 0;
+  virtual int vc_dispmanx_element_change_attributes( DISPMANX_UPDATE_HANDLE_T update,
+                                                              DISPMANX_ELEMENT_HANDLE_T element,
+                                                              uint32_t change_flags,
+                                                              int32_t layer,
+                                                              uint8_t opacity,
+                                                              const VC_RECT_T *dest_rect,
+                                                              const VC_RECT_T *src_rect,
+                                                              DISPMANX_RESOURCE_HANDLE_T mask,
+                                                              DISPMANX_TRANSFORM_T transform ) = 0;
   virtual int vc_dispmanx_display_close( DISPMANX_DISPLAY_HANDLE_T display ) = 0;
   virtual int vc_dispmanx_display_get_info( DISPMANX_DISPLAY_HANDLE_T display, DISPMANX_MODEINFO_T * pinfo ) = 0;
   virtual int vc_dispmanx_display_set_background( DISPMANX_UPDATE_HANDLE_T update, DISPMANX_DISPLAY_HANDLE_T display,
@@ -138,8 +149,20 @@ public:
     { return ::vc_dispmanx_element_add(update, display, layer, dest_rect, src, src_rect, protection, alpha, clamp, transform); };
   virtual int vc_dispmanx_update_submit_sync( DISPMANX_UPDATE_HANDLE_T update )
     { return ::vc_dispmanx_update_submit_sync(update); };
+  virtual int vc_dispmanx_update_submit( DISPMANX_UPDATE_HANDLE_T update, DISPMANX_CALLBACK_FUNC_T cb_func, void *cb_arg )
+    { return ::vc_dispmanx_update_submit(update, cb_func, cb_arg); };
   virtual int vc_dispmanx_element_remove( DISPMANX_UPDATE_HANDLE_T update, DISPMANX_ELEMENT_HANDLE_T element )
     { return ::vc_dispmanx_element_remove(update, element); };
+  virtual int vc_dispmanx_element_change_attributes( DISPMANX_UPDATE_HANDLE_T update,
+                                                              DISPMANX_ELEMENT_HANDLE_T element,
+                                                              uint32_t change_flags,
+                                                              int32_t layer,
+                                                              uint8_t opacity,
+                                                              const VC_RECT_T *dest_rect,
+                                                              const VC_RECT_T *src_rect,
+                                                              DISPMANX_RESOURCE_HANDLE_T mask,
+                                                              DISPMANX_TRANSFORM_T transform )
+    { return ::vc_dispmanx_element_change_attributes( update, element, change_flags, layer, opacity, dest_rect, src_rect, mask, transform ); };
   virtual int vc_dispmanx_display_close( DISPMANX_DISPLAY_HANDLE_T display )
     { return ::vc_dispmanx_display_close(display); };
   virtual int vc_dispmanx_display_get_info( DISPMANX_DISPLAY_HANDLE_T display, DISPMANX_MODEINFO_T *pinfo )
@@ -192,7 +215,17 @@ class DllBcmHost : public DllDynamic, DllBcmHostInterface
                                                                        VC_DISPMANX_ALPHA_T *p8,
                                                                        DISPMANX_CLAMP_T *p9, DISPMANX_TRANSFORM_T p10 ))
   DEFINE_METHOD1(int, vc_dispmanx_update_submit_sync, (DISPMANX_UPDATE_HANDLE_T p1))
+  DEFINE_METHOD3(int, vc_dispmanx_update_submit, (DISPMANX_UPDATE_HANDLE_T p1, DISPMANX_CALLBACK_FUNC_T p2, void *p3))
   DEFINE_METHOD2(int, vc_dispmanx_element_remove, (DISPMANX_UPDATE_HANDLE_T p1, DISPMANX_ELEMENT_HANDLE_T p2))
+  DEFINE_METHOD9(int, vc_dispmanx_element_change_attributes, ( DISPMANX_UPDATE_HANDLE_T p1,
+                                                                DISPMANX_ELEMENT_HANDLE_T p2,
+                                                                uint32_t p3,
+                                                                int32_t p4,
+                                                                uint8_t p5,
+                                                                const VC_RECT_T *p6,
+                                                                const VC_RECT_T *p7rect,
+                                                                DISPMANX_RESOURCE_HANDLE_T p8,
+                                                                DISPMANX_TRANSFORM_T p9))
   DEFINE_METHOD1(int, vc_dispmanx_display_close, (DISPMANX_DISPLAY_HANDLE_T p1))
   DEFINE_METHOD2(int, vc_dispmanx_display_get_info, (DISPMANX_DISPLAY_HANDLE_T p1, DISPMANX_MODEINFO_T *p2))
   DEFINE_METHOD5(int, vc_dispmanx_display_set_background, ( DISPMANX_UPDATE_HANDLE_T p1, DISPMANX_DISPLAY_HANDLE_T p2,
@@ -219,7 +252,9 @@ class DllBcmHost : public DllDynamic, DllBcmHostInterface
     RESOLVE_METHOD(vc_dispmanx_update_start)
     RESOLVE_METHOD(vc_dispmanx_element_add)
     RESOLVE_METHOD(vc_dispmanx_update_submit_sync)
+    RESOLVE_METHOD(vc_dispmanx_update_submit)
     RESOLVE_METHOD(vc_dispmanx_element_remove)
+    RESOLVE_METHOD(vc_dispmanx_element_change_attributes)
     RESOLVE_METHOD(vc_dispmanx_display_close)
     RESOLVE_METHOD(vc_dispmanx_display_get_info)
     RESOLVE_METHOD(vc_dispmanx_display_set_background)

--- a/xbmc/windowing/rpi/RPIUtils.h
+++ b/xbmc/windowing/rpi/RPIUtils.h
@@ -30,6 +30,7 @@ public:
   CRPIUtils();
   virtual ~CRPIUtils();
   virtual void DestroyDispmanxWindow();
+  virtual void SetVisible(bool enable);
   virtual bool GetNativeResolution(RESOLUTION_INFO *res) const;
   virtual bool SetNativeResolution(const RESOLUTION_INFO res, EGLSurface m_nativeWindow);
   virtual bool ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
@@ -42,6 +43,10 @@ private:
   RESOLUTION_INFO m_desktopRes;
   int m_width;
   int m_height;
+  int m_screen_width;
+  int m_screen_height;
+  bool m_shown;
+
   int m_initDesktopRes;
 
   void GetSupportedModes(HDMI_RES_GROUP_T group, std::vector<RESOLUTION_INFO> &resolutions);

--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -226,6 +226,11 @@ bool CWinSystemRpi::Show(bool raise)
   return true;
 }
 
+void CWinSystemRpi::SetVisible(bool visible)
+{
+  m_rpi->SetVisible(visible);
+}
+
 void CWinSystemRpi::Register(IDispResource *resource)
 {
   CSingleLock lock(m_resourceSection);

--- a/xbmc/windowing/rpi/WinSystemRpi.h
+++ b/xbmc/windowing/rpi/WinSystemRpi.h
@@ -47,6 +47,7 @@ public:
 
   bool Hide() override;
   bool Show(bool raise = true) override;
+  void SetVisible(bool visible);
   virtual void Register(IDispResource *resource);
   virtual void Unregister(IDispResource *resource);
 protected:

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -18,8 +18,10 @@
  *
  */
 
+#include "Application.h"
 #include "VideoSyncPi.h"
 #include "WinSystemRpiGLESContext.h"
+#include "guilib/GUIWindowManager.h"
 #include "utils/log.h"
 
 bool CWinSystemRpiGLESContext::InitWindowSystem()
@@ -111,6 +113,8 @@ void CWinSystemRpiGLESContext::SetVSyncImpl(bool enable)
 
 void CWinSystemRpiGLESContext::PresentRenderImpl(bool rendered)
 {
+  CWinSystemRpi::SetVisible(g_windowManager.HasVisibleControls() || g_application.m_pPlayer->IsRenderingGuiLayer());
+
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
GUI: Provide mechanism to disable gui overlay when empty

## Motivation and Context
1080p60 requires 480MB/s of sdram bandwidth to display the Kodi GUI.
When playing a video that doesn't use subtitles or have the OSD active this bandwidth
is just wasted fetching transparent pixels.
Benchmarks show about 10% better performance when software decoding HEVC on a Pi3
when this bandwidth is not being consumed.

## How Has This Been Tested?
This has been in recent Milhouse builds and improved HEVC performance has been observed.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
