### PR TITLE
smbclient: cleanup smbclient configuration

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19740,7 +19740,49 @@ msgctxt "#36620"
 msgid "Enable high quality downscaling of pictures (uses more memory and has moderate performance impact)."
 msgstr ""
 
-#empty strings from id 36621 to 36899
+#. Label of a setting, allow the maximum smbclient protocol to be configured
+#: system/settings/settings.xml
+msgctxt "#36621"
+msgid "Maximum protocol version"
+msgstr ""
+
+#. Description of setting with label #36621 "Maximum protocol version"
+#: system/settings/settings.xml
+msgctxt "#36622"
+msgid "Set the maximum SMB protocol version to negotiate when making connections. Forcing SMBv2 or SMBv1 compatibility may be required with older NAS and Windows shares."
+msgstr ""
+
+#. Values for setting with label #36621 "Maximum protocol version" - none means "no protocol version is forced"
+#: system/settings/settings.xml
+msgctxt "#36623"
+msgid "None"
+msgstr ""
+
+#. Values for setting with label #36621 "Maximum protocol version"
+#: system/settings/settings.xml
+msgctxt "#36624"
+msgid "SMBv1"
+msgstr ""
+
+#. Values for setting with label #36621 "Maximum protocol version"
+#: system/settings/settings.xml
+msgctxt "#36625"
+msgid "SMBv2"
+msgstr ""
+
+#. Values for setting with label #36621 "Maximum protocol version"
+#: system/settings/settings.xml
+msgctxt "#36626"
+msgid "SMBv3"
+msgstr ""
+
+#. Label of a group, that allows configuration of the system SMB client
+#: system/settings/settings.xml
+msgctxt "#36627"
+msgid "Client"
+msgstr ""
+
+#empty strings from id 36628 to 36899
 
 #: xbmc/media/MediaType.cpp
 msgctxt "#36900"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1907,15 +1907,30 @@
     <category id="smb" label="1200" help="36346">
       <requirement>HAS_FILESYSTEM_SMB</requirement>
       <group id="1" label="16000">
+        <setting id="smb.workgroup" type="string" label="1202" help="36348">
+          <level>2</level>
+          <default>WORKGROUP</default>
+          <control type="edit" format="string" />
+        </setting>
+      </group>
+      <group id="2" label="36627">
         <setting id="smb.winsserver" type="string" label="1207" help="36347">
           <level>2</level>
           <default>0.0.0.0</default>
           <control type="edit" format="ip" />
         </setting>
-        <setting id="smb.workgroup" type="string" label="1202" help="36348">
+        <setting id="smb.maxprotocol" type="integer" label="36621" help="36622">
           <level>2</level>
-          <default>WORKGROUP</default>
-          <control type="edit" format="string" />
+          <default>3</default>
+          <constraints>
+            <options>
+              <option label="36623">0</option>
+              <option label="36624">1</option>
+              <option label="36625">2</option>
+              <option label="36626">3</option>
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
         </setting>
       </group>
     </category>

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -118,6 +118,7 @@ CNetworkServices::CNetworkServices()
   , m_httpWebinterfaceAddonsHandler(*new CHTTPWebinterfaceAddonsHandler)
 #endif // HAS_WEB_INTERFACE
 #endif // HAS_WEB_SERVER
+
 {
 #ifdef HAS_WEB_SERVER
   m_webserver.RegisterRequestHandler(&m_httpImageHandler);
@@ -439,7 +440,8 @@ void CNetworkServices::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   else
 #endif // HAS_WEB_SERVER
   if (settingId == CSettings::SETTING_SMB_WINSSERVER ||
-      settingId == CSettings::SETTING_SMB_WORKGROUP)
+      settingId == CSettings::SETTING_SMB_WORKGROUP ||
+      settingId == CSettings::SETTING_SMB_MAXPROTOCOL)
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     //! @todo - General way of handling setting changes that require restart

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -333,6 +333,7 @@ const std::string CSettings::SETTING_SERVICES_AIRPLAYPASSWORD = "services.airpla
 const std::string CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT = "services.airplayvideosupport";
 const std::string CSettings::SETTING_SMB_WINSSERVER = "smb.winsserver";
 const std::string CSettings::SETTING_SMB_WORKGROUP = "smb.workgroup";
+const std::string CSettings::SETTING_SMB_MAXPROTOCOL = "smb.maxprotocol";
 const std::string CSettings::SETTING_VIDEOSCREEN_MONITOR = "videoscreen.monitor";
 const std::string CSettings::SETTING_VIDEOSCREEN_SCREEN = "videoscreen.screen";
 const std::string CSettings::SETTING_VIDEOSCREEN_RESOLUTION = "videoscreen.resolution";
@@ -1002,6 +1003,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_SERVICES_ESCONTINUOUSDELAY);
   settingSet.insert(CSettings::SETTING_SMB_WINSSERVER);
   settingSet.insert(CSettings::SETTING_SMB_WORKGROUP);
+  settingSet.insert(CSettings::SETTING_SMB_MAXPROTOCOL);
   GetSettingsManager()->RegisterCallback(&CNetworkServices::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -277,6 +277,7 @@ public:
   static const std::string SETTING_SERVICES_AIRPLAYVIDEOSUPPORT;
   static const std::string SETTING_SMB_WINSSERVER;
   static const std::string SETTING_SMB_WORKGROUP;
+  static const std::string SETTING_SMB_MAXPROTOCOL;
   static const std::string SETTING_VIDEOSCREEN_MONITOR;
   static const std::string SETTING_VIDEOSCREEN_SCREEN;
   static const std::string SETTING_VIDEOSCREEN_RESOLUTION;


### PR DESCRIPTION
This PR does some overdue cleanup on the smbclient configuration used by Kodi.

## Description

* Removed by fritch: ~~`socket options` tuning that is not recommended: https://lists.samba.org/archive/samba/2013-February/171836.html~~

* Removes `preferred master`, `local master`, `domain master` smbd configuration that is irrelevant to smbclient.

* Removes `client lanman auth` so smbclient can use more secure hash algorithms. This breaks compatibility with Windows 95/98 and pre Samba 2.2 shares (c.2000) that do not support NTLM or NTLMv2.

* Removes `lanman auth` smbd configuration that is irrelevant to smbclient.

* Sets `client max protocol` to SMB3. Without this smbclient (and thus Kodi) defaults to NT1 (SMB1) and will not attempt connecting at higher protocol versions. Setting to SMB3 allows smbclient to auto-negotiate a higher protocol with most devices. Some older Windows and Samba versions can require `client max protocol` to be reduced to SMB2 or SMB1 to solve connectivity issues (server side bugs or misconfiguration) so we expose this as a configuration option in Kodi settings. Using SMB3 with smbclient versions below 4.1 that do not support SMB2+ are not affected; older smbclient versions simply negotiate up to what they understand, i.e. NT1. This is part based on https://github.com/koying/SPMC/commit/833aacd4698a7c5af09a94000784c492210959ef that forces NT1 connectivity.

* Fixes a bug where `smb.conf` was not written if the file was not already present. The smb.conf file is also created under the Kodi home folder to prevent clashes with other smb.conf files that may exist on the users' system. The smb.con file is rewritten if the user changes the client max protocol setting (and the user is prompted to restart Kodi to effect the change). This borrows from https://github.com/koying/SPMC/commit/2771cb222d4d09082dac06ce970dba0f6293cd56 that made rewrite on start user configurable and other ideas from Slack.

## Motivation and Context
Wannacry ransomware attacks have woken people up to the security issues with SMB1 and Kodi refusing to use anything newer forces people to continue using insecure shares. LE plans to use a Krypton version of this with samba 4.6 in a future release to bring SMB2/3 support. NB: This PR is intended as a nip/tuck improvement to the existing regime until someone comes up with a more long-term replacement for smbclient.

## How Has This Been Tested?
Lots of experimentation and detective work from @MilhouseVH. An earlier variant of the max client protocol change and samba 4 have been in his nightly builds for several months and this specific PR will be included shortly. It has not been tested with other Kodi build targets that use smbclient (macOS, Android, etc.) but testing with older smbclient 3.6 on Linux hasn't thrown up any obvious issues.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed