### PR TITLE
FIX: [droid] trap App icons not being bitmaps

### DIFF
--- a/xbmc/filesystem/AndroidAppFile.cpp
+++ b/xbmc/filesystem/AndroidAppFile.cpp
@@ -25,6 +25,7 @@
 
 #include <android/bitmap.h>
 #include <androidjni/Bitmap.h>
+#include <androidjni/Drawable.h>
 #include <androidjni/BitmapDrawable.h>
 #include <androidjni/Build.h>
 #include <androidjni/Context.h>
@@ -93,6 +94,8 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
   int densities[] = { CJNIDisplayMetrics::DENSITY_XXXHIGH, CJNIDisplayMetrics::DENSITY_XXHIGH, CJNIDisplayMetrics::DENSITY_XHIGH, -1 };
 
   CJNIBitmap bmp;
+  jclass cBmpDrw = env->FindClass("android/graphics/drawable/BitmapDrawable");
+
   if (CJNIBuild::SDK_INT >= 15 && m_icon)
   {
     CJNIResources res = CJNIContext::GetPackageManager().getResourcesForApplication(m_packageName);
@@ -101,18 +104,39 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
       for (int i=0; densities[i] != -1 && !bmp; ++i)
       {
         int density = densities[i];
-        CJNIBitmapDrawable resbmp = res.getDrawableForDensity(m_icon, density);
+        CJNIDrawable drw = res.getDrawableForDensity(m_icon, density);
         if (xbmc_jnienv()->ExceptionCheck())
           xbmc_jnienv()->ExceptionClear();
+        else if (!drw);
         else
-          if (resbmp.getBitmap())
-            bmp = resbmp.getBitmap();
+        {
+          if (env->IsInstanceOf(drw.get_raw(), cBmpDrw))
+          {
+            CJNIBitmapDrawable resbmp = drw;
+            if (resbmp)
+              bmp = resbmp.getBitmap();
+          }
+        }
       }
     }
   }
 
   if (!bmp)
-    bmp = ((CJNIBitmapDrawable)(CJNIContext::GetPackageManager().getApplicationIcon(m_packageName))).getBitmap();
+  {
+    CJNIDrawable drw = CJNIContext::GetPackageManager().getApplicationIcon(m_packageName);
+    if (xbmc_jnienv()->ExceptionCheck())
+      xbmc_jnienv()->ExceptionClear();
+    else if (!drw);
+    else
+    {
+      if (env->IsInstanceOf(drw.get_raw(), cBmpDrw))
+      {
+        CJNIBitmapDrawable resbmp = drw;
+        if (resbmp)
+          bmp = resbmp.getBitmap();
+      }
+    }
+  }
   if (!bmp)
     return 0;
 


### PR DESCRIPTION
Report from Android O testing on O below.
Bottom-line: Have to check that the Drawable is a Bitmap first.

From: <android-developer-preview-no-reply@google.com>
Date: Apr 19, 2017 21:20
Subject: Native crash when trying to open Kodi addon
To: <developers@kodi.tv>
Cc: <androidsupport@kodi.tv>

Hello,
In preparation for the upcoming release of Android O, we've been
rigorously testing popular applications on Google Play, including ”Kodi"
[org.xbmc.kodi].
During testing, we uncovered a bug specific to your application running
on the Android O Developer Preview. Here are the details:

Step(s) to Reproduce:

    Install “Kodi” application from Play store

    Launch the application

    Tap Add-Ons from the menu

Expected Result(s):

    App should not crash when tapping Add-Ons

Observed Result(s):

    App crashes when tapping Add-Ons

Possible Root Cause(s):

    It looks like Kodi is fetching an icon from PackageManager and
calling this method: icon.getBitmap(). This used to work in N and below
because all Icons were png, in which they could be cast to
BitmapDrawable. However, starting in the next OS, there is no guarantee
icon drawable objects can automatically convert to BitmapDrawable.
There is also no guarantee that all of BitmapDrawable's methods (such as
getBitmap) will be readily available.

Log:

java_vm_ext.cc:504] JNI DETECTED ERROR IN APPLICATION: mid == null
Revision: '0'
ABI: 'arm64'
pid: 9423, tid: 9469, name: Thread-5  >>> org.xbmc.kodi <<<
signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
Abort message: 'java_vm_ext.cc:504] JNI DETECTED ERROR IN APPLICATION:
mid == null'
    x0   0000000000000000  x1   00000000000024fd  x2   0000000000000006
x3   0000000000000008
    x4   0000000000000114  x5   00000000000000ff  x6   0000000000000000
x7   0080808080808080
    x8   0000000000000083  x9   6cd9bf0d77661d2f  x10  0000000000000001
x11  0000000000000001
    x12  ffffffffffffffff  x13  0000000000000008  x14  ffffffffffffffff
x15  0030fcf94d051582
    x16  00000073abd6d300  x17  00000073abd0f3fc  x18  0000000000000020
x19  00000000000024cf
    x20  00000000000024fd  x21  0000007388714700  x22  0000000000000002
x23  00000000000000c1
    x24  00000000000009b7  x25  000000738c527600  x26  00000000000009b6
x27  00000073883fea20
    x28  0000000000000059  x29  00000073883fe8c0  x30  00000073abcc390c
    sp   00000073883fe880  pc   00000073abd0f404  pstate
0000000000000000
backtrace:
    #00 pc 0000000000069404  /system/lib64/libc.so (tgkill+8)
    #01 pc 000000000001d908  /system/lib64/libc.so (abort+80)
    #02 pc 00000000004325bc  /system/lib64/libart.so
(_ZN3art7Runtime5AbortEPKc+528)
    #03 pc 0000000000432ccc  /system/lib64/libart.so
(_ZN3art7Runtime7AborterEPKc+24)
    #04 pc 000000000051c578  /system/lib64/libart.so
(_ZN7android4base10LogMessageD1Ev+1016)
    #05 pc 00000000002d0920  /system/lib64/libart.so
(_ZN3art9JavaVMExt8JniAbortEPKcS2_+1716)
    #06 pc 00000000002d0bec  /system/lib64/libart.so
(_ZN3art9JavaVMExt9JniAbortFEPKcS2_z+176)
    #07 pc 000000000031482c  /system/lib64/libart.so
(_ZN3art3JNI17CallObjectMethodVEP7_JNIEnvP8_jobjectP10_jmethodIDSt9__va_list+1440)
    #08 pc 00000000013b8920  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so
(_ZN3jni7details20call_jhobject_methodEP7_JNIEnvP8_jobjectP10_jmethodIDz+148)
    #09 pc 000000000139f7a4  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so
(_ZN18CJNIBitmapDrawable9getBitmapEv+148)
    #10 pc 000000000130b8ac  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so
(_ZN5XFILE15CFileAndroidApp8ReadIconEPPhPjS3_+1008)
    #11 pc 0000000000cb33fc  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so
(_ZN12CBaseTexture12LoadFromFileERKSsjjbS1_+232)
    #12 pc 0000000000e8d6b0  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so (_ZN12CImageLoader6DoWorkEv+524)
    #13 pc 0000000000ad8ab8  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so (_ZN10CJobWorker7ProcessEv+68)
    #14 pc 0000000000b69184  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so (_ZN7CThread6ActionEv+44)
    #15 pc 0000000000b69418  /data/app/org.xbmc.kodi-TYKIN-
5zBb80hcqOZMy_tw==/lib/arm64/libkodi.so
(_ZN7CThread12staticThreadEPv+148)
    #16 pc 0000000000065db4  /system/lib64/libc.so
(_ZL15__pthread_startPv+36)
    #17 pc 000000000001ec9c  /system/lib64/libc.so (__start_thread+68)

We wanted to let you know so you could take a look and address the
issue.

Please do not reply to this message. If you discover an issue with the
platform running Android O Dev Preview, please file a bug in our issue
tracker.

Thanks!

Android Support Team
