### PR TITLE
reenable mark as watched/unwatched for folders

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -56,6 +56,7 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
 
   if (item.m_bIsFolder) //Only allow db content and recording folders to be updated recursively
   {
+    return true;
     if (item.HasVideoInfoTag())
       return item.IsVideoDb();
     else
@@ -80,6 +81,7 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
 
   if (item.m_bIsFolder) //Only allow db content and recording folders to be updated recursively
   {
+    return true;
     if (item.HasVideoInfoTag())
       return item.IsVideoDb();
     else


### PR DESCRIPTION
this is just a quick hack to reenable mark as watched/unwatched for folders. it works just fine, but i wonder why you went to length to nuiter the functionality so i open this to get the attention.

ref http://forum.kodi.tv/showthread.php?tid=311447&pid=2581701#pid2581701