### PR TITLE
AESinkAUDIOTRACK: Runtime-detect IEC6137 format

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -82,6 +82,7 @@ private:
   static CAEDeviceInfo m_info;
   static std::set<unsigned int>       m_sink_sampleRates;
   static bool m_sinkSupportsFloat;
+  static bool m_sinkSupportsIEC;
 
   AEAudioFormat      m_format;
   double             m_volume;


### PR DESCRIPTION
Auto-detection if IEC format is usable.

This aligns to the float support work. Upcoming Sony Firmware will have Android N but won't open IEC while defining it. 