### PR TITLE
ActiveAE: Fix stereo upmix after ADSP removal

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1578,47 +1578,6 @@ void CActiveAE::ChangeResamplers()
   }
 }
 
-static CAEChannelInfo GetInternalChannelLayout(AEStdChLayout stdLayout)
-{
-  uint64_t channelLayoutOut;
-  switch (stdLayout)
-  {
-    default:
-    case AE_CH_LAYOUT_2_0:
-      channelLayoutOut = AV_CH_LAYOUT_STEREO;
-      break;
-    case AE_CH_LAYOUT_2_1:
-      channelLayoutOut = AV_CH_LAYOUT_2POINT1;
-      break;
-    case AE_CH_LAYOUT_3_0:
-      channelLayoutOut = AV_CH_LAYOUT_SURROUND;
-      break;
-    case AE_CH_LAYOUT_3_1:
-      channelLayoutOut = AV_CH_LAYOUT_3POINT1;
-      break;
-    case AE_CH_LAYOUT_4_0:
-      channelLayoutOut = AV_CH_LAYOUT_2_2;
-      break;
-    case AE_CH_LAYOUT_4_1:
-      channelLayoutOut = AV_CH_LAYOUT_2_2|AV_CH_LOW_FREQUENCY;
-      break;
-    case AE_CH_LAYOUT_5_0:
-      channelLayoutOut = AV_CH_LAYOUT_5POINT0;
-      break;
-    case AE_CH_LAYOUT_5_1:
-      channelLayoutOut = AV_CH_LAYOUT_5POINT1;
-      break;
-    case AE_CH_LAYOUT_7_0:
-      channelLayoutOut = AV_CH_LAYOUT_7POINT0;
-      break;
-    case AE_CH_LAYOUT_7_1:
-      channelLayoutOut = AV_CH_LAYOUT_7POINT1;
-      break;
-  }
-  return CAEUtil::GetAEChannelLayout(channelLayoutOut);
-}
-
-
 void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &settings, int *mode)
 {
   int oldMode = m_mode;
@@ -1654,34 +1613,30 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
     // consider user channel layout for those cases
     // 1. input stream is multichannel
     // 2. stereo upmix is selected
-    // 3. audio dsp is used
-    // 4. fixed mode
+    // 3. fixed mode
     if ((format.m_channelLayout.Count() > 2) ||
          settings.stereoupmix ||
-         settings.dspaddonsenabled ||
          (settings.config == AE_CONFIG_FIXED))
     {
-      AEStdChLayout stdChannelLayout;
+      CAEChannelInfo stdLayout;
       switch (settings.channels)
       {
         default:
-        case  0: stdChannelLayout = AE_CH_LAYOUT_2_0; break;
-        case  1: stdChannelLayout = AE_CH_LAYOUT_2_0; break;
-        case  2: stdChannelLayout = AE_CH_LAYOUT_2_1; break;
-        case  3: stdChannelLayout = AE_CH_LAYOUT_3_0; break;
-        case  4: stdChannelLayout = AE_CH_LAYOUT_3_1; break;
-        case  5: stdChannelLayout = AE_CH_LAYOUT_4_0; break;
-        case  6: stdChannelLayout = AE_CH_LAYOUT_4_1; break;
-        case  7: stdChannelLayout = AE_CH_LAYOUT_5_0; break;
-        case  8: stdChannelLayout = AE_CH_LAYOUT_5_1; break;
-        case  9: stdChannelLayout = AE_CH_LAYOUT_7_0; break;
-        case 10: stdChannelLayout = AE_CH_LAYOUT_7_1; break;
+        case  0: stdLayout = AE_CH_LAYOUT_2_0; break;
+        case  1: stdLayout = AE_CH_LAYOUT_2_0; break;
+        case  2: stdLayout = AE_CH_LAYOUT_2_1; break;
+        case  3: stdLayout = AE_CH_LAYOUT_3_0; break;
+        case  4: stdLayout = AE_CH_LAYOUT_3_1; break;
+        case  5: stdLayout = AE_CH_LAYOUT_4_0; break;
+        case  6: stdLayout = AE_CH_LAYOUT_4_1; break;
+        case  7: stdLayout = AE_CH_LAYOUT_5_0; break;
+        case  8: stdLayout = AE_CH_LAYOUT_5_1; break;
+        case  9: stdLayout = AE_CH_LAYOUT_7_0; break;
+        case 10: stdLayout = AE_CH_LAYOUT_7_1; break;
       }
 
-      CAEChannelInfo stdLayout(stdChannelLayout);
-
-      if (m_settings.config == AE_CONFIG_FIXED || settings.dspaddonsenabled || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
-        format.m_channelLayout = GetInternalChannelLayout(stdChannelLayout);
+      if (m_settings.config == AE_CONFIG_FIXED || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
+        format.m_channelLayout = stdLayout;
       else if (m_extKeepConfig && (settings.config == AE_CONFIG_AUTO) && (oldMode != MODE_RAW))
         format.m_channelLayout = m_internalFormat.m_channelLayout;
       else

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1578,6 +1578,47 @@ void CActiveAE::ChangeResamplers()
   }
 }
 
+static CAEChannelInfo GetInternalChannelLayout(AEStdChLayout stdLayout)
+{
+  uint64_t channelLayoutOut;
+  switch (stdLayout)
+  {
+    default:
+    case AE_CH_LAYOUT_2_0:
+      channelLayoutOut = AV_CH_LAYOUT_STEREO;
+      break;
+    case AE_CH_LAYOUT_2_1:
+      channelLayoutOut = AV_CH_LAYOUT_2POINT1;
+      break;
+    case AE_CH_LAYOUT_3_0:
+      channelLayoutOut = AV_CH_LAYOUT_SURROUND;
+      break;
+    case AE_CH_LAYOUT_3_1:
+      channelLayoutOut = AV_CH_LAYOUT_3POINT1;
+      break;
+    case AE_CH_LAYOUT_4_0:
+      channelLayoutOut = AV_CH_LAYOUT_2_2;
+      break;
+    case AE_CH_LAYOUT_4_1:
+      channelLayoutOut = AV_CH_LAYOUT_2_2|AV_CH_LOW_FREQUENCY;
+      break;
+    case AE_CH_LAYOUT_5_0:
+      channelLayoutOut = AV_CH_LAYOUT_5POINT0;
+      break;
+    case AE_CH_LAYOUT_5_1:
+      channelLayoutOut = AV_CH_LAYOUT_5POINT1;
+      break;
+    case AE_CH_LAYOUT_7_0:
+      channelLayoutOut = AV_CH_LAYOUT_7POINT0;
+      break;
+    case AE_CH_LAYOUT_7_1:
+      channelLayoutOut = AV_CH_LAYOUT_7POINT1;
+      break;
+  }
+  return CAEUtil::GetAEChannelLayout(channelLayoutOut);
+}
+
+
 void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &settings, int *mode)
 {
   int oldMode = m_mode;
@@ -1638,7 +1679,10 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
       }
 
       CAEChannelInfo stdLayout(stdChannelLayout);
-      if (m_extKeepConfig && (settings.config == AE_CONFIG_AUTO) && (oldMode != MODE_RAW))
+
+      if (m_settings.config == AE_CONFIG_FIXED || settings.dspaddonsenabled || (settings.stereoupmix && format.m_channelLayout.Count() <= 2))
+        format.m_channelLayout = GetInternalChannelLayout(stdChannelLayout);
+      else if (m_extKeepConfig && (settings.config == AE_CONFIG_AUTO) && (oldMode != MODE_RAW))
         format.m_channelLayout = m_internalFormat.m_channelLayout;
       else
       {


### PR DESCRIPTION
Stereo upmix was broken by:
https://github.com/xbmc/xbmc/pull/11765/commits/fc18b5d3d42eee1a5355c134a076f3b03477178a

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
See: https://forum.kodi.tv/showthread.php?tid=298461&pid=2596637#pid2596637

## How Has This Been Tested?
Reported working in last Milhouse build:
https://forum.kodi.tv/showthread.php?tid=298461&pid=2597199#pid2597199

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
