### PR TITLE
[addons] add callback function to get the MD5 digest of the given text

### DIFF
--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -29,6 +29,7 @@
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/md5.h"
 #include "utils/StringUtils.h"
 
 using namespace kodi; // addon-dev-kit namespace
@@ -45,6 +46,7 @@ void Interface_General::Init(AddonGlobalInterface* addonInterface)
   addonInterface->toKodi->kodi->unknown_to_utf8 = unknown_to_utf8;
   addonInterface->toKodi->kodi->get_language = get_language;
   addonInterface->toKodi->kodi->queue_notification = queue_notification;
+  addonInterface->toKodi->kodi->get_md5 = get_md5;
 }
 
 void Interface_General::DeInit(AddonGlobalInterface* addonInterface)
@@ -221,5 +223,18 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
   }
   return true;
 }
-  
+
+void Interface_General::get_md5(void* kodiBase, const char* text, char* md5)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (addon == nullptr || text == nullptr)
+  {
+    CLog::Log(LOGERROR, "Interface_General::%s - invalid data (addon='%p', text='%p')", __FUNCTION__, addon, text);
+    return;
+  }
+
+  std::string md5Int = XBMC::XBMC_MD5::GetMD5(std::string(text));
+  strncpy(md5, md5Int.c_str(), 40);
+}
+
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/General.h
+++ b/xbmc/addons/interfaces/General.h
@@ -56,6 +56,7 @@ namespace ADDON
     static char* unknown_to_utf8(void* kodiBase, const char* source, bool* ret, bool failOnBadChar);
     static char* get_language(void* kodiBase, int format, bool region);
     static bool queue_notification(void* kodiBase, int type, const char* header, const char* message, const char* imageFile, unsigned int displayTime, bool withSound, unsigned int messageTime);
+    static void get_md5(void* kodiBase, const char* text, char* md5);
     //@}
   };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -39,6 +39,7 @@ typedef struct AddonToKodiFuncTable_kodi
   char* (*get_localized_string)(void* kodiBase, long dwCode);
   char* (*get_language)(void* kodiBase, int format, bool region);
   bool (*queue_notification)(void* kodiBase, int type, const char* header, const char* message, const char* imageFile, unsigned int displayTime, bool withSound, unsigned int messageTime);
+  void (*get_md5)(void* kodiBase, const char* text, char* md5);
 } AddonToKodiFuncTable_kodi;
 
 //==============================================================================
@@ -374,3 +375,35 @@ inline void QueueNotification(QueueMsg type, const std::string& header,
 }
 } /* namespace kodi */
 //------------------------------------------------------------------------------
+
+//============================================================================
+namespace kodi {
+///
+/// \ingroup cpp_kodi
+/// @brief Get the MD5 digest of the given text
+///
+/// @param[in]  text  text to compute the MD5 for
+/// @return           Returned MD5 digest
+///
+///
+/// ------------------------------------------------------------------------
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/General.h>
+/// ...
+/// std::string md5 = kodi::GetMD5("Make me as md5");
+/// fprintf(stderr, "My md5 digest is: '%s'\n", md5.c_str());
+/// ...
+/// ~~~~~~~~~~~~~
+///
+inline std::string GetMD5(const std::string& text)
+{
+  char* md5ret = static_cast<char*>(malloc(40*sizeof(char))); // md5 size normally 32 bytes
+  ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_md5(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, text.c_str(), md5ret);
+  std::string md5 = md5ret;
+  free(md5ret);
+  return md5;
+}
+} /* namespace kodi */
+//----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -41,7 +41,7 @@
  * overview.
  */
 
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.7"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.8"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.2"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Is needed on my test on GUI addon callbacks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
