### PR TITLE
Expand tempo range to 0.5x-5.0x

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -142,7 +142,7 @@ static int PlayerControl(const std::vector<std::string>& params)
     if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
     {
       float playSpeed = g_application.m_pPlayer->GetPlaySpeed();
-      if (playSpeed >= 0.75 && playSpeed <= 1.55)
+      if (playSpeed >= 0.45 && playSpeed <= 1.55)
         playSpeed = 1;
 
       if (paramlow == "rewind" && playSpeed == 1) // Enables Rewinding
@@ -170,11 +170,11 @@ static int PlayerControl(const std::vector<std::string>& params)
         g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
     {
       float playSpeed = g_application.m_pPlayer->GetPlaySpeed();
-      if (playSpeed >= 0.75 && playSpeed <= 1.55)
+      if (playSpeed >= 0.45 && playSpeed <= 5.05)
       {
-        if (paramlow == "tempodown" && playSpeed > 0.85)
+        if (paramlow == "tempodown" && playSpeed > 0.55)
           playSpeed -= 0.1;
-        else if (paramlow == "tempoup" && playSpeed < 1.45)
+        else if (paramlow == "tempoup" && playSpeed < 4.95)
           playSpeed += 0.1;
 
         playSpeed = floor(playSpeed * 100 + 0.5) / 100;


### PR DESCRIPTION
## Description
This expands the range of tempo settings available via tempoup /
tempodown commands from 0.75x-1.5x to 0.5x-5.0x.

There is a minor chance that this will interact with fast forward
behavior, but that seems unlikely to be problematic: if the user
modifies the tempo at 2x or 4x fast forward, the new tempo setting
will take effect, and will be used as the base when multiplied
or divided by 2 if the user then presses "rewind" or "forward".

When the value exceeds 32x or gets down below 1.55x, the "rewind"
and "forward" commands will treat it as 1, escaping any odd
behavior. If necessary, we can clamp values in "rewind" and
"forward" to the nearest power of 2, but that seems like overkill
in this situation.

## Motivation and Context
I frequently watch content at speeds in excess of the existing 1.5x limit (2.0x-2.5x typically, occasionally higher). Merging this change allows me to do so in Kodi. I chose 5x as an arbitrary upper bound that seems excessive. I decreased the tempo minimum as well, in case other users would prefer to view media even slower.

## How Has This Been Tested?
It hasn't. I was unable to find any relevant tests, although I am extremely new to this codebase.

## Screenshots (if appropriate):
N/A

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
