### PR TITLE
[Music] Handle duplicate MusicBrainzTrackID within the same album

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -254,7 +254,7 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
     {
       if (!song->strMusicBrainzTrackID.empty())
         for (VECSONGS::const_iterator sourceSong = source.infoSongs.begin(); sourceSong != source.infoSongs.end(); ++sourceSong)
-          if (sourceSong->strMusicBrainzTrackID == song->strMusicBrainzTrackID)
+          if ((sourceSong->strMusicBrainzTrackID == song->strMusicBrainzTrackID) && (sourceSong->iTrack == song->iTrack))
             song->MergeScrapedSong(*sourceSong, override);
     }
   }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -230,7 +230,8 @@ void CMusicDatabase::CreateAnalytics()
   m_pDS->exec("CREATE INDEX idxSong2 ON song(lastplayed)");
   m_pDS->exec("CREATE INDEX idxSong3 ON song(idAlbum)");
   m_pDS->exec("CREATE INDEX idxSong6 ON song( idPath, strFileName(255) )");
-  m_pDS->exec("CREATE UNIQUE INDEX idxSong7 ON song( idAlbum, strMusicBrainzTrackID(36) )");
+  //Musicbrainz Track ID is not unique on an album, recordings are sometimes repeated e.g. "[silence]" or on a disc set
+  m_pDS->exec("CREATE UNIQUE INDEX idxSong7 ON song( idAlbum, iTrack, strMusicBrainzTrackID(36) )");
 
   m_pDS->exec("CREATE UNIQUE INDEX idxSongArtist_1 ON song_artist ( idSong, idArtist, idRole )");
   m_pDS->exec("CREATE INDEX idxSongArtist_2 ON song_artist ( idSong, idRole )");
@@ -684,8 +685,9 @@ int CMusicDatabase::AddSong(const int idAlbum,
     int idPath = AddPath(strPath);
 
     if (!strMusicBrainzTrackID.empty())
-      strSQL = PrepareSQL("SELECT idSong FROM song WHERE idAlbum = %i AND strMusicBrainzTrackID = '%s'",
-                          idAlbum,
+      strSQL = PrepareSQL("SELECT idSong FROM song WHERE idAlbum = %i AND iTrack=%i AND strMusicBrainzTrackID = '%s'",
+                          idAlbum, 
+                          iTrack,
                           strMusicBrainzTrackID.c_str());
     else
       strSQL = PrepareSQL("SELECT idSong FROM song WHERE idAlbum=%i AND strFileName='%s' AND strTitle='%s' AND iTrack=%i AND strMusicBrainzTrackID IS NULL",
@@ -5196,7 +5198,7 @@ void CMusicDatabase::UpdateTables(int version)
 
 int CMusicDatabase::GetSchemaVersion() const
 {
-  return 63;
+  return 64;
 }
 
 int CMusicDatabase::GetMusicNeedsTagScan()


### PR DESCRIPTION
Contrary to previous design assumptions in Kodi, the Musicbrainz database has is a many to many relationship between recordings and releases. This means that the Musicbrainz track id is not unique on an album, the same recording can be repeated e.g. multiple [Silence] tracks or duplications on a disc set.

Example albums:
https://musicbrainz.org/release/986fee20-c98d-3251-8f8d-fa43e0ff840e
https://musicbrainz.org/release/ce44c3b3-6a06-4332-8c6e-950a0f5b6603
these have multiple [silent] tracks with the same "ambient silence".

Blur - 10 Year Anniversary Box Set
https://musicbrainz.org/release/28465118-16ec-4f0f-aae7-bed8f9fc2ed5
track "Song 2" with the same recording ID appears on both CD 17 and CD 20.

Because of the index and processing when scraping albums with mbids, these albums are not correctly loading into the music library, the songs with duplicated Musicbrainz Track Ids get ommited. See discussion http://forum.kodi.tv/showthread.php?tid=305203

It is idAlbum, iTrack, strMusicBrainzTrackID that are the unique in the song table. Bump db for song table index change.