### PR TITLE
[addons] fix addons in case interface is changed

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -208,11 +208,11 @@ typedef struct AddonGlobalInterface
 
   // Callback function tables from addon to Kodi
   // Set from Kodi!
-  AddonToKodiFuncTable_Addon toKodi;
+  AddonToKodiFuncTable_Addon* toKodi;
 
   // Function tables from Kodi to addon
   // Set from addon header!
-  KodiToAddonFuncTable_Addon toAddon;
+  KodiToAddonFuncTable_Addon* toAddon;
 } AddonGlobalInterface;
 
 } /* extern "C" */
@@ -276,11 +276,11 @@ class CAddonBase
 public:
   CAddonBase()
   {
-    CAddonBase::m_interface->toAddon.destroy = ADDONBASE_Destroy;
-    CAddonBase::m_interface->toAddon.get_status = ADDONBASE_GetStatus;
-    CAddonBase::m_interface->toAddon.create_instance = ADDONBASE_CreateInstance;
-    CAddonBase::m_interface->toAddon.destroy_instance = ADDONBASE_DestroyInstance;
-    CAddonBase::m_interface->toAddon.set_setting = ADDONBASE_SetSetting;
+    CAddonBase::m_interface->toAddon->destroy = ADDONBASE_Destroy;
+    CAddonBase::m_interface->toAddon->get_status = ADDONBASE_GetStatus;
+    CAddonBase::m_interface->toAddon->create_instance = ADDONBASE_CreateInstance;
+    CAddonBase::m_interface->toAddon->destroy_instance = ADDONBASE_DestroyInstance;
+    CAddonBase::m_interface->toAddon->set_setting = ADDONBASE_SetSetting;
   }
 
   virtual ~CAddonBase() = default;
@@ -362,9 +362,9 @@ namespace kodi {
 ///
 inline std::string GetAddonPath()
 {
-  char* str = ::kodi::addon::CAddonBase::m_interface->toKodi.get_addon_path(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  char* str = ::kodi::addon::CAddonBase::m_interface->toKodi->get_addon_path(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
   std::string ret = str;
-  ::kodi::addon::CAddonBase::m_interface->toKodi.free_string(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, str);
+  ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, str);
   return ret;
 }
 } /* namespace kodi */
@@ -375,9 +375,9 @@ namespace kodi {
 ///
 inline std::string GetBaseUserPath()
 {
-  char* str = ::kodi::addon::CAddonBase::m_interface->toKodi.get_base_user_path(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  char* str = ::kodi::addon::CAddonBase::m_interface->toKodi->get_base_user_path(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
   std::string ret = str;
-  ::kodi::addon::CAddonBase::m_interface->toKodi.free_string(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, str);
+  ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, str);
   return ret;
 }
 } /* namespace kodi */
@@ -403,7 +403,7 @@ inline void Log(const AddonLog loglevel, const char* format, ...)
   va_start(args, format);
   vsprintf(buffer, format, args);
   va_end(args);
-  ::kodi::addon::CAddonBase::m_interface->toKodi.addon_log_msg(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, loglevel, buffer);
+  ::kodi::addon::CAddonBase::m_interface->toKodi->addon_log_msg(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, loglevel, buffer);
 }
 } /* namespace kodi */
 //------------------------------------------------------------------------------
@@ -414,12 +414,12 @@ namespace kodi {
 inline bool CheckSettingString(const std::string& settingName, std::string& settingValue)
 {
   char * buffer = nullptr;
-  bool ret = ::kodi::addon::CAddonBase::m_interface->toKodi.get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &buffer);
+  bool ret = ::kodi::addon::CAddonBase::m_interface->toKodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), &buffer);
   if (buffer)
   {
     if (ret)
       settingValue = buffer;
-    ::kodi::addon::CAddonBase::m_interface->toKodi.free_string(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, buffer);
+    ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, buffer);
   }
   return ret;
 }
@@ -443,7 +443,7 @@ namespace kodi {
 ///
 inline void SetSettingString(const std::string& settingName, const std::string& settingValue)
 {
-  ::kodi::addon::CAddonBase::m_interface->toKodi.set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), settingValue.c_str());
+  ::kodi::addon::CAddonBase::m_interface->toKodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), settingValue.c_str());
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
@@ -453,7 +453,7 @@ namespace kodi {
 ///
 inline bool CheckSettingInt(const std::string& settingName, int& settingValue)
 {
-  return ::kodi::addon::CAddonBase::m_interface->toKodi.get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  return ::kodi::addon::CAddonBase::m_interface->toKodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), &settingValue);
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
@@ -477,7 +477,7 @@ inline void SetSettingInt(const std::string& settingName, int settingValue)
 {
   char buffer[33];
   snprintf(buffer, sizeof(buffer), "%i", settingValue);
-  ::kodi::addon::CAddonBase::m_interface->toKodi.set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), buffer);
+  ::kodi::addon::CAddonBase::m_interface->toKodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), buffer);
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
@@ -487,7 +487,7 @@ namespace kodi {
 ///
 inline bool CheckSettingBoolean(const std::string& settingName, bool& settingValue)
 {
-  return ::kodi::addon::CAddonBase::m_interface->toKodi.get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  return ::kodi::addon::CAddonBase::m_interface->toKodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), &settingValue);
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
@@ -509,7 +509,7 @@ namespace kodi {
 ///
 inline void SetSettingBoolean(const std::string& settingName, bool settingValue)
 {
-  ::kodi::addon::CAddonBase::m_interface->toKodi.set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), settingValue ? "true" : "false");
+  ::kodi::addon::CAddonBase::m_interface->toKodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), settingValue ? "true" : "false");
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
@@ -519,7 +519,7 @@ namespace kodi {
 ///
 inline bool CheckSettingFloat(const std::string& settingName, float& settingValue)
 {
-  return ::kodi::addon::CAddonBase::m_interface->toKodi.get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  return ::kodi::addon::CAddonBase::m_interface->toKodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), &settingValue);
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
@@ -543,7 +543,7 @@ inline void SetSettingFloat(const std::string& settingName, float settingValue)
 {
   char buffer[50];
   snprintf(buffer, sizeof(buffer), "%f", settingValue);
-  ::kodi::addon::CAddonBase::m_interface->toKodi.set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), buffer);
+  ::kodi::addon::CAddonBase::m_interface->toKodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, settingName.c_str(), buffer);
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -41,8 +41,8 @@
  * overview.
  */
 
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.1"
-#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.1"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.2"
+#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.2"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \
                                                       "xbmc_addon_dll.h" \


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Has wrongly used static child structures in AddonGlobalInterface structure,
this produce massive problems if something becomes changed.

This change the structures to allocated ones by Kodi.

Currently is everything OK, but if a new function becomes added come the problem.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
