### PR TITLE
[gui] no need to store/restore modeless dialogs while unload/load skin

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1623,8 +1623,6 @@ bool CApplication::LoadSkin(const std::string& skinID)
   CGUIWindow* pWindow = g_windowManager.GetWindow(currentWindow);
   if (pWindow)
     iCtrlID = pWindow->GetFocusedControlID();
-  std::vector<int> currentModelessWindows;
-  g_windowManager.GetActiveModelessWindows(currentModelessWindows);
 
   UnloadSkin();
 
@@ -1697,12 +1695,6 @@ bool CApplication::LoadSkin(const std::string& skinID)
   if (currentWindow != WINDOW_INVALID)
   {
     g_windowManager.ActivateWindow(currentWindow);
-    for (unsigned int i = 0; i < currentModelessWindows.size(); i++)
-    {
-      CGUIDialog *dialog = g_windowManager.GetDialog(currentModelessWindows[i]);
-      if (dialog)
-        dialog->Open();
-    }
     if (iCtrlID != -1)
     {
       pWindow = g_windowManager.GetWindow(currentWindow);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1548,18 +1548,6 @@ void CGUIWindowManager::AddToWindowHistory(int newWindowID)
   }
 }
 
-void CGUIWindowManager::GetActiveModelessWindows(std::vector<int> &ids)
-{
-  // run through our modeless windows, and construct a vector of them
-  // useful for saving and restoring the modeless windows on skin change etc.
-  CSingleLock lock(g_graphicsContext);
-  for (const auto& window : m_activeDialogs)
-  {
-    if (!window->IsModalDialog())
-      ids.push_back(window->GetID());
-  }
-}
-
 CGUIWindow *CGUIWindowManager::GetTopMostDialog() const
 {
   CSingleLock lock(g_graphicsContext);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1244,6 +1244,7 @@ void CGUIWindowManager::DeInitialize()
   for (int i = 0; i < int(m_vecCustomWindows.size()); i++)
   {
     CGUIWindow *pWindow = m_vecCustomWindows[i];
+    RemoveFromWindowHistory(pWindow->GetID());
     Remove(pWindow->GetID());
     delete pWindow;
   }
@@ -1545,6 +1546,26 @@ void CGUIWindowManager::AddToWindowHistory(int newWindowID)
     // didn't find window in history - add it to the stack
     // but do not add the splash window to history, as we never want to travel back to it
     m_windowHistory.push(newWindowID);
+  }
+}
+
+void CGUIWindowManager::RemoveFromWindowHistory(int windowID)
+{
+  std::stack<int> stack = m_windowHistory;
+
+  // pop windows from stack until we found the window
+  while (!stack.empty())
+  {
+    if (stack.top() == windowID)
+      break;
+    stack.pop();
+  }
+
+  // found window in history
+  if (!stack.empty())
+  {
+    stack.pop(); // remove window from stack
+    m_windowHistory = stack;
   }
 }
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -210,7 +210,7 @@ public:
    * \return true if the given window is a python window, otherwise false.
    */
   bool IsPythonWindow(int id) const { return (id >= WINDOW_PYTHON_START && id <= WINDOW_PYTHON_END); };
-  void GetActiveModelessWindows(std::vector<int> &ids);
+
 #ifdef _DEBUG
   void DumpTextureUse();
 #endif

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -220,6 +220,15 @@ private:
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();
   void AddToWindowHistory(int newWindowID);
+
+  /*!
+   \brief Check if the given window id is in the window history, and if so, remove this
+    window and all overlying windows from the history so that we always have a predictable
+    "Back" behaviour for each window.
+
+   \param windowID the window id to remove from the window history
+   */
+  void RemoveFromWindowHistory(int windowID);
   void ClearWindowHistory();
   void CloseWindowSync(CGUIWindow *window, int nextWindowID = 0);
   CGUIWindow *GetTopMostDialog() const;


### PR DESCRIPTION
There is no need to store/restore modeless dialogs while unload/load skin. A modeless dialog will automatically be opened/closed depending on its visible condition.

This also leads to problems if different skins use custom modeless dialogs with the same id (skin A and B use window id 1000) and you switch between this skins (see http://forum.kodi.tv/showthread.php?tid=314185)

@BigNoid mind taking a look.