### PR TITLE
Games: Fix crash due to circular dependency

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -123,7 +123,7 @@ bool CServiceManager::Init3()
   m_peripherals->Initialise();
   m_PVRManager->Init();
   m_contextMenuManager->Init();
-  m_gameServices->Init();
+  m_gameServices->Init(*m_peripherals);
 
   init_level = 3;
   return true;

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -21,17 +21,29 @@
 #include "GameServices.h"
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
+#include "games/ports/PortManager.h"
 
 using namespace GAME;
 
 CGameServices::CGameServices() :
-  m_controllerManager(new CControllerManager)
+  m_controllerManager(new CControllerManager),
+  m_portManager(new CPortManager)
 {
 }
 
 CGameServices::~CGameServices()
 {
   Deinit();
+}
+
+void CGameServices::Init(PERIPHERALS::CPeripherals& peripheralManager)
+{
+  m_portManager->Initialize(peripheralManager);
+}
+
+void CGameServices::Deinit()
+{
+  m_portManager->Deinitialize();
 }
 
 ControllerPtr CGameServices::GetController(const std::string& controllerId)
@@ -47,4 +59,9 @@ ControllerPtr CGameServices::GetDefaultController()
 ControllerVector CGameServices::GetControllers()
 {
   return m_controllerManager->GetControllers();
+}
+
+CPortManager& CGameServices::PortManager()
+{
+  return *m_portManager;
 }

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -24,9 +24,15 @@
 #include <memory>
 #include <string>
 
+namespace PERIPHERALS
+{
+  class CPeripherals;
+}
+
 namespace GAME
 {
   class CControllerManager;
+  class CPortManager;
 
   class CGameServices
   {
@@ -34,14 +40,17 @@ namespace GAME
     CGameServices();
     ~CGameServices();
 
-    void Init() { }
-    void Deinit() { }
+    void Init(PERIPHERALS::CPeripherals& peripheralManager);
+    void Deinit();
 
     ControllerPtr GetController(const std::string& controllerId);
     ControllerPtr GetDefaultController();
     ControllerVector GetControllers();
 
+    CPortManager& PortManager();
+
   private:
     std::unique_ptr<CControllerManager> m_controllerManager;
+    std::unique_ptr<CPortManager> m_portManager;
   };
 }

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -756,7 +756,7 @@ bool CGameClient::OpenPort(unsigned int port)
     if (m_bSupportsKeyboard)
       device = PERIPHERALS::PERIPHERAL_JOYSTICK;
 
-    CPortManager::GetInstance().OpenPort(m_ports[port].get(), port, device);
+    CServiceBroker::GetGameServices().PortManager().OpenPort(m_ports[port].get(), port, device);
 
     UpdatePort(port, controller);
 
@@ -772,7 +772,7 @@ void CGameClient::ClosePort(unsigned int port)
   if (m_ports.find(port) == m_ports.end())
     return;
 
-  CPortManager::GetInstance().ClosePort(m_ports[port].get());
+  CServiceBroker::GetGameServices().PortManager().ClosePort(m_ports[port].get());
 
   m_ports.erase(port);
 

--- a/xbmc/games/ports/PortManager.cpp
+++ b/xbmc/games/ports/PortManager.cpp
@@ -19,9 +19,11 @@
  */
 
 #include "PortManager.h"
+#include "PortMapper.h"
 #include "peripherals/devices/Peripheral.h"
 #include "peripherals/devices/PeripheralJoystick.h"
 #include "peripherals/devices/PeripheralJoystickEmulation.h"
+#include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
 
 #include <algorithm>
@@ -45,10 +47,24 @@ namespace GAME
 
 // --- CPortManager -----------------------------------------------------------
 
-CPortManager& CPortManager::GetInstance()
+CPortManager::CPortManager() :
+  m_portMapper(new CPortMapper)
 {
-  static CPortManager instance;
-  return instance;
+}
+
+CPortManager::~CPortManager()
+{
+  Deinitialize();
+}
+
+void CPortManager::Initialize(CPeripherals& peripheralManager)
+{
+  m_portMapper->Initialize(peripheralManager, *this);
+}
+
+void CPortManager::Deinitialize()
+{
+  m_portMapper->Deinitialize();
 }
 
 void CPortManager::OpenPort(IInputHandler* handler,
@@ -137,7 +153,7 @@ void CPortManager::MapDevices(const PeripheralVector& devices,
     IInputHandler* handler = AssignToPort(device);
     if (handler)
       deviceToPortMap[device] = handler;
-  } 
+  }
 }
 
 IInputHandler* CPortManager::AssignToPort(const PeripheralPtr& device, bool checkPortNumber /* = true */)

--- a/xbmc/games/ports/PortManager.h
+++ b/xbmc/games/ports/PortManager.h
@@ -37,22 +37,24 @@ namespace JOYSTICK
 namespace PERIPHERALS
 {
   class CPeripheral;
+  class CPeripherals;
 }
 
 namespace GAME
 {
+  class CPortMapper;
+
   /*!
    * \brief Class to manage ports opened by game clients
    */
   class CPortManager : public Observable
   {
-  private:
-    CPortManager(void) = default;
-
   public:
-    static CPortManager& GetInstance();
+    CPortManager();
+    virtual ~CPortManager();
 
-    virtual ~CPortManager() = default;
+    void Initialize(PERIPHERALS::CPeripherals& peripheralManager);
+    void Deinitialize();
 
     /*!
      * \brief Request a new port be opened with input on that port sent to the
@@ -88,6 +90,8 @@ namespace GAME
 
   private:
     KODI::JOYSTICK::IInputHandler* AssignToPort(const PERIPHERALS::PeripheralPtr& device, bool checkPortNumber = true);
+
+    std::unique_ptr<CPortMapper> m_portMapper;
 
     struct SPort
     {

--- a/xbmc/games/ports/PortMapper.h
+++ b/xbmc/games/ports/PortMapper.h
@@ -39,20 +39,26 @@ namespace PERIPHERALS
 
 namespace GAME
 {
+  class CPortManager;
+
   class CPortMapper : public Observer
   {
   public:
-    CPortMapper(PERIPHERALS::CPeripherals& peripheralManager);
+    CPortMapper();
 
     virtual ~CPortMapper();
+
+    void Initialize(PERIPHERALS::CPeripherals& peripheralManager, CPortManager& portManager);
+    void Deinitialize();
 
     virtual void Notify(const Observable& obs, const ObservableMessage msg) override;
 
   private:
     void ProcessPeripherals();
 
-    // Construction parameters
-    PERIPHERALS::CPeripherals& m_peripheralManager;
+    // Initialization parameters
+    PERIPHERALS::CPeripherals* m_peripheralManager;
+    CPortManager* m_portManager;
 
     // Port paremters
     std::map<PERIPHERALS::PeripheralPtr, KODI::JOYSTICK::IInputHandler*>  m_portMap;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -79,16 +79,13 @@ using namespace PERIPHERALS;
 using namespace XFILE;
 
 CPeripherals::CPeripherals() :
-  m_eventScanner(this),
-  m_portMapper(*this)
+  m_eventScanner(this)
 {
-  RegisterObserver(&m_portMapper);
 }
 
 CPeripherals::~CPeripherals()
 {
   Clear();
-  UnregisterObserver(&m_portMapper);
 }
 
 void CPeripherals::Initialise()

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -24,7 +24,6 @@
 #include "EventScanner.h"
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
-#include "games/ports/PortMapper.h" //! @todo Find me a better place
 #include "interfaces/IAnnouncer.h"
 #include "messaging/IMessageTarget.h"
 #include "settings/lib/ISettingCallback.h"
@@ -323,7 +322,6 @@ namespace PERIPHERALS
     std::vector<PeripheralBusPtr>        m_busses;
     std::vector<PeripheralDeviceMapping> m_mappings;
     CEventScanner                        m_eventScanner;
-	GAME::CPortMapper                    m_portMapper; //! @todo Find me a better place
     CCriticalSection                     m_critSectionBusses;
     CCriticalSection                     m_critSectionMappings;
   };


### PR DESCRIPTION
## Description
If Kodi is aborted during startup, we can segfault while cleaning up. I believe this is only an issue if Kodi fails to start fully, but the circular dependency should be fixed nonetheless.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
