### PR TITLE
[settings] fix default formatting of slider settings

### DIFF
--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -259,11 +259,11 @@ bool CSettingControlSlider::Deserialize(const TiXmlNode *node, bool update /* = 
 bool CSettingControlSlider::SetFormat(const std::string &format)
 {
   if (StringUtils::EqualsNoCase(format, "percentage"))
-    m_format = "%i %%";
+    m_formatString = "%i %%";
   else if (StringUtils::EqualsNoCase(format, "integer"))
-    m_format = "%d";
+    m_formatString = "%d";
   else if (StringUtils::EqualsNoCase(format, "number"))
-    m_format = "%.1f";
+    m_formatString = "%.1f";
   else
     return false;
 


### PR DESCRIPTION
This fixes the default formatting for settings using a slider control which currently doesn't show any value at all.

There's no need for a backport because no setting in Krypton uses a slider control.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
