### PR TITLE
silence stat errors in texture cache job

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -231,6 +231,10 @@ bool CTextureCacheJob::UpdateableURL(const std::string &url) const
 
 std::string CTextureCacheJob::GetImageHash(const std::string &url)
 {
+  // silently ignore - we cannot state these
+  if (URIUtils::IsProtocol(url,"addons") || URIUtils::IsProtocol(url,"plugin"))
+    return "";
+
   struct __stat64 st;
   if (XFILE::CFile::Stat(url, &st) == 0)
   {


### PR DESCRIPTION
we cannot stat addon / plugin urls. silently ignore.

Quells a shitload of 13:17:20.901 T:5404 WARNING: XFILE::CFileFactory::CreateLoader - unsupported protocol(plugin) in plugin://xxxx