### PR TITLE
Posix/Win32 main refactor

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -13,6 +13,8 @@ endif()
 
 set(PLATFORM_DIR platform/win32)
 
+set(CORE_MAIN_SOURCE ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/WinMain.cpp)
+
 # Precompiled headers fail with per target output directory. (needs CMake 3.1)
 set(PRECOMPILEDHEADER_DIR ${PROJECT_BINARY_DIR}/${CORE_BUILD_CONFIG}/objs)
 

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -41,7 +41,7 @@ CAppParamParser::CAppParamParser()
   m_testmode = false;
 }
 
-void CAppParamParser::Parse(const char* argv[], int nArgs)
+void CAppParamParser::Parse(const char* const* argv, int nArgs)
 {
   if (nArgs > 1)
   {

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -24,7 +24,7 @@ class CAppParamParser
 {
   public:
     CAppParamParser();
-    void Parse(const char* argv[], int nArgs);
+    void Parse(const char* const* argv, int nArgs);
     CFileItemList m_playlist;
 
   private:

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -408,7 +408,7 @@ void CXBMCApp::run()
     argv[0] = exe_name.c_str();
     argv[1] = filenameToPlay.c_str();
 
-    appParamParser.Parse((const char **)argv, argc);
+    appParamParser.Parse(argv, argc);
 
     free(argv);
   }

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -88,8 +88,6 @@ int main(int argc, char* argv[])
   // set up some xbmc specific relationships
   XBMC::Context context;
 
-  bool renderGUI = true;
-#if defined(DEBUG)
   struct rlimit rlim;
   rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
   if (setrlimit(RLIMIT_CORE, &rlim) == -1)
@@ -110,5 +108,5 @@ int main(int argc, char* argv[])
   CAppParamParser appParamParser;
   appParamParser.Parse(argv, argc);
   
-  return XBMC_Run(renderGUI, appParamParser.m_playlist);
+  return XBMC_Run(true, appParamParser.m_playlist);
 }

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char* argv[])
   // set up some xbmc specific relationships
   XBMC::Context context;
 
+#if defined(_DEBUG)
   struct rlimit rlim;
   rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
   if (setrlimit(RLIMIT_CORE, &rlim) == -1)
@@ -103,8 +104,9 @@ int main(int argc, char* argv[])
   sigaction(SIGTERM, &signalHandler, nullptr);
 
   setlocale(LC_NUMERIC, "C");
+ 
+  // Initialize before CAppParamParser so it can set the log level
   g_advancedSettings.Initialize();
-
   CAppParamParser appParamParser;
   appParamParser.Parse(argv, argc);
   

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -89,17 +89,6 @@ int main(int argc, char* argv[])
   XBMC::Context context;
 
   bool renderGUI = true;
-  //this can't be set from CAdvancedSettings::Initialize() because it will overwrite
-  //the loglevel set with the --debug flag
-#ifdef _DEBUG
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
-#else
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_NORMAL;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_NORMAL;
-#endif
-  CLog::SetLogLevel(g_advancedSettings.m_logLevel);
-
 #if defined(DEBUG)
   struct rlimit rlim;
   rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -18,20 +18,11 @@
  *
  */
 
-#include "system.h"
-#include "AppParamParser.h"
-#include "settings/AdvancedSettings.h"
-#include "FileItem.h"
-#include "PlayListPlayer.h"
-#include "utils/log.h"
-#include "platform/xbmc.h"
-#ifdef TARGET_POSIX
 #include <sys/resource.h>
 #include <signal.h>
+
 #include <cstring>
-#include "messaging/ApplicationMessenger.h"
-#include "platform/MessagePrinter.h"
-#endif
+
 #if defined(TARGET_DARWIN_OSX)
   #include "Util.h"
   // SDL redefines main as SDL_main 
@@ -40,12 +31,23 @@
   #endif
 #include <locale.h>
 #endif
+
+#include "AppParamParser.h"
+#include "FileItem.h"
+#include "messaging/ApplicationMessenger.h"
+#include "PlayListPlayer.h"
+#include "platform/MessagePrinter.h"
+#include "platform/xbmc.h"
+#include "platform/XbmcContext.h"
+#include "settings/AdvancedSettings.h"
+#include "system.h"
+#include "utils/log.h"
+
 #ifdef HAS_LIRC
 #include "input/linux/LIRC.h"
 #endif
-#include "platform/XbmcContext.h"
-  
-#if defined(TARGET_POSIX)
+
+
 namespace
 {
 
@@ -79,11 +81,8 @@ void XBMC_POSIX_HandleSignal(int sig)
 }
 
 }
-#endif
 
-#ifdef __cplusplus
-extern "C"
-#endif
+
 int main(int argc, char* argv[])
 {
   // set up some xbmc specific relationships
@@ -101,7 +100,6 @@ int main(int argc, char* argv[])
 #endif
   CLog::SetLogLevel(g_advancedSettings.m_logLevel);
 
-#ifdef TARGET_POSIX
 #if defined(DEBUG)
   struct rlimit rlim;
   rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
@@ -116,7 +114,7 @@ int main(int argc, char* argv[])
   signalHandler.sa_flags = SA_RESTART;
   sigaction(SIGINT, &signalHandler, nullptr);
   sigaction(SIGTERM, &signalHandler, nullptr);
-#endif
+
   setlocale(LC_NUMERIC, "C");
   g_advancedSettings.Initialize();
 

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -23,6 +23,9 @@
 
 #include <cstring>
 
+// For HAS_SDL
+#include "system.h"
+
 #if defined(TARGET_DARWIN_OSX)
   #include "Util.h"
   // SDL redefines main as SDL_main 
@@ -40,7 +43,6 @@
 #include "platform/xbmc.h"
 #include "platform/XbmcContext.h"
 #include "settings/AdvancedSettings.h"
-#include "system.h"
 #include "utils/log.h"
 
 #ifdef HAS_LIRC

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
   g_advancedSettings.Initialize();
 
   CAppParamParser appParamParser;
-  appParamParser.Parse(const_cast<const char**>(argv), argc);
+  appParamParser.Parse(argv, argc);
   
   return XBMC_Run(renderGUI, appParamParser.m_playlist);
 }

--- a/xbmc/platform/win32/CMakeLists.txt
+++ b/xbmc/platform/win32/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(SOURCES CharsetConverter.cpp
             MessagePrinter.cpp
-            WinMain.cpp
             crts_caller.cpp
             dxerr.cpp
             Filesystem.cpp

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -35,7 +35,7 @@
 #endif
 
 #include "platform/MessagePrinter.h"
-
+#include "utils/log.h"
 
 extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist)
 {
@@ -43,15 +43,17 @@ extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist)
 
   if (!g_advancedSettings.Initialized())
   {
-#ifdef _DEBUG
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
-#else
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_NORMAL;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_NORMAL;
-#endif
+    // Initialize sets default log level of NORMAL
     g_advancedSettings.Initialize();
   }
+  
+#ifdef _DEBUG
+  // Override requested debug level if this is a debug build
+  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
+  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
+#endif
+  // Apply preliminary log level early for initialization code
+  CLog::SetLogLevel(g_advancedSettings.m_logLevel);
 
   if (!g_application.Create())
   {

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -43,17 +43,8 @@ extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist)
 
   if (!g_advancedSettings.Initialized())
   {
-    // Initialize sets default log level of NORMAL
     g_advancedSettings.Initialize();
   }
-  
-#ifdef _DEBUG
-  // Override requested debug level if this is a debug build
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
-#endif
-  // Apply preliminary log level early for initialization code
-  CLog::SetLogLevel(g_advancedSettings.m_logLevel);
 
   if (!g_application.Create())
   {


### PR DESCRIPTION
Follow-up from #12207 

## Description
Remove TARGET_POSIX ifdefs from posix/main.cpp and make win32 platform independent of posix/main.cpp

## Motivation and Context
WinMain() currently uses posix/main.cpp, which is unexpected and unnecessary.

## How Has This Been Tested?
Linux x86_64 works, other builds could fail - will update according to Jenkins results

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
