### PR TITLE
[Android MediaCodecSurface] Change Rendertype from GUILayer to VideoLayer

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2007-2015 Team Kodi
+ *      Copyright (C) 2007-2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -18,23 +18,61 @@
  *
  */
 
+#if defined(TARGET_ANDROID)
+
 #include "RendererMediaCodecSurface.h"
 
-#if defined(TARGET_ANDROID)
 #include "../RenderCapture.h"
-
+#include "settings/MediaSettings.h"
 #include "platform/android/activity/XBMCApp.h"
 #include "DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h"
 #include "utils/log.h"
+#include <thread>
 
 CRendererMediaCodecSurface::CRendererMediaCodecSurface()
+  : m_bConfigured(false)
+  , m_iRenderBuffer(0)
 {
 }
 
 CRendererMediaCodecSurface::~CRendererMediaCodecSurface()
 {
-  for (int i(0); i < m_NumYV12Buffers; ++i)
+  for (int i(0); i < m_numRenderBuffers; ++i)
     ReleaseBuffer(i);
+}
+
+bool CRendererMediaCodecSurface::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, void *hwPic, unsigned int orientation)
+{
+  CLog::Log(LOGNOTICE, "CRendererMediaCodecSurface::Configure");
+
+  m_sourceWidth = width;
+  m_sourceHeight = height;
+  m_renderOrientation = orientation;
+
+  // Save the flags.
+  m_iFlags = flags;
+  m_format = format;
+
+  // Calculate the input frame aspect ratio.
+  CalculateFrameAspectRatio(d_width, d_height);
+  SetViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode);
+  ManageRenderArea();
+
+  m_bConfigured = true;
+
+  for (int i = 0; i < m_numRenderBuffers; ++i)
+    m_buffers[i].hwPic = 0;
+
+  return true;
+}
+
+CRenderInfo CRendererMediaCodecSurface::GetRenderInfo()
+{
+  CRenderInfo info;
+  info.formats.push_back(RENDER_FMT_BYPASS);
+  info.max_buffer_size = m_numRenderBuffers;
+  info.optimal_buffer_size = m_numRenderBuffers;
+  return info;
 }
 
 bool CRendererMediaCodecSurface::RenderCapture(CRenderCapture* capture)
@@ -44,176 +82,78 @@ bool CRendererMediaCodecSurface::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
+int CRendererMediaCodecSurface::GetImage(YV12Image *image, int source, bool readonly)
+{
+  if (image == nullptr)
+    return -1;
+
+  /* take next available buffer */
+  if (source == -1)
+    source = (m_iRenderBuffer + 1) % m_numRenderBuffers;
+
+  return source;
+}
+
 void CRendererMediaCodecSurface::AddVideoPictureHW(VideoPicture &picture, int index)
 {
   ReleaseBuffer(index);
-  YUVBUFFER &buf = m_buffers[index];
-  buf.hwDec = picture.hwPic ? static_cast<CDVDMediaCodecInfo*>(picture.hwPic)->Retain() : nullptr;
-}
-
-bool CRendererMediaCodecSurface::RenderUpdateCheckForEmptyField()
-{
-  return false;
+  BUFFER &buf = m_buffers[index];
+  buf.hwPic = picture.hwPic ? static_cast<CDVDMediaCodecInfo*>(picture.hwPic)->Retain() : nullptr;
 }
 
 void CRendererMediaCodecSurface::ReleaseBuffer(int idx)
 {
-  YUVBUFFER &buf = m_buffers[idx];
-  if (buf.hwDec)
+  BUFFER &buf = m_buffers[idx];
+  if (buf.hwPic)
   {
-    CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(buf.hwDec);
+    CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(buf.hwPic);
     SAFE_RELEASE(mci);
-    buf.hwDec = NULL;
+    buf.hwPic = NULL;
   }
 }
 
-int CRendererMediaCodecSurface::GetImageHook(YV12Image *image, int source, bool readonly)
+void CRendererMediaCodecSurface::FlipPage(int source)
 {
-  return source;
+  if (source >= 0 && source < m_numRenderBuffers)
+    m_iRenderBuffer = source;
+  else
+    m_iRenderBuffer = (m_iRenderBuffer + 1) % m_numRenderBuffers;
+
+  CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[m_iRenderBuffer].hwPic);
+
+  if (mci)
+  {
+    ManageRenderArea();
+    mci->ReleaseOutputBuffer(true);
+    m_buffers[m_iRenderBuffer].hwPic = nullptr;
+  }
 }
 
-bool CRendererMediaCodecSurface::Supports(EINTERLACEMETHOD method)
+bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
 {
+  if (feature == RENDERFEATURE_ZOOM ||
+    feature == RENDERFEATURE_CONTRAST ||
+    feature == RENDERFEATURE_BRIGHTNESS ||
+    feature == RENDERFEATURE_STRETCH ||
+    feature == RENDERFEATURE_PIXEL_RATIO ||
+    feature == RENDERFEATURE_ROTATION)
+    return true;
+
   return false;
 }
 
-EINTERLACEMETHOD CRendererMediaCodecSurface::AutoInterlaceMethod()
+void CRendererMediaCodecSurface::Reset()
 {
-  return VS_INTERLACEMETHOD_NONE;
 }
 
-CRenderInfo CRendererMediaCodecSurface::GetRenderInfo()
+void CRendererMediaCodecSurface::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 {
-  CRenderInfo info;
-  info.formats = m_formats;
-  info.max_buffer_size = 4;
-  info.optimal_buffer_size = 3;
-  return info;
-}
-
-bool CRendererMediaCodecSurface::LoadShadersHook()
-{
-  CLog::Log(LOGNOTICE, "GL: Using MediaCodec (Surface) render method");
-  m_renderMethod = RENDER_MEDIACODECSURFACE;
-  m_textureTarget = GL_TEXTURE_2D;
-  return true;
-}
-
-bool CRendererMediaCodecSurface::RenderHook(int index)
-{
-  //glClearColor(0,0,0,0);
-  //glClear(GL_COLOR_BUFFER_BIT);
-
-  CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[index].hwDec);
-  if (mci && !mci->IsReleased())
   {
-    // this hack is needed to get the 2D mode of a 3D movie going
-    RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
-    if (stereo_mode)
-      g_graphicsContext.SetStereoView(RENDER_STEREO_VIEW_LEFT);
-
-    ManageRenderArea();
-
-    if (stereo_mode)
-      g_graphicsContext.SetStereoView(RENDER_STEREO_VIEW_OFF);
-
-    CRect dstRect(m_destRect);
-    CRect srcRect(m_sourceRect);
-    switch (stereo_mode)
-    {
-      case RENDER_STEREO_MODE_SPLIT_HORIZONTAL:
-        dstRect.y2 *= 2.0;
-        srcRect.y2 *= 2.0;
-      break;
-
-      case RENDER_STEREO_MODE_SPLIT_VERTICAL:
-        dstRect.x2 *= 2.0;
-        srcRect.x2 *= 2.0;
-      break;
-
-      case RENDER_STEREO_MODE_MONO:
-        dstRect.y2 = dstRect.y2 * (dstRect.y2 / m_sourceRect.y2);
-        dstRect.x2 = dstRect.x2 * (dstRect.x2 / m_sourceRect.x2);
-      break;
-
-      default:
-      break;
-    }
-
-
-    // Handle orientation
-    switch (m_renderOrientation)
-    {
-      case 90:
-      case 270:
-      {
-        int diffX = 0;
-        int diffY = 0;
-        int centerX = 0;
-        int centerY = 0;
-
-        int newWidth = dstRect.Height(); // new width is old height
-        int newHeight = dstRect.Width(); // new height is old width
-        int diffWidth = newWidth - dstRect.Width(); // difference between old and new width
-        int diffHeight = newHeight - dstRect.Height(); // difference between old and new height
-
-        // if the new width is bigger then the old or
-        // the new height is bigger then the old - we need to scale down
-        if (diffWidth > 0 || diffHeight > 0 )
-        {
-          float aspectRatio = GetAspectRatio();
-          // scale to fit screen width because
-          // the difference in width is bigger then the
-          // difference in height
-          if (diffWidth > diffHeight)
-          {
-            newWidth = dstRect.Width(); // clamp to the width of the old dest rect
-            newHeight *= aspectRatio;
-          }
-          else // scale to fit screen height
-          {
-            newHeight = dstRect.Height(); // clamp to the height of the old dest rect
-            newWidth /= aspectRatio;
-          }
-        }
-
-        // calculate the center point of the view
-        centerX = m_viewRect.x1 + m_viewRect.Width() / 2;
-        centerY = m_viewRect.y1 + m_viewRect.Height() / 2;
-
-        // calculate the number of pixels we need to go in each
-        // x direction from the center point
-        diffX = newWidth / 2;
-        // calculate the number of pixels we need to go in each
-        // y direction from the center point
-        diffY = newHeight / 2;
-
-        dstRect = CRect(centerX - diffX, centerY - diffY, centerX + diffX, centerY + diffY);
-
-        break;
-      }
-
-      default:
-        break;
-    }
-
-    mci->RenderUpdate(srcRect, dstRect);
+    std::chrono::milliseconds elapsed(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - m_prevTime).count());
+    if (elapsed < std::chrono::milliseconds(10))
+      std::this_thread::sleep_for(std::chrono::milliseconds(10) - elapsed);
+    m_prevTime = std::chrono::system_clock::now();
   }
-  return true;
 }
 
-bool CRendererMediaCodecSurface::CreateTexture(int index)
-{
-  return true; // nothing todo
-}
-
-void CRendererMediaCodecSurface::DeleteTexture(int index)
-{
-  return; // nothing todo
-}
-
-bool CRendererMediaCodecSurface::UploadTexture(int index)
-{
-  return true; // nothing todo
-}
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -32,9 +32,10 @@
 #include <thread>
 
 CRendererMediaCodecSurface::CRendererMediaCodecSurface()
-  : m_bConfigured(false)
-  , m_iRenderBuffer(0)
+  : m_iRenderBuffer(0)
   , m_prevTime(std::chrono::system_clock::now())
+  , m_bConfigured(false)
+  , m_renderingStarted(false)
   , m_updateCount(10)
 {
 }
@@ -124,10 +125,8 @@ void CRendererMediaCodecSurface::FlipPage(int source)
 
   CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[m_iRenderBuffer].hwPic);
 
-  if (mci)
-  {
+  if (mci && m_renderingStarted)
     mci->ReleaseOutputBuffer(true);
-  }
 }
 
 bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
@@ -144,6 +143,7 @@ bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
 void CRendererMediaCodecSurface::Reset()
 {
   m_updateCount = 10;
+  m_renderingStarted = false;
 }
 
 void CRendererMediaCodecSurface::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
@@ -211,6 +211,14 @@ void CRendererMediaCodecSurface::ReorderDrawPoints()
   CLog::Log(LOGDEBUG, "CRendererMediaCodecSurface::ReorderDrawPoints: dst: %0.1f+%0.1f-%0.1fx%0.1f, adj: %0.1f+%0.1f-%0.1fx%0.1f",
     dstRect.x1, dstRect.y1, dstRect.Width(), dstRect.Height(),
     adjRect.x1, adjRect.y1, adjRect.Width(), adjRect.Height());
+
+  if (!m_renderingStarted)
+  {
+    m_renderingStarted = true;
+    FlipPage(m_iRenderBuffer);
+  }
+
+
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -125,7 +125,6 @@ void CRendererMediaCodecSurface::FlipPage(int source)
   {
     ManageRenderArea();
     mci->ReleaseOutputBuffer(true);
-    m_buffers[m_iRenderBuffer].hwPic = nullptr;
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -35,7 +35,6 @@ CRendererMediaCodecSurface::CRendererMediaCodecSurface()
   : m_iRenderBuffer(0)
   , m_prevTime(std::chrono::system_clock::now())
   , m_bConfigured(false)
-  , m_renderingStarted(false)
   , m_updateCount(10)
 {
 }
@@ -129,7 +128,7 @@ void CRendererMediaCodecSurface::FlipPage(int source)
   // Android SurfaceFlinger has it's own clock, so we can release frames early.
   // Benefit of this place is that it is called from render-thread and not
   // affected by gui stalls when opening overlay dialogs
-  if (mci && m_renderingStarted)
+  if (mci)
     mci->ReleaseOutputBuffer(true);
 }
 
@@ -147,7 +146,6 @@ bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
 void CRendererMediaCodecSurface::Reset()
 {
   m_updateCount = 10;
-  m_renderingStarted = false;
 }
 
 void CRendererMediaCodecSurface::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
@@ -216,15 +214,6 @@ void CRendererMediaCodecSurface::ReorderDrawPoints()
   CLog::Log(LOGDEBUG, "CRendererMediaCodecSurface::ReorderDrawPoints: dst: %0.1f+%0.1f-%0.1fx%0.1f, adj: %0.1f+%0.1f-%0.1fx%0.1f",
     dstRect.x1, dstRect.y1, dstRect.Width(), dstRect.Height(),
     adjRect.x1, adjRect.y1, adjRect.Width(), adjRect.Height());
-
-  // Assumption: SurfaceFlinger starts PTS processing on arrival of first frame.
-  // To have the best match between kodi / android clock we start on first RenderUpdate call.
-  // Beside this the first frame should not be rendered before the SurfaceView is resized.
-  if (!m_renderingStarted)
-  {
-    m_renderingStarted = true;
-    FlipPage(m_iRenderBuffer);
-  }
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -73,7 +73,7 @@ private:
   } m_buffers[m_numRenderBuffers];
 
   std::chrono::time_point<std::chrono::system_clock> m_prevTime;
-  bool m_bConfigured;
+  bool m_bConfigured, m_renderingStarted;
   unsigned int m_updateCount;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -73,7 +73,7 @@ private:
   } m_buffers[m_numRenderBuffers];
 
   std::chrono::time_point<std::chrono::system_clock> m_prevTime;
-  bool m_bConfigured, m_renderingStarted;
+  bool m_bConfigured;
   unsigned int m_updateCount;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -58,6 +58,8 @@ public:
   virtual bool Supports(ERENDERFEATURE feature);
 
   virtual EINTERLACEMETHOD AutoInterlaceMethod() { return VS_INTERLACEMETHOD_NONE; };
+protected:
+  virtual void ReorderDrawPoints() override;
 
 private:
 
@@ -72,6 +74,7 @@ private:
 
   std::chrono::time_point<std::chrono::system_clock> m_prevTime;
   bool m_bConfigured;
+  unsigned int m_updateCount;
 };
 
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2007-2015 Team Kodi
+ *      Copyright (C) 2005-2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -20,42 +20,58 @@
 
 #pragma once
 
-#include "system.h"
-
 #if defined(TARGET_ANDROID)
 
-#include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+#include "system.h"
+#include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
+#include <chrono>
 
-class CRendererMediaCodecSurface : public CLinuxRendererGLES
+class CRendererMediaCodecSurface : public CBaseRenderer
 {
 public:
   CRendererMediaCodecSurface();
   virtual ~CRendererMediaCodecSurface();
-  
+
   virtual bool RenderCapture(CRenderCapture* capture);
+  virtual void AddVideoPictureHW(VideoPicture &picture, int index);
+  virtual void ReleaseBuffer(int idx);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, void *hwPic, unsigned int orientation);
+  virtual bool IsConfigured() { return m_bConfigured; };
+  virtual CRenderInfo GetRenderInfo();
+  virtual int GetImage(YV12Image *image, int source = -1, bool readonly = false);
+  virtual void ReleaseImage(int source, bool preserve = false) {};
+  virtual void FlipPage(int source);
+  virtual void PreInit() {};
+  virtual void UnInit() {};
+  virtual void Reset();
+  virtual void Update() {};
+  virtual void RenderUpdate(bool clear, unsigned int flags = 0, unsigned int alpha = 255);
+  virtual bool SupportsMultiPassRendering() { return false; };
 
   // Player functions
-  virtual void AddVideoPictureHW(VideoPicture &picture, int index);
-  virtual bool RenderUpdateCheckForEmptyField();
-  virtual void ReleaseBuffer(int idx);
+  virtual bool IsGuiLayer() { return false; };
 
   // Feature support
-  virtual bool Supports(EINTERLACEMETHOD method);
+  virtual bool Supports(EINTERLACEMETHOD method) { return false; };
+  virtual bool Supports(ESCALINGMETHOD method) { return false; };
 
-  virtual EINTERLACEMETHOD AutoInterlaceMethod();
-  virtual CRenderInfo GetRenderInfo();
+  virtual bool Supports(ERENDERFEATURE feature);
 
-protected:
+  virtual EINTERLACEMETHOD AutoInterlaceMethod() { return VS_INTERLACEMETHOD_NONE; };
 
-  // textures
-  virtual bool UploadTexture(int index);
-  virtual void DeleteTexture(int index);
-  virtual bool CreateTexture(int index);
-  
-  // hooks for hw dec renderer
-  virtual bool LoadShadersHook();
-  virtual bool RenderHook(int index);  
-  virtual int  GetImageHook(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
+private:
+
+  int m_iRenderBuffer;
+  static const int m_numRenderBuffers = 4;
+
+  struct BUFFER
+  {
+    void *hwPic;
+    int duration;
+  } m_buffers[m_numRenderBuffers];
+
+  std::chrono::time_point<std::chrono::system_clock> m_prevTime;
+  bool m_bConfigured;
 };
 
 #endif


### PR DESCRIPTION
see title

## Description
Currently MediaCodecSurface is rendered as GUILayer.
This is not correct because rendering takes place on an own surface layer,
This PR removes the binding of RendererMediaCodecSurface to LinuxRendererGLES and tells kodi that Rendering is NOT GUI but VideoPlane.

## Motivation and Context
Video is not visible if home GUI is opened above a running video.

## How Has This Been Tested?
Android / play video / press [ESC] / Esturay Skin

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notes
- Not tested on mobile phone (screen rotation)
- I have removed some 3D stuff, maybe it breaks already working 3D functionality.