### PR TITLE
[buildsteps][windows] optimize keeping of downloaded files

### DIFF
--- a/tools/buildsteps/windows/buildffmpeg.sh
+++ b/tools/buildsteps/windows/buildffmpeg.sh
@@ -121,13 +121,13 @@ cd $LOCALBUILDDIR
 
 if do_checkForOptions "--enable-gnutls"; then
 if do_pkgConfig "gnutls = $GNUTLS_VER"; then
-  if [[ ! -f "gnutls-${GNUTLS_VER}.tar.xz" ]]; then
+  if [[ ! -f "/downloads/gnutls-${GNUTLS_VER}.tar.xz" ]]; then
     do_wget "http://mirrors.xbmc.org/build-deps/sources/gnutls-${GNUTLS_VER}.tar.xz"
   fi
   if [ -d "gnutls-${GNUTLS_VER}" ]; then
     rm -r "gnutls-${GNUTLS_VER}"
   fi
-  tar -xaf "gnutls-${GNUTLS_VER}.tar.xz"
+  tar -xaf "/downloads/gnutls-${GNUTLS_VER}.tar.xz"
   cd "gnutls-${GNUTLS_VER}"
 
   do_print_status "gnutls-${GNUTLS_VER}" "$blue_color" "Configuring"

--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -34,9 +34,9 @@ do_wget() {
   local archive="$2"
 
   if [[ -z $archive ]]; then
-    wget --tries=5 --retry-connrefused --waitretry=2 --no-check-certificate -c $URL
+    wget --tries=5 --retry-connrefused --waitretry=2 --no-check-certificate -c -P /downloads/ $URL
   else
-    wget --tries=5 --retry-connrefused --waitretry=2 --no-check-certificate -c $URL -O $archive
+    wget --tries=5 --retry-connrefused --waitretry=2 --no-check-certificate -c $URL -O /downloads/$archive
   fi
 }
 
@@ -116,14 +116,14 @@ do_clean() {
 
 do_download() {
   if [ ! -d $LIBNAME ]; then
-    if [ ! -f $ARCHIVE ]; then
+    if [ ! -f /downloads/$ARCHIVE ]; then
       do_print_status "$ARCHIVE" "$orange_color" "Downloading"
       do_wget $BASE_URL/$VERSION.tar.gz $ARCHIVE
     fi
 
     do_print_status "$ARCHIVE" "$blue_color" "Extracting"
     mkdir $LIBNAME && cd $LIBNAME
-    tar -xaf ../$ARCHIVE --strip 1
+    tar -xaf /downloads/$ARCHIVE --strip 1
   else
     cd $LIBNAME
   fi

--- a/tools/buildsteps/windows/download-msys2.bat
+++ b/tools/buildsteps/windows/download-msys2.bat
@@ -249,6 +249,7 @@ if "%searchRes%"=="local64" GOTO installbase
     (
         echo.
         echo.%instdir%\build\           /build
+        echo.%instdir%\downloads\       /downloads
         echo.%instdir%\local32\         /local32
         echo.%instdir%\local64\         /local64
         echo.%instdir%\%msys2%\mingw32\ /mingw32

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,8 +13,8 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
-ECHO running git clean -xfd -e "lib/libdvd" -e "lib/win32/ffmpeg" -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
-git clean -xfd -e "lib/libdvd" -e "lib/win32/ffmpeg" -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2"
+ECHO running git clean -xffd -e "lib/libdvd" -e "lib/win32/ffmpeg" -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/Win32BuildSetup/dependencies/vcredist"
+git clean -xffd -e "lib/libdvd" -e "lib/win32/ffmpeg" -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/Win32BuildSetup/dependencies/vcredist"
 
 rem cleaning additional directories
 ECHO delete build directories


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Don't remove the downloaded ffmpeg, gnutls and libdvd source code and vcredist for every build on jenkins.
<!--- Describe your change in detail -->

## Motivation and Context
speed up jenkins job and no need to redownload files that never change.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
run the commands execute by jenkins locally
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
