### PR TITLE
[windows] fix doxygen comments on GUIMediaWindow.cpp

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -520,9 +520,14 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
   return CGUIWindow::OnMessage(message);
 }
 
-// \brief Updates the states (enable, disable, visible...)
-// of the controls defined by this window
-// Override this function in a derived class to add new controls
+/*!
+ * \brief Updates the states
+ *
+ * This updates the states (enable, disable, visible...) of the controls defined
+ * by this window.
+ *
+ * \note Override this function in a derived class to add new controls
+ */
 void CGUIMediaWindow::UpdateButtons()
 {
   if (m_guiState.get())
@@ -565,7 +570,12 @@ void CGUIMediaWindow::ClearFileItems()
   m_unfilteredItems->Clear();
 }
 
-// \brief Sorts Fileitems based on the sort method and sort oder provided by guiViewState
+/*!
+ * \brief Sort file items
+ *
+ * This sorts file items based on the sort method and sort order provided by
+ * guiViewState.
+ */
 void CGUIMediaWindow::SortItems(CFileItemList &items)
 {
   std::unique_ptr<CGUIViewState> guiState(CGUIViewState::GetViewState(GetID(), items));
@@ -599,7 +609,11 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
   }
 }
 
-// \brief Formats item labels based on the formatting provided by guiViewState
+/*!
+ * \brief Formats item labels
+ *
+ * This is based on the formatting provided by guiViewState.
+ */
 void CGUIMediaWindow::FormatItemLabels(CFileItemList &items, const LABEL_MASKS &labelMasks)
 {
   CLabelFormatter fileFormatter(labelMasks.m_strLabelFile, labelMasks.m_strLabel2File);
@@ -621,7 +635,11 @@ void CGUIMediaWindow::FormatItemLabels(CFileItemList &items, const LABEL_MASKS &
     items.ClearSortState();
 }
 
-// \brief Prepares and adds the fileitems list/thumb panel
+/*!
+ * \brief Format and sort file items
+ *
+ * Prepares and adds the fileitems to list/thumb panel
+ */
 void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
 {
   std::unique_ptr<CGUIViewState> viewState(CGUIViewState::GetViewState(GetID(), items));
@@ -637,10 +655,12 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
 }
 
 /*!
-  \brief Overwrite to fill fileitems from a source
-  \param strDirectory Path to read
-  \param items Fill with items specified in \e strDirectory
-  */
+ * \brief Overwrite to fill fileitems from a source
+ *
+ * \param[in] strDirectory Path to read
+ * \param[out] items Fill with items specified in \e strDirectory
+ * \return false if given directory not present
+ */
 bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
   const CURL pathToUrl(strDirectory);
@@ -878,18 +898,30 @@ bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
   return true;
 }
 
-// \brief This function will be called by Update() before the
-// labels of the fileitems are formatted. Override this function
-// to set custom thumbs or load additional media info.
-// It's used to load tag info for music.
+/*!
+ * \brief On prepare file items
+ *
+ * This function will be called by Update() before the labels of the fileitems
+ * are formatted.
+ *
+ * \note Override this function to set custom thumbs or load additional media
+ * info.
+ *
+ * It's used to load tag info for music.
+ */
 void CGUIMediaWindow::OnPrepareFileItems(CFileItemList &items)
 {
   CFileItemListModification::GetInstance().Modify(items);
 }
 
-// \brief This function will be called by Update() before
-// any additional formatting, filtering or sorting is applied.
-// Override this function to define a custom caching behaviour.
+/*!
+ * \brief On cache file items
+ *
+ * This function will be called by Update() before
+ * any additional formatting, filtering or sorting is applied.
+ * 
+ * \note Override this function to define a custom caching behaviour.
+ */
 void CGUIMediaWindow::OnCacheFileItems(CFileItemList &items)
 {
   // Should these items be saved to the hdd
@@ -897,9 +929,13 @@ void CGUIMediaWindow::OnCacheFileItems(CFileItemList &items)
     items.Save(GetID());
 }
 
-// \brief With this function you can react on a users click in the list/thumb panel.
-// It returns true, if the click is handled.
-// This function calls OnPlayMedia()
+/*!
+ * \brief On click
+ *
+ * With this function you can react on a users click in the list/thumb panel.
+ * It returns true, if the click is handled.
+ * This function calls OnPlayMedia()
+ */
 bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 {
   if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return true;
@@ -1068,8 +1104,12 @@ bool CGUIMediaWindow::OnSelect(int item)
   return OnClick(item);
 }
 
-// \brief Checks if there is a disc in the dvd drive and whether the
-// network is connected or not.
+/*!
+ * \brief Check disc or connection present
+ *
+ * Checks if there is a disc in the dvd drive and whether the
+ * network is connected or not.
+ */
 bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriveType)
 {
   if (iDriveType==CMediaSource::SOURCE_TYPE_DVD)
@@ -1093,7 +1133,9 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriv
   return true;
 }
 
-// \brief Shows a standard errormessage for a given pItem.
+/*!
+ * \brief Shows a standard error message for a given pItem.
+ */
 void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem) const
 {
   if (!pItem->m_bIsShareOrDrive)
@@ -1112,7 +1154,11 @@ void CGUIMediaWindow::ShowShareErrorMessage(CFileItem* pItem) const
   CGUIDialogOK::ShowAndGetInput(CVariant{220}, CVariant{idMessageText});
 }
 
-// \brief The function goes up one level in the directory tree
+/*!
+ * \brief Go one directory up on list items
+ *
+ * The function goes up one level in the directory tree
+ */
 bool CGUIMediaWindow::GoParentFolder()
 {
   if (m_vecItems->IsVirtualDirectoryRoot())
@@ -1204,8 +1250,12 @@ void CGUIMediaWindow::RestoreSelectedItemFromHistory()
   m_viewControl.SetSelectedItem(0);
 }
 
-// \brief Override the function to change the default behavior on how
-// a selected item history should look like
+/*!
+ * \brief Get history string for given file item
+ *
+ * \note Override the function to change the default behavior on how
+ * a selected item history should look like
+ */
 void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::string& strHistoryString) const
 {
   if (pItem->m_bIsShareOrDrive)
@@ -1264,8 +1314,12 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, std::str
   StringUtils::ToLower(strHistoryString);
 }
 
-// \brief Call this function to create a directory history for the
-// path given by strDirectory.
+/*!
+ * \brief Set history for path
+ *
+ * Call this function to create a directory history for the
+ * path given by strDirectory.
+ */
 void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
 {
   // Make sure our shares are configured
@@ -1330,9 +1384,14 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
   //m_history.DumpPathHistory();
 }
 
-// \brief Override if you want to change the default behavior, what is done
-// when the user clicks on a file.
-// This function is called by OnClick()
+/*!
+ * \brief On media play
+ *
+ * \note Override if you want to change the default behavior, what is done
+ * when the user clicks on a file.
+ *
+ * This function is called by OnClick()
+ */
 bool CGUIMediaWindow::OnPlayMedia(int iItem, const std::string &player)
 {
   // Reset Playlistplayer, playback started now does
@@ -1355,9 +1414,14 @@ bool CGUIMediaWindow::OnPlayMedia(int iItem, const std::string &player)
   return bResult;
 }
 
-// \brief Override if you want to change the default behavior of what is done
-// when the user clicks on a file in a "folder" with similar files.
-// This function is called by OnClick()
+/*!
+ * \brief On play and media queue
+ *
+ * \note Override if you want to change the default behavior of what is done
+ * when the user clicks on a file in a "folder" with similar files.
+ *
+ * This function is called by OnClick()
+ */
 bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string player)
 {
   //play and add current directory to temporary playlist
@@ -1417,9 +1481,13 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string 
   return true;
 }
 
-// \brief Synchronize the fileitems with the playlistplayer
-// It recreated the playlist of the playlistplayer based
-// on the fileitems of the window
+/*!
+ * \brief Update file list
+ *
+ * Synchronize the fileitems with the playlistplayer
+ * also recreates the playlist of the playlistplayer based
+ * on the fileitems of the window
+ */
 void CGUIMediaWindow::UpdateFileList()
 {
   int nItem = m_viewControl.GetSelectedItem();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
On GUIMediaWindow.cpp was on many places the `\brief` used
but not the line started with `\\\`, `\*!` or `\**`, this
change to use with doxygen.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
