### PR TITLE
RetroPlayer: Fixes for RPi after videobuffers update

### DIFF
--- a/xbmc/cores/RetroPlayer/PixelConverter.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverter.cpp
@@ -162,6 +162,11 @@ void CPixelBufferPoolFFmpeg::Return(int id)
 // main class
 //------------------------------------------------------------------------------
 
+void CPixelConverter::delete_buffer_pool::operator()(CPixelBufferPoolFFmpeg *p) const
+{
+  delete p;
+}
+
 CPixelConverter::CPixelConverter() :
   m_targetFormat(AV_PIX_FMT_NONE),
   m_width(0),
@@ -237,9 +242,12 @@ bool CPixelConverter::Decode(const uint8_t* pData, unsigned int size)
 
 void CPixelConverter::GetPicture(VideoPicture& dvdVideoPicture)
 {
-  CPixelBufferFFmpeg *buffer = dynamic_cast<CPixelBufferFFmpeg*>(m_pixelBufferPool->Get());
-  buffer->SetRef(m_pFrame);
-  dvdVideoPicture.videoBuffer = buffer;
+  if (m_pFrame != nullptr)
+  {
+    CPixelBufferFFmpeg *buffer = dynamic_cast<CPixelBufferFFmpeg*>(m_pixelBufferPool->Get());
+    buffer->SetRef(m_pFrame);
+    dvdVideoPicture.videoBuffer = buffer;
+  }
 
   dvdVideoPicture.dts            = DVD_NOPTS_VALUE;
   dvdVideoPicture.pts            = DVD_NOPTS_VALUE;

--- a/xbmc/cores/RetroPlayer/PixelConverter.h
+++ b/xbmc/cores/RetroPlayer/PixelConverter.h
@@ -44,10 +44,15 @@ public:
 protected:
   bool AllocateBuffers(AVFrame *pFrame) const;
 
+  struct delete_buffer_pool
+  {
+    void operator()(CPixelBufferPoolFFmpeg *p) const;
+  };
+
   AVPixelFormat m_targetFormat;
   unsigned int m_width;
   unsigned int m_height;
   SwsContext* m_swsContext;
   AVFrame *m_pFrame;
-  std::unique_ptr<CPixelBufferPoolFFmpeg> m_pixelBufferPool;
+  std::unique_ptr<CPixelBufferPoolFFmpeg, delete_buffer_pool> m_pixelBufferPool;
 };

--- a/xbmc/cores/RetroPlayer/PixelConverterRBP.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverterRBP.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "PixelConverterRBP.h"
-#include "cores/VideoPlayer/DVDClock.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h"
 #include "linux/RBP.h"
 #include "utils/log.h"


### PR DESCRIPTION
RPi is still broken because it needs to be updated for the videobuffers update, but these changes should fix RetroPlayer for when RPi is working again