### PR TITLE
[osx/windowing] - fix regression after removing deprecated video mode enumeration API

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1305,6 +1305,21 @@ bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate,
     if (!match)
       dispMode = BestMatchForMode(display_id, 16, width, height, match);
 
+    // still no match? fallback to current resolution of the display which HAS to work [tm]
+    if (!match)
+    {
+      int tmpWidth;
+      int tmpHeight;
+      double tmpRefresh;
+
+      GetScreenResolution(&tmpWidth, &tmpHeight, &tmpRefresh, screenIdx);
+      dispMode = GetMode(tmpWidth, tmpHeight, tmpRefresh, screenIdx);
+
+      // no way to get a resolution set
+      if (!dispMode)
+        return false;
+    }
+
     if (!match)
       return false;
   }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -268,7 +268,7 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display, size_t bitsPerPixel
     if(DisplayBitsPerPixelForMode(mode) != bitsPerPixel)
       continue;
     
-    if((CGDisplayModeGetWidth(mode) >= width) && (CGDisplayModeGetHeight(mode) >= height))
+    if((CGDisplayModeGetWidth(mode) == width) && (CGDisplayModeGetHeight(mode) == height))
     {
       CGDisplayModeRelease(displayMode); // release the copy we got before ...
       displayMode = mode;
@@ -286,7 +286,7 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display, size_t bitsPerPixel
       if(DisplayBitsPerPixelForMode(mode) >= bitsPerPixel)
         continue;
       
-      if((CGDisplayModeGetWidth(mode) >= width) && (CGDisplayModeGetHeight(mode) >= height))
+      if((CGDisplayModeGetWidth(mode) == width) && (CGDisplayModeGetHeight(mode) == height))
       {
         displayMode = mode;
         match = true;


### PR DESCRIPTION
This PR is meant to fix the regression introduced by changed behavior of the new Screen mode enumeration API of Apple which was added due to deprecation in PR #12064.

@ksooo can you give this a shot and confirm that it fixes your macbook retina issue?