### PR TITLE
[dependencies][windows] bump libmicrohttpd to 0.9.55

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win32.list
@@ -22,7 +22,7 @@ libcec-4.0.1-win32-vc140-2.7z
 libfribidi-0.19.2-win32.7z
 libiconv-1.14-win32-vc140-v2.7z
 libjpeg-turbo-1.4.90-win32-vc140.7z
-libmicrohttpd-0.9.50-win32-vc140.7z
+libmicrohttpd-0.9.55-win32-vc140.7z
 libnfs-1.10.0-win32.7z
 libplist-1.13.0-win32-vc140.7z
 libpng-1.6.21-win32-vc140.7z

--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -20,7 +20,7 @@ libcdio-0.94-x64-vc140.7z
 libcec-4.0.2-x64-vc140.7z
 libfribidi-0.19.7-x64-vc140.7z
 libiconv-1.15-x64-vc140.7z
-libmicrohttpd-0.9.52-x64-vc140.7z
+libmicrohttpd-0.9.55-x64-vc140.7z
 libnfs-1.11.0-x64-vc140-v2.7z
 libplist-1.12-x64-vc140.7z
 libssh-0.7.4-x64-vc140.7z


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
bumps libmicrohttpd to 0.9.55 for 32 and 64 bit
<!--- Describe your change in detail -->

## Motivation and Context
corresponding windows bump for #12192
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled and tested the webinterface
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
