### PR TITLE
VideoPlayer: Fix missing include and virtual destructors

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -132,7 +132,7 @@ void CVideoBufferFFmpeg::Unref()
 class CVideoBufferPoolFFmpeg : public IVideoBufferPool
 {
 public:
-  ~CVideoBufferPoolFFmpeg();
+  virtual ~CVideoBufferPoolFFmpeg();
   virtual void Return(int id) override;
   virtual CVideoBuffer* Get() override;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -25,6 +25,7 @@
 #include "DVDVideoCodec.h"
 #include "DVDResource.h"
 #include "DVDVideoPPFFmpeg.h"
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -74,7 +74,7 @@ CVPixelBufferRef CVideoBufferVTB::GetPB()
 class VTB::CVideoBufferPoolVTB : public IVideoBufferPool
 {
 public:
-  ~CVideoBufferPoolVTB();
+  virtual ~CVideoBufferPoolVTB();
   virtual void Return(int id) override;
   virtual CVideoBuffer* Get() override;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.h
@@ -52,7 +52,7 @@ class CDecoder: public IHardwareDecoder
 {
 public:
   CDecoder(CProcessInfo& processInfo);
- ~CDecoder();
+  virtual ~CDecoder();
   virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx,
                     const enum AVPixelFormat) override;
   virtual CDVDVideoCodec::VCReturn Decode(AVCodecContext* avctx, AVFrame* frame) override;

--- a/xbmc/cores/VideoPlayer/Process/VideoBuffer.h
+++ b/xbmc/cores/VideoPlayer/Process/VideoBuffer.h
@@ -57,6 +57,8 @@ class IVideoBufferPool;
 class IVideoBufferPool : public std::enable_shared_from_this<IVideoBufferPool>
 {
 public:
+  virtual ~IVideoBufferPool() = default;
+
   // get a free buffer from the pool, sets ref count to 1
   virtual CVideoBuffer* Get() = 0;
 
@@ -86,6 +88,7 @@ class CVideoBuffer
 {
 public:
   CVideoBuffer() = delete;
+  virtual ~CVideoBuffer() = default;
   void Acquire();
   void Acquire(std::shared_ptr<IVideoBufferPool> pool);
   void Release();


### PR DESCRIPTION
Just some improvements I came across while adapting RetroPlayer to the new video buffers.