### PR TITLE
[OSX/Windowing] - replace deprecated functions for display mode switching

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -227,9 +227,9 @@ CGDirectDisplayID GetDisplayID(int screen_index)
   return(displayArray[screen_index]);
 }
 
-int DisplayBitsPerPixelForMode(CGDisplayModeRef mode)
+size_t DisplayBitsPerPixelForMode(CGDisplayModeRef mode)
 {
-  int bitsPerPixel = 0;
+  size_t bitsPerPixel = 0;
   
   CFStringRef pixEnc = CGDisplayModeCopyPixelEncoding(mode);
   if(CFStringCompare(pixEnc, CFSTR(IO32BitDirectPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)


### PR DESCRIPTION
As the topic says. This replaces some deprecated calls for switching display modes on osx (refreshrate switching for example).

## Motivation and Context
Just stumbled over it while investigating on how to switch displays into 3d mode via hdmi modes. (which doesn't work at all so there is no PR for this).

## How Has This Been Tested?
Tested on MacMini OSX Sierra (10.12.4) and OSX El Capitan 10.11.6.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Cleanup?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

@FernetMenta for a readover.