### PR TITLE
VideoPlayer: Fix uninitialized variables

### DIFF
--- a/xbmc/cores/RetroPlayer/PixelConverter.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverter.cpp
@@ -21,6 +21,7 @@
 #include "PixelConverter.h"
 #include "cores/VideoPlayer/DVDClock.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDCodecUtils.h"
+#include "cores/VideoPlayer/TimingConstants.h"
 #include "utils/log.h"
 
 extern "C"

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -29,6 +29,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "cores/VideoPlayer/DVDStreamInfo.h"
+#include "cores/VideoPlayer/TimingConstants.h"
 #include "utils/log.h"
 
 #include <atomic> //! @todo

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -74,7 +74,7 @@ protected:
   double m_timeOfPts;
   double m_syncError;
   unsigned int m_syncErrorTime;
-  double m_resampleRatio;
+  double m_resampleRatio = 0.0;
   CCriticalSection m_critSection;
 
   unsigned int m_sampleRate;

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -56,7 +56,12 @@ public:
   double GetDelay(); // returns the time it takes to play a packet if we add one at this time
   double GetSyncError();
   void SetSyncErrorCorrection(double correction);
+
+  /*!
+   * \brief Returns the resample ratio, or 0.0 if unknown/invalid
+   */
   double GetResampleRatio();
+
   void SetResampleMode(int mode);
   void Flush();
   void Drain();
@@ -74,7 +79,7 @@ protected:
   double m_timeOfPts;
   double m_syncError;
   unsigned int m_syncErrorTime;
-  double m_resampleRatio = 0.0;
+  double m_resampleRatio = 0.0; // invalid
   CCriticalSection m_critSection;
 
   unsigned int m_sampleRate;

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DVDClock.h"
+#include "TimingConstants.h"
 #include "VideoReferenceClock.h"
 #include <math.h>
 #include "utils/MathUtils.h"

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -36,6 +36,7 @@ CDVDClock::CDVDClock()
   m_pauseClock = 0;
   m_bReset = true;
   m_paused = false;
+  m_speedAfterPause = DVD_PLAYSPEED_PAUSE;
   m_iDisc = 0;
   m_maxspeedadjust = 0.0;
   m_systemAdjust = 0;

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -21,7 +21,6 @@
  */
 
 #include "threads/CriticalSection.h"
-#include "TimingConstants.h"
 
 #include <memory>
 #include <stdint.h>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -61,6 +61,7 @@ CDVDAudioCodecAndroidMediaCodec::CDVDAudioCodecAndroidMediaCodec(CProcessInfo &p
   m_buffer(NULL),
   m_bufferSize(0),
   m_bufferUsed(0),
+  m_currentPts(DVD_NOPTS_VALUE),
   m_crypto(0)
 {
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -42,7 +42,7 @@ CDVDAudioCodecFFmpeg::CDVDAudioCodecFFmpeg(CProcessInfo &processInfo) : CDVDAudi
 
   m_channels = 0;
   m_layout = 0;
-  
+
   m_pFrame = nullptr;
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
   m_eof = false;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -26,6 +26,7 @@ extern "C" {
 #include "libavcodec/avcodec.h"
 #include "libavformat/avformat.h"
 #include "libavutil/avutil.h"
+#include "libavutil/channel_layout.h"
 #include "libswresample/swresample.h"
 }
 
@@ -61,7 +62,7 @@ protected:
   AVCodecContext* m_pCodecContext;
   enum AVSampleFormat m_iSampleFormat;
   CAEChannelInfo m_channelLayout;
-  enum AVMatrixEncoding m_matrixEncoding;
+  enum AVMatrixEncoding m_matrixEncoding = AV_MATRIX_ENCODING_NONE;
   AVFrame* m_pFrame;
   bool m_eof;
   int m_channels;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -37,6 +37,8 @@ CDVDAudioCodecPassthrough::CDVDAudioCodecPassthrough(CProcessInfo &processInfo, 
   CDVDAudioCodec(processInfo),
   m_buffer(NULL),
   m_bufferSize(0),
+  m_currentPts(DVD_NOPTS_VALUE),
+  m_nextPts(DVD_NOPTS_VALUE),
   m_trueHDoffset(0)
 {
   m_format.m_streamInfo.m_type = streamType;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -52,10 +52,10 @@ private:
   CAEStreamParser m_parser;
   uint8_t* m_buffer;
   unsigned int m_bufferSize;
-  unsigned int m_dataSize;
+  unsigned int m_dataSize = 0;
   AEAudioFormat m_format;
   uint8_t m_backlogBuffer[61440];
-  unsigned int m_backlogSize;
+  unsigned int m_backlogSize = 0;
   double m_currentPts;
   double m_nextPts;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1323,6 +1323,7 @@ int set_header_info(am_private_t *para)
 CAMLCodec::CAMLCodec()
   : m_opened(false)
   , m_ptsIs64us(false)
+  , m_speed(DVD_PLAYSPEED_NORMAL)
   , m_cur_pts(INT64_0)
   , m_last_pts(0)
   , m_bufferIndex(-1)
@@ -1370,7 +1371,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
   m_drain = false;
   m_cur_pts = INT64_0;
   m_dst_rect.SetRect(0, 0, 0, 0);
-  m_zoom = -1;
+  m_zoom = -1.0f;
   m_contrast = -1;
   m_brightness = -1;
   m_start_adj = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -23,6 +23,7 @@
 #include "cores/VideoPlayer/DVDStreamInfo.h"
 #include "cores/IPlayer.h"
 #include "guilib/Geometry.h"
+#include "guilib/Resolution.h"
 #include "rendering/RenderSystem.h"
 
 #include <deque>
@@ -81,25 +82,25 @@ private:
   DllLibAmCodec   *m_dll;
   bool             m_opened;
   bool             m_ptsIs64us;
-  bool             m_drain;
+  bool             m_drain = false;
   am_private_t    *am_private;
   CDVDStreamInfo   m_hints;
   int              m_speed;
   int64_t          m_cur_pts;
-  int64_t          m_start_adj;
+  int64_t          m_start_adj = 0;
   int64_t          m_last_pts;
   uint32_t         m_bufferIndex;
 
   CRect            m_dst_rect;
   CRect            m_display_rect;
 
-  int              m_view_mode;
-  RENDER_STEREO_MODE m_stereo_mode;
-  RENDER_STEREO_VIEW m_stereo_view;
-  float            m_zoom;
-  int              m_contrast;
-  int              m_brightness;
-  RESOLUTION       m_video_res;
+  int              m_view_mode = -1;
+  RENDER_STEREO_MODE m_stereo_mode = RENDER_STEREO_MODE_OFF;
+  RENDER_STEREO_VIEW m_stereo_view = RENDER_STEREO_VIEW_OFF;
+  float            m_zoom = -1.0f;
+  int              m_contrast = -1;
+  int              m_brightness = -1;
+  RESOLUTION       m_video_res = RES_INVALID;
 
   static const unsigned int STATE_PREFILLED  = 1;
   static const unsigned int STATE_HASPTS     = 2;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -184,6 +184,7 @@ CDVDDemuxFFmpeg::CDVDDemuxFFmpeg() : CDVDDemux()
   memset(&m_pkt.pkt, 0, sizeof(AVPacket));
   m_streaminfo = true; /* set to true if we want to look for streams before playback */
   m_checkvideo = false;
+  m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
 }
 
 CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -167,7 +167,7 @@ protected:
 
   bool m_streaminfo;
   bool m_checkvideo;
-  int m_displayTime;
+  int m_displayTime = 0;
   double m_dtsAtDisplayTime;
 };
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -76,7 +76,7 @@ private:
   std::vector<STimestamp>            m_Timestamps;
   std::vector<STimestamp>::iterator  m_Timestamp;
   std::vector<CStream*> m_Streams;
-  int m_source;
+  int m_source = -1;
 
   typedef struct SState
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -140,7 +140,7 @@ protected:
   uint32_t            m_angle;
   bool                m_menu;
   bool                m_navmode;
-  int m_dispTimeBeforeRead;
+  int m_dispTimeBeforeRead = 0;
 
   typedef std::shared_ptr<CDVDOverlayImage> SOverlay;
   typedef std::list<SOverlay>                 SOverlays;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -26,7 +26,6 @@
 CInputStreamAddon::CInputStreamAddon(const CFileItem& fileitem, std::shared_ptr<ADDON::CInputStream> inputStream)
 : CDVDInputStream(DVDSTREAM_TYPE_ADDON, fileitem), m_addon(inputStream)
 {
-  m_hasDemux = false;
 }
 
 CInputStreamAddon::~CInputStreamAddon()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "InputStreamAddon.h"
+#include "TimingConstants.h"
 #include "addons/InputStream.h"
 #include "cores/VideoPlayer/DVDClock.h"
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -88,9 +88,9 @@ public:
 
 protected:
   std::shared_ptr<ADDON::CInputStream> m_addon;
-  bool m_hasDemux;
-  bool m_hasDisplayTime;
-  bool m_hasPosTime;
-  bool m_canPause;
-  bool m_canSeek;
+  bool m_hasDemux = false;
+  bool m_hasDisplayTime = false;
+  bool m_hasPosTime = false;
+  bool m_canPause = false;
+  bool m_canSeek = false;
 };

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -119,7 +119,7 @@ private:
 
   std::atomic<bool> m_bAbortRequest;
   bool m_bInitialized;
-  bool m_drain;
+  bool m_drain = false;
 
   int m_iDataSize;
   double m_TimeFront;

--- a/xbmc/cores/VideoPlayer/PTSTracker.cpp
+++ b/xbmc/cores/VideoPlayer/PTSTracker.cpp
@@ -21,6 +21,7 @@
 #include "PTSTracker.h"
 #include "DVDClock.h"
 #include "DVDCodecs/DVDCodecUtils.h"
+#include "cores/VideoPlayer/TimingConstants.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include <cmath>

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -30,6 +30,7 @@
 #include "IVideoPlayer.h"
 #include "DVDMessageQueue.h"
 #include "DVDClock.h"
+#include "TimingConstants.h"
 #include "VideoPlayerVideo.h"
 #include "VideoPlayerSubtitle.h"
 #include "VideoPlayerTeletext.h"

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -27,6 +27,7 @@
 #include "DVDMessageQueue.h"
 #include "DVDStreamInfo.h"
 #include "IVideoPlayer.h"
+#include "TimingConstants.h"
 #include "threads/Thread.h"
 #include "utils/BitstreamStats.h"
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -518,6 +518,8 @@ CDVDRadioRDSData::CDVDRadioRDSData(CProcessInfo &processInfo)
   , m_speed(DVD_PLAYSPEED_NORMAL)
   , m_messageQueue("rds")
 {
+  ResetRDSCache();
+
   CLog::Log(LOGDEBUG, "Radio UECP (RDS) Processor - new %s", __FUNCTION__);
 
   m_messageQueue.SetMaxDataSize(40 * 256 * 1024);

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -26,6 +26,7 @@
 #include "DVDSubtitles/DVDSubtitleParser.h"
 #include "DVDCodecs/DVDFactoryCodec.h"
 #include "DVDDemuxers/DVDDemuxPacket.h"
+#include "TimingConstants.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -32,6 +32,7 @@
 #include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
 #include "DVDDemuxers/DVDDemux.h"
 #include "DVDDemuxers/DVDDemuxPacket.h"
+#include "TimingConstants.h"
 #include "guilib/GraphicContext.h"
 #include <sstream>
 #include <iomanip>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -152,5 +152,5 @@ protected:
 
   // rendering flags
   unsigned m_iFlags;
-  ERenderFormat m_format;
+  ERenderFormat m_format = RENDER_FMT_NONE;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -79,11 +79,11 @@ protected:
 
   uint32_t m_width;
   uint32_t m_height;
-  uint32_t m_flags;
-  uint32_t m_renderFormat;
-  uint8_t  m_size;
-  uint8_t  m_max_back_refs;
-  uint8_t  m_max_fwd_refs;
+  uint32_t m_flags = 0;
+  uint32_t m_renderFormat = 0;
+  uint8_t  m_size = 0;
+  uint8_t  m_max_back_refs = 0;
+  uint8_t  m_max_fwd_refs = 0;
 
   struct ProcAmpInfo
   {
@@ -101,7 +101,7 @@ protected:
   CSurfaceContext *m_context;
   CCriticalSection m_section;
 
-  uint32_t m_procIndex;
+  uint32_t m_procIndex = 0;
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps;
   D3D11_TEXTURE2D_DESC m_texDesc;
   PROCESSOR_VIEW_TYPE m_eViewType;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -21,6 +21,7 @@
 #include "system.h"
 #include "RenderManager.h"
 #include "RenderFlags.h"
+#include "cores/VideoPlayer/TimingConstants.h"
 #include "guilib/GraphicContext.h"
 #include "utils/MathUtils.h"
 #include "threads/SingleLock.h"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -228,9 +228,9 @@ protected:
   std::deque<int> m_discard;
 
   ERenderFormat m_format;
-  void *m_hwPic;
+  void *m_hwPic = nullptr;
   unsigned int m_width, m_height, m_dwidth, m_dheight;
-  unsigned int m_flags;
+  unsigned int m_flags = 0;
   float m_fps;
   unsigned int m_orientation;
   int m_NumberBuffers;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShader.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShader.h
@@ -54,7 +54,7 @@ namespace Shaders {
     // shader attribute handles
     GLint m_hSourceTex;
     GLint m_hStepXY;
-    GLint m_hStretch;
+    GLint m_hStretch = 0;
   };
 
   class ConvolutionFilterShader : public BaseVideoFilterShader

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -235,7 +235,7 @@ protected:
   unsigned int         m_destHeight;
 
   int                  m_neededBuffers;
-  unsigned int         m_frameIdx;
+  unsigned int         m_frameIdx = 0;
   CRenderCapture*      m_capture = nullptr;
 };
 


### PR DESCRIPTION
First of all, sorry to send a PR so close to the VP update merge. Feel free to merge the PR without this patch and I'll resubmit to master.

I came across an uninitialized var that led to UB when used without initialization, so I went through and made sure all vars were initialized in their constructors.