### PR TITLE
platinum: Fix upnp:lastPlaybackPosition parsing

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
@@ -762,7 +762,10 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
     m_MiscInfo.original_track_number = value;
 
     PLT_XmlHelper::GetChildText(entry, "lastPlaybackPosition", str, didl_namespace_upnp);
-    if (NPT_FAILED(str.ToInteger(value))) value = 0;
+    if (NPT_FAILED(PLT_Didl::ParseTimeStamp(str, value))) {
+        // fall back to raw integer parsing
+        if (NPT_FAILED(str.ToInteger(value))) value = 0;
+    }
     m_MiscInfo.last_position = value;
 
     PLT_XmlHelper::GetChildText(entry, "lastPlaybackTime", m_MiscInfo.last_time, didl_namespace_upnp, 256);

--- a/lib/libUPnP/patches/0043-platinum-Fix-upnp-lastPlaybackPosition-parsing.patch
+++ b/lib/libUPnP/patches/0043-platinum-Fix-upnp-lastPlaybackPosition-parsing.patch
@@ -1,0 +1,32 @@
+From f65143c87c8d35e26b0876e9789c47b2dddaaf12 Mon Sep 17 00:00:00 2001
+From: Justin Maggard <jmaggard@netgear.com>
+Date: Wed, 17 May 2017 14:11:44 -0700
+Subject: [PATCH] platinum: Fix upnp:lastPlaybackPosition parsing
+
+According to the UPnP spec, upnp:lastPlaybackPosition should use the
+same format as duration (HH:MM:SS). So we should at least accept the
+proper format if it exists, and fall back to the raw integer value if
+it's not in the proper format.
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+index 5324dcb0e4..fac16902f7 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaItem.cpp
+@@ -762,7 +762,10 @@ PLT_MediaObject::FromDidl(NPT_XmlElementNode* entry)
+     m_MiscInfo.original_track_number = value;
+ 
+     PLT_XmlHelper::GetChildText(entry, "lastPlaybackPosition", str, didl_namespace_upnp);
+-    if (NPT_FAILED(str.ToInteger(value))) value = 0;
++    if (NPT_FAILED(PLT_Didl::ParseTimeStamp(str, value))) {
++        // fall back to raw integer parsing
++        if (NPT_FAILED(str.ToInteger(value))) value = 0;
++    }
+     m_MiscInfo.last_position = value;
+ 
+     PLT_XmlHelper::GetChildText(entry, "lastPlaybackTime", m_MiscInfo.last_time, didl_namespace_upnp, 256);
+-- 
+2.13.0
+


### PR DESCRIPTION
According to the UPnP spec, upnp:lastPlaybackPosition should use the
same format as duration (HH:MM:SS). So we should at least accept the
proper format if it exists, and fall back to the raw integer value if
it's not in the proper format.

Signed-off-by: Justin Maggard <jmaggard@netgear.com>

## How Has This Been Tested?
I verified that both the existing format (number of seconds integer value) and the proper format (HH:MM:SS) both work.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
