### PR TITLE
[add-ons/settings] add python setting getters/setters for bool/int/number/string

### DIFF
--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -148,6 +148,34 @@ public:
    */
   void UpdateSetting(const std::string& key, const std::string& value) override;
 
+  /*! \brief Update a user-configured setting with a new boolean value
+  \param key the id of the setting to update
+  \param value the value that the setting should take
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting
+  */
+  bool UpdateSettingBool(const std::string& key, bool value) override;
+
+  /*! \brief Update a user-configured setting with a new integer value
+  \param key the id of the setting to update
+  \param value the value that the setting should take
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting
+  */
+  bool UpdateSettingInt(const std::string& key, int value) override;
+
+  /*! \brief Update a user-configured setting with a new number value
+  \param key the id of the setting to update
+  \param value the value that the setting should take
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting
+  */
+  bool UpdateSettingNumber(const std::string& key, double value) override;
+
+  /*! \brief Update a user-configured setting with a new string value
+  \param key the id of the setting to update
+  \param value the value that the setting should take
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting
+  */
+  bool UpdateSettingString(const std::string& key, const std::string& value) override;
+
   /*! \brief Retrieve a particular settings value
    If a previously configured user setting is available, we return it's value, else we return the default (if available)
    \param key the id of the setting to retrieve
@@ -155,6 +183,42 @@ public:
    \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, UpdateSetting
    */
   std::string GetSetting(const std::string& key) override;
+
+  /*! \brief Retrieve a particular settings value as boolean
+  If a previously configured user setting is available, we return it's value, else we return the default (if available)
+  \param key the id of the setting to retrieve
+  \param value the current value of the setting, or the default if the setting has yet to be configured
+  \return true if the setting's value was retrieved, false otherwise.
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, UpdateSetting
+  */
+  bool GetSettingBool(const std::string& key, bool& value) override;
+
+  /*! \brief Retrieve a particular settings value as integer
+  If a previously configured user setting is available, we return it's value, else we return the default (if available)
+  \param key the id of the setting to retrieve
+  \param value the current value of the setting, or the default if the setting has yet to be configured
+  \return true if the setting's value was retrieved, false otherwise.
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, UpdateSetting
+  */
+  bool GetSettingInt(const std::string& key, int& value) override;
+
+  /*! \brief Retrieve a particular settings value as number
+  If a previously configured user setting is available, we return it's value, else we return the default (if available)
+  \param key the id of the setting to retrieve
+  \param value the current value of the setting, or the default if the setting has yet to be configured
+  \return true if the setting's value was retrieved, false otherwise.
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, UpdateSetting
+  */
+  bool GetSettingNumber(const std::string& key, double& value) override;
+
+  /*! \brief Retrieve a particular settings value as string
+  If a previously configured user setting is available, we return it's value, else we return the default (if available)
+  \param key the id of the setting to retrieve
+  \param value the current value of the setting, or the default if the setting has yet to be configured
+  \return true if the setting's value was retrieved, false otherwise.
+  \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, UpdateSetting
+  */
+  bool GetSettingString(const std::string& key, std::string& value) override;
 
   CAddonSettings* GetSettings() const override;
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -127,7 +127,15 @@ namespace ADDON
     virtual bool HasSettings() =0;
     virtual void SaveSettings() =0;
     virtual void UpdateSetting(const std::string& key, const std::string& value) =0;
+    virtual bool UpdateSettingBool(const std::string& key, bool value) = 0;
+    virtual bool UpdateSettingInt(const std::string& key, int value) = 0;
+    virtual bool UpdateSettingNumber(const std::string& key, double value) = 0;
+    virtual bool UpdateSettingString(const std::string& key, const std::string& value) = 0;
     virtual std::string GetSetting(const std::string& key) =0;
+    virtual bool GetSettingBool(const std::string& key, bool& value) = 0;
+    virtual bool GetSettingInt(const std::string& key, int& value) = 0;
+    virtual bool GetSettingNumber(const std::string& key, double& value) = 0;
+    virtual bool GetSettingString(const std::string& key, std::string& value) = 0;
     virtual CAddonSettings* GetSettings() const =0;
     virtual const ADDONDEPS &GetDeps() const =0;
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -55,7 +55,9 @@ namespace ADDON
     // implementation of ISettingCallback
     void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
-    bool Initialize(const CXBMCTinyXML& doc);
+    std::shared_ptr<const IAddon> GetAddon() { return m_addon.lock(); }
+
+    bool Initialize(const CXBMCTinyXML& doc, bool allowEmpty = false);
     bool Load(const CXBMCTinyXML& doc);
     bool Save(CXBMCTinyXML& doc) const;
 
@@ -63,6 +65,9 @@ namespace ADDON
 
     std::string GetSettingLabel(int label) const;
 
+    std::shared_ptr<CSetting> AddSetting(const std::string& settingId, bool value);
+    std::shared_ptr<CSetting> AddSetting(const std::string& settingId, int value);
+    std::shared_ptr<CSetting> AddSetting(const std::string& settingId, double value);
     std::shared_ptr<CSetting> AddSetting(const std::string& settingId, const std::string& value);
 
   protected:
@@ -75,8 +80,6 @@ namespace ADDON
     bool InitializeDefinitions() override { return false; }
 
   private:
-    bool InitializeInternal(const CXBMCTinyXML& doc, bool allowEmptyDefinition);
-
     bool InitializeDefinitions(const CXBMCTinyXML& doc);
 
     bool ParseSettingVersion(const CXBMCTinyXML& doc, uint32_t& version) const;
@@ -96,9 +99,6 @@ namespace ADDON
     std::shared_ptr<CSetting> InitializeFromOldSettingRangeOfNum(const std::string& settingId, const TiXmlElement *settingElement, const std::string& defaultValue);
     std::shared_ptr<CSetting> InitializeFromOldSettingSlider(const std::string& settingId, const TiXmlElement *settingElement, const std::string& defaultValue);
     std::shared_ptr<CSetting> InitializeFromOldSettingFileWithSource(const std::string& settingId, const TiXmlElement *settingElement, const std::string& defaultValue, std::string source);
-    std::shared_ptr<CSetting> InitializeFromOldSettingWithoutDefinition(const std::string& settingId, const std::string& defaultValue);
-
-    std::shared_ptr<CSetting> AddSettingWithoutDefinition(const std::string& settingId, const std::string& defaultValue);
 
     bool LoadOldSettingValues(const CXBMCTinyXML& doc, std::map<std::string, std::string>& settings) const;
 

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -37,6 +37,26 @@ namespace XBMCAddon
 
     String Addon::getAddonVersion() { return languageHook == NULL ? emptyString : languageHook->GetAddonVersion(); }
 
+    bool Addon::UpdateSettingInActiveDialog(const char* id, const String& value)
+    {
+      ADDON::AddonPtr addon(pAddon);
+      if (!g_windowManager.IsWindowActive(WINDOW_DIALOG_ADDON_SETTINGS))
+        return false;
+
+      CGUIDialogAddonSettings* dialog = g_windowManager.GetWindow<CGUIDialogAddonSettings>(WINDOW_DIALOG_ADDON_SETTINGS);
+      if (dialog->GetCurrentAddonID() != addon->ID())
+        return false;
+
+      CGUIMessage message(GUI_MSG_SETTING_UPDATED, 0, 0);
+      std::vector<std::string> params;
+      params.push_back(id);
+      params.push_back(value);
+      message.SetStringParams(params);
+      g_windowManager.SendThreadMessage(message, WINDOW_DIALOG_ADDON_SETTINGS);
+
+      return true;
+    }
+
     Addon::Addon(const char* cid)
     {
       String id(cid ? cid : emptyString);
@@ -71,30 +91,111 @@ namespace XBMCAddon
       return pAddon->GetSetting(id);
     }
 
+    bool Addon::getSettingBool(const char* id) throw(XBMCAddon::WrongTypeException)
+    {
+      bool value = false;
+      if (!pAddon->GetSettingBool(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      return value;
+    }
+
+    int Addon::getSettingInt(const char* id) throw(XBMCAddon::WrongTypeException)
+    {
+      int value = 0;
+      if (!pAddon->GetSettingInt(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      return value;
+    }
+
+    double Addon::getSettingNumber(const char* id) throw(XBMCAddon::WrongTypeException)
+    {
+      double value = 0.0;
+      if (!pAddon->GetSettingNumber(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      return value;
+    }
+
+    String Addon::getSettingString(const char* id) throw(XBMCAddon::WrongTypeException)
+    {
+      std::string value;
+      if (!pAddon->GetSettingString(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      return value;
+    }
+
     void Addon::setSetting(const char* id, const String& value)
     {
       DelayedCallGuard dcguard(languageHook);
       ADDON::AddonPtr addon(pAddon);
-      bool save=true;
-      if (g_windowManager.IsWindowActive(WINDOW_DIALOG_ADDON_SETTINGS))
-      {
-        CGUIDialogAddonSettings* dialog = g_windowManager.GetWindow<CGUIDialogAddonSettings>(WINDOW_DIALOG_ADDON_SETTINGS);
-        if (dialog->GetCurrentAddonID() == addon->ID())
-        {
-          CGUIMessage message(GUI_MSG_SETTING_UPDATED,0,0);
-          std::vector<std::string> params;
-          params.push_back(id);
-          params.push_back(value);
-          message.SetStringParams(params);
-          g_windowManager.SendThreadMessage(message,WINDOW_DIALOG_ADDON_SETTINGS);
-          save=false;
-        }
-      }
-      if (save)
+      if (!UpdateSettingInActiveDialog(id, value))
       {
         addon->UpdateSetting(id, value);
         addon->SaveSettings();
       }
+    }
+
+    bool Addon::setSettingBool(const char* id, bool value) throw(XBMCAddon::WrongTypeException)
+    {
+      DelayedCallGuard dcguard(languageHook);
+      ADDON::AddonPtr addon(pAddon);
+      if (UpdateSettingInActiveDialog(id, value ? "true" : "false"))
+        return true;
+
+      if (!addon->UpdateSettingBool(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      addon->SaveSettings();
+
+      return true;
+    }
+
+    bool Addon::setSettingInt(const char* id, int value) throw(XBMCAddon::WrongTypeException)
+    {
+      DelayedCallGuard dcguard(languageHook);
+      ADDON::AddonPtr addon(pAddon);
+      if (UpdateSettingInActiveDialog(id, StringUtils::Format("%d", value)))
+        return true;
+
+      if (!addon->UpdateSettingInt(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      addon->SaveSettings();
+
+      return true;
+    }
+
+    bool Addon::setSettingNumber(const char* id, double value) throw(XBMCAddon::WrongTypeException)
+    {
+      DelayedCallGuard dcguard(languageHook);
+      ADDON::AddonPtr addon(pAddon);
+      if (UpdateSettingInActiveDialog(id, StringUtils::Format("%f", value)))
+        return true;
+
+      if (!addon->UpdateSettingNumber(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      addon->SaveSettings();
+
+      return true;
+    }
+
+    bool Addon::setSettingString(const char* id, const String& value) throw(XBMCAddon::WrongTypeException)
+    {
+      DelayedCallGuard dcguard(languageHook);
+      ADDON::AddonPtr addon(pAddon);
+      if (UpdateSettingInActiveDialog(id, value))
+        return true;
+
+      if (!addon->UpdateSettingString(id, value))
+        throw XBMCAddon::WrongTypeException("Invalid setting type");
+
+      addon->SaveSettings();
+
+      return true;
     }
 
     void Addon::openSettings()

--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -76,6 +76,8 @@ namespace XBMCAddon
 
       String getAddonVersion();
 
+      bool UpdateSettingInActiveDialog(const char* id, const String& value);
+
     public:
       Addon(const char* id = NULL);
       virtual ~Addon();
@@ -140,6 +142,122 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettingBool(id) }
+      ///-----------------------------------------------------------------------
+      /// Returns the value of a setting as a boolean.
+      ///
+      /// @param id                      string - id of the setting that the module
+      ///                                needs to access.
+      /// @return                        Setting as a boolean
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// enabled = self.Addon.getSettingBool('enabled')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getSettingBool(...);
+#else
+      bool getSettingBool(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettingInt(id) }
+      ///-----------------------------------------------------------------------
+      /// Returns the value of a setting as an integer.
+      ///
+      /// @param id                      string - id of the setting that the module
+      ///                                needs to access.
+      /// @return                        Setting as an integer
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// max = self.Addon.getSettingInt('max')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getSettingInt(...);
+#else
+      int getSettingInt(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettingNumber(id) }
+      ///-----------------------------------------------------------------------
+      /// Returns the value of a setting as a floating point number.
+      ///
+      /// @param id                      string - id of the setting that the module
+      ///                                needs to access.
+      /// @return                        Setting as a floating point number
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// max = self.Addon.getSettingNumber('max')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getSettingNumber(...);
+#else
+      double getSettingNumber(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettingString(id) }
+      ///-----------------------------------------------------------------------
+      /// Returns the value of a setting as a unicode string.
+      ///
+      /// @param id                      string - id of the setting that the module
+      ///                                needs to access.
+      /// @return                        Setting as a unicode string
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// apikey = self.Addon.getSettingString('apikey')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getSettingString(...);
+#else
+      String getSettingString(const char* id) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
       /// @brief \python_func{ xbmcaddon.Addon([id]).setSetting(id, value) }
       ///-----------------------------------------------------------------------
       /// Sets a script setting.
@@ -152,6 +270,9 @@ namespace XBMCAddon
       ///
       ///
       ///-----------------------------------------------------------------------
+      /// @python_v13
+      /// **id** is optional as it will be auto detected for this add-on instance.
+      ///
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -163,6 +284,134 @@ namespace XBMCAddon
       setSetting(...);
 #else
       void setSetting(const char* id, const String& value);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).setSettingBool(id, value) }
+      ///-----------------------------------------------------------------------
+      /// Sets a script setting.
+      ///
+      /// @param id                  string - id of the setting that the module needs to access.
+      /// @param value               boolean - value of the setting.
+      /// @return                    True if the value of the setting was set, false otherwise
+      ///
+      ///
+      /// @note You can use the above as keywords for arguments.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// self.Addon.setSettingBool(id='enabled', value=True)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      setSettingBool(...);
+#else
+      bool setSettingBool(const char* id, bool value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).setSettingInt(id, value) }
+      ///-----------------------------------------------------------------------
+      /// Sets a script setting.
+      ///
+      /// @param id                  string - id of the setting that the module needs to access.
+      /// @param value               integer - value of the setting.
+      /// @return                    True if the value of the setting was set, false otherwise
+      ///
+      ///
+      /// @note You can use the above as keywords for arguments.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// self.Addon.setSettingInt(id='max', value=5)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      setSettingInt(...);
+#else
+      bool setSettingInt(const char* id, int value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).setSettingNumber(id, value) }
+      ///-----------------------------------------------------------------------
+      /// Sets a script setting.
+      ///
+      /// @param id                  string - id of the setting that the module needs to access.
+      /// @param value               float - value of the setting.
+      /// @return                    True if the value of the setting was set, false otherwise
+      ///
+      ///
+      /// @note You can use the above as keywords for arguments.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// self.Addon.setSettingNumber(id='max', value=5.5)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      setSettingNumber(...);
+#else
+      bool setSettingNumber(const char* id, double value) throw(XBMCAddon::WrongTypeException);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).setSettingString(id, value) }
+      ///-----------------------------------------------------------------------
+      /// Sets a script setting.
+      ///
+      /// @param id                  string - id of the setting that the module needs to access.
+      /// @param value               string or unicode - value of the setting.
+      /// @return                    True if the value of the setting was set, false otherwise
+      ///
+      ///
+      /// @note You can use the above as keywords for arguments.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18
+      /// New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// self.Addon.setSettingString(id='username', value='teamkodi')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      setSettingString(...);
+#else
+      bool setSettingString(const char* id, const String& value) throw(XBMCAddon::WrongTypeException);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -601,18 +601,18 @@ std::string CSettingList::toString(const SettingList &values) const
 }
   
 CSettingBool::CSettingBool(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(false), m_default(false)
 { }
   
 CSettingBool::CSettingBool(const std::string &id, const CSettingBool &setting)
-  : CSetting(id, setting)
+  : CTraitedSetting(id, setting)
 {
   copy(setting);
 }
 
 CSettingBool::CSettingBool(const std::string &id, int label, bool value, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value)
 {
   m_label = label;
@@ -730,7 +730,7 @@ bool CSettingBool::fromString(const std::string &strValue, bool &value) const
 }
 
 CSettingInt::CSettingInt(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(0), m_default(0),
     m_min(0), m_step(1), m_max(0),
     m_optionsFiller(NULL),
@@ -738,7 +738,7 @@ CSettingInt::CSettingInt(const std::string &id, CSettingsManager *settingsManage
 { }
   
 CSettingInt::CSettingInt(const std::string &id, const CSettingInt &setting)
-  : CSetting(id, setting),
+  : CTraitedSetting(id, setting),
     m_optionsFiller(NULL),
     m_optionsFillerData(NULL)
 {
@@ -746,7 +746,7 @@ CSettingInt::CSettingInt(const std::string &id, const CSettingInt &setting)
 }
 
 CSettingInt::CSettingInt(const std::string &id, int label, int value, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value),
     m_min(0), m_step(1), m_max(0),
     m_optionsFiller(NULL),
@@ -756,7 +756,7 @@ CSettingInt::CSettingInt(const std::string &id, int label, int value, CSettingsM
 }
 
 CSettingInt::CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value),
     m_min(minimum), m_step(step), m_max(maximum),
     m_optionsFiller(NULL),
@@ -766,7 +766,7 @@ CSettingInt::CSettingInt(const std::string &id, int label, int value, int minimu
 }
 
 CSettingInt::CSettingInt(const std::string &id, int label, int value, const TranslatableIntegerSettingOptions &options, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value),
     m_min(0), m_step(1), m_max(0),
     m_translatableOptions(options),
@@ -1024,19 +1024,19 @@ bool CSettingInt::fromString(const std::string &strValue, int &value)
 }
 
 CSettingNumber::CSettingNumber(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(0.0), m_default(0.0),
     m_min(0.0), m_step(1.0), m_max(0.0)
 { }
   
 CSettingNumber::CSettingNumber(const std::string &id, const CSettingNumber &setting)
-  : CSetting(id, setting)
+  : CTraitedSetting(id, setting)
 {
   copy(setting);
 }
 
 CSettingNumber::CSettingNumber(const std::string &id, int label, float value, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value),
     m_min(0.0), m_step(1.0), m_max(0.0)
 {
@@ -1044,7 +1044,7 @@ CSettingNumber::CSettingNumber(const std::string &id, int label, float value, CS
 }
 
 CSettingNumber::CSettingNumber(const std::string &id, int label, float value, float minimum, float step, float maximum, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value),
     m_min(minimum), m_step(step), m_max(maximum)
 {
@@ -1195,14 +1195,14 @@ bool CSettingNumber::fromString(const std::string &strValue, double &value)
 }
 
 CSettingString::CSettingString(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_allowEmpty(false),
     m_optionsFiller(NULL),
     m_optionsFillerData(NULL)
 { }
   
 CSettingString::CSettingString(const std::string &id, const CSettingString &setting)
-  : CSetting(id, setting),
+  : CTraitedSetting(id, setting),
     m_optionsFiller(NULL),
     m_optionsFillerData(NULL)
 {
@@ -1210,7 +1210,7 @@ CSettingString::CSettingString(const std::string &id, const CSettingString &sett
 }
 
 CSettingString::CSettingString(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = NULL */)
-  : CSetting(id, settingsManager),
+  : CTraitedSetting(id, settingsManager),
     m_value(value), m_default(value),
     m_allowEmpty(false),
     m_optionsFiller(NULL),

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -154,6 +154,27 @@ protected:
 typedef std::shared_ptr<CSetting> SettingPtr;
 typedef std::vector<SettingPtr> SettingList;
 
+template<typename TValue, SettingType TSettingType>
+class CTraitedSetting : public CSetting
+{
+public:
+  typedef TValue Value;
+
+  // implementation of CSetting
+  virtual int GetType() const override { return TSettingType; }
+
+  static SettingType Type() { return TSettingType; }
+
+protected:
+  CTraitedSetting(const std::string &id, CSettingsManager *settingsManager = NULL)
+    : CSetting(id, settingsManager)
+  { }
+  CTraitedSetting(const std::string &id, const CTraitedSetting &setting)
+    : CSetting(id, setting)
+  { }
+  virtual ~CTraitedSetting() { }
+};
+
 class CSettingReference : public CSetting
 {
 public:
@@ -240,7 +261,7 @@ protected:
  \brief Boolean setting implementation.
  \sa CSetting
  */
-class CSettingBool : public CSetting
+class CSettingBool : public CTraitedSetting<bool, SettingTypeBool>
 {
 public:
   CSettingBool(const std::string &id, CSettingsManager *settingsManager = NULL);
@@ -252,7 +273,6 @@ public:
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const override { return SettingTypeBool; }
   virtual bool FromString(const std::string &value) override;
   virtual std::string ToString() const override;
   virtual bool Equals(const std::string &value) const override;
@@ -277,7 +297,7 @@ private:
  \brief Integer setting implementation
  \sa CSetting
  */
-class CSettingInt : public CSetting
+class CSettingInt : public CTraitedSetting<int, SettingTypeInteger>
 {
 public:
   CSettingInt(const std::string &id, CSettingsManager *settingsManager = NULL);
@@ -291,7 +311,6 @@ public:
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const override { return SettingTypeInteger; }
   virtual bool FromString(const std::string &value) override;
   virtual std::string ToString() const override;
   virtual bool Equals(const std::string &value) const override;
@@ -351,7 +370,7 @@ private:
  \brief Real number setting implementation.
  \sa CSetting
  */
-class CSettingNumber : public CSetting
+class CSettingNumber : public CTraitedSetting<double, SettingTypeNumber>
 {
 public:
   CSettingNumber(const std::string &id, CSettingsManager *settingsManager = NULL);
@@ -364,7 +383,6 @@ public:
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const override { return SettingTypeNumber; }
   virtual bool FromString(const std::string &value) override;
   virtual std::string ToString() const override;
   virtual bool Equals(const std::string &value) const override;
@@ -400,7 +418,7 @@ private:
  \brief String setting implementation.
  \sa CSetting
  */
-class CSettingString : public CSetting
+class CSettingString : public CTraitedSetting<std::string, SettingTypeString>
 {
 public:
   CSettingString(const std::string &id, CSettingsManager *settingsManager = NULL);
@@ -412,7 +430,6 @@ public:
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
-  virtual int GetType() const override { return SettingTypeString; }
   virtual bool FromString(const std::string &value) override { return SetValue(value); }
   virtual std::string ToString() const override { return m_value; }
   virtual bool Equals(const std::string &value) const override { return m_value == value; }


### PR DESCRIPTION
This is a follow-up of #12125 which adds typed getters and setters for bool/int/number/string settings. The difference to the existing getter/setter is that when a plugin e.g. tries to retrieve an integer setting using `getSettingString()` it will fail because the types don't match.

## How Has This Been Tested?
I've adjusted @ronie's `service.scrobbler.lastfm` to use the new methods and it still worked.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
