### PR TITLE
Show OSD from in game by holding start/guide/back for 1 second

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -22,7 +22,7 @@
 <!-- More documentation on keymaps can be found on http://kodi.wiki/view/keymaps          -->
 <keymap>
   <global>
-    <joystick>
+    <joystick profile="game.controller.default">
       <a>Select</a>
       <b>Back</b>
       <x>ContextMenu</x>
@@ -51,19 +51,19 @@
     </joystick>
   </global>
   <FileManager>
-    <joystick>
+    <joystick profile="game.controller.default">
       <rightbumper>Highlight</rightbumper>
     </joystick>
   </FileManager>
   <MusicPlaylist>
-    <joystick>
+    <joystick profile="game.controller.default">
       <leftbumper>Delete</leftbumper>
     </joystick>
   </MusicPlaylist>
   <Music>
   </Music>
   <FullscreenVideo>
-    <joystick>
+    <joystick profile="game.controller.default">
       <a>Pause</a>
       <b>Stop</b>
       <x>OSD</x>
@@ -92,7 +92,7 @@
     </joystick>
   </FullscreenVideo>
   <FullscreenGame>
-    <joystick>
+    <joystick profile="game.controller.default">
       <a>noop</a>
       <b>noop</b>
       <x>noop</x>
@@ -121,7 +121,7 @@
     </joystick>
   </FullscreenGame>
   <FullscreenLiveTV>
-    <joystick>
+    <joystick profile="game.controller.default">
       <up>ChannelUp</up>
       <down>ChannelDown</down>
       <left>StepBack</left>
@@ -129,7 +129,7 @@
     </joystick>
   </FullscreenLiveTV>
   <FullscreenRadio>
-    <joystick>
+    <joystick profile="game.controller.default">
       <up>ChannelUp</up>
       <down>ChannelDown</down>
       <left>StepBack</left>
@@ -137,7 +137,7 @@
     </joystick>
   </FullscreenRadio>
   <FullscreenInfo>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
       <x>OSD</x>
       <start>Close</start>
@@ -148,14 +148,14 @@
     </joystick>
   </FullscreenInfo>
   <PlayerControls>
-    <joystick>
+    <joystick profile="game.controller.default">
       <x>Close</x>
       <leftthumb>Close</leftthumb>
       <rightthumb>Close</rightthumb>
     </joystick>
   </PlayerControls>
   <Visualisation>
-    <joystick>
+    <joystick profile="game.controller.default">
       <a>Pause</a>
       <b>Stop</b>
       <x>ActivateWindow(AddonSettings)</x>
@@ -175,18 +175,18 @@
     </joystick>
   </Visualisation>
   <MusicOSD>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
       <start>Info</start>
     </joystick>
   </MusicOSD>
   <VisualisationPresetList>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </VisualisationPresetList>
   <SlideShow>
-    <joystick>
+    <joystick profile="game.controller.default">
       <a>Pause</a>
       <b>Stop</b>
       <y>ZoomNormal</y>
@@ -205,26 +205,26 @@
     </joystick>
   </SlideShow>
   <ScreenCalibration>
-    <joystick>
+    <joystick profile="game.controller.default">
       <x>ResetCalibration</x>
       <leftbumper>NextResolution</leftbumper>
       <rightbumper>NextCalibration</rightbumper>
     </joystick>
   </ScreenCalibration>
   <ScreenCalibration>
-    <joystick>
+    <joystick profile="game.controller.default">
       <x>ResetCalibration</x>
       <leftbumper>NextResolution</leftbumper>
       <rightbumper>NextCalibration</rightbumper>
     </joystick>
   </ScreenCalibration>
   <VideoOSD>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </VideoOSD>
   <VideoMenu>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Stop</b>
       <x>OSD</x>
       <leftbumper>AspectRatio</leftbumper>
@@ -232,31 +232,31 @@
     </joystick>
   </VideoMenu>
   <OSDVideoSettings>
-    <joystick>
+    <joystick profile="game.controller.default">
       <leftbumper>AspectRatio</leftbumper>
       <x>Close</x>
     </joystick>
   </OSDVideoSettings>
   <OSDAudioSettings>
-    <joystick>
+    <joystick profile="game.controller.default">
       <leftbumper>AspectRatio</leftbumper>
       <x>Close</x>
     </joystick>
   </OSDAudioSettings>
   <VideoBookmarks>
-    <joystick>
+    <joystick profile="game.controller.default">
       <leftbumper>Delete</leftbumper>
     </joystick>
   </VideoBookmarks>
   <Videos>
   </Videos>
   <VideoPlaylist>
-    <joystick>
+    <joystick profile="game.controller.default">
       <leftbumper>Delete</leftbumper>
     </joystick>
   </VideoPlaylist>
   <VirtualKeyboard>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>BackSpace</b>
       <y>Symbols</y>
       <leftbumper>Shift</leftbumper>
@@ -266,70 +266,70 @@
     </joystick>
   </VirtualKeyboard>
   <ContextMenu>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </ContextMenu>
   <Settings>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>PreviousMenu</b>
     </joystick>
   </Settings>
   <AddonInformation>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </AddonInformation>
   <AddonSettings>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </AddonSettings>
   <TextViewer>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </TextViewer>
   <shutdownmenu>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>PreviousMenu</b>
       <leftthumb>PreviousMenu</leftthumb>
     </joystick>
   </shutdownmenu>
   <submenu>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>PreviousMenu</b>
     </joystick>
   </submenu>
   <MusicInformation>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </MusicInformation>
   <MovieInformation>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>Close</b>
     </joystick>
   </MovieInformation>
   <NumericInput>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>BackSpace</b>
       <leftthumb>Enter</leftthumb>
     </joystick>
   </NumericInput>
   <GamepadInput>
-    <joystick>
+    <joystick profile="game.controller.default">
       <leftthumb>Stop</leftthumb>
     </joystick>
   </GamepadInput>
   <LockSettings>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>PreviousMenu</b>
       <leftthumb>Close</leftthumb>
     </joystick>
   </LockSettings>
   <ProfileSettings>
-    <joystick>
+    <joystick profile="game.controller.default">
       <b>PreviousMenu</b>
       <leftthumb>Close</leftthumb>
     </joystick>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -93,31 +93,9 @@
   </FullscreenVideo>
   <FullscreenGame>
     <joystick profile="game.controller.default">
-      <a>noop</a>
-      <b>noop</b>
-      <x>noop</x>
-      <y>noop</y>
-      <start>noop</start>
-      <back>noop</back>
-      <!--<guide>noop</guide>-->
-      <up>noop</up>
-      <down>noop</down>
-      <right>noop</right>
-      <left>noop</left>
-      <leftthumb>noop</leftthumb>
-      <rightthumb>noop</rightthumb>
-      <lefttrigger>noop</lefttrigger>
-      <righttrigger>noop</righttrigger>
-      <leftbumper>noop</leftbumper>
-      <rightbumper>noop</rightbumper>
-      <leftstickleft>noop</leftstickleft>
-      <leftstickright>noop</leftstickright>
-      <leftstickup>noop</leftstickup>
-      <leftstickdown>noop</leftstickdown>
-      <rightstickleft>noop</rightstickleft>
-      <rightstickright>noop</rightstickright>
-      <rightstickup>noop</rightstickup>
-      <rightstickdown>noop</rightstickdown>
+      <start holdtime="1000">OSD</start>
+      <back holdtime="1000">OSD</back>
+      <guide holdtime="1000">OSD</guide>
     </joystick>
   </FullscreenGame>
   <FullscreenLiveTV>

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -757,7 +757,7 @@ bool CGameClient::OpenPort(unsigned int port)
     if (m_bSupportsKeyboard)
       device = PERIPHERALS::PERIPHERAL_JOYSTICK;
 
-    CServiceBroker::GetGameServices().PortManager().OpenPort(m_ports[port].get(), port, device);
+    CServiceBroker::GetGameServices().PortManager().OpenPort(m_ports[port].get(), this, port, device);
 
     UpdatePort(port, controller);
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -171,6 +171,7 @@ CGameClient::CGameClient(ADDON::AddonProps props) :
 
 CGameClient::~CGameClient(void)
 {
+  CloseFile();
 }
 
 std::string CGameClient::LibPath() const
@@ -783,29 +784,34 @@ void CGameClient::UpdatePort(unsigned int port, const ControllerPtr& controller)
 {
   using namespace JOYSTICK;
 
-  if (controller != CController::EmptyPtr)
+  CSingleLock lock(m_critSection);
+
+  if (Initialized())
   {
-    std::string strId = controller->ID();
+    if (controller != CController::EmptyPtr)
+    {
+      std::string strId = controller->ID();
 
-    game_controller controllerStruct;
+      game_controller controllerStruct;
 
-    controllerStruct.controller_id        = strId.c_str();
-    controllerStruct.digital_button_count = controller->Layout().FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::DIGITAL);
-    controllerStruct.analog_button_count  = controller->Layout().FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::ANALOG);
-    controllerStruct.analog_stick_count   = controller->Layout().FeatureCount(FEATURE_TYPE::ANALOG_STICK);
-    controllerStruct.accelerometer_count  = controller->Layout().FeatureCount(FEATURE_TYPE::ACCELEROMETER);
-    controllerStruct.key_count            = 0; //! @todo
-    controllerStruct.rel_pointer_count    = controller->Layout().FeatureCount(FEATURE_TYPE::RELPOINTER);
-    controllerStruct.abs_pointer_count    = 0; //! @todo
-    controllerStruct.motor_count          = controller->Layout().FeatureCount(FEATURE_TYPE::MOTOR);
+      controllerStruct.controller_id        = strId.c_str();
+      controllerStruct.digital_button_count = controller->Layout().FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::DIGITAL);
+      controllerStruct.analog_button_count  = controller->Layout().FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::ANALOG);
+      controllerStruct.analog_stick_count   = controller->Layout().FeatureCount(FEATURE_TYPE::ANALOG_STICK);
+      controllerStruct.accelerometer_count  = controller->Layout().FeatureCount(FEATURE_TYPE::ACCELEROMETER);
+      controllerStruct.key_count            = 0; //! @todo
+      controllerStruct.rel_pointer_count    = controller->Layout().FeatureCount(FEATURE_TYPE::RELPOINTER);
+      controllerStruct.abs_pointer_count    = 0; //! @todo
+      controllerStruct.motor_count          = controller->Layout().FeatureCount(FEATURE_TYPE::MOTOR);
 
-    try { m_struct.toAddon.UpdatePort(port, true, &controllerStruct); }
-    catch (...) { LogException("UpdatePort()"); }
-  }
-  else
-  {
-    try { m_struct.toAddon.UpdatePort(port, false, nullptr); }
-    catch (...) { LogException("UpdatePort()"); }
+      try { m_struct.toAddon.UpdatePort(port, true, &controllerStruct); }
+      catch (...) { LogException("UpdatePort()"); }
+    }
+    else
+    {
+      try { m_struct.toAddon.UpdatePort(port, false, nullptr); }
+      catch (...) { LogException("UpdatePort()"); }
+    }
   }
 }
 
@@ -889,18 +895,30 @@ void CGameClient::OpenMouse(void)
 {
   m_mouse.reset(new CGameClientMouse(this, &m_struct.toAddon));
 
-  std::string strId = m_mouse->ControllerID();
+  CSingleLock lock(m_critSection);
 
-  game_controller controllerStruct = { strId.c_str() };
+  if (Initialized())
+  {
+    std::string strId = m_mouse->ControllerID();
 
-  try { m_struct.toAddon.UpdatePort(GAME_INPUT_PORT_MOUSE, true, &controllerStruct); }
-  catch (...) { LogException("UpdatePort()"); }
+    game_controller controllerStruct = { strId.c_str() };
+
+    try { m_struct.toAddon.UpdatePort(GAME_INPUT_PORT_MOUSE, true, &controllerStruct); }
+    catch (...) { LogException("UpdatePort()"); }
+  }
 }
 
 void CGameClient::CloseMouse(void)
 {
-  try { m_struct.toAddon.UpdatePort(GAME_INPUT_PORT_MOUSE, false, nullptr); }
-  catch (...) { LogException("UpdatePort()"); }
+  {
+    CSingleLock lock(m_critSection);
+
+    if (Initialized())
+    {
+      try { m_struct.toAddon.UpdatePort(GAME_INPUT_PORT_MOUSE, false, nullptr); }
+      catch (...) { LogException("UpdatePort()"); }
+    }
+  }
 
   m_mouse.reset();
 }

--- a/xbmc/games/addons/GameClientJoystick.cpp
+++ b/xbmc/games/addons/GameClientJoystick.cpp
@@ -66,15 +66,7 @@ bool CGameClientJoystick::AcceptsInput(void)
 
 JOYSTICK::INPUT_TYPE CGameClientJoystick::GetInputType(const std::string& feature) const
 {
-  const std::vector<CControllerFeature>& features = m_controller->Layout().Features();
-
-  for (std::vector<CControllerFeature>::const_iterator it = features.begin(); it != features.end(); ++it)
-  {
-    if (feature == it->Name())
-      return it->InputType();
-  }
-
-  return JOYSTICK::INPUT_TYPE::UNKNOWN;
+  return m_controller->GetInputType(feature);
 }
 
 bool CGameClientJoystick::OnButtonPress(const std::string& feature, bool bPressed)

--- a/xbmc/games/addons/GameClientJoystick.h
+++ b/xbmc/games/addons/GameClientJoystick.h
@@ -53,6 +53,7 @@ namespace GAME
     virtual bool HasFeature(const std::string& feature) const override;
     virtual bool AcceptsInput(void) override;
     virtual KODI::JOYSTICK::INPUT_TYPE GetInputType(const std::string& feature) const override;
+    virtual unsigned int GetDelayMs(const std::string& feature) const override { return 0; }
     virtual bool OnButtonPress(const std::string& feature, bool bPressed) override;
     virtual void OnButtonHold(const std::string& feature, unsigned int holdTimeMs) override { }
     virtual bool OnButtonMotion(const std::string& feature, float magnitude) override;

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -25,6 +25,7 @@
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
 
+using namespace KODI;
 using namespace GAME;
 
 const ControllerPtr CController::EmptyPtr;
@@ -52,6 +53,26 @@ std::string CController::ImagePath(void) const
   if (!m_layout.Image().empty())
     return URIUtils::AddFileToFolder(URIUtils::GetDirectory(LibPath()), m_layout.Image());
   return "";
+}
+
+void CController::GetFeatures(std::vector<std::string>& features,
+                              FEATURE_TYPE type /* = FEATURE_TYPE::UNKNOWN */) const
+{
+  for (const CControllerFeature& feature : m_layout.Features())
+  {
+    if (type == FEATURE_TYPE::UNKNOWN || type == feature.Type())
+      features.push_back(feature.Name());
+  }
+}
+
+JOYSTICK::INPUT_TYPE CController::GetInputType(const std::string& feature) const
+{
+  for (auto it = m_layout.Features().begin(); it != m_layout.Features().end(); ++it)
+  {
+    if (feature == it->Name())
+      return it->InputType();
+  }
+  return JOYSTICK::INPUT_TYPE::UNKNOWN;
 }
 
 bool CController::LoadLayout(void)

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -22,11 +22,14 @@
 #include "ControllerLayout.h"
 #include "ControllerTypes.h"
 #include "addons/Addon.h"
+#include "input/joysticks/JoystickTypes.h"
 
 #include <string>
+#include <vector>
 
 namespace GAME
 {
+using KODI::JOYSTICK::FEATURE_TYPE;
 
 class CController : public ADDON::CAddon
 {
@@ -41,6 +44,8 @@ public:
 
   std::string Label(void);
   std::string ImagePath(void) const;
+  void GetFeatures(std::vector<std::string>& features, FEATURE_TYPE type = FEATURE_TYPE::UNKNOWN) const;
+  KODI::JOYSTICK::INPUT_TYPE GetInputType(const std::string& feature) const;
 
   bool LoadLayout(void);
 

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -21,7 +21,7 @@
 #include "ControllerManager.h"
 #include "Controller.h"
 #include "addons/AddonManager.h"
-#include "input/joysticks/DefaultJoystick.h"
+#include "input/joysticks/JoystickIDs.h"
 
 using namespace GAME;
 

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -22,7 +22,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
-#include "input/joysticks/DefaultJoystick.h"
+#include "input/joysticks/JoystickIDs.h"
 #include "input/joysticks/IActionMap.h"
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/IButtonMapCallback.h"

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -37,7 +37,7 @@
 #include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/WindowIDs.h"
-#include "input/joysticks/DefaultJoystick.h" // for DEFAULT_CONTROLLER_ID
+#include "input/joysticks/JoystickIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "peripherals/Peripherals.h"
 #include "ServiceBroker.h"

--- a/xbmc/games/ports/CMakeLists.txt
+++ b/xbmc/games/ports/CMakeLists.txt
@@ -1,7 +1,14 @@
-set(SOURCES PortManager.cpp
+set(SOURCES InputSink.cpp
+            Port.cpp
+            PortInput.cpp
+            PortManager.cpp
             PortMapper.cpp)
 
-set(HEADERS PortManager.h
-            PortMapper.h)
+set(HEADERS InputSink.h
+            Port.h
+            PortInput.h
+            PortManager.h
+            PortMapper.h
+            PortTypes.h)
 
 core_add_library(gameports)

--- a/xbmc/games/ports/InputSink.cpp
+++ b/xbmc/games/ports/InputSink.cpp
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "InputSink.h"
+#include "games/addons/GameClient.h"
+#include "input/joysticks/JoystickIDs.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CInputSink::CInputSink(CGameClient &gameClient) :
+  m_gameClient(gameClient)
+{
+}
+
+std::string CInputSink::ControllerID(void) const
+{
+  return DEFAULT_CONTROLLER_ID;
+}
+
+bool CInputSink::AcceptsInput(void)
+{
+  return m_gameClient.AcceptsInput();
+}
+
+JOYSTICK::INPUT_TYPE CInputSink::GetInputType(const std::string& feature) const
+{
+  // Convert all input to analog. This is done to simplify this function
+  // and avoid any extra dependencies. Analog is chosen to avoid any
+  // thresholding effects.
+  return JOYSTICK::INPUT_TYPE::ANALOG;
+}

--- a/xbmc/games/ports/InputSink.h
+++ b/xbmc/games/ports/InputSink.h
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "games/controllers/ControllerTypes.h"
+#include "input/joysticks/IInputHandler.h"
+
+namespace GAME
+{
+  class CGameClient;
+
+  class CInputSink : public KODI::JOYSTICK::IInputHandler
+  {
+  public:
+    CInputSink(CGameClient &m_gameClient);
+
+    virtual ~CInputSink() = default;
+
+    // Implementation of IInputHandler
+    virtual std::string ControllerID(void) const override;
+    virtual bool HasFeature(const std::string& feature) const override { return true; }
+    virtual bool AcceptsInput(void) override;
+    virtual KODI::JOYSTICK::INPUT_TYPE GetInputType(const std::string& feature) const override;
+    virtual unsigned int GetDelayMs(const std::string& feature) const override { return 0; }
+    virtual bool OnButtonPress(const std::string& feature, bool bPressed) override { return true; }
+    virtual void OnButtonHold(const std::string& feature, unsigned int holdTimeMs) override { }
+    virtual bool OnButtonMotion(const std::string& feature, float magnitude) override { return true; }
+    virtual bool OnAnalogStickMotion(const std::string& feature, float x, float y, unsigned int motionTimeMs = 0) override { return true; }
+    virtual bool OnAccelerometerMotion(const std::string& feature, float x, float y, float z) override { return true; }
+
+  private:
+    const CGameClient &m_gameClient;
+    const ControllerPtr m_controller;
+  };
+}

--- a/xbmc/games/ports/Port.cpp
+++ b/xbmc/games/ports/Port.cpp
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Port.h"
+#include "PortInput.h"
+#include "InputSink.h"
+#include "peripherals/devices/Peripheral.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CPort::CPort(JOYSTICK::IInputHandler *inputHandler, CGameClient &gameClient) :
+  m_inputHandler(inputHandler),
+  m_controller(new CPortInput(gameClient)),
+  m_inputSink(new CInputSink(gameClient))
+{
+}
+
+CPort::~CPort()
+{
+}
+
+void CPort::RegisterDevice(PERIPHERALS::CPeripheral *device)
+{
+  // Register controller as promiscuous to not block any input from the game
+  device->RegisterJoystickInputHandler(m_controller.get(), true);
+
+  // Give input sink the lowest priority by registering it before the other
+  // non-promiscuous input handlers
+  device->RegisterJoystickInputHandler(m_inputSink.get(), false);
+
+  // Register input handler
+  device->RegisterJoystickInputHandler(m_inputHandler, false);
+}
+
+void CPort::UnregisterDevice(PERIPHERALS::CPeripheral *device)
+{
+  // Unregister in reverse order
+  device->UnregisterJoystickInputHandler(m_inputHandler);
+  device->UnregisterJoystickInputHandler(m_inputSink.get());
+  device->UnregisterJoystickInputHandler(m_controller.get());
+}

--- a/xbmc/games/ports/Port.h
+++ b/xbmc/games/ports/Port.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2015-2017 Team Kodi
+ *      Copyright (C) 2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,41 +19,37 @@
  */
 #pragma once
 
-#include "PortTypes.h"
-#include "peripherals/PeripheralTypes.h"
-#include "utils/Observer.h"
+#include <memory>
 
-#include <map>
+namespace KODI
+{
+namespace JOYSTICK
+{
+  class IInputHandler;
+}
+}
 
 namespace PERIPHERALS
 {
-  class CPeripherals;
+  class CPeripheral;
 }
 
 namespace GAME
 {
-  class CPortManager;
+  class CGameClient;
 
-  class CPortMapper : public Observer
+  class CPort
   {
   public:
-    CPortMapper();
+    CPort(KODI::JOYSTICK::IInputHandler* inputHandler, CGameClient& gameClient);
+    ~CPort();
 
-    virtual ~CPortMapper();
-
-    void Initialize(PERIPHERALS::CPeripherals& peripheralManager, CPortManager& portManager);
-    void Deinitialize();
-
-    virtual void Notify(const Observable& obs, const ObservableMessage msg) override;
+    void RegisterDevice(PERIPHERALS::CPeripheral *device);
+    void UnregisterDevice(PERIPHERALS::CPeripheral *device);
 
   private:
-    void ProcessPeripherals();
-
-    // Initialization parameters
-    PERIPHERALS::CPeripherals* m_peripheralManager;
-    CPortManager* m_portManager;
-
-    // Port paremters
-    std::map<PERIPHERALS::PeripheralPtr, PortPtr> m_portMap;
+    KODI::JOYSTICK::IInputHandler* const m_inputHandler;
+    std::unique_ptr<KODI::JOYSTICK::IInputHandler> m_controller;
+    std::unique_ptr<KODI::JOYSTICK::IInputHandler> m_inputSink;
   };
 }

--- a/xbmc/games/ports/PortInput.cpp
+++ b/xbmc/games/ports/PortInput.cpp
@@ -1,0 +1,40 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PortInput.h"
+#include "games/addons/GameClient.h"
+#include "guilib/WindowIDs.h"
+
+using namespace GAME;
+
+CPortInput::CPortInput(CGameClient &gameClient) :
+  m_gameClient(gameClient)
+{
+}
+
+bool CPortInput::AcceptsInput(void)
+{
+  return m_gameClient.AcceptsInput();
+}
+
+int CPortInput::GetWindowID() const
+{
+  return WINDOW_FULLSCREEN_GAME;
+}

--- a/xbmc/games/ports/PortInput.h
+++ b/xbmc/games/ports/PortInput.h
@@ -1,0 +1,66 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/joysticks/DefaultController.h"
+
+#include <string>
+
+namespace GAME
+{
+  class CGameClient;
+
+  /*!
+   * \ingroup games
+   * \brief Monitors for keymap actions in the background during gameplay
+   *
+   * This class inherits from the default controller that Kodi uses for
+   * normal input. However, it overrides some functions of CDefaultJoystick
+   * to customize the input handling behavior:
+   *
+   *   - GetWindowID():
+   *         This forces the keymap handler to use the FullscreenGame window
+   *
+   *   - GetFallthrough():
+   *         This prevents the keymap handler from falling through to
+   *         FullscreenVideo or the global keymap when looking up keys.
+   *
+   * This class is registered as a promiscuous input handler, so it receives
+   * all input but doesn't block any handled input from reaching the game
+   * client.
+   */
+  class CPortInput : public KODI::JOYSTICK::CDefaultController
+  {
+  public:
+    CPortInput(CGameClient &gameClient);
+
+    virtual ~CPortInput() = default;
+
+    // Implementation of IInputHandler via CDefaultController
+    virtual bool AcceptsInput(void) override;
+
+    // Implementation of CDefaultJoystick via CDefaultController
+    virtual int GetWindowID() const;
+    virtual bool GetFallthrough() const { return false; }
+
+  private:
+    const CGameClient &m_gameClient;
+  };
+}

--- a/xbmc/games/ports/PortManager.h
+++ b/xbmc/games/ports/PortManager.h
@@ -42,6 +42,7 @@ namespace PERIPHERALS
 
 namespace GAME
 {
+  class CGameClient;
   class CPortMapper;
 
   /*!
@@ -61,10 +62,12 @@ namespace GAME
      *        specified handler.
      *
      * \param handler      The instance accepting all input delivered to the port
+     * \param gameClient   The game client opening the port
      * \param port         The port number belonging to the game client
      * \param requiredType Used to restrict port to devices of only a certain type
      */
     void OpenPort(KODI::JOYSTICK::IInputHandler* handler,
+                  CGameClient* gameClient,
                   unsigned int port,
                   PERIPHERALS::PeripheralType requiredType = PERIPHERALS::PERIPHERAL_UNKNOWN);
 
@@ -86,7 +89,10 @@ namespace GAME
      * attempt to honor that request.
      */
     void MapDevices(const PERIPHERALS::PeripheralVector& devices,
-                    std::map<PERIPHERALS::PeripheralPtr, KODI::JOYSTICK::IInputHandler*>& deviceToPortMap);
+                    std::map<PERIPHERALS::CPeripheral*, KODI::JOYSTICK::IInputHandler*>& deviceToPortMap);
+
+    //! @todo Return game client from MapDevices()
+    CGameClient* GameClient(KODI::JOYSTICK::IInputHandler* handler);
 
   private:
     KODI::JOYSTICK::IInputHandler* AssignToPort(const PERIPHERALS::PeripheralPtr& device, bool checkPortNumber = true);
@@ -99,6 +105,7 @@ namespace GAME
       unsigned int                port;    // Port number belonging to the game client
       PERIPHERALS::PeripheralType requiredType;
       void*                       device;
+      CGameClient*                gameClient;
     };
 
     std::vector<SPort> m_ports;

--- a/xbmc/games/ports/PortTypes.h
+++ b/xbmc/games/ports/PortTypes.h
@@ -1,0 +1,30 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <memory>
+
+namespace GAME
+{
+
+class CPort;
+typedef std::shared_ptr<CPort> PortPtr;
+
+}

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1645,6 +1645,16 @@ uint32_t CButtonTranslator::TranslateJoystickCommand(const TiXmlElement *pButton
     else if (strButton == "rightbumper") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_SHOULDER;
     else if (strButton == "guide") buttonCode = KEY_JOYSTICK_BUTTON_GUIDE;
   }
+  else if (controllerId == DEFAULT_REMOTE_ID)
+  {
+    if (strButton == "ok") buttonCode = KEY_REMOTE_BUTTON_OK;
+    else if (strButton == "back") buttonCode = KEY_REMOTE_BUTTON_BACK;
+    else if (strButton == "up") buttonCode = KEY_REMOTE_BUTTON_UP;
+    else if (strButton == "down") buttonCode = KEY_REMOTE_BUTTON_DOWN;
+    else if (strButton == "left") buttonCode = KEY_REMOTE_BUTTON_LEFT;
+    else if (strButton == "right") buttonCode = KEY_REMOTE_BUTTON_RIGHT;
+    else if (strButton == "home") buttonCode = KEY_REMOTE_BUTTON_HOME;
+  }
 
   if (buttonCode == 0)
     CLog::Log(LOGERROR, "Joystick Translator: Can't find button %s for controller %s", strButton.c_str(), controllerId.c_str());

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -41,6 +41,7 @@ struct CButtonAction
 {
   int id;
   std::string strID; // needed for "ActivateWindow()" type actions
+  unsigned int holdtimeMs;
 };
 ///
 /// singleton class to map from buttons to actions
@@ -80,6 +81,13 @@ public:
    \return true if a longpress mapping exists
    */
   bool HasLongpressMapping(int window, const CKey &key);
+
+  /*! \brief Get the "holdtime" parameter if specified for this key
+   \param window id of the current window
+   \param key to search a mapping for
+   \return the holdtime in ms, or 0 if no holdtime was specified
+   */
+  unsigned int GetHoldTimeMs(int window, const CKey &key, bool fallback = true);
 
   /*! \brief Obtain the action configured for a given window and key
    \param window the window id
@@ -132,7 +140,7 @@ private:
   static uint32_t TranslateGamepadString(const char *szButton);
   static uint32_t TranslateRemoteString(const char *szButton);
   static uint32_t TranslateUniversalRemoteString(const char *szButton);
-  static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId);
+  static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs);
 
   static uint32_t TranslateKeyboardString(const char *szButton);
   static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);
@@ -142,7 +150,7 @@ private:
   static uint32_t TranslateAppCommand(const char *szButton);
 
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);
-  void MapAction(uint32_t buttonCode, const char *szAction, buttonMap &map);
+  void MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map);
   void MapCustomControllerActions(int windowID, TiXmlNode *pCustomController);
 
   bool LoadKeymap(const std::string &keymapPath);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -57,7 +57,7 @@ private:
   CButtonTranslator(const CButtonTranslator&);
   CButtonTranslator const& operator=(CButtonTranslator const&);
   virtual ~CButtonTranslator();
-  bool HasDeviceType(TiXmlNode *pWindow, std::string type);
+
 public:
   ///access to singleton
   static CButtonTranslator& GetInstance();
@@ -132,7 +132,7 @@ private:
   static uint32_t TranslateGamepadString(const char *szButton);
   static uint32_t TranslateRemoteString(const char *szButton);
   static uint32_t TranslateUniversalRemoteString(const char *szButton);
-  static uint32_t TranslateJoystickString(const char *szButton);
+  static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId);
 
   static uint32_t TranslateKeyboardString(const char *szButton);
   static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -77,6 +77,17 @@
 #define KEY_BUTTON_LEFT_THUMB_STICK_RIGHT   283
 
 /*
+ * joystick.xml keys for remote control emulation
+ */
+#define KEY_REMOTE_BUTTON_OK                         310
+#define KEY_REMOTE_BUTTON_BACK                       311
+#define KEY_REMOTE_BUTTON_UP                         312
+#define KEY_REMOTE_BUTTON_DOWN                       313
+#define KEY_REMOTE_BUTTON_RIGHT                      314
+#define KEY_REMOTE_BUTTON_LEFT                       315
+#define KEY_REMOTE_BUTTON_HOME                       316
+
+/*
  * joystick.xml keys based on Xbox 360 controller
  */
 #define KEY_JOYSTICK_BUTTON_A                        284

--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES DeadzoneFilter.cpp
+            DefaultController.cpp
             DefaultJoystick.cpp
             DriverPrimitive.cpp
             JoystickEasterEgg.cpp
@@ -8,6 +9,7 @@ set(SOURCES DeadzoneFilter.cpp
             RumbleGenerator.cpp)
 
 set(HEADERS DeadzoneFilter.h
+            DefaultController.h
             DefaultJoystick.h
             DriverPrimitive.h
             IActionMap.h

--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HEADERS DeadzoneFilter.h
             IInputReceiver.h
             IKeymapHandler.h
             JoystickEasterEgg.h
+            JoystickIDs.h
             JoystickMonitor.h
             JoystickTranslator.h
             JoystickTypes.h

--- a/xbmc/input/joysticks/CMakeLists.txt
+++ b/xbmc/input/joysticks/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES DeadzoneFilter.cpp
             DefaultController.cpp
             DefaultJoystick.cpp
+            DefaultRemote.cpp
             DriverPrimitive.cpp
             JoystickEasterEgg.cpp
             JoystickMonitor.cpp
@@ -11,6 +12,7 @@ set(SOURCES DeadzoneFilter.cpp
 set(HEADERS DeadzoneFilter.h
             DefaultController.h
             DefaultJoystick.h
+            DefaultRemote.h
             DriverPrimitive.h
             IActionMap.h
             IButtonMap.h

--- a/xbmc/input/joysticks/DeadzoneFilter.cpp
+++ b/xbmc/input/joysticks/DeadzoneFilter.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "DeadzoneFilter.h"
-#include "DefaultJoystick.h"
+#include "JoystickIDs.h"
 #include "IButtonMap.h"
 #include "peripherals/devices/Peripheral.h"
 #include "utils/log.h"

--- a/xbmc/input/joysticks/DefaultController.cpp
+++ b/xbmc/input/joysticks/DefaultController.cpp
@@ -1,0 +1,87 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DefaultController.h"
+#include "JoystickEasterEgg.h"
+#include "JoystickIDs.h"
+#include "input/Key.h"
+
+using namespace KODI;
+using namespace JOYSTICK;
+
+CDefaultController::CDefaultController(void) :
+  m_rumbleGenerator(GetControllerID())
+{
+  // initialize CDefaultJoystick
+  m_easterEgg.reset(new CJoystickEasterEgg(GetControllerID()));
+}
+
+std::string CDefaultController::GetControllerID(void) const
+{
+  return DEFAULT_CONTROLLER_ID;
+}
+
+unsigned int CDefaultController::GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir /* = ANALOG_STICK_DIRECTION::UNKNOWN */) const
+{
+  if      (feature == "a")             return KEY_JOYSTICK_BUTTON_A;
+  else if (feature == "b")             return KEY_JOYSTICK_BUTTON_B;
+  else if (feature == "x")             return KEY_JOYSTICK_BUTTON_X;
+  else if (feature == "y")             return KEY_JOYSTICK_BUTTON_Y;
+  else if (feature == "start")         return KEY_JOYSTICK_BUTTON_START;
+  else if (feature == "back")          return KEY_JOYSTICK_BUTTON_BACK;
+  else if (feature == "guide")         return KEY_JOYSTICK_BUTTON_GUIDE;
+  else if (feature == "leftbumper")    return KEY_JOYSTICK_BUTTON_LEFT_SHOULDER;
+  else if (feature == "rightbumper")   return KEY_JOYSTICK_BUTTON_RIGHT_SHOULDER;
+  else if (feature == "leftthumb")     return KEY_JOYSTICK_BUTTON_LEFT_STICK_BUTTON;
+  else if (feature == "rightthumb")    return KEY_JOYSTICK_BUTTON_RIGHT_STICK_BUTTON;
+  else if (feature == "up")            return KEY_JOYSTICK_BUTTON_DPAD_UP;
+  else if (feature == "down")          return KEY_JOYSTICK_BUTTON_DPAD_DOWN;
+  else if (feature == "right")         return KEY_JOYSTICK_BUTTON_DPAD_RIGHT;
+  else if (feature == "left")          return KEY_JOYSTICK_BUTTON_DPAD_LEFT;
+  else if (feature == "lefttrigger")   return KEY_JOYSTICK_BUTTON_LEFT_TRIGGER;
+  else if (feature == "righttrigger")  return KEY_JOYSTICK_BUTTON_RIGHT_TRIGGER;
+  else if (feature == "leftstick")
+  {
+    switch (dir)
+    {
+      case ANALOG_STICK_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_UP;
+      case ANALOG_STICK_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_DOWN;
+      case ANALOG_STICK_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_RIGHT;
+      case ANALOG_STICK_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_LEFT;
+      default:
+        break;
+    }
+  }
+  else if (feature == "rightstick")
+  {
+    switch (dir)
+    {
+      case ANALOG_STICK_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_UP;
+      case ANALOG_STICK_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_DOWN;
+      case ANALOG_STICK_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_RIGHT;
+      case ANALOG_STICK_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_LEFT;
+      default:
+        break;
+    }
+  }
+  else if (feature == "accelerometer") return 0; //! @todo implement
+
+  return 0;
+}

--- a/xbmc/input/joysticks/DefaultController.h
+++ b/xbmc/input/joysticks/DefaultController.h
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "DefaultJoystick.h"
+#include "RumbleGenerator.h"
+
+namespace KODI
+{
+namespace JOYSTICK
+{
+  class CDefaultController : public CDefaultJoystick
+  {
+  public:
+    CDefaultController(void);
+
+    virtual ~CDefaultController(void) = default;
+
+    // Forward rumble commands to rumble generator
+    void NotifyUser(void) { m_rumbleGenerator.NotifyUser(InputReceiver()); }
+    bool TestRumble(void) { return m_rumbleGenerator.DoTest(InputReceiver()); }
+    void AbortRumble() { m_rumbleGenerator.AbortRumble(); }
+
+  protected:
+    // implementation of CDefaultJoystick
+    virtual std::string GetControllerID() const;
+    virtual unsigned int GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN) const override;
+
+  private:
+    // Rumble functionality
+    CRumbleGenerator m_rumbleGenerator;
+  };
+}
+}

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -73,12 +73,12 @@ bool CDefaultJoystick::AcceptsInput()
 
 INPUT_TYPE CDefaultJoystick::GetInputType(const FeatureName& feature) const
 {
-  return m_handler->GetInputType(GetKeyID(feature), GetWindowID());
+  return m_handler->GetInputType(GetKeyID(feature), GetWindowID(), GetFallthrough());
 }
 
 unsigned int CDefaultJoystick::GetDelayMs(const FeatureName& feature) const
 {
-  return m_handler->GetHoldTimeMs(GetKeyID(feature), GetWindowID());
+  return m_handler->GetHoldTimeMs(GetKeyID(feature), GetWindowID(), GetFallthrough());
 }
 
 bool CDefaultJoystick::OnButtonPress(const FeatureName& feature, bool bPressed)
@@ -88,10 +88,11 @@ bool CDefaultJoystick::OnButtonPress(const FeatureName& feature, bool bPressed)
 
   const unsigned int keyId = GetKeyID(feature);
   const int windowId = GetWindowID();
+  const bool bFallthrough = GetFallthrough();
 
-  if (m_handler->GetInputType(keyId, windowId) == INPUT_TYPE::DIGITAL)
+  if (m_handler->GetInputType(keyId, windowId, bFallthrough) == INPUT_TYPE::DIGITAL)
   {
-    m_handler->OnDigitalKey(keyId, windowId, bPressed);
+    m_handler->OnDigitalKey(keyId, windowId, bFallthrough, bPressed);
     return true;
   }
 
@@ -102,18 +103,20 @@ void CDefaultJoystick::OnButtonHold(const FeatureName& feature, unsigned int hol
 {
   const unsigned int keyId = GetKeyID(feature);
   const int windowId = GetWindowID();
+  const bool bFallthrough = GetFallthrough();
 
-  m_handler->OnDigitalKey(keyId, windowId, true, holdTimeMs);
+  m_handler->OnDigitalKey(keyId, windowId, bFallthrough, true, holdTimeMs);
 }
 
 bool CDefaultJoystick::OnButtonMotion(const FeatureName& feature, float magnitude)
 {
   const unsigned int keyId = GetKeyID(feature);
   const int windowId = GetWindowID();
+  const bool bFallthrough = GetFallthrough();
 
-  if (m_handler->GetInputType(keyId, windowId) == INPUT_TYPE::ANALOG)
+  if (m_handler->GetInputType(keyId, windowId, bFallthrough) == INPUT_TYPE::ANALOG)
   {
-    m_handler->OnAnalogKey(keyId, windowId, magnitude);
+    m_handler->OnAnalogKey(keyId, windowId, bFallthrough, magnitude);
     return true;
   }
 
@@ -153,9 +156,10 @@ int CDefaultJoystick::GetActionID(const FeatureName& feature)
 {
   const unsigned int keyId = GetKeyID(feature);
   const int windowId = GetWindowID();
+  const bool bFallthrough = GetFallthrough();
 
   if (keyId > 0)
-    return m_handler->GetActionID(keyId, windowId);
+    return m_handler->GetActionID(keyId, windowId, bFallthrough);
 
   return ACTION_NONE;
 }
@@ -172,7 +176,8 @@ bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magni
   // Calculate the button key ID and input type for the analog stick's direction
   const unsigned int  keyId     = GetKeyID(feature, dir);
   const int           windowId  = GetWindowID();
-  const INPUT_TYPE    inputType = m_handler->GetInputType(keyId, windowId);
+  const bool          bFallthrough = GetFallthrough();
+  const INPUT_TYPE    inputType = m_handler->GetInputType(keyId, windowId, bFallthrough);
 
   if (inputType == INPUT_TYPE::DIGITAL)
   {
@@ -192,12 +197,12 @@ bool CDefaultJoystick::ActivateDirection(const FeatureName& feature, float magni
       m_holdStartTimes.erase(keyId);
     }
 
-    m_handler->OnDigitalKey(keyId, windowId, bIsPressed, holdTimeMs);
+    m_handler->OnDigitalKey(keyId, windowId, bFallthrough, bIsPressed, holdTimeMs);
     bHandled = true;
   }
   else if (inputType == INPUT_TYPE::ANALOG)
   {
-    m_handler->OnAnalogKey(keyId, windowId, magnitude);
+    m_handler->OnAnalogKey(keyId, windowId, bFallthrough, magnitude);
     bHandled = true;
   }
 
@@ -214,15 +219,16 @@ void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, ANALOG_ST
     // Calculate the button key ID and input type for this direction
     const unsigned int  keyId     = GetKeyID(feature, dir);
     const int           windowId  = GetWindowID();
-    const INPUT_TYPE    inputType = m_handler->GetInputType(keyId, windowId);
+    const bool          bFallthrough = GetFallthrough();
+    const INPUT_TYPE    inputType = m_handler->GetInputType(keyId, windowId, bFallthrough);
 
     if (inputType == INPUT_TYPE::DIGITAL)
     {
-      m_handler->OnDigitalKey(keyId, windowId, false);
+      m_handler->OnDigitalKey(keyId, windowId, bFallthrough, false);
     }
     else if (inputType == INPUT_TYPE::ANALOG)
     {
-      m_handler->OnAnalogKey(keyId, windowId, 0.0f);
+      m_handler->OnAnalogKey(keyId, windowId, bFallthrough, 0.0f);
     }
 
     m_holdStartTimes.erase(keyId);

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -36,9 +36,7 @@ using namespace KODI;
 using namespace JOYSTICK;
 
 CDefaultJoystick::CDefaultJoystick(void) :
-  m_handler(new CKeymapHandler),
-  m_rumbleGenerator(ControllerID()),
-  m_easterEgg(new CJoystickEasterEgg)
+  m_handler(new CKeymapHandler)
 {
 }
 
@@ -49,7 +47,7 @@ CDefaultJoystick::~CDefaultJoystick(void)
 
 std::string CDefaultJoystick::ControllerID(void) const
 {
-  return DEFAULT_CONTROLLER_ID;
+  return GetControllerID();
 }
 
 bool CDefaultJoystick::HasFeature(const FeatureName& feature) const
@@ -79,7 +77,7 @@ INPUT_TYPE CDefaultJoystick::GetInputType(const FeatureName& feature) const
 
 bool CDefaultJoystick::OnButtonPress(const FeatureName& feature, bool bPressed)
 {
-  if (bPressed && m_easterEgg->OnButtonPress(feature))
+  if (bPressed && m_easterEgg && m_easterEgg->OnButtonPress(feature))
     return true;
 
   const unsigned int keyId = GetKeyID(feature);
@@ -212,54 +210,6 @@ void CDefaultJoystick::DeactivateDirection(const FeatureName& feature, ANALOG_ST
     m_holdStartTimes.erase(keyId);
     m_currentDirections[feature] = ANALOG_STICK_DIRECTION::UNKNOWN;
   }
-}
-
-unsigned int CDefaultJoystick::GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir /* = ANALOG_STICK_DIRECTION::UNKNOWN */)
-{
-  if      (feature == "a")             return KEY_JOYSTICK_BUTTON_A;
-  else if (feature == "b")             return KEY_JOYSTICK_BUTTON_B;
-  else if (feature == "x")             return KEY_JOYSTICK_BUTTON_X;
-  else if (feature == "y")             return KEY_JOYSTICK_BUTTON_Y;
-  else if (feature == "start")         return KEY_JOYSTICK_BUTTON_START;
-  else if (feature == "back")          return KEY_JOYSTICK_BUTTON_BACK;
-  else if (feature == "guide")         return KEY_JOYSTICK_BUTTON_GUIDE;
-  else if (feature == "leftbumper")    return KEY_JOYSTICK_BUTTON_LEFT_SHOULDER;
-  else if (feature == "rightbumper")   return KEY_JOYSTICK_BUTTON_RIGHT_SHOULDER;
-  else if (feature == "leftthumb")     return KEY_JOYSTICK_BUTTON_LEFT_STICK_BUTTON;
-  else if (feature == "rightthumb")    return KEY_JOYSTICK_BUTTON_RIGHT_STICK_BUTTON;
-  else if (feature == "up")            return KEY_JOYSTICK_BUTTON_DPAD_UP;
-  else if (feature == "down")          return KEY_JOYSTICK_BUTTON_DPAD_DOWN;
-  else if (feature == "right")         return KEY_JOYSTICK_BUTTON_DPAD_RIGHT;
-  else if (feature == "left")          return KEY_JOYSTICK_BUTTON_DPAD_LEFT;
-  else if (feature == "lefttrigger")   return KEY_JOYSTICK_BUTTON_LEFT_TRIGGER;
-  else if (feature == "righttrigger")  return KEY_JOYSTICK_BUTTON_RIGHT_TRIGGER;
-  else if (feature == "leftstick")
-  {
-    switch (dir)
-    {
-      case ANALOG_STICK_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_UP;
-      case ANALOG_STICK_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_DOWN;
-      case ANALOG_STICK_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_RIGHT;
-      case ANALOG_STICK_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_LEFT;
-      default:
-        break;
-    }
-  }
-  else if (feature == "rightstick")
-  {
-    switch (dir)
-    {
-      case ANALOG_STICK_DIRECTION::UP:     return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_UP;
-      case ANALOG_STICK_DIRECTION::DOWN:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_DOWN;
-      case ANALOG_STICK_DIRECTION::RIGHT:  return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_RIGHT;
-      case ANALOG_STICK_DIRECTION::LEFT:   return KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_LEFT;
-      default:
-        break;
-    }
-  }
-  else if (feature == "accelerometer") return 0; //! @todo implement
-
-  return 0;
 }
 
 const std::vector<ANALOG_STICK_DIRECTION>& CDefaultJoystick::GetDirections(void)

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -76,6 +76,11 @@ INPUT_TYPE CDefaultJoystick::GetInputType(const FeatureName& feature) const
   return m_handler->GetInputType(GetKeyID(feature), GetWindowID());
 }
 
+unsigned int CDefaultJoystick::GetDelayMs(const FeatureName& feature) const
+{
+  return m_handler->GetHoldTimeMs(GetKeyID(feature), GetWindowID());
+}
+
 bool CDefaultJoystick::OnButtonPress(const FeatureName& feature, bool bPressed)
 {
   if (bPressed && m_easterEgg && m_easterEgg->OnButtonPress(feature))

--- a/xbmc/input/joysticks/DefaultJoystick.cpp
+++ b/xbmc/input/joysticks/DefaultJoystick.cpp
@@ -21,6 +21,7 @@
 #include "DefaultJoystick.h"
 #include "KeymapHandler.h"
 #include "JoystickEasterEgg.h"
+#include "JoystickIDs.h"
 #include "JoystickTranslator.h"
 #include "input/Key.h"
 #include "Application.h"

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -53,6 +53,7 @@ namespace JOYSTICK
     virtual bool HasFeature(const FeatureName& feature) const override;
     virtual bool AcceptsInput(void) override;
     virtual INPUT_TYPE GetInputType(const FeatureName& feature) const override;
+    virtual unsigned int GetDelayMs(const FeatureName& feature) const override;
     virtual bool OnButtonPress(const FeatureName& feature, bool bPressed) override;
     virtual void OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs) override;
     virtual bool OnButtonMotion(const FeatureName& feature, float magnitude) override;

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -91,6 +91,14 @@ namespace JOYSTICK
     virtual int GetWindowID() const;
 
     /*!
+     * \brief Check if we should use the fallthrough window when looking up keys
+     *
+     * \return True if we should use a key from a fallthrough window or the
+     *         global keymap
+     */
+    virtual bool GetFallthrough() const { return true; }
+
+    /*!
      * \brief Keep track of cheat code presses
      *
      * Child classes should initialize this with the appropriate controller ID.

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -22,7 +22,6 @@
 #include "IActionMap.h"
 #include "IInputHandler.h"
 #include "JoystickTypes.h"
-#include "RumbleGenerator.h"
 
 #include <map>
 #include <memory>
@@ -63,14 +62,11 @@ namespace JOYSTICK
     // implementation of IActionMap
     virtual int GetActionID(const FeatureName& feature) override;
 
-    // Forward rumble commands to rumble generator
-    void NotifyUser(void) { m_rumbleGenerator.NotifyUser(InputReceiver()); }
-    bool TestRumble(void) { return m_rumbleGenerator.DoTest(InputReceiver()); }
-    void AbortRumble() { return m_rumbleGenerator.AbortRumble(); }
-
-  private:
-    bool ActivateDirection(const FeatureName& feature, float magnitude, ANALOG_STICK_DIRECTION dir, unsigned int motionTimeMs);
-    void DeactivateDirection(const FeatureName& feature, ANALOG_STICK_DIRECTION dir);
+  protected:
+    /*!
+     * \brief Get the controller ID of this implementation
+     */
+    virtual std::string GetControllerID() const = 0;
 
     /*!
      * \brief Get the keymap key, as defined in Key.h, for the specified
@@ -81,7 +77,18 @@ namespace JOYSTICK
      *
      * \return The key ID, or 0 if unknown
      */
-    static unsigned int GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN);
+    virtual unsigned int GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN) const = 0;
+
+    /*!
+     * \brief Keep track of cheat code presses
+     *
+     * Child classes should initialize this with the appropriate controller ID.
+     */
+    std::unique_ptr<IButtonSequence> m_easterEgg;
+
+  private:
+    bool ActivateDirection(const FeatureName& feature, float magnitude, ANALOG_STICK_DIRECTION dir, unsigned int motionTimeMs);
+    void DeactivateDirection(const FeatureName& feature, ANALOG_STICK_DIRECTION dir);
 
     /*!
      * \brief Return a vector of the four cardinal directions
@@ -94,11 +101,6 @@ namespace JOYSTICK
     // State variables used to process joystick input
     std::map<unsigned int, unsigned int> m_holdStartTimes; // Key ID -> hold start time (ms)
     std::map<FeatureName, ANALOG_STICK_DIRECTION> m_currentDirections; // Analog stick name -> direction
-
-    // Rumble functionality
-    CRumbleGenerator m_rumbleGenerator;
-
-    std::unique_ptr<IButtonSequence> m_easterEgg;
   };
 }
 }

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -80,6 +80,16 @@ namespace JOYSTICK
     virtual unsigned int GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN) const = 0;
 
     /*!
+     * \brief Get the window ID that should be used in the keymap lookup
+     *
+     * A subclass can override this to force a key entry from a particular
+     * window.
+     *
+     * \return A window ID from WindowIDs.h
+     */
+    virtual int GetWindowID() const;
+
+    /*!
      * \brief Keep track of cheat code presses
      *
      * Child classes should initialize this with the appropriate controller ID.

--- a/xbmc/input/joysticks/DefaultJoystick.h
+++ b/xbmc/input/joysticks/DefaultJoystick.h
@@ -28,12 +28,6 @@
 #include <memory>
 #include <vector>
 
-#define DEFAULT_CONTROLLER_ID    "game.controller.default"
-
-// Analog sticks on the default controller
-#define DEFAULT_LEFT_STICK_NAME   "leftstick"
-#define DEFAULT_RIGHT_STICK_NAME  "rightstick"
-
 namespace KODI
 {
 namespace JOYSTICK

--- a/xbmc/input/joysticks/DefaultRemote.cpp
+++ b/xbmc/input/joysticks/DefaultRemote.cpp
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DefaultRemote.h"
+#include "JoystickEasterEgg.h"
+#include "JoystickIDs.h"
+#include "input/Key.h"
+
+using namespace KODI;
+using namespace JOYSTICK;
+
+CDefaultRemote::CDefaultRemote(void)
+{
+  // initialize CDefaultJoystick
+  m_easterEgg.reset(new CJoystickEasterEgg(GetControllerID()));
+}
+
+std::string CDefaultRemote::GetControllerID(void) const
+{
+  return DEFAULT_REMOTE_ID;
+}
+
+unsigned int CDefaultRemote::GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir /* = ANALOG_STICK_DIRECTION::UNKNOWN */) const
+{
+  if      (feature == "ok")            return KEY_REMOTE_BUTTON_OK;
+  else if (feature == "back")          return KEY_REMOTE_BUTTON_BACK;
+  else if (feature == "up")            return KEY_REMOTE_BUTTON_UP;
+  else if (feature == "down")          return KEY_REMOTE_BUTTON_DOWN;
+  else if (feature == "right")         return KEY_REMOTE_BUTTON_RIGHT;
+  else if (feature == "left")          return KEY_REMOTE_BUTTON_LEFT;
+  else if (feature == "home")          return KEY_REMOTE_BUTTON_HOME;
+
+  return 0;
+}

--- a/xbmc/input/joysticks/DefaultRemote.h
+++ b/xbmc/input/joysticks/DefaultRemote.h
@@ -19,9 +19,23 @@
  */
 #pragma once
 
-#define DEFAULT_CONTROLLER_ID    "game.controller.default"
-#define DEFAULT_REMOTE_ID        "game.controller.remote"
+#include "DefaultJoystick.h"
 
- // Analog sticks on the default controller
-#define DEFAULT_LEFT_STICK_NAME   "leftstick"
-#define DEFAULT_RIGHT_STICK_NAME  "rightstick"
+namespace KODI
+{
+namespace JOYSTICK
+{
+  class CDefaultRemote : public CDefaultJoystick
+  {
+  public:
+    CDefaultRemote(void);
+
+    virtual ~CDefaultRemote(void) = default;
+
+  protected:
+    // implementation of CDefaultJoystick
+    virtual std::string GetControllerID() const override;
+    virtual unsigned int GetKeyID(const FeatureName& feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN) const override;
+  };
+}
+}

--- a/xbmc/input/joysticks/IInputHandler.h
+++ b/xbmc/input/joysticks/IInputHandler.h
@@ -70,6 +70,15 @@ namespace JOYSTICK
     virtual INPUT_TYPE GetInputType(const FeatureName& feature) const = 0;
 
     /*!
+     * \brief Get the delay before this feature should be processed
+     *
+     * \param feature The feature
+     *
+     * \return The duration this feature must be held before sending events
+     */
+    virtual unsigned int GetDelayMs(const FeatureName& feature) const = 0;
+
+    /*!
      * \brief A digital button has been pressed or released
      *
      * \param feature      The feature being pressed

--- a/xbmc/input/joysticks/IKeymapHandler.h
+++ b/xbmc/input/joysticks/IKeymapHandler.h
@@ -60,6 +60,16 @@ namespace JOYSTICK
     virtual int GetActionID(unsigned int keyId, int windowId) const = 0;
 
     /*!
+     * \brief Get the time required to hold the button before calling OnDigitalKey()
+     *
+     * \param keyId      The key ID from Key.h
+     * \param windowId   The window ID from WindowIDs.h
+     *
+     * \return The hold time, in ms
+     */
+    virtual unsigned int GetHoldTimeMs(unsigned int keyId, int windowId) const = 0;
+
+    /*!
      * \brief A key mapped to a digital action has been pressed or released
      *
      * \param keyId      The key ID from Key.h

--- a/xbmc/input/joysticks/IKeymapHandler.h
+++ b/xbmc/input/joysticks/IKeymapHandler.h
@@ -42,53 +42,58 @@ namespace JOYSTICK
      *
      * \param keyId  The key ID from Key.h
      * \param windowId   The window ID from WindowIDs.h
+     * \param bFallthrough Use a key from an underlying window or global keymap
      *
      * \return The type of action mapped to keyId, or INPUT_TYPE::UNKNOWN if
      *         no action is mapped to the specified key
      */
-    virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId) const = 0;
+    virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId, bool bFallthrough) const = 0;
 
     /*!
      * \brief Get the action ID mapped to the specified key ID
      *
      * \param keyId  The key ID from Key.h
      * \param windowId   The window ID from WindowIDs.h
+     * \param bFallthrough Use a key from an underlying window or global keymap
      *
      * \return The action ID, or ACTION_NONE if no action is mapped to the
      *         specified key
      */
-    virtual int GetActionID(unsigned int keyId, int windowId) const = 0;
+    virtual int GetActionID(unsigned int keyId, int windowId, bool bFallthrough) const = 0;
 
     /*!
      * \brief Get the time required to hold the button before calling OnDigitalKey()
      *
      * \param keyId      The key ID from Key.h
      * \param windowId   The window ID from WindowIDs.h
+     * \param bFallthrough Use a key from an underlying window or global keymap
      *
      * \return The hold time, in ms
      */
-    virtual unsigned int GetHoldTimeMs(unsigned int keyId, int windowId) const = 0;
+    virtual unsigned int GetHoldTimeMs(unsigned int keyId, int windowId, bool bFallthrough) const = 0;
 
     /*!
      * \brief A key mapped to a digital action has been pressed or released
      *
      * \param keyId      The key ID from Key.h
      * \param windowId   The window ID from WindowIDs.h
+     * \param bFallthrough Use a key from an underlying window or global keymap
      * \param bPressed   true if the key's button/axis is activated, false if deactivated
      * \param holdTimeMs The held time in ms for pressed buttons, or 0 for released
      */
-    virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs = 0) = 0;
+    virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, bool bFallthrough, unsigned int holdTimeMs = 0) = 0;
 
     /*!
      * \brief Callback for keys mapped to analog actions
      *
      * \param keyId      The button key ID from Key.h
      * \param windowId   The window ID from WindowIDs.h
+     * \param bFallthrough Use a key from an underlying window or global keymap
      * \param magnitude  The amount of the analog action
      *
      * If keyId is not mapped to an analog action, no action need be taken
      */
-    virtual void OnAnalogKey(unsigned int keyId, int windowId, float magnitude) = 0;
+    virtual void OnAnalogKey(unsigned int keyId, int windowId, bool bFallthrough, float magnitude) = 0;
   };
 }
 }

--- a/xbmc/input/joysticks/IKeymapHandler.h
+++ b/xbmc/input/joysticks/IKeymapHandler.h
@@ -41,40 +41,44 @@ namespace JOYSTICK
      * \brief Get the type of action mapped to the specified key ID
      *
      * \param keyId  The key ID from Key.h
+     * \param windowId   The window ID from WindowIDs.h
      *
      * \return The type of action mapped to keyId, or INPUT_TYPE::UNKNOWN if
      *         no action is mapped to the specified key
      */
-    virtual INPUT_TYPE GetInputType(unsigned int keyId) const = 0;
+    virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId) const = 0;
 
     /*!
      * \brief Get the action ID mapped to the specified key ID
      *
      * \param keyId  The key ID from Key.h
+     * \param windowId   The window ID from WindowIDs.h
      *
      * \return The action ID, or ACTION_NONE if no action is mapped to the
      *         specified key
      */
-    virtual int GetActionID(unsigned int keyId) const = 0;
+    virtual int GetActionID(unsigned int keyId, int windowId) const = 0;
 
     /*!
      * \brief A key mapped to a digital action has been pressed or released
      *
      * \param keyId      The key ID from Key.h
+     * \param windowId   The window ID from WindowIDs.h
      * \param bPressed   true if the key's button/axis is activated, false if deactivated
      * \param holdTimeMs The held time in ms for pressed buttons, or 0 for released
      */
-    virtual void OnDigitalKey(unsigned int keyId, bool bPressed, unsigned int holdTimeMs = 0) = 0;
+    virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs = 0) = 0;
 
     /*!
      * \brief Callback for keys mapped to analog actions
      *
      * \param keyId      The button key ID from Key.h
+     * \param windowId   The window ID from WindowIDs.h
      * \param magnitude  The amount of the analog action
      *
      * If keyId is not mapped to an analog action, no action need be taken
      */
-    virtual void OnAnalogKey(unsigned int buttonKeyId, float magnitude) = 0;
+    virtual void OnAnalogKey(unsigned int keyId, int windowId, float magnitude) = 0;
   };
 }
 }

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "JoystickEasterEgg.h"
+#include "JoystickIDs.h"
 #include "ServiceBroker.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/WindowIDs.h"
@@ -27,20 +28,27 @@
 using namespace KODI;
 using namespace JOYSTICK;
 
-std::vector<FeatureName> CJoystickEasterEgg::m_sequence = {
-  "up",
-  "up",
-  "down",
-  "down",
-  "left",
-  "right",
-  "left",
-  "right",
-  "b",
-  "a",
+const std::map<std::string, std::vector<FeatureName>> CJoystickEasterEgg::m_sequence =
+{
+  {
+    DEFAULT_CONTROLLER_ID,
+    {
+      "up",
+      "up",
+      "down",
+      "down",
+      "left",
+      "right",
+      "left",
+      "right",
+      "b",
+      "a",
+    },
+  },
 };
 
-CJoystickEasterEgg::CJoystickEasterEgg(void) :
+CJoystickEasterEgg::CJoystickEasterEgg(const std::string& controllerId) :
+  m_controllerId(controllerId),
   m_state(0)
 {
 }
@@ -49,21 +57,27 @@ bool CJoystickEasterEgg::OnButtonPress(const FeatureName& feature)
 {
   bool bHandled = false;
 
-  // Update state
-  if (feature == m_sequence[m_state])
-    m_state++;
-  else
-    m_state = 0;
-
-  // Capture input when finished with arrows (2 x up/down/left/right)
-  if (m_state > 8)
+  auto it = m_sequence.find(m_controllerId);
+  if (it != m_sequence.end())
   {
-    bHandled = true;
+    const auto& sequence = it->second;
 
-    if (m_state >= m_sequence.size())
-    {
-      OnFinish();
+    // Update state
+    if (feature == sequence[m_state])
+      m_state++;
+    else
       m_state = 0;
+
+    // Capture input when finished with arrows (2 x up/down/left/right)
+    if (m_state > 8)
+    {
+      bHandled = true;
+
+      if (m_state >= sequence.size())
+      {
+        OnFinish();
+        m_state = 0;
+      }
     }
   }
 

--- a/xbmc/input/joysticks/JoystickEasterEgg.cpp
+++ b/xbmc/input/joysticks/JoystickEasterEgg.cpp
@@ -45,6 +45,21 @@ const std::map<std::string, std::vector<FeatureName>> CJoystickEasterEgg::m_sequ
       "a",
     },
   },
+  {
+    DEFAULT_REMOTE_ID,
+    {
+      "up",
+      "up",
+      "down",
+      "down",
+      "left",
+      "right",
+      "left",
+      "right",
+      "back",
+      "ok",
+    },
+  },
 };
 
 CJoystickEasterEgg::CJoystickEasterEgg(const std::string& controllerId) :

--- a/xbmc/input/joysticks/JoystickEasterEgg.h
+++ b/xbmc/input/joysticks/JoystickEasterEgg.h
@@ -21,6 +21,8 @@
 
 #include "IButtonSequence.h"
 
+#include <map>
+#include <string>
 #include <vector>
 
 namespace KODI
@@ -33,7 +35,7 @@ namespace JOYSTICK
   class CJoystickEasterEgg : public IButtonSequence
   {
   public:
-    CJoystickEasterEgg(void);
+    CJoystickEasterEgg(const std::string& controllerId);
     virtual ~CJoystickEasterEgg() = default;
 
     // implementation of IButtonSequence
@@ -42,7 +44,10 @@ namespace JOYSTICK
     static void OnFinish(void);
 
   private:
-    static std::vector<FeatureName> m_sequence;
+    // Construction parameters
+    const std::string m_controllerId;
+
+    static const std::map<std::string, std::vector<FeatureName>> m_sequence;
 
     unsigned int m_state;
   };

--- a/xbmc/input/joysticks/JoystickIDs.h
+++ b/xbmc/input/joysticks/JoystickIDs.h
@@ -1,0 +1,26 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define DEFAULT_CONTROLLER_ID    "game.controller.default"
+
+ // Analog sticks on the default controller
+#define DEFAULT_LEFT_STICK_NAME   "leftstick"
+#define DEFAULT_RIGHT_STICK_NAME  "rightstick"

--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -137,10 +137,16 @@ bool CKeymapHandler::SendDigitalAction(unsigned int keyId, unsigned int holdTime
   CAction action(CButtonTranslator::GetInstance().GetAction(g_windowManager.GetActiveWindowID(), CKey(keyId, holdTimeMs)));
   if (action.GetID() > 0)
   {
-    //! @todo Add "holdtime" parameter to joystick.xml. For now we MUST only
-    // send held actions for basic navigation commands!
-    if (holdTimeMs > 0)
+    // If button was pressed this frame, send action
+    if (action.GetHoldTime() == 0)
     {
+      CInputManager::GetInstance().QueueAction(action);
+    }
+    else
+    {
+      // Only send repeated actions for basic navigation commands
+      bool bIsNavigation = false;
+
       switch (action.GetID())
       {
       case ACTION_MOVE_LEFT:
@@ -149,14 +155,17 @@ bool CKeymapHandler::SendDigitalAction(unsigned int keyId, unsigned int holdTime
       case ACTION_MOVE_DOWN:
       case ACTION_PAGE_UP:
       case ACTION_PAGE_DOWN:
+        bIsNavigation = true;
         break;
 
       default:
-        return true;
+        break;
       }
+
+      if (bIsNavigation)
+        CInputManager::GetInstance().QueueAction(action);
     }
 
-    CInputManager::GetInstance().QueueAction(action);
     return true;
   }
 

--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -43,12 +43,12 @@ CKeymapHandler::~CKeymapHandler(void)
 {
 }
 
-INPUT_TYPE CKeymapHandler::GetInputType(unsigned int keyId, int windowId) const
+INPUT_TYPE CKeymapHandler::GetInputType(unsigned int keyId, int windowId, bool bFallthrough) const
 {
   CAction action(ACTION_NONE);
 
   if (keyId != 0)
-    action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), true);
+    action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), bFallthrough);
 
   if (action.GetID() > ACTION_NONE)
   {
@@ -61,28 +61,28 @@ INPUT_TYPE CKeymapHandler::GetInputType(unsigned int keyId, int windowId) const
   return INPUT_TYPE::UNKNOWN;
 }
 
-int CKeymapHandler::GetActionID(unsigned int keyId, int windowId) const
+int CKeymapHandler::GetActionID(unsigned int keyId, int windowId, bool bFallthrough) const
 {
   CAction action(ACTION_NONE);
 
   if (keyId != 0)
-    action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), true);
+    action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), bFallthrough);
 
   return action.GetID();
 }
 
-unsigned int CKeymapHandler::GetHoldTimeMs(unsigned int keyId, int windowId) const
+unsigned int CKeymapHandler::GetHoldTimeMs(unsigned int keyId, int windowId, bool bFallthrough) const
 {
-  return CButtonTranslator::GetInstance().GetHoldTimeMs(windowId, CKey(keyId), true);
+  return CButtonTranslator::GetInstance().GetHoldTimeMs(windowId, CKey(keyId), bFallthrough);
 }
 
-void CKeymapHandler::OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs /* = 0 */)
+void CKeymapHandler::OnDigitalKey(unsigned int keyId, int windowId, bool bFallthrough, bool bPressed, unsigned int holdTimeMs /* = 0 */)
 {
   if (keyId != 0)
   {
     if (bPressed)
     {
-      CAction action(CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId, holdTimeMs), true));
+      CAction action(CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId, holdTimeMs), bFallthrough));
       SendAction(action);
     }
     else
@@ -92,11 +92,11 @@ void CKeymapHandler::OnDigitalKey(unsigned int keyId, int windowId, bool bPresse
   }
 }
 
-void CKeymapHandler::OnAnalogKey(unsigned int keyId, int windowId, float magnitude)
+void CKeymapHandler::OnAnalogKey(unsigned int keyId, int windowId, bool bFallthrough, float magnitude)
 {
   if (keyId != 0)
   {
-    CAction action(CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), true));
+    CAction action(CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), bFallthrough));
     SendAnalogAction(action, magnitude);
   }
 }

--- a/xbmc/input/joysticks/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/KeymapHandler.cpp
@@ -48,7 +48,7 @@ INPUT_TYPE CKeymapHandler::GetInputType(unsigned int keyId, int windowId) const
   CAction action(ACTION_NONE);
 
   if (keyId != 0)
-    action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId));
+    action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), true);
 
   if (action.GetID() > ACTION_NONE)
   {
@@ -69,6 +69,11 @@ int CKeymapHandler::GetActionID(unsigned int keyId, int windowId) const
     action = CButtonTranslator::GetInstance().GetAction(windowId, CKey(keyId), true);
 
   return action.GetID();
+}
+
+unsigned int CKeymapHandler::GetHoldTimeMs(unsigned int keyId, int windowId) const
+{
+  return CButtonTranslator::GetInstance().GetHoldTimeMs(windowId, CKey(keyId), true);
 }
 
 void CKeymapHandler::OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs /* = 0 */)

--- a/xbmc/input/joysticks/KeymapHandler.h
+++ b/xbmc/input/joysticks/KeymapHandler.h
@@ -42,6 +42,7 @@ namespace JOYSTICK
     // implementation of IKeymapHandler
     virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId) const override;
     virtual int GetActionID(unsigned int keyId, int windowId) const override;
+    virtual unsigned int GetHoldTimeMs(unsigned int keyId, int windowId) const override;
     virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs = 0) override;
     virtual void OnAnalogKey(unsigned int keyId, int windowId, float magnitude) override;
 

--- a/xbmc/input/joysticks/KeymapHandler.h
+++ b/xbmc/input/joysticks/KeymapHandler.h
@@ -40,11 +40,11 @@ namespace JOYSTICK
     virtual ~CKeymapHandler(void);
 
     // implementation of IKeymapHandler
-    virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId) const override;
-    virtual int GetActionID(unsigned int keyId, int windowId) const override;
-    virtual unsigned int GetHoldTimeMs(unsigned int keyId, int windowId) const override;
-    virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs = 0) override;
-    virtual void OnAnalogKey(unsigned int keyId, int windowId, float magnitude) override;
+    virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId, bool bFallthrough) const override;
+    virtual int GetActionID(unsigned int keyId, int windowId, bool bFallthrough) const override;
+    virtual unsigned int GetHoldTimeMs(unsigned int keyId, int windowId, bool bFallthrough) const override;
+    virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bFallthrough, bool bPressed, unsigned int holdTimeMs = 0) override;
+    virtual void OnAnalogKey(unsigned int keyId, int windowId, bool bFallthrough, float magnitude) override;
 
   private:
     void SendAction(const CAction& action);

--- a/xbmc/input/joysticks/KeymapHandler.h
+++ b/xbmc/input/joysticks/KeymapHandler.h
@@ -23,6 +23,8 @@
 
 #include <vector>
 
+class CAction;
+
 namespace KODI
 {
 namespace JOYSTICK
@@ -38,18 +40,18 @@ namespace JOYSTICK
     virtual ~CKeymapHandler(void);
 
     // implementation of IKeymapHandler
-    virtual INPUT_TYPE GetInputType(unsigned int keyId) const override;
-    virtual int GetActionID(unsigned int keyId) const override;
-    virtual void OnDigitalKey(unsigned int keyId, bool bPressed, unsigned int holdTimeMs = 0) override;
-    virtual void OnAnalogKey(unsigned int keyId, float magnitude) override;
+    virtual INPUT_TYPE GetInputType(unsigned int keyId, int windowId) const override;
+    virtual int GetActionID(unsigned int keyId, int windowId) const override;
+    virtual void OnDigitalKey(unsigned int keyId, int windowId, bool bPressed, unsigned int holdTimeMs = 0) override;
+    virtual void OnAnalogKey(unsigned int keyId, int windowId, float magnitude) override;
 
   private:
-    void ProcessButtonPress(unsigned int keyId, unsigned int holdTimeMs);
+    void SendAction(const CAction& action);
     void ProcessButtonRelease(unsigned int keyId);
     bool IsPressed(unsigned int keyId) const;
 
-    static bool SendDigitalAction(unsigned int keyId, unsigned int holdTimeMs = 0);
-    static bool SendAnalogAction(unsigned int keyId, float magnitude);
+    static bool SendDigitalAction(const CAction& action);
+    static bool SendAnalogAction(const CAction& action, float magnitude);
 
     unsigned int              m_lastButtonPress;
     unsigned int              m_lastDigitalActionMs;

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -20,7 +20,6 @@
 
 #include "RumbleGenerator.h"
 #include "games/controllers/Controller.h"
-#include "games/controllers/ControllerFeature.h"
 #include "games/GameServices.h"
 #include "input/joysticks/IInputReceiver.h"
 #include "ServiceBroker.h"
@@ -125,16 +124,9 @@ std::vector<std::string> CRumbleGenerator::GetMotors(const std::string& controll
 
   std::vector<std::string> motors;
 
-  CGameServices& gameServices = CServiceBroker::GetGameServices();
-  ControllerPtr controller = gameServices.GetController(controllerId);
+  ControllerPtr controller = CServiceBroker::GetGameServices().GetController(controllerId);
   if (controller)
-  {
-    for (const CControllerFeature& feature : controller->Layout().Features())
-    {
-      if (feature.Type() == FEATURE_TYPE::MOTOR)
-        motors.push_back(feature.Name());
-    }
-  }
-
+    controller->GetFeatures(motors, FEATURE_TYPE::MOTOR);
+ 
   return motors;
 }

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -64,6 +64,7 @@ CScalarFeature::CScalarFeature(const FeatureName& name, IInputHandler* handler, 
   m_inputType(handler->GetInputType(name)),
   m_bDigitalState(false),
   m_bDigitalHandled(false),
+  m_bDigitalPressSent(false),
   m_motionStartTimeMs(0),
   m_analogState(0.0f),
   m_analogEvent(false),
@@ -103,21 +104,7 @@ bool CScalarFeature::OnAnalogMotion(const CDriverPrimitive& source, float magnit
 
 void CScalarFeature::ProcessMotions(void)
 {
-  if (m_bDigitalState && m_bDigitalHandled)
-  {
-    if (m_motionStartTimeMs == 0)
-    {
-      // Button was just pressed, record start time and exit
-      m_motionStartTimeMs = XbmcThreads::SystemClockMillis();
-    }
-    else
-    {
-      // Button has been pressed more than one event frame
-      const unsigned int elapsed = XbmcThreads::SystemClockMillis() - m_motionStartTimeMs;
-      m_handler->OnButtonHold(m_name, elapsed);
-    }
-  }
-  else if (m_analogEvent)
+  if (m_analogEvent)
   {
     float magnitude = m_analogState;
 
@@ -134,10 +121,43 @@ void CScalarFeature::ProcessMotions(void)
     }
 
     m_handler->OnButtonMotion(m_name, magnitude);
+
+    // Disable sending events after feature is reset
     if (m_analogState == 0.0f)
     {
       m_analogEvent = false;
       m_motionStartTimeMs = 0;
+    }
+  }
+  else if (m_bDigitalState)
+  {
+    if (m_motionStartTimeMs == 0)
+    {
+      // Button was just pressed, record start time and exit (button press
+      // event was already sent this frame)
+      m_motionStartTimeMs = XbmcThreads::SystemClockMillis();
+    }
+    else
+    {
+      // Calculate time elapsed
+      const unsigned int elapsed = XbmcThreads::SystemClockMillis() - m_motionStartTimeMs;
+
+      // Calculate holdtime, if any
+      const unsigned int holdtimeMs = m_handler->GetDelayMs(m_name);
+
+      // Only process button events if holdtime has elapsed
+      if (elapsed >= holdtimeMs)
+      {
+        if (m_bDigitalHandled)
+        {
+          m_handler->OnButtonHold(m_name, elapsed - holdtimeMs);
+        }
+        else if (!m_bDigitalPressSent)
+        {
+          m_bDigitalHandled = m_handler->OnButtonPress(m_name, true);
+          m_bDigitalPressSent = true;
+        }
+      }
     }
   }
 }
@@ -152,7 +172,31 @@ void CScalarFeature::OnDigitalMotion(bool bPressed)
     CLog::Log(LOGDEBUG, "FEATURE [ %s ] on %s %s", m_name.c_str(), m_handler->ControllerID().c_str(),
               bPressed ? "pressed" : "released");
 
-    m_bDigitalHandled = m_handler->OnButtonPress(m_name, bPressed);
+    if (bPressed)
+    {
+      // Don't send event if a holdtime was specified
+      bool bHasHoldtime = false;
+
+      if (m_handler->GetDelayMs(m_name) != 0)
+        bHasHoldtime = true;
+
+      if (bHasHoldtime)
+      {
+        m_bDigitalHandled = false;
+        m_bDigitalPressSent = false;
+      }
+      else
+      {
+        m_bDigitalHandled = m_handler->OnButtonPress(m_name, true);
+        m_bDigitalPressSent = true;
+      }
+    }
+    else
+    {
+      m_handler->OnButtonPress(m_name, false);
+      m_bDigitalHandled = false;
+      m_bDigitalPressSent = false;
+    }
   }
 }
 

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -114,6 +114,7 @@ namespace JOYSTICK
     const INPUT_TYPE m_inputType;
     bool             m_bDigitalState;
     bool             m_bDigitalHandled;
+    bool             m_bDigitalPressSent;
     unsigned int     m_motionStartTimeMs;
     float            m_analogState;
     bool             m_analogEvent;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -561,13 +561,13 @@ void CPeripheral::ClearSettings(void)
   m_settings.clear();
 }
 
-void CPeripheral::RegisterJoystickInputHandler(IInputHandler* handler)
+void CPeripheral::RegisterJoystickInputHandler(IInputHandler* handler, bool bPromiscuous)
 {
   auto it = m_inputHandlers.find(handler);
   if (it == m_inputHandlers.end())
   {
     CAddonInputHandling* addonInput = new CAddonInputHandling(m_manager, this, handler, GetDriverReceiver());
-    RegisterJoystickDriverHandler(addonInput, false);
+    RegisterJoystickDriverHandler(addonInput, bPromiscuous);
     m_inputHandlers[handler].reset(addonInput);
   }
 }

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -199,7 +199,7 @@ namespace PERIPHERALS
     virtual void RegisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler, bool bPromiscuous) { }
     virtual void UnregisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler) { }
 
-    virtual void RegisterJoystickInputHandler(KODI::JOYSTICK::IInputHandler* handler);
+    virtual void RegisterJoystickInputHandler(KODI::JOYSTICK::IInputHandler* handler, bool bPromiscuous);
     virtual void UnregisterJoystickInputHandler(KODI::JOYSTICK::IInputHandler* handler);
 
     virtual void RegisterJoystickButtonMapper(KODI::JOYSTICK::IButtonMapper* mapper);

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -20,6 +20,7 @@
 
 #include "PeripheralJoystick.h"
 #include "input/joysticks/DeadzoneFilter.h"
+#include "input/joysticks/JoystickIDs.h"
 #include "input/joysticks/JoystickTranslator.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/addons/AddonButtonMap.h"

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -52,8 +52,8 @@ CPeripheralJoystick::~CPeripheralJoystick(void)
 {
   m_deadzoneFilter.reset();
   m_buttonMap.reset();
-  m_defaultInputHandler.AbortRumble();
-  UnregisterJoystickInputHandler(&m_defaultInputHandler);
+  m_defaultController.AbortRumble();
+  UnregisterJoystickInputHandler(&m_defaultController);
   UnregisterJoystickDriverHandler(&m_joystickMonitor);
 }
 
@@ -75,7 +75,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
         InitializeDeadzoneFiltering();
 
         // Give joystick monitor priority over default controller
-        RegisterJoystickInputHandler(&m_defaultInputHandler);
+        RegisterJoystickInputHandler(&m_defaultController);
         RegisterJoystickDriverHandler(&m_joystickMonitor, false);
       }
     }
@@ -117,7 +117,7 @@ void CPeripheralJoystick::InitializeDeadzoneFiltering()
 
 void CPeripheralJoystick::OnUserNotification()
 {
-  m_defaultInputHandler.NotifyUser();
+  m_defaultController.NotifyUser();
 }
 
 bool CPeripheralJoystick::TestFeature(PeripheralFeature feature)
@@ -127,7 +127,7 @@ bool CPeripheralJoystick::TestFeature(PeripheralFeature feature)
   switch (feature)
   {
   case FEATURE_RUMBLE:
-    bSuccess = m_defaultInputHandler.TestRumble();
+    bSuccess = m_defaultController.TestRumble();
     break;
   case FEATURE_POWER_OFF:
     if (m_supportsPowerOff)

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -75,7 +75,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
         InitializeDeadzoneFiltering();
 
         // Give joystick monitor priority over default controller
-        RegisterJoystickInputHandler(&m_defaultController);
+        RegisterJoystickInputHandler(&m_defaultController, false);
         RegisterJoystickDriverHandler(&m_joystickMonitor, false);
       }
     }

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "Peripheral.h"
-#include "input/joysticks/DefaultJoystick.h"
+#include "input/joysticks/DefaultController.h"
 #include "input/joysticks/IDriverReceiver.h"
 #include "input/joysticks/JoystickMonitor.h"
 #include "input/joysticks/JoystickTypes.h"
@@ -61,7 +61,7 @@ namespace PERIPHERALS
     virtual void RegisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler, bool bPromiscuous) override;
     virtual void UnregisterJoystickDriverHandler(KODI::JOYSTICK::IDriverHandler* handler) override;
     virtual KODI::JOYSTICK::IDriverReceiver* GetDriverReceiver() override { return this; }
-    virtual KODI::JOYSTICK::IActionMap* GetActionMap() override { return &m_defaultInputHandler; }
+    virtual KODI::JOYSTICK::IActionMap* GetActionMap() override { return &m_defaultController; }
 
     bool OnButtonMotion(unsigned int buttonIndex, bool bPressed);
     bool OnHatMotion(unsigned int hatIndex, KODI::JOYSTICK::HAT_STATE state);
@@ -125,7 +125,7 @@ namespace PERIPHERALS
     unsigned int                        m_axisCount;
     unsigned int                        m_motorCount;
     bool                                m_supportsPowerOff;
-    KODI::JOYSTICK::CDefaultJoystick          m_defaultInputHandler;
+    KODI::JOYSTICK::CDefaultController        m_defaultController;
     KODI::JOYSTICK::CJoystickMonitor          m_joystickMonitor;
     std::unique_ptr<KODI::JOYSTICK::IButtonMap>      m_buttonMap;
     std::unique_ptr<KODI::JOYSTICK::CDeadzoneFilter> m_deadzoneFilter;


### PR DESCRIPTION
This PR changes how the &lt;FullscreenGame> tag works in joystick.xml. The &lt;noop> actions are no longer needed because all input is captured during gameplay. Start, guide and back have been set to the `OSD` action. A "holdtime" parameter was added to delay the opening of the OSD by 1 second.

Keys under &lt;FullscreenGame> now always take priority over games, but will never block input going to the game client. Input goes to the game client as long as the FullscreenGame window is active.

joystick.xml now looks like:

```xml
<FullscreenGame>
    <joystick profile="game.controller.default">
        <start holdtime="1000">OSD</start>
        <back holdtime="1000">OSD</back>
        <guide holdtime="1000">OSD</guide>
    </joystick>
</FullscreenGame>
```

## Motivation and Context
Twofold:
- Ability to add a "holdtime" to keys in joystick.xml (sadly, no overloading)
- Ability to run Kodi actions from within games using the &lt;FullscreenGame> tag

## How Has This Been Tested?
Install peripheral.joystick, game.libretro, and game.libretro.2048. Launch 2048 from the home add-ons tab. Hold start, guide or back/select for a second and the OSD will pop up. The controller can be used to control the OSD. When the OSD is closed, control returns back to the game.

(If #12166 is not applied then Kodi will crash when 2048 is closed.)

## Screenshots (if appropriate):
![screenshot000](https://cloud.githubusercontent.com/assets/531482/26526198/25c06016-4327-11e7-9349-bfbd22b588fd.png)

This shows the state of the current OSD for games. It is the same as for videos but the bookmarks button opens the Savestate manager.

Next task is to add a way to access video filters.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix ([report](http://forum.kodi.tv/showthread.php?tid=309313&pid=2545744#pid2545744))
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
