### PR TITLE
[fix] make optional dyload deps optional again

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -412,6 +412,7 @@ endfunction()
 #   dependency optionally added to ${SYSTEM_INCLUDES}, ${DEP_DEFINES}, ${dep}_SONAME is set up
 function(core_optional_dyload_dep)
   foreach(dep ${ARGN})
+    set(_required False)
     setup_enable_switch()
     if(${enable_switch} STREQUAL AUTO)
       find_package(${dep})


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
See https://github.com/xbmc/xbmc/pull/12134#issuecomment-304520437

## Description
Fix disable optional dependencies at configure time.

## Motivation and Context
See https://github.com/xbmc/xbmc/pull/12134#issuecomment-304520437

## How Has This Been Tested?
Build tested

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
