### PR TITLE
detect and delete zero-byte database files

### DIFF
--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -33,6 +33,7 @@
 #include "utils/log.h"
 #include "system.h" // for Sleep(), OutputDebugString() and GetLastError()
 #include "utils/URIUtils.h"
+#include "filesystem/File.h"
 
 #ifdef TARGET_WINDOWS
 #pragma comment(lib, "sqlite3.lib")
@@ -41,6 +42,8 @@
 #ifdef TARGET_POSIX
 #include "linux/XTimeUtils.h"
 #endif
+
+using namespace XFILE;
 
 namespace dbiplus {
 //************* Callback function ***************************
@@ -221,6 +224,21 @@ int SqliteDatabase::connect(bool create) {
     int flags = SQLITE_OPEN_READWRITE;
     if (create)
       flags |= SQLITE_OPEN_CREATE;
+
+    if (CFile::Exists(db_fullpath.c_str()))
+    {
+      CFile file;
+      if (file.Open(db_fullpath.c_str()))
+      {
+        if (file.GetLength() == 0)
+        {
+          CLog::Log(LOGWARNING, "Found zero byte SQLite database, deleting %s", db_fullpath.c_str());
+          CFile::Delete(db_fullpath.c_str());
+        }
+        file.Close();
+      }
+    }
+
     if (sqlite3_open_v2(db_fullpath.c_str(), &conn, flags, NULL)==SQLITE_OK)
     {
       sqlite3_busy_handler(conn, busy_callback, NULL);


### PR DESCRIPTION
## Description
This change detects and deletes zero-byte sqlite database files so they don't block the migration process when users upgrade from earlier Kodi versions.

## Motivation and Context
There is growing evidence that issues with Addons27.db are primarily caused by pirate add-ons opening the DB to perform self-enablement at startup, but allowing users to fester in their own self-inflicted pain results in onerous support work; we gain more from the hack.

## How Has This Been Tested?
This code change was tested in Milhouse builds for several weeks before LE elected to detect the problem and delete zero-byte files in a startup script (to avoid a code patch). Most of the Kodi-specific Linux distro's are now doing similar things but the issue is still seen in other Kodi build targets.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
