### PR TITLE
[fix] gcc 4.8 doesn’t correctly implement std::regex

### DIFF
--- a/xbmc/filesystem/ZipManager.h
+++ b/xbmc/filesystem/ZipManager.h
@@ -32,14 +32,13 @@
 #define ECDREC_SIZE 22
 
 #include <memory.h>
-#include <regex>
 #include <string>
 #include <vector>
 #include <map>
 
 class CURL;
 
-static const std::regex PATH_TRAVERSAL(R"_((^|\/|\\)\.{2}($|\/|\\))_");
+static const std::string PATH_TRAVERSAL(R"_((^|\/|\\)\.{2}($|\/|\\))_");
 
 struct SZipEntry {
   unsigned int header;

--- a/xbmc/filesystem/test/TestZipManager.cpp
+++ b/xbmc/filesystem/test/TestZipManager.cpp
@@ -19,20 +19,24 @@
  */
 
 #include "filesystem/ZipManager.h"
+#include "utils/RegExp.h"
 
 #include "gtest/gtest.h"
 
 TEST(TestZipManager, PathTraversal)
 {
-  ASSERT_TRUE(std::regex_search("..", PATH_TRAVERSAL));
-  ASSERT_TRUE(std::regex_search("../test.txt", PATH_TRAVERSAL));
-  ASSERT_TRUE(std::regex_search("..\\test.txt", PATH_TRAVERSAL));
-  ASSERT_TRUE(std::regex_search("test/../test.txt", PATH_TRAVERSAL));
-  ASSERT_TRUE(std::regex_search("test\\../test.txt", PATH_TRAVERSAL));
-  ASSERT_TRUE(std::regex_search("test\\..\\test.txt", PATH_TRAVERSAL));
+  CRegExp pathTraversal;
+  pathTraversal.RegComp(PATH_TRAVERSAL);
+
+  ASSERT_TRUE(pathTraversal.RegFind("..") >= 0);
+  ASSERT_TRUE(pathTraversal.RegFind("../test.txt") >= 0);
+  ASSERT_TRUE(pathTraversal.RegFind("..\\test.txt") >= 0);
+  ASSERT_TRUE(pathTraversal.RegFind("test/../test.txt") >= 0);
+  ASSERT_TRUE(pathTraversal.RegFind("test\\../test.txt") >= 0);
+  ASSERT_TRUE(pathTraversal.RegFind("test\\..\\test.txt") >= 0);
   
-  ASSERT_FALSE(std::regex_search("...", PATH_TRAVERSAL));
-  ASSERT_FALSE(std::regex_search("..test.txt", PATH_TRAVERSAL));
-  ASSERT_FALSE(std::regex_search("test.txt..", PATH_TRAVERSAL));
-  ASSERT_FALSE(std::regex_search("test..test.txt", PATH_TRAVERSAL));
+  ASSERT_FALSE(pathTraversal.RegFind("...") >= 0);
+  ASSERT_FALSE(pathTraversal.RegFind("..test.txt") >= 0);
+  ASSERT_FALSE(pathTraversal.RegFind("test.txt..") >= 0);
+  ASSERT_FALSE(pathTraversal.RegFind("test..test.txt") >= 0);
 }

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -22,6 +22,8 @@
 #ifndef REGEXP_H
 #define REGEXP_H
 
+//! @todo - move to std::regex (after switching to gcc 4.9 or higher) and get rid of CRegExp
+
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Use our own `CRegExp` implementation instead of `std::regex`.
<!--- Describe your change in detail -->

## Motivation and Context
Kodi compiled with GCC 4.8 (Ubuntu 14) crashes on startup, because `std::regex` is not implemented for that gcc version.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
tested with a malicious file and run the test suite
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
