### PR TITLE
Add CORS headers to HTTP web server

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1299,7 +1299,7 @@ std::string CWebServer::CreateMimeTypeFromExtension(const char *ext)
 
 void CWebServer::EnableCors(struct MHD_Response *response) const
 {
-  if (response == nullptr || name.empty())
+  if (response == nullptr)
     return;
 
   if (g_advancedSettings.CanLogComponent(LOGWEBSERVER))

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -63,6 +63,8 @@
 
 #define HEADER_NEWLINE        "\r\n"
 
+#define HEADER_CORS_ENABLED   true
+
 typedef struct {
   std::shared_ptr<XFILE::CFile> file;
   CHttpRanges ranges;
@@ -453,6 +455,11 @@ int CWebServer::FinalizeRequest(const std::shared_ptr<IHTTPRequestHandler>& hand
   // add all headers set by the request handler
   for (std::multimap<std::string, std::string>::const_iterator it = responseDetails.headers.begin(); it != responseDetails.headers.end(); ++it)
     AddHeader(response, it->first, it->second);
+
+  // add CORS headers
+  if (HEADER_CORS_ENABLED)
+    AddHeader(response, MHD_HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+    AddHeader(response, "Access-Control-Allow-Credentials", "true");
 
   return SendResponse(request, responseStatus, response);
 }

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -100,6 +100,7 @@ private:
   int SendResponse(HTTPRequest request, int responseStatus, MHD_Response *response) const;
   int SendErrorResponse(HTTPRequest request, int errorType, HTTPMethod method) const;
 
+  void EnableCors(struct MHD_Response *response) const;
   int AddHeader(struct MHD_Response *response, const std::string &name, const std::string &value) const;
 
   void LogRequest(HTTPRequest request) const;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This PR adds the CORS headers

* `Access-Control-Allow-Credentials: true`
* `Access-Control-Allow-Origin: *`

to every `MHD_OK` and `AskForAuthentication` response from the HTTP web server.

## Motivation and Context
This change enables usage of the new [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) which requires CORS headers to be present.

Code example:
```js
var headers = new Headers({
  "Authorization": "Basic " + window.btoa("kodi:kodi"),
  "Accept": "application/json",
  "Content-Type": "application/json;charset=UTF-8"
});

var params = {
  method: "POST",
  credentials: "include",
  headers: headers,
  mode: "cors",
  body: '{"foo": "bar"}'
};

fetch("http://kodi:8080/jsonrpc", params).then(function(response) {
  console.log(response);
});
```

### Long description

I'm developing a web-extension which talks to Kodi via HTTP. (Just like https://github.com/khloke/play-to-xbmc-chrome).

I could prevent cross-origin errors by requesting permissions to talk to all websites (see https://github.com/khloke/play-to-xbmc-chrome/blob/master/manifest.json#L12), but due to security concers I want to avoid this.

By adding CORS headers to Kodi, I can make cross-origin requests to Kodi and use the HTTP API without having to use a cross-origin workaround.

### Security concerns

Assuming a user enables remote control via HTTP and **does not** set a password, a malicious website could send cross-site requests to Kodi without the user noticing.    
But: in order for the attacker to succeed, he must know the IP and port of the Kodi HTTP server.

In order to mitigate this issue, a `Enable CORS` setting could be introduced.

## How Has This Been Tested?
I tested this change by sending fetch requests to Kodi (see code example above) and making `curl` requests to Kodi.

### Unauthenticated response
```
$ curl -v http://192.168.99.100:8080/jsonrpc
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 8080 (#0)
> GET /jsonrpc HTTP/1.1
> Host: 192.168.99.100:8080
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 401 Unauthorized
< Content-Length: 0
< WWW-Authenticate: Basic realm="XBMC"
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: *
< Connection: close
< Date: Sat, 03 Jun 2017 11:51:05 GMT
< 
* Closing connection 0
```

### Authenticated response
``` 
curl -v -o /dev/null http://kodi:kodi@192.168.99.100:8080/jsonrpc
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 8080 (#0)
* Server auth using Basic with user 'kodi'
> GET /jsonrpc HTTP/1.1
> Host: 192.168.99.100:8080
> Authorization: Basic a29kaTprb2Rp
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Connection: Keep-Alive
< Content-Type: application/json
< Content-Length: 232629
< Cache-Control: private, max-age=0, no-cache
< Accept-Ranges: none
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: *
< Date: Sat, 03 Jun 2017 12:23:21 GMT
```

I also successfully ran the test suite.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
