### PR TITLE
CVideoDatabase: fix setting named seasons when updating tvshow details

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -503,7 +503,7 @@ public:
   bool LoadVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int getDetails = VideoDbDetailsAll);
   bool GetMovieInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idMovie = -1, int getDetails = VideoDbDetailsAll);
   bool GetTvShowInfo(const std::string& strPath, CVideoInfoTag& details, int idTvShow = -1, CFileItem* item = NULL, int getDetails = VideoDbDetailsAll);
-  bool GetSeasonInfo(int idSeason, CVideoInfoTag& details);
+  bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, bool allDetails = true);
   bool GetEpisodeInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idEpisode = -1, int getDetails = VideoDbDetailsAll);
   bool GetMusicVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idMVideo = -1, int getDetails = VideoDbDetailsAll);
   bool GetSetInfo(int idSet, CVideoInfoTag& details);
@@ -846,7 +846,7 @@ public:
   \param season The season number we want to add.
   \return The dbId of the season.
   */
-  int AddSeason(int showID, int season);
+  int AddSeason(int showID, int season, const std::string& name = "");
   int AddSet(const std::string& strSet, const std::string& strOverview = "");
   void ClearMovieSet(int idMovie);
   void SetMovieSet(int idMovie, int idSet);


### PR DESCRIPTION
This fixes importing / setting named seasons. The problem was that with the introduction of `season_view` the call to `GetSeasonInfo()` caused a call to `GetSeasonsByWhere()` which in turn tried to access the `season_view` but if the season didn't exist before the current transaction querying the view makes no sense because it hasn't been updated yet. Therefore it always failed and therefore failed to set the name of the season.

This has been reported broken in http://forum.kodi.tv/showthread.php?tid=125749&pid=2584426#pid2584426.

It might make sense to backport this. I'll leave that decision up to @MartijnKaijser.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
