### PR TITLE
[pvr] rename addon callbacks to a "C" name

### DIFF
--- a/xbmc/addons/interfaces/PVR/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/interfaces/PVR/AddonCallbacksPVR.cpp
@@ -117,24 +117,24 @@ CAddonCallbacksPVR::CAddonCallbacksPVR(CAddon* addon)
     m_callbacks(new CB_PVRLib)
 {
   /* write XBMC PVR specific add-on function addresses to callback table */
-  m_callbacks->TransferEpgEntry           = PVRTransferEpgEntry;
-  m_callbacks->TransferChannelEntry       = PVRTransferChannelEntry;
-  m_callbacks->TransferTimerEntry         = PVRTransferTimerEntry;
-  m_callbacks->TransferRecordingEntry     = PVRTransferRecordingEntry;
-  m_callbacks->AddMenuHook                = PVRAddMenuHook;
-  m_callbacks->Recording                  = PVRRecording;
-  m_callbacks->TriggerChannelUpdate       = PVRTriggerChannelUpdate;
-  m_callbacks->TriggerChannelGroupsUpdate = PVRTriggerChannelGroupsUpdate;
-  m_callbacks->TriggerTimerUpdate         = PVRTriggerTimerUpdate;
-  m_callbacks->TriggerRecordingUpdate     = PVRTriggerRecordingUpdate;
-  m_callbacks->TriggerEpgUpdate           = PVRTriggerEpgUpdate;
-  m_callbacks->FreeDemuxPacket            = PVRFreeDemuxPacket;
-  m_callbacks->AllocateDemuxPacket        = PVRAllocateDemuxPacket;
-  m_callbacks->TransferChannelGroup       = PVRTransferChannelGroup;
-  m_callbacks->TransferChannelGroupMember = PVRTransferChannelGroupMember;
-  m_callbacks->ConnectionStateChange      = PVRConnectionStateChange;
-  m_callbacks->EpgEventStateChange        = PVREpgEventStateChange;
-  m_callbacks->GetCodecByName = GetCodecByName;
+  m_callbacks->TransferEpgEntry = cb_transfer_epg_entry;
+  m_callbacks->TransferChannelEntry = cb_transfer_channel_entry;
+  m_callbacks->TransferTimerEntry = cb_transfer_timer_entry;
+  m_callbacks->TransferRecordingEntry = cb_transfer_recording_entry;
+  m_callbacks->AddMenuHook = cb_add_menu_hook;
+  m_callbacks->Recording = cb_recording;
+  m_callbacks->TriggerChannelUpdate = cb_trigger_channel_update;
+  m_callbacks->TriggerChannelGroupsUpdate = cb_trigger_channel_groups_update;
+  m_callbacks->TriggerTimerUpdate = cb_trigger_timer_update;
+  m_callbacks->TriggerRecordingUpdate = cb_trigger_recording_update;
+  m_callbacks->TriggerEpgUpdate = cb_trigger_epg_update;
+  m_callbacks->FreeDemuxPacket = cb_free_demux_packet;
+  m_callbacks->AllocateDemuxPacket = cb_allocate_demux_packet;
+  m_callbacks->TransferChannelGroup = cb_transfer_channel_group;
+  m_callbacks->TransferChannelGroupMember = cb_transfer_channel_group_member;
+  m_callbacks->ConnectionStateChange = cb_connection_state_change;
+  m_callbacks->EpgEventStateChange = cb_epg_event_state_change;
+  m_callbacks->GetCodecByName = cb_get_codec_by_name;
 }
 
 CAddonCallbacksPVR::~CAddonCallbacksPVR()
@@ -155,7 +155,7 @@ CPVRClient *CAddonCallbacksPVR::GetPVRClient(void *addonData)
   return dynamic_cast<CPVRClient *>(static_cast<CAddonCallbacksPVR*>(addon->PVRLib_GetHelper())->m_addon);
 }
 
-void CAddonCallbacksPVR::PVRTransferChannelGroup(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
+void CAddonCallbacksPVR::cb_transfer_channel_group(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
 {
   if (!handle)
   {
@@ -181,7 +181,7 @@ void CAddonCallbacksPVR::PVRTransferChannelGroup(void *addonData, const ADDON_HA
   xbmcGroups->UpdateFromClient(transferGroup);
 }
 
-void CAddonCallbacksPVR::PVRTransferChannelGroupMember(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
+void CAddonCallbacksPVR::cb_transfer_channel_group_member(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
 {
   if (!handle)
   {
@@ -209,7 +209,7 @@ void CAddonCallbacksPVR::PVRTransferChannelGroupMember(void *addonData, const AD
   }
 }
 
-void CAddonCallbacksPVR::PVRTransferEpgEntry(void *addonData, const ADDON_HANDLE handle, const EPG_TAG *epgentry)
+void CAddonCallbacksPVR::cb_transfer_epg_entry(void *addonData, const ADDON_HANDLE handle, const EPG_TAG *epgentry)
 {
   if (!handle)
   {
@@ -228,7 +228,7 @@ void CAddonCallbacksPVR::PVRTransferEpgEntry(void *addonData, const ADDON_HANDLE
   xbmcEpg->UpdateEntry(epgentry, handle->dataIdentifier == 1 /* update db */);
 }
 
-void CAddonCallbacksPVR::PVRTransferChannelEntry(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL *channel)
+void CAddonCallbacksPVR::cb_transfer_channel_entry(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL *channel)
 {
   if (!handle)
   {
@@ -249,7 +249,7 @@ void CAddonCallbacksPVR::PVRTransferChannelEntry(void *addonData, const ADDON_HA
   xbmcChannels->UpdateFromClient(transferChannel);
 }
 
-void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_HANDLE handle, const PVR_RECORDING *recording)
+void CAddonCallbacksPVR::cb_transfer_recording_entry(void *addonData, const ADDON_HANDLE handle, const PVR_RECORDING *recording)
 {
   if (!handle)
   {
@@ -270,7 +270,7 @@ void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_
   xbmcRecordings->UpdateFromClient(transferRecording);
 }
 
-void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER *timer)
+void CAddonCallbacksPVR::cb_transfer_timer_entry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER *timer)
 {
   if (!handle)
   {
@@ -294,7 +294,7 @@ void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HAND
   xbmcTimers->UpdateFromClient(transferTimer);
 }
 
-void CAddonCallbacksPVR::PVRAddMenuHook(void *addonData, PVR_MENUHOOK *hook)
+void CAddonCallbacksPVR::cb_add_menu_hook(void *addonData, PVR_MENUHOOK *hook)
 {
   CPVRClient *client = GetPVRClient(addonData);
   if (!hook || !client)
@@ -316,7 +316,7 @@ void CAddonCallbacksPVR::PVRAddMenuHook(void *addonData, PVR_MENUHOOK *hook)
   }
 }
 
-void CAddonCallbacksPVR::PVRRecording(void *addonData, const char *strName, const char *strFileName, bool bOnOff)
+void CAddonCallbacksPVR::cb_recording(void *addonData, const char *strName, const char *strFileName, bool bOnOff)
 {
   CPVRClient *client = GetPVRClient(addonData);
   if (!client || !strFileName)
@@ -340,31 +340,31 @@ void CAddonCallbacksPVR::PVRRecording(void *addonData, const char *strName, cons
       __FUNCTION__, bOnOff ? "started" : "finished", client->Name().c_str(), strName, strFileName);
 }
 
-void CAddonCallbacksPVR::PVRTriggerChannelUpdate(void *addonData)
+void CAddonCallbacksPVR::cb_trigger_channel_update(void *addonData)
 {
   /* update the channels table in the next iteration of the pvrmanager's main loop */
   CServiceBroker::GetPVRManager().TriggerChannelsUpdate();
 }
 
-void CAddonCallbacksPVR::PVRTriggerTimerUpdate(void *addonData)
+void CAddonCallbacksPVR::cb_trigger_timer_update(void *addonData)
 {
   /* update the timers table in the next iteration of the pvrmanager's main loop */
   CServiceBroker::GetPVRManager().TriggerTimersUpdate();
 }
 
-void CAddonCallbacksPVR::PVRTriggerRecordingUpdate(void *addonData)
+void CAddonCallbacksPVR::cb_trigger_recording_update(void *addonData)
 {
   /* update the recordings table in the next iteration of the pvrmanager's main loop */
   CServiceBroker::GetPVRManager().TriggerRecordingsUpdate();
 }
 
-void CAddonCallbacksPVR::PVRTriggerChannelGroupsUpdate(void *addonData)
+void CAddonCallbacksPVR::cb_trigger_channel_groups_update(void *addonData)
 {
   /* update all channel groups in the next iteration of the pvrmanager's main loop */
   CServiceBroker::GetPVRManager().TriggerChannelGroupsUpdate();
 }
 
-void CAddonCallbacksPVR::PVRTriggerEpgUpdate(void *addonData, unsigned int iChannelUid)
+void CAddonCallbacksPVR::cb_trigger_epg_update(void *addonData, unsigned int iChannelUid)
 {
   // get the client
   CPVRClient *client = GetPVRClient(addonData);
@@ -377,17 +377,17 @@ void CAddonCallbacksPVR::PVRTriggerEpgUpdate(void *addonData, unsigned int iChan
   CServiceBroker::GetPVRManager().EpgContainer().UpdateRequest(client->GetID(), iChannelUid);
 }
 
-void CAddonCallbacksPVR::PVRFreeDemuxPacket(void *addonData, DemuxPacket* pPacket)
+void CAddonCallbacksPVR::cb_free_demux_packet(void *addonData, DemuxPacket* pPacket)
 {
   CDVDDemuxUtils::FreeDemuxPacket(pPacket);
 }
 
-DemuxPacket* CAddonCallbacksPVR::PVRAllocateDemuxPacket(void *addonData, int iDataSize)
+DemuxPacket* CAddonCallbacksPVR::cb_allocate_demux_packet(void *addonData, int iDataSize)
 {
   return CDVDDemuxUtils::AllocateDemuxPacket(iDataSize);
 }
 
-void CAddonCallbacksPVR::PVRConnectionStateChange(void* addonData, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage)
+void CAddonCallbacksPVR::cb_connection_state_change(void* addonData, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage)
 {
   CPVRClient *client = GetPVRClient(addonData);
   if (!client || !strConnectionString)
@@ -449,7 +449,7 @@ void CAddonCallbacksPVR::UpdateEpgEvent(const EpgEventStateChange &ch, bool bQue
               __FUNCTION__, ch.iUniqueChannelId, bQueued ? "queued " : "", ch.event->UniqueBroadcastID());
 }
 
-void CAddonCallbacksPVR::PVREpgEventStateChange(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState)
+void CAddonCallbacksPVR::cb_epg_event_state_change(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState)
 {
   CPVRClient *client = GetPVRClient(addonData);
   if (!client || !tag)
@@ -489,7 +489,7 @@ void CAddonCallbacksPVR::PVREpgEventStateChange(void* addonData, EPG_TAG* tag, u
   }
 }
 
-xbmc_codec_t CAddonCallbacksPVR::GetCodecByName(const void* addonData, const char* strCodecName)
+xbmc_codec_t CAddonCallbacksPVR::cb_get_codec_by_name(const void* addonData, const char* strCodecName)
 {
   (void)addonData;
   return CCodecIds::GetInstance().GetCodecByName(strCodecName);

--- a/xbmc/addons/interfaces/PVR/AddonCallbacksPVR.h
+++ b/xbmc/addons/interfaces/PVR/AddonCallbacksPVR.h
@@ -64,7 +64,7 @@ public:
    * @param handle The handle parameter that XBMC used when requesting the channel groups list
    * @param entry The entry to transfer to XBMC
    */
-  static void PVRTransferChannelGroup(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP* entry);
+  static void cb_transfer_channel_group(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP* entry);
 
   /*!
    * @brief Transfer a channel group member entry from the add-on to XBMC. The channel will be added to the group if the group can be found.
@@ -72,7 +72,7 @@ public:
    * @param handle The handle parameter that XBMC used when requesting the channel group members list
    * @param entry The entry to transfer to XBMC
    */
-  static void PVRTransferChannelGroupMember(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER* entry);
+  static void cb_transfer_channel_group_member(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER* entry);
 
   /*!
    * @brief Transfer an EPG tag from the add-on to XBMC
@@ -80,7 +80,7 @@ public:
    * @param handle The handle parameter that XBMC used when requesting the EPG data
    * @param entry The entry to transfer to XBMC
    */
-  static void PVRTransferEpgEntry(void* addonData, const ADDON_HANDLE handle, const EPG_TAG* entry);
+  static void cb_transfer_epg_entry(void* addonData, const ADDON_HANDLE handle, const EPG_TAG* entry);
 
   /*!
    * @brief Transfer a channel entry from the add-on to XBMC
@@ -88,7 +88,7 @@ public:
    * @param handle The handle parameter that XBMC used when requesting the channel list
    * @param entry The entry to transfer to XBMC
    */
-  static void PVRTransferChannelEntry(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL* entry);
+  static void cb_transfer_channel_entry(void* addonData, const ADDON_HANDLE handle, const PVR_CHANNEL* entry);
 
   /*!
    * @brief Transfer a timer entry from the add-on to XBMC
@@ -96,7 +96,7 @@ public:
    * @param handle The handle parameter that XBMC used when requesting the timers list
    * @param entry The entry to transfer to XBMC
    */
-  static void PVRTransferTimerEntry(void* addonData, const ADDON_HANDLE handle, const PVR_TIMER* entry);
+  static void cb_transfer_timer_entry(void* addonData, const ADDON_HANDLE handle, const PVR_TIMER* entry);
 
   /*!
    * @brief Transfer a recording entry from the add-on to XBMC
@@ -104,14 +104,14 @@ public:
    * @param handle The handle parameter that XBMC used when requesting the recordings list
    * @param entry The entry to transfer to XBMC
    */
-  static void PVRTransferRecordingEntry(void* addonData, const ADDON_HANDLE handle, const PVR_RECORDING* entry);
+  static void cb_transfer_recording_entry(void* addonData, const ADDON_HANDLE handle, const PVR_RECORDING* entry);
 
   /*!
    * @brief Add or replace a menu hook for the context menu for this add-on
    * @param addonData A pointer to the add-on.
    * @param hook The hook to add.
    */
-  static void PVRAddMenuHook(void* addonData, PVR_MENUHOOK* hook);
+  static void cb_add_menu_hook(void* addonData, PVR_MENUHOOK* hook);
 
   /*!
    * @brief Display a notification in XBMC that a recording started or stopped on the server
@@ -120,45 +120,45 @@ public:
    * @param strFileName The filename of the recording
    * @param bOnOff True when recording started, false when it stopped
    */
-  static void PVRRecording(void* addonData, const char* strName, const char* strFileName, bool bOnOff);
+  static void cb_recording(void* addonData, const char* strName, const char* strFileName, bool bOnOff);
 
   /*!
    * @brief Request XBMC to update it's list of channels
    * @param addonData A pointer to the add-on.
    */
-  static void PVRTriggerChannelUpdate(void* addonData);
+  static void cb_trigger_channel_update(void* addonData);
 
   /*!
    * @brief Request XBMC to update it's list of timers
    * @param addonData A pointer to the add-on.
    */
-  static void PVRTriggerTimerUpdate(void* addonData);
+  static void cb_trigger_timer_update(void* addonData);
 
   /*!
    * @brief Request XBMC to update it's list of recordings
    * @param addonData A pointer to the add-on.
    */
-  static void PVRTriggerRecordingUpdate(void* addonData);
+  static void cb_trigger_recording_update(void* addonData);
 
   /*!
    * @brief Request XBMC to update it's list of channel groups
    * @param addonData A pointer to the add-on.
    */
-  static void PVRTriggerChannelGroupsUpdate(void* addonData);
+  static void cb_trigger_channel_groups_update(void* addonData);
 
   /*!
    * @brief Schedule an EPG update for the given channel channel
    * @param addonData A pointer to the add-on
    * @param iChannelUid The unique id of the channel for this add-on
    */
-  static void PVRTriggerEpgUpdate(void* addonData, unsigned int iChannelUid);
+  static void cb_trigger_epg_update(void* addonData, unsigned int iChannelUid);
 
   /*!
    * @brief Free a packet that was allocated with AllocateDemuxPacket
    * @param addonData A pointer to the add-on.
    * @param pPacket The packet to free.
    */
-  static void PVRFreeDemuxPacket(void* addonData, DemuxPacket* pPacket);
+  static void cb_free_demux_packet(void* addonData, DemuxPacket* pPacket);
 
   /*!
    * @brief Allocate a demux packet. Free with FreeDemuxPacket
@@ -166,7 +166,7 @@ public:
    * @param iDataSize The size of the data that will go into the packet
    * @return The allocated packet.
    */
-  static DemuxPacket* PVRAllocateDemuxPacket(void* addonData, int iDataSize = 0);
+  static DemuxPacket* cb_allocate_demux_packet(void* addonData, int iDataSize = 0);
 
   /*!
    * @brief Notify a state change for a PVR backend connection
@@ -176,7 +176,7 @@ public:
    * @param strMessage A localized addon-defined string representing the new state, that can be displayed
    *        in the UI or NULL if the Kodi-defined default string for the new state shall be displayed.
    */
-  static void PVRConnectionStateChange(void* addonData, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage);
+  static void cb_connection_state_change(void* addonData, const char* strConnectionString, PVR_CONNECTION_STATE newState, const char *strMessage);
 
   /*!
    * @brief Notify a state change for an EPG event
@@ -187,12 +187,12 @@ public:
    * @param newState The new state. For EPG_EVENT_CREATED and EPG_EVENT_UPDATED, tag must be filled with all available
    *        event data, not just a delta. For EPG_EVENT_DELETED, it is sufficient to fill EPG_TAG.iUniqueBroadcastId
    */
-  static void PVREpgEventStateChange(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState);
+  static void cb_epg_event_state_change(void* addonData, EPG_TAG* tag, unsigned int iUniqueChannelId, EPG_EVENT_STATE newState);
 
   /*! @todo remove the use complete from them, or add as generl function?!
    * Returns the ffmpeg codec id from given ffmpeg codec string name
    */
-  static xbmc_codec_t GetCodecByName(const void* addonData, const char* strCodecName);
+  static xbmc_codec_t cb_get_codec_by_name(const void* addonData, const char* strCodecName);
 
 private:
   static ::PVR::CPVRClient* GetPVRClient(void* addonData);


### PR DESCRIPTION
## Description

Reasons for this change are:
- To identify callbacks from addon to kodi more easy and know that
functions are not used from Kodi itself and must be "C" style
- On next pull requests are this functions moved to CPVRClient and to
see that them are callbacks

Addons itself are not affected from this change.

@ksooo is this for you OK?
<!--- Provide a general summary of your change in the Title above -->

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
