### PR TITLE
Fix crash when closing standalone games

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -68,11 +68,14 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
     {
       m_audio.reset(new CRetroPlayerAudio(*m_processInfo));
       m_video.reset(new CRetroPlayerVideo(m_renderManager, *m_processInfo));
-      if (m_gameClient->OpenFile(file, m_audio.get(), m_video.get()))
-      {
+
+      if (!file.GetPath().empty())
+        bSuccess = m_gameClient->OpenFile(file, m_audio.get(), m_video.get());
+      else
+        bSuccess = m_gameClient->OpenStandalone(m_audio.get(), m_video.get());
+
+      if (bSuccess)
         CLog::Log(LOGDEBUG, "RetroPlayer: Using game client %s", m_gameClient->ID().c_str());
-        bSuccess = true;
-      }
       else
         CLog::Log(LOGERROR, "RetroPlayer: Failed to open file using %s", m_gameClient->ID().c_str());
     }

--- a/xbmc/games/addons/CMakeLists.txt
+++ b/xbmc/games/addons/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SOURCES GameClient.cpp
             GameClientInGameSaves.cpp
-            GameClientInput.cpp
+            GameClientJoystick.cpp
             GameClientKeyboard.cpp
             GameClientMouse.cpp
             GameClientProperties.cpp
@@ -10,7 +10,7 @@ set(SOURCES GameClient.cpp
 set(HEADERS GameClient.h
             GameClientCallbacks.h
             GameClientInGameSaves.h
-            GameClientInput.h
+            GameClientJoystick.h
             GameClientKeyboard.h
             GameClientMouse.h
             GameClientProperties.h

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -294,9 +294,6 @@ bool CGameClient::OpenFile(const CFileItem& file, IGameAudioCallback* audio, IGa
   if (!InitializeGameplay(file.GetPath(), audio, video))
     return false;
 
-  m_inGameSaves.reset(new CGameClientInGameSaves(this, &m_struct.toAddon));
-  m_inGameSaves->Load();
-
   return true;
 }
 
@@ -344,6 +341,9 @@ bool CGameClient::InitializeGameplay(const std::string& gamePath, IGameAudioCall
 
     if (m_bSupportsMouse)
       OpenMouse();
+
+    m_inGameSaves.reset(new CGameClientInGameSaves(this, &m_struct.toAddon));
+    m_inGameSaves->Load();
 
     // Start playback
     CreatePlayback();

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -21,7 +21,7 @@
 #include "GameClient.h"
 #include "GameClientCallbacks.h"
 #include "GameClientInGameSaves.h"
-#include "GameClientInput.h"
+#include "GameClientJoystick.h"
 #include "GameClientKeyboard.h"
 #include "GameClientMouse.h"
 #include "GameClientTranslator.h"
@@ -749,7 +749,7 @@ bool CGameClient::OpenPort(unsigned int port)
     //! @todo Choose controller
     ControllerPtr& controller = controllers[0];
 
-    m_ports[port].reset(new CGameClientInput(this, port, controller, &m_struct.toAddon));
+    m_ports[port].reset(new CGameClientJoystick(this, port, controller, &m_struct.toAddon));
 
     // If keyboard input is being captured by this add-on, force the port type to PERIPHERAL_JOYSTICK
     PERIPHERALS::PeripheralType device = PERIPHERALS::PERIPHERAL_UNKNOWN;

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -258,7 +258,7 @@ bool CGameClient::OpenFile(const CFileItem& file, IGameAudioCallback* audio, IGa
 
   // Check if we should open in standalone mode
   if (file.GetPath().empty())
-    return OpenStandalone(audio, video);
+    return false;
 
   // Resolve special:// URLs
   CURL translatedUrl(CSpecialProtocol::TranslatePath(file.GetPath()));

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -40,7 +40,7 @@ namespace GAME
 {
 
 class CGameClientInGameSaves;
-class CGameClientInput;
+class CGameClientJoystick;
 class CGameClientKeyboard;
 class CGameClientMouse;
 class IGameAudioCallback;
@@ -192,7 +192,7 @@ private:
   std::unique_ptr<CGameClientInGameSaves> m_inGameSaves;
 
   // Input
-  std::map<int, std::unique_ptr<CGameClientInput>> m_ports;
+  std::map<int, std::unique_ptr<CGameClientJoystick>> m_ports;
   std::unique_ptr<CGameClientKeyboard> m_keyboard;
   std::unique_ptr<CGameClientMouse> m_mouse;
 

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -78,6 +78,7 @@ public:
   bool Initialize(void);
   void Unload();
   bool OpenFile(const CFileItem& file, IGameAudioCallback* audio, IGameVideoCallback* video);
+  bool OpenStandalone(IGameAudioCallback* audio, IGameVideoCallback* video);
   void Reset();
   void CloseFile();
   const std::string& GetGamePath() const { return m_gamePath; }
@@ -118,7 +119,6 @@ public:
 
 private:
   // Private gameplay functions
-  bool OpenStandalone(IGameAudioCallback* audio, IGameVideoCallback* video);
   bool InitializeGameplay(const std::string& gamePath, IGameAudioCallback* audio, IGameVideoCallback* video);
   bool LoadGameInfo();
   bool NormalizeAudio(IGameAudioCallback* audioCallback);

--- a/xbmc/games/addons/GameClientJoystick.cpp
+++ b/xbmc/games/addons/GameClientJoystick.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "GameClientInput.h"
+#include "GameClientJoystick.h"
 #include "GameClient.h"
 #include "games/controllers/Controller.h"
 #include "input/joysticks/IInputReceiver.h"
@@ -30,7 +30,7 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameClientInput::CGameClientInput(CGameClient* gameClient, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game *dllStruct) :
+CGameClientJoystick::CGameClientJoystick(CGameClient* gameClient, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game *dllStruct) :
   m_gameClient(gameClient),
   m_port(port),
   m_controller(controller),
@@ -40,12 +40,12 @@ CGameClientInput::CGameClientInput(CGameClient* gameClient, int port, const Cont
   assert(m_controller.get() != NULL);
 }
 
-std::string CGameClientInput::ControllerID(void) const
+std::string CGameClientJoystick::ControllerID(void) const
 {
   return m_controller->ID();
 }
 
-bool CGameClientInput::HasFeature(const std::string& feature) const
+bool CGameClientJoystick::HasFeature(const std::string& feature) const
 {
   try
   {
@@ -59,12 +59,12 @@ bool CGameClientInput::HasFeature(const std::string& feature) const
   return false;
 }
 
-bool CGameClientInput::AcceptsInput(void)
+bool CGameClientJoystick::AcceptsInput(void)
 {
   return m_gameClient->AcceptsInput();
 }
 
-JOYSTICK::INPUT_TYPE CGameClientInput::GetInputType(const std::string& feature) const
+JOYSTICK::INPUT_TYPE CGameClientJoystick::GetInputType(const std::string& feature) const
 {
   const std::vector<CControllerFeature>& features = m_controller->Layout().Features();
 
@@ -77,7 +77,7 @@ JOYSTICK::INPUT_TYPE CGameClientInput::GetInputType(const std::string& feature) 
   return JOYSTICK::INPUT_TYPE::UNKNOWN;
 }
 
-bool CGameClientInput::OnButtonPress(const std::string& feature, bool bPressed)
+bool CGameClientJoystick::OnButtonPress(const std::string& feature, bool bPressed)
 {
   bool bHandled = false;
 
@@ -103,7 +103,7 @@ bool CGameClientInput::OnButtonPress(const std::string& feature, bool bPressed)
   return bHandled;
 }
 
-bool CGameClientInput::OnButtonMotion(const std::string& feature, float magnitude)
+bool CGameClientJoystick::OnButtonMotion(const std::string& feature, float magnitude)
 {
   bool bHandled = false;
 
@@ -129,7 +129,7 @@ bool CGameClientInput::OnButtonMotion(const std::string& feature, float magnitud
   return bHandled;
 }
 
-bool CGameClientInput::OnAnalogStickMotion(const std::string& feature, float x, float y, unsigned int motionTimeMs /* = 0 */)
+bool CGameClientJoystick::OnAnalogStickMotion(const std::string& feature, float x, float y, unsigned int motionTimeMs /* = 0 */)
 {
   bool bHandled = false;
 
@@ -156,7 +156,7 @@ bool CGameClientInput::OnAnalogStickMotion(const std::string& feature, float x, 
   return bHandled;
 }
 
-bool CGameClientInput::OnAccelerometerMotion(const std::string& feature, float x, float y, float z)
+bool CGameClientJoystick::OnAccelerometerMotion(const std::string& feature, float x, float y, float z)
 {
   bool bHandled = false;
 
@@ -184,7 +184,7 @@ bool CGameClientInput::OnAccelerometerMotion(const std::string& feature, float x
   return bHandled;
 }
 
-bool CGameClientInput::SetRumble(const std::string& feature, float magnitude)
+bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)
 {
   bool bHandled = false;
 

--- a/xbmc/games/addons/GameClientJoystick.h
+++ b/xbmc/games/addons/GameClientJoystick.h
@@ -34,7 +34,7 @@ namespace GAME
    *
    * Listens to game controller events and forwards them to the games (as game_input_event).
    */
-  class CGameClientInput : public KODI::JOYSTICK::IInputHandler
+  class CGameClientJoystick : public KODI::JOYSTICK::IInputHandler
   {
   public:
     /*!
@@ -44,7 +44,9 @@ namespace GAME
      * \param controller The game controller which is used (for controller mapping).
      * \param dllStruct The emulator or game to which the events are sent.
      */
-    CGameClientInput(CGameClient* addon, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game* dllStruct);
+    CGameClientJoystick(CGameClient* addon, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game* dllStruct);
+
+    virtual ~CGameClientJoystick() = default;
 
     // Implementation of IInputHandler
     virtual std::string ControllerID(void) const override;

--- a/xbmc/games/addons/GameClientKeyboard.h
+++ b/xbmc/games/addons/GameClientKeyboard.h
@@ -46,7 +46,7 @@ namespace GAME
     /*!
      * \brief Destructor unregisters from keyboard events from CInputManager.
      */
-    ~CGameClientKeyboard();
+    virtual ~CGameClientKeyboard();
 
     // implementation of IKeyboardHandler
     virtual bool OnKeyPress(const CKey& key) override;

--- a/xbmc/games/addons/GameClientMouse.h
+++ b/xbmc/games/addons/GameClientMouse.h
@@ -46,7 +46,7 @@ namespace GAME
     /*!
      * \brief Destructor unregisters from mouse events from CInputManager.
      */
-    ~CGameClientMouse();
+    virtual ~CGameClientMouse();
 
     // implementation of IMouseInputHandler
     virtual std::string ControllerID(void) const override;

--- a/xbmc/games/ports/PortManager.h
+++ b/xbmc/games/ports/PortManager.h
@@ -52,6 +52,8 @@ namespace GAME
   public:
     static CPortManager& GetInstance();
 
+    virtual ~CPortManager() = default;
+
     /*!
      * \brief Request a new port be opened with input on that port sent to the
      *        specified handler.

--- a/xbmc/games/tags/GameInfoTag.h
+++ b/xbmc/games/tags/GameInfoTag.h
@@ -35,7 +35,7 @@ namespace GAME
     CGameInfoTag() { Reset(); }
     CGameInfoTag(const CGameInfoTag& tag) { *this = tag; }
     CGameInfoTag& operator=(const CGameInfoTag& tag);
-    ~CGameInfoTag() { }
+    virtual ~CGameInfoTag() = default;
     void Reset();
 
     bool operator==(const CGameInfoTag& tag) const;

--- a/xbmc/games/windows/GUIViewStateWindowGames.h
+++ b/xbmc/games/windows/GUIViewStateWindowGames.h
@@ -28,6 +28,8 @@ namespace GAME
   public:
     CGUIViewStateWindowGames(const CFileItemList& items);
 
+    virtual ~CGUIViewStateWindowGames() = default;
+
     // implementation of CGUIViewState
     virtual std::string GetLockType() override;
     virtual std::string GetExtensions() override;


### PR DESCRIPTION
Currently, if a game add-on is loaded without a file (standalone mode), when closed it will segfault.

The cause is from #11380, where the in-game saves variable was only initialized for file-based games.

Also included are three code improvements for the games code.