### PR TITLE
[GUI] avoid unneccesary work

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -35,6 +35,7 @@ CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float po
   m_totalSize = 0;
   m_orientation = orientation;
   m_alignment = alignment;
+  m_lastScrollerValue = 0;
   m_useControlPositions = useControlPositions;
   ControlType = GUICONTROL_GROUPLIST;
   m_minSize = 0;
@@ -60,12 +61,13 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
   }
 
   ValidateOffset();
-  if (m_pageControl)
+  if (m_pageControl && m_lastScrollerValue != m_scroller.GetValue())
   {
     CGUIMessage message(GUI_MSG_LABEL_RESET, GetParentID(), m_pageControl, (int)Size(), (int)m_totalSize);
     SendWindowMessage(message);
     CGUIMessage message2(GUI_MSG_ITEM_SELECT, GetParentID(), m_pageControl, (int)m_scroller.GetValue());
     SendWindowMessage(message2);
+    m_lastScrollerValue = m_scroller.GetValue();
   }
   // we run through the controls, rendering as we go
   int index = 0;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -83,6 +83,7 @@ protected:
   float m_totalSize;
 
   CScroller m_scroller;
+  int m_lastScrollerValue;
 
   bool m_useControlPositions;
   ORIENTATION m_orientation;


### PR DESCRIPTION
Reduce cpu usage when checking for renderchanges

## Description
Kodi on idle eats a lot of cpu when checking for GUI changes.
Application::FrameMove() calls Process() of the active window and this function iterates through all the skin controls. Profiling this task leads to 2 places where we spend a lot of work for nothing.

This PR changes the idle load of an empty kodi home view from ~12-18% CPU to ~6% CPU usage.
(Android / WETEK HUB)

<!--- Describe your change in detail -->
1.) avoid SendMessage if scrollbar of Grouplist has not changed. SendMessage is one of the most time consuming things, as it iterates again through all the windows to find other receivers.

2.) GUIControl UpdateVisibility; added missing sign that Item is already pushed into the contol info list.

## Motivation and Context
Reduce heat / power consumtion if kodi is in idle
