### PR TITLE
DVDVideoCodecFFmpeg: Consistency fixes (buildsys rework in progress)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1162,7 +1162,11 @@ IHardwareDecoder* CDVDVideoCodecFFmpeg::GetHWAccel()
 }
 
 //------------------------------------------------------------------------------
-// temporary
+// The current way of handling build targets is way too complicated.
+// It's basically a long mess of combining options, which needs revisiting
+// This factory is temporary in its current state. That means certain
+// cmake options to remove certain decoders in certain combinations won't work
+// until the build system is revisited.
 //------------------------------------------------------------------------------
 
 #ifdef HAS_DX
@@ -1176,14 +1180,11 @@ IHardwareDecoder* CDVDVideoCodecFFmpeg::CreateVideoDecoderHW(AVPixelFormat pixfm
 }
 #endif
 
-// Linux X11
-#if defined(HAVE_LIBVA) || defined(HAVE_LIBVDPAU)
-#if defined(HAVE_LIBVA)
+// Linux X11 - Currently works only if both
+// VAAPI and VDPAU dependencies are available
+#if defined(HAVE_LIBVA) && defined(HAVE_LIBVDPAU)
 #include "VAAPI.h"
-#endif
-#if defined(HAVE_LIBVDPAU)
 #include "VDPAU.h"
-#endif
 
 #define VP_VIDEOCODEC_HW
 IHardwareDecoder* CDVDVideoCodecFFmpeg::CreateVideoDecoderHW(AVPixelFormat pixfmt, CProcessInfo &processInfo)


### PR DESCRIPTION
DVDVideoCodecFFmpeg currently needs both VAAPI and VDPAU dependencies to succesfully compile, therefore it conflicts with given CMAKE parameters to disable either or on X11.

That's not a fix to make it buildable for each alone, but a consistency workaround in order to reduce the massive ifdeffery.

For people with MIR / DRM/KMS this needs changes.

To my knowledge the buildsystem change that revisits "kodi platforms" is on its way.

@lrusak for information