### PR TITLE
[cmake][addons][windows] mingw: fix x64

### DIFF
--- a/cmake/addons/depends/windows/cmake/mingw/CMakeLists.txt
+++ b/cmake/addons/depends/windows/cmake/mingw/CMakeLists.txt
@@ -9,7 +9,11 @@ endfunction()
 get_filename_component(CORE_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../../../../../.. REALPATH)
 
 set(MSYS_PATH "${CORE_SOURCE_DIR}/project/BuildDependencies/msys64")
-set(MINGW_PATH "${MSYS_PATH}/mingw32")
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set(MINGW_PATH "${MSYS_PATH}/mingw32")
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(MINGW_PATH "${MSYS_PATH}/mingw64")
+endif()
 
 # configure the MinGW toolchain file
 configure_file(${PROJECT_SOURCE_DIR}/Toolchain_mingw32.cmake.in ${CMAKE_INSTALL_PREFIX}/Toolchain_mingw32.cmake @ONLY)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Differentiate between windows 32 and 64 bit builds at the binary addon mingw environment.
<!--- Describe your change in detail -->

## Motivation and Context
Build `game.libretro.2048` for windows x64.
@garbear FYI
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled `game.libretro.2048` for windows win32 and x64
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
