### PR TITLE
[vpupdates] don't enable vdpau on raspberry-pi

### DIFF
--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -26,7 +26,10 @@ ifeq ($(CROSS_COMPILING), yes)
 endif
 ifeq ($(OS), linux)
   ffmpg_config += --target-os=$(OS) --cpu=$(CPU)
-  ffmpg_config += --enable-vdpau --enable-vaapi --enable-pic
+  ifneq ($(TARGET_PLATFORM),raspberry-pi)
+    ffmpg_config += --enable-vdpau --enable-vaapi
+  endif
+  ffmpg_config += --enable-pic
 endif
 ifeq ($(OS), android)
   ifeq ($(findstring arm64, $(CPU)), arm64)


### PR DESCRIPTION
@FernetMenta @peak3d This adds the required switch for enabling vdpau and should fix the RPi compile issue.

@wsnipex Is this okay for you?