### PR TITLE
[cmake] move ifdef conditions to cmake

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -20,7 +20,6 @@
 
 #include "system.h"
 
-#ifdef HAS_DVD_DRIVE
 #include "Autorun.h"
 
 #include <stdlib.h>
@@ -525,5 +524,3 @@ void CAutorun::SettingOptionAudioCdActionsFiller(const CSetting *setting, std::v
   list.push_back(std::make_pair(g_localizeStrings.Get(14096), AUTOCD_RIP));
 #endif
 }
-
-#endif

--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(SOURCES Application.cpp
             ApplicationPlayer.cpp
             AppParamParser.cpp
-            Autorun.cpp
             AutoSwitch.cpp
             BackgroundInfoLoader.cpp
             ContextMenuItem.cpp
@@ -41,7 +40,6 @@ set(HEADERS AppParamParser.h
             Application.h
             ApplicationPlayer.h
             AutoSwitch.h
-            Autorun.h
             BackgroundInfoLoader.h
             CompileInfo.h
             ContextMenuItem.h
@@ -83,6 +81,11 @@ set(HEADERS AppParamParser.h
             XBDateTime.h
             system.h
             system_gl.h)
+
+if(ENABLE_OPTICAL)
+  list(APPEND SOURCES Autorun.cpp)
+  list(APPEND HEADERS Autorun.h)
+endif()
 
 core_add_library(xbmc)
 if(CAP_FOUND)

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -20,8 +20,6 @@
 
 #include "system.h"
 
-#ifdef HAS_DVD_DRIVE
-
 #include "CDDADirectory.h"
 #include "music/MusicDatabase.h"
 #include "FileItem.h"
@@ -87,5 +85,3 @@ bool CCDDADirectory::GetDirectory(const CURL& url, CFileItemList &items)
   }
   return true;
 }
-
-#endif

--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -20,8 +20,6 @@
 
 #include "system.h"
 
-#ifdef HAS_DVD_DRIVE
-
 #include "CDDAFile.h"
 #include <sys/stat.h>
 #include "URL.h"
@@ -236,6 +234,3 @@ int CFileCDDA::GetChunkSize()
 {
   return SECTOR_COUNT*CDIO_CD_FRAMESIZE_RAW;
 }
-
-#endif
-

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(SOURCES AddonsDirectory.cpp
             AudioBookFileDirectory.cpp
             CacheStrategy.cpp
-            CDDADirectory.cpp
-            CDDAFile.cpp
             CircularCache.cpp
             CurlFile.cpp
             DAVCommon.cpp
@@ -72,8 +70,6 @@ set(SOURCES AddonsDirectory.cpp
             ZipManager.cpp)
 
 set(HEADERS AddonsDirectory.h
-            CDDADirectory.h
-            CDDAFile.h
             CacheStrategy.h
             CircularCache.h
             CurlFile.h
@@ -169,6 +165,13 @@ if(BLURAY_FOUND)
                       BlurayFile.cpp)
   list(APPEND HEADERS BlurayDirectory.h
                       BlurayFile.h)
+endif()
+
+if(ENABLE_OPTICAL)
+  list(APPEND SOURCES CDDADirectory.cpp
+                      CDDAFile.cpp)
+  list(APPEND HEADERS CDDADirectory.h
+                      CDDAFile.h)
 endif()
 
 if(ENABLE_UPNP)

--- a/xbmc/linux/CMakeLists.txt
+++ b/xbmc/linux/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(SOURCES ConvUtils.cpp
-            DBusMessage.cpp
-            DBusReserve.cpp
-            DBusUtil.cpp
-            FDEventMonitor.cpp
             LinuxResourceCounter.cpp
             LinuxTimezone.cpp
             PosixMountProvider.cpp
@@ -13,11 +9,7 @@ set(SOURCES ConvUtils.cpp
             XTimeUtils.cpp)
 
 set(HEADERS ConvUtils.h
-            DBusMessage.h
-            DBusReserve.h
-            DBusUtil.h
             DllBCM.h
-            FDEventMonitor.h
             LinuxResourceCounter.h
             LinuxTimezone.h
             PlatformDefs.h
@@ -31,6 +23,20 @@ set(HEADERS ConvUtils.h
             XHandlePublic.h
             XMemUtils.h
             XTimeUtils.h)
+
+if(ALSA_FOUND)
+  list(APPEND SOURCES FDEventMonitor.cpp)
+  list(APPEND HEADERS FDEventMonitor.h)
+endif()
+
+if(DBUS_FOUND)
+  list(APPEND SOURCES DBusMessage.cpp
+                      DBusReserve.cpp
+                      DBusUtil.cpp)
+  list(APPEND HEADERS DBusMessage.h
+                      DBusReserve.h
+                      DBusUtil.h)
+endif()
 
 if(OMXLIB_FOUND)
   list(APPEND SOURCES OMXClock.cpp

--- a/xbmc/linux/DBusMessage.cpp
+++ b/xbmc/linux/DBusMessage.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "DBusMessage.h"
-#ifdef HAS_DBUS
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
 
@@ -153,4 +152,3 @@ void CDBusMessage::PrepareArgument()
 
   m_haveArgs = true;
 }
-#endif

--- a/xbmc/linux/DBusReserve.cpp
+++ b/xbmc/linux/DBusReserve.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "system.h"
-#ifdef HAS_DBUS
 #include "DBusReserve.h"
 
 #include <dbus/dbus.h>
@@ -179,5 +178,3 @@ bool CDBusReserve::ReleaseDevice(const std::string& device)
 
   return res == DBUS_RELEASE_NAME_REPLY_RELEASED;
 }
-
-#endif

--- a/xbmc/linux/DBusUtil.cpp
+++ b/xbmc/linux/DBusUtil.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "DBusUtil.h"
-#ifdef HAS_DBUS
 #include "utils/log.h"
 
 CVariant CDBusUtil::GetVariant(const char *destination, const char *object, const char *interface, const char *property)
@@ -167,4 +166,3 @@ CVariant CDBusUtil::ParseType(DBusMessageIter *itr)
 
   return value;
 }
-#endif

--- a/xbmc/linux/FDEventMonitor.cpp
+++ b/xbmc/linux/FDEventMonitor.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "system.h"
-#ifdef HAS_ALSA
 
 #include <poll.h>
 #include <sys/eventfd.h>
@@ -244,5 +243,3 @@ void CFDEventMonitor::InterruptPoll()
     CSingleLock pollLock(m_pollMutex);
   }
 }
-
-#endif

--- a/xbmc/network/CMakeLists.txt
+++ b/xbmc/network/CMakeLists.txt
@@ -1,5 +1,4 @@
-set(SOURCES cddb.cpp
-            DNSNameCache.cpp
+set(SOURCES DNSNameCache.cpp
             EventClient.cpp
             EventPacket.cpp
             EventServer.cpp
@@ -15,8 +14,7 @@ set(SOURCES cddb.cpp
             ZeroconfBrowser.cpp
             Zeroconf.cpp)
 
-set(HEADERS cddb.h
-            DNSNameCache.h
+set(HEADERS DNSNameCache.h
             EventClient.h
             EventPacket.h
             EventServer.h
@@ -31,6 +29,11 @@ set(HEADERS cddb.h
             WebServer.h
             Zeroconf.h
             ZeroconfBrowser.h)
+
+if(ENABLE_OPTICAL)
+  list(APPEND SOURCES cddb.cpp)
+  list(APPEND HEADERS cddb.h)
+endif()
 
 if(PLIST_FOUND)
   list(APPEND SOURCES AirPlayServer.cpp)

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -20,8 +20,6 @@
 
 #include "system.h"
 
-#ifdef HAS_DVD_DRIVE
-
 #include <taglib/id3v1genres.h>
 #include "cddb.h"
 #include "CompileInfo.h"
@@ -1076,6 +1074,3 @@ std::string Xcddb::TrimToUTF8(const std::string &untrimmedText)
   g_charsetConverter.unknownToUTF8(text);
   return text;
 }
-
-#endif
-

--- a/xbmc/network/linux/CMakeLists.txt
+++ b/xbmc/network/linux/CMakeLists.txt
@@ -1,9 +1,12 @@
-set(SOURCES NetworkLinux.cpp
-            ZeroconfAvahi.cpp
-            ZeroconfBrowserAvahi.cpp)
+set(SOURCES NetworkLinux.cpp)
 
-set(HEADERS NetworkLinux.h
-            ZeroconfAvahi.h
-            ZeroconfBrowserAvahi.h)
+set(HEADERS NetworkLinux.h)
+
+if(AVAHI_FOUND)
+  list(APPEND SOURCES ZeroconfAvahi.cpp
+                      ZeroconfBrowserAvahi.cpp)
+  list(APPEND HEADERS ZeroconfAvahi.h
+                      ZeroconfBrowserAvahi.h)
+endif()
 
 core_add_library(network_linux)

--- a/xbmc/network/linux/ZeroconfAvahi.cpp
+++ b/xbmc/network/linux/ZeroconfAvahi.cpp
@@ -21,8 +21,6 @@
 #include "PlatformDefs.h"
 #include "ZeroconfAvahi.h"
 
-#ifdef HAS_AVAHI
-
 #include <string>
 #include <iostream>
 #include <sstream>
@@ -431,6 +429,3 @@ void CZeroconfAvahi::addService(tServiceMap::mapped_type fp_service_info, AvahiC
     //! @todo what now? reset the group? free it?
   }
 }
-
-#endif // HAS_AVAHI
-

--- a/xbmc/network/linux/ZeroconfBrowserAvahi.cpp
+++ b/xbmc/network/linux/ZeroconfBrowserAvahi.cpp
@@ -20,8 +20,6 @@
 
 #include "ZeroconfBrowserAvahi.h"
 
-#ifdef HAS_AVAHI
-
 #include <utils/log.h>
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIMessage.h"
@@ -375,5 +373,3 @@ AvahiServiceBrowser* CZeroconfBrowserAvahi::createServiceBrowser ( const std::st
   }
   return ret;
 }
-
-#endif //HAS_AVAHI

--- a/xbmc/rendering/gles/CMakeLists.txt
+++ b/xbmc/rendering/gles/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES RenderSystemGLES.cpp)
+if(OPENGLES_FOUND)
+  set(SOURCES RenderSystemGLES.cpp)
 
-set(HEADERS RenderSystemGLES.h)
+  set(HEADERS RenderSystemGLES.h)
 
-core_add_library(rendering_gles)
+  core_add_library(rendering_gles)
+endif()

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -21,8 +21,6 @@
 
 #include "system.h"
 
-#if HAS_GLES == 2
-
 #include "guilib/GraphicContext.h"
 #include "settings/AdvancedSettings.h"
 #include "RenderSystemGLES.h"
@@ -672,5 +670,3 @@ GLint CRenderSystemGLES::GUIShaderGetModel()
 
   return -1;
 }
-
-#endif

--- a/xbmc/storage/CMakeLists.txt
+++ b/xbmc/storage/CMakeLists.txt
@@ -1,14 +1,17 @@
 set(SOURCES AutorunMediaJob.cpp
-            cdioSupport.cpp
-            DetectDVDType.cpp
             IoSupport.cpp
             MediaManager.cpp)
 
 set(HEADERS AutorunMediaJob.h
-            cdioSupport.h
-            DetectDVDType.h
             IoSupport.h
             IStorageProvider.h
             MediaManager.h)
+
+if(ENABLE_OPTICAL)
+  list(APPEND SOURCES cdioSupport.cpp
+                      DetectDVDType.cpp)
+  list(APPEND HEADERS cdioSupport.h
+                      DetectDVDType.h)
+endif()
 
 core_add_library(storage)

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -20,8 +20,6 @@
 
 #include "system.h"
 
-#ifdef HAS_DVD_DRIVE
-
 #include "DetectDVDType.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
@@ -498,4 +496,3 @@ const std::string &CDetectDVDMedia::GetDVDPath()
 {
   return m_diskPath;
 }
-#endif

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -20,8 +20,6 @@
 
 #include "system.h"
 
-#ifdef HAS_DVD_DRIVE
-
 #include "cdioSupport.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
@@ -947,6 +945,3 @@ uint32_t CCdIoSupport::CddbDiscId()
 
   return ((n % 0xff) << 24 | t << 8 | m_nNumTracks);
 }
-
-#endif
-


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Move condition checking to cmake if the whole `*.cpp` file is enclosed into one `#if ...` .
<!--- Describe your change in detail -->

## Motivation and Context
No need to compile empty files.
This also silences output like `.../usr/bin/ranlib: file: xbmc.a(Autorun.cpp.o) has no symbols` on osx.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
