### PR TITLE
[addons] Coverity fixes

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -549,11 +549,7 @@ bool Interface_Filesystem::curl_add_option(void* kodiBase, void* file, int type,
     return false;
   };
 
-  CFile* cfile = static_cast<CFile*>(file);
-  if (cfile)
-    return cfile->CURLAddOption(internalType, name, value);
-
-  return false;
+  return static_cast<CFile*>(file)->CURLAddOption(internalType, name, value);
 }
 
 bool Interface_Filesystem::curl_open(void* kodiBase, void* file, unsigned int flags)

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -565,11 +565,7 @@ bool Interface_Filesystem::curl_open(void* kodiBase, void* file, unsigned int fl
     return false;
   }
 
-  CFile* cfile = static_cast<CFile*>(file);
-  if (cfile)
-    return cfile->CURLOpen(flags);
-
-  return false;
+  return static_cast<CFile*>(file)->CURLOpen(flags);
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/GUI/Window.cpp
+++ b/xbmc/addons/interfaces/GUI/Window.cpp
@@ -335,9 +335,13 @@ void* Interface_GUIWindow::get_list_item(void* kodiBase, void* handle, int listP
   CFileItemPtr* pItem(pAddonWindow->GetListItem(listPos));
   if (pItem == nullptr || pItem->get() == nullptr)
   {
-    Interface_GUIGeneral::unlock();
     CLog::Log(LOGERROR, "ADDON::Interface_GUIWindow - %s: %s - Index out of range", __FUNCTION__, addon->Name().c_str());
-    return nullptr;
+
+    if (pItem)
+    {
+      delete pItem;
+      pItem = nullptr;
+    }
   }
   Interface_GUIGeneral::unlock();
 

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -184,11 +184,13 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
     usedHeader = header;
   else
     usedHeader = addon->Name();
-  
-  if (type != QUEUE_OWN_STYLE)
+
+  QueueMsg qtype = static_cast<QueueMsg>(type);
+
+  if (qtype != QUEUE_OWN_STYLE)
   {
     CGUIDialogKaiToast::eMessageType usedType;
-    switch (type)
+    switch (qtype)
     {
     case QUEUE_WARNING:
       usedType = CGUIDialogKaiToast::Warning;


### PR DESCRIPTION
Fixes some Coverity issues introduced with recent binary addons changes:

<pre>
*** CID 170202:  Resource leaks  (RESOURCE_LEAK)
/xbmc/addons/interfaces/GUI/Window.cpp: 340 in ADDON::Interface_GUIWindow::get_list_item(void *, void *, int)()
334       Interface_GUIGeneral::lock();
335       CFileItemPtr* pItem(pAddonWindow->GetListItem(listPos));
336       if (pItem == nullptr || pItem->get() == nullptr)
337       {
338         Interface_GUIGeneral::unlock();
339         CLog::Log(LOGERROR, "ADDON::Interface_GUIWindow - %s: %s - Index out of range", __FUNCTION__, addon->Name().c_str());
>>>     CID 170202:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "pItem" going out of scope leaks the storage it points to.
340         return nullptr;
341       }
342       Interface_GUIGeneral::unlock();
343     
344       return pItem;
345     }

*** CID 170199:    (MIXED_ENUMS)
/xbmc/addons/interfaces/General.cpp: 193 in ADDON::Interface_General::queue_notification(void *, int, const char *, const char *, const char *, unsigned int, bool, unsigned int)()
187       
188       if (type != QUEUE_OWN_STYLE)
189       {
190         CGUIDialogKaiToast::eMessageType usedType;
191         switch (type)
192         {
>>>     CID 170199:    (MIXED_ENUMS)
>>>     But this case, "ADDON::QUEUE_WARNING", is of different type "ADDON::queue_msg".
193         case QUEUE_WARNING:
194           usedType = CGUIDialogKaiToast::Warning;
195           withSound = true;
196           CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Warning Message: '%s'", __FUNCTION__, addon->Name().c_str(), message);
197           break;
198         case QUEUE_ERROR:
/xbmc/addons/interfaces/General.cpp: 198 in ADDON::Interface_General::queue_notification(void *, int, const char *, const char *, const char *, unsigned int, bool, unsigned int)()
192         {
193         case QUEUE_WARNING:
194           usedType = CGUIDialogKaiToast::Warning;
195           withSound = true;
196           CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Warning Message: '%s'", __FUNCTION__, addon->Name().c_str(), message);
197           break;
>>>     CID 170199:    (MIXED_ENUMS)
>>>     But this case, "ADDON::QUEUE_ERROR", is of different type "ADDON::queue_msg".
198         case QUEUE_ERROR:
199           usedType = CGUIDialogKaiToast::Error;
200           withSound = true;
201           CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Error Message : '%s'", __FUNCTION__, addon->Name().c_str(), message);
202           break;
203         case QUEUE_INFO:
/xbmc/addons/interfaces/General.cpp: 203 in ADDON::Interface_General::queue_notification(void *, int, const char *, const char *, const char *, unsigned int, bool, unsigned int)()
197           break;
198         case QUEUE_ERROR:
199           usedType = CGUIDialogKaiToast::Error;
200           withSound = true;
201           CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Error Message : '%s'", __FUNCTION__, addon->Name().c_str(), message);
202           break;
>>>     CID 170199:    (MIXED_ENUMS)
>>>     But this case, "ADDON::QUEUE_INFO", is of different type "ADDON::queue_msg".
203         case QUEUE_INFO:
204         default:
205           usedType = CGUIDialogKaiToast::Info;
206           withSound = false;
207           CLog::Log(LOGDEBUG, "Interface_General::%s - %s - Info Message : '%s'", __FUNCTION__, addon->Name().c_str(), message);
208           break;

*** CID 170198:  Control flow issues  (DEADCODE)
/xbmc/addons/interfaces/Filesystem.cpp: 572 in ADDON::Interface_Filesystem::curl_open(void *, void *, unsigned int)()
566       }
567     
568       CFile* cfile = static_cast<CFile*>(file);
569       if (cfile)
570         return cfile->CURLOpen(flags);
571     
>>>     CID 170198:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "return false;".
572       return false;
573     }
574     
575     } /* namespace ADDON */

*** CID 170195:  Control flow issues  (DEADCODE)
/xbmc/addons/interfaces/Filesystem.cpp: 556 in ADDON::Interface_Filesystem::curl_add_option(void *, void *, int, const char *, const char *)()
550       };
551     
552       CFile* cfile = static_cast<CFile*>(file);
553       if (cfile)
554         return cfile->CURLAddOption(internalType, name, value);
555     
>>>     CID 170195:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "return false;".
556       return false;
557     }
558     
559     bool Interface_Filesystem::curl_open(void* kodiBase, void* file, unsigned int flags)
560     {
561       CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
</pre>

@AlwinEsch mind taking a look.