### PR TITLE
sqlite: Close file before attempting deletion

### DIFF
--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -232,10 +232,12 @@ int SqliteDatabase::connect(bool create) {
       {
         if (file.GetLength() == 0)
         {
+          file.Close();
           CLog::Log(LOGWARNING, "Found zero byte SQLite database, deleting %s", db_fullpath.c_str());
           CFile::Delete(db_fullpath.c_str());
         }
-        file.Close();
+        else
+          file.Close();
       }
     }
 


### PR DESCRIPTION
Thanks for the [suggestion](http://forum.kodi.tv/showthread.php?tid=314965&pid=2591323#pid2591323), @stefansaraev 

This is just a hack on a hack, Windows might still fail to delete the file for many other reasons but it shouldn't fail because we still have the file open.