### PR TITLE
[depends] libcec: don't query git information

### DIFF
--- a/tools/depends/target/libcec/Makefile
+++ b/tools/depends/target/libcec/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile remove_git_info.patch
 
 # lib name, version
 LIBNAME=libcec
@@ -21,6 +21,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)/build
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../remove_git_info.patch
 	cd $(PLATFORM)/build; $(CMAKE) -DBUILD_SHARED_LIBS=1 -DSKIP_PYTHON_WRAPPER:STRING=1 -DCMAKE_INSTALL_LIBDIR=$(PREFIX)/lib ..
 
 $(LIBDYLIB): $(PLATFORM)

--- a/tools/depends/target/libcec/remove_git_info.patch
+++ b/tools/depends/target/libcec/remove_git_info.patch
@@ -1,0 +1,18 @@
+--- a/src/libcec/cmake/SetBuildInfo.cmake
++++ b/src/libcec/cmake/SetBuildInfo.cmake
+@@ -14,6 +14,7 @@
+   set(LIB_INFO "")
+ 
+   # add git revision to compile info
++  if(0)
+   find_program(HAVE_GIT_BIN git /bin /usr/bin /usr/local/bin)
+   if(HAVE_GIT_BIN)
+     exec_program(${CMAKE_CURRENT_SOURCE_DIR}/cmake/git-rev.sh HEAD OUTPUT_VARIABLE GIT_REVISION)
+@@ -22,6 +23,7 @@
+   if (GIT_REVISION)
+     set(LIB_INFO "git revision: ${GIT_REVISION},")
+   endif()
++  endif()
+ 
+   # add compilation date to compile info
+   find_program(HAVE_DATE_BIN date /bin /usr/bin /usr/local/bin)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Don't query git information in libcec build.
<!--- Describe your change in detail -->

## Motivation and Context
This sometimes produces a string broken up into multiple lines which isn't allowed.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
