### PR TITLE
[addons] add first step of gui on addon interface

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -154,6 +154,7 @@ install(FILES ${CMAKE_SOURCE_DIR}/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPac
               ${CMAKE_SOURCE_DIR}/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxCrypto.h
               ${CMAKE_SOURCE_DIR}/xbmc/cores/AudioEngine/Utils/AEChannelData.h
               ${CMAKE_SOURCE_DIR}/xbmc/filesystem/IFileTypes.h
+              ${CMAKE_SOURCE_DIR}/xbmc/input/ActionIDs.h
               ${CMAKE_SOURCE_DIR}/xbmc/input/XBMC_vkeys.h
         DESTINATION ${includedir}/${APP_NAME_LC}
         COMPONENT kodi-addon-dev)

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -41,6 +41,7 @@
 #include "addons/interfaces/Filesystem.h"
 #include "addons/interfaces/General.h"
 #include "addons/interfaces/Network.h"
+#include "addons/interfaces/GUI/General.h"
 
 namespace ADDON
 {
@@ -570,12 +571,14 @@ bool CAddonDll::InitInterface(KODI_HANDLE firstKodiInstance)
   Interface_AudioEngine::Init(&m_interface);
   Interface_Filesystem::Init(&m_interface);
   Interface_Network::Init(&m_interface);
+  Interface_GUIGeneral::Init(&m_interface);
 
   return true;
 }
 
 void CAddonDll::DeInitInterface()
 {
+  Interface_GUIGeneral::DeInit(&m_interface);
   Interface_Network::DeInit(&m_interface);
   Interface_Filesystem::DeInit(&m_interface);
   Interface_AudioEngine::DeInit(&m_interface);

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -8,4 +8,5 @@ xbmc/cores/AudioEngine/Utils/AEChannelData.h
 xbmc/cores/VideoPlayer/DVDDemuxers/DemuxCrypto.h
 xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
 xbmc/filesystem/IFileTypes.h
+xbmc/input/ActionIDs.h
 xbmc/input/XBMC_vkeys.h

--- a/xbmc/addons/interfaces/GUI/CMakeLists.txt
+++ b/xbmc/addons/interfaces/GUI/CMakeLists.txt
@@ -1,8 +1,30 @@
-set(SOURCES AddonCallbacksGUI.cpp
+set(SOURCES General.cpp
+            DialogContextMenu.cpp
+            DialogExtendedProgressBar.cpp
+            DialogFileBrowser.cpp
+            DialogKeyboard.cpp
+            DialogNumeric.cpp
+            DialogOK.cpp
+            DialogProgress.cpp
+            DialogSelect.cpp
+            DialogTextViewer.cpp
+            DialogYesNo.cpp
+            AddonCallbacksGUI.cpp
             AddonGUIRenderingControl.cpp
             AddonGUIWindow.cpp)
 
-set(HEADERS AddonCallbacksGUI.h
+set(HEADERS General.h
+            DialogContextMenu.h
+            DialogExtendedProgressBar.h
+            DialogFileBrowser.h
+            DialogKeyboard.h
+            DialogNumeric.h
+            DialogOK.h
+            DialogProgress.h
+            DialogSelect.h
+            DialogTextViewer.h
+            DialogYesNo.h
+            AddonCallbacksGUI.h
             AddonGUIRenderingControl.h
             AddonGUIWindow.h)
 

--- a/xbmc/addons/interfaces/GUI/DialogContextMenu.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogContextMenu.cpp
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogContextMenu.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogContextMenu.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogContextMenu.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogContextMenu::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogContextMenu = static_cast<AddonToKodiFuncTable_kodi_gui_dialogContextMenu*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogContextMenu)));
+
+  addonInterface->toKodi->kodi_gui->dialogContextMenu->open = open;
+}
+
+void Interface_GUIDialogContextMenu::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogContextMenu);
+}
+
+int Interface_GUIDialogContextMenu::open(void* kodiBase, const char *heading, const char *entries[], unsigned int size)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogContextMenu::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  CGUIDialogContextMenu* dialog = g_windowManager.GetWindow<CGUIDialogContextMenu>(WINDOW_DIALOG_CONTEXT_MENU);
+  if (!heading || !entries || !dialog)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogContextMenu::%s - invalid handler data (heading='%p', entries='%p', dialog='%p') on addon '%s'",
+                          __FUNCTION__, heading, entries, dialog, addon->ID().c_str());
+    return -1;
+  }
+
+  CContextButtons choices;
+  for (unsigned int i = 0; i < size; ++i)
+    choices.Add(i, entries[i]);
+
+  return dialog->Show(choices);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogContextMenu.h
+++ b/xbmc/addons/interfaces/GUI/DialogContextMenu.h
@@ -1,0 +1,59 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogContextMenu.h"
+   */
+  struct Interface_GUIDialogContextMenu
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static int open(void* kodiBase, const char *heading, const char *entries[], unsigned int size);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogExtendedProgressBar.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogExtendedProgressBar.cpp
@@ -1,0 +1,258 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogExtendedProgressBar.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogExtendedProgress.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogExtendedProgressBar.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogExtendedProgress::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress = static_cast<AddonToKodiFuncTable_kodi_gui_dialogExtendedProgress*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogExtendedProgress)));
+
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->new_dialog  = new_dialog;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->delete_dialog = delete_dialog;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->get_title = get_title;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->set_title = set_title;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->get_text = get_text;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->set_text = set_text;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->is_finished = is_finished;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->mark_finished = mark_finished;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->get_percentage = get_percentage;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->set_percentage = set_percentage;
+  addonInterface->toKodi->kodi_gui->dialogExtendedProgress->set_progress = set_progress;
+}
+
+void Interface_GUIDialogExtendedProgress::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogExtendedProgress);
+}
+
+void* Interface_GUIDialogExtendedProgress::new_dialog(void* kodiBase, const char *title)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return nullptr;
+  }
+
+  // setup the progress dialog
+  CGUIDialogExtendedProgressBar* dialog = g_windowManager.GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
+  if (!title || !dialog)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid handler data (title='%p', dialog='%p') on addon '%s'", __FUNCTION__, title, dialog, addon->ID().c_str());
+    return nullptr;
+  }
+
+  CGUIDialogProgressBarHandle* dlgProgressHandle = dialog->GetHandle(title);
+  return dlgProgressHandle;
+}
+
+void Interface_GUIDialogExtendedProgress::delete_dialog(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgressBarHandle*>(handle)->MarkFinished();
+}
+
+char* Interface_GUIDialogExtendedProgress::get_title(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return nullptr;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return nullptr;
+  }
+
+  return strdup(static_cast<CGUIDialogProgressBarHandle*>(handle)->Title().c_str());
+}
+
+void Interface_GUIDialogExtendedProgress::set_title(void* kodiBase, void* handle, const char *title)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle || !title)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid handler data (handle='%p', title='%p') on addon '%s'", __FUNCTION__, handle, title, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgressBarHandle*>(handle)->SetTitle(title);
+}
+
+char* Interface_GUIDialogExtendedProgress::get_text(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return nullptr;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid add-on data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return nullptr;
+  }
+
+  return strdup(static_cast<CGUIDialogProgressBarHandle*>(handle)->Text().c_str());
+}
+
+void Interface_GUIDialogExtendedProgress::set_text(void* kodiBase, void* handle, const char *text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid handler data (handle='%p', text='%p') on addon '%s'", __FUNCTION__, handle, text, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgressBarHandle*>(handle)->SetText(text);
+}
+
+bool Interface_GUIDialogExtendedProgress::is_finished(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return false;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid add-on data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return false;
+  }
+
+  return static_cast<CGUIDialogProgressBarHandle*>(handle)->IsFinished();
+}
+
+void Interface_GUIDialogExtendedProgress::mark_finished(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid add-on data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgressBarHandle*>(handle)->MarkFinished();
+}
+
+float Interface_GUIDialogExtendedProgress::get_percentage(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return 0.0f;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid add-on data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return 0.0f;
+  }
+
+  return static_cast<CGUIDialogProgressBarHandle*>(handle)->Percentage();
+}
+
+void Interface_GUIDialogExtendedProgress::set_percentage(void* kodiBase, void* handle, float percentage)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid add-on data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgressBarHandle*>(handle)->SetPercentage(percentage);
+}
+
+void Interface_GUIDialogExtendedProgress::set_progress(void* kodiBase, void* handle, int currentItem, int itemCount)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid kodi base data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogExtendedProgress::%s - invalid add-on data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgressBarHandle*>(handle)->SetProgress(currentItem, itemCount);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogExtendedProgressBar.h
+++ b/xbmc/addons/interfaces/GUI/DialogExtendedProgressBar.h
@@ -1,0 +1,69 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogExtendedProgress.h"
+   */
+  struct Interface_GUIDialogExtendedProgress
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void* new_dialog(void* kodiBase, const char* title);
+    static void delete_dialog(void* kodiBase, void* handle);
+    static char* get_title(void* kodiBase, void* handle);
+    static void set_title(void* kodiBase, void* handle, const char* title);
+    static char* get_text(void* kodiBase, void* handle);
+    static void set_text(void* kodiBase, void* handle, const char* text);
+    static bool is_finished(void* kodiBase, void* handle);
+    static void mark_finished(void* kodiBase, void* handle);
+    static float get_percentage(void* kodiBase, void* handle);
+    static void set_percentage(void* kodiBase, void* handle, float percentage);
+    static void set_progress(void* kodiBase, void* handle, int currentItem, int itemCount);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogFileBrowser.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogFileBrowser.cpp
@@ -1,0 +1,342 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogFileBrowser.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogFileBrowser.h"
+
+#include "URL.h"
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogFileBrowser.h"
+#include "settings/MediaSourceSettings.h"
+#include "storage/MediaManager.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogFileBrowser::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser = static_cast<AddonToKodiFuncTable_kodi_gui_dialogFileBrowser*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogFileBrowser)));
+
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_directory = show_and_get_directory;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_file = show_and_get_file;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_file_from_dir = show_and_get_file_from_dir;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_file_list = show_and_get_file_list;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_source = show_and_get_source;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_image = show_and_get_image;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_image_list = show_and_get_image_list;
+  addonInterface->toKodi->kodi_gui->dialogFileBrowser->clear_file_list = clear_file_list;
+}
+
+void Interface_GUIDialogFileBrowser::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogFileBrowser);
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_directory(void* kodiBase, const char* shares, const char* heading,
+                                                            const char* path_in, char** path_out, bool write_only)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!shares || !heading || !path_in || !path_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (shares='%p', heading='%p', path_in='%p', path_out='%p') on addon '%s'",
+                          __FUNCTION__, shares, heading, path_in, path_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string strPath = path_in;
+
+  VECSOURCES vecShares;
+  GetVECShares(vecShares, shares, strPath);
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetDirectory(vecShares, heading, strPath, write_only);
+  if (bRet)
+    *path_out = strdup(strPath.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_file(void* kodiBase, const char* shares, const char* mask, const char* heading,
+                                                       const char* path_in, char** path_out, bool use_thumbs, bool use_file_directories)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!shares || !mask || !heading || !path_in || !path_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (shares='%p', mask='%p', heading='%p', path_in='%p', path_out='%p') on addon '%s'",
+                          __FUNCTION__, shares, mask, heading, path_in, path_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string strPath = path_in;
+
+  VECSOURCES vecShares;
+  GetVECShares(vecShares, shares, strPath);
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetFile(vecShares, mask, heading, strPath, use_thumbs, use_file_directories);
+  if (bRet)
+    *path_out = strdup(strPath.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_file_from_dir(void* kodiBase, const char* directory, const char* mask,
+                                                                const char* heading, const char* path_in, char** path_out,
+                                                                bool use_thumbs, bool use_file_directories, bool single_list)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!directory || !mask || !heading || !path_in || !path_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (directory='%p', mask='%p', heading='%p', path_in='%p', path_out='%p') on addon '%s'",
+                          __FUNCTION__, directory, mask, heading, path_in, path_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string strPath = path_in;
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetFile(directory, mask, heading, strPath, use_thumbs, use_file_directories, single_list);
+  if (bRet)
+    *path_out = strdup(strPath.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_file_list(void* kodiBase, const char* shares, const char* mask,
+                                                            const char* heading, char*** file_list, unsigned int* entries,
+                                                            bool use_thumbs, bool use_file_directories)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!shares || !mask || !heading || !file_list || !entries)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (shares='%p', mask='%p', heading='%p', file_list='%p', entries='%p') on addon '%s'",
+                          __FUNCTION__, shares, mask, heading, file_list, entries, addon->ID().c_str());
+    return false;
+  }
+
+  VECSOURCES vecShares;
+  GetVECShares(vecShares, shares, "");
+
+  std::vector<std::string> pathsInt;
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetFileList(vecShares, mask, heading, pathsInt, use_thumbs, use_file_directories);
+  if (bRet)
+  {
+    *entries = pathsInt.size();
+    *file_list = static_cast<char**>(malloc(*entries*sizeof(char*)));
+    for (unsigned int i = 0; i < *entries; ++i)
+      (*file_list)[i] = strdup(pathsInt[i].c_str());
+  }
+  else
+    *entries = 0;
+  return bRet;
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_source(void* kodiBase, const char* path_in, char** path_out,
+                                                         bool allowNetworkShares, const char* additionalShare,
+                                                         const char* strType)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!strType || !additionalShare || !path_in || !path_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (additionalShare='%p', strType='%p', path_in='%p', path_out='%p') on addon '%s'",
+                          __FUNCTION__, additionalShare, strType, path_in, path_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string strPath = path_in;
+
+  VECSOURCES vecShares;
+  if (additionalShare)
+    GetVECShares(vecShares, additionalShare, strPath);
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetSource(strPath, allowNetworkShares, &vecShares, strType);
+  if (bRet)
+    *path_out = strdup(strPath.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_image(void* kodiBase, const char* shares, const char* heading,
+                                                        const char* path_in, char** path_out)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!shares || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (shares='%p', heading='%p') on addon '%s'", __FUNCTION__, shares, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string strPath = path_in;
+
+  VECSOURCES vecShares;
+  GetVECShares(vecShares, shares, strPath);
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetImage(vecShares, heading, strPath);
+  if (bRet)
+    *path_out = strdup(strPath.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogFileBrowser::show_and_get_image_list(void* kodiBase, const char* shares, const char* heading, char*** file_list, unsigned int* entries)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!shares || !heading || !file_list || !entries)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (shares='%p', heading='%p', file_list='%p', entries='%p') on addon '%s'",
+                          __FUNCTION__, shares, heading, file_list, entries, addon->ID().c_str());
+    return false;
+  }
+
+  VECSOURCES vecShares;
+  GetVECShares(vecShares, shares, "");
+
+  std::vector<std::string> pathsInt;
+  bool bRet = CGUIDialogFileBrowser::ShowAndGetImageList(vecShares, heading, pathsInt);
+  if (bRet)
+  {
+    *entries = pathsInt.size();
+    *file_list = static_cast<char**>(malloc(*entries*sizeof(char*)));
+    for (unsigned int i = 0; i < *entries; ++i)
+      (*file_list)[i] = strdup(pathsInt[i].c_str());
+  }
+  else
+    *entries = 0;
+  return bRet;
+}
+
+void Interface_GUIDialogFileBrowser::clear_file_list(void* kodiBase, char*** file_list, unsigned int entries)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (*file_list)
+  {
+    for (unsigned int i = 0; i < entries; ++i)
+      free((*file_list)[i]);
+    free(*file_list);
+    *file_list = nullptr;
+  }
+  else
+    CLog::Log(LOGERROR, "Interface_GUIDialogFileBrowser::%s - invalid handler data (file_list='%p') on addon '%s'", __FUNCTION__, file_list, addon->ID().c_str());
+}
+
+void Interface_GUIDialogFileBrowser::GetVECShares(VECSOURCES& vecShares, const std::string& strShares, const std::string& strPath)
+{
+  std::size_t found;
+  found = strShares.find("local");
+  if (found!=std::string::npos)
+    g_mediaManager.GetLocalDrives(vecShares);
+  found = strShares.find("network");
+  if (found!=std::string::npos)
+    g_mediaManager.GetNetworkLocations(vecShares);
+  found = strShares.find("removable");
+  if (found!=std::string::npos)
+    g_mediaManager.GetRemovableDrives(vecShares);
+  found = strShares.find("programs");
+  if (found!=std::string::npos)
+  {
+    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("programs");
+    if (sources != nullptr)
+      vecShares.insert(vecShares.end(), sources->begin(), sources->end());
+  }
+  found = strShares.find("files");
+  if (found!=std::string::npos)
+  {
+    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("files");
+    if (sources != nullptr)
+      vecShares.insert(vecShares.end(), sources->begin(), sources->end());
+  }
+  found = strShares.find("music");
+  if (found!=std::string::npos)
+  {
+    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("music");
+    if (sources != nullptr)
+      vecShares.insert(vecShares.end(), sources->begin(), sources->end());
+  }
+  found = strShares.find("video");
+  if (found!=std::string::npos)
+  {
+    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("video");
+    if (sources != nullptr)
+      vecShares.insert(vecShares.end(), sources->begin(), sources->end());
+  }
+  found = strShares.find("pictures");
+  if (found!=std::string::npos)
+  {
+    VECSOURCES* sources = CMediaSourceSettings::GetInstance().GetSources("pictures");
+    if (sources != nullptr)
+      vecShares.insert(vecShares.end(), sources->begin(), sources->end());
+  }
+
+  if (vecShares.empty())
+  {
+    CMediaSource share;
+    std::string basePath = strPath;
+    std::string tempPath;
+    while (URIUtils::GetParentPath(basePath, tempPath))
+      basePath = tempPath;
+    share.strPath = basePath;
+    // don't include the user details in the share name
+    CURL url(share.strPath);
+    share.strName = url.GetWithoutUserDetails();
+    vecShares.push_back(share);
+  }
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogFileBrowser.h
+++ b/xbmc/addons/interfaces/GUI/DialogFileBrowser.h
@@ -1,0 +1,100 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <vector>
+
+class CMediaSource;
+
+typedef std::vector<CMediaSource> VECSOURCES;
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+  
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogFileBrowser.h"
+   */
+  struct Interface_GUIDialogFileBrowser
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static bool show_and_get_directory(void* kodiBase, const char* shares, 
+                                       const char* heading, const char* path_in,
+                                       char** path_out, bool write_only);
+
+    static bool show_and_get_file(void* kodiBase, const char* shares,
+                                  const char* mask, const char* heading,
+                                  const char* path_in, char** path_out,
+                                  bool use_thumbs, bool use_file_directories);
+
+    static bool show_and_get_file_from_dir(void* kodiBase, const char* directory,
+                                           const char* mask, const char* heading,
+                                           const char* path_in, char** path_out,
+                                           bool use_thumbs, bool use_file_directories,
+                                           bool singleList);
+
+    static bool show_and_get_file_list(void* kodiBase, const char* shares, 
+                                       const char* mask, const char* heading, 
+                                       char*** file_list, unsigned int* entries, 
+                                       bool use_thumbs, bool use_file_directories);
+
+    static bool show_and_get_source(void* kodiBase, const char* path_in, char** path_out,
+                                    bool allow_network_shares, const char* additional_share, 
+                                    const char* type);
+
+    static bool show_and_get_image(void* kodiBase, const char* shares, const char* heading,
+                                   const char* path_in, char** path_out);
+
+    static bool show_and_get_image_list(void* kodiBase, const char* shares,
+                                        const char* heading, char*** file_list,
+                                        unsigned int* entries);
+
+    static void clear_file_list(void* kodiBase, char*** file_list, unsigned int entries);
+    //@}
+
+  private:
+    static void GetVECShares(VECSOURCES& vecShares, const std::string& strShares, const std::string& strPath);
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogKeyboard.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogKeyboard.cpp
@@ -1,0 +1,269 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogKeyboard.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogKeyboard.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIKeyboardFactory.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+
+namespace ADDON
+{
+extern "C"
+{
+
+void Interface_GUIDialogKeyboard::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogKeyboard = static_cast<AddonToKodiFuncTable_kodi_gui_dialogKeyboard*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogKeyboard)));
+
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_get_input_with_head = show_and_get_input_with_head;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_get_input = show_and_get_input;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_get_new_password_with_head = show_and_get_new_password_with_head;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_get_new_password = show_and_get_new_password;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_verify_new_password_with_head = show_and_verify_new_password_with_head;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_verify_new_password = show_and_verify_new_password;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_verify_password = show_and_verify_password;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->show_and_get_filter = show_and_get_filter;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->send_text_to_active_keyboard = send_text_to_active_keyboard;
+  addonInterface->toKodi->kodi_gui->dialogKeyboard->is_keyboard_activated = is_keyboard_activated;
+}
+
+void Interface_GUIDialogKeyboard::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogKeyboard);
+}
+
+bool Interface_GUIDialogKeyboard::show_and_get_input_with_head(void* kodiBase, const char* text_in, char** text_out,
+                                                               const char* heading, bool allow_empty_result,
+                                                               bool hidden_input, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!text_in || !text_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (text_in='%p', text_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, text_in, text_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = text_in;
+  bool bRet = CGUIKeyboardFactory::ShowAndGetInput(str, CVariant{heading}, allow_empty_result, hidden_input, auto_close_ms);
+  if (bRet)
+    *text_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogKeyboard::show_and_get_input(void* kodiBase, const char* text_in, char** text_out, bool allow_empty_result, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!text_in || !text_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (text_in='%p', text_out='%p') on addon '%s'",
+                          __FUNCTION__, text_in, text_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = text_in;
+  bool bRet = CGUIKeyboardFactory::ShowAndGetInput(str, allow_empty_result, auto_close_ms);
+  if (bRet)
+    *text_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogKeyboard::show_and_get_new_password_with_head(void* kodiBase, const char* password_in, char** password_out,
+                                                                      const char* heading, bool allow_empty_result, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!password_in || !password_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (password_in='%p', password_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, password_in, password_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = password_in;
+  bool bRet = CGUIKeyboardFactory::ShowAndGetNewPassword(str, heading, allow_empty_result, auto_close_ms);
+  if (bRet)
+    *password_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogKeyboard::show_and_get_new_password(void* kodiBase, const char* password_in, char** password_out, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!password_in || !password_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (password_in='%p', password_out='%p') on addon '%s'",
+                          __FUNCTION__, password_in, password_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = password_in;
+  bool bRet = CGUIKeyboardFactory::ShowAndGetNewPassword(str, auto_close_ms);
+  if (bRet)
+    *password_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogKeyboard::show_and_verify_new_password_with_head(void* kodiBase, char** password_out, const char* heading,
+                                                                         bool allowEmpty, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!password_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (password_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, password_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str;
+  bool bRet = CGUIKeyboardFactory::ShowAndVerifyNewPassword(str, heading, allowEmpty, auto_close_ms);
+  if (bRet)
+    *password_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogKeyboard::show_and_verify_new_password(void* kodiBase, char** password_out, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!password_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (password_out='%p') on addon '%s'",
+                          __FUNCTION__, password_out, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str;
+  bool bRet = CGUIKeyboardFactory::ShowAndVerifyNewPassword(str, auto_close_ms);
+  if (bRet)
+    *password_out = strdup(str.c_str());
+  return bRet;
+}
+
+int Interface_GUIDialogKeyboard::show_and_verify_password(void* kodiBase, const char* password_in, char** password_out, const char* heading, int retries, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!password_in || !password_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (password_in='%p', password_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, password_in, password_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = password_in;
+  int iRet = CGUIKeyboardFactory::ShowAndVerifyPassword(str, heading, retries, auto_close_ms);
+  if (iRet)
+    *password_out = strdup(str.c_str());
+  return iRet;
+}
+
+bool Interface_GUIDialogKeyboard::show_and_get_filter(void* kodiBase, const char* text_in, char** text_out, bool searching, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!text_in || !text_out)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid handler data (text_in='%p', text_out='%p') on addon '%s'",
+                          __FUNCTION__, text_in, text_out, addon->ID().c_str());
+    return false;
+  }
+
+
+  std::string str = text_in;
+  bool bRet = CGUIKeyboardFactory::ShowAndGetFilter(str, searching, auto_close_ms);
+  if (bRet)
+    *text_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogKeyboard::send_text_to_active_keyboard(void* kodiBase, const char* text, bool close_keyboard)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  return CGUIKeyboardFactory::SendTextToActiveKeyboard(text, close_keyboard);
+}
+
+bool Interface_GUIDialogKeyboard::is_keyboard_activated(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogKeyboard::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  return CGUIKeyboardFactory::isKeyboardActivated();
+}
+
+} /* extern "C" */
+} /* namespace ADDON */

--- a/xbmc/addons/interfaces/GUI/DialogKeyboard.h
+++ b/xbmc/addons/interfaces/GUI/DialogKeyboard.h
@@ -1,0 +1,68 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogKeyboard.h"
+   */
+  struct Interface_GUIDialogKeyboard
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static bool show_and_get_input_with_head(void* kodiBase, const char* text_in, char** text_out, const char* heading, bool allow_empty_result, bool hidden_input, unsigned int auto_close_ms);
+    static bool show_and_get_input(void* kodiBase, const char* text_in, char** text_out, bool allow_empty_result, unsigned int auto_close_ms);
+    static bool show_and_get_new_password_with_head(void* kodiBase, const char* password_in, char** password_out, const char* heading, bool allow_empty_result, unsigned int auto_close_ms);
+    static bool show_and_get_new_password(void* kodiBase, const char* password_in, char** password_out, unsigned int auto_close_ms);
+    static bool show_and_verify_new_password_with_head(void* kodiBase, char** password_out, const char* heading, bool allowEmpty, unsigned int auto_close_ms);
+    static bool show_and_verify_new_password(void* kodiBase, char** password_out, unsigned int auto_close_ms);
+    static int show_and_verify_password(void* kodiBase, const char* password_in, char** password_out, const char* heading, int retries, unsigned int auto_close_ms);
+    static bool show_and_get_filter(void* kodiBase, const char* text_in, char** text_out, bool searching, unsigned int auto_close_ms);
+    static bool send_text_to_active_keyboard(void* kodiBase, const char* text, bool close_keyboard);
+    static bool is_keyboard_activated(void* kodiBase);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogNumeric.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogNumeric.cpp
@@ -1,0 +1,238 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogNumeric.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogNumeric.h"
+
+#include "XBDateTime.h"
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogNumeric.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogNumeric::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogNumeric = static_cast<AddonToKodiFuncTable_kodi_gui_dialogNumeric*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogNumeric)));
+
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_verify_new_password = show_and_verify_new_password;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_verify_password = show_and_verify_password;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_verify_input = show_and_verify_input;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_get_time = show_and_get_time;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_get_date = show_and_get_date;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_get_ip_address = show_and_get_ip_address;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_get_number = show_and_get_number;
+  addonInterface->toKodi->kodi_gui->dialogNumeric->show_and_get_seconds = show_and_get_seconds;
+}
+
+void Interface_GUIDialogNumeric::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogNumeric);
+}
+
+bool Interface_GUIDialogNumeric::show_and_verify_new_password(void* kodiBase, char** password)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  std::string str;
+  bool bRet = CGUIDialogNumeric::ShowAndVerifyNewPassword(str);
+  if (bRet)
+    *password = strdup(str.c_str());
+  return bRet;
+}
+
+int Interface_GUIDialogNumeric::show_and_verify_password(void* kodiBase, const char* password, const char* heading, int retries)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  if (!password || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (password='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, password, heading, addon->ID().c_str());
+    return -1;
+  }
+
+  std::string pw(password);
+  return CGUIDialogNumeric::ShowAndVerifyPassword(pw, heading, retries);
+}
+
+bool Interface_GUIDialogNumeric::show_and_verify_input(void* kodiBase, const char* verify_in, char** verify_out, const char* heading, bool verify_input)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!verify_in || !verify_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (verify_in='%p', verify_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, verify_in, verify_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = verify_in;
+  bool bRet = CGUIDialogNumeric::ShowAndVerifyInput(str, heading, verify_input);
+  if (bRet)
+    *verify_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogNumeric::show_and_get_time(void* kodiBase, tm* time, const char* heading)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!time || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (time='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, time, heading, addon->ID().c_str());
+    return false;
+  }
+
+  SYSTEMTIME systemTime;
+  CDateTime dateTime(*time);
+  dateTime.GetAsSystemTime(systemTime);
+  if (CGUIDialogNumeric::ShowAndGetTime(systemTime, heading))
+  {
+    dateTime = systemTime;
+    dateTime.GetAsTm(*time);
+    return true;
+  }
+  return false;
+}
+
+bool Interface_GUIDialogNumeric::show_and_get_date(void* kodiBase, tm *date, const char *heading)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!date || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (date='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, date, heading, addon->ID().c_str());
+    return false;
+  }
+
+  SYSTEMTIME systemTime;
+  CDateTime dateTime(*date);
+  dateTime.GetAsSystemTime(systemTime);
+  if (CGUIDialogNumeric::ShowAndGetDate(systemTime, heading))
+  {
+    dateTime = systemTime;
+    dateTime.GetAsTm(*date);
+    return true;
+  }
+  return false;
+}
+
+bool Interface_GUIDialogNumeric::show_and_get_ip_address(void* kodiBase, const char* ip_address_in, char** ip_address_out, const char *heading)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!ip_address_in || !ip_address_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (ip_address_in='%p', ip_address_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, ip_address_in, ip_address_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string strIP = ip_address_in;
+  bool bRet = CGUIDialogNumeric::ShowAndGetIPAddress(strIP, heading);
+  if (bRet)
+    *ip_address_out = strdup(strIP.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogNumeric::show_and_get_number(void* kodiBase, const char* number_in, char** number_out, const char *heading, unsigned int auto_close_ms)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!number_in || !number_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (number_in='%p', number_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, number_in, number_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = number_in;
+  bool bRet = CGUIDialogNumeric::ShowAndGetNumber(str, heading, auto_close_ms);
+  if (bRet)
+    *number_out = strdup(str.c_str());
+  return bRet;
+}
+
+bool Interface_GUIDialogNumeric::show_and_get_seconds(void* kodiBase, const char* time_in, char** time_out, const char *heading)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!time_in || !time_out || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogNumeric::%s - invalid handler data (time_in='%p', time_out='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, time_in, time_out, heading, addon->ID().c_str());
+    return false;
+  }
+
+  std::string str = time_in;
+  bool bRet = CGUIDialogNumeric::ShowAndGetSeconds(str, heading);
+  if (bRet)
+    *time_out = strdup(str.c_str());
+  return bRet;
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogNumeric.h
+++ b/xbmc/addons/interfaces/GUI/DialogNumeric.h
@@ -1,0 +1,68 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <time.h>
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogNumeric.h"
+   */
+  struct Interface_GUIDialogNumeric
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static bool show_and_verify_new_password(void* kodiBase, char** password);
+    static int show_and_verify_password(void* kodiBase, const char* password, const char *heading, int retries);
+    static bool show_and_verify_input(void* kodiBase, const char* verify_in, char** verify_out, const char* heading, bool verify_input);
+    static bool show_and_get_time(void* kodiBase, tm *time, const char *heading);
+    static bool show_and_get_date(void* kodiBase, tm *date, const char *heading);
+    static bool show_and_get_ip_address(void* kodiBase, const char* ip_address_in, char** ip_address_out, const char *heading);
+    static bool show_and_get_number(void* kodiBase, const char* number_in, char** number_out, const char *heading, unsigned int auto_close_ms);
+    static bool show_and_get_seconds(void* kodiBase, const char* time_in, char** time_out, const char *heading);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogOK.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogOK.cpp
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogOK.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogOK.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogOK::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogOK = static_cast<AddonToKodiFuncTable_kodi_gui_dialogOK*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogOK)));
+
+  addonInterface->toKodi->kodi_gui->dialogOK->show_and_get_input_single_text = show_and_get_input_single_text;
+  addonInterface->toKodi->kodi_gui->dialogOK->show_and_get_input_line_text = show_and_get_input_line_text;
+}
+
+void Interface_GUIDialogOK::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogOK);
+}
+
+void Interface_GUIDialogOK::show_and_get_input_single_text(void* kodiBase, const char *heading, const char *text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon || !heading || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogOK:%s - invalid data (addon='%p', heading='%p', text='%p')",
+                                        __FUNCTION__, addon, heading, text);
+    return;
+  }
+
+  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{text});
+}
+
+void Interface_GUIDialogOK::show_and_get_input_line_text(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon || !heading || !line0 || !line1 || !line2)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogOK::%s - invalid data (addon='%p', heading='%p', line0='%p', line1='%p', line2='%p')",
+                                        __FUNCTION__, addon, heading, line0, line1, line2);
+    return;
+  }
+
+  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogOK.h
+++ b/xbmc/addons/interfaces/GUI/DialogOK.h
@@ -1,0 +1,60 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h"
+   */
+  struct Interface_GUIDialogOK
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note For add of new functions use the "_" style to identify direct a
+     * add-on callback function. Everything with CamelCase is only for the
+     * usage in Kodi only.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void show_and_get_input_single_text(void* kodiBase, const char *heading, const char *text);
+    static void show_and_get_input_line_text(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogProgress.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogProgress.cpp
@@ -1,0 +1,295 @@
+/*
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogProgress.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogProgress.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogProgress.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+
+namespace ADDON
+{
+extern "C"
+{
+
+void Interface_GUIDialogProgress::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogProgress = static_cast<AddonToKodiFuncTable_kodi_gui_dialogProgress*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogProgress)));
+
+  addonInterface->toKodi->kodi_gui->dialogProgress->new_dialog = new_dialog;
+  addonInterface->toKodi->kodi_gui->dialogProgress->delete_dialog = delete_dialog;
+  addonInterface->toKodi->kodi_gui->dialogProgress->open = open;
+  addonInterface->toKodi->kodi_gui->dialogProgress->set_heading = set_heading;
+  addonInterface->toKodi->kodi_gui->dialogProgress->set_line = set_line;
+  addonInterface->toKodi->kodi_gui->dialogProgress->set_can_cancel = set_can_cancel;
+  addonInterface->toKodi->kodi_gui->dialogProgress->is_canceled = is_canceled;
+  addonInterface->toKodi->kodi_gui->dialogProgress->set_percentage = set_percentage;
+  addonInterface->toKodi->kodi_gui->dialogProgress->get_percentage = get_percentage;
+  addonInterface->toKodi->kodi_gui->dialogProgress->show_progress_bar = show_progress_bar;
+  addonInterface->toKodi->kodi_gui->dialogProgress->set_progress_max = set_progress_max;
+  addonInterface->toKodi->kodi_gui->dialogProgress->set_progress_advance = set_progress_advance;
+  addonInterface->toKodi->kodi_gui->dialogProgress->abort = abort;
+}
+
+void Interface_GUIDialogProgress::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogProgress);
+}
+
+void* Interface_GUIDialogProgress::new_dialog(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return nullptr;
+  }
+
+  CGUIDialogProgress *dialog = g_windowManager.GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
+  if (!dialog)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (dialog='%p') on addon '%s'", __FUNCTION__, dialog, addon->ID().c_str());
+    return nullptr;
+  }
+
+  return dialog;
+}
+
+void Interface_GUIDialogProgress::delete_dialog(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->Close();
+}
+
+void Interface_GUIDialogProgress::open(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->Open();
+}
+
+void Interface_GUIDialogProgress::set_heading(void* kodiBase, void* handle, const char* heading)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p', heading='%p') on addon '%s'", __FUNCTION__, handle, heading, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->SetHeading(heading);
+}
+
+void Interface_GUIDialogProgress::set_line(void* kodiBase, void* handle, unsigned int line, const char* text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p', text='%p') on addon '%s'", __FUNCTION__, handle, text, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->SetLine(line, text);
+}
+
+void Interface_GUIDialogProgress::set_can_cancel(void* kodiBase, void* handle, bool canCancel)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->SetCanCancel(canCancel);
+}
+
+bool Interface_GUIDialogProgress::is_canceled(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return false;
+  }
+
+  return static_cast<CGUIDialogProgress*>(handle)->IsCanceled();
+}
+
+void Interface_GUIDialogProgress::set_percentage(void* kodiBase, void* handle, int percentage)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->SetPercentage(percentage);
+}
+
+int Interface_GUIDialogProgress::get_percentage(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return 0;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return 0;
+  }
+
+  return static_cast<CGUIDialogProgress*>(handle)->GetPercentage();
+}
+
+void Interface_GUIDialogProgress::show_progress_bar(void* kodiBase, void* handle, bool onOff)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->ShowProgressBar(onOff);
+}
+
+void Interface_GUIDialogProgress::set_progress_max(void* kodiBase, void* handle, int max)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->SetProgressMax(max);
+}
+
+void Interface_GUIDialogProgress::set_progress_advance(void* kodiBase, void* handle, int nSteps)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return;
+  }
+
+  static_cast<CGUIDialogProgress*>(handle)->SetProgressAdvance(nSteps);
+}
+
+bool Interface_GUIDialogProgress::abort(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogProgress::%s - invalid handler data (handle='%p') on addon '%s'", __FUNCTION__, handle, addon->ID().c_str());
+    return false;
+  }
+
+  return static_cast<CGUIDialogProgress*>(handle)->Abort();
+}
+
+} /* extern "C" */
+} /* namespace ADDON */

--- a/xbmc/addons/interfaces/GUI/DialogProgress.h
+++ b/xbmc/addons/interfaces/GUI/DialogProgress.h
@@ -1,0 +1,71 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogProgress.h"
+   */
+  struct Interface_GUIDialogProgress
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void* new_dialog(void* kodiBase);
+    static void delete_dialog(void* kodiBase, void* handle);
+    static void open(void* kodiBase, void* handle);
+    static void set_heading(void* kodiBase, void* handle, const char* heading);
+    static void set_line(void* kodiBase, void* handle, unsigned int line, const char* text);
+    static void set_can_cancel(void* kodiBase, void* handle, bool canCancel);
+    static bool is_canceled(void* kodiBase, void* handle);
+    static void set_percentage(void* kodiBase, void* handle, int percentage);
+    static int get_percentage(void* kodiBase, void* handle);
+    static void show_progress_bar(void* kodiBase, void* handle, bool bOnOff);
+    static void set_progress_max(void* kodiBase, void* handle, int max);
+    static void set_progress_advance(void* kodiBase, void* handle, int nSteps);
+    static bool abort(void* kodiBase, void* handle);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogSelect.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogSelect.cpp
@@ -1,0 +1,80 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogSelect.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogSelect.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogSelect.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+
+namespace ADDON
+{
+extern "C"
+{
+
+void Interface_GUIDialogSelect::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogSelect = static_cast<AddonToKodiFuncTable_kodi_gui_dialogSelect*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogSelect)));
+
+  addonInterface->toKodi->kodi_gui->dialogSelect->open = open;
+}
+
+void Interface_GUIDialogSelect::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogSelect);
+}
+
+int Interface_GUIDialogSelect::open(void* kodiBase, const char *heading, const char *entries[], unsigned int size, int selected, bool autoclose)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogSelect::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  CGUIDialogSelect* dialog = g_windowManager.GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+  if (!heading || !entries || !dialog)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogSelect::%s - invalid handler data (heading='%p', entries='%p', dialog='%p') on addon '%s'", __FUNCTION__, 
+                            heading, entries, dialog, addon->ID().c_str());
+    return -1;
+  }
+
+  dialog->Reset();
+  dialog->SetHeading(CVariant{heading});
+
+  for (unsigned int i = 0; i < size; ++i)
+    dialog->Add(entries[i]);
+
+  if (selected > 0)
+    dialog->SetSelected(selected);
+  if (autoclose > 0)
+    dialog->SetAutoClose(autoclose);
+
+  dialog->Open();
+  return dialog->GetSelectedItem();
+}
+
+} /* extern "C" */
+} /* namespace ADDON */

--- a/xbmc/addons/interfaces/GUI/DialogSelect.h
+++ b/xbmc/addons/interfaces/GUI/DialogSelect.h
@@ -1,0 +1,59 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogSelect.h"
+   */
+  struct Interface_GUIDialogSelect
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static int open(void* kodiBase, const char *heading, const char *entries[], unsigned int size, int selected, bool autoclose);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogTextViewer.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogTextViewer.cpp
@@ -1,0 +1,69 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogTextViewer.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogTextViewer.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogTextViewer.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogTextViewer::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogTextViewer = static_cast<AddonToKodiFuncTable_kodi_gui_dialogTextViewer*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogTextViewer)));
+
+  addonInterface->toKodi->kodi_gui->dialogTextViewer->open = open;
+}
+
+void Interface_GUIDialogTextViewer::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogTextViewer);
+}
+
+void Interface_GUIDialogTextViewer::open(void* kodiBase, const char *heading, const char *text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogTextViewer::%s - invalid data", __FUNCTION__);
+    return;
+  }
+
+  CGUIDialogTextViewer* dialog = g_windowManager.GetWindow<CGUIDialogTextViewer>(WINDOW_DIALOG_TEXT_VIEWER);
+  if (!heading || !text || !dialog)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogTextViewer::%s - invalid handler data (heading='%p', text='%p', dialog='%p') on addon '%s'", __FUNCTION__,
+                            heading, text, dialog, addon->ID().c_str());
+    return;
+  }
+
+  dialog->SetHeading(heading);
+  dialog->SetText(text);
+  dialog->Open();
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogTextViewer.h
+++ b/xbmc/addons/interfaces/GUI/DialogTextViewer.h
@@ -1,0 +1,59 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogTextViewer.h"
+   */
+  struct Interface_GUIDialogTextViewer
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void open(void* kodiBase, const char *heading, const char *text);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogYesNo.cpp
+++ b/xbmc/addons/interfaces/GUI/DialogYesNo.cpp
@@ -1,0 +1,135 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogYesNo.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogYesNo.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogYesNo.h"
+#include "messaging/helpers/DialogHelper.h"
+#include "utils/log.h"
+
+using namespace KODI::MESSAGING;
+using KODI::MESSAGING::HELPERS::DialogResponse;
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogYesNo::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->dialogYesNo = static_cast<AddonToKodiFuncTable_kodi_gui_dialogYesNo*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_dialogYesNo)));
+
+  addonInterface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_single_text = show_and_get_input_single_text;
+  addonInterface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_line_text = show_and_get_input_line_text;
+  addonInterface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_line_button_text = show_and_get_input_line_button_text;
+}
+
+void Interface_GUIDialogYesNo::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->dialogYesNo);
+}
+
+bool Interface_GUIDialogYesNo::show_and_get_input_single_text(void* kodiBase,
+                                                              const char* heading,
+                                                              const char* text,
+                                                              bool* canceled,
+                                                              const char* noLabel,
+                                                              const char* yesLabel)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!heading || !text || !canceled || !noLabel || !yesLabel)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::%s - invalid handler data (heading='%p', text='%p', "
+                        "canceled='%p', noLabel='%p', yesLabel='%p') on addon '%s'", __FUNCTION__,
+                            heading, text, canceled, noLabel, yesLabel, addon->ID().c_str());
+    return false;
+  }
+
+  DialogResponse result = HELPERS::ShowYesNoDialogText(heading, text, noLabel, yesLabel);
+  *canceled = (result == DialogResponse::CANCELLED);
+  return (result == DialogResponse::YES);
+}
+
+bool Interface_GUIDialogYesNo::show_and_get_input_line_text(void* kodiBase,
+                                                            const char* heading,
+                                                            const char* line0,
+                                                            const char* line1,
+                                                            const char* line2,
+                                                            const char* noLabel,
+                                                            const char* yesLabel)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!heading || !line0 || !line1 || !line2 || !noLabel || !yesLabel)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::%s - invalid handler data (heading='%p', line0='%p', line1='%p', line2='%p', "
+                        "noLabel='%p', yesLabel='%p') on addon '%s'", __FUNCTION__,
+                            heading, line0, line1, line2, noLabel, yesLabel, addon->ID().c_str());
+    return false;
+  }
+
+  return HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel) ==
+    DialogResponse::YES;
+}
+
+bool Interface_GUIDialogYesNo::show_and_get_input_line_button_text(void* kodiBase,
+                                                                   const char* heading,
+                                                                   const char* line0,
+                                                                   const char* line1,
+                                                                   const char* line2,
+                                                                   bool* canceled,
+                                                                   const char* noLabel,
+                                                                   const char* yesLabel)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::%s - invalid data", __FUNCTION__);
+    return false;
+  }
+
+  if (!heading || !line0 || !line1 || !line2 || !canceled || !noLabel || !yesLabel)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIDialogYesNo::%s - invalid handler data (heading='%p', line0='%p', line1='%p', line2='%p', "
+                        "canceled='%p', noLabel='%p', yesLabel='%p') on addon '%s'", __FUNCTION__,
+                            heading, line0, line1, line2, canceled, noLabel, yesLabel, addon->ID().c_str());
+    return false;
+  }
+
+  DialogResponse result = HELPERS::ShowYesNoDialogLines(heading, line0, line1, line2, noLabel, yesLabel);
+  *canceled = (result == DialogResponse::CANCELLED);
+  return (result == DialogResponse::YES);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/DialogYesNo.h
+++ b/xbmc/addons/interfaces/GUI/DialogYesNo.h
@@ -1,0 +1,81 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+  
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogYesNo.h"
+   */
+  struct Interface_GUIDialogYesNo
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static bool show_and_get_input_single_text(void* kodiBase,
+                                               const char* heading,
+                                               const char* text,
+                                               bool* canceled,
+                                               const char* noLabel,
+                                               const char* yesLabel);
+
+    static bool show_and_get_input_line_text(void* kodiBase,
+                                             const char* heading,
+                                             const char* line0,
+                                             const char* line1,
+                                             const char* line2,
+                                             const char* noLabel,
+                                             const char* yesLabel);
+
+    static bool show_and_get_input_line_button_text(void* kodiBase,
+                                                    const char* heading,
+                                                    const char* line0,
+                                                    const char* line1,
+                                                    const char* line2,
+                                                    bool* canceled,
+                                                    const char* noLabel,
+                                                    const char* yesLabel);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/General.cpp
+++ b/xbmc/addons/interfaces/GUI/General.cpp
@@ -1,0 +1,188 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "General.h"
+#include "DialogContextMenu.h"
+#include "DialogExtendedProgressBar.h"
+#include "DialogFileBrowser.h"
+#include "DialogKeyboard.h"
+#include "DialogNumeric.h"
+#include "DialogOK.h"
+#include "DialogProgress.h"
+#include "DialogSelect.h"
+#include "DialogTextViewer.h"
+#include "DialogYesNo.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/General.h"
+
+#include "addons/AddonDll.h"
+#include "input/Key.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+using namespace kodi; // addon-dev-kit namespace
+using namespace kodi::gui; // addon-dev-kit namespace
+
+namespace ADDON
+{
+int Interface_GUIGeneral::m_iAddonGUILockRef = 0;
+};
+
+extern "C"
+{
+
+namespace ADDON
+{
+
+void Interface_GUIGeneral::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui = static_cast<AddonToKodiFuncTable_kodi_gui*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui)));
+
+  Interface_GUIDialogContextMenu::Init(addonInterface);
+  Interface_GUIDialogExtendedProgress::Init(addonInterface);
+  Interface_GUIDialogFileBrowser::Init(addonInterface);
+  Interface_GUIDialogKeyboard::Init(addonInterface);
+  Interface_GUIDialogNumeric::Init(addonInterface);
+  Interface_GUIDialogOK::Init(addonInterface);
+  Interface_GUIDialogProgress::Init(addonInterface);
+  Interface_GUIDialogSelect::Init(addonInterface);
+  Interface_GUIDialogTextViewer::Init(addonInterface);
+  Interface_GUIDialogYesNo::Init(addonInterface);
+
+  addonInterface->toKodi->kodi_gui->general = static_cast<AddonToKodiFuncTable_kodi_gui_general*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_general)));
+
+  addonInterface->toKodi->kodi_gui->general->lock = lock;
+  addonInterface->toKodi->kodi_gui->general->unlock = unlock;
+  addonInterface->toKodi->kodi_gui->general->get_screen_height = get_screen_height;
+  addonInterface->toKodi->kodi_gui->general->get_screen_width = get_screen_width;
+  addonInterface->toKodi->kodi_gui->general->get_video_resolution = get_video_resolution;
+  addonInterface->toKodi->kodi_gui->general->get_current_window_dialog_id = get_current_window_dialog_id;
+  addonInterface->toKodi->kodi_gui->general->get_current_window_id = get_current_window_id;
+}
+
+void Interface_GUIGeneral::DeInit(AddonGlobalInterface* addonInterface)
+{
+  if (addonInterface->toKodi && /* <-- needed as long as the old addon way is used */
+      addonInterface->toKodi->kodi_gui)
+  {
+    Interface_GUIDialogContextMenu::DeInit(addonInterface);
+    Interface_GUIDialogExtendedProgress::DeInit(addonInterface);
+    Interface_GUIDialogFileBrowser::DeInit(addonInterface);
+    Interface_GUIDialogKeyboard::DeInit(addonInterface);
+    Interface_GUIDialogNumeric::DeInit(addonInterface);
+    Interface_GUIDialogOK::DeInit(addonInterface);
+    Interface_GUIDialogProgress::DeInit(addonInterface);
+    Interface_GUIDialogSelect::DeInit(addonInterface);
+    Interface_GUIDialogTextViewer::DeInit(addonInterface);
+    Interface_GUIDialogYesNo::DeInit(addonInterface);
+
+    free(addonInterface->toKodi->kodi_gui->general);
+    free(addonInterface->toKodi->kodi_gui);
+    addonInterface->toKodi->kodi_gui = nullptr;
+  }
+}
+
+//@{
+void Interface_GUIGeneral::lock()
+{
+  if (m_iAddonGUILockRef == 0)
+    g_graphicsContext.Lock();
+  ++m_iAddonGUILockRef;
+}
+
+void Interface_GUIGeneral::unlock()
+{
+  if (m_iAddonGUILockRef > 0)
+  {
+    --m_iAddonGUILockRef;
+    if (m_iAddonGUILockRef == 0)
+      g_graphicsContext.Unlock();
+  }
+}
+//@}
+
+//@{
+int Interface_GUIGeneral::get_screen_height(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  return g_graphicsContext.GetHeight();
+}
+
+int Interface_GUIGeneral::get_screen_width(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  return g_graphicsContext.GetWidth();
+}
+
+int Interface_GUIGeneral::get_video_resolution(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  return (int)g_graphicsContext.GetVideoResolution();
+}
+//@}
+
+//@{
+int Interface_GUIGeneral::get_current_window_dialog_id(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  CSingleLock gl(g_graphicsContext);
+  return g_windowManager.GetTopMostModalDialogID();
+}
+
+int Interface_GUIGeneral::get_current_window_id(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  CSingleLock gl(g_graphicsContext);
+  return g_windowManager.GetActiveWindow();
+}
+
+//@}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/General.h
+++ b/xbmc/addons/interfaces/GUI/General.h
@@ -1,0 +1,69 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h"
+   */
+  struct Interface_GUIGeneral
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note For add of new functions use the "_" style to identify direct a
+     * add-on callback function. Everything with CamelCase is only for the
+     * usage in Kodi only.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void lock();
+    static void unlock();
+
+    static int get_screen_height(void* kodiBase);
+    static int get_screen_width(void* kodiBase);
+    static int get_video_resolution(void* kodiBase);
+    static int get_current_window_dialog_id(void* kodiBase);
+    static int get_current_window_id(void* kodiBase);
+    //@}
+
+  private:
+    static int m_iAddonGUILockRef;
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -101,7 +101,7 @@ typedef enum AddonLog
 {
   ///
   ADDON_LOG_DEBUG = 0,
-  
+
   ///
   ADDON_LOG_INFO = 1,
 
@@ -110,7 +110,7 @@ typedef enum AddonLog
 
   ///
   ADDON_LOG_WARNING = 3,
-  
+
   ///
   ADDON_LOG_ERROR = 4,
 
@@ -147,6 +147,7 @@ struct AddonToKodiFuncTable_kodi;
 struct AddonToKodiFuncTable_kodi_audioengine;
 struct AddonToKodiFuncTable_kodi_filesystem;
 struct AddonToKodiFuncTable_kodi_network;
+struct AddonToKodiFuncTable_kodi_gui;
 typedef struct AddonToKodiFuncTable_Addon
 {
   // Pointer inside Kodi, used on callback functions to give related handle
@@ -164,6 +165,7 @@ typedef struct AddonToKodiFuncTable_Addon
   AddonToKodiFuncTable_kodi* kodi;
   AddonToKodiFuncTable_kodi_audioengine* kodi_audioengine;
   AddonToKodiFuncTable_kodi_filesystem* kodi_filesystem;
+  AddonToKodiFuncTable_kodi_gui* kodi_gui;
   AddonToKodiFuncTable_kodi_network *kodi_network;
 } AddonToKodiFuncTable_Addon;
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogContextMenu.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogContextMenu.h
@@ -1,0 +1,95 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogContextMenu Dialog Context Menu
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_namespace{ kodi::gui::DialogContextMenu }
+  /// **Context menu dialog**
+  ///
+  /// The function listed below permits the call of a dialogue as context menu to
+  /// select of an entry as a key
+  ///
+  /// It has the header \ref DialogContextMenu.h "#include <kodi/gui/DialogContextMenu.h>"
+  /// be included to enjoy it.
+  ///
+  ///
+  namespace DialogContextMenu
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogContextMenu
+    /// @brief Show a context menu dialog about given parts.
+    ///
+    /// @param[in] heading   Dialog heading name
+    /// @param[in] entries   String list about entries
+    /// @return          The selected entry, if return <tt>-1</tt> was nothing selected or canceled
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogContextMenu.h>
+    ///
+    /// const std::vector<std::string> entries
+    /// {
+    ///   "Test 1",
+    ///   "Test 2",
+    ///   "Test 3",
+    ///   "Test 4",
+    ///   "Test 5"
+    /// };
+    ///
+    /// int selected = kodi::gui::DialogContextMenu::Show("Test selection", entries);
+    /// if (selected < 0)
+    ///   fprintf(stderr, "Item selection canceled\n");
+    /// else
+    ///   fprintf(stderr, "Selected item is: %i\n", selected);
+    /// ~~~~~~~~~~~~~
+    ///
+    inline int Show(const std::string& heading, const std::vector<std::string>& entries)
+    {
+      using namespace ::kodi::addon;
+      unsigned int size = entries.size();
+      const char** cEntries = static_cast<const char**>(malloc(size*sizeof(const char**)));
+      for (unsigned int i = 0; i < size; ++i)
+      {
+        cEntries[i] = entries[i].c_str();
+      }
+      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogContextMenu->open(CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), cEntries, size);
+      free(cEntries);
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogExtendedProgress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogExtendedProgress.h
@@ -1,0 +1,244 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_CDialogExtendedProgress Dialog Extended Progress
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::CDialogExtendedProgress }
+  /// **Progress dialog shown for background work**
+  ///
+  /// The with \ref DialogExtendedProgress.h "#include <kodi/gui/DialogExtendedProgress.h>"
+  /// given class are basically used to create Kodi's extended progress.
+  ///
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// #include <kodi/gui/DialogExtendedProgress.h>
+  ///
+  /// kodi::gui::CDialogExtendedProgress *ext_progress = new kodi::gui::CDialogExtendedProgress("Test Extended progress");
+  /// ext_progress->SetText("Test progress");
+  /// for (unsigned int i = 0; i < 50; i += 10)
+  /// {
+  ///   ext_progress->SetProgress(i, 100);
+  ///   sleep(1);
+  /// }
+  ///
+  /// ext_progress->SetTitle("Test Extended progress - Second round");
+  /// ext_progress->SetText("Test progress - Step 2");
+  ///
+  /// for (unsigned int i = 50; i < 100; i += 10)
+  /// {
+  ///   ext_progress->SetProgress(i, 100);
+  ///   sleep(1);
+  /// }
+  /// delete ext_progress;
+  /// ~~~~~~~~~~~~~
+  ///
+  class CDialogExtendedProgress
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// Construct a new dialog
+    ///
+    /// @param[in] title  Title string
+    ///
+    CDialogExtendedProgress(const std::string& title = "")
+    {
+      using namespace ::kodi::addon;
+      m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->new_dialog(CAddonBase::m_interface->toKodi->kodiBase, title.c_str());
+      if (!m_DialogHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::CDialogExtendedProgress can't create window class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// Destructor
+    ///
+    ~CDialogExtendedProgress()
+    {
+      using namespace ::kodi::addon;
+      if (m_DialogHandle)
+        CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->delete_dialog(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief Get the used title
+    ///
+    /// @return Title string
+    ///
+    std::string Title() const
+    {
+      using namespace ::kodi::addon;
+      std::string text;
+      char* strMsg = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_title(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+      if (strMsg != nullptr)
+      {
+        if (std::strlen(strMsg))
+          text = strMsg;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, strMsg);
+      }
+      return text;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief To set the title of dialog
+    ///
+    /// @param[in] title     Title string
+    ///
+    void SetTitle(const std::string& title)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_title(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, title.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief Get the used text information string
+    ///
+    /// @return Text string
+    ///
+    std::string Text() const
+    {
+      using namespace ::kodi::addon;
+      std::string text;
+      char* strMsg = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_text(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+      if (strMsg != nullptr)
+      {
+        if (std::strlen(strMsg))
+          text = strMsg;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, strMsg);
+      }
+      return text;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief To set the used text information string
+    ///
+    /// @param[in] text         information text to set
+    ///
+    void SetText(const std::string& text)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_text(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief To ask dialog is finished
+    ///
+    /// @return True if on end
+    ///
+    bool IsFinished() const
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->is_finished(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief Mark progress finished
+    ///
+    void MarkFinished()
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->mark_finished(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief Get the current progress position as percent
+    ///
+    /// @return Position
+    ///
+    float Percentage() const
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->get_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief To set the current progress position as percent
+    ///
+    /// @param[in] percentage   Position to use from 0.0 to 100.0
+    ///
+    void SetPercentage(float percentage)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, percentage);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogExtendedProgress
+    /// @brief To set progress position with predefined places
+    ///
+    /// @param[in] currentItem    Place position to use
+    /// @param[in] itemCount      Amount of used places
+    ///
+    void SetProgress(int currentItem, int itemCount)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->set_progress(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, currentItem, itemCount);
+    }
+    //--------------------------------------------------------------------------
+
+  private:
+    void* m_DialogHandle;
+  };
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogFileBrowser.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogFileBrowser.h
@@ -1,0 +1,293 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogFileBrowser Dialog File Browser
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_namespace{ kodi::gui::DialogFileBrowser }
+  /// **File browser dialog**
+  ///
+  /// The functions listed below of the class "DialogFileBrowser" offer
+  /// the possibility to select to a file by the user of the add-on.
+  ///
+  /// It allows all the options that are possible in Kodi itself and offers all
+  /// support file types.
+  ///
+  /// It has the header \ref DialogFileBrowser.h "#include <kodi/gui/DialogFileBrowser.h>"
+  /// be included to enjoy it.
+  ///
+  namespace DialogFileBrowser
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief Directory selection dialog
+    ///
+    /// @param[in] shares       With Shares becomes the available start folders
+    ///                         be set.
+    /// @param[in] heading      Dialog header name
+    /// @param[in,out] path     As in the path to start and return value about
+    ///                         selected directory
+    /// @param[in] writeOnly    If set only writeable folders are shown.
+    /// @return                 False if selection becomes canceled.
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogFileBrowser.h>
+    ///
+    /// /*
+    ///  * Example show directory selection dialog with on 'share' (first value)
+    ///  * defined directory types.
+    ///  *
+    ///  * If this becomes leaved empty and 'directory' is empty goes it to the
+    ///  * base path of the hard disk.
+    ///  *
+    ///  * Also can be with path written to 'directory' before the dialog forced
+    ///  * to a start place.
+    ///  */
+    /// std::string directory;
+    /// bool ret = kodi::gui::DialogFileBrowser::ShowAndGetDirectory("local|network|removable",
+    ///                                                    "Test directory selection",
+    ///                                                    directory,
+    ///                                                    false);
+    /// fprintf(stderr, "Selected directory is : %s and was %s\n", directory.c_str(), ret ? "OK" : "Canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetDirectory(const std::string& shares, const std::string& heading, std::string& path, bool writeOnly = false)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_directory(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                      shares.c_str(), heading.c_str(), path.c_str(), &retString, writeOnly);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          path = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief File selection dialog
+    ///
+    /// @param[in] shares               With Shares becomes the available  start
+    ///                                 folders be set.
+    /// @param[in] mask                 The mask to filter visible  files,  e.g.
+    ///                                 ".m3u|.pls|.b4s|.wpl".
+    /// @param[in] heading              Dialog header name
+    /// @param[in,out] path             As in the path to start and Return value
+    ///                                 about selected file
+    /// @param[in] useThumbs            If set show thumbs if possible on dialog.
+    /// @param[in] useFileDirectories   If set also  packages  (e.g. *.zip)  are
+    ///                                 handled as directories.
+    /// @return                         False if selection becomes canceled.
+    ///
+    inline bool ShowAndGetFile(const std::string& shares, const std::string& mask, const std::string& heading,
+                               std::string& path, bool useThumbs = false, bool useFileDirectories = false)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_file(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                 shares.c_str(), mask.c_str(), heading.c_str(), path.c_str(), &retString,
+                                                                                                 useThumbs, useFileDirectories);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          path = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief File selection from a directory
+    ///
+    /// @param[in] directory            The  directory  name  where  the  dialog
+    ///                                 start, possible  are  normal  names  and
+    ///                                 kodi's special names.
+    /// @param[in] mask                 The mask to filter visible  files,  e.g.
+    ///                                 ".m3u|.pls|.b4s|.wpl".
+    /// @param[in] heading              Dialog header name
+    /// @param[in,out] path             As in the path to start and Return value
+    ///                                 about selected file
+    /// @param[in] useThumbs            If set show thumbs if possible on dialog.
+    /// @param[in] useFileDirectories   If set also  packages  (e.g. *.zip)  are
+    ///                                 handled as directories.
+    /// @param[in] singleList
+    /// @return                         False if selection becomes canceled.
+    ///
+    inline bool ShowAndGetFileFromDir(const std::string& directory, const std::string& mask, const std::string& heading, std::string& path,
+                                      bool useThumbs = false, bool useFileDirectories = false, bool singleList = false)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_file_from_dir(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                          directory.c_str(), mask.c_str(), heading.c_str(),
+                                                                                                          path.c_str(), &retString, useThumbs, 
+                                                                                                          useFileDirectories, singleList);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          path = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief File selection dialog to get several in to a list
+    ///
+    /// @param[in] shares             With Shares becomes  the  available  start
+    ///                               folders be set.
+    /// @param[in] mask               The mask to  filter  visible  files,  e.g.
+    ///                               ".m3u|.pls|.b4s|.wpl".
+    /// @param[in] heading            Dialog header name
+    /// @param[out] fileList          Return value about selected files
+    /// @param[in] useThumbs          If set show thumbs if possible on dialog.
+    /// @param[in] useFileDirectories If  set  also  packages  (e.g. *.zip)  are
+    ///                               handled as directories.
+    /// @return False if selection becomes canceled.
+    ///
+    inline bool ShowAndGetFileList(const std::string& shares, const std::string& mask, const std::string& heading,
+                                   std::vector<std::string>& fileList, bool useThumbs = false, bool useFileDirectories = false)
+    {
+      using namespace ::kodi::addon;
+      char** list = nullptr;
+      unsigned int listSize = 0;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_file_list(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                      shares.c_str(), mask.c_str(), heading.c_str(), &list, &listSize,
+                                                                                                      useThumbs, useFileDirectories);
+      if (ret)
+      {
+        for (unsigned int i = 0; i < listSize; ++i)
+          fileList.push_back(list[i]);
+        CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->clear_file_list(CAddonBase::m_interface->toKodi->kodiBase, &list, listSize);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief Source selection dialog
+    ///
+    /// @param[in,out] path           As in the path to start and Return value
+    ///                               about selected source
+    /// @param[in] allowNetworkShares Allow also access to network
+    /// @param[in] additionalShare    With additionalShare becomes the available
+    ///                               start folders be set (optional).
+    /// @param[in] type
+    /// @return                       False if selection becomes canceled.
+    ///
+    inline bool ShowAndGetSource(std::string& path, bool allowNetworkShares, const std::string& additionalShare = "", const std::string& type = "")
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_source(CAddonBase::m_interface->toKodi->kodiBase, path.c_str(), &retString, 
+                                                                                                   allowNetworkShares, additionalShare.c_str(), type.c_str());
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          path = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief Image selection dialog
+    ///
+    /// @param[in] shares     With Shares becomes the available start folders be
+    ///                       set.
+    /// @param[in] heading    Dialog header name
+    /// @param[out] path      Return value about selected image
+    /// @return               False if selection becomes canceled.
+    ///
+    inline bool ShowAndGetImage(const std::string& shares, const std::string& heading, std::string& path)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_image(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                  shares.c_str(), heading.c_str(), path.c_str(), &retString);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          path = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogFileBrowser
+    /// @brief Image selection dialog to get several in to a list
+    ///
+    /// @param[in] shares       With Shares becomes the available  start folders
+    ///                         be set.
+    /// @param[in] heading      Dialog header name
+    /// @param[out] file_list   Return value about selected images
+    /// @return                 False if selection becomes canceled.
+    ///
+    inline bool ShowAndGetImageList(const std::string& shares, const std::string& heading, std::vector<std::string>& file_list)
+    {
+      using namespace ::kodi::addon;
+      char** list = nullptr;
+      unsigned int listSize = 0;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->show_and_get_image_list(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                       shares.c_str(), heading.c_str(), &list, &listSize);
+      if (ret)
+      {
+        for (unsigned int i = 0; i < listSize; ++i)
+          file_list.push_back(list[i]);
+        CAddonBase::m_interface->toKodi->kodi_gui->dialogFileBrowser->clear_file_list(CAddonBase::m_interface->toKodi->kodiBase, &list, listSize);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogKeyboard.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogKeyboard.h
@@ -1,0 +1,416 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogKeyboard Dialog Keyboard
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_namespace{ kodi::gui::DialogKeyboard }
+  /// **Keyboard dialogs**
+  ///
+  /// The functions listed below have to be permitted by the user for the
+  /// representation of a keyboard around an input.
+  ///
+  /// The class supports several kinds, from an easy text choice up to the
+  /// passport Word production and their confirmation for add-on.
+  ///
+  /// It has the header \ref DialogKeyboard.h "#include <kodi/gui/DialogKeyboard.h>"
+  /// be included to enjoy it.
+  ///
+  namespace DialogKeyboard
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Show keyboard with initial value `text` and replace with  result
+    /// string.
+    ///
+    /// @param[in,out] text          Overwritten with user input if return=true.
+    /// @param[in] heading           String shown on dialog title.
+    /// @param[in] allowEmptyResult  Whether a blank password is valid or not.
+    /// @param[in] hiddenInput       The inserted input is not shown as text.
+    /// @param[in] autoCloseMs       To  close  the  dialog  after  a  specified
+    ///                              time, in milliseconds, default is  0  which
+    ///                              keeps the dialog open indefinitely.
+    /// @return                      true if successful display and user  input.
+    ///                              false  if  unsuccessful  display,  no  user
+    ///                              input, or canceled editing.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogKeyboard.h>
+    ///
+    /// /*
+    ///  * The example shows the display of keyboard call dialog at Kodi from the add-on.
+    ///  * Below all values are set, however, can last two (hidden input = false and autoCloseMs = 0)
+    ///  * to be released if not needed.
+    ///  */
+    /// std::string text = "Please change me to them want you want"; /*< It can be leaved empty or a
+    ///                                                                  entry text added */
+    /// bool bRet = ::kodi::gui::DialogKeyboard::ShowAndGetInput(text,
+    ///                                                      "Demonstration text entry",
+    ///                                                      true,
+    ///                                                      false,
+    ///                                                      0);
+    /// fprintf(stderr, "Written keyboard input is : '%s' and was %s\n",
+    ///                   text.c_str(), bRet ? "OK" : "Canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetInput(std::string& text, const std::string& heading, bool allowEmptyResult, bool hiddenInput = false, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_input_with_head(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                         text.c_str(), &retString, heading.c_str(), allowEmptyResult,
+                                                                                                         hiddenInput, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          text = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief The example shows the display of keyboard  call dialog  at  Kodi
+    /// from the add-on.
+    ///
+    /// @param[out] text            Overwritten with user input if return=true.
+    /// @param[in] allowEmptyResult If  set  to true  keyboard can  also  exited
+    ///                             without entered text.
+    /// @param[in] autoCloseMs      To close the dialog after a specified  time,
+    ///                             in milliseconds,  default is  0 which  keeps
+    ///                             the dialog open indefinitely.
+    /// @return                     true if successful display and user input.
+    ///                             false  if  unsuccessful   display,  no  user
+    ///                             input, or canceled editing.
+    ///
+    inline bool ShowAndGetInput(std::string& text, bool allowEmptyResult, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_input(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                               text.c_str(), &retString,
+                                                                                               allowEmptyResult, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          text = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Shows  keyboard  and  prompts  for  a  password.   Differs  from
+    /// `ShowAndVerifyNewPassword()` in that no second verification
+    ///
+    /// @param[in,out] newPassword   Overwritten with user input if return=true.
+    /// @param[in] heading           String shown on dialog title.
+    /// @param[in] allowEmptyResult  Whether a blank password is valid or not.
+    /// @param[in] autoCloseMs       To close the dialog after a specified time,
+    ///                              in milliseconds, default is  0  which keeps
+    ///                              the dialog open indefinitely.
+    /// @return                      true if successful display  and user input.
+    ///                              false  if  unsuccessful  display,  no  user
+    ///                              input, or canceled editing.
+    ///
+    inline bool ShowAndGetNewPassword(std::string& newPassword, const std::string& heading, bool allowEmptyResult, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_new_password_with_head(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                                newPassword.c_str(), &retString, heading.c_str(),
+                                                                                                                allowEmptyResult, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          newPassword = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Shows keyboard and prompts for a password. Differs from
+    /// `ShowAndVerifyNewPassword()` in that no second verification
+    ///
+    /// @param[in,out] newPassword    Overwritten with user input if return=true.
+    /// @param[in] autoCloseMs        To close the dialog after a specified time,
+    ///                               in milliseconds, default is 0 which  keeps
+    ///                               the dialog open indefinitely.
+    /// @return                       true if successful display  and user input.
+    ///                               false  if  unsuccessful  display,  no  user
+    ///                               input, or canceled editing.
+    ///
+    inline bool ShowAndGetNewPassword(std::string& newPassword, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_new_password(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                      newPassword.c_str(), &retString, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          newPassword = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Show keyboard twice to  get and confirm a  user-entered  password
+    /// string.
+    ///
+    /// @param[out] newPassword    Overwritten with user input if return=true.
+    /// @param[in] heading         String shown on dialog title.
+    /// @param[in] allowEmptyResult
+    /// @param[in] autoCloseMs     To close the dialog after a  specified  time,
+    ///                            in milliseconds,  default  is 0  which  keeps
+    ///                            the dialog open indefinitely.
+    /// @return                    true if successful display  and  user  input.
+    ///                            false  if  unsuccessful   display,   no  user
+    ///                            input, or canceled editing.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/General.h>
+    /// #include <kodi/gui/DialogKeyboard.h>
+    ///
+    /// /*
+    ///  * The example below shows the complete use of keyboard dialog for password
+    ///  * check. If only one check from add-on needed can be function with retries
+    ///  * set to '0' called alone.
+    ///  *
+    ///  * The use of MD5 translated password is always required for the check on Kodi!
+    ///  */
+    ///
+    /// int maxretries = 3;
+    /// /*
+    ///  * Password names need to be send as md5 sum to kodi.
+    ///  */
+    /// std::string password;
+    /// kodi::GetMD5("kodi", password);
+    ///
+    /// /*
+    ///  * To the loop about password checks.
+    ///  */
+    /// int ret;
+    /// for (unsigned int i = 0; i < maxretries; i++)
+    /// {
+    ///   /*
+    ///    * Ask the user about the password.
+    ///    */
+    ///   ret = ::kodi::gui::DialogKeyboard::ShowAndVerifyPassword(password, "Demo password call for PW 'kodi'", i, 0);
+    ///   if (ret == 0)
+    ///   {
+    ///     fprintf(stderr, "Password successfull confirmed after '%i' tries\n", i+1);
+    ///     break;
+    ///   }
+    ///   else if (ret < 0)
+    ///   {
+    ///     fprintf(stderr, "Canceled editing on try '%i'\n", i+1);
+    ///     break;
+    ///   }
+    ///   else /* if (ret > 0) */
+    ///   {
+    ///     fprintf(stderr, "Wrong password entered on try '%i'\n", i+1);
+    ///   }
+    /// }
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndVerifyNewPassword(std::string& newPassword, const std::string& heading, bool allowEmptyResult, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_verify_new_password_with_head(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                                   &retString, heading.c_str(), allowEmptyResult,
+                                                                                                                   autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          newPassword = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Show keyboard twice to get and confirm  a user-entered  password
+    /// string.
+    ///
+    /// @param[out] newPassword    Overwritten with user input if return=true.
+    /// @param[in] autoCloseMs     To close the dialog after a specified   time,
+    ///                            in milliseconds, default  is  0  which  keeps
+    ///                            the dialog open indefinitely.
+    /// @return                    true if successful display  and  user  input.
+    ///                            false  if  unsuccessful   display,   no  user
+    ///                            input, or canceled editing.
+    ///
+    inline bool ShowAndVerifyNewPassword(std::string& newPassword, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_verify_new_password(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                         &retString, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          newPassword = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Show keyboard and verify user input against `password`.
+    ///
+    /// @param[in,out] password    Value to compare against user input.
+    /// @param[in] heading         String shown on dialog title.
+    /// @param[in] retries         If   greater   than   0,   shows   "Incorrect
+    ///                            password,  %d retries left" on dialog line 2,
+    ///                            else line 2 is blank.
+    /// @param[in] autoCloseMs     To close the dialog  after a specified  time,
+    ///                            in milliseconds,  default is  0  which  keeps
+    ///                            the dialog open indefinitely.
+    /// @return                    0 if successful display  and user input. 1 if
+    ///                            unsuccessful input. -1 if no user  input  or
+    ///                            canceled editing.
+    ///
+    inline int ShowAndVerifyPassword(std::string& password, const std::string& heading, int retries, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_verify_password(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                    password.c_str(), &retString, heading.c_str(),
+                                                                                                    retries, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          password = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Shows a filter related keyboard
+    ///
+    /// @param[in,out] text        Overwritten with user input if  return=true.
+    /// @param[in] searching       Use dialog for  search and  send  our  search
+    ///                            message in safe way (only  the active  window
+    ///                            needs it)
+    ///  - header name if true is "Enter search string"
+    ///  - header name if false is "Enter value"
+    /// @param autoCloseMs         To close the dialog after  a specified  time,
+    ///                            in milliseconds, default  is  0  which  keeps
+    ///                            the dialog open indefinitely.
+    /// @return                    true if successful display  and  user  input.
+    ///                            false   if  unsuccessful  display,   no  user
+    ///                            input, or canceled editing.
+    ///
+    inline bool ShowAndGetFilter(std::string& text, bool searching, unsigned int autoCloseMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->show_and_get_filter(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                text.c_str(), &retString, searching, autoCloseMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          text = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Send a text to a visible keyboard
+    ///
+    /// @param[in] text            Overwritten with user input if  return=true.
+    /// @param[in] closeKeyboard   The open dialog is if also closed on 'true'.
+    /// @return                    true   if    successful   done,    false   if
+    ///                            unsuccessful or keyboard not present.
+    ///
+    inline bool SendTextToActiveKeyboard(const std::string& text, bool closeKeyboard = false)
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->send_text_to_active_keyboard(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                     text.c_str(), closeKeyboard);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogKeyboard
+    /// @brief Check for visible keyboard on GUI
+    ///
+    /// @return  true if keyboard present, false if not present
+    ///
+    inline bool IsKeyboardActivated()
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogKeyboard->is_keyboard_activated(CAddonBase::m_interface->toKodi->kodiBase);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogNumeric.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogNumeric.h
@@ -1,0 +1,366 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogNumeric Dialog Numeric
+  /// \ingroup cpp_kodi_gui
+  /// @{
+  /// @brief \cpp_namespace{ kodi::gui::DialogNumeric }
+  /// **Numeric dialogs**
+  ///
+  /// The functions listed below have to be permitted by the user for the
+  /// representation of a numeric keyboard around an input.
+  ///
+  /// The class supports several kinds, from an easy number choice up to the
+  /// passport Word production and their confirmation for add-on.
+  ///
+  /// It has the header \ref DialogNumeric.h "#include <kodi/gui/DialogNumeric.h>"
+  /// be included to enjoy it.
+  ///
+  namespace DialogNumeric
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to get numeric new password
+    ///
+    /// @param[out] newPassword        String to preload into the keyboard
+    ///                                accumulator. Overwritten with user input
+    ///                                if return=true. Returned in MD5 format.
+    /// @return                        true if successful display and user
+    ///                                input entry/re-entry.
+    ///                                false if unsuccessful display, no user
+    ///                                input, or canceled editing.
+    ///
+    inline bool ShowAndVerifyNewPassword(std::string& newPassword)
+    {
+      using namespace ::kodi::addon;
+      char* pw = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_verify_new_password(CAddonBase::m_interface->toKodi->kodiBase, &pw);
+      if (pw != nullptr)
+      {
+        if (std::strlen(pw))
+          newPassword = pw;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, pw);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to verify numeric password.
+    ///
+    /// @param[in] password             Password to compare with user input, need
+    ///                                 in MD5 format.
+    /// @param[in] heading              Heading to display
+    /// @param[in] retries              If greater than 0, shows "Incorrect
+    ///                                 password, %d retries left" on dialog
+    ///                                 line 2, else line 2 is blank.
+    /// @return                         Possible values:
+    ///                                 - 0 if successful display and user input.
+    ///                                 - 1 if unsuccessful input.
+    ///                                 - -1 if no user input or canceled editing.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <stdio.h>      /* fprintf */
+    /// #include <kodi/General.h>
+    /// #include <kodi/gui/DialogNumeric.h>
+    ///
+    /// /*
+    ///  * The example below shows the complete use of keyboard dialog for password
+    ///  * check. If only one check from add-on needed can be function with retries
+    ///  * set to '0' called alone.
+    ///  *
+    ///  * The use of MD5 translated password is always required for the check on Kodi!
+    ///  */
+    ///
+    /// int maxretries = 3;
+    ///
+    /// /*
+    ///  * Password names need to be send as md5 sum to kodi.
+    ///  */
+    /// std::string password = kodi::GetMD5("1234");
+    ///
+    /// /*
+    ///  * To the loop about password checks.
+    ///  */
+    /// int ret;
+    /// for (unsigned int i = 0; i < maxretries; i++)
+    /// {
+    ///   /*
+    ///    * Ask the user about the password.
+    ///    */
+    ///   ret = kodi::gui::DialogNumeric::ShowAndVerifyPassword(password, "Demo numeric password call for PW '1234'", i);
+    ///   if (ret == 0)
+    ///   {
+    ///     fprintf(stderr, "Numeric password successfull confirmed after '%i' tries\n", i+1);
+    ///     break;
+    ///   }
+    ///   else if (ret < 0)
+    ///   {
+    ///     fprintf(stderr, "Canceled editing on try '%i'\n", i+1);
+    ///     break;
+    ///   }
+    ///   else /* if (ret > 0) */
+    ///   {
+    ///     fprintf(stderr, "Wrong numeric password entered on try '%i'\n", i+1);
+    ///   }
+    /// }
+    /// ~~~~~~~~~~~~~
+    ///
+    inline int ShowAndVerifyPassword(const std::string& password, const std::string& heading, int retries)
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_verify_password(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                password.c_str(), heading.c_str(), retries);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to verify numeric password
+    ///
+    /// @param[in,out] toVerify         Value to compare against user input.
+    /// @param[in] heading              Heading to display
+    /// @param[in] verifyInput          If set as true we verify the users input
+    ///                                 versus toVerify.
+    /// @return                         true if successful display and user
+    ///                                 input. false if unsuccessful display, no
+    ///                                 user input, or canceled editing.
+    ///
+    inline bool ShowAndVerifyInput(std::string& toVerify, const std::string& heading, bool verifyInput)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_verify_input(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                 toVerify.c_str(), &retString, heading.c_str(), verifyInput);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          toVerify = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to get time value.
+    ///
+    /// @param[out] time                Overwritten with user input if
+    ///                                 return=true and time inserted.
+    /// @param[in] heading              Heading to display.
+    /// @return                         true if successful display and user
+    ///                                 input. false if unsuccessful display, no
+    ///                                 user input, or canceled editing.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <stdio.h>      /* printf */
+    /// #include <time.h>       /* time_t, struct tm, time, localtime, strftime */
+    /// #include <kodi/gui/DialogNumeric.h>
+    ///
+    /// time_t rawtime;
+    /// struct tm * timeinfo;
+    /// char buffer [10];
+    ///
+    /// time (&rawtime);
+    /// timeinfo = localtime(&rawtime);
+    /// bool bRet = kodi::gui::DialogNumeric::ShowAndGetTime(*timeinfo, "Selected time test call");
+    /// strftime(buffer, sizeof(buffer), "%H:%M.", timeinfo);
+    /// printf("Selected time it's %s and was on Dialog %s\n", buffer, bRet ? "OK" : "Canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetTime(tm& time, const std::string& heading)
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_time(CAddonBase::m_interface->toKodi->kodiBase, &time, heading.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to get date value.
+    ///
+    /// @param[in,out] date             Overwritten with user input if
+    ///                                 return=true and date inserted.
+    /// @param[in] heading              Heading to display
+    /// @return                         true if successful display and user
+    ///                                 input. false if unsuccessful display, no
+    ///                                 user input, or canceled editing.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <stdio.h>      /* printf */
+    /// #include <time.h>       /* time_t, struct tm, time, localtime, strftime */
+    /// #include <kodi/gui/DialogNumeric.h>
+    ///
+    /// time_t rawtime;
+    /// struct tm * timeinfo;
+    /// char buffer [20];
+    ///
+    /// time (&rawtime);
+    /// timeinfo = localtime(&rawtime);
+    /// bool bRet = kodi::gui::DialogNumeric::ShowAndGetDate(*timeinfo, "Selected date test call");
+    /// strftime(buffer, sizeof(buffer), "%Y-%m-%d", timeinfo);
+    /// printf("Selected date it's %s and was on Dialog %s\n", buffer, bRet ? "OK" : "Canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetDate(tm& date, const std::string& heading)
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_date(CAddonBase::m_interface->toKodi->kodiBase, &date, heading.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to get a IP
+    ///
+    /// @param[in,out] ipAddress        Overwritten with user input if
+    ///                                 return=true and IP address inserted.
+    /// @param[in] heading              Heading to display.
+    /// @return                         true if successful display and
+    ///                                 user input. false if unsuccessful
+    ///                                 display, no user input, or canceled
+    ///                                 editing.
+    ///
+    inline bool ShowAndGetIPAddress(std::string& ipAddress, const std::string& heading)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_ip_address(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                   ipAddress.c_str(), &retString, heading.c_str());
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          ipAddress = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Use dialog to get normal number.
+    ///
+    /// @param[in,out] input            Overwritten with user input if
+    ///                                 return=true and time in seconds inserted
+    /// @param[in] heading              Heading to display
+    /// @param[in] autoCloseTimeoutMs   To close the dialog after a specified
+    ///                                 time, in milliseconds, default is 0
+    ///                                 which keeps the dialog open
+    ///                                 indefinitely.
+    /// @return                         true if successful display and user
+    ///                                 input. false if unsuccessful display, no
+    ///                                 user input, or canceled editing.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    ///   #include <stdio.h>      /* printf */
+    ///   #include <stdlib.h>     /* strtoull (C++11) */
+    ///   #include <kodi/gui/DialogNumeric.h>
+    ///
+    ///   std::string number;
+    ///   bool bRet = kodi::gui::DialogNumeric::ShowAndGetNumber(number, "Number test call");
+    ///   printf("Written number input is : %llu and was %s\n",
+    ///                  strtoull(number.c_str(), nullptr, 0), bRet ? "OK" : "Canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetNumber(std::string& input, const std::string& heading, unsigned int autoCloseTimeoutMs = 0)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_number(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                               input.c_str(), &retString, heading.c_str(), autoCloseTimeoutMs);
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          input = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogNumeric
+    /// @brief Show numeric keypad to get seconds.
+    ///
+    /// @param[in,out] time     Overwritten with user input if return=true and
+    ///                         time in seconds inserted.
+    /// @param[in] heading      Heading to display
+    /// @return                 true if successful display and user input. false
+    ///                         if unsuccessful display, no user input, or
+    ///                         canceled editing.
+    ///
+    inline bool ShowAndGetSeconds(std::string& time, const std::string& heading)
+    {
+      using namespace ::kodi::addon;
+      char* retString = nullptr;
+      bool ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogNumeric->show_and_get_seconds(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                time.c_str(), &retString, heading.c_str());
+      if (retString != nullptr)
+      {
+        if (std::strlen(retString))
+          time = retString;
+        CAddonBase::m_interface->toKodi->free_string(CAddonBase::m_interface->toKodi->kodiBase, retString);
+      }
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+  };
+  /// @}
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h
@@ -1,0 +1,104 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../AddonBase.h"
+#include "definitions.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogOK Dialog OK
+  /// \ingroup cpp_kodi_gui
+  /// @{
+  /// @brief \cpp_namespace{ kodi::gui::DialogOK }
+  /// **OK dialog**
+  ///
+  /// The functions listed below permit the call of a dialogue of information, a
+  /// confirmation of the user by press from OK required.
+  ///
+  /// It has the header \ref DialogOK.h "#include <kodi/gui/DialogOK.h>"
+  /// be included to enjoy it.
+  ///
+  namespace DialogOK
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogOK
+    /// @brief Use dialog to inform user with text and confirmation with OK with continued string.
+    ///
+    /// @param[in] heading Dialog heading.
+    /// @param[in] text Multi-line text.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogOK.h>
+    /// ...
+    /// kodi::gui::DialogOK::ShowAndGetInput("Test dialog", "Hello World!\nI'm a call from add-on\n :) :D");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline void ShowAndGetInput(const std::string& heading, const std::string& text)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogOK->show_and_get_input_single_text(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                          heading.c_str(), text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogOK
+    /// @brief Use dialog to inform user with text and confirmation with OK with strings separated to the lines.
+    ///
+    /// @param[in] heading Dialog heading.
+    /// @param[in] line0 Line #1 text.
+    /// @param[in] line1 Line #2 text.
+    /// @param[in] line2 Line #3 text.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogOK.h>
+    /// ...
+    /// kodi::gui::DialogOK::ShowAndGetInput("Test dialog", "Hello World!", "I'm a call from add-on", " :) :D");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline void ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogOK->show_and_get_input_line_text(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                        heading.c_str(), line0.c_str(), line1.c_str(),
+                                                                                        line2.c_str());
+    }
+    //--------------------------------------------------------------------------
+  }
+  /// @}
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogProgress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogProgress.h
@@ -1,0 +1,249 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_CDialogProgress Dialog Progress
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::CDialogProgress }
+  /// **Progress dialog shown in center**
+  ///
+  /// The with \ref DialogProgress.h "#include <kodi/gui/DialogProgress.h>"
+  /// given class are basically used to create Kodi's progress dialog with named
+  /// text fields.
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// #include <kodi/gui/DialogProgress.h>
+  ///
+  /// kodi::gui::CDialogProgress *progress = new kodi::gui::CDialogProgress;
+  /// progress->SetHeading("Test progress");
+  /// progress->SetLine(1, "line 1");
+  /// progress->SetLine(2, "line 2");
+  /// progress->SetLine(3, "line 3");
+  /// progress->SetCanCancel(true);
+  /// progress->ShowProgressBar(true);
+  /// progress->Open();
+  /// for (unsigned int i = 0; i < 100; i += 10)
+  /// {
+  ///   progress->SetPercentage(i);
+  ///   sleep(1);
+  /// }
+  /// delete progress;
+  /// ~~~~~~~~~~~~~
+  ///
+  class CDialogProgress
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief Construct a new dialog
+    ///
+    CDialogProgress()
+    {
+      using namespace ::kodi::addon;
+      m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->new_dialog(CAddonBase::m_interface->toKodi->kodiBase);
+      if (!m_DialogHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::CDialogProgress can't create window class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief Destructor
+    ///
+    ~CDialogProgress()
+    {
+      using namespace ::kodi::addon;
+      if (m_DialogHandle)
+        CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->delete_dialog(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To open the dialog
+    ///
+    void Open()
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->open(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief Set the heading title of dialog
+    ///
+    /// @param[in] heading Title string to use
+    ///
+    void SetHeading(const std::string& heading)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_heading(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, heading.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To set the line text field on dialog from 0 - 2
+    ///
+    /// @param[in] iLine Line number
+    /// @param[in] line Text string
+    ///
+    void SetLine(unsigned int iLine, const std::string& line)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_line(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, iLine, line.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To enable and show cancel button on dialog
+    ///
+    /// @param[in] canCancel if true becomes it shown
+    ///
+    void SetCanCancel(bool canCancel)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_can_cancel(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, canCancel);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To check dialog for clicked cancel button
+    ///
+    /// @return True if canceled
+    ///
+    bool IsCanceled() const
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->is_canceled(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief Get the current progress position as percent
+    ///
+    /// @param[in] percentage Position to use from 0 to 100
+    ///
+    void SetPercentage(int percentage)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, percentage);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To set the current progress position as percent
+    ///
+    /// @return Current Position used from 0 to 100
+    ///
+    int GetPercentage() const
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->get_percentage(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To show or hide progress bar dialog
+    ///
+    /// @param[in] onOff If true becomes it shown
+    ///
+    void ShowProgressBar(bool onOff)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->show_progress_bar(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, onOff);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief Set the maximum position of progress, needed if `SetProgressAdvance(...)` is used
+    ///
+    /// @param[in] max Biggest usable position to use
+    ///
+    void SetProgressMax(int max)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_progress_max(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, max);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To increase progress bar by defined step size until reach of maximum position
+    ///
+    /// @param[in] steps Step size to increase, default is 1
+    ///
+    void SetProgressAdvance(int steps=1)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->set_progress_advance(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle, steps);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CDialogProgress
+    /// @brief To check progress was canceled on work
+    ///
+    /// @return True if aborted
+    ///
+    bool Abort()
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogProgress->abort(CAddonBase::m_interface->toKodi->kodiBase, m_DialogHandle);
+    }
+    //--------------------------------------------------------------------------
+
+  private:
+    void* m_DialogHandle;
+  };
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogSelect.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogSelect.h
@@ -1,0 +1,101 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogSelect Dialog Select
+  /// \ingroup cpp_kodi_gui
+  /// @{
+  /// @brief \cpp_namespace{ kodi::gui::DialogSelect }
+  /// **Selection dialog**
+  ///
+  /// The function listed below permits the call of a dialogue to select of an
+  /// entry as a key
+  ///
+  /// It has the header \ref DialogSelect.h "#include <kodi/gui/DialogSelect.h>"
+  /// be included to enjoy it.
+  ///
+  ///
+  namespace DialogSelect
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogSelect
+    /// @brief Show a selection dialog about given parts.
+    ///
+    /// @param[in] heading      Dialog heading name
+    /// @param[in] entries      String list about entries
+    /// @param[in] selected     [opt] Predefined selection (default is
+    ///                         <tt>-1</tt> for the first)
+    /// @param[in] autoclose    [opt] To close dialog automatic after a time
+    /// @return                 The selected entry, if return <tt>-1</tt> was
+    ///                         nothing selected or canceled
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogSelect.h>
+    ///
+    /// const std::vector<std::string> entries
+    /// {
+    ///   "Test 1",
+    ///   "Test 2",
+    ///   "Test 3",
+    ///   "Test 4",
+    ///   "Test 5"
+    /// };
+    ///
+    /// int selected = kodi::gui::DialogSelect::Show("Test selection", entries, -1);
+    /// if (selected < 0)
+    ///   fprintf(stderr, "Item selection canceled\n");
+    /// else
+    ///   fprintf(stderr, "Selected item is: %i\n", selected);
+    /// ~~~~~~~~~~~~~
+    ///
+    inline int Show(const std::string& heading, const std::vector<std::string>& entries, int selected = -1, bool autoclose = false)
+    {
+      using namespace ::kodi::addon;
+      unsigned int size = entries.size();
+      const char** cEntries = (const char**)malloc(size*sizeof(const char**));
+      for (unsigned int i = 0; i < size; ++i)
+      {
+        cEntries[i] = entries[i].c_str();
+      }
+      int ret = CAddonBase::m_interface->toKodi->kodi_gui->dialogSelect->open(CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), cEntries, size, selected, autoclose);
+      free(cEntries);
+      return ret;
+    }
+    //--------------------------------------------------------------------------
+  };
+  /// @}
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogTextViewer.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogTextViewer.h
@@ -1,0 +1,115 @@
+#pragma once
+/*
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogTextViewer Dialog Text Viewer
+  /// \ingroup cpp_kodi_gui
+  /// @{
+  /// @brief \cpp_namespace{ kodi::gui::DialogTextViewer }
+  /// **Text viewer dialog**
+  ///
+  /// The text viewer dialog can be used to display descriptions, help texts or
+  /// other larger texts.
+  ///
+  /// In order to achieve a line break is a <b>\\n</b> directly in the text or
+  /// in the <em>"./resources/language/resource.language.??_??/strings.po"</em>
+  /// to call with <b>std::string kodi::general::GetLocalizedString(...);</b>.
+  ///
+  /// It has the header \ref DialogTextViewer.h "#include <kodi/gui/DialogTextViewer.h>"
+  /// be included to enjoy it.
+  ///
+  namespace DialogTextViewer
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogTextViewer
+    /// @brief Show info text dialog
+    ///
+    /// @param[in] heading  Small heading text
+    /// @param[in] text     Showed text on dialog
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogTextViewer.h>
+    ///
+    /// kodi::gui::DialogTextViewer::Show("The Wizard of Oz (1939 film)",
+    ///  "The Wizard of Oz is a 1939 American musical comedy-drama fantasy film "
+    ///  "produced by Metro-Goldwyn-Mayer, and the most well-known and commercially "
+    ///  "successful adaptation based on the 1900 novel The Wonderful Wizard of Oz "
+    ///  "by L. Frank Baum. The film stars Judy Garland as Dorothy Gale. The film"
+    ///  "co-stars Terry the dog, billed as Toto; Ray Bolger, Jack Haley, Bert Lahr, "
+    ///  "Frank Morgan, Billie Burke, Margaret Hamilton, with Charley Grapewin and "
+    ///  "Clara Blandick, and the Singer Midgets as the Munchkins.\n"
+    ///  "\n"
+    ///  "Notable for its use of Technicolor, fantasy storytelling, musical score and "
+    ///  "unusual characters, over the years it has become an icon of American popular "
+    ///  "culture. It was nominated for six Academy Awards, including Best Picture but "
+    ///  "lost to Gone with the Wind. It did win in two other categories including Best "
+    ///  "Original Song for \"Over the Rainbow\". However, the film was a box office "
+    ///  "disappointment on its initial release, earning only $3,017,000 on a $2,777,000 "
+    ///  "budget, despite receiving largely positive reviews. It was MGM's most "
+    ///  "expensive production at that time, and did not completely recoup the studio's "
+    ///  "investment and turn a profit until theatrical re-releases starting in 1949.\n"
+    ///  "\n"
+    ///  "The 1956 broadcast television premiere of the film on CBS re-introduced the "
+    ///  "film to the wider public and eventually made the presentation an annual "
+    ///  "tradition, making it one of the most known films in cinema history. The "
+    ///  "film was named the most-viewed motion picture on television syndication by "
+    ///  "the Library of Congress who also included the film in its National Film "
+    ///  "Registry in its inaugural year in 1989. Designation on the registry calls "
+    ///  "for efforts to preserve it for being \"culturally, historically, and "
+    ///  "aesthetically significant\". It is also one of the few films on UNESCO's "
+    ///  "Memory of the World Register.\n"
+    ///  "\n"
+    ///  "The Wizard of Oz is often ranked on best-movie lists in critics' and public "
+    ///  "polls. It is the source of many quotes referenced in modern popular culture. "
+    ///  "It was directed primarily by Victor Fleming (who left production to take "
+    ///  "over direction on the troubled Gone with the Wind production). Noel Langley, "
+    ///  "Florence Ryerson and Edgar Allan Woolf received credit for the screenplay, "
+    ///  "but there were uncredited contributions by others. The songs were written "
+    ///  "by Edgar \"Yip\" Harburg (lyrics) and Harold Arlen (music). The incidental "
+    ///  "music, based largely on the songs, was composed by Herbert Stothart, with "
+    ///  "interspersed renderings from classical composers.\n");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline void Show(const std::string& heading, const std::string& text)
+    {
+      using namespace ::kodi::addon;
+      CAddonBase::m_interface->toKodi->kodi_gui->dialogTextViewer->open(CAddonBase::m_interface->toKodi->kodiBase, heading.c_str(), text.c_str());
+    }
+    //--------------------------------------------------------------------------
+  };
+  /// @}
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogYesNo.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogYesNo.h
@@ -1,0 +1,187 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "definitions.h"
+#include "../AddonBase.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogYesNo Dialog Yes/No
+  /// \ingroup cpp_kodi_gui
+  /// @{
+  /// @brief \cpp_namespace{ kodi::gui::DialogYesNo }
+  /// **Yes / No dialog**
+  ///
+  /// The Yes / No dialog can be used to inform the user about questions and get
+  /// the answer.
+  ///
+  /// In order to achieve a line break is a <b>\\n</b> directly in the text or
+  /// in the <em>"./resources/language/resource.language.??_??/strings.po"</em>
+  /// to call with <b>std::string kodi::general::GetLocalizedString(...);</b>.
+  ///
+  /// It has the header \ref DialogYesNo.h "#include <kodi/gui/DialogYesNo.h>"
+  /// be included to enjoy it.
+  ///
+  ///
+  namespace DialogYesNo
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogYesNo
+    /// @brief Use dialog to get numeric new password with one text string shown
+    /// everywhere and cancel return field
+    ///
+    /// @param[in] heading    Dialog heading
+    /// @param[in] text       Multi-line text
+    /// @param[out] canceled  Return value about cancel button
+    /// @param[in] noLabel    [opt] label to put on the no button
+    /// @param[in] yesLabel   [opt] label to put on the yes button
+    /// @return           Returns True if 'Yes' was pressed, else False
+    ///
+    /// @note It is preferred to only use this as it is actually a multi-line text.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogYesNo.h>
+    ///
+    /// bool canceled;
+    /// bool ret = kodi::gui::DialogYesNo::ShowAndGetInput(
+    ///    "Yes / No test call",   /* The Header */
+    ///    "You has opened Yes / No dialog for test\n\nIs this OK for you?",
+    ///    canceled,               /* return value about cancel button */
+    ///    "Not really",           /* No label, is optional and if empty "No" */
+    ///    "Ohhh yes");            /* Yes label, also optional and if empty "Yes" */
+    /// fprintf(stderr, "You has called Yes/No, returned '%s' and was %s\n",
+    ///          ret ? "yes" : "no",
+    ///          canceled ? "canceled" : "not canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetInput(const std::string& heading, const std::string& text,
+                                bool& canceled, const std::string& noLabel = "",
+                                const std::string& yesLabel = "")
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_single_text(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                    heading.c_str(), text.c_str(), &canceled,
+                                                                                                    noLabel.c_str(), yesLabel.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogYesNo
+    /// @brief Use dialog to get numeric new password with separated line strings
+    ///
+    /// @param[in] heading      Dialog heading
+    /// @param[in] line0        Line #0 text
+    /// @param[in] line1        Line #1 text
+    /// @param[in] line2        Line #2 text
+    /// @param[in] noLabel      [opt] label to put on the no button.
+    /// @param[in] yesLabel     [opt] label to put on the yes button.
+    /// @return                 Returns True if 'Yes' was pressed, else False.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogYesNo.h>
+    ///
+    /// bool ret = kodi::gui::DialogYesNo::ShowAndGetInput(
+    ///    "Yes / No test call",   // The Header
+    ///    "You has opened Yes / No dialog for test",
+    ///    "",
+    ///    "Is this OK for you?",
+    ///    "Not really",           // No label, is optional and if empty "No"
+    ///    "Ohhh yes");            // Yes label, also optional and if empty "Yes"
+    /// fprintf(stderr, "You has called Yes/No, returned '%s'\n",
+    ///          ret ? "yes" : "no");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1,
+                                const std::string& line2, const std::string& noLabel = "",
+                                const std::string& yesLabel = "")
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_line_text(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                  heading.c_str(), line0.c_str(), line1.c_str(), line2.c_str(),
+                                                                                                  noLabel.c_str(), yesLabel.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogYesNo
+    /// @brief Use dialog to get numeric new password with separated line strings and cancel return field
+    ///
+    /// @param[in] heading      Dialog heading
+    /// @param[in] line0        Line #0 text
+    /// @param[in] line1        Line #1 text
+    /// @param[in] line2        Line #2 text
+    /// @param[out] canceled    Return value about cancel button
+    /// @param[in] noLabel      [opt] label to put on the no button
+    /// @param[in] yesLabel     [opt] label to put on the yes button
+    /// @return                 Returns True if 'Yes' was pressed, else False
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogYesNo.h>
+    ///
+    /// bool canceled;
+    /// bool ret = kodi::gui::DialogYesNo::ShowAndGetInput(
+    ///    "Yes / No test call",   // The Header
+    ///    "You has opened Yes / No dialog for test",
+    ///    "",
+    ///    "Is this OK for you?",
+    ///    canceled,               // return value about cancel button
+    ///    "Not really",           // No label, is optional and if empty "No"
+    ///    "Ohhh yes");            // Yes label, also optional and if empty "Yes"
+    /// fprintf(stderr, "You has called Yes/No, returned '%s' and was %s\n",
+    ///          ret ? "yes" : "no",
+    ///          canceled ? "canceled" : "not canceled");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline bool ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1,
+                                const std::string& line2, bool& canceled, const std::string& noLabel = "",
+                                const std::string& yesLabel = "")
+    {
+      using namespace ::kodi::addon;
+      return CAddonBase::m_interface->toKodi->kodi_gui->dialogYesNo->show_and_get_input_line_button_text(CAddonBase::m_interface->toKodi->kodiBase,
+                                                                                                         heading.c_str(), line0.c_str(), line1.c_str(), line2.c_str(),
+                                                                                                         &canceled, noLabel.c_str(), yesLabel.c_str());
+    }
+    //--------------------------------------------------------------------------
+  };
+  /// @}
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h
@@ -1,0 +1,156 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../AddonBase.h"
+#include "definitions.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  // \defgroup cpp_kodi_gui ::general
+  /// \addtogroup cpp_kodi_gui
+  /// @{
+  /// @brief **Allow use of binary classes and function to use on add-on's**
+  ///
+  /// Permits the use of the required functions of the add-on to Kodi. This class
+  /// also contains some functions to the control.
+  ///
+  /// These are pure functions them no other initialization need.
+  ///
+  /// It has the header \ref kodi/gui/General.h "#include <kodi/gui/General.h>" be included
+  /// to enjoy it.
+  ///
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Performs a graphical lock of rendering engine
+  ///
+  inline void Lock()
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->general->lock();
+  }
+
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Performs a graphical unlock of previous locked rendering engine
+  ///
+  inline void Unlock()
+  {
+    using namespace ::kodi::addon;
+    CAddonBase::m_interface->toKodi->kodi_gui->general->unlock();
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Return the the current screen height with pixel
+  ///
+  inline int GetScreenHeight()
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->general->get_screen_height(CAddonBase::m_interface->toKodi->kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Return the the current screen width with pixel
+  ///
+  inline int GetScreenWidth()
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->general->get_screen_width(CAddonBase::m_interface->toKodi->kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Return the the current screen rendering resolution
+  ///
+  inline int GetVideoResolution()
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->general->get_video_resolution(CAddonBase::m_interface->toKodi->kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Returns the id for the current 'active' dialog as an integer.
+  ///
+  /// @return                        The currently active dialog Id
+  ///
+  ///
+  ///-------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// ..
+  /// int wid = kodi::gui::GetCurrentWindowDialogId()
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  inline int GetCurrentWindowDialogId()
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->general->get_current_window_dialog_id(CAddonBase::m_interface->toKodi->kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Returns the id for the current 'active' window as an integer.
+  ///
+  /// @return                        The currently active window Id
+  ///
+  ///
+  ///-------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// ..
+  /// int wid = kodi::gui::GetCurrentWindowId()
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  inline int GetCurrentWindowId()
+  {
+    using namespace ::kodi::addon;
+    return CAddonBase::m_interface->toKodi->kodi_gui->general->get_current_window_id(CAddonBase::m_interface->toKodi->kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
@@ -1,0 +1,164 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <time.h>
+
+/*
+ * Internal Structures to have "C"-Style data transfer
+ */
+extern "C"
+{
+
+typedef struct AddonToKodiFuncTable_kodi_gui_general
+{
+  void (*lock)();
+  void (*unlock)();
+  int (*get_screen_height)(void* kodiBase);
+  int (*get_screen_width)(void* kodiBase);
+  int (*get_video_resolution)(void* kodiBase);
+  int (*get_current_window_dialog_id)(void* kodiBase);
+  int (*get_current_window_id)(void* kodiBase);
+} AddonToKodiFuncTable_kodi_gui_general;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogContextMenu
+{
+  int (*open)(void* kodiBase, const char *heading, const char *entries[], unsigned int size);
+} AddonToKodiFuncTable_kodi_gui_dialogContextMenu;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogExtendedProgress
+{
+  void* (*new_dialog)(void* kodiBase, const char *title);
+  void (*delete_dialog)(void* kodiBase, void* handle);
+  char* (*get_title)(void* kodiBase, void* handle);
+  void (*set_title)(void* kodiBase, void* handle, const char *title);
+  char* (*get_text)(void* kodiBase, void* handle);
+  void (*set_text)(void* kodiBase, void* handle, const char *text);
+  bool (*is_finished)(void* kodiBase, void* handle);
+  void (*mark_finished)(void* kodiBase, void* handle);
+  float (*get_percentage)(void* kodiBase, void* handle);
+  void (*set_percentage)(void* kodiBase, void* handle, float percentage);
+  void (*set_progress)(void* kodiBase, void* handle, int currentItem, int itemCount);
+} AddonToKodiFuncTable_kodi_gui_dialogExtendedProgress;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogFileBrowser
+{
+  bool (*show_and_get_directory)(void* kodiBase, const char* shares, const char* heading, const char* path_in, char** path_out, bool writeOnly);
+  bool (*show_and_get_file)(void* kodiBase, const char* shares, const char* mask, const char* heading, const char* path_in, char** path_out, bool use_thumbs, bool use_file_directories);
+  bool (*show_and_get_file_from_dir)(void* kodiBase, const char* directory, const char* mask, const char* heading, const char* path_in, char** path_out, bool use_thumbs, bool use_file_directories, bool singleList);
+  bool (*show_and_get_file_list)(void* kodiBase, const char* shares, const char* mask, const char* heading, char*** file_list, unsigned int* entries, bool use_thumbs, bool use_file_directories);
+  bool (*show_and_get_source)(void* kodiBase, const char* path_in, char** path_out, bool allow_network_shares, const char* additional_share, const char* type);
+  bool (*show_and_get_image)(void* kodiBase, const char* shares, const char* heading, const char* path_in, char** path_out);
+  bool (*show_and_get_image_list)(void* kodiBase,  const char* shares, const char* heading, char*** file_list, unsigned int* entries);
+  void (*clear_file_list)(void* kodiBase, char*** file_list, unsigned int entries);
+} AddonToKodiFuncTable_kodi_gui_dialogFileBrowser;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogKeyboard
+{
+  bool (*show_and_get_input_with_head)(void* kodiBase, const char* text_in, char** text_out, const char* heading, bool allow_empty_result, bool hiddenInput, unsigned int auto_close_ms);
+  bool (*show_and_get_input)(void* kodiBase, const char* text_in, char** text_out, bool allow_empty_result, unsigned int auto_close_ms);
+  bool (*show_and_get_new_password_with_head)(void* kodiBase, const char* password_in, char** password_out, const char* heading, bool allow_empty_result, unsigned int auto_close_ms);
+  bool (*show_and_get_new_password)(void* kodiBase, const char* password_in, char** password_out, unsigned int auto_close_ms);
+  bool (*show_and_verify_new_password_with_head)(void* kodiBase, char** password_out, const char* heading, bool allow_empty_result, unsigned int auto_close_ms);
+  bool (*show_and_verify_new_password)(void* kodiBase, char** password_out, unsigned int auto_close_ms);
+  int (*show_and_verify_password)(void* kodiBase, const char* password_in, char** password_out, const char* heading, int retries, unsigned int auto_close_ms);
+  bool (*show_and_get_filter)(void* kodiBase, const char* text_in, char** text_out, bool searching, unsigned int auto_close_ms);
+  bool (*send_text_to_active_keyboard)(void* kodiBase, const char* text, bool close_keyboard);
+  bool (*is_keyboard_activated)(void* kodiBase);
+} AddonToKodiFuncTable_kodi_gui_dialogKeyboard;
+  
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogNumeric
+{
+  bool (*show_and_verify_new_password)(void* kodiBase, char** password);
+  int (*show_and_verify_password)(void* kodiBase, const char* password, const char *heading, int retries);
+  bool (*show_and_verify_input)(void* kodiBase, const char* verify_in, char** verify_out, const char* heading, bool verify_input);
+  bool (*show_and_get_time)(void* kodiBase, tm *time, const char *heading);
+  bool (*show_and_get_date)(void* kodiBase, tm *date, const char *heading);
+  bool (*show_and_get_ip_address)(void* kodiBase, const char* ip_address_in, char** ip_address_out, const char *heading);
+  bool (*show_and_get_number)(void* kodiBase, const char* input_in, char** input_out, const char *heading, unsigned int auto_close_ms);
+  bool (*show_and_get_seconds)(void* kodiBase, const char* time_in, char** time_out, const char *heading);
+} AddonToKodiFuncTable_kodi_gui_dialogNumeric;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogOK
+{
+  void (*show_and_get_input_single_text)(void* kodiBase, const char *heading, const char *text);
+  void (*show_and_get_input_line_text)(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2);
+} AddonToKodiFuncTable_kodi_gui_dialogOK;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogProgress
+{
+  void* (*new_dialog)(void* kodiBase);
+  void (*delete_dialog)(void* kodiBase, void* handle);
+  void (*open)(void* kodiBase, void* handle);
+  void (*set_heading)(void* kodiBase, void* handle, const char* heading);
+  void (*set_line)(void* kodiBase, void* handle, unsigned int lineNo, const char* line);
+  void (*set_can_cancel)(void* kodiBase, void* handle, bool canCancel);
+  bool (*is_canceled)(void* kodiBase, void* handle);
+  void (*set_percentage)(void* kodiBase, void* handle, int percentage);
+  int (*get_percentage)(void* kodiBase, void* handle);
+  void (*show_progress_bar)(void* kodiBase, void* handle, bool pnOff);
+  void (*set_progress_max)(void* kodiBase, void* handle, int max);
+  void (*set_progress_advance)(void* kodiBase, void* handle, int nSteps);
+  bool (*abort)(void* kodiBase, void* handle);
+} AddonToKodiFuncTable_kodi_gui_dialogProgress;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogSelect
+{
+  int (*open)(void* kodiBase, const char *heading, const char *entries[], unsigned int size, int selected, bool autoclose);
+} AddonToKodiFuncTable_kodi_gui_dialogSelect;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogTextViewer
+{
+  void (*open)(void* kodiBase, const char *heading, const char *text);
+} AddonToKodiFuncTable_kodi_gui_dialogTextViewer;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogYesNo
+{
+  bool (*show_and_get_input_single_text)(void* kodiBase, const char *heading, const char *text, bool *canceled, const char *noLabel, const char *yesLabel);
+  bool (*show_and_get_input_line_text)(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2, const char *noLabel, const char *yesLabel);
+  bool (*show_and_get_input_line_button_text)(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2, bool *canceled, const char *noLabel, const char *yesLabel);
+} AddonToKodiFuncTable_kodi_gui_dialogYesNo;
+
+typedef struct AddonToKodiFuncTable_kodi_gui
+{
+  AddonToKodiFuncTable_kodi_gui_general* general;
+  AddonToKodiFuncTable_kodi_gui_dialogContextMenu* dialogContextMenu;
+  AddonToKodiFuncTable_kodi_gui_dialogExtendedProgress* dialogExtendedProgress;
+  AddonToKodiFuncTable_kodi_gui_dialogFileBrowser* dialogFileBrowser;
+  AddonToKodiFuncTable_kodi_gui_dialogKeyboard* dialogKeyboard;
+  AddonToKodiFuncTable_kodi_gui_dialogNumeric* dialogNumeric;
+  AddonToKodiFuncTable_kodi_gui_dialogOK* dialogOK;
+  AddonToKodiFuncTable_kodi_gui_dialogProgress* dialogProgress;
+  AddonToKodiFuncTable_kodi_gui_dialogSelect* dialogSelect;
+  AddonToKodiFuncTable_kodi_gui_dialogTextViewer* dialogTextViewer;
+  AddonToKodiFuncTable_kodi_gui_dialogYesNo* dialogYesNo;
+} AddonToKodiFuncTable_kodi_gui;
+
+} /* extern "C" */
+
+//============================================================================
+///
+/// \ingroup cpp_kodi_gui_CControlRendering_Defs cpp_kodi_gui_CWindow_Defs
+/// @{
+/// @brief Handle to use as independent pointer for GUI
+typedef void* GUIHANDLE;
+/// @}
+//----------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

This add the first parts of gui related addon callback parts to new
style. There becomes standard functions and the dialogs added.

On next request comes the controls list item and window.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
