### PR TITLE
[gui] refactor methods involved in loading windows

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -755,7 +755,7 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
   return SendControlMessage(message);
 }
 
-bool CGUIWindow::NeedXMLReload() const
+bool CGUIWindow::NeedLoad() const
 {
   return !m_windowLoaded || g_infoManager.ConditionsChangedValues(m_xmlIncludeConditions);
 }
@@ -768,8 +768,8 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   int64_t start;
   start = CurrentHostCounter();
 #endif
-  // use forceLoad to determine if xml file needs loading
-  forceLoad |= NeedXMLReload() || (m_loadType == LOAD_EVERY_TIME);
+  // use forceLoad to determine if window needs (re)loading
+  forceLoad |= NeedLoad() || (m_loadType == LOAD_EVERY_TIME);
 
   // if window is loaded and load is forced we have to free window resources first
   if (m_windowLoaded && forceLoad)
@@ -781,7 +781,7 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
     if (xmlFile.size())
     {
       bool bHasPath = xmlFile.find("\\") != std::string::npos || xmlFile.find("/") != std::string::npos;
-      Load(xmlFile,bHasPath);
+      Load(xmlFile, bHasPath);
     }
   }
 
@@ -841,10 +841,10 @@ void CGUIWindow::ClearAll()
 bool CGUIWindow::Initialize()
 {
   if (!g_windowManager.Initialized())
-    return false;     // can't load if we have no skin yet
-  if(!NeedXMLReload())
+    return false;
+  if (!NeedLoad())
     return true;
-  if(g_application.IsCurrentThread())
+  if (g_application.IsCurrentThread())
     AllocResources();
   else
   {

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -91,6 +91,7 @@ bool CGUIWindow::Load(const std::string& strFileName, bool bContainsPath)
   int64_t start;
   start = CurrentHostCounter();
 #endif
+
   const char* strLoadType;
   switch (m_loadType)
   {
@@ -122,13 +123,19 @@ bool CGUIWindow::Load(const std::string& strFileName, bool bContainsPath)
   }
 
   bool ret = LoadXML(strPath, strLowerPath);
+  if (ret)
+  {
+    m_windowLoaded = true;
+    OnWindowLoaded();
 
 #ifdef _DEBUG
-  int64_t end, freq;
-  end = CurrentHostCounter();
-  freq = CurrentHostFrequency();
-  CLog::Log(LOGDEBUG,"Load %s: %.2fms", GetProperty("xmlfile").c_str(), 1000.f * (end - start) / freq);
+    int64_t end, freq;
+    end = CurrentHostCounter();
+    freq = CurrentHostFrequency();
+    CLog::Log(LOGDEBUG, "Skin file %s loaded in %.2fms", strPath.c_str(), 1000.f * (end - start) / freq);
 #endif
+  }
+
   return ret;
 }
 
@@ -142,39 +149,50 @@ bool CGUIWindow::LoadXML(const std::string &strPath, const std::string &strLower
     StringUtils::ToLower(strPathLower);
     if (!xmlDoc.LoadFile(strPath) && !xmlDoc.LoadFile(strPathLower) && !xmlDoc.LoadFile(strLowerPath))
     {
-      CLog::Log(LOGERROR, "unable to load:%s, Line %d\n%s", strPath.c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+      CLog::Log(LOGERROR, "Unable to load window XML: %s. Line %d\n%s", strPath.c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
       SetID(WINDOW_INVALID);
       return false;
     }
-    m_windowXMLRootElement = (TiXmlElement*)xmlDoc.RootElement()->Clone();
+
+    // xml need a <window> root element
+    if (!StringUtils::EqualsNoCase(xmlDoc.RootElement()->Value(), "window"))
+    {
+      CLog::Log(LOGERROR, "XML file %s does not contain a <window> root element", GetProperty("xmlfile").c_str());
+      return false;
+    }
+
+    // store XML for further processing if window's load type is LOAD_EVERY_TIME or a reload is needed
+    m_windowXMLRootElement = static_cast<TiXmlElement*>(xmlDoc.RootElement()->Clone());
   }
   else
     CLog::Log(LOGDEBUG, "Using already stored xml root node for %s", strPath.c_str());
 
-  return Load(m_windowXMLRootElement);
+  return Load(Prepare(m_windowXMLRootElement).get());
 }
 
-bool CGUIWindow::Load(TiXmlElement* pRootElement)
+std::unique_ptr<TiXmlElement> CGUIWindow::Prepare(TiXmlElement *pRootElement)
+{
+  if (!pRootElement)
+    return nullptr;
+
+  // clone the root element as we will manipulate it
+  auto preparedRoot = std::unique_ptr<TiXmlElement>(static_cast<TiXmlElement*>(pRootElement->Clone()));
+
+  // Resolve any includes, constants, expressions that may be present
+  // and save include's conditions to the given map
+  g_SkinInfo->ResolveIncludes(preparedRoot.get(), &m_xmlIncludeConditions);
+
+  return preparedRoot;
+}
+
+bool CGUIWindow::Load(TiXmlElement *pRootElement)
 {
   if (!pRootElement)
     return false;
-  
-  if (!StringUtils::EqualsNoCase(pRootElement->Value(), "window"))
-  {
-    CLog::Log(LOGERROR, "XML file %s does not contain a <window> root element", GetProperty("xmlfile").c_str());
-    return false;
-  }
-
-  // we must create copy of root element as we will manipulate it when resolving includes
-  // and we don't want original root element to change
-  pRootElement = (TiXmlElement*)pRootElement->Clone();
 
   // set the scaling resolution so that any control creation or initialisation can
   // be done with respect to the correct aspect ratio
   g_graphicsContext.SetScalingResolution(m_coordsRes, m_needsScaling);
-
-  // Resolve any includes that may be present and save conditions used to do it
-  g_SkinInfo->ResolveIncludes(pRootElement, &m_xmlIncludeConditions);
 
   // now load in the skin file
   SetDefaults();
@@ -266,11 +284,7 @@ bool CGUIWindow::Load(TiXmlElement* pRootElement)
 
     pChild = pChild->NextSiblingElement();
   }
-  LoadAdditionalTags(pRootElement);
 
-  m_windowLoaded = true;
-  OnWindowLoaded();
-  delete pRootElement;
   return true;
 }
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -237,10 +237,10 @@ protected:
    */
   virtual std::unique_ptr<TiXmlElement> Prepare(TiXmlElement *pRootElement);
 
-  /*! \brief Check if XML file needs (re)loading
-   XML file has to be (re)loaded when window is not loaded or include conditions values were changed
+  /*!
+   \brief Check if window needs a (re)load. The window need to be (re)loaded when window is not loaded or include conditions values were changed
    */
-  bool NeedXMLReload() const;
+  bool NeedLoad() const;
 
   virtual void SetDefaults();
   virtual void OnWindowUnload() {}

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -215,7 +215,13 @@ public:
   virtual void OnDeinitWindow(int nextWindowID);
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual bool LoadXML(const std::string& strPath, const std::string &strLowerPath);  ///< Loads from the given file
+
+  /*!
+   \brief Load the window XML from the given path
+   \param strPath the path to the window XML
+   \param strLowerPath a lowered path to the window XML
+   */
+  virtual bool LoadXML(const std::string& strPath, const std::string &strLowerPath);
 
   /*!
    \brief Loads the window from the given XML element
@@ -224,11 +230,17 @@ protected:
    */
   virtual bool Load(TiXmlElement *pRootElement);
 
+  /*!
+   \brief Prepare the XML for load
+   \param pRootElement the original XML element
+   \return the prepared XML (resolved includes, constants and expression)
+   */
+  virtual std::unique_ptr<TiXmlElement> Prepare(TiXmlElement *pRootElement);
+
   /*! \brief Check if XML file needs (re)loading
    XML file has to be (re)loaded when window is not loaded or include conditions values were changed
    */
   bool NeedXMLReload() const;
-  virtual void LoadAdditionalTags(TiXmlElement *root) {}; ///< Load additional information from the XML document
 
   virtual void SetDefaults();
   virtual void OnWindowUnload() {}

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -467,19 +467,7 @@ namespace XBMCAddon
     bool WindowXML::LoadXML(const String &strPath, const String &strLowerPath)
     {
       XBMC_TRACE;
-      // load our window
-      CXBMCTinyXML xmlDoc;
-
-      std::string strPathLower = strPath;
-      StringUtils::ToLower(strPathLower);
-      if (!xmlDoc.LoadFile(strPath) && !xmlDoc.LoadFile(strPathLower) && !xmlDoc.LoadFile(strLowerPath))
-      {
-        // fail - can't load the file
-        CLog::Log(LOGERROR, "%s: Unable to load skin file %s", __FUNCTION__, strPath.c_str());
-        return false;
-      }
-
-      return interceptor->Load(xmlDoc.RootElement());
+      return A(CGUIWindow::LoadXML(strPath, strLowerPath));
     }
 
     void WindowXML::SetupShares()

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -103,13 +103,17 @@ CGUIMediaWindow::~CGUIMediaWindow()
   delete m_unfilteredItems;
 }
 
-void CGUIMediaWindow::LoadAdditionalTags(TiXmlElement *root)
+bool CGUIMediaWindow::Load(TiXmlElement *pRootElement)
 {
-  CGUIWindow::LoadAdditionalTags(root);
+  bool retVal = CGUIWindow::Load(pRootElement);
+
+  if (!retVal)
+    return false;
+
   // configure our view control
   m_viewControl.Reset();
   m_viewControl.SetParentWindow(GetID());
-  TiXmlElement *element = root->FirstChildElement("views");
+  TiXmlElement *element = pRootElement->FirstChildElement("views");
   if (element && element->FirstChild())
   { // format is <views>50,29,51,95</views>
     const std::string &allViews = element->FirstChild()->ValueStr();
@@ -123,6 +127,8 @@ void CGUIMediaWindow::LoadAdditionalTags(TiXmlElement *root)
     }
   }
   m_viewControl.SetViewControlID(CONTROL_BTNVIEWASICONS);
+
+  return true;
 }
 
 void CGUIMediaWindow::OnWindowLoaded()

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -67,8 +67,7 @@ protected:
   // specializations of CGUIControlGroup
   CGUIControl *GetFirstFocusableControl(int id) override;
 
-  // specializations of CGUIWindow
-  void LoadAdditionalTags(TiXmlElement *root) override;
+  bool Load(TiXmlElement *pRootElement) override;
 
   // custom methods
   virtual void SetupShares();


### PR DESCRIPTION
This PR refactor some methods involved in loading windows.

* move the preparation of window XML object to its own method `Prepare`
* use a unique_ptr to hold the prepared XML object
* remove method `CGUWindow::LoadAdditionalTags` in favor of override `CGUWindow::Load` directly
* call `CGUIWindow::LoadXML` in our legacy (python) `WindowXML`
* rename method `NeedXMLReload` to `NeedLoad` because it does not reload the entire XML file
