### PR TITLE
Improve GUI message handling / gui::smartredraw

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4594,6 +4594,8 @@ void CApplication::ProcessSlow()
 
   m_ServiceManager->GetActiveAE().GarbageCollect();
 
+  RefreshControls();
+
   // if we don't render the gui there's no reason to start the screensaver.
   // that way the screensaver won't kick in if we maximize the XBMC window
   // after the screensaver start time.
@@ -5230,6 +5232,12 @@ void CApplication::CloseNetworkShares()
     VFSEntryPtr vfs = std::static_pointer_cast<CVFSEntry>(addon);
     vfs->DisconnectAll();
   }
+}
+
+void CApplication::RefreshControls()
+{
+  CGUIMessage msg(GUI_MSG_REFRESH_TIMER, 0, 0, 0);
+  g_windowManager.SendThreadMessage(msg);
 }
 
 void CApplication::RegisterActionListener(IActionListener *listener)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -33,7 +33,6 @@
 #include "Util.h"
 #include "URL.h"
 #include "guilib/TextureManager.h"
-#include "cores/DataCacheCore.h"
 #include "cores/IPlayer.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
@@ -4595,7 +4594,7 @@ void CApplication::ProcessSlow()
 
   m_ServiceManager->GetActiveAE().GarbageCollect();
 
-  SendGUIMessage(GUI_MSG_REFRESH_TIMER);
+  g_windowManager.SendMessage(GUI_MSG_REFRESH_TIMER,0,0);
 
   // if we don't render the gui there's no reason to start the screensaver.
   // that way the screensaver won't kick in if we maximize the XBMC window
@@ -5233,12 +5232,6 @@ void CApplication::CloseNetworkShares()
     VFSEntryPtr vfs = std::static_pointer_cast<CVFSEntry>(addon);
     vfs->DisconnectAll();
   }
-}
-
-void CApplication::SendGUIMessage(int dwMsg, int senderID/* = 0*/, int controlID/* = 0*/, int param1/* = 0*/, int param2/* = 0*/)
-{
-  CGUIMessage msg(dwMsg, senderID, controlID, param1, param2);
-  g_windowManager.SendThreadMessage(msg);
 }
 
 void CApplication::RegisterActionListener(IActionListener *listener)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1909,13 +1909,13 @@ void CApplication::Render()
 
   g_Windowing.EndRender();
 
-  // reset our info cache - we do this at the end of Render so that it is
-  // fresh for the next process(), or after a windowclose animation (where process()
-  // isn't called)
-  g_infoManager.ResetCache();
-
   if (hasRendered)
   {
+    // reset our info cache - we do this at the end of Render so that it is
+    // fresh for the next process(), or after a windowclose animation (where process()
+    // isn't called)
+    g_infoManager.ResetCache();
+
     g_infoManager.UpdateFPS();
   }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1909,13 +1909,13 @@ void CApplication::Render()
 
   g_Windowing.EndRender();
 
+  // reset our info cache - we do this at the end of Render so that it is
+  // fresh for the next process(), or after a windowclose animation (where process()
+  // isn't called)
+  g_infoManager.ResetCache();
+
   if (hasRendered)
   {
-    // reset our info cache - we do this at the end of Render so that it is
-    // fresh for the next process(), or after a windowclose animation (where process()
-    // isn't called)
-    g_infoManager.ResetCache();
-
     g_infoManager.UpdateFPS();
   }
 
@@ -4594,7 +4594,7 @@ void CApplication::ProcessSlow()
 
   m_ServiceManager->GetActiveAE().GarbageCollect();
 
-  RefreshControls();
+  SendGUIMessage(GUI_MSG_REFRESH_TIMER);
 
   // if we don't render the gui there's no reason to start the screensaver.
   // that way the screensaver won't kick in if we maximize the XBMC window
@@ -5234,9 +5234,9 @@ void CApplication::CloseNetworkShares()
   }
 }
 
-void CApplication::RefreshControls()
+void CApplication::SendGUIMessage(int dwMsg, int senderID/* = 0*/, int controlID/* = 0*/, int param1/* = 0*/, int param2/* = 0*/)
 {
-  CGUIMessage msg(GUI_MSG_REFRESH_TIMER, 0, 0, 0);
+  CGUIMessage msg(dwMsg, senderID, controlID, param1, param2);
   g_windowManager.SendThreadMessage(msg);
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -33,6 +33,7 @@
 #include "Util.h"
 #include "URL.h"
 #include "guilib/TextureManager.h"
+#include "cores/DataCacheCore.h"
 #include "cores/IPlayer.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
@@ -2718,6 +2719,9 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     }
     if (m_ProcessedExternalDecay && --m_ProcessedExternalDecay == 0)
       m_ProcessedExternalCalls = 0;
+
+    if (CDataCacheCore::GetInstance().IsPlayerStateChanged())
+      SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
   }
 
   if (processGUI && m_renderGUI)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2719,9 +2719,6 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     }
     if (m_ProcessedExternalDecay && --m_ProcessedExternalDecay == 0)
       m_ProcessedExternalCalls = 0;
-
-    if (CDataCacheCore::GetInstance().IsPlayerStateChanged())
-      SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
   }
 
   if (processGUI && m_renderGUI)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -195,7 +195,6 @@ public:
   void ActivateScreenSaver(bool forceType = false);
   bool SetupNetwork();
   void CloseNetworkShares();
-  void SendGUIMessage(int dwMsg, int senderID = 0, int controlID = 0, int param1 = 0, int param2 = 0);
 
   void ShowAppMigrationMessage();
   virtual void Process() override;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -195,7 +195,7 @@ public:
   void ActivateScreenSaver(bool forceType = false);
   bool SetupNetwork();
   void CloseNetworkShares();
-  void RefreshControls();
+  void SendGUIMessage(int dwMsg, int senderID = 0, int controlID = 0, int param1 = 0, int param2 = 0);
 
   void ShowAppMigrationMessage();
   virtual void Process() override;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -195,6 +195,7 @@ public:
   void ActivateScreenSaver(bool forceType = false);
   bool SetupNetwork();
   void CloseNetworkShares();
+  void RefreshControls();
 
   void ShowAppMigrationMessage();
   virtual void Process() override;

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ApplicationPlayer.h"
+#include "cores/DataCacheCore.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "Application.h"
@@ -749,7 +750,12 @@ void CApplicationPlayer::FrameMove()
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
+  {
     player->FrameMove();
+
+    if (CDataCacheCore::GetInstance().IsPlayerStateChanged())
+      g_application.SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
+  }
 }
 
 void CApplicationPlayer::Render(bool clear, uint32_t alpha, bool gui)

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -22,6 +22,7 @@
 #include "cores/DataCacheCore.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
+#include "guilib/GUIWindowManager.h"
 #include "Application.h"
 #include "PlayListPlayer.h"
 #include "settings/MediaSettings.h"
@@ -754,7 +755,8 @@ void CApplicationPlayer::FrameMove()
     player->FrameMove();
 
     if (CDataCacheCore::GetInstance().IsPlayerStateChanged())
-      g_application.SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
+      // CApplicationMessenger would be overhead because we are already in gui thread
+      g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
   }
 }
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -328,7 +328,9 @@ protected:
   int m_nextWindowID;
   int m_prevWindowID;
 
-  std::vector<INFO::InfoPtr> m_bools;
+  typedef std::set<INFO::InfoPtr, bool(*)(const INFO::InfoPtr&, const INFO::InfoPtr&)> INFOBOOLTYPE;
+  INFOBOOLTYPE m_bools;
+  unsigned int m_refreshCounter;
   std::vector<INFO::CSkinVariableString> m_skinVariableStrings;
 
   int m_libraryHasMusic;

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -227,7 +227,7 @@ void CDataCacheCore::SetStateSeeking(bool active)
   CSingleLock lock(m_stateSection);
 
   m_stateInfo.m_stateSeeking = active;
-  m_playStateChanged = true;
+  m_playerStateChanged = true;
 }
 
 bool CDataCacheCore::CDataCacheCore::IsSeeking()

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -23,11 +23,12 @@
 #include "ServiceBroker.h"
 
 CDataCacheCore::CDataCacheCore()
+  :m_playStateChanged(false)
 {
   m_hasAVInfoChanges = false;
 }
 
-CDataCacheCore& GetInstance()
+CDataCacheCore& CDataCacheCore::GetInstance()
 {
   return CServiceBroker::GetDataCacheCore();
 }
@@ -227,6 +228,7 @@ void CDataCacheCore::SetStateSeeking(bool active)
   CSingleLock lock(m_stateSection);
 
   m_stateInfo.m_stateSeeking = active;
+  m_playStateChanged = true;
 }
 
 bool CDataCacheCore::CDataCacheCore::IsSeeking()
@@ -234,4 +236,14 @@ bool CDataCacheCore::CDataCacheCore::IsSeeking()
   CSingleLock lock(m_stateSection);
 
   return m_stateInfo.m_stateSeeking;
+}
+
+bool CDataCacheCore::PlayStateChanged()
+{
+  CSingleLock lock(m_stateSection);
+
+  bool ret(m_playStateChanged);
+  m_playStateChanged = false;
+
+  return ret;
 }

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -23,7 +23,6 @@
 #include "ServiceBroker.h"
 
 CDataCacheCore::CDataCacheCore()
-  :m_playStateChanged(false)
 {
   m_hasAVInfoChanges = false;
 }
@@ -238,12 +237,12 @@ bool CDataCacheCore::CDataCacheCore::IsSeeking()
   return m_stateInfo.m_stateSeeking;
 }
 
-bool CDataCacheCore::PlayStateChanged()
+bool CDataCacheCore::IsPlayerStateChanged()
 {
   CSingleLock lock(m_stateSection);
 
-  bool ret(m_playStateChanged);
-  m_playStateChanged = false;
+  bool ret(m_playerStateChanged);
+  m_playerStateChanged = false;
 
   return ret;
 }

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -99,6 +99,7 @@ protected:
   } m_renderInfo;
 
   CCriticalSection m_stateSection;
+  bool m_playStateChanged;
   struct SStateInfo
   {
     bool m_stateSeeking;

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -66,6 +66,7 @@ public:
   // player states
   void SetStateSeeking(bool active);
   bool IsSeeking();
+  bool IsPlayerStateChanged();
 
 protected:
   std::atomic_bool m_hasAVInfoChanges;
@@ -99,7 +100,7 @@ protected:
   } m_renderInfo;
 
   CCriticalSection m_stateSection;
-  bool m_playStateChanged;
+  bool m_playerStateChanged = false;
   struct SStateInfo
   {
     bool m_stateSeeking;

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -55,6 +55,8 @@ bool CGUIDialogSeekBar::OnMessage(CGUIMessage& message)
     if (message.GetSenderId() == GetID() && message.GetControlId() == POPUP_SEEK_PROGRESS)
       return CGUIDialog::OnMessage(message);
     break;
+  case GUI_MSG_REFRESH_TIMER:
+    return CGUIDialog::OnMessage(message);
   }
   return false; // don't process anything other than what we need!
 }

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -30,6 +30,7 @@
 
 CGUIDialogSeekBar::CGUIDialogSeekBar(void)
   : CGUIDialog(WINDOW_DIALOG_SEEK_BAR, "DialogSeekBar.xml", DialogModalityType::MODELESS)
+  , m_lastPercent(~0)
 {
   m_loadType = LOAD_ON_GUI_INIT;    // the application class handles our resources
 }
@@ -55,19 +56,6 @@ bool CGUIDialogSeekBar::OnMessage(CGUIMessage& message)
     if (message.GetSenderId() == GetID() && message.GetControlId() == POPUP_SEEK_PROGRESS)
       return CGUIDialog::OnMessage(message);
     break;
-  case GUI_MSG_REFRESH_TIMER:
-    // update controls
-    if (!CSeekHandler::GetInstance().InProgress() && g_infoManager.GetTotalPlayTime())
-    { // position the bar at our current time
-      CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, lrintf(g_application.GetPercentage()));
-      SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentPlayTime());
-    }
-    else
-    {
-      CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)g_infoManager.GetSeekPercent());
-      SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentSeekTime());
-    }
-    return CGUIDialog::OnMessage(message);
   }
   return false; // don't process anything other than what we need!
 }
@@ -79,6 +67,13 @@ void CGUIDialogSeekBar::FrameMove()
     Close(true);
     return;
   }
+
+  unsigned int percent((!CSeekHandler::GetInstance().InProgress() && g_infoManager.GetTotalPlayTime())
+    ? lrintf(g_application.GetPercentage())
+    : (unsigned int)g_infoManager.GetSeekPercent());
+
+  if (percent != m_lastPercent)
+    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, m_lastPercent = percent);
 
   CGUIDialog::FrameMove();
 }

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -30,7 +30,6 @@
 
 CGUIDialogSeekBar::CGUIDialogSeekBar(void)
   : CGUIDialog(WINDOW_DIALOG_SEEK_BAR, "DialogSeekBar.xml", DialogModalityType::MODELESS)
-  , m_lastPercent(~0)
 {
   m_loadType = LOAD_ON_GUI_INIT;    // the application class handles our resources
 }

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -55,6 +55,19 @@ bool CGUIDialogSeekBar::OnMessage(CGUIMessage& message)
     if (message.GetSenderId() == GetID() && message.GetControlId() == POPUP_SEEK_PROGRESS)
       return CGUIDialog::OnMessage(message);
     break;
+  case GUI_MSG_REFRESH_TIMER:
+    // update controls
+    if (!CSeekHandler::GetInstance().InProgress() && g_infoManager.GetTotalPlayTime())
+    { // position the bar at our current time
+      CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, lrintf(g_application.GetPercentage()));
+      SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentPlayTime());
+    }
+    else
+    {
+      CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)g_infoManager.GetSeekPercent());
+      SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentSeekTime());
+    }
+    return CGUIDialog::OnMessage(message);
   }
   return false; // don't process anything other than what we need!
 }
@@ -65,18 +78,6 @@ void CGUIDialogSeekBar::FrameMove()
   {
     Close(true);
     return;
-  }
-
-  // update controls
-  if (!CSeekHandler::GetInstance().InProgress() && g_infoManager.GetTotalPlayTime())
-  { // position the bar at our current time
-    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, lrintf(g_application.GetPercentage()));
-    SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentPlayTime());
-  }
-  else
-  {
-    CONTROL_SELECT_ITEM(POPUP_SEEK_PROGRESS, (unsigned int)g_infoManager.GetSeekPercent());
-    SET_CONTROL_LABEL(POPUP_SEEK_LABEL, g_infoManager.GetCurrentSeekTime());
   }
 
   CGUIDialog::FrameMove();

--- a/xbmc/dialogs/GUIDialogSeekBar.h
+++ b/xbmc/dialogs/GUIDialogSeekBar.h
@@ -29,4 +29,6 @@ public:
   virtual ~CGUIDialogSeekBar(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
+private:
+  unsigned int m_lastPercent;
 };

--- a/xbmc/dialogs/GUIDialogSeekBar.h
+++ b/xbmc/dialogs/GUIDialogSeekBar.h
@@ -30,5 +30,5 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
 private:
-  unsigned int m_lastPercent;
+  unsigned int m_lastPercent = ~0U;
 };

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1364,6 +1364,8 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter) const
 
 void CGUIBaseContainer::SetCursor(int cursor)
 {
+  if (m_cursor != cursor)
+    MarkDirtyRegion();
   m_cursor = cursor;
 }
 

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -161,7 +161,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
   {
     if (!item->GetFocusedLayout())
     {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*m_focusedLayout);
+      CGUIListItemLayout *layout = new CGUIListItemLayout(*m_focusedLayout, this);
       item->SetFocusedLayout(layout);
     }
     if (item->GetFocusedLayout())
@@ -189,6 +189,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
     if (!item->GetLayout())
     {
       CGUIListItemLayout *layout = new CGUIListItemLayout(*m_layout);
+      layout->SetParentControl(this);
       item->SetLayout(layout);
     }
     if (item->GetFocusedLayout())
@@ -1149,6 +1150,7 @@ void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
     m_layouts.emplace_back();
     m_layouts.back().LoadLayout(itemElement, GetParentID(), false, m_width, m_height);
     itemElement = itemElement->NextSiblingElement("itemlayout");
+    m_layouts.back().SetParentControl(this);
   }
   itemElement = layout->FirstChildElement("focusedlayout");
   while (itemElement)
@@ -1156,6 +1158,7 @@ void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
     m_focusedLayouts.emplace_back();
     m_focusedLayouts.back().LoadLayout(itemElement, GetParentID(), true, m_width, m_height);
     itemElement = itemElement->NextSiblingElement("focusedlayout");
+    m_focusedLayouts.back().SetParentControl(this);
   }
 }
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -924,16 +924,6 @@ void CGUIControl::UnfocusFromPoint(const CPoint &point)
   }
 }
 
-bool CGUIControl::HasID(int id) const
-{
-  return GetID() == id;
-}
-
-bool CGUIControl::HasVisibleID(int id) const
-{
-  return GetID() == id && IsVisible();
-}
-
 void CGUIControl::SaveStates(std::vector<CControlState> &states)
 {
   // empty for now - do nothing with the majority of controls

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -54,6 +54,7 @@ CGUIControl::CGUIControl() :
   m_pulseOnSelect = false;
   m_controlIsDirty = true;
   m_stereo = 0.0f;
+  m_controlStats = nullptr;
 }
 
 CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, float width, float height)
@@ -82,6 +83,7 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_pulseOnSelect = false;
   m_controlIsDirty = false;
   m_stereo = 0.0f;
+  m_controlStats = nullptr;
 }
 
 
@@ -153,6 +155,8 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
       g_graphicsContext.RestoreCameraPosition();
     g_graphicsContext.RemoveTransform();
   }
+
+  UpdateControlStats();
 
   changed |= m_controlIsDirty;
 
@@ -925,6 +929,16 @@ void CGUIControl::UnfocusFromPoint(const CPoint &point)
 void CGUIControl::SaveStates(std::vector<CControlState> &states)
 {
   // empty for now - do nothing with the majority of controls
+}
+
+void CGUIControl::UpdateControlStats()
+{
+  if (m_controlStats)
+  {
+    ++m_controlStats->nCountTotal;
+    if (IsVisible() && IsVisibleFromSkin())
+      ++m_controlStats->nCountVisible;
+  }
 }
 
 void CGUIControl::SetHitRect(const CRect &rect, const color_t &color)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -175,6 +175,7 @@ public:
   virtual float GetHeight() const;
 
   void MarkDirtyRegion();
+  bool IsControlDirty() const { return m_controlIsDirty; };
 
   /*! \brief return the render region in screen coordinates of this control
    */

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -54,6 +54,17 @@ public:
   int m_data;
 };
 
+struct GUICONTROLSTATS
+{
+  unsigned int nCountTotal;
+  unsigned int nCountVisible;
+
+  void Reset()
+  {
+    nCountTotal = nCountVisible = 0;
+  };
+};
+
 /*!
  \brief Results of OnMouseEvent()
  Any value not equal to EVENT_RESULT_UNHANDLED indicates that the event was handled.
@@ -246,6 +257,9 @@ public:
   CGUIControl *GetParentControl(void) const { return m_parentControl; };
   virtual void SaveStates(std::vector<CControlState> &states);
 
+  void SetControlStats(GUICONTROLSTATS *controlStats) { m_controlStats = controlStats; };
+  virtual void UpdateControlStats();
+
   enum GUICONTROLTYPES {
     GUICONTROL_UNKNOWN,
     GUICONTROL_BUTTON,
@@ -334,6 +348,7 @@ protected:
   bool m_bAllocated;
   bool m_pulseOnSelect;
   GUICONTROLTYPES ControlType;
+  GUICONTROLSTATS *m_controlStats;
 
   CGUIControl *m_parentControl;   // our parent control if we're part of a group
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -153,8 +153,6 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual int GetID(void) const;
   virtual void SetID(int id) { m_controlID = id; };
-  virtual bool HasID(int id) const;
-  virtual bool HasVisibleID(int id) const;
   int GetParentID() const;
   virtual bool HasFocus() const;
   virtual void AllocResources();

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -508,6 +508,7 @@ void CGUIControlGroup::AddControl(CGUIControl *control, int position /* = -1*/)
     position = (int)m_children.size();
   m_children.insert(m_children.begin() + position, control);
   control->SetParentControl(this);
+  control->SetControlStats(m_controlStats);
   control->SetPushUpdates(m_pushedUpdates);
   AddLookup(control);
   SetInvalid();

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -222,7 +222,7 @@ bool CGUIControlGroup::OnMessage(CGUIMessage& message)
       // set all subcontrols unfocused
       for (auto *control : m_children)
         control->SetFocus(false);
-      if (!HasID(message.GetParam1()))
+      if (!GetControl(message.GetParam1()))
       { // we don't have the new id, so unfocus
         SetFocus(false);
         if (m_parentControl)
@@ -264,25 +264,17 @@ bool CGUIControlGroup::OnMessage(CGUIMessage& message)
 
 bool CGUIControlGroup::SendControlMessage(CGUIMessage &message)
 {
+  CGUIControl *ctrl = GetControl(message.GetControlId(), &m_idCollector);
   // see if a child matches, and send to the child control if so
-  for (auto *control : m_children)
-  {
-    if (control->HasVisibleID(message.GetControlId()))
-    {
-      if (control->OnMessage(message))
-        return true;
-    }
-  }
+  if (ctrl && ctrl->OnMessage(message))
+    return true;
+
   // Unhandled - send to all matching invisible controls as well
   bool handled(false);
-  for (auto *control : m_children)
-  {
-    if (control->HasID(message.GetControlId()))
-    {
-      if (control->OnMessage(message))
-        handled = true;
-    }
-  }
+  for (auto *control : m_idCollector)
+    if (control->OnMessage(message))
+      handled = true;
+
   return handled;
 }
 
@@ -406,34 +398,13 @@ void CGUIControlGroup::UnfocusFromPoint(const CPoint &point)
   CGUIControl::UnfocusFromPoint(point);
 }
 
-bool CGUIControlGroup::HasID(int id) const
+CGUIControl *CGUIControlGroup::GetControl(int iControl, std::vector<CGUIControl*> *idCollector)
 {
-  if (CGUIControl::HasID(id)) return true;
-  for (auto *child : m_children)
-  {
-    if (child->HasID(id))
-      return true;
-  }
-  return false;
-}
+  if (idCollector)
+    idCollector->clear();
 
-bool CGUIControlGroup::HasVisibleID(int id) const
-{
-  // call base class first as the group may be the requested control
-  if (CGUIControl::HasVisibleID(id)) return true;
-  // if the group isn't visible, then none of it's children can be
-  if (!IsVisible()) return false;
-  for (auto *child : m_children)
-  {
-    if (child->HasVisibleID(id))
-      return true;
-  }
-  return false;
-}
+  CGUIControl* pPotential(nullptr);
 
-CGUIControl *CGUIControlGroup::GetControl(int iControl)
-{
-  CGUIControl *pPotential = NULL;
   LookupMap::iterator first = m_lookup.find(iControl);
   if (first != m_lookup.end())
   {
@@ -443,6 +414,8 @@ CGUIControl *CGUIControlGroup::GetControl(int iControl)
       CGUIControl *control = i->second;
       if (control->IsVisible())
         return control;
+      else if (idCollector)
+        idCollector->push_back(control);
       else if (!pPotential)
         pPotential = control;
     }

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -65,13 +65,10 @@ public:
   virtual void ResetAnimation(ANIMATION_TYPE anim);
   virtual void ResetAnimations();
 
-  virtual bool HasID(int id) const;
-  virtual bool HasVisibleID(int id) const;
-
   int GetFocusedControlID() const;
   CGUIControl *GetFocusedControl() const;
   const CGUIControl *GetControl(int id) const;
-  CGUIControl *GetControl(int id);
+  CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr);
   virtual CGUIControl *GetFirstFocusableControl(int id);
 
   virtual void AddControl(CGUIControl *control, int position = -1);
@@ -99,7 +96,7 @@ protected:
   bool IsValidControl(const CGUIControl *control) const;
 
   // sub controls
-  std::vector<CGUIControl *> m_children;
+  std::vector<CGUIControl *> m_children, m_idCollector;
   typedef std::vector<CGUIControl *>::iterator iControls;
   typedef std::vector<CGUIControl *>::const_iterator ciControls;
   typedef std::vector<CGUIControl *>::reverse_iterator rControls;

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -152,7 +152,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
         CGUIControl *control = *it;
         if (!control->IsVisible())
           continue;
-        if (control->HasID(message.GetControlId()))
+        if (control->GetID() == message.GetControlId())
         {
           // find out whether this is the first or last control
           if (IsFirstFocusableControl(control))
@@ -181,7 +181,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
         CGUIControl *control = *it;
         if (!control->IsVisible())
           continue;
-        if (control->HasID(m_focusedControl))
+        if (control->GetID() == m_focusedControl)
         {
           if (IsControlOnScreen(offset, control))
             return CGUIControlGroup::OnMessage(message);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -363,6 +363,7 @@ void CGUIControlGroupList::ScrollTo(float offset)
   m_scroller.ScrollTo(offset);
   if (m_scroller.IsScrolling())
     SetInvalid();
+  MarkDirtyRegion();
 }
 
 EVENT_RESULT CGUIControlGroupList::SendMouseEvent(const CPoint &point, const CMouseEvent &event)

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -35,6 +35,7 @@ CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float po
   m_totalSize = 0;
   m_orientation = orientation;
   m_alignment = alignment;
+  m_lastScrollerValue = 0;
   m_useControlPositions = useControlPositions;
   ControlType = GUICONTROL_GROUPLIST;
   m_minSize = 0;
@@ -60,12 +61,13 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
   }
 
   ValidateOffset();
-  if (m_pageControl)
+  if (m_pageControl && m_lastScrollerValue != m_scroller.GetValue())
   {
     CGUIMessage message(GUI_MSG_LABEL_RESET, GetParentID(), m_pageControl, (int)Size(), (int)m_totalSize);
     SendWindowMessage(message);
     CGUIMessage message2(GUI_MSG_ITEM_SELECT, GetParentID(), m_pageControl, (int)m_scroller.GetValue());
     SendWindowMessage(message2);
+    m_lastScrollerValue = m_scroller.GetValue();
   }
   // we run through the controls, rendering as we go
   int index = 0;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -83,6 +83,7 @@ protected:
   float m_totalSize;
 
   CScroller m_scroller;
+  int m_lastScrollerValue;
 
   bool m_useControlPositions;
   ORIENTATION m_orientation;

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -202,6 +202,8 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
   if (!m_focusedLayout || !m_layout)
     return false;
 
+  MarkDirtyRegion();
+
   const float mouse_scroll_speed = 0.25f;
   const float mouse_max_amount = 1.5f;
   float sizeOfItem = m_layout->Size(m_orientation);
@@ -272,6 +274,7 @@ void CGUIFixedListContainer::SelectItem(int item)
       SetContainerMoving(cursor - GetCursor());
     SetCursor(cursor);
     ScrollToOffset(item - GetCursor());
+    MarkDirtyRegion();
   }
 }
 

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -131,7 +131,7 @@ bool CGUIFont::UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo)
   if (scrollInfo.waitTime)
   {
     scrollInfo.waitTime--;
-    return false;
+    return true;
   }
 
   if (text.empty())
@@ -153,6 +153,9 @@ bool CGUIFont::UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo)
   assert(scrollInfo.m_totalWidth != 0);
   while (scrollInfo.pixelPos >= scrollInfo.m_totalWidth)
     scrollInfo.pixelPos -= scrollInfo.m_totalWidth;
+
+  if (scrollInfo.pixelPos < old.pixelPos)
+    ++scrollInfo.m_loopCount;
 
   if (scrollInfo.pixelPos != old.pixelPos)
     return true;

--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -89,6 +89,7 @@ public:
     m_textWidth = 0;
     m_totalWidth = 0;
     m_widthValid = false;
+    m_loopCount = 0;
   }
   float GetPixelsPerFrame();
 
@@ -101,6 +102,8 @@ public:
   mutable float m_textWidth;
   mutable float m_totalWidth;
   mutable bool m_widthValid;
+
+  unsigned int m_loopCount;
 
   static const int defaultSpeed = 60;
 private:

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -43,11 +43,17 @@ bool CGUILabel::SetScrolling(bool scrolling)
   bool changed = m_scrolling != scrolling;
 
   m_scrolling = scrolling;
-  if (!m_scrolling)
+  if (changed)
     m_scrollInfo.Reset();
 
   return changed;
 }
+
+unsigned int CGUILabel::GetScrollLoopCount() const
+{
+  return m_scrollInfo.m_loopCount;
+}
+
 
 bool CGUILabel::SetOverflow(OVER_FLOW overflow)
 {

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -155,6 +155,10 @@ public:
    */
   bool SetScrolling(bool scrolling);
 
+  /*! \brief returns how often Text has already passed
+  */
+  unsigned int GetScrollLoopCount()const;
+
   /*! \brief Set how this label should handle overflowing text.
    \param overflow the overflow type
    \sa OVER_FLOW

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -202,7 +202,7 @@ void CGUILabelControl::SetWidth(float width)
 
 bool CGUILabelControl::OnMessage(CGUIMessage& message)
 {
-  if ( message.GetControlId() == GetID() )
+  if (message.GetControlId() == GetID())
   {
     if (message.GetMessage() == GUI_MSG_LABEL_SET)
     {
@@ -210,6 +210,8 @@ bool CGUILabelControl::OnMessage(CGUIMessage& message)
       return true;
     }
   }
+  if (message.GetMessage() == GUI_MSG_REFRESH_TIMER)
+    UpdateInfo();
 
   return CGUIControl::OnMessage(message);
 }

--- a/xbmc/guilib/GUIListGroup.cpp
+++ b/xbmc/guilib/GUIListGroup.cpp
@@ -185,7 +185,7 @@ unsigned int CGUIListGroup::GetFocusedItem() const
     if ((*it)->GetControlType() == CGUIControl::GUICONTROL_LISTGROUP && ((CGUIListGroup *)(*it))->GetFocusedItem())
       return ((CGUIListGroup *)(*it))->GetFocusedItem();
   }
-  return 0;
+  return m_bHasFocus ? 1 : 0;
 }
 
 bool CGUIListGroup::MoveLeft()
@@ -216,7 +216,6 @@ void CGUIListGroup::SetState(bool selected, bool focused)
     {
       CGUIListLabel *label = (CGUIListLabel *)(*it);
       label->SetSelected(selected);
-      label->SetScrolling(focused);
     }
     else if ((*it)->GetControlType() == CGUIControl::GUICONTROL_LISTGROUP)
       ((CGUIListGroup *)(*it))->SetState(selected, focused);

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -37,7 +37,7 @@ CGUIListItemLayout::CGUIListItemLayout()
   m_group.SetPushUpdates(true);
 }
 
-CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout &from)
+CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout &from, CGUIControl *control)
 : m_group(from.m_group), m_isPlaying(from.m_isPlaying)
 {
   m_width = from.m_width;
@@ -45,6 +45,7 @@ CGUIListItemLayout::CGUIListItemLayout(const CGUIListItemLayout &from)
   m_focused = from.m_focused;
   m_condition = from.m_condition;
   m_invalidated = true;
+  m_group.SetParentControl(control);
 }
 
 CGUIListItemLayout::~CGUIListItemLayout()

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -32,7 +32,7 @@ class CGUIListItemLayout
 {
 public:
   CGUIListItemLayout();
-  CGUIListItemLayout(const CGUIListItemLayout &from);
+  CGUIListItemLayout(const CGUIListItemLayout &from, CGUIControl *control);
   virtual ~CGUIListItemLayout();
   void LoadLayout(TiXmlElement *layout, int context, bool focused, float maxWidth, float maxHeight);
   void Process(CGUIListItem *item, int parentID, unsigned int currentTime, CDirtyRegionList &dirtyregions);
@@ -44,6 +44,7 @@ public:
   void ResetAnimation(ANIMATION_TYPE animType);
   void SetInvalid() { m_invalidated = true; };
   void FreeResources(bool immediately = false);
+  void SetParentControl(CGUIControl *control) { m_group.SetParentControl(control); };
 
 //#ifdef GUILIB_PYTHON_COMPATIBILITY
   void CreateListControlLayouts(float width, float height, bool focused, const CLabelInfo &labelInfo, const CLabelInfo &labelInfo2, const CTextureInfo &texture, const CTextureInfo &textureFocus, float texHeight, float iconWidth, float iconHeight, const std::string &nofocusCondition, const std::string &focusCondition);

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -39,10 +39,7 @@ CGUIListLabel::~CGUIListLabel(void)
 
 void CGUIListLabel::SetScrolling(bool scrolling)
 {
-  if (m_scroll == CGUIControl::FOCUS)
-    m_label.SetScrolling(scrolling);
-  else
-    m_label.SetScrolling((m_scroll == CGUIControl::ALWAYS) ? true : false);
+  m_label.SetScrolling(scrolling);
 }
 
 void CGUIListLabel::SetSelected(bool selected)
@@ -54,8 +51,7 @@ void CGUIListLabel::SetSelected(bool selected)
 void CGUIListLabel::SetFocus(bool focus)
 {
   CGUIControl::SetFocus(focus);
-  if (!focus)
-    SetScrolling(false);
+  SetScrolling(focus);
 }
 
 CRect CGUIListLabel::CalcRenderRegion() const
@@ -75,6 +71,9 @@ void CGUIListLabel::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
 {
   if (m_label.Process(currentTime))
     MarkDirtyRegion();
+
+  if (m_label.GetScrollLoopCount() >= 3)
+    SetScrolling(false);
 
   CGUIControl::Process(currentTime, dirtyregions);
 }

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -161,6 +161,11 @@
  */
 #define GUI_MSG_UI_READY       49
 
+ /*!
+ \brief Called every 500ms to allow time dependent updates
+ */
+#define GUI_MSG_REFRESH_TIMER  50
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -166,6 +166,12 @@
  */
 #define GUI_MSG_REFRESH_TIMER  50
 
+ /*!
+ \brief Called if state has changed wich could lead to GUI changes
+ */
+#define GUI_MSG_STATE_CHANGED  51
+
+
 #define GUI_MSG_USER         1000
 
 /*!

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -346,6 +346,8 @@ void CGUISliderControl::SetPercentage(float percent, RangeSelector selector /* =
 
   float percentLower = selector == RangeSelectorLower ? percent : m_percentValues[0];
   float percentUpper = selector == RangeSelectorUpper ? percent : m_percentValues[1];
+  float oldValues[2] = { m_percentValues[0],m_percentValues[1] };
+
 
   if (!m_rangeSelection || percentLower <= percentUpper)
   {
@@ -361,6 +363,8 @@ void CGUISliderControl::SetPercentage(float percent, RangeSelector selector /* =
     if (updateCurrent)
         m_currentSelector = (selector == RangeSelectorLower ? RangeSelectorUpper : RangeSelectorLower);
   }
+  if (oldValues[0] != m_percentValues[0] || oldValues[1] != m_percentValues[1])
+    MarkDirtyRegion();
 }
 
 float CGUISliderControl::GetPercentage(RangeSelector selector /* = RangeSelectorLower */) const

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -151,6 +151,9 @@ bool CGUITextureBase::Process(unsigned int currentTime)
   if (m_invalid)
     changed |= CalculateSize();
 
+  if (m_isAllocated)
+    changed |= !ReadyToRender();
+
   return changed;
 }
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -36,6 +36,7 @@
 #include "GUIAudioManager.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "settings/AdvancedSettings.h"
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
 
@@ -341,6 +342,9 @@ void CGUIWindow::CenterWindow()
 
 void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  if (!m_controlIsDirty && g_advancedSettings.m_guiSmartRedraw)
+    return;
+
   g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
   g_graphicsContext.AddGUITransform();
   CGUIControlGroup::DoProcess(currentTime, dirtyregions);
@@ -752,7 +756,7 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
     break;
   }
 
-  return SendControlMessage(message);
+  return CGUIControlGroup::OnMessage(message);
 }
 
 bool CGUIWindow::NeedLoad() const

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -72,6 +72,7 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   m_menuControlID = 0;
   m_menuLastFocusedControlID = 0;
   m_custom = false;
+  m_forceProcess = true;
 }
 
 CGUIWindow::~CGUIWindow()
@@ -342,8 +343,10 @@ void CGUIWindow::CenterWindow()
 
 void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  if (!m_controlIsDirty && g_advancedSettings.m_guiSmartRedraw)
+  if (!m_controlIsDirty && !m_forceProcess && g_advancedSettings.m_guiSmartRedraw)
     return;
+
+  m_forceProcess = false;
 
   g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
   g_graphicsContext.AddGUITransform();
@@ -751,6 +754,8 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
             control->OnMessage(msg);
           }
         }
+        else if (message.GetParam1() == GUI_MSG_STATE_CHANGED)
+          m_forceProcess = true;
       }
     }
     break;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -166,6 +166,7 @@ public:
   virtual bool IsVisible() const { return true; }; // windows are always considered visible as they implement their own
                                                    // versions of UpdateVisibility, and are deemed visible if they're in
                                                    // the window manager's active list.
+  virtual bool HasVisibleControls() { return true; }; //Assume that window always has visible controls
 
   virtual bool IsAnimating(ANIMATION_TYPE animType);
 
@@ -184,6 +185,7 @@ public:
   void DisableAnimations();
 
   virtual void ResetControlStates();
+  virtual void UpdateControlStats() {}; // Do not count window itself
 
   void       SetRunActionsManually();
   void       RunLoadActions() const;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -318,6 +318,7 @@ protected:
 private:
   std::map<std::string, CVariant, icompare> m_mapProperties;
   std::map<INFO::InfoPtr, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
+  bool m_forceProcess;
 };
 
 #endif

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1020,21 +1020,21 @@ void CGUIWindowManager::Process(unsigned int currentTime)
   assert(g_application.IsCurrentThread());
   CSingleLock lock(g_graphicsContext);
 
-  CDirtyRegionList dirtyregions;
+  m_dirtyregions.clear();
 
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
   if (pWindow)
-    pWindow->DoProcess(currentTime, dirtyregions);
+    pWindow->DoProcess(currentTime, m_dirtyregions);
 
   // process all dialogs - visibility may change etc.
   for (const auto& entry : m_mapWindows)
   {
     CGUIWindow *pWindow = entry.second;
     if (pWindow && pWindow->IsDialog())
-      pWindow->DoProcess(currentTime, dirtyregions);
+      pWindow->DoProcess(currentTime, m_dirtyregions);
   }
 
-  for (CDirtyRegionList::iterator itr = dirtyregions.begin(); itr != dirtyregions.end(); ++itr)
+  for (CDirtyRegionList::iterator itr = m_dirtyregions.begin(); itr != m_dirtyregions.end(); ++itr)
     m_tracker.MarkDirtyRegion(*itr);
 }
 
@@ -1148,7 +1148,12 @@ void CGUIWindowManager::AfterRender()
   for (const auto& window : activeDialogs)
   {
     if (window->IsDialogRunning())
+    {
       window->AfterRender();
+      // Dialog state can affect visibility states
+      if (pWindow && window->IsControlDirty())
+        pWindow->MarkDirtyRegion();
+    }
   }
 }
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1611,10 +1611,10 @@ bool CGUIWindowManager::HasVisibleControls()
   if (m_activeDialogs.empty())
   {
     CGUIWindow *window(GetWindow(GetActiveWindow()));
-    return window && window->HasVisibleControls();
+    return !window || window->HasVisibleControls();
   }
   else
-    return false;
+    return true;
 }
 
 void CGUIWindowManager::ClearWindowHistory()

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -36,6 +36,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/SeekHandler.h"
+#include "cores/DataCacheCore.h"
 
 #include "windows/GUIWindowHome.h"
 #include "events/windows/GUIWindowEventLog.h"
@@ -1173,6 +1174,9 @@ void CGUIWindowManager::FrameMove()
     }
     m_deleteWindows.clear();
   }
+
+  if (CDataCacheCore::GetInstance().PlayStateChanged())
+    SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
 
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
   if (pWindow)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -36,7 +36,6 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/SeekHandler.h"
-#include "cores/DataCacheCore.h"
 
 #include "windows/GUIWindowHome.h"
 #include "events/windows/GUIWindowEventLog.h"
@@ -1174,9 +1173,6 @@ void CGUIWindowManager::FrameMove()
     }
     m_deleteWindows.clear();
   }
-
-  if (CDataCacheCore::GetInstance().PlayStateChanged())
-    SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
 
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
   if (pWindow)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1604,6 +1604,19 @@ bool CGUIWindowManager::IsWindowTopMost(const std::string &xmlFile) const
   return false;
 }
 
+bool CGUIWindowManager::HasVisibleControls()
+{
+  CSingleExit lock(g_graphicsContext);
+
+  if (m_activeDialogs.empty())
+  {
+    CGUIWindow *window(GetWindow(GetActiveWindow()));
+    return window && window->HasVisibleControls();
+  }
+  else
+    return false;
+}
+
 void CGUIWindowManager::ClearWindowHistory()
 {
   while (!m_windowHistory.empty())

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -211,6 +211,8 @@ public:
    */
   bool IsPythonWindow(int id) const { return (id >= WINDOW_PYTHON_START && id <= WINDOW_PYTHON_END); };
 
+  bool HasVisibleControls();
+
 #ifdef _DEBUG
   void DumpTextureUse();
 #endif

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -261,6 +261,7 @@ private:
   int  m_iNested;
   bool m_initialized;
 
+  CDirtyRegionList m_dirtyregions;
   CDirtyRegionTracker m_tracker;
 };
 

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -707,7 +707,6 @@ CScroller::CScroller(unsigned int duration /* = 200 */, std::shared_ptr<Tweener>
   m_startTime = 0;
   m_startPosition = 0;
   m_hasResumePoint = false;
-  m_lastTime = 0;
   m_duration = duration > 0 ? duration : 1;
   m_pTweener = tweener;
 }
@@ -727,7 +726,6 @@ CScroller& CScroller::operator=(const CScroller &right)
   m_startTime = right.m_startTime;
   m_startPosition = right.m_startPosition;
   m_hasResumePoint = right.m_hasResumePoint;
-  m_lastTime = right.m_lastTime;
   m_duration = right.m_duration;
   m_pTweener = right.m_pTweener;
   return *this;
@@ -745,7 +743,7 @@ void CScroller::ScrollTo(float endPos)
 
   m_delta = delta;
   m_startPosition = m_scrollValue;
-  m_startTime = m_lastTime;
+  m_startTime = 0;
 }
 
 float CScroller::Tween(float progress)
@@ -777,7 +775,8 @@ float CScroller::Tween(float progress)
 
 bool CScroller::Update(unsigned int time)
 {
-  m_lastTime = time;
+  if (!m_startTime)
+    m_startTime = time;
   if (m_delta != 0)
   {
     if (time - m_startTime >= m_duration) // we are finished

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -257,7 +257,6 @@ private:
   float        m_startPosition;           //!< Brief starting position of scroll
   bool         m_hasResumePoint;          //!< Brief check if we should tween from middle of the tween
   unsigned int m_startTime;               //!< Brief starting time of scroll
-  unsigned int m_lastTime;                //!< Brief last remember time (updated each time Scroll() method is called)
 
   unsigned int m_duration;                //!< Brief duration of scroll
   std::shared_ptr<Tweener> m_pTweener;

--- a/xbmc/interfaces/info/InfoBool.cpp
+++ b/xbmc/interfaces/info/InfoBool.cpp
@@ -23,12 +23,12 @@
 
 namespace INFO
 {
-  InfoBool::InfoBool(const std::string &expression, int context)
+  InfoBool::InfoBool(const std::string &expression, int context, unsigned int &refreshCounter)
     : m_value(false),
       m_context(context),
       m_listItemDependent(false),
       m_expression(expression),
-      m_dirty(true)
+      m_parentRefreshCounter(refreshCounter)
   {
     StringUtils::ToLower(m_expression);
   }

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -34,16 +34,9 @@ namespace INFO
 class InfoBool
 {
 public:
-  InfoBool(const std::string &expression, int context);
+  InfoBool(const std::string &expression, int context, unsigned int &refreshCounter);
   virtual ~InfoBool() {};
 
-  /*! \brief Set the info bool dirty.
-   Will cause the info bool to be re-evaluated next call to Get()
-   */
-  void SetDirty()
-  {
-    m_dirty = true;
-  }
   /*! \brief Get the value of this info bool
    This is called to update (if dirty) and fetch the value of the info bool
    \param item the item used to evaluate the bool
@@ -52,10 +45,10 @@ public:
   {
     if (item && m_listItemDependent)
       Update(item);
-    else if (m_dirty)
+    else if (m_refeshCounter != m_parentRefreshCounter)
     {
       Update(NULL);
-      m_dirty = false;
+      m_refeshCounter = m_parentRefreshCounter;
     }
     return m_value;
   }
@@ -64,6 +57,16 @@ public:
   {
     return (m_context == right.m_context &&
             m_expression == right.m_expression);
+  }
+
+  bool operator<(const InfoBool &right) const
+  {
+    if (m_context < right.m_context)
+      return true;
+    else if (m_context == right.m_context)
+      return m_expression < right.m_expression;
+    else
+      return false;
   }
 
   /*! \brief Update the value of this info bool
@@ -81,7 +84,8 @@ protected:
 
 private:
   std::string  m_expression;   ///< original expression
-  bool         m_dirty;        ///< whether we need an update
+  unsigned int m_refeshCounter;
+  unsigned int &m_parentRefreshCounter;
 };
 
 typedef std::shared_ptr<InfoBool> InfoPtr;

--- a/xbmc/interfaces/info/InfoExpression.cpp
+++ b/xbmc/interfaces/info/InfoExpression.cpp
@@ -27,8 +27,8 @@
 
 using namespace INFO;
 
-InfoSingle::InfoSingle(const std::string &expression, int context)
-: InfoBool(expression, context)
+InfoSingle::InfoSingle(const std::string &expression, int context, unsigned int& refreshCounter)
+: InfoBool(expression, context, refreshCounter)
 {
   m_condition = g_infoManager.TranslateSingleString(expression, m_listItemDependent);
 }
@@ -38,8 +38,8 @@ void InfoSingle::Update(const CGUIListItem *item)
   m_value = g_infoManager.GetBool(m_condition, m_context, item);
 }
 
-InfoExpression::InfoExpression(const std::string &expression, int context)
-: InfoBool(expression, context)
+InfoExpression::InfoExpression(const std::string &expression, int context, unsigned int& refreshCounter)
+: InfoBool(expression, context, refreshCounter)
 {
   if (!Parse(expression))
   {

--- a/xbmc/interfaces/info/InfoExpression.h
+++ b/xbmc/interfaces/info/InfoExpression.h
@@ -34,7 +34,7 @@ namespace INFO
 class InfoSingle : public InfoBool
 {
 public:
-  InfoSingle(const std::string &condition, int context);
+  InfoSingle(const std::string &condition, int context, unsigned int& refreshCounter);
   virtual ~InfoSingle() {};
 
   virtual void Update(const CGUIListItem *item);
@@ -47,7 +47,7 @@ private:
 class InfoExpression : public InfoBool
 {
 public:
-  InfoExpression(const std::string &expression, int context);
+  InfoExpression(const std::string &expression, int context, unsigned int& refreshCounter);
   virtual ~InfoExpression() {};
 
   virtual void Update(const CGUIListItem *item);

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -1092,6 +1092,7 @@ void CGUIEPGGridContainer::SetChannel(int channel)
     if (m_item)
     {
       m_channelCursor = channel;
+      MarkDirtyRegion();
       SetBlock(GetBlock(m_item->item, channel), false);
     }
   }
@@ -1112,6 +1113,7 @@ void CGUIEPGGridContainer::SetBlock(int block, bool bUpdateBlockTravelAxis /* = 
     m_blockTravelAxis = m_blockOffset + m_blockCursor;
 
   m_item = GetItem(m_channelCursor);
+  MarkDirtyRegion();
 }
 
 CGUIListItemLayout *CGUIEPGGridContainer::GetFocusedLayout() const
@@ -1491,6 +1493,7 @@ void CGUIEPGGridContainer::ScrollToChannelOffset(int offset)
 
   m_channelScrollSpeed = (offset * size - m_channelScrollOffset) / m_scrollTime;
   m_channelOffset = offset;
+  MarkDirtyRegion();
 }
 
 void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
@@ -1520,6 +1523,7 @@ void CGUIEPGGridContainer::ScrollToBlockOffset(int offset)
 
   m_programmeScrollSpeed = (offset * size - m_programmeScrollOffset) / m_scrollTime;
   m_blockOffset = offset;
+  MarkDirtyRegion();
 }
 
 void CGUIEPGGridContainer::ValidateOffset()
@@ -1831,6 +1835,9 @@ void CGUIEPGGridContainer::UpdateScrollOffset(unsigned int currentTime)
   }
 
   m_programmeScrollLastTime = currentTime;
+
+  if (m_channelScrollSpeed || m_programmeScrollSpeed)
+    MarkDirtyRegion();
 }
 
 void CGUIEPGGridContainer::GetCurrentLayouts()

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -379,6 +379,7 @@ void CAdvancedSettings::Initialize()
 #endif
   m_guiVisualizeDirtyRegions = false;
   m_guiAlgorithmDirtyRegions = 3;
+  m_guiSmartRedraw = false;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
 
@@ -1194,6 +1195,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   {
     XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
+    XMLUtils::GetBoolean(pElement, "smartredraw", m_guiSmartRedraw);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -343,6 +343,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     bool m_guiVisualizeDirtyRegions;
     int  m_guiAlgorithmDirtyRegions;
+    bool m_guiSmartRedraw;
     unsigned int m_addonPackageFolderSize;
 
     unsigned int m_cacheMemSize;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -313,7 +313,6 @@ void CGUIDialogSettingsBase::DoProcess(unsigned int currentTime, CDirtyRegionLis
   CGUIDialog::DoProcess(currentTime, dirtyregions);
   if (control && bAlphaFaded)
   {
-    control->SetFocus(false);
     if (control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)
       ((CGUIButtonControl *)control)->SetAlpha(0xFF);
     else

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -27,6 +27,7 @@
 #include "cores/DataCacheCore.h"
 #include "FileItem.h"
 #include "guilib/GraphicContext.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
@@ -181,7 +182,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
       Reset();
     }
   }
-  g_application.SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
+  m_seekChanged = true;
   m_timer.StartZero();
 }
 
@@ -219,12 +220,20 @@ void CSeekHandler::FrameMove()
     // perform relative seek
     g_application.m_pPlayer->SeekTimeRelative(static_cast<int64_t>(m_seekSize * 1000));
 
+    m_seekChanged = true;
+
     Reset();
   }
 
   if (m_timeCodePosition > 0 && m_timerTimeCode.GetElapsedMilliseconds() >= 2500)
   {
     m_timeCodePosition = 0;
+  }
+
+  if (m_seekChanged)
+  {
+    m_seekChanged = false;
+    g_windowManager.SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
   }
 }
 

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -181,7 +181,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
       Reset();
     }
   }
-
+  g_application.RefreshControls();
   m_timer.StartZero();
 }
 

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -181,7 +181,7 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
       Reset();
     }
   }
-  g_application.RefreshControls();
+  g_application.SendGUIMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
   m_timer.StartZero();
 }
 

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -72,6 +72,7 @@ private:
   int m_seekDelay;
   std::map<SeekType, int > m_seekDelays;
   bool m_requireSeek;
+  bool m_seekChanged = false;
   bool m_analogSeek;
   double m_seekSize;
   int m_seekStep;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -78,7 +78,7 @@ static CLinuxResourceCounter m_resourceCounter;
 CGUIWindowFullScreen::CGUIWindowFullScreen(void)
     : CGUIWindow(WINDOW_FULLSCREEN_VIDEO, "VideoFullScreen.xml")
 {
-  m_bShowViewModeInfo = false;
+  m_viewModeChanged = true;
   m_dwShowViewModeTimeout = 0;
   m_bShowCurrentTime = false;
   m_loadType = KEEP_IN_MEMORY;
@@ -155,13 +155,14 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
 
   case ACTION_ASPECT_RATIO:
     { // toggle the aspect ratio mode (only if the info is onscreen)
-      if (m_bShowViewModeInfo)
+      if (m_dwShowViewModeTimeout)
       {
 #ifdef HAS_VIDEO_PLAYBACK
         g_application.m_pPlayer->SetRenderViewMode(CViewModeSettings::GetNextQuickCycleViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode));
 #endif
       }
-      m_bShowViewModeInfo = true;
+      else
+        m_viewModeChanged = true;
       m_dwShowViewModeTimeout = XbmcThreads::SystemClockMillis();
     }
     return true;
@@ -258,7 +259,9 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       // now call the base class to load our windows
       CGUIWindow::OnMessage(message);
 
-      m_bShowViewModeInfo = false;
+      m_dwShowViewModeTimeout = 0;
+      m_viewModeChanged = true;
+
 
       return true;
     }
@@ -318,11 +321,13 @@ void CGUIWindowFullScreen::FrameMove()
   //----------------------
   // ViewMode Information
   //----------------------
-  if (m_bShowViewModeInfo && XbmcThreads::SystemClockMillis() - m_dwShowViewModeTimeout > 2500)
+  if (m_dwShowViewModeTimeout && XbmcThreads::SystemClockMillis() - m_dwShowViewModeTimeout > 2500)
   {
-    m_bShowViewModeInfo = false;
+    m_dwShowViewModeTimeout = 0;
+    m_viewModeChanged = true;
   }
-  if (m_bShowViewModeInfo)
+
+  if (m_dwShowViewModeTimeout)
   {
     RESOLUTION_INFO res = g_graphicsContext.GetResInfo();
 
@@ -381,19 +386,23 @@ void CGUIWindowFullScreen::FrameMove()
     }
   }
 
-  if (m_bShowViewModeInfo)
+  if (m_viewModeChanged)
   {
-    SET_CONTROL_VISIBLE(LABEL_ROW1);
-    SET_CONTROL_VISIBLE(LABEL_ROW2);
-    SET_CONTROL_VISIBLE(LABEL_ROW3);
-    SET_CONTROL_VISIBLE(BLUE_BAR);
-  }
-  else
-  {
-    SET_CONTROL_HIDDEN(LABEL_ROW1);
-    SET_CONTROL_HIDDEN(LABEL_ROW2);
-    SET_CONTROL_HIDDEN(LABEL_ROW3);
-    SET_CONTROL_HIDDEN(BLUE_BAR);
+    if (m_dwShowViewModeTimeout)
+    {
+      SET_CONTROL_VISIBLE(LABEL_ROW1);
+      SET_CONTROL_VISIBLE(LABEL_ROW2);
+      SET_CONTROL_VISIBLE(LABEL_ROW3);
+      SET_CONTROL_VISIBLE(BLUE_BAR);
+    }
+    else
+    {
+      SET_CONTROL_HIDDEN(LABEL_ROW1);
+      SET_CONTROL_HIDDEN(LABEL_ROW2);
+      SET_CONTROL_HIDDEN(LABEL_ROW3);
+      SET_CONTROL_HIDDEN(BLUE_BAR);
+    }
+    m_viewModeChanged = false;
   }
 }
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -99,10 +99,13 @@ CGUIWindowFullScreen::CGUIWindowFullScreen(void)
   //  - delay
   //  - language
 
+  m_controlStats = new GUICONTROLSTATS;
 }
 
 CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
-{}
+{
+  delete m_controlStats;
+}
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
@@ -411,6 +414,8 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
   if (g_application.m_pPlayer->IsRenderingGuiLayer())
     MarkDirtyRegion();
 
+  m_controlStats->Reset();
+
   CGUIWindow::Process(currentTime, dirtyregion);
 
   //! @todo This isn't quite optimal - ideally we'd only be dirtying up the actual video render rect
@@ -464,4 +469,9 @@ void CGUIWindowFullScreen::TriggerOSD()
     pOSD->SetAutoClose(3000);
     pOSD->Open();
   }
+}
+
+bool CGUIWindowFullScreen::HasVisibleControls()
+{
+  return m_controlStats->nCountVisible > 0;
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -44,7 +44,7 @@ private:
   void ToggleOSD();
   void TriggerOSD();
 
-  bool m_bShowViewModeInfo;
+  bool m_viewModeChanged;
   unsigned int m_dwShowViewModeTimeout;
 
   bool m_bShowCurrentTime;

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -35,6 +35,7 @@ public:
   virtual void Render();
   virtual void RenderEx();
   virtual void OnWindowLoaded();
+  virtual bool HasVisibleControls();
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);


### PR DESCRIPTION
GUI optimizations (Message handling through lookup) and SmartRedraw (only Processes GUI if anything has changed).

## Description
1.) Use alreaedy existing gui-control-lookup for sending control messages.
2.) [Experimental]: If advancedsettings::gui:guismartredraw is set to true, the GUI Process call (and therefore the render call), wich is usually called on every vsync, is only done if anything is changed.

## Motivation and Context
Speed up GUI / Remove load if kodi idle / plays videos (factor ~10)

## How Has This Been Tested?
Win32 / Android / Esturay

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

##Note
I'm pushing this PR quite early (regarding smartredraw) because @mkortstiege seems to play around with GUI.