### PR TITLE
[Fix][Backport]Merge album type and label correctly

### DIFF
--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -205,13 +205,15 @@ void CAlbum::MergeScrapedAlbum(const CAlbum& source, bool override /* = true */)
     if (override || art.find(i->first) == art.end())
       art[i->first] = i->second;
   }
-  strLabel = source.strLabel;
+  if ((override && !source.strLabel.empty()) || strLabel.empty())
+    strLabel = source.strLabel;
   thumbURL = source.thumbURL;
   moods = source.moods;
   styles = source.styles;
   themes = source.themes;
   strReview = source.strReview;
-  strType = source.strType;
+  if ((override && !source.strType.empty()) || strType.empty())
+    strType = source.strType;
 //  strPath = source.strPath; // don't merge the path
   m_strDateOfRelease = source.m_strDateOfRelease;
   fRating = source.fRating;


### PR DESCRIPTION
Fix merge scraped album type and label correctly with that derived from tags.

Bug was introduced by #10573 which added populating record label and album type by processing of the LABEL (TPUB) and RELEASETYPE (MUSICBRAINZ ALBUM TYPE) music file tags. These tag derived values were always being overwritten by any scraping. Fix is to add appropriate check before scraped valued is merged.

Backport of #12216