### PR TITLE
ADD: [droid] allow autostarting at boot (via xbmc_env.proprties)

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
@@ -91,6 +92,7 @@
                 <action android:name="android.intent.action.DREAMING_STOPPED" />
                 <action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED" />
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCBroadcastReceiver.java.in
+++ b/tools/android/packaging/xbmc/src/org/xbmc/kodi/XBMCBroadcastReceiver.java.in
@@ -3,20 +3,38 @@ package @APP_PACKAGE@;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Environment;
 import android.util.Log;
 
 public class XBMCBroadcastReceiver extends BroadcastReceiver
 {
   native void _onReceive(Intent intent);
 
+  private static final String TAG = "@APP_NAME@Receiver";
+
   @Override
   public void onReceive(Context context, Intent intent)
   {
-    Log.d("XBMCBroadcastReceiver", "Received Intent");
-    try {
-      _onReceive(intent);
-    } catch (UnsatisfiedLinkError e) {
-      Log.e("XBMCBroadcastReceiver", "Native not registered");
+    if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction()))
+    {
+      if (XBMCProperties.getBoolProperty("xbmc.autostart"))
+      {
+        // Run @APP_NAME@
+        Intent i = new Intent();
+        PackageManager manager = context.getPackageManager();
+        i = manager.getLaunchIntentForPackage("@APP_PACKAGE@");
+        i.addCategory(Intent.CATEGORY_LAUNCHER);
+        context.startActivity(i);
+      }
+    }
+    else
+    {
+      try {
+        _onReceive(intent);
+      } catch (UnsatisfiedLinkError e) {
+        Log.e(TAG, "Native not registered");
+      }
     }
   }
 }


### PR DESCRIPTION
As the title says, add much-requested possibility to start kodi on boot.
Enable via xbmc_env.properties, `xbmc.autostart=yes`