### PR TITLE
[gui][refactor] rework custom window's visible condition and modality handling

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1665,8 +1665,8 @@ bool CApplication::LoadSkin(const std::string& skinID)
 
   CLog::Log(LOGINFO, "  load new skin...");
 
-  // Load the user windows
-  LoadUserWindows();
+  // Load custom windows
+  LoadCustomWindows();
 
   int64_t end, freq;
   end = CurrentHostCounter();
@@ -1755,28 +1755,31 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
 // and as a result a race condition on exit can cause a crash.
 }
 
-bool CApplication::LoadUserWindows()
+bool CApplication::LoadCustomWindows()
 {
   // Start from wherever home.xml is
   std::vector<std::string> vecSkinPath;
   g_SkinInfo->GetSkinPaths(vecSkinPath);
-  for (unsigned int i = 0;i < vecSkinPath.size();++i)
+
+  for (const auto &skinPath : vecSkinPath)
   {
-    CLog::Log(LOGINFO, "Loading user windows, path %s", vecSkinPath[i].c_str());
+    CLog::Log(LOGINFO, "Loading custom window XMLs from skin path %s", skinPath.c_str());
+
     CFileItemList items;
-    if (CDirectory::GetDirectory(vecSkinPath[i], items, ".xml", DIR_FLAG_NO_FILE_DIRS))
+    if (CDirectory::GetDirectory(skinPath, items, ".xml", DIR_FLAG_NO_FILE_DIRS))
     {
-      for (int i = 0; i < items.Size(); ++i)
+      for (const auto &item : items.GetList())
       {
-        if (items[i]->m_bIsFolder)
+        if (item->m_bIsFolder)
           continue;
-        std::string skinFile = URIUtils::GetFileName(items[i]->GetPath());
+
+        std::string skinFile = URIUtils::GetFileName(item->GetPath());
         if (StringUtils::StartsWithNoCase(skinFile, "custom"))
         {
           CXBMCTinyXML xmlDoc;
-          if (!xmlDoc.LoadFile(items[i]->GetPath()))
+          if (!xmlDoc.LoadFile(item->GetPath()))
           {
-            CLog::Log(LOGERROR, "unable to load: %s, Line %d\n%s", items[i]->GetPath().c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+            CLog::Log(LOGERROR, "Unable to load custom window XML %s. Line %d\n%s", item->GetPath().c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
             continue;
           }
 
@@ -1785,13 +1788,14 @@ bool CApplication::LoadUserWindows()
           std::string strValue = pRootElement->Value();
           if (!StringUtils::EqualsNoCase(strValue, "window"))
           {
-            CLog::Log(LOGERROR, "file: %s doesnt contain <window>", skinFile.c_str());
+            CLog::Log(LOGERROR, "No <window> root element found for custom window in %s", skinFile.c_str());
             continue;
           }
 
-          // Read the <type> element to get the window type to create
+          int id = WINDOW_INVALID;
+
+          // Read the type attribute or element to get the window type to create
           // If no type is specified, create a CGUIWindow as default
-          CGUIWindow* pWindow = NULL;
           std::string strType;
           if (pRootElement->Attribute("type"))
             strType = pRootElement->Attribute("type");
@@ -1801,38 +1805,56 @@ bool CApplication::LoadUserWindows()
             if (pType && pType->FirstChild())
               strType = pType->FirstChild()->Value();
           }
-          int id = WINDOW_INVALID;
+
+          // Read the id attribute or element to get the window id
           if (!pRootElement->Attribute("id", &id))
           {
             const TiXmlNode *pType = pRootElement->FirstChild("id");
             if (pType && pType->FirstChild())
               id = atol(pType->FirstChild()->Value());
           }
-          std::string visibleCondition;
-          CGUIControlFactory::GetConditionalVisibility(pRootElement, visibleCondition);
 
-          if (StringUtils::EqualsNoCase(strType, "dialog"))
-            pWindow = new CGUIDialog(id + WINDOW_HOME, skinFile, visibleCondition.empty() ? DialogModalityType::MODAL : DialogModalityType::MODELESS);
-          else if (StringUtils::EqualsNoCase(strType, "submenu"))
-            pWindow = new CGUIDialogSubMenu(id + WINDOW_HOME, skinFile);
-          else if (StringUtils::EqualsNoCase(strType, "buttonmenu"))
-            pWindow = new CGUIDialogButtonMenu(id + WINDOW_HOME, skinFile);
-          else
-            pWindow = new CGUIWindow(id + WINDOW_HOME, skinFile);
-
-          // Check to make sure the pointer isn't still null
-          if (pWindow == NULL)
+          int windowId = id + WINDOW_HOME;
+          if (id == WINDOW_INVALID || g_windowManager.GetWindow(windowId))
           {
-            CLog::Log(LOGERROR, "Out of memory / Failed to create new object in LoadUserWindows");
-            return false;
-          }
-          if (id == WINDOW_INVALID || g_windowManager.GetWindow(WINDOW_HOME + id))
-          {
-            delete pWindow;
+            // No id specified or id already in use
+            CLog::Log(LOGERROR, "No id specified or id already in use for custom window in %s", skinFile.c_str());
             continue;
           }
-          pWindow->SetVisibleCondition(visibleCondition);
-          pWindow->SetLoadType(CGUIWindow::KEEP_IN_MEMORY);
+
+          CGUIWindow* pWindow = NULL;
+          bool hasVisibleCondition = false;
+
+          if (StringUtils::EqualsNoCase(strType, "dialog"))
+          {
+            hasVisibleCondition = pRootElement->FirstChildElement("visible");
+            pWindow = new CGUIDialog(windowId, skinFile);
+          }
+          else if (StringUtils::EqualsNoCase(strType, "submenu"))
+          {
+            pWindow = new CGUIDialogSubMenu(windowId, skinFile);
+          }
+          else if (StringUtils::EqualsNoCase(strType, "buttonmenu"))
+          {
+            pWindow = new CGUIDialogButtonMenu(windowId, skinFile);
+          }
+          else
+          {
+            pWindow = new CGUIWindow(windowId, skinFile);
+          }
+
+          if (!pWindow)
+          {
+            CLog::Log(LOGERROR, "Failed to create custom window from %s", skinFile.c_str());
+            continue;
+          }
+
+          pWindow->SetCustom(true);
+
+          // Determining whether our custom dialog is modeless (visible condition is present)
+          // will be done on load. Therefore we need to initialize the custom dialog on gui init.
+          pWindow->SetLoadType(hasVisibleCondition ? CGUIWindow::LOAD_ON_GUI_INIT : CGUIWindow::KEEP_IN_MEMORY);
+
           g_windowManager.AddCustomWindow(pWindow);
         }
       }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -149,7 +149,7 @@ public:
   void Stop(int exitCode);
   void RestartApp();
   void UnloadSkin(bool forReload = false);
-  bool LoadUserWindows();
+  bool LoadCustomWindows();
   void ReloadSkin(bool confirm = false);
   const std::string& CurrentFile();
   CFileItem& CurrentFileItem();

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIDialog.h"
 #include "GUIWindowManager.h"
+#include "GUIControlFactory.h"
 #include "GUILabelControl.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
@@ -44,6 +45,20 @@ CGUIDialog::CGUIDialog(int id, const std::string &xmlFile, DialogModalityType mo
 
 CGUIDialog::~CGUIDialog(void)
 {}
+
+bool CGUIDialog::Load(TiXmlElement* pRootElement)
+{
+  bool retVal = CGUIWindow::Load(pRootElement);
+
+  if (retVal && IsCustom())
+  {
+    // custom dialog's modality type is modeless if visible condition is specified.
+    if (m_visibleCondition)
+      m_modalityType = DialogModalityType::MODELESS;
+  }
+
+  return retVal;
+}
 
 void CGUIDialog::OnWindowLoaded()
 {

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -68,6 +68,7 @@ public:
   virtual bool IsSoundEnabled() const { return m_enableSound; };
 
 protected:
+  bool Load(TiXmlElement *pRootElement) override;
   virtual void SetDefaults();
   virtual void OnWindowLoaded();
   virtual void UpdateVisibility();

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -354,19 +354,22 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<INFO::Inf
     }
   }
 
-  // run through this element's attributes, resolving any constants
+  // resolve constants and expressions $EXP[xyz] for configured attributes and nodes
   TiXmlAttribute *attribute = node->FirstAttribute();
   while (attribute)
-  { // check the attribute against our set
+  {
     if (m_constantAttributes.count(attribute->Name()))
       attribute->SetValue(ResolveConstant(attribute->ValueStr()));
+
     if (m_expressionAttributes.count(attribute->Name()))
       attribute->SetValue(ResolveExpressions(attribute->ValueStr()));
+
     attribute = attribute->Next();
   }
-  // also do the value
+
   if (node->FirstChild() && node->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT && m_constantNodes.count(node->ValueStr()))
     node->FirstChild()->SetValue(ResolveConstant(node->FirstChild()->ValueStr()));
+
   if (node->FirstChild() && node->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT && m_expressionNodes.count(node->ValueStr()))
     node->FirstChild()->SetValue(ResolveExpressions(node->FirstChild()->ValueStr()));
 }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -70,6 +70,7 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   m_windowXMLRootElement = nullptr;
   m_menuControlID = 0;
   m_menuLastFocusedControlID = 0;
+  m_custom = false;
 }
 
 CGUIWindow::~CGUIWindow()
@@ -160,7 +161,7 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
   
   if (!StringUtils::EqualsNoCase(pRootElement->Value(), "window"))
   {
-    CLog::Log(LOGERROR, "file : XML file doesnt contain <window>");
+    CLog::Log(LOGERROR, "XML file %s does not contain a <window> root element", GetProperty("xmlfile").c_str());
     return false;
   }
 
@@ -174,6 +175,7 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
 
   // Resolve any includes that may be present and save conditions used to do it
   g_SkinInfo->ResolveIncludes(pRootElement, &m_xmlIncludeConditions);
+
   // now load in the skin file
   SetDefaults();
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -168,6 +168,19 @@ public:
                                                    // the window manager's active list.
 
   virtual bool IsAnimating(ANIMATION_TYPE animType);
+
+  /*!
+   \brief Return if the window is a custom window
+   \return true if the window is an custom window otherwise false
+   */
+  bool IsCustom() const { return m_custom; };
+
+  /*!
+   \brief Mark this window as custom window
+   \param custom true if this window is a custom window, false if not
+   */
+  void SetCustom(bool custom) { m_custom = custom; };
+
   void DisableAnimations();
 
   virtual void ResetControlStates();
@@ -203,7 +216,14 @@ public:
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool LoadXML(const std::string& strPath, const std::string &strLowerPath);  ///< Loads from the given file
-  bool Load(TiXmlElement *pRootElement);                 ///< Loads from the given XML root element
+
+  /*!
+   \brief Loads the window from the given XML element
+   \param pRootElement the XML element
+   \return true if the window is loaded from the given XML otherwise false.
+   */
+  virtual bool Load(TiXmlElement *pRootElement);
+
   /*! \brief Check if XML file needs (re)loading
    XML file has to be (re)loaded when window is not loaded or include conditions values were changed
    */
@@ -281,6 +301,7 @@ protected:
 
   int m_menuControlID;
   int m_menuLastFocusedControlID;
+  bool m_custom;
 
 private:
   std::map<std::string, CVariant, icompare> m_mapProperties;


### PR DESCRIPTION
This PR serves as preparation for #12035. It refactors the custom window handling so expressions used in visible conditions for custom dialogs are resolved in `CGUIWindow::Load` -> `CGUIInclude::ResolveInclude` too.

The following is done to achieve it.
* add a new boolean in GUIWindow to indicate if the window is a custom
window
* move the visible condition handling into CGUIWindow::Load, because it
support skin expressions there.
* move identification of modeless custom dialogs to CGUIDialog::Load
* rename method LoadUserWindows to LoadCustomWindows to unify wording

@ronie @BigNoid not sure who needs a ping

@rmrector fyi
