### PR TITLE
[windows] retry download depends & vcredist if it fails

### DIFF
--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -59,7 +59,7 @@ IF EXIST %1 (
 ) ELSE (
   CALL :setSubStageName Downloading %1...
   SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
-  %WGET% "!DOWNLOAD_URL!" 2>&1 || ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST% && EXIT /B 7
+  %WGET% --tries=5 --retry-connrefused --waitretry=2 "!DOWNLOAD_URL!" 2>&1 || ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST% && EXIT /B 7
   TITLE Getting %1
 )
 

--- a/project/Win32BuildSetup/getdeploydependencies.bat
+++ b/project/Win32BuildSetup/getdeploydependencies.bat
@@ -12,7 +12,7 @@ if not exist dependencies\vcredist\2015 mkdir dependencies\vcredist\2015
 
 if not exist dependencies\vcredist\2015\vcredist_%TARGET_ARCHITECTURE%.exe (
   echo Downloading vc140 redist...
-  ..\BuildDependencies\bin\wget -nv -O dependencies\vcredist\2015\vcredist_%TARGET_ARCHITECTURE%.exe %KODI_MIRROR%/build-deps/win32/vcredist/2015/vcredist_%TARGET_ARCHITECTURE%.exe
+  ..\BuildDependencies\bin\wget --tries=5 --retry-connrefused --waitretry=2 -nv -O dependencies\vcredist\2015\vcredist_%TARGET_ARCHITECTURE%.exe %KODI_MIRROR%/build-deps/win32/vcredist/2015/vcredist_%TARGET_ARCHITECTURE%.exe
 )
 :: Restore the previous current directory
 POPD


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Retry to download depends and vcredist in case of a failure.
<!--- Describe your change in detail -->

## Motivation and Context
If a download from a mirror fails the retry will be hopefully redirect to a different mirror which doesn't fail.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
No way to test this properly as I can't force download errors.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!-- ## Screenshots (if appropriate): -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
