### PR TITLE
Increase commbreakautowait and commbreakautowind max seconds to 60

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -628,9 +628,19 @@ bool CEdl::AddCut(const Cut& newCut)
     int autowind = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iEdlCommBreakAutowind * 1000; // seconds -> ms
 
     if (cut.start > 0) // Only autowait if not at the start.
-     cut.start += autowait;
-    if (cut.end > cut.start + autowind) // Only autowind if it won't go back past the start (should never happen).
-     cut.end -= autowind;
+    {
+      /* get the cut length so we don't start skipping after the end */
+      int cutLength = cut.end - cut.start;
+      /* add the lesser of the cut length or the autowait to the start */
+      cut.start += autowait > cutLength ? cutLength : autowait;
+    }
+    if (cut.end > cut.start) // Only autowind if there is any cut time remaining.
+    {
+      /* get the remaining cut length so we don't rewind to before the start */
+      int cutLength = cut.end - cut.start;
+      /* subtract the lesser of the cut length or the autowind from the end */
+      cut.end -= autowind > cutLength ? cutLength : autowind;
+    }
   }
 
   /*

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -919,8 +919,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "mincommbreaklength", m_iEdlMinCommBreakLength, 0, 5 * 60);  // Between 0 and 5 minutes
     XMLUtils::GetInt(pElement, "maxcommbreakgap", m_iEdlMaxCommBreakGap, 0, 5 * 60);        // Between 0 and 5 minutes.
     XMLUtils::GetInt(pElement, "maxstartgap", m_iEdlMaxStartGap, 0, 10 * 60);               // Between 0 and 10 minutes
-    XMLUtils::GetInt(pElement, "commbreakautowait", m_iEdlCommBreakAutowait, 0, 10);        // Between 0 and 10 seconds
-    XMLUtils::GetInt(pElement, "commbreakautowind", m_iEdlCommBreakAutowind, 0, 10);        // Between 0 and 10 seconds
+    XMLUtils::GetInt(pElement, "commbreakautowait", m_iEdlCommBreakAutowait, -60, 60);        // Between -60 and 60 seconds
+    XMLUtils::GetInt(pElement, "commbreakautowind", m_iEdlCommBreakAutowind, -60, 60);        // Between -60 and 60 seconds
   }
 
   // picture exclude regexps


### PR DESCRIPTION
Increase commbreakautowait and commbreakautowind max seconds from 10 to 60.

## Description
Allow max commbreakautowait time to be up to 60 seconds. 
Modify Edl.cpp autowait and autowind logic to handle the situation where the wait and or wind time results in the start time being greater than the end time.

## Motivation and Context
The mythtv backend usually flags the beginning of commercial breaks 20-30 seconds before the break starts. Kodi only allows a 10 second wait.

I'm not sure if this is an open issue, but I did find a user complaining about it in the link below when searching the web for the issue.
http://forum.kodi.tv/showthread.php?tid=257520
This user had the exact behavior wrong, but I believe was suffering from the same issue as me. I was not able to determine the exact behavior until looking at the code.

## How Has This Been Tested?
I am not able to test as I don't have a test environment.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
(The wiki does not specify a maximum value for these settings, but I would have found it useful if it did)

- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
