### PR TITLE
fix build with -DENABLE_VAAPI=no

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1188,12 +1188,14 @@ IHardwareDecoder* CDVDVideoCodecFFmpeg::CreateVideoDecoderHW(AVPixelFormat pixfm
 #define VP_VIDEOCODEC_HW
 IHardwareDecoder* CDVDVideoCodecFFmpeg::CreateVideoDecoderHW(AVPixelFormat pixfmt, CProcessInfo &processInfo)
 {
+#if defined(HAVE_LIBVA)
   if (pixfmt == AV_PIX_FMT_VAAPI_VLD && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVAAPI))
     return new VAAPI::CDecoder(m_processInfo);
-
+#endif
+#if defined(HAVE_LIBVDPAU)
   if(VDPAU::CDecoder::IsVDPAUFormat(pixfmt) && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVDPAU))
     return new VDPAU::CDecoder(m_processInfo);
-
+#endif
   return nullptr;
 }
 #endif


### PR DESCRIPTION
## Description
fix:
```
cmake -C ... -DENABLE_VAAPI=no -DENABLE_VDPAU=yes
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp: In member function ‘IHardwareDecoder* CDVDVideoCodecFFmpeg::CreateVideoDecoderHW(AVPixelFormat, CProcessInfo&)’:
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:1192:16: error: ‘VAAPI’ does not name a type
     return new VAAPI::CDecoder(m_processInfo);
                ^
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:1192:21: error: expected ‘;’ before ‘::’ token
     return new VAAPI::CDecoder(m_processInfo);
                     ^
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:1192:21: error: ‘::CDecoder’ has not been declared
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:1192:21: note: suggested alternative:
In file included from /var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp:1185:0:
/var/tmp/portage/media-tv/kodi-9999/work/kodi-9999/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h:546:7: note:   ‘VDPAU::CDecoder’
 class CDecoder
       ^
make[2]: *** [build/cores/VideoPlayer/codecs/video/CMakeFiles/dvdvideocodecs.dir/build.make:87: build/cores/VideoPlayer/codecs/video/CMakeFiles/dvdvideocodecs.dir/DVDVideoCodecFFmpeg.cpp.o] Error 1
```

## Motivation and Context
build failure

## How Has This Been Tested?
successfully built with -DENABLE_VAAPI=no -DENABLE_VDPAU=yes

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
