### PR TITLE
[settings] CGUIControlListSetting: don't disable control for multiselect settings

### DIFF
--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -366,10 +366,11 @@ bool CGUIControlListSetting::OnClick()
     return false;
 
   CFileItemList options;
-  if (!GetItems(m_pSetting, options) || options.Size() <= 1)
-    return false;
-
   const CSettingControlList *control = static_cast<const CSettingControlList*>(m_pSetting->GetControl());
+  if (!GetItems(m_pSetting, options) ||
+      options.Size() <= 0 ||
+     (!control->CanMultiSelect() && options.Size() <= 1))
+    return false;
   
   dialog->Reset();
   dialog->SetHeading(CVariant{g_localizeStrings.Get(m_pSetting->GetLabel())});
@@ -454,8 +455,12 @@ void CGUIControlListSetting::Update(bool updateDisplayOnly /* = false */)
 
   m_pButton->SetLabel2(label2);
 
-  // disable the control if it has less than two items
-  if (!m_pButton->IsDisabled() && options.Size() <= 1)
+  // disable the control if
+  // * there are no items to be chosen
+  // * only one value can be chosen and there are less than two items available
+  if (!m_pButton->IsDisabled() &&
+     (options.Size() <= 0 ||
+     (!control->CanMultiSelect() && options.Size() <= 1)))
     m_pButton->SetEnabled(false);
 }
 


### PR DESCRIPTION
This prevents the setting control for multiselect settings to be disabled if there's only one setting because the user can still decide whether or not to select that single item.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
