### PR TITLE
[addons/settings] Fix some fallout from the add-on settings PR

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -328,7 +328,7 @@ bool CAddonSettings::ParseSettingVersion(const CXBMCTinyXML& doc, uint32_t& vers
 
 bool CAddonSettings::InitializeFromOldSettingDefinitions(const CXBMCTinyXML& doc)
 {
-  CLog::Log(LOGWARNING, "CAddonSettings[%s]: trying to load setting definitions from old format...", m_addon.lock()->ID().c_str());
+  CLog::Log(LOGDEBUG, "CAddonSettings[%s]: trying to load setting definitions from old format...", m_addon.lock()->ID().c_str());
 
   const TiXmlElement* root = doc.RootElement();
   if (root == nullptr)

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -980,8 +980,7 @@ void CPeripherals::OnSettingAction(std::shared_ptr<const CSetting> setting)
   else if (settingId == CSettings::SETTING_INPUT_PERIPHERALLIBRARIES)
   {
     std::string strAddonId;
-    CGUIWindowAddonBrowser::SelectAddonID(ADDON::ADDON_PERIPHERALDLL, strAddonId, false, true, true, false, true);
-    if (!strAddonId.empty())
+    if (CGUIWindowAddonBrowser::SelectAddonID(ADDON::ADDON_PERIPHERALDLL, strAddonId, false, true, true, false, true) == 1 && !strAddonId.empty())
     {
       ADDON::AddonPtr addon;
       if (ADDON::CAddonMgr::GetInstance().GetAddon(strAddonId, addon))

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -30,12 +30,14 @@
 
 CSettingPath::CSettingPath(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSettingString(id, settingsManager),
-    m_writable(true)
+    m_writable(true),
+    m_hideExtension(false)
 { }
 
 CSettingPath::CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = NULL */)
   : CSettingString(id, label, value, settingsManager),
-    m_writable(true)
+    m_writable(true),
+    m_hideExtension(false)
 { }
   
 CSettingPath::CSettingPath(const std::string &id, const CSettingPath &setting)
@@ -106,4 +108,6 @@ void CSettingPath::copy(const CSettingPath &setting)
   CExclusiveLock lock(m_critical);
   m_writable = setting.m_writable;
   m_sources = setting.m_sources;
+  m_hideExtension = setting.m_hideExtension;
+  m_masking = setting.m_masking;
 }

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -240,8 +240,9 @@ void CGUIDialogContentSettings::OnSettingAction(std::shared_ptr<const CSetting> 
       m_content = static_cast<CONTENT_TYPE>(selected.second);
 
       AddonPtr scraperAddon;
-      CAddonSystemSettings::GetInstance().GetActive(ADDON::ScraperTypeFromContent(m_content),
-          scraperAddon);
+      if (!CAddonSystemSettings::GetInstance().GetActive(ADDON::ScraperTypeFromContent(m_content), scraperAddon))
+        return;
+
       m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
 
       SetupView();

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -408,7 +408,8 @@ void CWeather::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   {
     // clear "WeatherProviderLogo" property that some weather addons set
     CGUIWindow* window = g_windowManager.GetWindow(WINDOW_WEATHER);
-    window->SetProperty("WeatherProviderLogo", "");
+    if (window != nullptr)
+      window->SetProperty("WeatherProviderLogo", "");
     Refresh();
   }
 }


### PR DESCRIPTION
This fixes some fallout from the addon-settings PR #12125. It fixes some coverity issues and reduces the log spam when loading add-on settings in the old format.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
