### PR TITLE
[fix] amlogic: 4k resolutions after f9d8ab7

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -131,8 +131,8 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
   m_bFullScreen = fullScreen;
 
   fbdev_window *nativeWindow = new fbdev_window;
-  nativeWindow->width = res.iScreenWidth;
-  nativeWindow->height = res.iScreenHeight;
+  nativeWindow->width = res.iWidth;
+  nativeWindow->height = res.iHeight;
   m_nativeWindow = static_cast<EGLNativeWindowType>(nativeWindow);
 
   aml_set_native_resolution(res, m_framebuffer_name);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

#11986 accidentally broke 4k resolutions on amlogic/linux, and I failed to test that ;)

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

```
ERROR: failed to create EGL window surface 12291
```
^ then screen is split into 2 (or 4) depending if video is playing or not, and an old frame of kodi GUI is drawn stretched

I dont understand most of the egl code, but it seems to me that GUI is not supposed to run at 4k

ref https://github.com/xbmc/xbmc/blob/master/xbmc/utils/AMLUtils.cpp#L497-L498 and below.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

runtime tested on wetek play 2.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

fyi @lrusak 

cc @wrxtasy @kszaq can you reproduce and confirm this fixes the bug for you ?