### PR TITLE
When playing back an item that is an addon pass a new script param to…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2918,8 +2918,9 @@ bool CApplication::PlayMedia(const CFileItem& item, const std::string &player, i
   //If item is a plugin, expand out now and run ourselves again
   if (item.IsPlugin())
   {
+    bool resume = item.m_lStartOffset == STARTOFFSET_RESUME;
     CFileItem item_new(item);
-    if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new))
+    if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new, resume))
       return PlayMedia(item_new, player, iPlaylist);
     return false;
   }
@@ -3197,8 +3198,9 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
 
   if (item.IsPlugin())
   { // we modify the item so that it becomes a real URL
+    bool resume = item.m_lStartOffset == STARTOFFSET_RESUME;
     CFileItem item_new(item);
-    if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new))
+    if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new, resume))
       return PlayFile(std::move(item_new), player, false);
     return PLAYBACK_FAIL;
   }
@@ -4227,7 +4229,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       // handle plugin://
       CURL url(file.GetPath());
       if (url.IsProtocol("plugin"))
-        XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
+        XFILE::CPluginDirectory::GetPluginResult(url.Get(), file, false);
 
       // Don't queue if next media type is different from current one
       if ((!file.IsVideo() && m_pPlayer->IsPlayingVideo())

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -503,7 +503,7 @@ CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
 
     CFileItem item("resolve me", false);
 
-    if (XFILE::CPluginDirectory::GetPluginResult(str.str(), item))
+    if (XFILE::CPluginDirectory::GetPluginResult(str.str(), item, false))
       scurlRet.ParseString(item.GetPath());
 
     return scurlRet;
@@ -883,7 +883,7 @@ static bool PythonDetails(const std::string& ID,
 
   CFileItem item(url, false);
 
-  if (!XFILE::CPluginDirectory::GetPluginResult(str.str(), item))
+  if (!XFILE::CPluginDirectory::GetPluginResult(str.str(), item, false))
     return false;
 
   DetailsFromFileItem(item, result);

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -112,7 +112,7 @@ CPluginDirectory *CPluginDirectory::dirFromHandle(int handle)
   return NULL;
 }
 
-bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDir)
+bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDir, bool resume)
 {
   CURL url(strPath);
 
@@ -151,8 +151,13 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   argv.push_back(strHandle);
   argv.push_back(options);
 
+  std::string strResume = "resume:false";
+  if (resume)
+    strResume = "resume:true";
+  argv.push_back(strResume);
+
   // run the script
-  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s')", __FUNCTION__, m_addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str());
+  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s','%s')", __FUNCTION__, m_addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str(), argv[3].c_str());
   bool success = false;
   std::string file = m_addon->LibPath();
   int id = CScriptInvocationManager::GetInstance().ExecuteAsync(file, m_addon, argv);
@@ -170,12 +175,12 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   return success;
 }
 
-bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &resultItem)
+bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &resultItem, bool resume)
 {
   CURL url(strPath);
   CPluginDirectory newDir;
 
-  bool success = newDir.StartScript(strPath, false);
+  bool success = newDir.StartScript(strPath, false, resume);
 
   if (success)
   { // update the play path and metadata, saving the old one as needed
@@ -429,7 +434,7 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const s
 bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   const std::string pathToUrl(url.Get());
-  bool success = StartScript(pathToUrl, true);
+  bool success = StartScript(pathToUrl, true, false);
 
   // append the items to the list
   items.Assign(*m_listItems, true); // true to keep the current items
@@ -437,7 +442,7 @@ bool CPluginDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   return success;
 }
 
-bool CPluginDirectory::RunScriptWithParams(const std::string& strPath)
+bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resume)
 {
   CURL url(strPath);
   if (url.GetHostName().empty()) // called with no script - should never happen
@@ -464,8 +469,13 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath)
   argv.push_back(strHandle);
   argv.push_back(options);
 
+  std::string strResume = "resume:false";
+  if (resume)
+    strResume = "resume:true";
+  argv.push_back(strResume);
+
   // run the script
-  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s')", __FUNCTION__, addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str());
+  CLog::Log(LOGDEBUG, "%s - calling plugin %s('%s','%s','%s','%s')", __FUNCTION__, addon->Name().c_str(), argv[0].c_str(), argv[1].c_str(), argv[2].c_str(), argv[3].c_str());
   if (CScriptInvocationManager::GetInstance().ExecuteAsync(addon->LibPath(), addon, argv) >= 0)
     return true;
   else

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -49,8 +49,8 @@ public:
   bool Exists(const CURL& url) override { return true; }
   float GetProgress() const override;
   void CancelDirectory() override;
-  static bool RunScriptWithParams(const std::string& strPath);
-  static bool GetPluginResult(const std::string& strPath, CFileItem &resultItem);
+  static bool RunScriptWithParams(const std::string& strPath, bool resume);
+  static bool GetPluginResult(const std::string& strPath, CFileItem &resultItem, bool resume);
 
   // callbacks from python
   static bool AddItem(int handle, const CFileItem *item, int totalItems);
@@ -66,7 +66,7 @@ public:
 
 private:
   ADDON::AddonPtr m_addon;
-  bool StartScript(const std::string& strPath, bool retrievingDir);
+  bool StartScript(const std::string& strPath, bool retrievingDir, bool resume);
   bool WaitOnScriptResult(const std::string &scriptPath, int scriptId, const std::string &scriptName, bool retrievingDir);
 
   static std::map<int,CPluginDirectory*> globalHandles;

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -74,7 +74,7 @@ static int RunPlugin(const std::vector<std::string>& params)
     if (!item.m_bIsFolder)
     {
       item.SetPath(params[0]);
-      XFILE::CPluginDirectory::RunScriptWithParams(item.GetPath());
+      XFILE::CPluginDirectory::RunScriptWithParams(item.GetPath(), false);
     }
   }
   else

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -482,6 +482,8 @@ namespace XBMCAddon
             videotag.SetTrailer(value);
           else if (key == "path")
             videotag.SetPath(value);
+          else if (key == "filenameandpath")
+            videotag.SetFileNameAndPath(value);
           else if (key == "date")
           {
             if (value.length() == 10)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1039,7 +1039,8 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
   }
   else if (pItem->IsPlugin() && !pItem->GetProperty("isplayable").asBoolean())
   {
-    return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath());
+    bool resume = pItem->m_lStartOffset == STARTOFFSET_RESUME;
+    return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath(), resume);
   }
 #if defined(TARGET_ANDROID)
   else if (pItem->IsAndroidApp())


### PR DESCRIPTION
… addon script that lets the addon know if the user selected resume of not in the built in resume dialog question.

If a user selected resume then the string resume will be passed to the addon script.

<!--- Provide a general summary of your change in the Title above -->

## Description
When the user plays an item that is an addon item and there is a progress set they will be given a resume dialog. All this change does is pass the result of the resume question on to the addon via a new script param string "resume".
This allows addons to use the built in resume question response instead of having to handle this in the addon, the addon will have the answer to what the user wanted to do.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have written a number of addons over the years and this allows you to build addons that are more in line with the global look and feel of the app.
Having this data passed to the addon script gives the user a smoother experience.
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Tested with addons and playback process to test regressions.
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on Windows, Run all the built in tests.
<!--- see how your change affects other areas of the code, etc -->
This change is low risk, none of the internal logic is being changed, if a user asks for resume a new script param is added when the addon is called, that is all.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
