### PR TITLE
[cmake][windows] add project/BuildDependencies/${ARCH}/lib as link directory for win32

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -62,6 +62,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
 # TODO: It would certainly be better to handle these libraries via CMake modules.
 if(${ARCH} STREQUAL win32)
   link_directories(${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg/bin
+                   ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH}/lib
                    ${CMAKE_SOURCE_DIR}/project/BuildDependencies/lib)
 else()
   link_directories(${CMAKE_SOURCE_DIR}/lib/win32/ffmpeg/bin


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description
Allow to also place libs for win32 at project/BuildDependencies/${ARCH}/lib.

<!--- Describe your change in detail -->
## Motivation and Context
Missed at #11822
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
