### PR TITLE
[python] fix ListItem being forced to be a video item after 27dc9a69

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -63,8 +63,6 @@ namespace XBMCAddon
         item->SetArt("thumb",  thumbnailImage );
       if (!path.empty())
         item->SetPath(path);
-
-      item->GetVideoInfoTag()->ResetPlayCount();
     }
 
     ListItem::~ListItem()
@@ -158,7 +156,7 @@ namespace XBMCAddon
       if (!item) return;
 
       LOCKGUIIF(m_offscreen);
-      CVideoInfoTag& vtag = *item->GetVideoInfoTag();
+      CVideoInfoTag& vtag = *GetVideoInfoTag();
       for (const auto& it : dictionary)
         vtag.SetUniqueID(it.second, it.first, it.first == defaultrating);
     }
@@ -168,7 +166,7 @@ namespace XBMCAddon
       if (!item) return;
 
       LOCKGUIIF(m_offscreen);
-      item->GetVideoInfoTag()->SetRating(rating, votes, type, defaultt);
+      GetVideoInfoTag()->SetRating(rating, votes, type, defaultt);
     }
 
     void ListItem::addSeason(int number, std::string name /* = "" */)
@@ -176,7 +174,7 @@ namespace XBMCAddon
       if (!item) return;
 
       LOCKGUIIF(m_offscreen);
-      item->GetVideoInfoTag()->m_namedSeasons[number] = name;
+      GetVideoInfoTag()->m_namedSeasons[number] = name;
     }
 
     void ListItem::select(bool selected)
@@ -218,15 +216,15 @@ namespace XBMCAddon
       }
       else if (lowerKey == "totaltime")
       {
-        CBookmark resumePoint(item->GetVideoInfoTag()->GetResumePoint());
+        CBookmark resumePoint(GetVideoInfoTag()->GetResumePoint());
         resumePoint.totalTimeInSeconds = static_cast<float>(atof(value.c_str()));
-        item->GetVideoInfoTag()->SetResumePoint(resumePoint);
+        GetVideoInfoTag()->SetResumePoint(resumePoint);
       }
       else if (lowerKey == "resumetime")
       {
-        CBookmark resumePoint(item->GetVideoInfoTag()->GetResumePoint());
+        CBookmark resumePoint(GetVideoInfoTag()->GetResumePoint());
         resumePoint.timeInSeconds = static_cast<float>(atof(value.c_str()));
-        item->GetVideoInfoTag()->SetResumePoint(resumePoint);
+        GetVideoInfoTag()->SetResumePoint(resumePoint);
       }
       else if (lowerKey == "specialsort")
       {
@@ -253,9 +251,9 @@ namespace XBMCAddon
         value = StringUtils::Format("%f", item->m_lStartOffset / 75.0);
       }
       else if (lowerKey == "totaltime")
-        value = StringUtils::Format("%f", item->GetVideoInfoTag()->GetResumePoint().totalTimeInSeconds);
+        value = StringUtils::Format("%f", GetVideoInfoTag()->GetResumePoint().totalTimeInSeconds);
       else if (lowerKey == "resumetime")
-        value = StringUtils::Format("%f", item->GetVideoInfoTag()->GetResumePoint().timeInSeconds);
+        value = StringUtils::Format("%f", GetVideoInfoTag()->GetResumePoint().timeInSeconds);
       else if (lowerKey == "fanart_image")
         value = item->GetArt("fanart");
       else
@@ -273,19 +271,19 @@ namespace XBMCAddon
     String ListItem::getUniqueID(const char* key)
     {
       LOCKGUIIF(m_offscreen);
-      return item->GetVideoInfoTag()->GetUniqueID(key);
+      return GetVideoInfoTag()->GetUniqueID(key);
     }
 
     float ListItem::getRating(const char* key)
     {
       LOCKGUIIF(m_offscreen);
-      return item->GetVideoInfoTag()->GetRating(key).rating;
+      return GetVideoInfoTag()->GetRating(key).rating;
     }
 
     int ListItem::getVotes(const char* key)
     {
       LOCKGUIIF(m_offscreen);
-      return item->GetVideoInfoTag()->GetRating(key).votes;
+      return GetVideoInfoTag()->GetRating(key).votes;
     }
 
     void ListItem::setPath(const String& path)
@@ -323,7 +321,7 @@ namespace XBMCAddon
       if (item->HasVideoInfoTag())
       {
         std::ostringstream oss;
-        oss << item->GetVideoInfoTag()->GetDuration();
+        oss << GetVideoInfoTag()->GetDuration();
         return oss.str();
       }
       return "0";
@@ -346,7 +344,7 @@ namespace XBMCAddon
 
       if (strcmpi(type, "video") == 0)
       {
-        auto& videotag = *item->GetVideoInfoTag();
+        auto& videotag = *GetVideoInfoTag();
         for (const auto& it: infoLabels)
         {
           String key = it.first;
@@ -689,7 +687,7 @@ namespace XBMCAddon
     void ListItem::setCast(const std::vector<Properties>& actors)
     {
       LOCKGUIIF(m_offscreen);
-      item->GetVideoInfoTag()->m_cast.clear();
+      GetVideoInfoTag()->m_cast.clear();
       for (const auto& dictionary: actors)
       {
         SActorInfo info;
@@ -706,14 +704,14 @@ namespace XBMCAddon
           else if (key == "order")
             info.order = strtol(value.c_str(), nullptr, 10);
         }
-        item->GetVideoInfoTag()->m_cast.push_back(std::move(info));
+        GetVideoInfoTag()->m_cast.push_back(std::move(info));
       }
     }
 
     void ListItem::setAvailableFanart(const std::vector<Properties>& images)
     {
       LOCKGUIIF(m_offscreen);
-      item->GetVideoInfoTag()->m_fanart.Clear();
+      GetVideoInfoTag()->m_fanart.Clear();
       for (const auto& dictionary : images)
       {
         std::string image;
@@ -730,15 +728,15 @@ namespace XBMCAddon
           else if (key == "colors")
             colors = value;
         }
-        item->GetVideoInfoTag()->m_fanart.AddFanart(image, preview, colors);
+        GetVideoInfoTag()->m_fanart.AddFanart(image, preview, colors);
       }
-      item->GetVideoInfoTag()->m_fanart.Pack();
+      GetVideoInfoTag()->m_fanart.Pack();
     }
 
     void ListItem::addAvailableThumb(std::string url, std::string aspect, std::string referrer, std::string cache, bool post, bool isgz, int season)
     {
       LOCKGUIIF(m_offscreen);
-      item->GetVideoInfoTag()->m_strPictureURL.AddElement(url, aspect, referrer, cache, post, isgz, season);
+      GetVideoInfoTag()->m_strPictureURL.AddElement(url, aspect, referrer, cache, post, isgz, season);
     }
 
     void ListItem::addStreamInfo(const char* cType, const Properties& dictionary)
@@ -768,7 +766,7 @@ namespace XBMCAddon
           else if (key == "language")
             video->m_strLanguage = value;
         }
-        item->GetVideoInfoTag()->m_streamDetails.AddStream(video);
+        GetVideoInfoTag()->m_streamDetails.AddStream(video);
       }
       else if (strcmpi(cType, "audio") == 0)
       {
@@ -785,7 +783,7 @@ namespace XBMCAddon
           else if (key == "channels")
             audio->m_iChannels = strtol(value.c_str(), nullptr, 10);
         }
-        item->GetVideoInfoTag()->m_streamDetails.AddStream(audio);
+        GetVideoInfoTag()->m_streamDetails.AddStream(audio);
       }
       else if (strcmpi(cType, "subtitle") == 0)
       {
@@ -798,9 +796,9 @@ namespace XBMCAddon
           if (key == "language")
             subtitle->m_strLanguage = value;
         }
-        item->GetVideoInfoTag()->m_streamDetails.AddStream(subtitle);
+        GetVideoInfoTag()->m_streamDetails.AddStream(subtitle);
       }
-      item->GetVideoInfoTag()->m_streamDetails.DetermineBestStreams();
+      GetVideoInfoTag()->m_streamDetails.DetermineBestStreams();
     } // end ListItem::addStreamInfo
 
     void ListItem::addContextMenuItems(const std::vector<Tuple<String,String> >& items, bool replaceItems /* = false */)
@@ -832,7 +830,7 @@ namespace XBMCAddon
     {
       LOCKGUIIF(m_offscreen);
       if (item->HasVideoInfoTag())
-        return new xbmc::InfoTagVideo(*item->GetVideoInfoTag());
+        return new xbmc::InfoTagVideo(*GetVideoInfoTag());
       return new xbmc::InfoTagVideo();
     }
 
@@ -861,6 +859,20 @@ namespace XBMCAddon
         els.emplace_back(el.former());
       }
       return els;
+    }
+
+    CVideoInfoTag* ListItem::GetVideoInfoTag()
+    {
+      // make sure the playcount is reset to -1
+      if (!item->HasVideoInfoTag())
+        item->GetVideoInfoTag()->ResetPlayCount();
+
+      return item->GetVideoInfoTag();
+    }
+
+    const CVideoInfoTag* ListItem::GetVideoInfoTag() const
+    {
+      return item->GetVideoInfoTag();
     }
   }
 }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -1132,6 +1132,9 @@ namespace XBMCAddon
 
 private:
       std::vector<std::string> getStringArray(const InfoLabelValue& alt, const std::string& tag, std::string value = "");
+
+      CVideoInfoTag* GetVideoInfoTag();
+      const CVideoInfoTag* GetVideoInfoTag() const;
     };
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS


### PR DESCRIPTION
## Description
This should fix the issues reported by @notspiff in #11998 by introducing a `ListItem::GetVideoInfoTag()` wrapper which resets the video playcount if and only if the plugin accesses the video properties of the `ListItem`.

## How Has This Been Tested?
I haven't tested this myself. @faush01 could you give this a try please?
## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
