### PR TITLE
Log a message if ListItem-Type is missing / wrong

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -264,7 +264,10 @@ bool CPlayListPlayer::Play(const CFileItemPtr &pItem, std::string player)
   else if (pItem->IsVideo())
     playlist = PLAYLIST_VIDEO;
   else
+  {
+    CLog::Log(LOGWARNING,"Playlist Player: ListItem type must be audio or video, use ListItem::setInfo to specify!");
     return false;
+  }
 
   ClearPlaylist(playlist);
   Reset();


### PR DESCRIPTION
Log a message if ListItem-Type is missing / wrong

## Description
Older plugins don't use ListItem::setInfo(type=[audio/video] wich fails when trying to play.
Took me some time to figure it out with debugger, now it should be easier just by looking in log.
