### PR TITLE
[windows][x64] add libbluray

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -15,6 +15,7 @@ expat-2.2.0-x64-vc140.7z
 fmt-3.0.1-x64-vc140.7z
 freetype-db5a224-x64-vc140.7z
 libass-d18a5f1-x64-vc140.7z
+libbluray-1.0.0-x64-vc140.7z
 libcdio-0.94-x64-vc140.7z
 libcec-4.0.2-x64-vc140.7z
 libfribidi-0.19.7-x64-vc140.7z


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
add libbluray dependency 
<!--- Describe your change in detail -->

## Motivation and Context
get bluray support for windows x64
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
played bluray iso
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
