### PR TITLE
[xbmc][cmake][win32] Use PCH as intended to speed up build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,7 @@ target_link_libraries(lib${APP_NAME_LC} PUBLIC ${core_DEPENDS} ${SYSTEM_LDFLAGS}
 set_target_properties(lib${APP_NAME_LC} PROPERTIES PROJECT_LABEL "xbmc")
 source_group_by_folder(lib${APP_NAME_LC} RELATIVE ${CMAKE_SOURCE_DIR}/xbmc)
 if(WIN32)
-  add_precompiled_header(lib${APP_NAME_LC} pch.h ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/pch.cpp PCH_TARGET kodi)
+  add_precompiled_header(lib${APP_NAME_LC} pch.h ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/pch.cpp)
   set_language_cxx(lib${APP_NAME_LC})
 endif()
 
@@ -381,9 +381,6 @@ whole_archive(_TEST_LIBRARIES ${core_DEPENDS} gtest)
 target_link_libraries(${APP_NAME_LC}-test PRIVATE ${SYSTEM_LDFLAGS} ${_TEST_LIBRARIES} lib${APP_NAME_LC} ${DEPLIBS} ${CMAKE_DL_LIBS})
 unset(_TEST_LIBRARIES)
 add_dependencies(${APP_NAME_LC}-test ${APP_NAME_LC}-libraries export-files)
-if(WIN32)
-  add_precompiled_header(${APP_NAME_LC}-test pch.h ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/pch.cpp PCH_TARGET kodi)
-endif()
 
 # Enable unit-test related targets
 if(CORE_HOST_IS_TARGET)

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -21,6 +21,13 @@
 %module(directors="1") xbmc
 
 %{
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "interfaces/legacy/Player.h"
 #include "interfaces/legacy/RenderCapture.h"
 #include "interfaces/legacy/Keyboard.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
@@ -21,6 +21,13 @@
 %module xbmcaddon
 
 %{
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "interfaces/legacy/Addon.h"
 
 using namespace XBMCAddon;

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -21,6 +21,13 @@
 %module(directors="1") xbmcgui
 
 %{
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "interfaces/legacy/Dialog.h"
 #include "interfaces/legacy/ModuleXbmcgui.h"
 #include "interfaces/legacy/Control.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcplugin.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcplugin.i
@@ -21,6 +21,13 @@
 %module xbmcplugin
 
 %{
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "interfaces/legacy/ModuleXbmcplugin.h"
 
 using namespace XBMCAddon;

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -21,6 +21,13 @@
 %module xbmcvfs
 
 %{
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "interfaces/legacy/ModuleXbmcvfs.h"
 #include "interfaces/legacy/File.h"
 #include "interfaces/legacy/Stat.h"

--- a/xbmc/interfaces/swig/AddonModuleXbmcwsgi.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcwsgi.i
@@ -19,6 +19,13 @@
  */
 
 %begin %{
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "system.h"
 
 #ifdef HAS_WEB_SERVER

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -44,6 +44,3 @@ add_library(python_binding STATIC ${SOURCES})
 set_target_properties(python_binding PROPERTIES POSITION_INDEPENDENT_CODE TRUE
                                                 FOLDER "Build Utilities")
 set(core_DEPENDS python_binding ${core_DEPENDS} CACHE STRING "" FORCE)
-if(WIN32)
-  add_precompiled_header(python_binding pch.h ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/pch.cpp PCH_TARGET kodi)
-endif()

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -18,6 +18,13 @@
  *
  */
 
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include <errno.h>
 #include <stdlib.h>
 

--- a/xbmc/utils/test/TestArchive.cpp
+++ b/xbmc/utils/test/TestArchive.cpp
@@ -18,6 +18,13 @@
  *
  */
 
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "utils/Archive.h"
 #include "utils/Variant.h"
 #include "filesystem/File.h"

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -18,6 +18,13 @@
  *
  */
 
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#  if !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  include <windows.h>
+#endif
+
 #include "utils/CPUInfo.h"
 #include "utils/Temperature.h"
 #include "settings/AdvancedSettings.h"


### PR DESCRIPTION
PCH was being built in a separate library to work around the lack of includes in certain parts of other libraries.
This only complicated the build and wasn't really the intended use of a pch which is to speed up the build process.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
