### PR TITLE
[cmake] bump required vaapi version to 0.39 (libva 1.7.3)

### DIFF
--- a/cmake/modules/FindVAAPI.cmake
+++ b/cmake/modules/FindVAAPI.cmake
@@ -36,7 +36,7 @@ elseif(VAAPI_INCLUDE_DIR AND EXISTS "${VAAPI_INCLUDE_DIR}/va/va_version.h")
 endif()
 
 if(NOT VAAPI_FIND_VERSION)
-  set(VAAPI_FIND_VERSION 0.38.0)
+  set(VAAPI_FIND_VERSION 0.39.0)
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
needed after 58ef4a0e5242d93a0a295628d5532bad1241c1f4