### PR TITLE
[cmake] fix addon depends check if headers are in separate folders

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -93,7 +93,7 @@ macro (build_addon target prefix libs)
       if(loop_var MATCHES "#define ADDON_")
         string(REGEX REPLACE "\\\n" " " loop_var ${loop_var}) # remove header line breaks 
         string(REGEX REPLACE "#define " "" loop_var ${loop_var}) # remove the #define name from string
-        string(REGEX MATCHALL "[a-zA-Z0-9._]+" loop_var "${loop_var}") # separate the define values to a list
+        string(REGEX MATCHALL "[//a-zA-Z0-9._-]+" loop_var "${loop_var}") # separate the define values to a list
 
         # Get the definition name
         list(GET loop_var 0 include_name)
@@ -117,7 +117,7 @@ macro (build_addon target prefix libs)
                 if("${matchres}" EQUAL 0)
                   string(REPLACE " " ";" loop_var "${loop_var}")
                   list(GET loop_var 1 include_name)
-                  string(REGEX REPLACE "[<>\"]" "" include_name "${include_name}")
+                  string(REGEX REPLACE "[<>\"]|kodi/" "" include_name "${include_name}")
                   if(include_name STREQUAL ${depend_header})
                     set(ADDON_DEPENDS "${ADDON_DEPENDS}\n<import addon=\"${${xml_entry_name}}\" version=\"${${depends_name}}\"/>")
                     # Inform with them the addon header about used type


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Is to handle the cases where header is in different folders, e.g. the coming "#include <kodi/gui/DialogOK.h>"
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
