### PR TITLE
[guilib] resolve includes in font.xml

### DIFF
--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -354,7 +354,8 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
     CLog::Log(LOGERROR, "file %s doesnt start with <fonts>", strPath.c_str());
     return;
   }
-
+  // Resolve includes in Font.xml
+  g_SkinInfo->ResolveIncludes(pRootElement);
   // take note of the first font available in case we can't load the one specified
   std::string firstFont;
 


### PR DESCRIPTION
Follow up to #11379. To actually use the includes in Font.xml, they must be resolved first.
