### PR TITLE
[backport][windows] libass: use correct font

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -16,7 +16,7 @@ expat-2.2.0-win32-vc140.7z
 freetype-db5a22-win32-vc140.7z
 giflib-5.1.4-win32-vc140.7z
 jsonschemabuilder-1.0.0-win32-3.7z
-libass-ddb383-win32-vc140.7z
+libass-d18a5f1-win32-vc140.7z
 libbluray-0.9.3-win32-vc140.7z
 libcdio-0.9.3-win32-vc140.7z
 libcec-4.0.1-win32-vc140-2.7z


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use the correct ttc font from the video file for subtitles.
Backports #12135 
<!--- Describe your change in detail -->

<!--## Motivation and Context-->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
@Paxxi tested it
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
