### PR TITLE
Joysticks: Fix handling of analog sticks

### DIFF
--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -52,10 +52,6 @@ bool CJoystickFeature::AcceptsInput(bool bActivation)
   {
     if (m_handler->AcceptsInput())
       bAcceptsInput = true;
-
-    // Avoid sticking
-    if (!bActivation)
-      bAcceptsInput = true;
   }
 
   return bAcceptsInput;


### PR DESCRIPTION
This fixes analog sticks not working outside a game while a game is still active in the background. The bug was introduced in #10261.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
