### PR TITLE
fixup! Remove ClearPicture from VPV and all Codecs

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -192,7 +192,6 @@ bool CRetroPlayerVideo::GetPicture(const uint8_t* data, unsigned int size, Video
     DemuxPacket packet(const_cast<uint8_t*>(data), size, DVD_NOPTS_VALUE, DVD_NOPTS_VALUE);
     if (m_pVideoCodec->AddData(packet))
     {
-      m_pVideoCodec->ClearPicture(&picture);
       CDVDVideoCodec::VCReturn ret = m_pVideoCodec->GetPicture(&picture);
       if (ret == CDVDVideoCodec::VC_PICTURE)
       {


### PR DESCRIPTION
@FernetMenta This just removes the call to `ClearPicture` in RetroPlayer, not runtime tested just compiled.