### PR TITLE
[cmake] improve addon related version handling

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -118,7 +118,7 @@ macro (build_addon target prefix libs)
                   string(REPLACE " " ";" loop_var "${loop_var}")
                   list(GET loop_var 1 include_name)
                   string(REGEX REPLACE "[<>\"]|kodi/" "" include_name "${include_name}")
-                  if(include_name STREQUAL ${depend_header})
+                  if(include_name MATCHES ${depend_header})
                     set(ADDON_DEPENDS "${ADDON_DEPENDS}\n<import addon=\"${${xml_entry_name}}\" version=\"${${depends_name}}\"/>")
                     # Inform with them the addon header about used type
                     add_definitions(-D${used_type_name})

--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -701,4 +701,7 @@ macro(find_addon_xml_in_files)
     endforeach()
     unset(xml_name)
   endforeach()
+
+  # Append also versions.h to depends
+  list(APPEND ADDON_XML_DEPENDS "${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h")
 endmacro()

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -51,8 +51,8 @@
                                                       "kodi_audioengine_types.h" \
                                                       "libKODI_audioengine.h" \
                                                       "libXBMC_addon.h" \
-                                                      "addon-instance/Screensaver.h"
-// @note "addon-instance/Screensaver.h" above must be improved to check only to included directory with "addon-instance"!
+                                                      "addon-instance/"
+
 #define ADDON_GLOBAL_VERSION_GUI                      "5.11.0"
 #define ADDON_GLOBAL_VERSION_GUI_MIN                  "5.10.0"
 #define ADDON_GLOBAL_VERSION_GUI_XML_ID               "kodi.binary.global.gui"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
The first commit alow the check of defininition also by given include folder.
The second delete the generated addon.xml's in case the versions.h file is changed.

Without them comes it to problems if a version is changed. The related addon.xml.in are not generated new and has needed always a delete by hand before.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
