### PR TITLE
[Music]Better artist and album scraping during library update, store scraped mbids

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -719,6 +719,7 @@ void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
 {
   album.strAlbum = item.GetLabel();
   album.strMusicBrainzAlbumID = FromString(item, "album.musicbrainzid");
+  album.strReleaseGroupMBID = FromString(item, "album.releasegroupid");
 
   int nArtists = item.GetProperty("album.artists").asInteger();
   album.artistCredits.reserve(nArtists);

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -46,6 +46,8 @@ public:
     , bCompilation(false)
     , iTimesPlayed(0)
     , releaseType(Album)
+    , bScrapedMBID(false)
+    , bArtistSongMerge(false)
   {};
   bool operator<(const CAlbum &a) const;
   void MergeScrapedAlbum(const CAlbum& album, bool override = true);
@@ -55,6 +57,7 @@ public:
     idAlbum = -1;
     strAlbum.clear();
     strMusicBrainzAlbumID.clear();
+    strReleaseGroupMBID.clear();
     artistCredits.clear();
     strArtistDesc.clear();
     strArtistSort.clear();
@@ -80,6 +83,8 @@ public:
     songs.clear();
     infoSongs.clear();
     releaseType = Album;
+    bScrapedMBID = false;
+    bArtistSongMerge = false;
   }
 
   /*! \brief Get album artist names from the vector of artistcredits objects
@@ -136,6 +141,7 @@ public:
   long idAlbum;
   std::string strAlbum;
   std::string strMusicBrainzAlbumID;
+  std::string strReleaseGroupMBID;
   std::string strArtistDesc;
   std::string strArtistSort;
   VECARTISTCREDITS artistCredits;
@@ -161,6 +167,8 @@ public:
   VECSONGS songs;     ///< Local songs
   VECSONGS infoSongs; ///< Scraped songs
   ReleaseType releaseType;
+  bool bScrapedMBID;
+  bool bArtistSongMerge;
 };
 
 typedef std::vector<CAlbum> VECALBUMS;

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -26,13 +26,24 @@
 
 void CArtist::MergeScrapedArtist(const CArtist& source, bool override /* = true */)
 {
-  /*
-   We don't merge musicbrainz artist ID so that a refresh of artist information
-   allows a lookup based on name rather than directly (re)using musicbrainz.
-   In future, we may wish to be able to override lookup by musicbrainz so
-   this might be dropped.
+  /*   
+  Initial scraping of artist information when the mbid is derived from tags is done directly
+  using that ID, otherwise the lookup is based on name and can mis-identify the artist
+  (many have same name). It is useful to store the scraped mbid, but we need to be
+  able to correct any mistakes. Hence a manual refresh of artist information uses either 
+  the mbid is derived from tags or the artist name, not any previously scraped mbid.
+
+   A Musicbrainz artist ID derived from music file tags is always taken as accurate and so can
+   not be overwritten by a scraped value. When the artist does not already have an mbid or has
+   a previously scraped mbid, merge the new scraped value, flagging it as being from the 
+   scraper rather than derived from music file tags.
    */
-  //  strMusicBrainzArtistID = source.strMusicBrainzArtistID;
+  if (!source.strMusicBrainzArtistID.empty() && (strMusicBrainzArtistID.empty() || bScrapedMBID))
+  {
+    strMusicBrainzArtistID = source.strMusicBrainzArtistID;
+    bScrapedMBID = true;
+  }
+
   if ((override && !source.strArtist.empty()) || strArtist.empty())
     strArtist = source.strArtist;
 

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -73,6 +73,7 @@ public:
     idArtist = -1;
     strPath.clear();
     dateAdded.Reset();
+    bScrapedMBID = false;
   }
 
   /*! \brief Load artist information from an XML file.
@@ -105,6 +106,7 @@ public:
   CFanart fanart;
   std::vector<std::pair<std::string,std::string> > discography;
   CDateTime dateAdded;
+  bool bScrapedMBID;
 };
 
 class CArtistCredit
@@ -113,7 +115,7 @@ class CArtistCredit
   friend class CMusicDatabase;
 
 public:
-  CArtistCredit() : idArtist(-1) { }
+  CArtistCredit() : idArtist(-1), m_bScrapedMBID(false) { }
   CArtistCredit(std::string strArtist) : m_strArtist(strArtist) { }
   CArtistCredit(std::string strArtist, std::string strMusicBrainzArtistID)
     : m_strArtist(strArtist), m_strMusicBrainzArtistID(strMusicBrainzArtistID) {  }
@@ -138,16 +140,19 @@ public:
   std::string GetSortName() const              { return m_strSortName; }
   std::string GetMusicBrainzArtistID() const   { return m_strMusicBrainzArtistID; }
   int         GetArtistId() const              { return idArtist; }
+  bool HasScrapedMBID() const { return m_bScrapedMBID; }
   void SetArtist(const std::string &strArtist) { m_strArtist = strArtist; }
   void SetSortName(const std::string &strSortName) { m_strSortName = strSortName; }
   void SetMusicBrainzArtistID(const std::string &strMusicBrainzArtistID) { m_strMusicBrainzArtistID = strMusicBrainzArtistID; }
   void SetArtistId(int idArtist)               { this->idArtist = idArtist; }
+  void SetScrapedMBID(bool scrapedMBID) { this->m_bScrapedMBID = scrapedMBID; }
 
 private:
   long idArtist;
   std::string m_strArtist;
   std::string m_strSortName;
   std::string m_strMusicBrainzArtistID;
+  bool m_bScrapedMBID; // Flag that mbid is from album merge of scarper results not derived from tags
 };
 
 typedef std::vector<CArtist> VECARTISTS;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -126,7 +126,8 @@ void CMusicDatabase::CreateTables()
               " strStyles text, strInstruments text, strBiography text, "
               " strDied text, strDisbanded text, strYearsActive text, "
               " strImage text, strFanart text, "
-              " lastScraped varchar(20) default NULL)");
+              " lastScraped varchar(20) default NULL, "
+              " bScrapedMBID INTEGER NOT NULL DEFAULT 0)");
   // Create missing artist tag artist [Missing].
   std::string strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strSortName, strMusicBrainzArtistID) "
      "VALUES( %i, '%s', '%s', '%s' )",
@@ -137,6 +138,7 @@ void CMusicDatabase::CreateTables()
   CLog::Log(LOGINFO, "create album table");
   m_pDS->exec("CREATE TABLE album (idAlbum integer primary key, "
               " strAlbum varchar(256), strMusicBrainzAlbumID text, "
+              " strReleaseGroupMBID text, "
               " strArtistDisp text, strArtistSort text, strGenres text, "
               " iYear integer, "
               " bCompilation integer not null default '0', "
@@ -146,6 +148,7 @@ void CMusicDatabase::CreateTables()
               " fRating FLOAT NOT NULL DEFAULT 0, "
               " iUserrating INTEGER NOT NULL DEFAULT 0, "
               " lastScraped varchar(20) default NULL, "
+              " bScrapedMBID INTEGER NOT NULL DEFAULT 0, "
               " strReleaseType text, "
               " iVotes INTEGER NOT NULL DEFAULT 0)");
   CLog::Log(LOGINFO, "create audiobook table");
@@ -397,6 +400,7 @@ bool CMusicDatabase::AddAlbum(CAlbum& album)
 
   album.idAlbum = AddAlbum(album.strAlbum,
                            album.strMusicBrainzAlbumID,
+                           album.strReleaseGroupMBID,
                            album.GetAlbumArtistString(),
                            album.GetAlbumArtistSort(),
                            album.GetGenreString(),
@@ -465,12 +469,13 @@ bool CMusicDatabase::AddAlbum(CAlbum& album)
   return true;
 }
 
-bool CMusicDatabase::UpdateAlbum(CAlbum& album, bool OverrideTagData /* = true*/)
+bool CMusicDatabase::UpdateAlbum(CAlbum& album)
 {
   BeginTransaction();
 
   UpdateAlbum(album.idAlbum,
               album.strAlbum, album.strMusicBrainzAlbumID,
+              album.strReleaseGroupMBID,
               album.GetAlbumArtistString(), album.GetAlbumArtistSort(),
               album.GetGenreString(),
               StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator).c_str(),
@@ -479,25 +484,32 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album, bool OverrideTagData /* = true*/
               album.strReview,
               album.thumbURL.m_xml.c_str(),
               album.strLabel, album.strType,
-              album.fRating, album.iUserrating, album.iVotes, album.iYear, album.bCompilation, album.releaseType);
+              album.fRating, album.iUserrating, album.iVotes, album.iYear, album.bCompilation, album.releaseType,
+              album.bScrapedMBID);
 
-  if (OverrideTagData)
+  if (!album.bArtistSongMerge)
   {
-    // Replace the album artists 
+    // Album artist(s) already exist and names are not changing, but may have scraped Musicbrainz ids to add
+    for (const auto &artistCredit : album.artistCredits)
+      UpdateArtistScrapedMBID(artistCredit.GetArtistId(), artistCredit.GetMusicBrainzArtistID());
+  }
+  else
+  {
+    // Replace the album artists with those scraped
     DeleteAlbumArtistsByAlbum(album.idAlbum);
     if (album.artistCredits.empty())
       AddAlbumArtist(BLANKARTIST_ID, album.idAlbum, BLANKARTIST_NAME, 0); // Album must have at least one artist so set artist to [Missing]
     for (auto artistCredit = album.artistCredits.begin(); artistCredit != album.artistCredits.end(); ++artistCredit)
     {
       artistCredit->idArtist = AddArtist(artistCredit->GetArtist(),
-        artistCredit->GetMusicBrainzArtistID(), artistCredit->GetSortName());
+        artistCredit->GetMusicBrainzArtistID(), artistCredit->GetSortName(), true);
       AddAlbumArtist(artistCredit->idArtist,
         album.idAlbum,
         artistCredit->GetArtist(),
         std::distance(album.artistCredits.begin(), artistCredit));
     }
-
-  for (auto &song : album.songs)
+    // Replace the songs with those scraped
+    for (auto &song : album.songs)
     {
       UpdateSong(song.idSong,
         song.strTitle,
@@ -789,6 +801,7 @@ int CMusicDatabase::UpdateSong(int idSong,
 }
 
 int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
+                             const std::string& strReleaseGroupMBID,
                              const std::string& strArtist, const std::string& strArtistSort, 
                              const std::string& strGenre, int year,
                              const std::string& strRecordLabel, const std::string& strType,
@@ -814,7 +827,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       m_pDS->close();
       // doesnt exists, add it
       strSQL = PrepareSQL("INSERT INTO album (idAlbum, strAlbum, strArtistDisp, strGenres, iYear, "
-        "strLabel, strType, bCompilation, strReleaseType, strMusicBrainzAlbumID, strArtistSort) "
+        "strLabel, strType, bCompilation, strReleaseType, strMusicBrainzAlbumID, strReleaseGroupMBID, strArtistSort) "
         "values( NULL, '%s', '%s', '%s', %i, '%s', '%s', %i, '%s'",
         strAlbum.c_str(),
         strArtist.c_str(),
@@ -829,6 +842,10 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
         strSQL += PrepareSQL(", NULL");
       else
         strSQL += PrepareSQL(",'%s'", strMusicBrainzAlbumID.c_str());
+      if (strReleaseGroupMBID.empty())
+        strSQL += PrepareSQL(", NULL");
+      else
+        strSQL += PrepareSQL(",'%s'", strReleaseGroupMBID.c_str());
       if (strArtistSort.empty())
         strSQL += PrepareSQL(", NULL");
       else
@@ -855,6 +872,10 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
       strSQL = "UPDATE album SET ";
       if (!strMusicBrainzAlbumID.empty())   
         strSQL += PrepareSQL("strAlbum = '%s', strArtistDisp = '%s', ", strAlbum.c_str(), strArtist.c_str());
+      if (strReleaseGroupMBID.empty())
+        strSQL += PrepareSQL(" strReleaseGroupMBID = NULL,");
+      else
+        strSQL += PrepareSQL(" strReleaseGroupMBID ='%s', ", strReleaseGroupMBID.c_str());
       if (strArtistSort.empty())
         strSQL += PrepareSQL(" strArtistSort = NULL");
       else
@@ -885,6 +906,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum, const std::string& str
 
 int  CMusicDatabase::UpdateAlbum(int idAlbum,
                                  const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
+                                 const std::string& strReleaseGroupMBID,
                                  const std::string& strArtist, const std::string& strArtistSort,
                                  const std::string& strGenre,
                                  const std::string& strMoods, const std::string& strStyles,
@@ -892,7 +914,8 @@ int  CMusicDatabase::UpdateAlbum(int idAlbum,
                                  const std::string& strImage, const std::string& strLabel,
                                  const std::string& strType,
                                  float fRating, int iUserrating, int iVotes, int iYear, bool bCompilation,
-                                 CAlbum::ReleaseType releaseType)
+                                 CAlbum::ReleaseType releaseType,
+                                 bool bScrapedMBID)
 {
   if (idAlbum < 0)
     return -1;
@@ -904,18 +927,23 @@ int  CMusicDatabase::UpdateAlbum(int idAlbum,
                       " strReview = '%s', strImage = '%s', strLabel = '%s', "
                       " strType = '%s', fRating = %f, iUserrating = %i, iVotes = %i,"
                       " iYear = %i, bCompilation = %i, strReleaseType = '%s', "
-                      " lastScraped = '%s'",
+                      " lastScraped = '%s', bScrapedMBID = %i",
                       strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(),
                       strMoods.c_str(), strStyles.c_str(), strThemes.c_str(),
                       strReview.c_str(), strImage.c_str(), strLabel.c_str(),
                       strType.c_str(), fRating, iUserrating, iVotes,
                       iYear, bCompilation,
                       CAlbum::ReleaseTypeToString(releaseType).c_str(),
-                      CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str());
+                      CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str(),
+                      bScrapedMBID);
   if (strMusicBrainzAlbumID.empty())
     strSQL += PrepareSQL(", strMusicBrainzAlbumID = NULL");
   else
     strSQL += PrepareSQL(", strMusicBrainzAlbumID = '%s'", strMusicBrainzAlbumID.c_str());
+  if (strReleaseGroupMBID.empty())
+    strSQL += PrepareSQL(", strReleaseGroupMBID = NULL");
+  else
+    strSQL += PrepareSQL(", strReleaseGroupMBID = '%s'", strReleaseGroupMBID.c_str());
   if (strArtistSort.empty())
     strSQL += PrepareSQL(", strArtistSort = NULL");
   else
@@ -1052,6 +1080,12 @@ bool CMusicDatabase::HasAlbumBeenScraped(int idAlbum)
   return GetSingleValue(strSQL).empty();
 }
 
+bool CMusicDatabase::HasScrapedAlbumMBID(int idAlbum)
+{
+  std::string strSQL = PrepareSQL("SELECT idAlbum FROM album WHERE idAlbum = %i AND strMusicbrainzAlbumID IS NOT NULL AND bScrapedMBID = 1", idAlbum);
+  return !GetSingleValue(strSQL).empty();
+}
+
 int CMusicDatabase::AddGenre(const std::string& strGenre1)
 {
   std::string strSQL;
@@ -1104,7 +1138,7 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
 {
   UpdateArtist(artist.idArtist,
                artist.strArtist, artist.strSortName,
-               artist.strMusicBrainzArtistID,
+               artist.strMusicBrainzArtistID, artist.bScrapedMBID,
                artist.strBorn, artist.strFormed,
                StringUtils::Join(artist.genre, g_advancedSettings.m_musicItemSeparator),
                StringUtils::Join(artist.moods, g_advancedSettings.m_musicItemSeparator),
@@ -1125,10 +1159,10 @@ bool CMusicDatabase::UpdateArtist(const CArtist& artist)
   return true;
 }
 
-int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName)
+int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName, bool bScrapedMBID /* = false*/)
 {
   std::string strSQL;
-  int idArtist = AddArtist(strArtist, strMusicBrainzArtistID);
+  int idArtist = AddArtist(strArtist, strMusicBrainzArtistID, bScrapedMBID);
   if (idArtist < 0 || strSortName.empty())
     return idArtist;
   
@@ -1173,7 +1207,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
   return -1;
 }
 
-int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID)
+int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, bool bScrapedMBID /* = false*/)
 {
   std::string strSQL;
   try
@@ -1212,10 +1246,11 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
       {
         int idArtist = (int)m_pDS->fv("idArtist").get_asInt();
         m_pDS->close();
-        // 1.b.a) We found an artist by name but with no MusicBrainz ID set, update it and assume it is our artist
-        strSQL = PrepareSQL("UPDATE artist SET strArtist = '%s', strMusicBrainzArtistID = '%s' WHERE idArtist = %i",
+        // 1.b.a) We found an artist by name but with no MusicBrainz ID set, update it and assume it is our artist, flag when mbid scraped
+        strSQL = PrepareSQL("UPDATE artist SET strArtist = '%s', strMusicBrainzArtistID = '%s', bScrapedMBID = %i WHERE idArtist = %i",
           strArtist.c_str(),
           strMusicBrainzArtistID.c_str(),
+          bScrapedMBID,
           idArtist);
         m_pDS->exec(strSQL);
         return idArtist;
@@ -1240,14 +1275,15 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
       m_pDS->close();
     }
 
-    // 3) No artist exists at all - add it
+    // 3) No artist exists at all - add it, flagging when has scraped mbid
     if (strMusicBrainzArtistID.empty())
       strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID) VALUES( NULL, '%s', NULL )",
         strArtist.c_str());
     else
-      strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID) VALUES( NULL, '%s', '%s' )",
+      strSQL = PrepareSQL("INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID, bScrapedMBID) VALUES( NULL, '%s', '%s', %i )",
         strArtist.c_str(),
-        strMusicBrainzArtistID.c_str());
+        strMusicBrainzArtistID.c_str(),
+        bScrapedMBID);
 
     m_pDS->exec(strSQL);
     int idArtist = (int)m_pDS->lastinsertid();
@@ -1263,7 +1299,7 @@ int CMusicDatabase::AddArtist(const std::string& strArtist, const std::string& s
 
 int  CMusicDatabase::UpdateArtist(int idArtist,
                                   const std::string& strArtist, const std::string& strSortName,
-                                  const std::string& strMusicBrainzArtistID,
+                                  const std::string& strMusicBrainzArtistID, const bool bScrapedMBID,
                                   const std::string& strBorn, const std::string& strFormed,
                                   const std::string& strGenres, const std::string& strMoods,
                                   const std::string& strStyles, const std::string& strInstruments,
@@ -1283,7 +1319,7 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       " strMoods = '%s', strStyles = '%s', strInstruments = '%s', "
                       " strBiography = '%s', strDied = '%s', strDisbanded = '%s', "
                       " strYearsActive = '%s', strImage = '%s', strFanart = '%s', "
-                      " lastScraped = '%s'",
+                      " lastScraped = '%s', bScrapedMBID = %i",
                       strArtist.c_str(), 
                       /* strSortName.c_str(),*/
                       /* strMusicBrainzArtistID.c_str(), */
@@ -1291,7 +1327,8 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
                       strMoods.c_str(), strStyles.c_str(), strInstruments.c_str(),
                       strBiography.c_str(), strDied.c_str(), strDisbanded.c_str(),
                       strYearsActive.c_str(), strImage.c_str(), strFanart.c_str(),
-                      CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str());
+                      CDateTime::GetCurrentDateTime().GetAsDBDateTime().c_str(),
+                      bScrapedMBID);
   if (strMusicBrainzArtistID.empty())
     strSQL += PrepareSQL(", strMusicBrainzArtistID = NULL");
   else
@@ -1307,6 +1344,26 @@ int  CMusicDatabase::UpdateArtist(int idArtist,
   if (status)
     AnnounceUpdate(MediaTypeArtist, idArtist);
   return idArtist;
+}
+
+bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist, const std::string& strMusicBrainzArtistID)
+{
+  if (strMusicBrainzArtistID.empty() || idArtist < 0)
+    return false;
+
+  // Set scraped artist Musicbrainz ID for a previously added artist with no MusicBrainz ID
+  std::string strSQL;
+  strSQL = PrepareSQL("UPDATE artist SET strMusicBrainzArtistID = '%s', bScrapedMBID = 1 "
+    "WHERE idArtist = %i AND strMusicBrainzArtistID IS NULL", 
+    strMusicBrainzArtistID.c_str(), idArtist);
+
+  bool status = ExecuteQuery(strSQL);
+  if (status)
+  {
+    AnnounceUpdate(MediaTypeArtist, idArtist);
+    return true;
+  }
+  return false;
 }
 
 bool CMusicDatabase::GetArtist(int idArtist, CArtist &artist, bool fetchAll /* = false */)
@@ -1394,6 +1451,13 @@ bool CMusicDatabase::ClearArtistLastScrapedTime(int idArtist)
   std::string strSQL = PrepareSQL("UPDATE artist SET lastScraped = NULL WHERE idArtist = %i", idArtist);
   return ExecuteQuery(strSQL);
 }
+
+bool CMusicDatabase::HasScrapedArtistMBID(int idArtist)
+{
+  std::string strSQL = PrepareSQL("SELECT idArtist FROM artist WHERE idArtist = %i AND strMusicbrainzArtistID IS NOT NULL AND bScrapedMBID = 1", idArtist);
+  return !GetSingleValue(strSQL).empty();
+}
+
 
 int CMusicDatabase::AddArtistDiscography(int idArtist, const std::string& strAlbum, const std::string& strYear)
 {
@@ -5065,13 +5129,20 @@ void CMusicDatabase::UpdateTables(int version)
     m_pDS->exec("DROP TABLE song");
     m_pDS->exec("ALTER TABLE song_new RENAME TO song");
   }
-
   if (version < 65)
   {
     // Remove cue table
     m_pDS->exec("DROP TABLE cue");
     // Add strReplayGain to song table
     m_pDS->exec("ALTER TABLE song ADD strReplayGain TEXT\n");
+  }
+  if (version < 66)
+  {
+    // Add a new columns strReleaseGroupMBID, bScrapedMBID for albums
+    m_pDS->exec("ALTER TABLE album ADD bScrapedMBID INTEGER NOT NULL DEFAULT 0\n");
+    m_pDS->exec("ALTER TABLE album ADD strReleaseGroupMBID TEXT \n");
+    // Add a new column bScrapedMBID for artists
+    m_pDS->exec("ALTER TABLE artist ADD bScrapedMBID INTEGER NOT NULL DEFAULT 0\n");
   }
   // Set the verion of tag scanning required. 
   // Not every schema change requires the tags to be rescanned, set to the highest schema version 
@@ -5094,7 +5165,7 @@ void CMusicDatabase::UpdateTables(int version)
 
 int CMusicDatabase::GetSchemaVersion() const
 {
-  return 65;
+  return 66;
 }
 
 int CMusicDatabase::GetMusicNeedsTagScan()

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -215,10 +215,9 @@ public:
 
   /*! \brief Update an album and all its nested entities (artists, songs, infoSongs, etc)
    \param album the album to update
-   \param OverrideTagData whether or not to replace the artist and song data, defaults to true.
    \return true or false
    */
-  bool UpdateAlbum(CAlbum& album, bool OverrideTagData = true);
+  bool UpdateAlbum(CAlbum& album);
 
   /*! \brief Add an album to the database
    \param strAlbum the album title
@@ -234,6 +233,7 @@ public:
    \return the id of the album
    */
   int  AddAlbum(const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
+                const std::string& strReleaseGroupMBID,
                 const std::string& strArtist, const std::string& strArtistSort, 
                 const std::string& strGenre, int year,
                 const std::string& strRecordLabel, const std::string& strType,
@@ -249,6 +249,7 @@ public:
   int  UpdateAlbum(int idAlbum, const CAlbum &album);
   int  UpdateAlbum(int idAlbum,
                    const std::string& strAlbum, const std::string& strMusicBrainzAlbumID,
+                   const std::string& strReleaseGroupMBID,
                    const std::string& strArtist, const std::string& strArtistSort,
                    const std::string& strGenre,
                    const std::string& strMoods, const std::string& strStyles,
@@ -256,9 +257,11 @@ public:
                    const std::string& strImage, const std::string& strLabel,
                    const std::string& strType,
                    float fRating, int iUserrating, int iVotes, int iYear, bool bCompilation,
-                   CAlbum::ReleaseType releaseType);
+                   CAlbum::ReleaseType releaseType,
+                   bool bScrapedMBID);
   bool ClearAlbumLastScrapedTime(int idAlbum);
   bool HasAlbumBeenScraped(int idAlbum);
+  bool HasScrapedAlbumMBID(int idArtist);
   int  AddAlbumInfoSong(int idAlbum, const CSong& song);
 
   /////////////////////////////////////////////////
@@ -286,23 +289,25 @@ public:
   /////////////////////////////////////////////////
   bool UpdateArtist(const CArtist& artist);
 
-  int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName);
-  int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID);
+  int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, const std::string& strSortName, bool bScrapedMBID = false);
+  int  AddArtist(const std::string& strArtist, const std::string& strMusicBrainzArtistID, bool bScrapedMBID = false);
   bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = true);
   bool GetArtistExists(int idArtist);
   int  UpdateArtist(int idArtist,
                     const std::string& strArtist, const std::string& strSortName,
-                    const std::string& strMusicBrainzArtistID,
+                    const std::string& strMusicBrainzArtistID, bool bScrapedMBID,
                     const std::string& strBorn, const std::string& strFormed,
                     const std::string& strGenres, const std::string& strMoods,
                     const std::string& strStyles, const std::string& strInstruments,
                     const std::string& strBiography, const std::string& strDied,
                     const std::string& strDisbanded, const std::string& strYearsActive,
                     const std::string& strImage, const std::string& strFanart);
+  bool UpdateArtistScrapedMBID(int idArtist, const std::string& strMusicBrainzArtistID);
   bool GetTranslateBlankArtist() { return m_translateBlankArtist; }
   void SetTranslateBlankArtist(bool translate) { m_translateBlankArtist = translate; }
   bool HasArtistBeenScraped(int idArtist);
   bool ClearArtistLastScrapedTime(int idArtist);
+  bool HasScrapedArtistMBID(int idArtist);
   int  AddArtistDiscography(int idArtist, const std::string& strAlbum, const std::string& strYear);
   bool DeleteArtistDiscography(int idArtist);
 

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -194,15 +194,16 @@ CSong::CSong()
 
 void CSong::MergeScrapedSong(const CSong& source, bool override)
 {
+  // Merge when MusicBrainz Track ID match (checked in CAlbum::MergeScrapedAlbum)
   if ((override && !source.strTitle.empty()) || strTitle.empty())
     strTitle = source.strTitle;
   if ((override && source.iTrack != 0) || iTrack == 0)
     iTrack = source.iTrack;
-  // artist = source.artist; // artist is read-only from the database
   if (override)
-    artistCredits = source.artistCredits;
-  else if (source.artistCredits.size() > artistCredits.size())
-    artistCredits.insert(artistCredits.end(), source.artistCredits.begin()+artistCredits.size(), source.artistCredits.end());
+  {
+    artistCredits = source.artistCredits; // Replace artists and store mbid returned by scraper   
+    strArtistDesc.clear();  // @todo: set artist display string e.g. "artist1 feat. artist2" when scraped 
+  }
 }
 
 void CSong::Serialize(CVariant& value) const

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -144,9 +144,10 @@ public:
    \param album [in] a partially or fully filled out album structure containing the search query
    \param scraper [in] the scraper to query, usually the default or the relevant scraper for the musicdb path
    \param albumInfo [in/out] a CMusicAlbumInfo struct which will be populated with the output of the scraper
+   \param bUseScrapedMBID [in] should scraper use any previously scraped mbid to identify the artist, or use artist name?
    \param pDialog [in] a progress dialog which this and downstream functions can update with status, if required
    */
-  INFO_RET DownloadAlbumInfo(const CAlbum& album, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicAlbumInfo& albumInfo, CGUIDialogProgress* pDialog = NULL);
+  INFO_RET DownloadAlbumInfo(const CAlbum& album, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicAlbumInfo& albumInfo, bool bUseScrapedMBID, CGUIDialogProgress* pDialog = NULL);
 
   /*! \brief Using the scrapers download metadata for an artist
    Given a CAlbum style struct containing some data about an artist, query
@@ -156,9 +157,10 @@ public:
    \param artist [in] a partially or fully filled out artist structure containing the search query
    \param scraper [in] the scraper to query, usually the default or the relevant scraper for the musicdb path
    \param artistInfo [in/out] a CMusicAlbumInfo struct which will be populated with the output of the scraper
+   \param bUseScrapedMBID [in] should scraper use any previously scraped mbid to identify the album, or use album and artist name?
    \param pDialog [in] a progress dialog which this and downstream functions can update with status, if required
    */
-  INFO_RET DownloadArtistInfo(const CArtist& artist, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, CGUIDialogProgress* pDialog = NULL);
+  INFO_RET DownloadArtistInfo(const CArtist& artist, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, bool bUseScrapedMBID, CGUIDialogProgress* pDialog = NULL);
 
   /*! \brief Search for art for an artist
    Look for art for an artist. Checks the artist structure for thumbs, and checks
@@ -172,11 +174,14 @@ protected:
   /*! \brief Scan in the ID3/Ogg/FLAC tags for a bunch of FileItems
    Given a list of FileItems, scan in the tags for those FileItems
    and populate a new FileItemList with the files that were successfully scanned.
+   Add album to library, populate a list of album ids added for possible scraping later.
    Any files which couldn't be scanned (no/bad tags) are discarded in the process.
    \param items [in] list of FileItems to scan
    \param scannedItems [in] list to populate with the scannedItems
    */
   int RetrieveMusicInfo(const std::string& strDirectory, CFileItemList& items);
+
+  void ScrapeInfoAddedAlbums();
 
   /*! \brief Scan in the ID3/Ogg/FLAC tags for a bunch of FileItems
     Given a list of FileItems, scan in the tags for those FileItems
@@ -216,8 +221,7 @@ protected:
   int m_scanType; // 0 - load from files, 1 - albums, 2 - artists
   CMusicDatabase m_musicDatabase;
 
-  std::map<CAlbum, CAlbum> m_albumCache;
-  std::map<CArtistCredit, CArtist> m_artistCache;
+  std::vector<int> m_albumsAdded;
 
   std::set<std::string> m_pathsToScan;
   std::set<std::string> m_seenPaths;

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -116,6 +116,7 @@ const CMusicInfoTag& CMusicInfoTag::operator =(const CMusicInfoTag& tag)
   m_musicBrainzArtistID = tag.m_musicBrainzArtistID;
   m_musicBrainzArtistHints = tag.m_musicBrainzArtistHints;
   m_strMusicBrainzAlbumID = tag.m_strMusicBrainzAlbumID;
+  m_strMusicBrainzReleaseGroupID = tag.m_strMusicBrainzReleaseGroupID;
   m_musicBrainzAlbumArtistID = tag.m_musicBrainzAlbumArtistID;
   m_musicBrainzAlbumArtistHints = tag.m_musicBrainzAlbumArtistHints;
   m_musicRoles = tag.m_musicRoles;
@@ -608,6 +609,11 @@ const std::string& CMusicInfoTag::GetMusicBrainzAlbumID() const
   return m_strMusicBrainzAlbumID;
 }
 
+const std::string & MUSIC_INFO::CMusicInfoTag::GetMusicBrainzReleaseGroupID() const
+{
+  return m_strMusicBrainzReleaseGroupID;
+}
+
 const std::vector<std::string>& CMusicInfoTag::GetMusicBrainzAlbumArtistID() const
 {
   return m_musicBrainzAlbumArtistID;
@@ -651,6 +657,11 @@ void CMusicInfoTag::SetMusicBrainzAlbumArtistID(const std::vector<std::string>& 
 void CMusicInfoTag::SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints)
 {
     m_musicBrainzAlbumArtistHints = musicBrainzAlbumArtistHints;
+}
+
+void MUSIC_INFO::CMusicInfoTag::SetMusicBrainzReleaseGroupID(const std::string & strReleaseGroupID)
+{
+  m_strMusicBrainzReleaseGroupID = strReleaseGroupID;
 }
 
 void CMusicInfoTag::SetMusicBrainzReleaseType(const std::string& ReleaseType)
@@ -710,6 +721,7 @@ void CMusicInfoTag::SetAlbum(const CAlbum& album)
   SetAlbum(album.strAlbum);
   SetTitle(album.strAlbum);
   SetMusicBrainzAlbumID(album.strMusicBrainzAlbumID);
+  SetMusicBrainzReleaseGroupID(album.strReleaseGroupMBID);
   SetMusicBrainzReleaseType(album.strType);
   SetGenre(album.genre);
   SetMood(StringUtils::Join(album.moods, g_advancedSettings.m_musicItemSeparator));
@@ -814,6 +826,7 @@ void CMusicInfoTag::Serialize(CVariant& value) const
   value["musicbrainztrackid"] = m_strMusicBrainzTrackID;
   value["musicbrainzartistid"] = m_musicBrainzArtistID;
   value["musicbrainzalbumid"] = m_strMusicBrainzAlbumID;
+  value["musicbrainzreleasegroupid"] = m_strMusicBrainzReleaseGroupID;
   value["musicbrainzalbumartistid"] = m_musicBrainzAlbumArtistID; 
   value["comment"] = m_strComment;
   value["contributors"] = CVariant(CVariant::VariantTypeArray);
@@ -902,6 +915,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar << m_strMusicBrainzTrackID;
     ar << m_musicBrainzArtistID;
     ar << m_strMusicBrainzAlbumID;
+    ar << m_strMusicBrainzReleaseGroupID;
     ar << m_musicBrainzAlbumArtistID;
     ar << m_strMusicBrainzReleaseType;
     ar << m_lastPlayed;
@@ -949,6 +963,7 @@ void CMusicInfoTag::Archive(CArchive& ar)
     ar >> m_strMusicBrainzTrackID;
     ar >> m_musicBrainzArtistID;
     ar >> m_strMusicBrainzAlbumID;
+    ar >> m_strMusicBrainzReleaseGroupID;
     ar >> m_musicBrainzAlbumArtistID;
     ar >> m_strMusicBrainzReleaseType;
     ar >> m_lastPlayed;
@@ -1003,6 +1018,7 @@ void CMusicInfoTag::Clear()
   m_strMusicBrainzTrackID.clear();
   m_musicBrainzArtistID.clear();
   m_strMusicBrainzAlbumID.clear();
+  m_strMusicBrainzReleaseGroupID.clear();
   m_musicBrainzAlbumArtistID.clear();
   m_strMusicBrainzReleaseType.clear();
   m_musicRoles.clear();

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -74,6 +74,7 @@ public:
   const std::vector<std::string>& GetMusicBrainzArtistID() const;
   const std::vector<std::string>& GetMusicBrainzArtistHints() const;
   const std::string& GetMusicBrainzAlbumID() const;
+  const std::string& GetMusicBrainzReleaseGroupID() const;
   const std::vector<std::string>& GetMusicBrainzAlbumArtistID() const;
   const std::vector<std::string>& GetMusicBrainzAlbumArtistHints() const;
   const std::string& GetMusicBrainzReleaseType() const;
@@ -126,6 +127,7 @@ public:
   void SetMusicBrainzAlbumID(const std::string& strAlbumID);
   void SetMusicBrainzAlbumArtistID(const std::vector<std::string>& musicBrainzAlbumArtistId);
   void SetMusicBrainzAlbumArtistHints(const std::vector<std::string>& musicBrainzAlbumArtistHints);
+  void SetMusicBrainzReleaseGroupID(const std::string& strReleaseGroupID);
   void SetMusicBrainzReleaseType(const std::string& ReleaseType);
   void SetComment(const std::string& comment);
   void SetMood(const std::string& mood);
@@ -205,6 +207,7 @@ protected:
   std::string m_strMusicBrainzAlbumID;
   std::vector<std::string> m_musicBrainzAlbumArtistID;
   std::vector<std::string> m_musicBrainzAlbumArtistHints;
+  std::string m_strMusicBrainzReleaseGroupID;
   std::string m_strMusicBrainzReleaseType;
   VECMUSICROLES m_musicRoles; //Artists contributing to the recording and role (from tags other than ARTIST or ALBUMARTIST)
   std::string m_strComment;

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -194,6 +194,8 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
       tag.SetMusicBrainzArtistID(SplitMBID(GetASFStringList(it->second)));
     else if (it->first == "MusicBrainz/Album Id")
       tag.SetMusicBrainzAlbumID(it->second.front().toString().to8Bit(true));
+    else if (it->first == "MusicBrainz/Release Group Id")
+      tag.SetMusicBrainzReleaseGroupID(it->second.front().toString().to8Bit(true));
     else if (it->first == "MusicBrainz/Album Artist")
       SetAlbumArtist(tag, GetASFStringList(it->second));
     else if (it->first == "MusicBrainz/Album Artist Id")
@@ -345,6 +347,8 @@ bool CTagLoaderTagLib::ParseTag(ID3v2::Tag *id3v2, MUSIC_INFO::EmbeddedArt *art,
           tag.SetMusicBrainzArtistID(SplitMBID(StringListToVectorString(stringList)));
         else if (desc == "MUSICBRAINZ ALBUM ID")
           tag.SetMusicBrainzAlbumID(stringList.front().to8Bit(true));
+        else if (desc == "MUSICBRAINZ RELEASE GROUP ID")
+          tag.SetMusicBrainzReleaseGroupID(stringList.front().to8Bit(true));
         else if (desc == "MUSICBRAINZ ALBUM ARTIST ID")
           tag.SetMusicBrainzAlbumArtistID(SplitMBID(StringListToVectorString(stringList)));
         else if (desc == "MUSICBRAINZ ALBUM ARTIST")
@@ -562,6 +566,8 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
       SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "MUSICBRAINZ_ALBUMID")
       tag.SetMusicBrainzAlbumID(it->second.toString().to8Bit(true));
+    else if (it->first == "MUSICBRAINZ_RELEASEGROUPID")
+      tag.SetMusicBrainzReleaseGroupID(it->second.toString().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_TRACKID")
       tag.SetMusicBrainzTrackID(it->second.toString().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_ALBUMTYPE")
@@ -673,6 +679,8 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
       SetAlbumArtist(tag, StringListToVectorString(it->second));
     else if (it->first == "MUSICBRAINZ_ALBUMID")
       tag.SetMusicBrainzAlbumID(it->second.front().to8Bit(true));
+    else if (it->first == "MUSICBRAINZ_RELEASEGROUPID")
+      tag.SetMusicBrainzReleaseGroupID(it->second.front().to8Bit(true));
     else if (it->first == "MUSICBRAINZ_TRACKID")
       tag.SetMusicBrainzTrackID(it->second.front().to8Bit(true));
     else if (it->first == "RELEASETYPE")
@@ -844,6 +852,8 @@ bool CTagLoaderTagLib::ParseTag(MP4::Tag *mp4, EmbeddedArt *art, CMusicInfoTag& 
       SetAlbumArtist(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Id")
       tag.SetMusicBrainzAlbumID(it->second.toStringList().front().to8Bit(true));
+    else if (it->first == "----:com.apple.iTunes:MusicBrainz Release Group Id")
+      tag.SetMusicBrainzReleaseGroupID(it->second.toStringList().front().to8Bit(true));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Track Id")
       tag.SetMusicBrainzTrackID(it->second.toStringList().front().to8Bit(true));
     else if (it->first == "----:com.apple.iTunes:MusicBrainz Album Type")

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -373,7 +373,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
   CArtist artist;
   if (!m_musicdatabase.GetArtist(params.GetArtistId(), artist))
       return;
-
+  artist.bScrapedMBID = m_musicdatabase.HasScrapedArtistMBID(artist.idArtist);
   m_musicdatabase.GetArtistPath(params.GetArtistId(), artist.strPath);
   bool refresh = false;
   while (1)
@@ -446,7 +446,7 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
   CAlbum album;
   if (!m_musicdatabase.GetAlbum(params.GetAlbumId(), album))
     return false;
-
+  album.bScrapedMBID = m_musicdatabase.HasScrapedAlbumMBID(album.idAlbum);
   m_musicdatabase.GetAlbumPath(params.GetAlbumId(), album.strPath);
   bool refresh = false;
   while (1)


### PR DESCRIPTION
Make online scraping of additional artist and album information a bit more efficient - avoid futile repeat requests and make better use of Musicbrainz IDs.

When fetching additional info on library update:
- Scan all metadata tags from the music files first before scraping (rather than do it album at a time).  
*This populates the library with the basic music without delay so the user can start using it.
*Tagging can be mixed quality - some with mbids, some without, so artist mbid may be obtained from music files later in the scan.
*Avoids unwanted consequnces that can arise from the order in which folders are processed. The common example of this is when the user has their Various Artist compilations in a folder called "Compilations" such that it gets processed _before_ the albums of artists in folders beginning with a letter later in the alphabet. The additional info for the song artists from these compilation albums get added to the library and scraped before the other albums by that artist had been scanned, and so the artist.nfo file is never found and applied. 
*Having passed through all the music during scanning tags we know how many albums we are processing, so during scraping phases the progress bar can show meaningful position though task.
*Repeat of failed scraping due to server timeouts could be added at a later time.
- Scrape album artists even when scraping the album has failed (as proposed in #11673 )
Otherwise known artists can go unscraped just because the albums in the library are not found.
- Avoid repeatedly requesting artists that are unknown (could happen every song, and for every album otherwise), just try once.

Currently only Musicbrainz album ids (release id) derived from music file tags are stored in the db, despite the fact that every time scraping is attempted Musicbrainz ids are fetched for those items that don't have them. This can mean repeated lookups of the same item from Musicbrainz over and over again, leading to their server being unnecessarily overloaded and subsequent requests timing-out. 

Also lookups of artwork at Fanart.tv and TADB use Musicbrainz release group id, which has to be fetched each time despite that it could be scanned from music files tags and stored.

This change scans and stores Musicbrainz release group id (in addition to release id)  from tags, and stores both scraped mbids in the db for later use by scrapers and other addons that do a mbid based lookup such as cdArt etc., but flags them as scraped so that any mis-identified artists or albums can be corrected manually by refresh from the info dialog (it doesn't use any scraped mbids, only those from tags, but does a name lookup again instead). 

When scraping an album, even if "Prefer online information" is disabled, any missing artist mbids are taken from the scraped values when names match.

Also fix the way that scraped albums are merged when "Prefer online information" is enabled. Restore the original intent which was to be able to keep the library upto date with Musicbrainz database changes, including changes to album and song artist credits  and song titles,  without having to re-tag. This only applies when the original music files are tagged with mbids. For music not tagged with mbids, and thus lookup is by name only, with "Prefer online information" enabled Kodi does not attempt to change the artist credits, only the album informations only a few fields of which could have been populated by tag data.