### PR TITLE
Fix win64 DLL wrapping and Debug build

### DIFF
--- a/xbmc/cores/DllLoader/Win32DllLoader.cpp
+++ b/xbmc/cores/DllLoader/Win32DllLoader.cpp
@@ -297,7 +297,7 @@ void Win32DllLoader::OverrideImports(const std::string &dll)
         VirtualProtect((PVOID)&first_thunk[j].u1.Function, 4, PAGE_EXECUTE_READWRITE, &old_prot);
 
         // patch the address of function to point to our overridden version
-        first_thunk[j].u1.Function = (DWORD)fixup;
+        first_thunk[j].u1.Function = (uintptr_t)fixup;
 
         // reset to old settings
         VirtualProtect((PVOID)&first_thunk[j].u1.Function, 4, old_prot, &old_prot);
@@ -338,7 +338,7 @@ void Win32DllLoader::RestoreImports()
     DWORD old_prot = 0;
     VirtualProtect(import.table, 4, PAGE_EXECUTE_READWRITE, &old_prot);
 
-    *static_cast<DWORD *>(import.table) = import.function;
+    *static_cast<uintptr_t *>(import.table) = import.function;
 
     // reset to old settings
     VirtualProtect(import.table, 4, old_prot, &old_prot);

--- a/xbmc/cores/DllLoader/Win32DllLoader.h
+++ b/xbmc/cores/DllLoader/Win32DllLoader.h
@@ -31,7 +31,7 @@ public:
   {
   public:
     void *table;
-    DWORD function;
+    uintptr_t function;
   };
 
   Win32DllLoader(const std::string& dll, bool isSystemDll);

--- a/xbmc/filesystem/XbtFile.cpp
+++ b/xbmc/filesystem/XbtFile.cpp
@@ -24,6 +24,8 @@
 #ifdef TARGET_WINDOWS
 #ifdef NDEBUG
 #pragma comment(lib,"lzo2.lib")
+#elif defined _WIN64
+#pragma comment(lib, "lzo2d.lib")
 #else
 #pragma comment(lib, "lzo2-no_idb.lib")
 #endif

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -37,6 +37,8 @@
 #ifdef TARGET_WINDOWS
 #ifdef NDEBUG
 #pragma comment(lib,"lzo2.lib")
+#elif defined _WIN64
+#pragma comment(lib, "lzo2d.lib")
 #else
 #pragma comment(lib, "lzo2-no_idb.lib")
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
- fixes crash when trying to play back DVDs on Win 64 build
- fixes Win x64 debug build as lzo2-no_idb not existing. Pointing to lzo2d instead.

## Description
<!--- Describe your change in detail -->
Use 64-bit function pointers when hooking our emulated functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes an issue in 64-bit nightly builds (reported on slack channel).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested using DVD iso image.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
