### PR TITLE
VideoPlayer: some codecs have no extradata

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -125,7 +125,18 @@ bool CVideoPlayerVideo::OpenStream(CDVDStreamInfo hint)
   if (hint.flags & AV_DISPOSITION_ATTACHED_PIC)
     return false;
   if (hint.extrasize == 0)
-    return false;
+  {
+    // codecs which require extradata
+    if (hint.codec == AV_CODEC_ID_MPEG1VIDEO ||
+        hint.codec == AV_CODEC_ID_MPEG2VIDEO ||
+        hint.codec == AV_CODEC_ID_MPEG2VIDEO_XVMC ||
+        hint.codec == AV_CODEC_ID_H264 ||
+        hint.codec == AV_CODEC_ID_HEVC ||
+        hint.codec == AV_CODEC_ID_MPEG4 ||
+        hint.codec == AV_CODEC_ID_WMV3 ||
+        hint.codec == AV_CODEC_ID_VC1)
+      return false;
+  }
 
   CLog::Log(LOGNOTICE, "Creating video codec with codec id: %i", hint.codec);
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

<!--## Description-->
<!--- Describe your change in detail -->

## Motivation and Context
VP8 and VP9 videos were not working
@FernetMenta I've picked the patch from your repo and added the VP8 and VP9.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
played VP8 & VP9 video
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
