### PR TITLE
[addons] add all needed addon window interface calls

### DIFF
--- a/xbmc/addons/interfaces/GUI/Window.h
+++ b/xbmc/addons/interfaces/GUI/Window.h
@@ -56,6 +56,7 @@ namespace ADDON
      * class.
      */
     //@{
+    /* Window creation functions */
     static void* create(void* kodiBase, const char* xml_filename, const char* default_skin, bool as_dialog, bool is_media);
     static void destroy(void* kodiBase, void* handle);
     static void set_callbacks(void* kodiBase,
@@ -70,9 +71,39 @@ namespace ADDON
     static bool show(void* kodiBase, void* handle);
     static bool close(void* kodiBase, void* handle);
     static bool do_modal(void* kodiBase, void* handle);
+
+    /* Window control functions */
+    static bool set_focus_id(void* kodiBase, void* handle, int control_id);
+    static int get_focus_id(void* kodiBase, void* handle);
+    static void set_control_label(void* kodiBase, void* handle, int control_id, const char* label);
+
+    /* Window property functions */
+    static void set_property(void* kodiBase, void* handle, const char* key, const char* value);
+    static void set_property_int(void* kodiBase, void* handle, const char* key, int value);
+    static void set_property_bool(void* kodiBase, void* handle, const char* key, bool value);
+    static void set_property_double(void* kodiBase, void* handle, const char* key, double value);
+    static char* get_property(void* kodiBase, void* handle, const char* key);
+    static int get_property_int(void* kodiBase, void* handle, const char* key);
+    static bool get_property_bool(void* kodiBase, void* handle, const char* key);
+    static double get_property_double(void* kodiBase, void* handle, const char* key);
+    static void clear_properties(void* kodiBase, void* handle);
+    static void clear_property(void* kodiBase, void* handle, const char* key);
+
+    /* List item functions */
     static void clear_item_list(void* kodiBase, void* handle);
-    static void add_list_item(void* kodiBase, void* handle, void* item, int item_position);
-    static void* get_list_item(void* kodiBase, void* handle, int listPos);
+    static void add_list_item(void* kodiBase, void* handle, void* item, int list_position);
+    static void remove_list_item_from_position(void* kodiBase, void* handle, int list_position);
+    static void remove_list_item(void* kodiBase, void* handle, void* item);
+    static void* get_list_item(void* kodiBase, void* handle, int list_position);
+    static void set_current_list_position(void* kodiBase, void* handle, int list_position);
+    static int get_current_list_position(void* kodiBase, void* handle);
+    static int get_list_size(void* kodiBase, void* handle);
+    static void set_container_property(void* kodiBase, void* handle, const char* key, const char* value);
+    static void set_container_content(void* kodiBase, void* handle, const char* value);
+    static int get_current_container_id(void* kodiBase, void* handle);
+
+    /* Various functions */
+    static void mark_dirty_region(void* kodiBase, void* handle);
     //@}
 
   private:
@@ -103,6 +134,9 @@ namespace ADDON
     int GetListSize();
     int GetCurrentListPosition();
     void SetCurrentListPosition(int item);
+    void SetContainerProperty(const std::string& key, const std::string& value);
+    void SetContainerContent(const std::string& value);
+    int GetCurrentContainerControlId();
     CGUIControl* GetAddonControl(int controlId, CGUIControl::GUICONTROLTYPES type, std::string typeName);
 
   protected:

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/Window.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/Window.h
@@ -166,6 +166,232 @@ namespace gui
     //==========================================================================
     ///
     /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Gives the control with the supplied focus.
+    ///
+    /// @param[in] iControlId           On skin defined id of control
+    /// @return                         Return true if call and focus is successed,
+    ///                                 if false was something failed to get needed
+    ///                                 skin parts.
+    ///
+    ///
+    bool SetFocusId(int iControlId)
+    {
+      return m_interface->kodi_gui->window->set_focus_id(m_interface->kodiBase, m_controlHandle, iControlId);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Returns the id of the control which is focused.
+    ///
+    /// @return                         Focused control id
+    ///
+    ///
+    int GetFocusId()
+    {
+      return m_interface->kodi_gui->window->get_focus_id(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief To set the used label on given control id
+    ///
+    /// @param[in] controlId            Control id where label need to set
+    /// @param[in] label                Label to use
+    ///
+    ///
+    void SetControlLabel(int controlId, const std::string& label)
+    {
+      m_interface->kodi_gui->window->set_control_label(m_interface->kodiBase, m_controlHandle, controlId, label.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Sets a window property, similar to an infolabel.
+    ///
+    /// @param[in] key                  string - property name.
+    /// @param[in] value                string or unicode - value of property.
+    ///
+    /// @note  Key is NOT case sensitive. Setting value to an empty string is
+    ///        equivalent to clearProperty(key).\n
+    ///        You can use the above as keywords for arguments and skip certain
+    ///        optional arguments.\n
+    ///        Once you use a keyword, all following arguments require the keyword.
+    ///
+    void SetProperty(const std::string& key, const std::string& value)
+    {
+      m_interface->kodi_gui->window->set_property(m_interface->kodiBase, m_controlHandle, key.c_str(), value.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Returns a window property as a string, similar to an infolabel.
+    ///
+    /// @param[in] key                  string - property name.
+    /// @return                         The property as strin (if present)
+    ///
+    /// @note  Key is NOT case sensitive. Setting value to an empty string is
+    ///        equivalent to clearProperty(key).\n
+    ///        You can use the above as keywords for arguments and skip certain
+    ///        optional arguments.\n
+    ///        Once you use a keyword, all following arguments require the keyword.
+    ///
+    ///
+    std::string GetProperty(const std::string& key) const
+    {
+      std::string label;
+      char* ret = m_interface->kodi_gui->window->get_property(m_interface->kodiBase, m_controlHandle, key.c_str());
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          label = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return label;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Sets a window property with integer value
+    ///
+    /// @param[in] key                  string - property name.
+    /// @param[in] value                integer value to set
+    ///
+    ///
+    void SetPropertyInt(const std::string& key, int value)
+    {
+      m_interface->kodi_gui->window->set_property_int(m_interface->kodiBase, m_controlHandle, key.c_str(), value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Returns a window property with integer value
+    ///
+    /// @param[in] key                  string - property name.
+    /// @return                         integer value of property
+    ///
+    int GetPropertyInt(const std::string& key) const
+    {
+      return m_interface->kodi_gui->window->get_property_int(m_interface->kodiBase, m_controlHandle, key.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Sets a window property with boolean value
+    ///
+    /// @param[in] key                  string - property name.
+    /// @param[in] value                boolean value to set
+    ///
+    ///
+    void SetPropertyBool(const std::string& key, bool value)
+    {
+      m_interface->kodi_gui->window->set_property_bool(m_interface->kodiBase, m_controlHandle, key.c_str(), value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Returns a window property with boolean value
+    ///
+    /// @param[in] key                  string - property name.
+    /// @return                         boolean value of property
+    ///
+    bool GetPropertyBool(const std::string& key) const
+    {
+      return m_interface->kodi_gui->window->get_property_bool(m_interface->kodiBase, m_controlHandle, key.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Sets a window property with double value
+    ///
+    /// @param[in] key                  string - property name.
+    /// @param[in] value                double value to set
+    ///
+    ///
+    void SetPropertyDouble(const std::string& key, double value)
+    {
+      m_interface->kodi_gui->window->set_property_double(m_interface->kodiBase, m_controlHandle, key.c_str(), value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Returns a window property with double value
+    ///
+    /// @param[in] key                  string - property name.
+    /// @return                         double value of property
+    ///
+    ///
+    double GetPropertyDouble(const std::string& key) const
+    {
+      return m_interface->kodi_gui->window->get_property_double(m_interface->kodiBase, m_controlHandle, key.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Remove all present properties from window
+    ///
+    ///
+    ///
+    void ClearProperties()
+    {
+      m_interface->kodi_gui->window->clear_properties(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Clears the specific window property.
+    ///
+    /// @param[in] key                string - property name.
+    ///
+    /// @note Key is NOT case sensitive. Equivalent to SetProperty(key, "")
+    ///       You can use the above as keywords for arguments and skip certain
+    ///       optional arguments.
+    ///       Once you use a keyword, all following arguments require the
+    ///       keyword.
+    ///
+    ///
+    ///-----------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// ..
+    /// ClearProperty('Category')
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    void ClearProperty(const std::string& key)
+    {
+      m_interface->kodi_gui->window->clear_property(m_interface->kodiBase, m_controlHandle, key.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //@{
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
     /// @brief Function delete all entries in integrated list.
     ///
     ///
@@ -209,6 +435,34 @@ namespace gui
     //==========================================================================
     ///
     /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Remove list item on position.
+    ///
+    /// @param[in] itemPosition         List position to remove
+    ///
+    ///
+    void RemoveListItem(int itemPosition)
+    {
+      m_interface->kodi_gui->window->remove_list_item_from_position(m_interface->kodiBase, m_controlHandle, itemPosition);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Remove item with given control class from list.
+    ///
+    /// @param[in] item                 List item control class to remove
+    ///
+    ///
+    void RemoveListItem(ListItemPtr item)
+    {
+      m_interface->kodi_gui->window->remove_list_item(m_interface->kodiBase, m_controlHandle, item->m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
     /// @brief To get list item control class on wanted position.
     ///
     /// @param[in] listPos              Position from where control is needed
@@ -223,6 +477,135 @@ namespace gui
         return ListItemPtr();
 
       return std::make_shared<kodi::gui::CListItem>(handle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief To set position of selected part in list.
+    ///
+    /// @param[in] listPos              Position to use
+    ///
+    ///
+    void SetCurrentListPosition(int listPos)
+    {
+      m_interface->kodi_gui->window->set_current_list_position(m_interface->kodiBase, m_controlHandle, listPos);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief To get current selected position in list
+    ///
+    /// @return                         Current list position
+    ///
+    ///
+    int GetCurrentListPosition()
+    {
+      return m_interface->kodi_gui->window->get_current_list_position(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief To get the amount of entries in the list.
+    ///
+    /// @return                         Size of in window integrated control class
+    ///
+    ///
+    int GetListSize()
+    {
+      return m_interface->kodi_gui->window->get_list_size(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Sets a container property, similar to an infolabel.
+    ///
+    /// @param[in] key        string - property name.
+    /// @param[in] value      string or unicode - value of property.
+    ///
+    /// @note Key is NOT case sensitive.\n
+    /// You can use the above as keywords for arguments and skip certain
+    /// optional arguments.\n
+    /// Once you use a keyword, all following arguments require the keyword.
+    ///
+    ///
+    void SetContainerProperty(const std::string& key, const std::string& value)
+    {
+      m_interface->kodi_gui->window->set_container_property(m_interface->kodiBase, m_controlHandle, key.c_str(), value.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Sets the content type of the container.
+    ///
+    /// @param[in] value      string or unicode - content value.
+    ///
+    /// __Available content types__
+    /// | Name        | Media                                    |
+    /// |:-----------:|:-----------------------------------------|
+    /// | actors      | Videos
+    /// | addons      | Addons, Music, Pictures, Programs, Videos
+    /// | albums      | Music, Videos
+    /// | artists     | Music, Videos
+    /// | countries   | Music, Videos
+    /// | directors   | Videos
+    /// | files       | Music, Videos
+    /// | games       | Games
+    /// | genres      | Music, Videos
+    /// | images      | Pictures
+    /// | mixed       | Music, Videos
+    /// | movies      | Videos
+    /// | Musicvideos | Music, Videos
+    /// | playlists   | Music, Videos
+    /// | seasons     | Videos
+    /// | sets        | Videos
+    /// | songs       | Music
+    /// | studios     | Music, Videos
+    /// | tags        | Music, Videos
+    /// | tvshows     | Videos
+    /// | videos      | Videos
+    /// | years       | Music, Videos
+    ///
+    ///
+    void SetContainerContent(const std::string& value)
+    {
+      m_interface->kodi_gui->window->set_container_content(m_interface->kodiBase, m_controlHandle, value.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief Get the id of the currently visible container.
+    ///
+    /// @return               currently visible container id
+    ///
+    ///
+    int GetCurrentContainerId()
+    {
+      return m_interface->kodi_gui->window->get_current_container_id(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+    //@}
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_CWindow
+    /// @brief To inform Kodi that it need to render region new.
+    ///
+    ///
+    void MarkDirtyRegion()
+    {
+      return m_interface->kodi_gui->window->mark_dirty_region(m_interface->kodiBase, m_controlHandle);
     }
     //--------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
@@ -160,9 +160,10 @@ typedef struct gui_context_menu_pair
   unsigned int id;
   char name[ADDON_MAX_CONTEXT_ENTRY_NAME_LENGTH];
 } gui_context_menu_pair;
-    
+
 typedef struct AddonToKodiFuncTable_kodi_gui_window
 {
+  /* Window creation functions */
   void* (*create)(void* kodiBase, const char* xml_filename, const char* default_skin, bool as_dialog, bool is_media);
   void (*destroy)(void* kodiBase, void* handle);
   void (*set_callbacks)(void* kodiBase, void* handle, void* clienthandle,
@@ -175,9 +176,39 @@ typedef struct AddonToKodiFuncTable_kodi_gui_window
   bool (*show)(void* kodiBase, void* handle);
   bool (*close)(void* kodiBase, void* handle);
   bool (*do_modal)(void* kodiBase, void* handle);
+
+  /* Window control functions */
+  bool (*set_focus_id)(void* kodiBase, void* handle, int control_id);
+  int (*get_focus_id)(void* kodiBase, void* handle);
+  void (*set_control_label)(void* kodiBase, void* handle, int control_id, const char* label);
+
+  /* Window property functions */
+  void (*set_property)(void* kodiBase, void* handle, const char* key, const char* value);
+  void (*set_property_int)(void* kodiBase, void* handle, const char* key, int value);
+  void (*set_property_bool)(void* kodiBase, void* handle, const char* key, bool value);
+  void (*set_property_double)(void* kodiBase, void* handle, const char* key, double value);
+  char* (*get_property)(void* kodiBase, void* handle, const char* key);
+  int (*get_property_int)(void* kodiBase, void* handle, const char* key);
+  bool (*get_property_bool)(void* kodiBase, void* handle, const char* key);
+  double (*get_property_double)(void* kodiBase, void* handle, const char* key);
+  void (*clear_properties)(void* kodiBase, void* handle);
+  void (*clear_property)(void* kodiBase, void* handle, const char* key);
+
+  /* List item functions */
   void (*clear_item_list)(void* kodiBase, void* handle);
-  void (*add_list_item)(void* kodiBase, void* handle, void* item, int item_position);
-  void* (*get_list_item)(void* kodiBase, void* handle, int listPos);
+  void (*add_list_item)(void* kodiBase, void* handle, void* item, int list_position);
+  void (*remove_list_item_from_position)(void* kodiBase, void* handle, int list_position);
+  void (*remove_list_item)(void* kodiBase, void* handle, void* item);
+  void* (*get_list_item)(void* kodiBase, void* handle, int list_position);
+  void (*set_current_list_position)(void* kodiBase, void* handle, int list_position);
+  int (*get_current_list_position)(void* kodiBase, void* handle);
+  int (*get_list_size)(void* kodiBase, void* handle);
+  void (*set_container_property)(void* kodiBase, void* handle, const char* key, const char* value);
+  void (*set_container_content)(void* kodiBase, void* handle, const char* value);
+  int (*get_current_container_id)(void* kodiBase, void* handle);
+
+  /* Various functions */
+  void (*mark_dirty_region)(void* kodiBase, void* handle);
 } AddonToKodiFuncTable_kodi_gui_window;
 
 typedef struct AddonToKodiFuncTable_kodi_gui


### PR DESCRIPTION
## Description
<!--- Describe your change in detail -->
Next step for binary addon interface rework.

This is nearly the last change on addon Window class. There becomes
all parts added to have needed functionality, also is it with supported
parts now nearly equal with a Python addon window interface.

As last changes on window part comes on next request only the support
for the various control types.

<!--- Provide a general summary of your change in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
