### PR TITLE
[settings] fix custom localization of setting labels/options

### DIFF
--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -158,7 +158,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag, std::
     strDirectory = recordingpathSetting->GetValue();
     if (strDirectory.empty())
     {
-      if (CGUIControlButtonSetting::GetPath(recordingpathSetting))
+      if (CGUIControlButtonSetting::GetPath(recordingpathSetting, &g_localizeStrings))
         strDirectory = recordingpathSetting->GetValue();
     }
   }

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -35,6 +35,8 @@
 #include <string>
 #include <stdint.h>
 
+#include "utils/ILocalizer.h"
+
 /*!
  \ingroup strings
  \brief
@@ -50,7 +52,7 @@ struct LocStr
 const std::string LANGUAGE_DEFAULT = "resource.language.en_gb";
 const std::string LANGUAGE_OLD_DEFAULT = "English";
 
-class CLocalizeStrings
+class CLocalizeStrings : public ILocalizer
 {
 public:
   CLocalizeStrings(void);
@@ -62,6 +64,9 @@ public:
   const std::string& Get(uint32_t code) const;
   std::string GetAddonString(const std::string& addonId, uint32_t code);
   void Clear();
+
+  // implementation of ILocalizer
+  std::string Localize(std::uint32_t code) const override { return Get(code); }
 
 protected:
   void Clear(uint32_t start, uint32_t end);

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -620,7 +620,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
       return NULL;
 
     ((CGUIRadioButtonControl *)pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlRadioButtonSetting((CGUIRadioButtonControl *)pControl, iControlID, pSetting));
+    pSettingControl.reset(new CGUIControlRadioButtonSetting((CGUIRadioButtonControl *)pControl, iControlID, pSetting, this));
   }
   else if (controlType == "spinner")
   {
@@ -630,7 +630,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
       return NULL;
 
     ((CGUISpinControlEx *)pControl)->SetText(label);
-    pSettingControl.reset(new CGUIControlSpinExSetting((CGUISpinControlEx *)pControl, iControlID, pSetting));
+    pSettingControl.reset(new CGUIControlSpinExSetting((CGUISpinControlEx *)pControl, iControlID, pSetting, this));
   }
   else if (controlType == "edit")
   {
@@ -640,7 +640,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
       return NULL;
       
     ((CGUIEditControl *)pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlEditSetting((CGUIEditControl *)pControl, iControlID, pSetting));
+    pSettingControl.reset(new CGUIControlEditSetting((CGUIEditControl *)pControl, iControlID, pSetting, this));
   }
   else if (controlType == "list")
   {
@@ -650,7 +650,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
       return NULL;
 
     ((CGUIButtonControl *)pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlListSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
+    pSettingControl.reset(new CGUIControlListSetting((CGUIButtonControl *)pControl, iControlID, pSetting, this));
   }
   else if (controlType == "button" || controlType == "slider")
   {
@@ -663,7 +663,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
         return NULL;
       
       ((CGUIButtonControl *)pControl)->SetLabel(label);
-      pSettingControl.reset(new CGUIControlButtonSetting((CGUIButtonControl *)pControl, iControlID, pSetting));
+      pSettingControl.reset(new CGUIControlButtonSetting((CGUIButtonControl *)pControl, iControlID, pSetting, this));
     }
     else
     {
@@ -673,7 +673,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
         return NULL;
       
       ((CGUISettingsSliderControl *)pControl)->SetText(label);
-      pSettingControl.reset(new CGUIControlSliderSetting((CGUISettingsSliderControl *)pControl, iControlID, pSetting));
+      pSettingControl.reset(new CGUIControlSliderSetting((CGUISettingsSliderControl *)pControl, iControlID, pSetting, this));
     }
   }
   else if (controlType == "range")
@@ -684,7 +684,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(CSetting *pSetting, float width,
       return NULL;
 
     ((CGUISettingsSliderControl *)pControl)->SetText(label);
-    pSettingControl.reset(new CGUIControlRangeSetting((CGUISettingsSliderControl *)pControl, iControlID, pSetting));
+    pSettingControl.reset(new CGUIControlRangeSetting((CGUISettingsSliderControl *)pControl, iControlID, pSetting, this));
   }
   else
     return NULL;
@@ -704,7 +704,7 @@ CGUIControl* CGUIDialogSettingsBase::AddSeparator(float width, int &iControlID)
   if (pControl == NULL)
     return NULL;
 
-  return AddSettingControl(pControl, BaseSettingControlPtr(new CGUIControlSeparatorSetting((CGUIImage *)pControl, iControlID)), width, iControlID);
+  return AddSettingControl(pControl, BaseSettingControlPtr(new CGUIControlSeparatorSetting((CGUIImage *)pControl, iControlID, this)), width, iControlID);
 }
 
 CGUIControl* CGUIDialogSettingsBase::AddLabel(float width, int &iControlID, int label)
@@ -718,7 +718,7 @@ CGUIControl* CGUIDialogSettingsBase::AddLabel(float width, int &iControlID, int 
 
   ((CGUILabelControl *)pControl)->SetLabel(GetLocalizedString(label));
 
-  return AddSettingControl(pControl, BaseSettingControlPtr(new CGUIControlGroupTitleSetting((CGUILabelControl *)pControl, iControlID)), width, iControlID);
+  return AddSettingControl(pControl, BaseSettingControlPtr(new CGUIControlGroupTitleSetting((CGUILabelControl *)pControl, iControlID, this)), width, iControlID);
 }
 
 CGUIControl* CGUIDialogSettingsBase::AddSettingControl(CGUIControl *pControl, BaseSettingControlPtr pSettingControl, float width, int &iControlID)

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -26,6 +26,7 @@
 #include "settings/SettingControl.h"
 #include "settings/lib/ISettingCallback.h"
 #include "threads/Timer.h"
+#include "utils/ILocalizer.h"
 
 #define CONTROL_SETTINGS_LABEL          2
 #define CONTROL_SETTINGS_DESCRIPTION    6
@@ -64,6 +65,7 @@ typedef std::shared_ptr<CGUIControlBaseSetting> BaseSettingControlPtr;
 class CGUIDialogSettingsBase
   : public CGUIDialog,
     public CSettingControlCreator,
+    public ILocalizer,
     protected ITimerCallback,
     protected ISettingCallback
 {
@@ -78,6 +80,9 @@ public:
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
 
   virtual bool IsConfirmed() const { return m_confirmed; }
+
+  // implementation of ILocalizer
+  std::string Localize(std::uint32_t code) const override { return GetLocalizedString(code); }
 
 protected:
   // specializations of CGUIWindow

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -19,9 +19,12 @@
  *
  */
 
-#include "guilib/ISliderCallback.h"
 #include <stdlib.h>
+#include <functional>
 #include <string>
+
+#include "guilib/ISliderCallback.h"
+#include "utils/ILocalizer.h"
 
 class CGUIControl;
 class CGUIImage;
@@ -40,10 +43,10 @@ class CSettingPath;
 class CFileItemList;
 class CVariant;
 
-class CGUIControlBaseSetting
+class CGUIControlBaseSetting : protected ILocalizer
 {
 public:
-  CGUIControlBaseSetting(int id, CSetting *pSetting);
+  CGUIControlBaseSetting(int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlBaseSetting() {}
   
   int GetID() const { return m_id; }
@@ -88,8 +91,12 @@ public:
   virtual void Update(bool updateDisplayOnly = false);
   virtual void Clear() = 0;  ///< Clears the attached control
 protected:
+  // implementation of ILocalizer
+  std::string Localize(std::uint32_t code) const override;
+
   int m_id;
   CSetting* m_pSetting;
+  ILocalizer* m_localizer;
   bool m_delayed;
   bool m_valid;
 };
@@ -97,7 +104,7 @@ protected:
 class CGUIControlRadioButtonSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlRadioButtonSetting(CGUIRadioButtonControl* pRadioButton, int id, CSetting *pSetting);
+  CGUIControlRadioButtonSetting(CGUIRadioButtonControl* pRadioButton, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlRadioButtonSetting();
 
   void Select(bool bSelect);
@@ -113,7 +120,7 @@ private:
 class CGUIControlSpinExSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlSpinExSetting(CGUISpinControlEx* pSpin, int id, CSetting *pSetting);
+  CGUIControlSpinExSetting(CGUISpinControlEx* pSpin, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlSpinExSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pSpin; }
@@ -129,7 +136,7 @@ private:
 class CGUIControlListSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlListSetting(CGUIButtonControl* pButton, int id, CSetting *pSetting);
+  CGUIControlListSetting(CGUIButtonControl* pButton, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlListSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pButton; }
@@ -137,8 +144,9 @@ public:
   virtual void Update(bool updateDisplayOnly = false);
   virtual void Clear() { m_pButton = NULL; }
 private:
-  static bool GetItems(const CSetting *setting, CFileItemList &items);
-  static bool GetIntegerItems(const CSetting *setting, CFileItemList &items);
+  bool GetItems(const CSetting *setting, CFileItemList &items) const;
+  bool GetIntegerItems(const CSetting *setting, CFileItemList &items) const;
+
   static bool GetStringItems(const CSetting *setting, CFileItemList &items);
 
   CGUIButtonControl *m_pButton;
@@ -147,7 +155,7 @@ private:
 class CGUIControlButtonSetting : public CGUIControlBaseSetting, protected ISliderCallback
 {
 public:
-  CGUIControlButtonSetting(CGUIButtonControl* pButton, int id, CSetting *pSetting);
+  CGUIControlButtonSetting(CGUIButtonControl* pButton, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlButtonSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pButton; }
@@ -155,7 +163,7 @@ public:
   virtual void Update(bool updateDisplayOnly = false);
   virtual void Clear() { m_pButton = NULL; }
 
-  static bool GetPath(CSettingPath *pathSetting);
+  static bool GetPath(CSettingPath *pathSetting, ILocalizer* localizer);
 protected:
   // implementations of ISliderCallback
   virtual void OnSliderChange(void *data, CGUISliderControl *slider);
@@ -167,7 +175,7 @@ private:
 class CGUIControlEditSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlEditSetting(CGUIEditControl* pButton, int id, CSetting *pSetting);
+  CGUIControlEditSetting(CGUIEditControl* pButton, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlEditSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pEdit; }
@@ -183,7 +191,7 @@ private:
 class CGUIControlSliderSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlSliderSetting(CGUISettingsSliderControl* pSlider, int id, CSetting *pSetting);
+  CGUIControlSliderSetting(CGUISettingsSliderControl* pSlider, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlSliderSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pSlider; }
@@ -191,7 +199,7 @@ public:
   virtual void Update(bool updateDisplayOnly = false);
   virtual void Clear() { m_pSlider = NULL; }
 
-  static std::string GetText(const CSettingControlSlider *control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum);
+  static std::string GetText(const CSettingControlSlider *control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum, ILocalizer* localizer);
 
 private:
   CGUISettingsSliderControl *m_pSlider;
@@ -200,7 +208,7 @@ private:
 class CGUIControlRangeSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlRangeSetting(CGUISettingsSliderControl* pSlider, int id, CSetting *pSetting);
+  CGUIControlRangeSetting(CGUISettingsSliderControl* pSlider, int id, CSetting *pSetting, ILocalizer* localizer);
   virtual ~CGUIControlRangeSetting();
   
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pSlider; }
@@ -215,7 +223,7 @@ private:
 class CGUIControlSeparatorSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlSeparatorSetting(CGUIImage* pImage, int id);
+  CGUIControlSeparatorSetting(CGUIImage* pImage, int id, ILocalizer* localizer);
   virtual ~CGUIControlSeparatorSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pImage; }
@@ -229,7 +237,7 @@ private:
 class CGUIControlGroupTitleSetting : public CGUIControlBaseSetting
 {
 public:
-  CGUIControlGroupTitleSetting(CGUILabelControl* pLabel, int id);
+  CGUIControlGroupTitleSetting(CGUILabelControl* pLabel, int id, ILocalizer* localizer);
   virtual ~CGUIControlGroupTitleSetting();
 
   virtual CGUIControl* GetControl() { return (CGUIControl*)m_pLabel; }

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -108,6 +108,7 @@ set(HEADERS ActorProtocol.h
             HttpRangeUtils.h
             HttpResponse.h
             IArchivable.h
+            ILocalizer.h
             InfoLoader.h
             IRssObserver.h
             ISerializable.h

--- a/xbmc/utils/ILocalizer.h
+++ b/xbmc/utils/ILocalizer.h
@@ -1,0 +1,34 @@
+#pragma once
+/*
+*      Copyright (C) 2017 Team XBMC
+*      http://xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, see
+*  <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include <cstdint>
+#include <string>
+
+class ILocalizer
+{
+public:
+  virtual ~ILocalizer() = default;
+
+  virtual std::string Localize(std::uint32_t code) const = 0;
+
+protected:
+  ILocalizer() = default;
+};

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -43,6 +43,7 @@
 #include "filesystem/File.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 
 #include "utils/JobManager.h"
 #include "utils/URIUtils.h"
@@ -251,7 +252,7 @@ void CScreenShot::TakeScreenshot()
     strDir = screenshotSetting->GetValue();
     if (strDir.empty())
     {
-      if (CGUIControlButtonSetting::GetPath(screenshotSetting))
+      if (CGUIControlButtonSetting::GetPath(screenshotSetting, &g_localizeStrings))
         strDir = screenshotSetting->GetValue();
     }
   }
@@ -285,7 +286,7 @@ void CScreenShot::TakeScreenshot()
           newDir = screenshotSetting->GetValue();
           if (newDir.empty())
           {
-            if (CGUIControlButtonSetting::GetPath(screenshotSetting))
+            if (CGUIControlButtonSetting::GetPath(screenshotSetting, &g_localizeStrings))
               newDir = screenshotSetting->GetValue();
           }
         }


### PR DESCRIPTION
Right now any settings dialog deriving from `CGUIDialogSettingsBase` can provide its own localization implementation for setting labels etc. This works great but I did not consider the labels used as part of the setting controls which currently all use `g_localizeStrings` instead of the settings dialog's specific localization implementation. This PR fixes it by passing an `ILocalizer` interface implementation to all the relevant parts of the settings GUI code.

Right now probably nobody will notice this because all strings are available through `g_localizeStrings` but it's inconsistent with the initial idea and it will fail when migrating add-on settings to core's settings system. Therefore there's no need for a backport to Krypton.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
