### PR TITLE
[buildsteps][windows] download-msys2: disable build32 if build64 specified

### DIFF
--- a/tools/buildsteps/windows/download-msys2.bat
+++ b/tools/buildsteps/windows/download-msys2.bat
@@ -51,7 +51,10 @@ set downloaddir=%instdir%\downloads2
 set unpack_exe=%instdir%\..\Win32BuildSetup\tools\7z\7za.exe
 
 for %%b in (%1, %2, %3) do (
-  if %%b==build64 (set build64=yes)
+  if %%b==build64 (
+    set build32=no
+    set build64=yes
+  )
   if %%b==sh (set opt=sh)
 )
 
@@ -539,7 +542,8 @@ for %%i in (%locals32%) do (
     )
     if errorlevel == 1 del "%downloaddir%\!pkgfile!"
     if exist "%downloaddir%\!pkgfile!" (
-      %unpack_exe% x %downloaddir%\!pkgfile! -so | %unpack_exe% x -aoa -si -ttar -o%instdir%
+      %unpack_exe% x %downloaddir%\!pkgfile!^
+        -so | %unpack_exe% x -aoa -si -ttar -o%instdir%
     )
     endlocal
   )
@@ -554,7 +558,8 @@ for %%i in (%locals64%) do (
     )
     if errorlevel == 1 del "%downloaddir%\!pkgfile!"
     if exist "%downloaddir%\!pkgfile!" (
-      %unpack_exe% x %downloaddir%\!pkgfile! -so | %unpack_exe% x -aoa -si -ttar -o%instdir%
+      %unpack_exe% x %downloaddir%\!pkgfile!^
+        -so | %unpack_exe% x -aoa -si -ttar -o%instdir%
     )
     endlocal
   )


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
No need to install 32 bit dependencies / packages, if building for 64 bit.
<!--- Describe your change in detail -->

## Motivation and Context
speed up build time
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled on windows 32 and 64 bit
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
