### PR TITLE
[settings] move to C++11

### DIFF
--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -432,28 +432,28 @@ ADDON_STATUS CAddonDll::TransferSettings()
             const char* id = setting->GetId().c_str();
             switch (setting->GetType())
             {
-              case SettingTypeBool:
+              case SettingType::Boolean:
               {
                 bool tmp = std::static_pointer_cast<CSettingBool>(setting)->GetValue();
                 status = m_pDll->SetSetting(id, &tmp);
                 break;
               }
 
-              case SettingTypeInteger:
+              case SettingType::Integer:
               {
                 int tmp = std::static_pointer_cast<CSettingInt>(setting)->GetValue();
                 status = m_pDll->SetSetting(id, &tmp);
                 break;
               }
 
-              case SettingTypeNumber:
+              case SettingType::Number:
               {
                 float tmpf = static_cast<float>(std::static_pointer_cast<CSettingNumber>(setting)->GetValue());
                 status = m_pDll->SetSetting(id, &tmpf);
                 break;
               }
 
-              case SettingTypeString:
+              case SettingType::String:
                 status = m_pDll->SetSetting(id, std::static_pointer_cast<CSettingString>(setting)->GetValue().c_str());
                 break;
 
@@ -669,19 +669,19 @@ bool CAddonDll::get_setting(void* kodiBase, const char* settingName, void* setti
 
   switch (setting->GetType())
   {
-    case SettingTypeBool:
+    case SettingType::Boolean:
       *static_cast<bool*>(settingValue) = std::static_pointer_cast<CSettingBool>(setting)->GetValue();
       return true;
 
-    case SettingTypeInteger:
+    case SettingType::Integer:
       *static_cast<int*>(settingValue) = std::static_pointer_cast<CSettingInt>(setting)->GetValue();
       return true;
 
-    case SettingTypeNumber:
+    case SettingType::Number:
       *static_cast<float*>(settingValue) = static_cast<float>(std::static_pointer_cast<CSettingNumber>(setting)->GetValue());
       return true;
 
-    case SettingTypeString:
+    case SettingType::String:
       *static_cast<char**>(settingValue) = strdup(std::static_pointer_cast<CSettingString>(setting)->GetValue().c_str());
       break;
 

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
@@ -220,19 +220,19 @@ bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSetti
 
     switch (setting->GetType())
     {
-      case SettingTypeBool:
+      case SettingType::Boolean:
         *static_cast<bool*>(settingValue) = std::static_pointer_cast<CSettingBool>(setting)->GetValue();
         return true;
 
-      case SettingTypeInteger:
+      case SettingType::Integer:
         *static_cast<int*>(settingValue) = std::static_pointer_cast<CSettingInt>(setting)->GetValue();
         return true;
 
-      case SettingTypeNumber:
+      case SettingType::Number:
         *static_cast<float*>(settingValue) = static_cast<float>(std::static_pointer_cast<CSettingNumber>(setting)->GetValue());
         return true;
 
-      case SettingTypeString:
+      case SettingType::String:
         strcpy((char*)settingValue, std::static_pointer_cast<CSettingString>(setting)->GetValue().c_str());
         return true;
 

--- a/xbmc/addons/settings/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.cpp
@@ -157,7 +157,7 @@ std::string CGUIDialogAddonSettings::GetSettingsLabel(std::shared_ptr<CSetting> 
 
 int CGUIDialogAddonSettings::GetSettingLevel() const
 {
-  return static_cast<int>(SettingLevelStandard);
+  return static_cast<int>(SettingLevel::Standard);
 }
 
 std::shared_ptr<CSettingSection> CGUIDialogAddonSettings::GetSection()

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -52,73 +52,73 @@
 #define CHECK_LABEL_YES           107
 
 static const CGUIDialogMediaFilter::Filter filterList[] = {
-  { "movies",       FieldTitle,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  { "movies",       FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "movies",       FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  //{ "movies",       FieldTime,          180,    SettingTypeInteger, "range",  "time",     CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "movies",       FieldInProgress,    575,    SettingTypeInteger, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
-  { "movies",       FieldYear,          562,    SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "movies",       FieldTag,           20459,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "movies",       FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "movies",       FieldActor,         20337,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "movies",       FieldDirector,      20339,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "movies",       FieldStudio,        572,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldTitle,         556,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "movies",       FieldRating,        563,    SettingType::Number,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "movies",       FieldUserRating,    38018,  SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  //{ "movies",       FieldTime,          180,    SettingType::Integer, "range",  "time",     CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "movies",       FieldInProgress,    575,    SettingType::Integer, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
+  { "movies",       FieldYear,          562,    SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "movies",       FieldTag,           20459,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldGenre,         515,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldActor,         20337,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldDirector,      20339,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "movies",       FieldStudio,        572,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "tvshows",      FieldTitle,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  //{ "tvshows",      FieldTvShowStatus,  126,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "tvshows",      FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "tvshows",      FieldInProgress,    575,    SettingTypeInteger, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
-  { "tvshows",      FieldYear,          562,    SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "tvshows",      FieldTag,           20459,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldActor,         20337,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldDirector,      20339,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "tvshows",      FieldStudio,        572,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldTitle,         556,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+  //{ "tvshows",      FieldTvShowStatus,  126,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldRating,        563,    SettingType::Number,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "tvshows",      FieldUserRating,    38018,  SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "tvshows",      FieldInProgress,    575,    SettingType::Integer, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
+  { "tvshows",      FieldYear,          562,    SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "tvshows",      FieldTag,           20459,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldGenre,         515,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldActor,         20337,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldDirector,      20339,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "tvshows",      FieldStudio,        572,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "episodes",     FieldTitle,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  { "episodes",     FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "episodes",     FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "episodes",     FieldAirDate,       20416,  SettingTypeInteger, "range",  "date",     CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "episodes",     FieldInProgress,    575,    SettingTypeInteger, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
-  { "episodes",     FieldActor,         20337,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "episodes",     FieldDirector,      20339,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "episodes",     FieldTitle,         556,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "episodes",     FieldRating,        563,    SettingType::Number,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "episodes",     FieldUserRating,    38018,  SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "episodes",     FieldAirDate,       20416,  SettingType::Integer, "range",  "date",     CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "episodes",     FieldInProgress,    575,    SettingType::Integer, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
+  { "episodes",     FieldActor,         20337,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "episodes",     FieldDirector,      20339,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "musicvideos",  FieldTitle,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  { "musicvideos",  FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "musicvideos",  FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "musicvideos",  FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldAlbum,         558,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  //{ "musicvideos",  FieldTime,          180,    SettingTypeInteger, "range",  "time",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "musicvideos",  FieldYear,          562,    SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "musicvideos",  FieldTag,           20459,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldDirector,      20339,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "musicvideos",  FieldStudio,        572,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldTitle,         556,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "musicvideos",  FieldRating,        563,    SettingType::Number,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "musicvideos",  FieldUserRating,    38018,  SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "musicvideos",  FieldArtist,        557,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldAlbum,         558,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  //{ "musicvideos",  FieldTime,          180,    SettingType::Integer, "range",  "time",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "musicvideos",  FieldYear,          562,    SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "musicvideos",  FieldTag,           20459,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldGenre,         515,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldDirector,      20339,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "musicvideos",  FieldStudio,        572,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "artists",      FieldArtist,        557,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  { "artists",      FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "artists",      FieldArtist,        557,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "artists",      FieldGenre,         515,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
 
-  { "albums",       FieldAlbum,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-//  { "albums",       FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "albums",       FieldAlbumArtist,   566,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "albums",       FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "albums",       FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "albums",       FieldAlbumType,     564,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "albums",       FieldYear,          562,    SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "albums",       FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "albums",       FieldMusicLabel,    21899,  SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "albums",       FieldCompilation,   204,    SettingTypeBool,    "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
+  { "albums",       FieldAlbum,         556,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+//  { "albums",       FieldArtist,        557,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldAlbumArtist,   566,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldRating,        563,    SettingType::Number,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "albums",       FieldUserRating,    38018,  SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "albums",       FieldAlbumType,     564,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldYear,          562,    SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "albums",       FieldGenre,         515,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldMusicLabel,    21899,  SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "albums",       FieldCompilation,   204,    SettingType::Boolean, "toggle", "",         CDatabaseQueryRule::OPERATOR_FALSE },
 
-  { "songs",        FieldTitle,         556,    SettingTypeString,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
-  { "songs",        FieldAlbum,         558,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "songs",        FieldArtist,        557,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "songs",        FieldTime,          180,    SettingTypeInteger, "range",  "time",     CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "songs",        FieldRating,        563,    SettingTypeNumber,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "songs",        FieldUserRating,    38018,  SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "songs",        FieldYear,          562,    SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
-  { "songs",        FieldGenre,         515,    SettingTypeList,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
-  { "songs",        FieldPlaycount,     567,    SettingTypeInteger, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldTitle,         556,    SettingType::String,  "edit",   "string",   CDatabaseQueryRule::OPERATOR_CONTAINS },
+  { "songs",        FieldAlbum,         558,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "songs",        FieldArtist,        557,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "songs",        FieldTime,          180,    SettingType::Integer, "range",  "time",     CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldRating,        563,    SettingType::Number,  "range",  "number",   CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldUserRating,    38018,  SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldYear,          562,    SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
+  { "songs",        FieldGenre,         515,    SettingType::List,    "list",   "string",   CDatabaseQueryRule::OPERATOR_EQUALS },
+  { "songs",        FieldPlaycount,     567,    SettingType::Integer, "range",  "integer",  CDatabaseQueryRule::OPERATOR_BETWEEN },
 };
 
 #define NUM_FILTERS sizeof(filterList) / sizeof(CGUIDialogMediaFilter::Filter)
@@ -272,7 +272,7 @@ void CGUIDialogMediaFilter::OnSettingChanged(std::shared_ptr<const CSetting> set
     std::string strValueLower, strValueUpper;
 
     SettingConstPtr definition = settingList->GetDefinition();
-    if (definition->GetType() == SettingTypeInteger)
+    if (definition->GetType() == SettingType::Integer)
     {
       const std::shared_ptr<const CSettingInt> definitionInt = std::static_pointer_cast<const CSettingInt>(definition);
       int valueLower = static_cast<int>(values.at(0).asInteger());
@@ -293,7 +293,7 @@ void CGUIDialogMediaFilter::OnSettingChanged(std::shared_ptr<const CSetting> set
         }
       }
     }
-    else if (definition->GetType() == SettingTypeNumber)
+    else if (definition->GetType() == SettingType::Number)
     {
       const std::shared_ptr<const CSettingNumber> definitionNumber = std::static_pointer_cast<const CSettingNumber>(definition);
       float valueLower = values.at(0).asFloat();
@@ -414,12 +414,12 @@ void CGUIDialogMediaFilter::InitializeSettings()
       if (filter.rule != NULL && filter.rule->m_parameter.size() == 1)
         data = filter.rule->m_parameter.at(0);
 
-      if (filter.settingType == SettingTypeString)
-        filter.setting = AddEdit(group, settingId, filter.label, 0, data.asString(), true, false, filter.label, true);
-      else if (filter.settingType == SettingTypeInteger)
-        filter.setting = AddEdit(group, settingId, filter.label, 0, static_cast<int>(data.asInteger()), 0, 1, 0, false,  static_cast<int>(filter.label), true);
-      else if (filter.settingType == SettingTypeNumber)
-        filter.setting = AddEdit(group, settingId, filter.label, 0, data.asFloat(), 0.0f, 1.0f, 0.0f, false, filter.label, true);
+      if (filter.settingType == SettingType::String)
+        filter.setting = AddEdit(group, settingId, filter.label, SettingLevel::Basic, data.asString(), true, false, filter.label, true);
+      else if (filter.settingType == SettingType::Integer)
+        filter.setting = AddEdit(group, settingId, filter.label, SettingLevel::Basic, static_cast<int>(data.asInteger()), 0, 1, 0, false,  static_cast<int>(filter.label), true);
+      else if (filter.settingType == SettingType::Number)
+        filter.setting = AddEdit(group, settingId, filter.label, SettingLevel::Basic, data.asFloat(), 0.0f, 1.0f, 0.0f, false, filter.label, true);
     }
     else if (filter.controlType == "toggle")
     {
@@ -432,7 +432,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
       entries.push_back(std::pair<int, int>(CHECK_LABEL_NO,  CHECK_NO));
       entries.push_back(std::pair<int, int>(CHECK_LABEL_YES, CHECK_YES));
 
-      filter.setting = AddSpinner(group, settingId, filter.label, 0, value, entries, true);
+      filter.setting = AddSpinner(group, settingId, filter.label, SettingLevel::Basic, value, entries, true);
     }
     else if (filter.controlType == "list")
     {
@@ -444,7 +444,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
           values.erase(values.begin());
       }
 
-      filter.setting = AddList(group, settingId, filter.label, 0, values, GetStringListOptions, filter.label);
+      filter.setting = AddList(group, settingId, filter.label, SettingLevel::Basic, values, GetStringListOptions, filter.label);
     }
     else if (filter.controlType == "range")
     {
@@ -463,7 +463,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
         }
       }
 
-      if (filter.settingType == SettingTypeInteger)
+      if (filter.settingType == SettingType::Integer)
       {
         int min, interval, max;
         GetRange(filter, min, interval, max);
@@ -476,15 +476,15 @@ void CGUIDialogMediaFilter::InitializeSettings()
         int iValueUpper = valueUpper.isNull() ? max : static_cast<int>(valueUpper.asInteger());
 
         if (filter.controlFormat == "integer")
-          filter.setting = AddRange(group, settingId, filter.label, 0, iValueLower, iValueUpper, min, interval, max, -1, 21469, true);
+          filter.setting = AddRange(group, settingId, filter.label, SettingLevel::Basic, iValueLower, iValueUpper, min, interval, max, -1, 21469, true);
         else if (filter.controlFormat == "percentage")
-          filter.setting = AddPercentageRange(group, settingId, filter.label, 0, iValueLower, iValueUpper, -1, 1, 21469, true);
+          filter.setting = AddPercentageRange(group, settingId, filter.label, SettingLevel::Basic, iValueLower, iValueUpper, -1, 1, 21469, true);
         else if (filter.controlFormat == "date")
-          filter.setting = AddDateRange(group, settingId, filter.label, 0, iValueLower, iValueUpper, min, interval, max, -1, 21469, true);
+          filter.setting = AddDateRange(group, settingId, filter.label, SettingLevel::Basic, iValueLower, iValueUpper, min, interval, max, -1, 21469, true);
         else if (filter.controlFormat == "time")
-          filter.setting = AddTimeRange(group, settingId, filter.label, 0, iValueLower, iValueUpper, min, interval, max, -1, 21469, true);
+          filter.setting = AddTimeRange(group, settingId, filter.label, SettingLevel::Basic, iValueLower, iValueUpper, min, interval, max, -1, 21469, true);
       }
-      else if (filter.settingType == SettingTypeNumber)
+      else if (filter.settingType == SettingType::Number)
       {
         float min, interval, max;
         GetRange(filter, min, interval, max);
@@ -496,7 +496,7 @@ void CGUIDialogMediaFilter::InitializeSettings()
         float fValueLower = valueLower.isNull() ? min : valueLower.asFloat();
         float fValueUpper = valueUpper.isNull() ? max : valueUpper.asFloat();
 
-        filter.setting = AddRange(group, settingId, filter.label, 0, fValueLower, fValueUpper, min, interval, max, -1, 21469, true);
+        filter.setting = AddRange(group, settingId, filter.label, SettingLevel::Basic, fValueLower, fValueUpper, min, interval, max, -1, 21469, true);
       }
     }
     else

--- a/xbmc/dialogs/GUIDialogMediaFilter.h
+++ b/xbmc/dialogs/GUIDialogMediaFilter.h
@@ -27,6 +27,7 @@
 #include "dbwrappers/Database.h"
 #include "dbwrappers/DatabaseQuery.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
+#include "settings/lib/SettingType.h"
 #include "utils/DatabaseUtils.h"
 
 class CDbUrl;
@@ -49,7 +50,7 @@ public:
     std::string mediaType;
     Field field;
     uint32_t label;
-    int settingType;
+    SettingType settingType;
     std::string controlType;
     std::string controlFormat;
     CDatabaseQueryRule::SEARCH_OPERATOR ruleOperator;

--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -215,30 +215,30 @@ JSONRPC_STATUS CSettingsOperations::GetSettingValue(const std::string &method, I
   CVariant value;
   switch (setting->GetType())
   {
-  case SettingTypeBool:
+  case SettingType::Boolean:
     value = std::static_pointer_cast<CSettingBool>(setting)->GetValue();
     break;
 
-  case SettingTypeInteger:
+  case SettingType::Integer:
     value = std::static_pointer_cast<CSettingInt>(setting)->GetValue();
     break;
 
-  case SettingTypeNumber:
+  case SettingType::Number:
     value = std::static_pointer_cast<CSettingNumber>(setting)->GetValue();
     break;
 
-  case SettingTypeString:
+  case SettingType::String:
     value = std::static_pointer_cast<CSettingString>(setting)->GetValue();
     break;
 
-  case SettingTypeList:
+  case SettingType::List:
   {
     SerializeSettingListValues(CServiceBroker::GetSettings().GetList(settingId), value);
     break;
   }
 
-  case SettingTypeNone:
-  case SettingTypeAction:
+  case SettingType::Unknown:
+  case SettingType::Action:
   default:
     return InvalidParams;
   }
@@ -260,35 +260,35 @@ JSONRPC_STATUS CSettingsOperations::SetSettingValue(const std::string &method, I
 
   switch (setting->GetType())
   {
-  case SettingTypeBool:
+  case SettingType::Boolean:
     if (!value.isBoolean())
       return InvalidParams;
 
     result = std::static_pointer_cast<CSettingBool>(setting)->SetValue(value.asBoolean());
     break;
 
-  case SettingTypeInteger:
+  case SettingType::Integer:
     if (!value.isInteger() && !value.isUnsignedInteger())
       return InvalidParams;
 
     result = std::static_pointer_cast<CSettingInt>(setting)->SetValue((int)value.asInteger());
     break;
 
-  case SettingTypeNumber:
+  case SettingType::Number:
     if (!value.isDouble())
       return InvalidParams;
 
     result = std::static_pointer_cast<CSettingNumber>(setting)->SetValue(value.asDouble());
     break;
 
-  case SettingTypeString:
+  case SettingType::String:
     if (!value.isString())
       return InvalidParams;
 
     result = std::static_pointer_cast<CSettingString>(setting)->SetValue(value.asString());
     break;
 
-  case SettingTypeList:
+  case SettingType::List:
   {
     if (!value.isArray())
       return InvalidParams;
@@ -301,8 +301,8 @@ JSONRPC_STATUS CSettingsOperations::SetSettingValue(const std::string &method, I
     break;
   }
 
-  case SettingTypeNone:
-  case SettingTypeAction:
+  case SettingType::Unknown:
+  case SettingType::Action:
   default:
     return InvalidParams;
   }
@@ -321,16 +321,16 @@ JSONRPC_STATUS CSettingsOperations::ResetSettingValue(const std::string &method,
 
   switch (setting->GetType())
   {
-  case SettingTypeBool:
-  case SettingTypeInteger:
-  case SettingTypeNumber:
-  case SettingTypeString:
-  case SettingTypeList:
+  case SettingType::Boolean:
+  case SettingType::Integer:
+  case SettingType::Number:
+  case SettingType::String:
+  case SettingType::List:
     setting->Reset();
     break;
 
-  case SettingTypeNone:
-  case SettingTypeAction:
+  case SettingType::Unknown:
+  case SettingType::Action:
   default:
     return InvalidParams;
   }
@@ -338,16 +338,16 @@ JSONRPC_STATUS CSettingsOperations::ResetSettingValue(const std::string &method,
   return ACK;
 }
 
-int CSettingsOperations::ParseSettingLevel(const std::string &strLevel)
+SettingLevel CSettingsOperations::ParseSettingLevel(const std::string &strLevel)
 {
   if (StringUtils::EqualsNoCase(strLevel, "basic"))
-    return SettingLevelBasic;
+    return SettingLevel::Basic;
   if (StringUtils::EqualsNoCase(strLevel, "advanced"))
-    return SettingLevelAdvanced;
+    return SettingLevel::Advanced;
   if (StringUtils::EqualsNoCase(strLevel, "expert"))
-    return SettingLevelExpert;
+    return SettingLevel::Expert;
 
-  return SettingLevelStandard;
+  return SettingLevel::Standard;
 }
 
 bool CSettingsOperations::SerializeISetting(std::shared_ptr<const ISetting> setting, CVariant &obj)
@@ -400,19 +400,19 @@ bool CSettingsOperations::SerializeSetting(std::shared_ptr<const CSetting> setti
 
   switch (setting->GetLevel())
   {
-    case SettingLevelBasic:
+    case SettingLevel::Basic:
       obj["level"] = "basic";
       break;
 
-    case SettingLevelStandard:
+    case SettingLevel::Standard:
       obj["level"] = "standard";
       break;
 
-    case SettingLevelAdvanced:
+    case SettingLevel::Advanced:
       obj["level"] = "advanced";
       break;
 
-    case SettingLevelExpert:
+    case SettingLevel::Expert:
       obj["level"] = "expert";
       break;
 
@@ -429,37 +429,37 @@ bool CSettingsOperations::SerializeSetting(std::shared_ptr<const CSetting> setti
 
   switch (setting->GetType())
   {
-    case SettingTypeBool:
+    case SettingType::Boolean:
       obj["type"] = "boolean";
       if (!SerializeSettingBool(std::static_pointer_cast<const CSettingBool>(setting), obj))
         return false;
       break;
 
-    case SettingTypeInteger:
+    case SettingType::Integer:
       obj["type"] = "integer";
       if (!SerializeSettingInt(std::static_pointer_cast<const CSettingInt>(setting), obj))
         return false;
       break;
 
-    case SettingTypeNumber:
+    case SettingType::Number:
       obj["type"] = "number";
       if (!SerializeSettingNumber(std::static_pointer_cast<const CSettingNumber>(setting), obj))
         return false;
       break;
 
-    case SettingTypeString:
+    case SettingType::String:
       obj["type"] = "string";
       if (!SerializeSettingString(std::static_pointer_cast<const CSettingString>(setting), obj))
         return false;
       break;
 
-    case SettingTypeAction:
+    case SettingType::Action:
       obj["type"] = "action";
       if (!SerializeSettingAction(std::static_pointer_cast<const CSettingAction>(setting), obj))
         return false;
       break;
 
-    case SettingTypeList:
+    case SettingType::List:
       obj["type"] = "list";
       if (!SerializeSettingList(std::static_pointer_cast<const CSettingList>(setting), obj))
         return false;
@@ -493,7 +493,7 @@ bool CSettingsOperations::SerializeSettingInt(std::shared_ptr<const CSettingInt>
 
   switch (setting->GetOptionsType())
   {
-    case SettingOptionsTypeStaticTranslatable:
+    case SettingOptionsType::StaticTranslatable:
     {
       obj["options"] = CVariant(CVariant::VariantTypeArray);
       const TranslatableIntegerSettingOptions& options = setting->GetTranslatableOptions();
@@ -507,7 +507,7 @@ bool CSettingsOperations::SerializeSettingInt(std::shared_ptr<const CSettingInt>
       break;
     }
 
-    case SettingOptionsTypeStatic:
+    case SettingOptionsType::Static:
     {
       obj["options"] = CVariant(CVariant::VariantTypeArray);
       const IntegerSettingOptions& options = setting->GetOptions();
@@ -521,7 +521,7 @@ bool CSettingsOperations::SerializeSettingInt(std::shared_ptr<const CSettingInt>
       break;
     }
 
-    case SettingOptionsTypeDynamic:
+    case SettingOptionsType::Dynamic:
     {
       obj["options"] = CVariant(CVariant::VariantTypeArray);
       IntegerSettingOptions options = std::const_pointer_cast<CSettingInt>(setting)->UpdateDynamicOptions();
@@ -535,7 +535,7 @@ bool CSettingsOperations::SerializeSettingInt(std::shared_ptr<const CSettingInt>
       break;
     }
 
-    case SettingOptionsTypeNone:
+    case SettingOptionsType::Unknown:
     default:
       obj["minimum"] = setting->GetMinimum();
       obj["step"] = setting->GetStep();
@@ -573,7 +573,7 @@ bool CSettingsOperations::SerializeSettingString(std::shared_ptr<const CSettingS
 
   switch (setting->GetOptionsType())
   {
-    case SettingOptionsTypeStaticTranslatable:
+    case SettingOptionsType::StaticTranslatable:
     {
       obj["options"] = CVariant(CVariant::VariantTypeArray);
       const TranslatableStringSettingOptions& options = setting->GetTranslatableOptions();
@@ -587,7 +587,7 @@ bool CSettingsOperations::SerializeSettingString(std::shared_ptr<const CSettingS
       break;
     }
 
-    case SettingOptionsTypeStatic:
+    case SettingOptionsType::Static:
     {
       obj["options"] = CVariant(CVariant::VariantTypeArray);
       const StringSettingOptions& options = setting->GetOptions();
@@ -601,7 +601,7 @@ bool CSettingsOperations::SerializeSettingString(std::shared_ptr<const CSettingS
       break;
     }
 
-    case SettingOptionsTypeDynamic:
+    case SettingOptionsType::Dynamic:
     {
       obj["options"] = CVariant(CVariant::VariantTypeArray);
       StringSettingOptions options = std::const_pointer_cast<CSettingString>(setting)->UpdateDynamicOptions();
@@ -615,7 +615,7 @@ bool CSettingsOperations::SerializeSettingString(std::shared_ptr<const CSettingS
       break;
     }
 
-    case SettingOptionsTypeNone:
+    case SettingOptionsType::Unknown:
     default:
       break;
   }

--- a/xbmc/interfaces/json-rpc/SettingsOperations.h
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "JSONRPC.h"
+#include "settings/lib/SettingLevel.h"
 
 class CVariant;
 class ISetting;
@@ -55,7 +56,7 @@ namespace JSONRPC
     static JSONRPC_STATUS ResetSettingValue(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
   private:
-    static int ParseSettingLevel(const std::string &strLevel);
+    static SettingLevel ParseSettingLevel(const std::string &strLevel);
 
     static bool SerializeISetting(std::shared_ptr<const ISetting> setting, CVariant &obj);
     static bool SerializeSettingSection(std::shared_ptr<const CSettingSection> setting, CVariant &obj);

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -209,16 +209,16 @@ void CGUIDialogNetworkSetup::InitializeSettings()
   labels.push_back(std::make_pair(20260, NET_PROTOCOL_SFTP));
 #endif
 
-  AddSpinner(group, SETTING_PROTOCOL, 1008, 0, m_protocol, labels);
-  AddEdit(group, SETTING_SERVER_ADDRESS, 1010, 0, m_server, true);
-  std::shared_ptr<CSettingAction> subsetting = AddButton(group, SETTING_SERVER_BROWSE, 1024, 0, "", false);
+  AddSpinner(group, SETTING_PROTOCOL, 1008, SettingLevel::Basic, m_protocol, labels);
+  AddEdit(group, SETTING_SERVER_ADDRESS, 1010, SettingLevel::Basic, m_server, true);
+  std::shared_ptr<CSettingAction> subsetting = AddButton(group, SETTING_SERVER_BROWSE, 1024, SettingLevel::Basic, "", false);
   if (subsetting != NULL)
     subsetting->SetParent(SETTING_SERVER_ADDRESS);
 
-  AddEdit(group, SETTING_REMOTE_PATH, 1012, 0, m_path, true);
-  AddEdit(group, SETTING_PORT_NUMBER, 1013, 0, m_port, true);
-  AddEdit(group, SETTING_USERNAME, 1014, 0, m_username, true);
-  AddEdit(group, SETTING_PASSWORD, 15052, 0, m_password, true, true);
+  AddEdit(group, SETTING_REMOTE_PATH, 1012, SettingLevel::Basic, m_path, true);
+  AddEdit(group, SETTING_PORT_NUMBER, 1013, SettingLevel::Basic, m_port, true);
+  AddEdit(group, SETTING_USERNAME, 1014, SettingLevel::Basic, m_username, true);
+  AddEdit(group, SETTING_PASSWORD, 15052, SettingLevel::Basic, m_password, true, true);
 }
 
 void CGUIDialogNetworkSetup::OnServerBrowse()

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -236,7 +236,7 @@ void CPeripheral::AddSetting(const std::string &strKey, SettingConstPtr setting,
     PeripheralDeviceSetting deviceSetting = { NULL, order };
     switch(setting->GetType())
     {
-    case SettingTypeBool:
+    case SettingType::Boolean:
       {
         std::shared_ptr<const CSettingBool> mappedSetting = std::static_pointer_cast<const CSettingBool>(setting);
         std::shared_ptr<CSettingBool> boolSetting = std::make_shared<CSettingBool>(strKey, *mappedSetting);
@@ -247,7 +247,7 @@ void CPeripheral::AddSetting(const std::string &strKey, SettingConstPtr setting,
         }
       }
       break;
-    case SettingTypeInteger:
+    case SettingType::Integer:
       {
         std::shared_ptr<const CSettingInt> mappedSetting = std::static_pointer_cast<const CSettingInt>(setting);
         std::shared_ptr<CSettingInt> intSetting = std::make_shared<CSettingInt>(strKey, *mappedSetting);
@@ -258,7 +258,7 @@ void CPeripheral::AddSetting(const std::string &strKey, SettingConstPtr setting,
         }
       }
       break;
-    case SettingTypeNumber:
+    case SettingType::Number:
       {
         std::shared_ptr<const CSettingNumber> mappedSetting = std::static_pointer_cast<const CSettingNumber>(setting);
         std::shared_ptr<CSettingNumber> floatSetting = std::make_shared<CSettingNumber>(strKey, *mappedSetting);
@@ -269,7 +269,7 @@ void CPeripheral::AddSetting(const std::string &strKey, SettingConstPtr setting,
         }
       }
       break;
-    case SettingTypeString:
+    case SettingType::String:
       {
         std::shared_ptr<const CSettingString> mappedSetting = std::static_pointer_cast<const CSettingString>(setting);
         std::shared_ptr<CSettingString> stringSetting = std::make_shared<CSettingString>(strKey, *mappedSetting);
@@ -322,7 +322,7 @@ bool CPeripheral::HasConfigurableSettings(void) const
 bool CPeripheral::GetSettingBool(const std::string &strKey) const
 {
   std::map<std::string, PeripheralDeviceSetting>::const_iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeBool)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::Boolean)
   {
     std::shared_ptr<CSettingBool> boolSetting = std::static_pointer_cast<CSettingBool>((*it).second.m_setting);
     if (boolSetting)
@@ -335,7 +335,7 @@ bool CPeripheral::GetSettingBool(const std::string &strKey) const
 int CPeripheral::GetSettingInt(const std::string &strKey) const
 {
   std::map<std::string, PeripheralDeviceSetting>::const_iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeInteger)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::Integer)
   {
     std::shared_ptr<CSettingInt> intSetting = std::static_pointer_cast<CSettingInt>((*it).second.m_setting);
     if (intSetting)
@@ -348,7 +348,7 @@ int CPeripheral::GetSettingInt(const std::string &strKey) const
 float CPeripheral::GetSettingFloat(const std::string &strKey) const
 {
   std::map<std::string, PeripheralDeviceSetting>::const_iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeNumber)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::Number)
   {
     std::shared_ptr<CSettingNumber> floatSetting = std::static_pointer_cast<CSettingNumber>((*it).second.m_setting);
     if (floatSetting)
@@ -361,7 +361,7 @@ float CPeripheral::GetSettingFloat(const std::string &strKey) const
 const std::string CPeripheral::GetSettingString(const std::string &strKey) const
 {
   std::map<std::string, PeripheralDeviceSetting>::const_iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeString)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::String)
   {
     std::shared_ptr<CSettingString> stringSetting = std::static_pointer_cast<CSettingString>((*it).second.m_setting);
     if (stringSetting)
@@ -375,7 +375,7 @@ bool CPeripheral::SetSetting(const std::string &strKey, bool bValue)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeBool)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::Boolean)
   {
     std::shared_ptr<CSettingBool> boolSetting = std::static_pointer_cast<CSettingBool>((*it).second.m_setting);
     if (boolSetting)
@@ -393,7 +393,7 @@ bool CPeripheral::SetSetting(const std::string &strKey, int iValue)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeInteger)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::Integer)
   {
     std::shared_ptr<CSettingInt> intSetting = std::static_pointer_cast<CSettingInt>((*it).second.m_setting);
     if (intSetting)
@@ -411,7 +411,7 @@ bool CPeripheral::SetSetting(const std::string &strKey, float fValue)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
-  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingTypeNumber)
+  if (it != m_settings.end() && (*it).second.m_setting->GetType() == SettingType::Number)
   {
     std::shared_ptr<CSettingNumber> floatSetting = std::static_pointer_cast<CSettingNumber>((*it).second.m_setting);
     if (floatSetting)
@@ -446,7 +446,7 @@ bool CPeripheral::SetSetting(const std::string &strKey, const std::string &strVa
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
   if (it != m_settings.end())
   {
-    if ((*it).second.m_setting->GetType() == SettingTypeString)
+    if ((*it).second.m_setting->GetType() == SettingType::String)
     {
       std::shared_ptr<CSettingString> stringSetting = std::static_pointer_cast<CSettingString>((*it).second.m_setting);
       if (stringSetting)
@@ -457,11 +457,11 @@ bool CPeripheral::SetSetting(const std::string &strKey, const std::string &strVa
           m_changedSettings.insert(strKey);
       }
     }
-    else if ((*it).second.m_setting->GetType() == SettingTypeInteger)
+    else if ((*it).second.m_setting->GetType() == SettingType::Integer)
       bChanged = SetSetting(strKey, (int) (strValue.empty() ? 0 : atoi(strValue.c_str())));
-    else if ((*it).second.m_setting->GetType() == SettingTypeNumber)
+    else if ((*it).second.m_setting->GetType() == SettingType::Number)
       bChanged = SetSetting(strKey, (float) (strValue.empty() ? 0 : atof(strValue.c_str())));
-    else if ((*it).second.m_setting->GetType() == SettingTypeBool)
+    else if ((*it).second.m_setting->GetType() == SettingType::Boolean)
       bChanged = SetSetting(strKey, strValue == "1");
   }
   return bChanged;
@@ -479,28 +479,28 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
     std::string strValue;
     switch ((*itr).second.m_setting->GetType())
     {
-    case SettingTypeString:
+    case SettingType::String:
       {
         std::shared_ptr<CSettingString> stringSetting = std::static_pointer_cast<CSettingString>((*itr).second.m_setting);
         if (stringSetting)
           strValue = stringSetting->GetValue();
       }
       break;
-    case SettingTypeInteger:
+    case SettingType::Integer:
       {
         std::shared_ptr<CSettingInt> intSetting = std::static_pointer_cast<CSettingInt>((*itr).second.m_setting);
         if (intSetting)
           strValue = StringUtils::Format("%d", intSetting->GetValue());
       }
       break;
-    case SettingTypeNumber:
+    case SettingType::Number:
       {
         std::shared_ptr<CSettingNumber> floatSetting = std::static_pointer_cast<CSettingNumber>((*itr).second.m_setting);
         if (floatSetting)
           strValue = StringUtils::Format("%.2f", floatSetting->GetValue());
       }
       break;
-    case SettingTypeBool:
+    case SettingType::Boolean:
       {
         std::shared_ptr<CSettingBool> boolSetting = std::static_pointer_cast<CSettingBool>((*itr).second.m_setting);
         if (boolSetting)

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -182,7 +182,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
     SettingPtr settingCopy;
     switch(setting->GetType())
     {
-      case SettingTypeBool:
+      case SettingType::Boolean:
       {
         std::shared_ptr<CSettingBool> settingBool = std::make_shared<CSettingBool>(setting->GetId(), *std::static_pointer_cast<CSettingBool>(setting));
         settingBool->SetControl(GetCheckmarkControl());
@@ -191,7 +191,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
         break;
       }
 
-      case SettingTypeInteger:
+      case SettingType::Integer:
       {
         std::shared_ptr<CSettingInt> settingInt = std::make_shared<CSettingInt>(setting->GetId(), *std::static_pointer_cast<CSettingInt>(setting));
         if (settingInt->GetTranslatableOptions().empty())
@@ -203,7 +203,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
         break;
       }
 
-      case SettingTypeNumber:
+      case SettingType::Number:
       {
         std::shared_ptr<CSettingNumber> settingNumber = std::make_shared<CSettingNumber>(setting->GetId(), *std::static_pointer_cast<CSettingNumber>(setting));
         settingNumber->SetControl(GetSliderControl("number", false, -1, usePopup, -1, "%2.2f"));
@@ -212,7 +212,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
         break;
       }
 
-      case SettingTypeString:
+      case SettingType::String:
       {
         std::shared_ptr<CSettingString> settingString = std::make_shared<CSettingString>(setting->GetId(), *std::static_pointer_cast<CSettingString>(setting));
         settingString->SetControl(GetEditControl("string"));
@@ -229,7 +229,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
 
     if (settingCopy != NULL && settingCopy->GetControl() != NULL)
     {
-      settingCopy->SetLevel(SettingLevelBasic);
+      settingCopy->SetLevel(SettingLevel::Basic);
       group->AddSetting(settingCopy);
       m_settingsMap.insert(std::make_pair(setting->GetId(), setting));
     }

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -254,15 +254,15 @@ void CGUIDialogLockSettings::InitializeSettings()
 
   if (m_getUser)
   {
-    AddEdit(group, SETTING_USERNAME, 20142, 0, m_user);
-    AddEdit(group, SETTING_PASSWORD, 12326, 0, m_locks.code, false, true);
+    AddEdit(group, SETTING_USERNAME, 20142, SettingLevel::Basic, m_user);
+    AddEdit(group, SETTING_PASSWORD, 12326, SettingLevel::Basic, m_locks.code, false, true);
     if (m_saveUserDetails != NULL)
-      AddToggle(group, SETTING_PASSWORD_REMEMBER, 13423, 0, *m_saveUserDetails);
+      AddToggle(group, SETTING_PASSWORD_REMEMBER, 13423, SettingLevel::Basic, *m_saveUserDetails);
 
     return;
   }
 
-  AddButton(group, SETTING_LOCKCODE, m_buttonLabel, 0);
+  AddButton(group, SETTING_LOCKCODE, m_buttonLabel, SettingLevel::Basic);
 
   if (m_details)
   {
@@ -273,11 +273,11 @@ void CGUIDialogLockSettings::InitializeSettings()
       return;
     }
 
-    AddToggle(groupDetails, SETTING_LOCK_MUSIC, 20038, 0, m_locks.music);
-    AddToggle(groupDetails, SETTING_LOCK_VIDEOS, 20039, 0, m_locks.video);
-    AddToggle(groupDetails, SETTING_LOCK_PICTURES, 20040, 0, m_locks.pictures);
-    AddToggle(groupDetails, SETTING_LOCK_PROGRAMS, 20041, 0, m_locks.programs);
-    AddToggle(groupDetails, SETTING_LOCK_FILEMANAGER, 20042, 0, m_locks.files);
+    AddToggle(groupDetails, SETTING_LOCK_MUSIC, 20038, SettingLevel::Basic, m_locks.music);
+    AddToggle(groupDetails, SETTING_LOCK_VIDEOS, 20039, SettingLevel::Basic, m_locks.video);
+    AddToggle(groupDetails, SETTING_LOCK_PICTURES, 20040, SettingLevel::Basic, m_locks.pictures);
+    AddToggle(groupDetails, SETTING_LOCK_PROGRAMS, 20041, SettingLevel::Basic, m_locks.programs);
+    AddToggle(groupDetails, SETTING_LOCK_FILEMANAGER, 20042, SettingLevel::Basic, m_locks.files);
 
     TranslatableIntegerSettingOptions settingsLevelOptions;
     settingsLevelOptions.push_back(std::make_pair(106,    LOCK_LEVEL::NONE));
@@ -285,9 +285,9 @@ void CGUIDialogLockSettings::InitializeSettings()
     settingsLevelOptions.push_back(std::make_pair(10037,  LOCK_LEVEL::STANDARD));
     settingsLevelOptions.push_back(std::make_pair(10038,  LOCK_LEVEL::ADVANCED));
     settingsLevelOptions.push_back(std::make_pair(10039,  LOCK_LEVEL::EXPERT));
-    AddSpinner(groupDetails, SETTING_LOCK_SETTINGS, 20043, 0, static_cast<int>(m_locks.settings), settingsLevelOptions);
+    AddSpinner(groupDetails, SETTING_LOCK_SETTINGS, 20043, SettingLevel::Basic, static_cast<int>(m_locks.settings), settingsLevelOptions);
     
-    AddToggle(groupDetails, SETTING_LOCK_ADDONMANAGER, 24090, 0, m_locks.addonManager);
+    AddToggle(groupDetails, SETTING_LOCK_ADDONMANAGER, 24090, SettingLevel::Basic, m_locks.addonManager);
   }
 
   m_changed = false;

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -331,15 +331,15 @@ void CGUIDialogProfileSettings::InitializeSettings()
     return;
   }
 
-  AddEdit(group, SETTING_PROFILE_NAME, 20093, 0, m_name);
-  AddButton(group, SETTING_PROFILE_IMAGE, 20065, 0);
+  AddEdit(group, SETTING_PROFILE_NAME, 20093, SettingLevel::Basic, m_name);
+  AddButton(group, SETTING_PROFILE_IMAGE, 20065, SettingLevel::Basic);
 
   if (!m_isDefault && m_showDetails)
-    AddButton(group, SETTING_PROFILE_DIRECTORY, 20070, 0);
+    AddButton(group, SETTING_PROFILE_DIRECTORY, 20070, SettingLevel::Basic);
 
   if (m_showDetails ||
      (m_locks.mode == LOCK_MODE_EVERYONE && CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE))
-    AddButton(group, SETTING_PROFILE_LOCKS, 20066, 0);
+    AddButton(group, SETTING_PROFILE_LOCKS, 20066, SettingLevel::Basic);
 
   if (!m_isDefault && m_showDetails)
   {
@@ -357,8 +357,8 @@ void CGUIDialogProfileSettings::InitializeSettings()
     if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
       entries.push_back(std::make_pair(20107, 3));
 
-    AddSpinner(groupMedia, SETTING_PROFILE_MEDIA, 20060, 0, m_dbMode, entries);
-    AddSpinner(groupMedia, SETTING_PROFILE_MEDIA_SOURCES, 20094, 0, m_sourcesMode, entries);
+    AddSpinner(groupMedia, SETTING_PROFILE_MEDIA, 20060, SettingLevel::Basic, m_dbMode, entries);
+    AddSpinner(groupMedia, SETTING_PROFILE_MEDIA_SOURCES, 20094, SettingLevel::Basic, m_sourcesMode, entries);
   }
 }
 

--- a/xbmc/pvr/PVRSettings.cpp
+++ b/xbmc/pvr/PVRSettings.cpp
@@ -69,7 +69,7 @@ bool CPVRSettings::GetBoolValue(const std::string &settingName) const
 {
   CSingleLock lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
-  if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingTypeBool)
+  if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::Boolean)
   {
     std::shared_ptr<const CSettingBool> setting = std::dynamic_pointer_cast<const CSettingBool>((*settingIt).second);
     if (setting)
@@ -84,7 +84,7 @@ int CPVRSettings::GetIntValue(const std::string &settingName) const
 {
   CSingleLock lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
-  if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingTypeInteger)
+  if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::Integer)
   {
     std::shared_ptr<const CSettingInt> setting = std::dynamic_pointer_cast<const CSettingInt>((*settingIt).second);
     if (setting)
@@ -99,7 +99,7 @@ std::string CPVRSettings::GetStringValue(const std::string &settingName) const
 {
   CSingleLock lock(m_critSection);
   auto settingIt = m_settings.find(settingName);
-  if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingTypeString)
+  if (settingIt != m_settings.end() && (*settingIt).second->GetType() == SettingType::String)
   {
     std::shared_ptr<const CSettingString> setting = std::dynamic_pointer_cast<const CSettingString>((*settingIt).second);
     if (setting)

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -247,30 +247,30 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   std::shared_ptr<CSetting> setting = NULL;
 
   // Timer type
-  setting = AddList(group, SETTING_TMR_TYPE, 803, 0, 0, TypesFiller, 803);
+  setting = AddList(group, SETTING_TMR_TYPE, 803, SettingLevel::Basic, 0, TypesFiller, 803);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_TYPE);
 
   // Timer enabled/disabled
-  setting = AddToggle(group, SETTING_TMR_ACTIVE, 305, 0, m_bTimerActive);
+  setting = AddToggle(group, SETTING_TMR_ACTIVE, 305, SettingLevel::Basic, m_bTimerActive);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_ACTIVE);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_ACTIVE);
 
   // Name
-  setting = AddEdit(group, SETTING_TMR_NAME, 19075, 0, m_strTitle, true, false, 19097);
+  setting = AddEdit(group, SETTING_TMR_NAME, 19075, SettingLevel::Basic, m_strTitle, true, false, 19097);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_NAME);
 
   // epg search string (only for epg-based timer rules)
-  setting = AddEdit(group, SETTING_TMR_EPGSEARCH, 804, 0, m_strEpgSearchString, true, false, 805);
+  setting = AddEdit(group, SETTING_TMR_EPGSEARCH, 804, SettingLevel::Basic, m_strEpgSearchString, true, false, 805);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_EPGSEARCH);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_EPGSEARCH);
 
   // epg fulltext search (only for epg-based timer rules)
-  setting = AddToggle(group, SETTING_TMR_FULLTEXT, 806, 0, m_bFullTextEpgSearch);
+  setting = AddToggle(group, SETTING_TMR_FULLTEXT, 806, SettingLevel::Basic, m_bFullTextEpgSearch);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_FULLTEXT);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_FULLTEXT);
 
   // Channel
-  setting = AddList(group, SETTING_TMR_CHANNEL, 19078, 0, 0, ChannelsFiller, 19078);
+  setting = AddList(group, SETTING_TMR_CHANNEL, 19078, SettingLevel::Basic, 0, ChannelsFiller, 19078);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_CHANNEL);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_CHANNEL);
 
@@ -291,85 +291,85 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   if (m_iWeekdays & PVR_WEEKDAY_SUNDAY)
     weekdaysPreselect.push_back(PVR_WEEKDAY_SUNDAY);
 
-  setting = AddList(group, SETTING_TMR_WEEKDAYS, 19079, 0, weekdaysPreselect, WeekdaysFiller, 19079, 1, -1, true, -1, WeekdaysValueFormatter);
+  setting = AddList(group, SETTING_TMR_WEEKDAYS, 19079, SettingLevel::Basic, weekdaysPreselect, WeekdaysFiller, 19079, 1, -1, true, -1, WeekdaysValueFormatter);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_WEEKDAYS);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_WEEKDAYS);
 
   // "Start any time" (only for timer rules)
-  setting = AddToggle(group, SETTING_TMR_START_ANYTIME, 810, 0, m_bStartAnyTime);
+  setting = AddToggle(group, SETTING_TMR_START_ANYTIME, 810, SettingLevel::Basic, m_bStartAnyTime);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_START_ANYTIME);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_START_ANYTIME);
 
   // Start day (day + month + year only, no hours, minutes)
-  setting = AddSpinner(group, SETTING_TMR_START_DAY, 19128, 0, GetDateAsIndex(m_startLocalTime), DaysFiller);
+  setting = AddSpinner(group, SETTING_TMR_START_DAY, 19128, SettingLevel::Basic, GetDateAsIndex(m_startLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_START_DAY);
   AddStartAnytimeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
 
   // Start time (hours + minutes only, no day, month, year)
-  setting = AddButton(group, SETTING_TMR_BEGIN, 19126, 0);
+  setting = AddButton(group, SETTING_TMR_BEGIN, 19126, SettingLevel::Basic);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_BEGIN);
   AddStartAnytimeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN);
 
   // "End any time" (only for timer rules)
-  setting = AddToggle(group, SETTING_TMR_END_ANYTIME, 817, 0, m_bEndAnyTime);
+  setting = AddToggle(group, SETTING_TMR_END_ANYTIME, 817, SettingLevel::Basic, m_bEndAnyTime);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_ANYTIME);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_ANYTIME);
 
   // End day (day + month + year only, no hours, minutes)
-  setting = AddSpinner(group, SETTING_TMR_END_DAY, 19129, 0, GetDateAsIndex(m_endLocalTime), DaysFiller);
+  setting = AddSpinner(group, SETTING_TMR_END_DAY, 19129, SettingLevel::Basic, GetDateAsIndex(m_endLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_DAY);
   AddEndAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
 
   // End time (hours + minutes only, no day, month, year)
-  setting = AddButton(group, SETTING_TMR_END, 19127, 0);
+  setting = AddButton(group, SETTING_TMR_END, 19127, SettingLevel::Basic);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END);
   AddEndAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END);
 
   // First day (only for timer rules)
-  setting = AddSpinner(group, SETTING_TMR_FIRST_DAY, 19084, 0, GetDateAsIndex(m_firstDayLocalTime), DaysFiller);
+  setting = AddSpinner(group, SETTING_TMR_FIRST_DAY, 19084, SettingLevel::Basic, GetDateAsIndex(m_firstDayLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_FIRST_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_FIRST_DAY);
 
   // "Prevent duplicate episodes" (only for timer rules)
-  setting = AddList(group, SETTING_TMR_NEW_EPISODES, 812, 0, m_iPreventDupEpisodes, DupEpisodesFiller, 812);
+  setting = AddList(group, SETTING_TMR_NEW_EPISODES, 812, SettingLevel::Basic, m_iPreventDupEpisodes, DupEpisodesFiller, 812);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_NEW_EPISODES);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_NEW_EPISODES);
 
   // Pre and post record time
-  setting = AddList(group, SETTING_TMR_BEGIN_PRE, 813, 0, m_iMarginStart, MarginTimeFiller, 813);
+  setting = AddList(group, SETTING_TMR_BEGIN_PRE, 813, SettingLevel::Basic, m_iMarginStart, MarginTimeFiller, 813);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN_PRE);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_BEGIN_PRE);
 
-  setting = AddList(group, SETTING_TMR_END_POST,  814, 0, m_iMarginEnd, MarginTimeFiller, 814);
+  setting = AddList(group, SETTING_TMR_END_POST,  814, SettingLevel::Basic, m_iMarginEnd, MarginTimeFiller, 814);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_POST);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_POST);
 
   // Priority
-  setting = AddList(group, SETTING_TMR_PRIORITY, 19082, 0, m_iPriority, PrioritiesFiller, 19082);
+  setting = AddList(group, SETTING_TMR_PRIORITY, 19082, SettingLevel::Basic, m_iPriority, PrioritiesFiller, 19082);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_PRIORITY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_PRIORITY);
 
   // Lifetime
-  setting = AddList(group, SETTING_TMR_LIFETIME, 19083, 0, m_iLifetime, LifetimesFiller, 19083);
+  setting = AddList(group, SETTING_TMR_LIFETIME, 19083, SettingLevel::Basic, m_iLifetime, LifetimesFiller, 19083);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_LIFETIME);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_LIFETIME);
 
   // MaxRecordings
-  setting = AddList(group, SETTING_TMR_MAX_REC, 818, 0, m_iMaxRecordings, MaxRecordingsFiller, 818);
+  setting = AddList(group, SETTING_TMR_MAX_REC, 818, SettingLevel::Basic, m_iMaxRecordings, MaxRecordingsFiller, 818);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_MAX_REC);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_MAX_REC);
 
   // Recording folder
-  setting = AddEdit(group, SETTING_TMR_DIR, 19076, 0, m_strDirectory, true, false, 19104);
+  setting = AddEdit(group, SETTING_TMR_DIR, 19076, SettingLevel::Basic, m_strDirectory, true, false, 19104);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_DIR);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_DIR);
 
   // Recording group
-  setting = AddList(group, SETTING_TMR_REC_GROUP, 811, 0, m_iRecordingGroup, RecordingGroupFiller, 811);
+  setting = AddList(group, SETTING_TMR_REC_GROUP, 811, SettingLevel::Basic, m_iRecordingGroup, RecordingGroupFiller, 811);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_REC_GROUP);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_REC_GROUP);
 }
@@ -377,7 +377,7 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
 int CGUIDialogPVRTimerSettings::GetWeekdaysFromSetting(SettingConstPtr setting)
 {
   std::shared_ptr<const CSettingList> settingList = std::static_pointer_cast<const CSettingList>(setting);
-  if (settingList->GetElementType() != SettingTypeInteger)
+  if (settingList->GetElementType() != SettingType::Integer)
   {
     CLog::Log(LOGERROR, "CGUIDialogPVRTimerSettings::GetWeekdaysFromSetting - wrong weekdays element type");
     return 0;
@@ -1100,7 +1100,7 @@ void CGUIDialogPVRTimerSettings::AddTypeDependentEnableCondition(std::shared_ptr
   // Enable setting depending on read-only attribute of the selected timer type
   std::string id(identifier);
   id.append(TYPE_DEP_ENABLE_COND_ID_POSTFIX);
-  AddCondition(setting, id, TypeReadOnlyCondition, SettingDependencyTypeEnable, SETTING_TMR_TYPE);
+  AddCondition(setting, id, TypeReadOnlyCondition, SettingDependencyType::Enable, SETTING_TMR_TYPE);
 }
 
 bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
@@ -1163,7 +1163,7 @@ void CGUIDialogPVRTimerSettings::AddTypeDependentVisibilityCondition(std::shared
   // Show or hide setting depending on attributes of the selected timer type
   std::string id(identifier);
   id.append(TYPE_DEP_VISIBI_COND_ID_POSTFIX);
-  AddCondition(setting, id, TypeSupportsCondition, SettingDependencyTypeVisible, SETTING_TMR_TYPE);
+  AddCondition(setting, id, TypeSupportsCondition, SettingDependencyType::Visible, SETTING_TMR_TYPE);
 }
 
 bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
@@ -1242,7 +1242,7 @@ void CGUIDialogPVRTimerSettings::AddStartAnytimeDependentVisibilityCondition(std
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
   id.append(START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX);
-  AddCondition(setting, id, StartAnytimeSetCondition, SettingDependencyTypeVisible, SETTING_TMR_START_ANYTIME);
+  AddCondition(setting, id, StartAnytimeSetCondition, SettingDependencyType::Visible, SETTING_TMR_START_ANYTIME);
 }
 
 bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
@@ -1285,7 +1285,7 @@ void CGUIDialogPVRTimerSettings::AddEndAnytimeDependentVisibilityCondition(std::
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
   id.append(END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX);
-  AddCondition(setting, id, EndAnytimeSetCondition, SettingDependencyTypeVisible, SETTING_TMR_END_ANYTIME);
+  AddCondition(setting, id, EndAnytimeSetCondition, SettingDependencyType::Visible, SETTING_TMR_END_ANYTIME);
 }
 
 bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -25,14 +25,12 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 
-CSettingAddon::CSettingAddon(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : CSettingString(id, settingsManager),
-    m_addonType(ADDON::ADDON_UNKNOWN)
+CSettingAddon::CSettingAddon(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
+  : CSettingString(id, settingsManager)
 { }
 
-CSettingAddon::CSettingAddon(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = NULL */)
-  : CSettingString(id, label, value, settingsManager),
-    m_addonType(ADDON::ADDON_UNKNOWN)
+CSettingAddon::CSettingAddon(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = nullptr */)
+  : CSettingString(id, label, value, settingsManager)
 { }
   
 CSettingAddon::CSettingAddon(const std::string &id, const CSettingAddon &setting)
@@ -53,7 +51,7 @@ bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */
   if (!CSettingString::Deserialize(node, update))
     return false;
     
-  if (m_control != NULL &&
+  if (m_control != nullptr &&
      (m_control->GetType() != "button" || m_control->GetFormat() != "addon"))
   {
     CLog::Log(LOGERROR, "CSettingAddon: invalid <control> of \"%s\"", m_id.c_str());
@@ -62,8 +60,8 @@ bool CSettingAddon::Deserialize(const TiXmlNode *node, bool update /* = false */
     
   bool ok = false;
   std::string strAddonType;
-  const TiXmlNode *constraints = node->FirstChild("constraints");
-  if (constraints != NULL)
+  auto constraints = node->FirstChild("constraints");
+  if (constraints != nullptr)
   {
     // get the addon type
     if (XMLUtils::GetString(constraints, "addontype", strAddonType) && !strAddonType.empty())

--- a/xbmc/settings/SettingAddon.h
+++ b/xbmc/settings/SettingAddon.h
@@ -25,10 +25,10 @@
 class CSettingAddon : public CSettingString
 {
 public:
-  CSettingAddon(const std::string &id, CSettingsManager *settingsManager = NULL);
-  CSettingAddon(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = NULL);
+  CSettingAddon(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  CSettingAddon(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = nullptr);
   CSettingAddon(const std::string &id, const CSettingAddon &setting);
-  virtual ~CSettingAddon() { }
+  virtual ~CSettingAddon() = default;
 
   virtual SettingPtr Clone(const std::string &id) const override;
 
@@ -40,5 +40,5 @@ public:
 private:
   void copyaddontype(const CSettingAddon &setting);
 
-  ADDON::TYPE m_addonType;
+  ADDON::TYPE m_addonType = ADDON::ADDON_UNKNOWN;
 };

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -27,9 +27,9 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 
-#define SHOW_ADDONS_ALL               "all"
-#define SHOW_ADDONS_INSTALLED         "installed"
-#define SHOW_ADDONS_INSTALLABLE       "installable"
+const char* SHOW_ADDONS_ALL = "all";
+const char* SHOW_ADDONS_INSTALLED = "installed";
+const char* SHOW_ADDONS_INSTALLABLE = "installable";
 
 std::shared_ptr<ISettingControl> CSettingControlCreator::CreateControl(const std::string &controlType) const
 {
@@ -50,7 +50,7 @@ std::shared_ptr<ISettingControl> CSettingControlCreator::CreateControl(const std
   else if (StringUtils::EqualsNoCase(controlType, "title"))
     return std::make_shared<CSettingControlTitle>();
 
-  return NULL;
+  return nullptr;
 }
 
 bool CSettingControlCheckmark::SetFormat(const std::string &format)
@@ -68,17 +68,17 @@ bool CSettingControlFormattedRange::Deserialize(const TiXmlNode *node, bool upda
     XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_FORMATLABEL, m_formatLabel);
 
     // get the minimum label from <setting><constraints><minimum label="X" />
-    const TiXmlNode *settingNode = node->Parent();
-    if (settingNode != NULL)
+    auto settingNode = node->Parent();
+    if (settingNode != nullptr)
     {
-      const TiXmlNode *constraintsNode = settingNode->FirstChild(SETTING_XML_ELM_CONSTRAINTS);
-      if (constraintsNode != NULL)
+      auto constraintsNode = settingNode->FirstChild(SETTING_XML_ELM_CONSTRAINTS);
+      if (constraintsNode != nullptr)
       {
-        const TiXmlNode *minimumNode = constraintsNode->FirstChild(SETTING_XML_ELM_MINIMUM);
-        if (minimumNode != NULL)
+        auto minimumNode = constraintsNode->FirstChild(SETTING_XML_ELM_MINIMUM);
+        if (minimumNode != nullptr)
         {
-          const TiXmlElement *minimumElem = minimumNode->ToElement();
-          if (minimumElem != NULL)
+          auto minimumElem = minimumNode->ToElement();
+          if (minimumElem != nullptr)
           {
             if (minimumElem->QueryIntAttribute(SETTING_XML_ATTR_LABEL, &m_minimumLabel) != TIXML_SUCCESS)
               m_minimumLabel = -1;
@@ -170,11 +170,11 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
       else
         CLog::Log(LOGWARNING, "CSettingControlButton: invalid <show>");
 
-      const TiXmlElement *show = node->FirstChildElement("show");
-      if (show != NULL)
+      auto show = node->FirstChildElement("show");
+      if (show != nullptr)
       {
-        const char *strShowDetails = NULL;
-        if ((strShowDetails = show->Attribute(SETTING_XML_ATTR_SHOW_DETAILS)) != NULL)
+        const char *strShowDetails = nullptr;
+        if ((strShowDetails = show->Attribute(SETTING_XML_ATTR_SHOW_DETAILS)) != nullptr)
         {
           if (StringUtils::EqualsNoCase(strShowDetails, "false") || StringUtils::EqualsNoCase(strShowDetails, "true"))
             m_showAddonDetails = StringUtils::EqualsNoCase(strShowDetails, "true");
@@ -184,8 +184,8 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
 
         if (!m_showInstallableAddons)
         {
-          const char *strShowMore = NULL;
-          if ((strShowMore = show->Attribute(SETTING_XML_ATTR_SHOW_MORE)) != NULL)
+          const char *strShowMore = nullptr;
+          if ((strShowMore = show->Attribute(SETTING_XML_ATTR_SHOW_MORE)) != nullptr)
           {
             if (StringUtils::EqualsNoCase(strShowMore, "false") || StringUtils::EqualsNoCase(strShowMore, "true"))
               m_showMoreAddons = StringUtils::EqualsNoCase(strShowMore, "true");
@@ -283,18 +283,18 @@ bool CSettingControlRange::Deserialize(const TiXmlNode *node, bool update /* = f
   if (!ISettingControl::Deserialize(node, update))
     return false;
 
-  const TiXmlElement *formatLabel = node->FirstChildElement(SETTING_XML_ELM_CONTROL_FORMATLABEL);
-  if (formatLabel != NULL)
+  auto formatLabel = node->FirstChildElement(SETTING_XML_ELM_CONTROL_FORMATLABEL);
+  if (formatLabel != nullptr)
   {
     XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_FORMATLABEL, m_formatLabel);
     if (m_formatLabel < 0)
       return false;
 
-    const char *formatValue = formatLabel->Attribute(SETTING_XML_ELM_CONTROL_FORMATVALUE);
-    if (formatValue != NULL)
+    auto formatValue = formatLabel->Attribute(SETTING_XML_ELM_CONTROL_FORMATVALUE);
+    if (formatValue != nullptr)
     {
       if (StringUtils::IsInteger(formatValue))
-        m_valueFormatLabel = (int)strtol(formatValue, NULL, 0);
+        m_valueFormatLabel = (int)strtol(formatValue, nullptr, 0);
       else
       {
         m_valueFormat = formatValue;

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -22,29 +22,30 @@
 #include "settings/lib/ISettingControl.h"
 #include "settings/lib/ISettingControlCreator.h"
 
-#define SETTING_XML_ELM_CONTROL_FORMATLABEL  "formatlabel"
-#define SETTING_XML_ELM_CONTROL_HIDDEN       "hidden"
-#define SETTING_XML_ELM_CONTROL_VERIFYNEW    "verifynew"
-#define SETTING_XML_ELM_CONTROL_HEADING      "heading"
-#define SETTING_XML_ELM_CONTROL_HIDEVALUE    "hidevalue"
-#define SETTING_XML_ELM_CONTROL_MULTISELECT  "multiselect"
-#define SETTING_XML_ELM_CONTROL_POPUP        "popup"
-#define SETTING_XML_ELM_CONTROL_FORMATVALUE  "value"
-#define SETTING_XML_ATTR_SHOW_MORE           "more"
-#define SETTING_XML_ATTR_SHOW_DETAILS        "details"
-#define SETTING_XML_ATTR_SEPARATOR_POSITION  "separatorposition"
-#define SETTING_XML_ATTR_HIDE_SEPARATOR      "hideseparator"
+#define SETTING_XML_ELM_CONTROL_FORMATLABEL "formatlabel"
+#define SETTING_XML_ELM_CONTROL_HIDDEN "hidden"
+#define SETTING_XML_ELM_CONTROL_VERIFYNEW "verifynew"
+#define SETTING_XML_ELM_CONTROL_HEADING "heading"
+#define SETTING_XML_ELM_CONTROL_HIDEVALUE "hidevalue"
+#define SETTING_XML_ELM_CONTROL_MULTISELECT "multiselect"
+#define SETTING_XML_ELM_CONTROL_POPUP "popup"
+#define SETTING_XML_ELM_CONTROL_FORMATVALUE "value"
+#define SETTING_XML_ATTR_SHOW_MORE "more"
+#define SETTING_XML_ATTR_SHOW_DETAILS "details"
+#define SETTING_XML_ATTR_SEPARATOR_POSITION "separatorposition"
+#define SETTING_XML_ATTR_HIDE_SEPARATOR "hideseparator"
 
 class CVariant;
 
 class CSettingControlCreator : public ISettingControlCreator
 {
 public:
-  CSettingControlCreator() { }
-  virtual ~CSettingControlCreator() { }
-
   // implementation of ISettingControlCreator
   virtual std::shared_ptr<ISettingControl> CreateControl(const std::string &controlType) const override;
+
+protected:
+  CSettingControlCreator() = default;
+  virtual ~CSettingControlCreator() = default;
 };
 
 class CSettingControlCheckmark : public ISettingControl
@@ -54,7 +55,7 @@ public:
   {
     m_format = "boolean";
   }
-  virtual ~CSettingControlCheckmark() { }
+  virtual ~CSettingControlCheckmark() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "toggle"; }
@@ -64,7 +65,7 @@ public:
 class CSettingControlFormattedRange : public ISettingControl
 {
 public:
-  virtual ~CSettingControlFormattedRange() { }
+  virtual ~CSettingControlFormattedRange() = default;
 
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
 
@@ -76,22 +77,18 @@ public:
   void SetMinimumLabel(int minimumLabel) { m_minimumLabel = minimumLabel; }
 
 protected:
-  CSettingControlFormattedRange()
-    : m_formatLabel(-1),
-    m_formatString("%i"),
-    m_minimumLabel(-1)
-  { }
+  CSettingControlFormattedRange() = default;
 
-  int m_formatLabel;
-  std::string m_formatString;
-  int m_minimumLabel;
+  int m_formatLabel = -1;
+  std::string m_formatString = "%i";
+  int m_minimumLabel = -1;
 };
 
 class CSettingControlSpinner : public CSettingControlFormattedRange
 {
 public:
-  CSettingControlSpinner() { }
-  virtual ~CSettingControlSpinner() { }
+  CSettingControlSpinner() = default;
+  virtual ~CSettingControlSpinner() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "spinner"; }
@@ -104,13 +101,10 @@ class CSettingControlEdit : public ISettingControl
 {
 public:
   CSettingControlEdit()
-    : m_hidden(false),
-      m_verifyNewValue(false),
-      m_heading(-1)
   {
     m_delayed = true;
   }
-  virtual ~CSettingControlEdit() { }
+  virtual ~CSettingControlEdit() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "edit"; }
@@ -125,26 +119,16 @@ public:
   void SetHeading(int heading) { m_heading = heading; }
 
 protected:
-  bool m_hidden;
-  bool m_verifyNewValue;
-  int m_heading;
+  bool m_hidden = false;
+  bool m_verifyNewValue = false;
+  int m_heading = -1;
 };
 
 class CSettingControlButton : public ISettingControl
 {
 public:
-  CSettingControlButton()
-    : m_heading(-1),
-      m_hideValue(false),
-      m_showAddonDetails(true),
-      m_showInstalledAddons(true),
-      m_showInstallableAddons(false),
-      m_showMoreAddons(true),
-      m_useImageThumbs(false),
-      m_useFileDirectories(false),
-      m_actionData()
-  { }
-  virtual ~CSettingControlButton() { }
+  CSettingControlButton() = default;
+  virtual ~CSettingControlButton() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "button"; }
@@ -175,33 +159,28 @@ public:
   void SetActionData(const std::string& actionData) { m_actionData = actionData; }
 
 protected:
-  int m_heading;
-  bool m_hideValue;
+  int m_heading = -1;
+  bool m_hideValue = false;
 
-  bool m_showAddonDetails;
-  bool m_showInstalledAddons;
-  bool m_showInstallableAddons;
-  bool m_showMoreAddons;
+  bool m_showAddonDetails = true;
+  bool m_showInstalledAddons = true;
+  bool m_showInstallableAddons = false;
+  bool m_showMoreAddons = true;
 
-  bool m_useImageThumbs;
-  bool m_useFileDirectories;
+  bool m_useImageThumbs = false;
+  bool m_useFileDirectories = false;
 
   std::string m_actionData;
 };
 
 class CSetting;
-typedef std::string (*SettingControlListValueFormatter)(std::shared_ptr<const CSetting> setting);
+using SettingControlListValueFormatter = std::string (*)(std::shared_ptr<const CSetting> setting);
 
 class CSettingControlList : public CSettingControlFormattedRange
 {
 public:
-  CSettingControlList()
-    : m_heading(-1),
-      m_multiselect(false),
-      m_hideValue(false),
-      m_formatter(NULL)
-  { }
-  virtual ~CSettingControlList() { }
+  CSettingControlList() = default;
+  virtual ~CSettingControlList() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "list"; }
@@ -221,26 +200,20 @@ public:
   void SetFormatter(SettingControlListValueFormatter formatter) { m_formatter = formatter; }
 
 protected:
-  int m_heading;
-  bool m_multiselect;
-  bool m_hideValue;
-  SettingControlListValueFormatter m_formatter;
+  int m_heading = -1;
+  bool m_multiselect = false;
+  bool m_hideValue = false;
+  SettingControlListValueFormatter m_formatter = nullptr;
 };
 
 class CSettingControlSlider;
-typedef std::string (*SettingControlSliderFormatter)(std::shared_ptr<const CSettingControlSlider> control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum);
+using SettingControlSliderFormatter = std::string (*)(std::shared_ptr<const CSettingControlSlider> control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum);
 
 class CSettingControlSlider : public ISettingControl
 {
 public:
-  CSettingControlSlider()
-    : m_heading(-1),
-      m_popup(false),
-      m_formatLabel(-1),
-      m_formatString("%i"),
-      m_formatter(NULL)
-  { }
-  virtual ~CSettingControlSlider() { }
+  CSettingControlSlider() = default;
+  virtual ~CSettingControlSlider() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "slider"; }
@@ -260,22 +233,18 @@ public:
   void SetFormatter(SettingControlSliderFormatter formatter) { m_formatter = formatter; }
 
 protected:
-  int m_heading;
-  bool m_popup;
-  int m_formatLabel;
-  std::string m_formatString;
-  SettingControlSliderFormatter m_formatter;
+  int m_heading = -1;
+  bool m_popup = false;
+  int m_formatLabel = -1;
+  std::string m_formatString = "%i";
+  SettingControlSliderFormatter m_formatter = nullptr;
 };
 
 class CSettingControlRange : public ISettingControl
 {
 public:
-  CSettingControlRange()
-    : m_formatLabel(21469),
-      m_valueFormatLabel(-1),
-      m_valueFormat("%s")
-  { }
-  virtual ~CSettingControlRange() { }
+  CSettingControlRange() = default;
+  virtual ~CSettingControlRange() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "range"; }
@@ -290,19 +259,16 @@ public:
   void SetValueFormat(const std::string &valueFormat) { m_valueFormat = valueFormat; }
 
 protected:
-  int m_formatLabel;
-  int m_valueFormatLabel;
-  std::string m_valueFormat;
+  int m_formatLabel = 21469;
+  int m_valueFormatLabel = -1;
+  std::string m_valueFormat = "%s";
 };
 
 class CSettingControlTitle : public ISettingControl
 {
 public:
-  CSettingControlTitle()
-    : m_separatorHidden(false),
-      m_separatorBelowLabel(true)
-  { }
-  virtual ~CSettingControlTitle() { }
+  CSettingControlTitle() = default;
+  virtual ~CSettingControlTitle() = default;
 
   // implementation of ISettingControl
   virtual std::string GetType() const override { return "title"; }
@@ -314,6 +280,6 @@ public:
   void SetSeparatorBelowLabel(bool below) { m_separatorBelowLabel = below; }
 
 protected:
-  bool m_separatorHidden;
-  bool m_separatorBelowLabel;
+  bool m_separatorHidden = false;
+  bool m_separatorBelowLabel = true;
 };

--- a/xbmc/settings/SettingCreator.cpp
+++ b/xbmc/settings/SettingCreator.cpp
@@ -24,7 +24,7 @@
 #include "settings/SettingPath.h"
 #include "utils/StringUtils.h"
 
-std::shared_ptr<CSetting> CSettingCreator::CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager /* = NULL */) const
+std::shared_ptr<CSetting> CSettingCreator::CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager /* = nullptr */) const
 {
   if (StringUtils::EqualsNoCase(settingType, "addon"))
     return std::make_shared<CSettingAddon>(settingId, settingsManager);
@@ -35,5 +35,5 @@ std::shared_ptr<CSetting> CSettingCreator::CreateSetting(const std::string &sett
   else if (StringUtils::EqualsNoCase(settingType, "time"))
     return std::make_shared<CSettingTime>(settingId, settingsManager);
 
-  return NULL;
+  return nullptr;
 }

--- a/xbmc/settings/SettingCreator.h
+++ b/xbmc/settings/SettingCreator.h
@@ -24,9 +24,10 @@
 class CSettingCreator : public ISettingCreator
 {
 public:
-  CSettingCreator() { }
-  virtual ~CSettingCreator() { }
-
   // implementation of ISettingCreator
-  virtual std::shared_ptr<CSetting> CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const override;
+  virtual std::shared_ptr<CSetting> CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = nullptr) const override;
+
+protected:
+  CSettingCreator() = default;
+  virtual ~CSettingCreator() = default;
 };

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -28,16 +28,12 @@
 #define XML_ELM_DEFAULT     "default"
 #define XML_ELM_CONSTRAINTS "constraints"
 
-CSettingPath::CSettingPath(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : CSettingString(id, settingsManager),
-    m_writable(true),
-    m_hideExtension(false)
+CSettingPath::CSettingPath(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
+  : CSettingString(id, settingsManager)
 { }
 
-CSettingPath::CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = NULL */)
-  : CSettingString(id, label, value, settingsManager),
-    m_writable(true),
-    m_hideExtension(false)
+CSettingPath::CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = nullptr */)
+  : CSettingString(id, label, value, settingsManager)
 { }
   
 CSettingPath::CSettingPath(const std::string &id, const CSettingPath &setting)
@@ -58,26 +54,26 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (!CSettingString::Deserialize(node, update))
     return false;
     
-  if (m_control != NULL &&
+  if (m_control != nullptr &&
      (m_control->GetType() != "button" || m_control->GetFormat() != "path"))
   {
     CLog::Log(LOGERROR, "CSettingPath: invalid <control> of \"%s\"", m_id.c_str());
     return false;
   }
     
-  const TiXmlNode *constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
-  if (constraints != NULL)
+  auto constraints = node->FirstChild(XML_ELM_CONSTRAINTS);
+  if (constraints != nullptr)
   {
     // get writable
     XMLUtils::GetBoolean(constraints, "writable", m_writable);
 
     // get sources
-    const TiXmlNode *sources = constraints->FirstChild("sources");
-    if (sources != NULL)
+    auto sources = constraints->FirstChild("sources");
+    if (sources != nullptr)
     {
       m_sources.clear();
-      const TiXmlNode *source = sources->FirstChild("source");
-      while (source != NULL)
+      auto source = sources->FirstChild("source");
+      while (source != nullptr)
       {
         std::string strSource = source->FirstChild()->ValueStr();
         if (!strSource.empty())

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -26,10 +26,10 @@
 class CSettingPath : public CSettingString
 {
 public:
-  CSettingPath(const std::string &id, CSettingsManager *settingsManager = NULL);
-  CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = NULL);
+  CSettingPath(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = nullptr);
   CSettingPath(const std::string &id, const CSettingPath &setting);
-  virtual ~CSettingPath() { }
+  virtual ~CSettingPath() = default;
 
   virtual SettingPtr Clone(const std::string &id) const override;
 
@@ -48,8 +48,8 @@ public:
 private:
   void copy(const CSettingPath &setting);
 
-  bool m_writable;
+  bool m_writable = true;
   std::vector<std::string> m_sources;
-  bool m_hideExtension;
+  bool m_hideExtension = false;
   std::string m_masking;
 };

--- a/xbmc/settings/SettingUtils.cpp
+++ b/xbmc/settings/SettingUtils.cpp
@@ -44,24 +44,24 @@ std::vector<CVariant> CSettingUtils::ListToValues(std::shared_ptr<const CSetting
   if (setting == NULL)
     return realValues;
 
-  for (SettingList::const_iterator it = values.begin(); it != values.end(); ++it)
+  for (const auto& value : values)
   {
     switch (setting->GetElementType())
     {
-      case SettingTypeBool:
-        realValues.push_back(std::static_pointer_cast<const CSettingBool>(*it)->GetValue());
+      case SettingType::Boolean:
+        realValues.push_back(std::static_pointer_cast<const CSettingBool>(value)->GetValue());
         break;
 
-      case SettingTypeInteger:
-        realValues.push_back(std::static_pointer_cast<const CSettingInt>(*it)->GetValue());
+      case SettingType::Integer:
+        realValues.push_back(std::static_pointer_cast<const CSettingInt>(value)->GetValue());
         break;
 
-      case SettingTypeNumber:
-        realValues.push_back(std::static_pointer_cast<const CSettingNumber>(*it)->GetValue());
+      case SettingType::Number:
+        realValues.push_back(std::static_pointer_cast<const CSettingNumber>(value)->GetValue());
         break;
 
-      case SettingTypeString:
-        realValues.push_back(std::static_pointer_cast<const CSettingString>(*it)->GetValue());
+      case SettingType::String:
+        realValues.push_back(std::static_pointer_cast<const CSettingString>(value)->GetValue());
         break;
 
       default:
@@ -80,7 +80,7 @@ bool CSettingUtils::ValuesToList(std::shared_ptr<const CSettingList> setting, co
 
   int index = 0;
   bool ret = true;
-  for (std::vector<CVariant>::const_iterator itValue = values.begin(); itValue != values.end(); ++itValue)
+  for (const auto& value : values)
   {
     SettingPtr settingValue = setting->GetDefinition()->Clone(StringUtils::Format("%s.%d", setting->GetId().c_str(), index++));
     if (settingValue == NULL)
@@ -88,32 +88,32 @@ bool CSettingUtils::ValuesToList(std::shared_ptr<const CSettingList> setting, co
 
     switch (setting->GetElementType())
     {
-      case SettingTypeBool:
-        if (!itValue->isBoolean())
+      case SettingType::Boolean:
+        if (!value.isBoolean())
           ret = false;
         else
-          ret = std::static_pointer_cast<CSettingBool>(settingValue)->SetValue(itValue->asBoolean());
+          ret = std::static_pointer_cast<CSettingBool>(settingValue)->SetValue(value.asBoolean());
         break;
 
-      case SettingTypeInteger:
-        if (!itValue->isInteger())
+      case SettingType::Integer:
+        if (!value.isInteger())
           ret = false;
         else
-          ret = std::static_pointer_cast<CSettingInt>(settingValue)->SetValue((int)itValue->asInteger());
+          ret = std::static_pointer_cast<CSettingInt>(settingValue)->SetValue(static_cast<int>(value.asInteger()));
         break;
 
-      case SettingTypeNumber:
-        if (!itValue->isDouble())
+      case SettingType::Number:
+        if (!value.isDouble())
           ret = false;
         else
-          ret = std::static_pointer_cast<CSettingNumber>(settingValue)->SetValue(itValue->asDouble());
+          ret = std::static_pointer_cast<CSettingNumber>(settingValue)->SetValue(value.asDouble());
         break;
 
-      case SettingTypeString:
-        if (!itValue->isString())
+      case SettingType::String:
+        if (!value.isString())
           ret = false;
         else
-          ret = std::static_pointer_cast<CSettingString>(settingValue)->SetValue(itValue->asString());
+          ret = std::static_pointer_cast<CSettingString>(settingValue)->SetValue(value.asString());
         break;
 
       default:

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -257,7 +257,7 @@ std::vector<CVariant> CSettingsBase::GetList(const std::string& id) const
 {
   CSingleLock lock(m_critical);
   std::shared_ptr<CSetting> setting = m_settingsManager->GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingTypeList)
+  if (setting == nullptr || setting->GetType() != SettingType::List)
     return std::vector<CVariant>();
 
   return CSettingUtils::GetList(std::static_pointer_cast<CSettingList>(setting));
@@ -267,7 +267,7 @@ bool CSettingsBase::SetList(const std::string& id, const std::vector<CVariant>& 
 {
   CSingleLock lock(m_critical);
   std::shared_ptr<CSetting> setting = m_settingsManager->GetSetting(id);
-  if (setting == nullptr || setting->GetType() != SettingTypeList)
+  if (setting == nullptr || setting->GetType() != SettingType::List)
     return false;
 
   return CSettingUtils::SetList(std::static_pointer_cast<CSettingList>(setting), value);

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -373,7 +373,7 @@ void CGUIDialogAudioDSPSettings::OnSettingAction(std::shared_ptr<const CSetting>
 
 void CGUIDialogAudioDSPSettings::Save()
 {
-  if (!g_passwordManager.CheckSettingLevelLock(SettingLevelExpert) &&
+  if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
       CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -335,9 +335,9 @@ void CGUIDialogContentSettings::InitializeSettings()
     return;
   }
 
-  AddButton(group, SETTING_CONTENT_TYPE, 20344, 0);
-  AddButton(group, SETTING_SCRAPER_LIST, 38025, 0);
-  std::shared_ptr<CSettingAction> subsetting = AddButton(group, SETTING_SCRAPER_SETTINGS, 10004, 0);
+  AddButton(group, SETTING_CONTENT_TYPE, 20344, SettingLevel::Basic);
+  AddButton(group, SETTING_SCRAPER_LIST, 38025, SettingLevel::Basic);
+  std::shared_ptr<CSettingAction> subsetting = AddButton(group, SETTING_SCRAPER_SETTINGS, 10004, SettingLevel::Basic);
   if (subsetting != NULL)
     subsetting->SetParent(SETTING_SCRAPER_LIST);
 
@@ -351,32 +351,32 @@ void CGUIDialogContentSettings::InitializeSettings()
   {
     case CONTENT_TVSHOWS:
     {
-      AddToggle(groupDetails, SETTING_CONTAINS_SINGLE_ITEM, 20379, 0, m_containsSingleItem, false, m_showScanSettings);
-      AddToggle(groupDetails, SETTING_NO_UPDATING, 20432, 0, m_noUpdating, false, m_showScanSettings);
+      AddToggle(groupDetails, SETTING_CONTAINS_SINGLE_ITEM, 20379, SettingLevel::Basic, m_containsSingleItem, false, m_showScanSettings);
+      AddToggle(groupDetails, SETTING_NO_UPDATING, 20432, SettingLevel::Basic, m_noUpdating, false, m_showScanSettings);
       break;
     }
 
     case CONTENT_MOVIES:
     case CONTENT_MUSICVIDEOS:
     {
-      AddToggle(groupDetails, SETTING_USE_DIRECTORY_NAMES, m_content == CONTENT_MOVIES ? 20329 : 20330, 0, m_useDirectoryNames, false, m_showScanSettings);
-      std::shared_ptr<CSettingBool> settingScanRecursive = AddToggle(groupDetails, SETTING_SCAN_RECURSIVE, 20346, 0, m_scanRecursive, false, m_showScanSettings);
-      std::shared_ptr<CSettingBool> settingContainsSingleItem = AddToggle(groupDetails, SETTING_CONTAINS_SINGLE_ITEM, 20383, 0, m_containsSingleItem, false, m_showScanSettings);
-      AddToggle(groupDetails, SETTING_NO_UPDATING, 20432, 0, m_noUpdating, false, m_showScanSettings);
+      AddToggle(groupDetails, SETTING_USE_DIRECTORY_NAMES, m_content == CONTENT_MOVIES ? 20329 : 20330, SettingLevel::Basic, m_useDirectoryNames, false, m_showScanSettings);
+      std::shared_ptr<CSettingBool> settingScanRecursive = AddToggle(groupDetails, SETTING_SCAN_RECURSIVE, 20346, SettingLevel::Basic, m_scanRecursive, false, m_showScanSettings);
+      std::shared_ptr<CSettingBool> settingContainsSingleItem = AddToggle(groupDetails, SETTING_CONTAINS_SINGLE_ITEM, 20383, SettingLevel::Basic, m_containsSingleItem, false, m_showScanSettings);
+      AddToggle(groupDetails, SETTING_NO_UPDATING, 20432, SettingLevel::Basic, m_noUpdating, false, m_showScanSettings);
       
       // define an enable dependency with (m_useDirectoryNames && !m_containsSingleItem) || !m_useDirectoryNames
-      CSettingDependency dependencyScanRecursive(SettingDependencyTypeEnable, GetSettingsManager());
+      CSettingDependency dependencyScanRecursive(SettingDependencyType::Enable, GetSettingsManager());
       dependencyScanRecursive.Or()
         ->Add(CSettingDependencyConditionCombinationPtr((new CSettingDependencyConditionCombination(BooleanLogicOperationAnd, GetSettingsManager()))                                     // m_useDirectoryNames && !m_containsSingleItem
-          ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperatorEquals, false, GetSettingsManager())))      // m_useDirectoryNames
-          ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_CONTAINS_SINGLE_ITEM, "false", SettingDependencyOperatorEquals, false, GetSettingsManager())))))  // !m_containsSingleItem
-        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "false", SettingDependencyOperatorEquals, false, GetSettingsManager())));      // !m_useDirectoryNames
+          ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperator::Equals, false, GetSettingsManager())))      // m_useDirectoryNames
+          ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_CONTAINS_SINGLE_ITEM, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())))))  // !m_containsSingleItem
+        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())));      // !m_useDirectoryNames
 
       // define an enable dependency with m_useDirectoryNames && !m_scanRecursive
-      CSettingDependency dependencyContainsSingleItem(SettingDependencyTypeEnable, GetSettingsManager());
+      CSettingDependency dependencyContainsSingleItem(SettingDependencyType::Enable, GetSettingsManager());
       dependencyContainsSingleItem.And()
-        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperatorEquals, false, GetSettingsManager())))        // m_useDirectoryNames
-        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_SCAN_RECURSIVE, "false", SettingDependencyOperatorEquals, false, GetSettingsManager())));           // !m_scanRecursive
+        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperator::Equals, false, GetSettingsManager())))        // m_useDirectoryNames
+        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_SCAN_RECURSIVE, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())));           // !m_scanRecursive
 
       SettingDependencies deps;
       deps.push_back(dependencyScanRecursive);
@@ -394,7 +394,7 @@ void CGUIDialogContentSettings::InitializeSettings()
 
     case CONTENT_NONE:
     default:
-      AddToggle(groupDetails, SETTING_EXCLUDE, 20380, 0, m_exclude, false, !m_showScanSettings);
+      AddToggle(groupDetails, SETTING_EXCLUDE, 20380, SettingLevel::Basic, m_exclude, false, !m_showScanSettings);
       break;
   }
 }

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -485,8 +485,8 @@ void CGUIDialogSettingsBase::OnTimeout()
 
 void CGUIDialogSettingsBase::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 {
-  if (setting == NULL || setting->GetType() == SettingTypeNone ||
-      setting->GetType() == SettingTypeAction)
+  if (setting == NULL || setting->GetType() == SettingType::Unknown ||
+      setting->GetType() == SettingType::Action)
     return;
 
   UpdateSettingControl(setting->GetId());

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -121,7 +121,7 @@ SettingGroupPtr CGUIDialogSettingsManualBase::AddGroup(SettingCategoryPtr catego
   return group;
 }
 
-std::shared_ptr<CSettingBool> CGUIDialogSettingsManualBase::AddToggle(SettingGroupPtr group, const std::string &id, int label, int level, bool value,
+std::shared_ptr<CSettingBool> CGUIDialogSettingsManualBase::AddToggle(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, bool value,
                                                       bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 ||
@@ -139,7 +139,7 @@ std::shared_ptr<CSettingBool> CGUIDialogSettingsManualBase::AddToggle(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddEdit(SettingGroupPtr group, const std::string &id, int label, int level, int value,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddEdit(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value,
                                                    int minimum /* = 0 */, int step /* = 1 */, int maximum /* = 0 */, bool verifyNewValue /* = false */,
                                                    int heading /* = -1 */, bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
@@ -158,7 +158,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddEdit(SettingGroupP
   return setting;
 }
 
-std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddEdit(SettingGroupPtr group, const std::string &id, int label, int level, float value,
+std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddEdit(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float value,
                                                       float minimum /* = 0.0f */, float step /* = 1.0f */, float maximum /* = 0.0f */,
                                                       bool verifyNewValue /* = false */, int heading /* = -1 */, bool delayed /* = false */,
                                                       bool visible /* = true */, int help /* = -1 */)
@@ -178,7 +178,7 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddEdit(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddEdit(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddEdit(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                       bool allowEmpty /* = false */, bool hidden /* = false */,
                                                       int heading /* = -1 */, bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
@@ -198,7 +198,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddEdit(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddIp(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddIp(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                     bool allowEmpty /* = false */, int heading /* = -1 */, bool delayed /* = false */,
                                                     bool visible /* = true */, int help /* = -1 */)
 {
@@ -218,7 +218,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddIp(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddPasswordMd5(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddPasswordMd5(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                              bool allowEmpty /* = false */, int heading /* = -1 */, bool delayed /* = false */,
                                                              bool visible /* = true */, int help /* = -1 */)
 {
@@ -238,7 +238,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddPasswordMd5(Set
   return setting;
 }
 
-std::shared_ptr<CSettingAction> CGUIDialogSettingsManualBase::AddButton(SettingGroupPtr group, const std::string &id, int label, int level, const std::string& data /* = "" */,
+std::shared_ptr<CSettingAction> CGUIDialogSettingsManualBase::AddButton(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, const std::string& data /* = "" */,
                                                         bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 ||
@@ -257,7 +257,7 @@ std::shared_ptr<CSettingAction> CGUIDialogSettingsManualBase::AddButton(SettingG
   return setting;
 }
 
-std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddInfoLabelButton(SettingGroupPtr group, const std::string &id, int label, int level, std::string info,
+std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddInfoLabelButton(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string info,
                                                                  bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 ||
@@ -275,7 +275,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddInfoLabelButton
   return setting;
 }
 
-std::shared_ptr<CSettingAddon> CGUIDialogSettingsManualBase::AddAddon(SettingGroupPtr group, const std::string &id, int label, int level, std::string value, ADDON::TYPE addonType,
+std::shared_ptr<CSettingAddon> CGUIDialogSettingsManualBase::AddAddon(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value, ADDON::TYPE addonType,
                                                       bool allowEmpty /* = false */, int heading /* = -1 */, bool hideValue /* = false */, bool showInstalledAddons /* = true */,
                                                       bool showInstallableAddons /* = false */, bool showMoreAddons /* = true */, bool delayed /* = false */,
                                                       bool visible /* = true */, int help /* = -1 */)
@@ -297,7 +297,7 @@ std::shared_ptr<CSettingAddon> CGUIDialogSettingsManualBase::AddAddon(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingPath> CGUIDialogSettingsManualBase::AddPath(SettingGroupPtr group, const std::string &id, int label, int level, std::string value, bool writable /* = true */,
+std::shared_ptr<CSettingPath> CGUIDialogSettingsManualBase::AddPath(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value, bool writable /* = true */,
                                                     const std::vector<std::string> &sources /* = std::vector<std::string>() */, bool allowEmpty /* = false */,
                                                     int heading /* = -1 */, bool hideValue /* = false */, bool delayed /* = false */,
                                                     bool visible /* = true */, int help /* = -1 */)
@@ -320,7 +320,7 @@ std::shared_ptr<CSettingPath> CGUIDialogSettingsManualBase::AddPath(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingDate> CGUIDialogSettingsManualBase::AddDate(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingDate> CGUIDialogSettingsManualBase::AddDate(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                     bool allowEmpty /* = false */, int heading /* = -1 */, bool delayed /* = false */,
                                                     bool visible /* = true */, int help /* = -1 */)
 {
@@ -339,7 +339,7 @@ std::shared_ptr<CSettingDate> CGUIDialogSettingsManualBase::AddDate(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingTime> CGUIDialogSettingsManualBase::AddTime(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingTime> CGUIDialogSettingsManualBase::AddTime(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                     bool allowEmpty /* = false */, int heading /* = -1 */, bool delayed /* = false */,
                                                     bool visible /* = true */, int help /* = -1 */)
 {
@@ -358,7 +358,7 @@ std::shared_ptr<CSettingTime> CGUIDialogSettingsManualBase::AddTime(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                          StringSettingOptionsFiller filler, bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
@@ -377,7 +377,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddSpinner(Setting
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, int value, int minimum, int step, int maximum,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, int minimum, int step, int maximum,
                                                       int formatLabel /* = -1 */, int minimumLabel /* = -1 */, bool delayed /* = false */,
                                                       bool visible /* = true */, int help /* = -1 */)
 {
@@ -399,7 +399,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, int value, int minimum, int step, int maximum,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, int minimum, int step, int maximum,
                                                       const std::string &formatString, int minimumLabel /* = -1 */, bool delayed /* = false */,
                                                       bool visible /* = true */, int help /* = -1 */)
 {
@@ -421,7 +421,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, int value, const TranslatableIntegerSettingOptions &entries,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, const TranslatableIntegerSettingOptions &entries,
                                                       bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
@@ -440,7 +440,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, int value, const IntegerSettingOptions &entries,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, const IntegerSettingOptions &entries,
                                                       bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
@@ -459,7 +459,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, int value, IntegerSettingOptionsFiller filler,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, IntegerSettingOptionsFiller filler,
                                                       bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
@@ -478,7 +478,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSpinner(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, float value, float minimum, float step, float maximum,
+std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float value, float minimum, float step, float maximum,
                                                          int formatLabel /* = -1 */, int minimumLabel /* = -1 */, bool delayed /* = false */,
                                                          bool visible /* = true */, int help /* = -1 */)
 {
@@ -500,7 +500,7 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(Setting
   return setting;
 }
 
-std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, int level, float value, float minimum, float step, float maximum,
+std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float value, float minimum, float step, float maximum,
                                                          const std::string &formatString, int minimumLabel /* = -1 */, bool delayed /* = false */,
                                                          bool visible /* = true */, int help /* = -1 */)
 {
@@ -522,7 +522,7 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSpinner(Setting
   return setting;
 }
 
-std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, std::string value,
+std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::string value,
                                                       StringSettingOptionsFiller filler, int heading, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
@@ -541,7 +541,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddList(SettingGro
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, int value, const TranslatableIntegerSettingOptions &entries,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, const TranslatableIntegerSettingOptions &entries,
                                                   int heading, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
@@ -560,7 +560,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupP
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, int value, const IntegerSettingOptions &entries,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, const IntegerSettingOptions &entries,
                                                   int heading, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
@@ -579,7 +579,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupP
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, int value, IntegerSettingOptionsFiller filler,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, IntegerSettingOptionsFiller filler,
                                                    int heading, bool visible /* = true */, int help /* = -1 */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
@@ -598,7 +598,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(SettingGroupP
   return setting;
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, std::vector<std::string> values,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::vector<std::string> values,
                                                     StringSettingOptionsFiller filler, int heading, int minimumItems /* = 0 */, int maximumItems /* = -1 */,
                                                     bool visible /* = true */, int help /* = -1 */)
 {
@@ -634,7 +634,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, std::vector<int> values,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::vector<int> values,
                                                     const TranslatableIntegerSettingOptions &entries, int heading, int minimumItems /* = 0 */, int maximumItems /* = -1 */,
                                                     bool visible /* = true */, int help /* = -1 */)
 {
@@ -670,7 +670,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, std::vector<int> values,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::vector<int> values,
                                                     const IntegerSettingOptions &entries, int heading, int minimumItems /* = 0 */, int maximumItems /* = -1 */,
                                                     bool visible /* = true */, int help /* = -1 */)
 {
@@ -706,7 +706,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, int level, std::vector<int> values,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, std::vector<int> values,
                                                     IntegerSettingOptionsFiller filler, int heading, int minimumItems /* = 0 */, int maximumItems /* = -1 */,
                                                     bool visible /* = true */, int help /* = -1 */, SettingControlListValueFormatter formatter /* = NULL */)
 {
@@ -742,7 +742,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(SettingGroup
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(SettingGroupPtr group, const std::string &id, int label, int level, int value, int formatLabel,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, int formatLabel,
                                                                int step /* = 1 */, int heading /* = -1 */, bool usePopup /* = false */, bool delayed /* = false */,
                                                                bool visible /* = true */, int help /* = -1 */)
 {
@@ -764,7 +764,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(S
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(SettingGroupPtr group, const std::string &id, int label, int level, int value, const std::string &formatString,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, const std::string &formatString,
                                                                int step /* = 1 */, int heading /* = -1 */, bool usePopup /* = false */, bool delayed /* = false */,
                                                                bool visible /* = true */, int help /* = -1 */)
 {
@@ -786,7 +786,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddPercentageSlider(S
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, int level, int value, int formatLabel, int minimum, int step,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, int formatLabel, int minimum, int step,
                                                      int maximum, int heading /* = -1 */, bool usePopup /* = false */, bool delayed /* = false */,
                                                      bool visible /* = true */, int help /* = -1 */)
 {
@@ -808,7 +808,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(SettingGrou
   return setting;
 }
 
-std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, int level, int value, const std::string &formatString,
+std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int value, const std::string &formatString,
                                                      int minimum, int step, int maximum, int heading /* = -1 */, bool usePopup /* = false */, bool delayed /* = false */,
                                                      bool visible /* = true */, int help /* = -1 */)
 {
@@ -830,7 +830,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddSlider(SettingGrou
   return setting;
 }
 
-std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, int level, float value, int formatLabel, float minimum,
+std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float value, int formatLabel, float minimum,
                                                         float step, float maximum, int heading /* = -1 */, bool usePopup /* = false */, bool delayed /* = false */,
                                                         bool visible /* = true */, int help /* = -1 */)
 {
@@ -852,7 +852,7 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(SettingG
   return setting;
 }
 
-std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, int level, float value, const std::string &formatString,
+std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float value, const std::string &formatString,
                                                         float minimum, float step, float maximum, int heading /* = -1 */, bool usePopup /* = false */,
                                                         bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
@@ -874,77 +874,77 @@ std::shared_ptr<CSettingNumber> CGUIDialogSettingsManualBase::AddSlider(SettingG
   return setting;
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddPercentageRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddPercentageRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper,
                                                                int valueFormatLabel, int step /* = 1 */, int formatLabel /* = 21469 */, bool delayed /* = false */,
                                                                bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, 0, step, 100, "percentage", formatLabel, valueFormatLabel, "", delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddPercentageRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddPercentageRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper,
                                                                const std::string &valueFormatString /* = "%i %%" */, int step /* = 1 */, int formatLabel /* = 21469 */,
                                                                bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, 0, step, 100, "percentage", formatLabel, -1, valueFormatString, delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                      int step, int maximum, int valueFormatLabel, int formatLabel /* = 21469 */, bool delayed /* = false */,
                                                      bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "integer", formatLabel, valueFormatLabel, "", delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                      int step, int maximum, const std::string &valueFormatString /* = "%d" */, int formatLabel /* = 21469 */,
                                                      bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "integer", formatLabel, -1, valueFormatString, delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, int level, float valueLower, float valueUpper, float minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float valueLower, float valueUpper, float minimum,
                                                      float step, float maximum, int valueFormatLabel, int formatLabel /* = 21469 */, bool delayed /* = false */,
                                                      bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "number", formatLabel, valueFormatLabel, "", delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, int level, float valueLower, float valueUpper, float minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float valueLower, float valueUpper, float minimum,
                                                      float step, float maximum, const std::string &valueFormatString /* = "%.1f" */, int formatLabel /* = 21469 */,
                                                      bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "number", formatLabel, -1, valueFormatString, delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddDateRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddDateRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                          int step, int maximum, int valueFormatLabel, int formatLabel /* = 21469 */, bool delayed /* = false */,
                                                          bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "date", formatLabel, valueFormatLabel, "", delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddDateRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddDateRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                          int step, int maximum, const std::string &valueFormatString /* = "" */, int formatLabel /* = 21469 */,
                                                          bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "date", formatLabel, -1, valueFormatString, delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddTimeRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddTimeRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                          int step, int maximum, int valueFormatLabel, int formatLabel /* = 21469 */, bool delayed /* = false */,
                                                          bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "time", formatLabel, valueFormatLabel, "", delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddTimeRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddTimeRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                          int step, int maximum, const std::string &valueFormatString /* = "mm:ss" */, int formatLabel /* = 21469 */,
                                                          bool delayed /* = false */, bool visible /* = true */, int help /* = -1 */)
 {
   return AddRange(group, id, label, level, valueLower, valueUpper, minimum, step, maximum, "time", formatLabel, -1, valueFormatString, delayed, visible, help);
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum,
                                                      int step, int maximum, const std::string &format, int formatLabel, int valueFormatLabel,
                                                      const std::string &valueFormatString, bool delayed, bool visible, int help)
 {
@@ -983,7 +983,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGrou
   return setting;
 }
 
-std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, int level, float valueLower, float valueUpper, float minimum,
+std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGroupPtr group, const std::string &id, int label, SettingLevel level, float valueLower, float valueUpper, float minimum,
                                                      float step, float maximum, const std::string &format, int formatLabel, int valueFormatLabel,
                                                      const std::string &valueFormatString, bool delayed, bool visible, int help)
 {
@@ -1022,15 +1022,15 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddRange(SettingGrou
   return setting;
 }
 
-void CGUIDialogSettingsManualBase::setSettingDetails(std::shared_ptr<CSetting> setting, int level, bool visible, int help)
+void CGUIDialogSettingsManualBase::setSettingDetails(std::shared_ptr<CSetting> setting, SettingLevel level, bool visible, int help)
 {
   if (setting == NULL)
     return;
 
-  if (level < 0)
-    level = SettingLevelBasic;
-  else if (level > SettingLevelExpert)
-    level = SettingLevelExpert;
+  if (level < SettingLevel::Basic)
+    level = SettingLevel::Basic;
+  else if (level > SettingLevel::Expert)
+    level = SettingLevel::Expert;
 
   setting->SetLevel(static_cast<SettingLevel>(level));
   setting->SetVisible(visible);

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -28,6 +28,7 @@
 #include "addons/IAddon.h"
 #include "settings/dialogs/GUIDialogSettingsManagerBase.h"
 #include "settings/lib/SettingDefinitions.h"
+#include "settings/lib/SettingLevel.h"
 
 class CSetting;
 class CSettingAction;
@@ -64,103 +65,103 @@ protected:
   std::shared_ptr<CSettingCategory> AddCategory(const std::string &id, int label, int help = -1);
   std::shared_ptr<CSettingGroup> AddGroup(std::shared_ptr<CSettingCategory> category, int label = -1, int help = -1, bool separatorBelowLabel = true, bool hideSeparator = false);
   // checkmark control
-  std::shared_ptr<CSettingBool> AddToggle(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, bool value, bool delayed = false, bool visible = true, int help = -1);
+  std::shared_ptr<CSettingBool> AddToggle(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, bool value, bool delayed = false, bool visible = true, int help = -1);
   // edit controls
-  std::shared_ptr<CSettingInt> AddEdit(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, int minimum = 0, int step = 1, int maximum = 0,
+  std::shared_ptr<CSettingInt> AddEdit(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, int minimum = 0, int step = 1, int maximum = 0,
     bool verifyNewValue = false, int heading = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingNumber> AddEdit(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float value, float minimum = 0.0f, float step = 1.0f, float maximum = 0.0f,
+  std::shared_ptr<CSettingNumber> AddEdit(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float value, float minimum = 0.0f, float step = 1.0f, float maximum = 0.0f,
     bool verifyNewValue = false, int heading = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingString> AddEdit(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, bool allowEmpty = false,
+  std::shared_ptr<CSettingString> AddEdit(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, bool allowEmpty = false,
     bool hidden = false, int heading = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingString> AddIp(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, bool allowEmpty = false,
+  std::shared_ptr<CSettingString> AddIp(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, bool allowEmpty = false,
     int heading = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingString> AddPasswordMd5(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, bool allowEmpty = false,
+  std::shared_ptr<CSettingString> AddPasswordMd5(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, bool allowEmpty = false,
     int heading = -1, bool delayed = false, bool visible = true, int help = -1);
   // button controls
-  std::shared_ptr<CSettingAction> AddButton(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, const std::string& data = "", bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingString> AddInfoLabelButton(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string info, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingAddon> AddAddon(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, ADDON::TYPE addonType,
+  std::shared_ptr<CSettingAction> AddButton(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, const std::string& data = "", bool delayed = false, bool visible = true, int help = -1);
+  std::shared_ptr<CSettingString> AddInfoLabelButton(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string info, bool visible = true, int help = -1);
+  std::shared_ptr<CSettingAddon> AddAddon(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, ADDON::TYPE addonType,
     bool allowEmpty = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true, bool showInstallableAddons = false,
     bool showMoreAddons = true, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingPath> AddPath(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, bool writable = true,
+  std::shared_ptr<CSettingPath> AddPath(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, bool writable = true,
     const std::vector<std::string> &sources = std::vector<std::string>(), bool allowEmpty = false, int heading = -1, bool hideValue = false,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingDate> AddDate(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, bool allowEmpty = false, int heading = -1,
+  std::shared_ptr<CSettingDate> AddDate(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, bool allowEmpty = false, int heading = -1,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingTime> AddTime(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, bool allowEmpty = false, int heading = -1,
+  std::shared_ptr<CSettingTime> AddTime(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, bool allowEmpty = false, int heading = -1,
     bool delayed = false, bool visible = true, int help = -1);
 
   // spinner controls
-  std::shared_ptr<CSettingString> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, StringSettingOptionsFiller filler,
+  std::shared_ptr<CSettingString> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, StringSettingOptionsFiller filler,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, int minimum, int step, int maximum, int formatLabel = -1,
+  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, int minimum, int step, int maximum, int formatLabel = -1,
     int minimumLabel = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, int minimum, int step, int maximum, const std::string &formatString,
+  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, int minimum, int step, int maximum, const std::string &formatString,
     int minimumLabel = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, const TranslatableIntegerSettingOptions &entries,
+  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, const TranslatableIntegerSettingOptions &entries,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, const IntegerSettingOptions &entries,
+  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, const IntegerSettingOptions &entries,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, IntegerSettingOptionsFiller filler,
+  std::shared_ptr<CSettingInt> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, IntegerSettingOptionsFiller filler,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingNumber> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float value, float minimum, float step, float maximum,
+  std::shared_ptr<CSettingNumber> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float value, float minimum, float step, float maximum,
     int formatLabel = -1, int minimumLabel = -1, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingNumber> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float value, float minimum, float step, float maximum,
+  std::shared_ptr<CSettingNumber> AddSpinner(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float value, float minimum, float step, float maximum,
     const std::string &formatString, int minimumLabel = -1, bool delayed = false, bool visible = true, int help = -1);
 
   // list controls
-  std::shared_ptr<CSettingString> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::string value, StringSettingOptionsFiller filler,
+  std::shared_ptr<CSettingString> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::string value, StringSettingOptionsFiller filler,
     int heading, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, const TranslatableIntegerSettingOptions &entries,
+  std::shared_ptr<CSettingInt> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, const TranslatableIntegerSettingOptions &entries,
     int heading, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, const IntegerSettingOptions &entries,
+  std::shared_ptr<CSettingInt> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, const IntegerSettingOptions &entries,
     int heading, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, IntegerSettingOptionsFiller filler,
+  std::shared_ptr<CSettingInt> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, IntegerSettingOptionsFiller filler,
     int heading, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::vector<std::string> values, StringSettingOptionsFiller filler,
+  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::vector<std::string> values, StringSettingOptionsFiller filler,
     int heading, int minimumItems = 0, int maximumItems = -1, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::vector<int> values, const TranslatableIntegerSettingOptions &entries,
+  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::vector<int> values, const TranslatableIntegerSettingOptions &entries,
     int heading, int minimumItems = 0, int maximumItems = -1, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::vector<int> values, const IntegerSettingOptions &entries,
+  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::vector<int> values, const IntegerSettingOptions &entries,
     int heading, int minimumItems = 0, int maximumItems = -1, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, std::vector<int> values, IntegerSettingOptionsFiller filler,
+  std::shared_ptr<CSettingList> AddList(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, std::vector<int> values, IntegerSettingOptionsFiller filler,
     int heading, int minimumItems = 0, int maximumItems = -1, bool visible = true, int help = -1, SettingControlListValueFormatter formatter = NULL);
 
   // slider controls
-  std::shared_ptr<CSettingInt> AddPercentageSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, int formatLabel, int step = 1, int heading = -1,
+  std::shared_ptr<CSettingInt> AddPercentageSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, int formatLabel, int step = 1, int heading = -1,
     bool usePopup = false, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddPercentageSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, const std::string &formatString, int step = 1,
+  std::shared_ptr<CSettingInt> AddPercentageSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, const std::string &formatString, int step = 1,
     int heading = -1, bool usePopup = false, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, int formatLabel, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingInt> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, int formatLabel, int minimum, int step, int maximum,
     int heading = -1, bool usePopup = false, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingInt> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int value, const std::string &formatString, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingInt> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int value, const std::string &formatString, int minimum, int step, int maximum,
     int heading = -1, bool usePopup = false, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingNumber> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float value, int formatLabel, float minimum, float step, float maximum,
+  std::shared_ptr<CSettingNumber> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float value, int formatLabel, float minimum, float step, float maximum,
     int heading = -1, bool usePopup = false, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingNumber> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float value, const std::string &formatString, float minimum, float step,
+  std::shared_ptr<CSettingNumber> AddSlider(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float value, const std::string &formatString, float minimum, float step,
     float maximum, int heading = -1, bool usePopup = false, bool delayed = false, bool visible = true, int help = -1);
 
   // range controls
-  std::shared_ptr<CSettingList> AddPercentageRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int valueFormatLabel, int step = 1,
+  std::shared_ptr<CSettingList> AddPercentageRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int valueFormatLabel, int step = 1,
     int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddPercentageRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper,
+  std::shared_ptr<CSettingList> AddPercentageRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper,
     const std::string &valueFormatString = "%i %%", int step = 1, int formatLabel = 21469,
     bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
     int valueFormatLabel, int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
     const std::string &valueFormatString = "%d", int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float valueLower, float valueUpper, float minimum, float step, float maximum,
+  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float valueLower, float valueUpper, float minimum, float step, float maximum,
     int valueFormatLabel, int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float valueLower, float valueUpper, float minimum, float step, float maximum,
+  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float valueLower, float valueUpper, float minimum, float step, float maximum,
     const std::string &valueFormatString = "%.1f", int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddDateRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddDateRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
      int valueFormatLabel, int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddDateRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddDateRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
      const std::string &valueFormatString = "", int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddTimeRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddTimeRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
      int valueFormatLabel, int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
-  std::shared_ptr<CSettingList> AddTimeRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddTimeRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
      const std::string &valueFormatString = "mm:ss", int formatLabel = 21469, bool delayed = false, bool visible = true, int help = -1);
 
   std::shared_ptr<ISettingControl> GetTitleControl(bool separatorBelowLabel = true, bool hideSeparator = false);
@@ -174,12 +175,12 @@ protected:
   std::shared_ptr<ISettingControl> GetRangeControl(const std::string &format, bool delayed = false, int formatLabel = -1, int valueFormatLabel = -1, const std::string &valueFormatString = "");
 
 private:
-  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, int valueLower, int valueUpper, int minimum, int step, int maximum,
+  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, int valueLower, int valueUpper, int minimum, int step, int maximum,
     const std::string &format, int formatLabel, int valueFormatLabel, const std::string &valueFormatString, bool delayed, bool visible, int help);
-  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, int level, float valueLower, float valueUpper, float minimum, float step, float maximum,
+  std::shared_ptr<CSettingList> AddRange(std::shared_ptr<CSettingGroup> group, const std::string &id, int label, SettingLevel level, float valueLower, float valueUpper, float minimum, float step, float maximum,
     const std::string &format, int formatLabel, int valueFormatLabel, const std::string &valueFormatString, bool delayed, bool visible, int help);
 
-  void setSettingDetails(std::shared_ptr<CSetting> setting, int level, bool visible, int help);
+  void setSettingDetails(std::shared_ptr<CSetting> setting, SettingLevel level, bool visible, int help);
 
   mutable CSettingsManager *m_settingsManager;
   std::shared_ptr<CSettingSection> m_section;

--- a/xbmc/settings/lib/CMakeLists.txt
+++ b/xbmc/settings/lib/CMakeLists.txt
@@ -21,9 +21,11 @@ set(HEADERS ISetting.h
             SettingConditions.h
             SettingDefinitions.h
             SettingDependency.h
+            SettingLevel.h
             SettingRequirement.h
             SettingSection.h
             SettingsManager.h
+            SettingType.h
             SettingUpdate.h)
 
 core_add_library(settings_lib)

--- a/xbmc/settings/lib/ISetting.cpp
+++ b/xbmc/settings/lib/ISetting.cpp
@@ -25,26 +25,23 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 
-ISetting::ISetting(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
-  : m_id(id),
-    m_settingsManager(settingsManager),
-    m_visible(true),
-    m_label(-1), m_help(-1),
-    m_meetsRequirements(true),
-    m_requirementCondition(settingsManager)
+ISetting::ISetting(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
+  : m_id(id)
+  , m_settingsManager(settingsManager)
+  , m_requirementCondition(settingsManager)
 { }
   
 bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  if (node == NULL)
+  if (node == nullptr)
     return false;
 
   bool value;
   if (XMLUtils::GetBoolean(node, SETTING_XML_ELM_VISIBLE, value))
     m_visible = value;
 
-  const TiXmlElement *element = node->ToElement();
-  if (element == NULL)
+  auto element = node->ToElement();
+  if (element == nullptr)
     return false;
 
   int iValue = -1;
@@ -53,8 +50,8 @@ bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (element->QueryIntAttribute(SETTING_XML_ATTR_HELP, &iValue) == TIXML_SUCCESS && iValue > 0)
     m_help = iValue;
 
-  const TiXmlNode *requirementNode = node->FirstChild(SETTING_XML_ELM_REQUIREMENT);
-  if (requirementNode == NULL)
+  auto requirementNode = node->FirstChild(SETTING_XML_ELM_REQUIREMENT);
+  if (requirementNode == nullptr)
     return true;
 
   return m_requirementCondition.Deserialize(requirementNode);
@@ -62,15 +59,15 @@ bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
 
 bool ISetting::DeserializeIdentification(const TiXmlNode *node, std::string &identification)
 {
-  if (node == NULL)
+  if (node == nullptr)
     return false;
 
-  const TiXmlElement *element = node->ToElement();
-  if (element == NULL)
+  auto element = node->ToElement();
+  if (element == nullptr)
     return false;
 
-  const char *idAttribute = element->Attribute(SETTING_XML_ATTR_ID);
-  if (idAttribute == NULL || strlen(idAttribute) <= 0)
+  auto idAttribute = element->Attribute(SETTING_XML_ATTR_ID);
+  if (idAttribute == nullptr || strlen(idAttribute) <= 0)
     return false;
 
   identification = idAttribute;

--- a/xbmc/settings/lib/ISetting.h
+++ b/xbmc/settings/lib/ISetting.h
@@ -19,7 +19,6 @@
  *
  */
 #include <string>
-#include <vector>
 
 #include "SettingRequirement.h"
 
@@ -39,8 +38,8 @@ public:
    \param id Identifier of the setting object
    \param settingsManager Reference to the settings manager
    */
-  ISetting(const std::string &id, CSettingsManager *settingsManager = NULL);
-  virtual ~ISetting() { }
+  ISetting(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  virtual ~ISetting() = default;
 
   /*!
    \brief Deserializes the given XML node into the properties of the setting
@@ -129,9 +128,9 @@ protected:
   CSettingsManager *m_settingsManager;
 
 private:
-  bool m_visible;
-  int m_label;
-  int m_help;
-  bool m_meetsRequirements;
+  bool m_visible = true;
+  int m_label = -1;
+  int m_help = -1;
+  bool m_meetsRequirements = true;
   CSettingRequirement m_requirementCondition;
 };

--- a/xbmc/settings/lib/ISettingCallback.h
+++ b/xbmc/settings/lib/ISettingCallback.h
@@ -27,7 +27,7 @@ class TiXmlNode;
 class ISettingCallback
 {
 public:
-  virtual ~ISettingCallback() { }
+  virtual ~ISettingCallback() = default;
 
   /*!
    \brief The value of the given setting is being changed.

--- a/xbmc/settings/lib/ISettingControl.cpp
+++ b/xbmc/settings/lib/ISettingControl.cpp
@@ -26,16 +26,16 @@
 
 bool ISettingControl::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {
-  if (node == NULL)
+  if (node == nullptr)
     return false;
 
-  const TiXmlElement *elem = node->ToElement();
-  if (elem == NULL)
+  auto elem = node->ToElement();
+  if (elem == nullptr)
     return false;
 
-  const char *strTmp = elem->Attribute(SETTING_XML_ATTR_FORMAT);
+  auto strTmp = elem->Attribute(SETTING_XML_ATTR_FORMAT);
   std::string format;
-  if (strTmp != NULL)
+  if (strTmp != nullptr)
     format = strTmp;
   if (!SetFormat(format))
   {
@@ -43,7 +43,7 @@ bool ISettingControl::Deserialize(const TiXmlNode *node, bool update /* = false 
     return false;
   }
 
-  if ((strTmp = elem->Attribute(SETTING_XML_ATTR_DELAYED)) != NULL)
+  if ((strTmp = elem->Attribute(SETTING_XML_ATTR_DELAYED)) != nullptr)
   {
     if (!StringUtils::EqualsNoCase(strTmp, "false") && !StringUtils::EqualsNoCase(strTmp, "true"))
     {

--- a/xbmc/settings/lib/ISettingControl.h
+++ b/xbmc/settings/lib/ISettingControl.h
@@ -26,10 +26,8 @@ class TiXmlNode;
 class ISettingControl
 {
 public:
-  ISettingControl()
-    : m_delayed(false)
-  { }
-  virtual ~ISettingControl() { }
+  ISettingControl() = default;
+  virtual ~ISettingControl() = default;
 
   virtual std::string GetType() const = 0;
   const std::string& GetFormat() const { return m_format; }
@@ -40,6 +38,6 @@ public:
   virtual bool SetFormat(const std::string &format) { return true; }
 
 protected:
-  bool m_delayed;
+  bool m_delayed = false;
   std::string m_format;
 };

--- a/xbmc/settings/lib/ISettingCreator.h
+++ b/xbmc/settings/lib/ISettingCreator.h
@@ -32,7 +32,7 @@ class CSettingsManager;
 class ISettingCreator
 {
 public:
-  virtual ~ISettingCreator() { }
+  virtual ~ISettingCreator() = default;
 
   /*!
    \brief Creates a new setting of the given custom setting type.
@@ -40,7 +40,7 @@ public:
    \param settingType string representation of the setting type
    \param settingId Identifier of the setting to be created
    \param settingsManager Reference to the settings manager
-   \return A new setting object of the given (custom) setting type or NULL if the setting type is unknown
+   \return A new setting object of the given (custom) setting type or nullptr if the setting type is unknown
    */
-  virtual std::shared_ptr<CSetting> CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const = 0;
+  virtual std::shared_ptr<CSetting> CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = nullptr) const = 0;
 };

--- a/xbmc/settings/lib/ISettingsHandler.h
+++ b/xbmc/settings/lib/ISettingsHandler.h
@@ -27,7 +27,7 @@
 class ISettingsHandler
 {
 public:
-  virtual ~ISettingsHandler() { }
+  virtual ~ISettingsHandler() = default;
 
   /*!
    \brief Settings loading has been initiated.

--- a/xbmc/settings/lib/ISubSettings.h
+++ b/xbmc/settings/lib/ISubSettings.h
@@ -29,7 +29,7 @@ class TiXmlNode;
 class ISubSettings
 {
 public:
-  virtual ~ISubSettings() { }
+  virtual ~ISubSettings() = default;
 
   /*!
    \brief Load settings from the given XML node.

--- a/xbmc/settings/lib/SettingCategoryAccess.cpp
+++ b/xbmc/settings/lib/SettingCategoryAccess.cpp
@@ -27,7 +27,7 @@ bool CSettingCategoryAccessCondition::Check() const
   if (m_value.empty())
     return true;
 
-  if (m_settingsManager == NULL)
+  if (m_settingsManager == nullptr)
     return false;
 
   bool found = m_settingsManager->GetConditions().Check(m_value, "true");
@@ -45,7 +45,7 @@ bool CSettingCategoryAccessConditionCombination::Check() const
   return CSettingConditionCombination::Check();
 }
 
-CSettingCategoryAccess::CSettingCategoryAccess(CSettingsManager *settingsManager /* = NULL */)
+CSettingCategoryAccess::CSettingCategoryAccess(CSettingsManager *settingsManager /* = nullptr */)
   : CSettingCondition(settingsManager)
 {
   m_operation = CBooleanLogicOperationPtr(new CSettingCategoryAccessConditionCombination(m_settingsManager));

--- a/xbmc/settings/lib/SettingCategoryAccess.h
+++ b/xbmc/settings/lib/SettingCategoryAccess.h
@@ -27,10 +27,10 @@
 class CSettingCategoryAccessCondition : public CSettingConditionItem
 {
 public:
-  CSettingCategoryAccessCondition(CSettingsManager *settingsManager = NULL)
+  CSettingCategoryAccessCondition(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionItem(settingsManager)
   { }
-  virtual ~CSettingCategoryAccessCondition() { }
+  virtual ~CSettingCategoryAccessCondition() = default;
 
   virtual bool Check() const;
 };
@@ -38,10 +38,10 @@ public:
 class CSettingCategoryAccessConditionCombination : public CSettingConditionCombination
 {
 public:
-  CSettingCategoryAccessConditionCombination(CSettingsManager *settingsManager = NULL)
+  CSettingCategoryAccessConditionCombination(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionCombination(settingsManager)
   { }
-  virtual ~CSettingCategoryAccessConditionCombination() { }
+  virtual ~CSettingCategoryAccessConditionCombination() = default;
 
   virtual bool Check() const;
 
@@ -53,6 +53,6 @@ private:
 class CSettingCategoryAccess : public CSettingCondition
 {
 public:
-  CSettingCategoryAccess(CSettingsManager *settingsManager = NULL);
-  virtual ~CSettingCategoryAccess() { }
+  CSettingCategoryAccess(CSettingsManager *settingsManager = nullptr);
+  virtual ~CSettingCategoryAccess() = default;
 };

--- a/xbmc/settings/lib/SettingConditions.h
+++ b/xbmc/settings/lib/SettingConditions.h
@@ -30,7 +30,7 @@
 class CSettingsManager;
 class CSetting;
 
-typedef bool (*SettingConditionCheck)(const std::string &condition, const std::string &value, std::shared_ptr<const CSetting> setting, void *data);
+using SettingConditionCheck = bool (*)(const std::string &condition, const std::string &value, std::shared_ptr<const CSetting> setting, void *data);
 
 class ISettingCondition
 {
@@ -38,7 +38,7 @@ public:
   ISettingCondition(CSettingsManager *settingsManager)
     : m_settingsManager(settingsManager)
   { }
-  virtual ~ISettingCondition() { }
+  virtual ~ISettingCondition() = default;
 
   virtual bool Check() const = 0;
 
@@ -49,10 +49,10 @@ protected:
 class CSettingConditionItem : public CBooleanLogicValue, public ISettingCondition
 {
 public:
-  CSettingConditionItem(CSettingsManager *settingsManager = NULL)
+  CSettingConditionItem(CSettingsManager *settingsManager = nullptr)
     : ISettingCondition(settingsManager)
   { }
-  virtual ~CSettingConditionItem() { }
+  virtual ~CSettingConditionItem() = default;
   
   virtual bool Deserialize(const TiXmlNode *node);
   virtual const char* GetTag() const { return SETTING_XML_ELM_CONDITION; }
@@ -66,10 +66,10 @@ protected:
 class CSettingConditionCombination : public CBooleanLogicOperation, public ISettingCondition
 {
 public:
-  CSettingConditionCombination(CSettingsManager *settingsManager = NULL)
+  CSettingConditionCombination(CSettingsManager *settingsManager = nullptr)
     : ISettingCondition(settingsManager)
   { }
-  virtual ~CSettingConditionCombination() { }
+  virtual ~CSettingConditionCombination() = default;
 
   virtual bool Check() const;
 
@@ -81,8 +81,8 @@ private:
 class CSettingCondition : public CBooleanLogic, public ISettingCondition
 {
 public:
-  CSettingCondition(CSettingsManager *settingsManager = NULL);
-  virtual ~CSettingCondition() { }
+  CSettingCondition(CSettingsManager *settingsManager = nullptr);
+  virtual ~CSettingCondition() = default;
 
   virtual bool Check() const;
 };
@@ -90,20 +90,19 @@ public:
 class CSettingConditionsManager
 {
 public:
-  CSettingConditionsManager();
-  virtual ~CSettingConditionsManager();
+  CSettingConditionsManager() = default;
+  CSettingConditionsManager(const CSettingConditionsManager&) = delete;
+  CSettingConditionsManager const& operator=(CSettingConditionsManager const&) = delete;
+  virtual ~CSettingConditionsManager() = default;
 
-  void AddCondition(const std::string &condition);
-  void AddCondition(const std::string &identifier, SettingConditionCheck condition, void *data = NULL);
+  void AddCondition(std::string condition);
+  void AddCondition(std::string identifier, SettingConditionCheck condition, void *data = nullptr);
 
-  bool Check(const std::string &condition, const std::string &value = "", std::shared_ptr<const CSetting> setting = std::shared_ptr<const CSetting>()) const;
+  bool Check(std::string condition, const std::string &value = "", std::shared_ptr<const CSetting> setting = std::shared_ptr<const CSetting>()) const;
 
 private:
-  CSettingConditionsManager(const CSettingConditionsManager&);
-  CSettingConditionsManager const& operator=(CSettingConditionsManager const&);
-  
-  typedef std::pair<std::string, std::pair<SettingConditionCheck, void*> > SettingConditionPair;
-  typedef std::map<std::string, std::pair<SettingConditionCheck, void*> > SettingConditionMap;
+  using SettingConditionPair = std::pair<std::string, std::pair<SettingConditionCheck, void*>>;
+  using SettingConditionMap = std::map<std::string, std::pair<SettingConditionCheck, void*>>;
 
   SettingConditionMap m_conditions;
   std::set<std::string> m_defines;

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -24,60 +24,60 @@
 #include <utility>
 #include <vector>
 
-#define SETTING_XML_ROOT              "settings"
-#define SETTING_XML_ROOT_VERSION      "version"
+#define SETTING_XML_ROOT "settings"
+#define SETTING_XML_ROOT_VERSION "version"
 
-#define SETTING_XML_ELM_SECTION       "section"
-#define SETTING_XML_ELM_CATEGORY      "category"
-#define SETTING_XML_ELM_GROUP         "group"
-#define SETTING_XML_ELM_SETTING       "setting"
-#define SETTING_XML_ELM_VISIBLE       "visible"
-#define SETTING_XML_ELM_REQUIREMENT   "requirement"
-#define SETTING_XML_ELM_CONDITION     "condition"
-#define SETTING_XML_ELM_LEVEL         "level"
-#define SETTING_XML_ELM_DEFAULT       "default"
-#define SETTING_XML_ELM_VALUE         "value"
-#define SETTING_XML_ELM_CONTROL       "control"
-#define SETTING_XML_ELM_CONSTRAINTS   "constraints"
-#define SETTING_XML_ELM_OPTIONS       "options"
-#define SETTING_XML_ELM_OPTION        "option"
-#define SETTING_XML_ELM_MINIMUM       "minimum"
-#define SETTING_XML_ELM_STEP          "step"
-#define SETTING_XML_ELM_MAXIMUM       "maximum"
-#define SETTING_XML_ELM_ALLOWEMPTY    "allowempty"
-#define SETTING_XML_ELM_DEPENDENCIES  "dependencies"
-#define SETTING_XML_ELM_DEPENDENCY    "dependency"
-#define SETTING_XML_ELM_UPDATES       "updates"
-#define SETTING_XML_ELM_UPDATE        "update"
-#define SETTING_XML_ELM_ACCESS        "access"
-#define SETTING_XML_ELM_DELIMITER     "delimiter"
+#define SETTING_XML_ELM_SECTION "section"
+#define SETTING_XML_ELM_CATEGORY "category"
+#define SETTING_XML_ELM_GROUP "group"
+#define SETTING_XML_ELM_SETTING "setting"
+#define SETTING_XML_ELM_VISIBLE "visible"
+#define SETTING_XML_ELM_REQUIREMENT "requirement"
+#define SETTING_XML_ELM_CONDITION "condition"
+#define SETTING_XML_ELM_LEVEL "level"
+#define SETTING_XML_ELM_DEFAULT "default"
+#define SETTING_XML_ELM_VALUE "value"
+#define SETTING_XML_ELM_CONTROL "control"
+#define SETTING_XML_ELM_CONSTRAINTS "constraints"
+#define SETTING_XML_ELM_OPTIONS "options"
+#define SETTING_XML_ELM_OPTION "option"
+#define SETTING_XML_ELM_MINIMUM "minimum"
+#define SETTING_XML_ELM_STEP "step"
+#define SETTING_XML_ELM_MAXIMUM "maximum"
+#define SETTING_XML_ELM_ALLOWEMPTY "allowempty"
+#define SETTING_XML_ELM_DEPENDENCIES "dependencies"
+#define SETTING_XML_ELM_DEPENDENCY "dependency"
+#define SETTING_XML_ELM_UPDATES "updates"
+#define SETTING_XML_ELM_UPDATE "update"
+#define SETTING_XML_ELM_ACCESS "access"
+#define SETTING_XML_ELM_DELIMITER "delimiter"
 #define SETTING_XML_ELM_MINIMUM_ITEMS "minimumitems"
 #define SETTING_XML_ELM_MAXIMUM_ITEMS "maximumitems"
-#define SETTING_XML_ELM_DATA          "data"
+#define SETTING_XML_ELM_DATA "data"
 
-#define SETTING_XML_ATTR_ID           "id"
-#define SETTING_XML_ATTR_LABEL        "label"
-#define SETTING_XML_ATTR_HELP         "help"
-#define SETTING_XML_ATTR_TYPE         "type"
-#define SETTING_XML_ATTR_PARENT       "parent"
-#define SETTING_XML_ATTR_FORMAT       "format"
-#define SETTING_XML_ATTR_DELAYED      "delayed"
-#define SETTING_XML_ATTR_ON           "on"
-#define SETTING_XML_ATTR_OPERATOR     "operator"
-#define SETTING_XML_ATTR_NAME         "name"
-#define SETTING_XML_ATTR_SETTING      "setting"
-#define SETTING_XML_ATTR_BEFORE       "before"
-#define SETTING_XML_ATTR_AFTER        "after"
+#define SETTING_XML_ATTR_ID "id"
+#define SETTING_XML_ATTR_LABEL "label"
+#define SETTING_XML_ATTR_HELP "help"
+#define SETTING_XML_ATTR_TYPE "type"
+#define SETTING_XML_ATTR_PARENT "parent"
+#define SETTING_XML_ATTR_FORMAT "format"
+#define SETTING_XML_ATTR_DELAYED "delayed"
+#define SETTING_XML_ATTR_ON "on"
+#define SETTING_XML_ATTR_OPERATOR "operator"
+#define SETTING_XML_ATTR_NAME "name"
+#define SETTING_XML_ATTR_SETTING "setting"
+#define SETTING_XML_ATTR_BEFORE "before"
+#define SETTING_XML_ATTR_AFTER "after"
 
-typedef std::pair<int, int> TranslatableIntegerSettingOption;
-typedef std::vector<TranslatableIntegerSettingOption> TranslatableIntegerSettingOptions;
-typedef std::pair<std::string, int> IntegerSettingOption;
-typedef std::vector<IntegerSettingOption> IntegerSettingOptions;
-typedef std::pair<int, std::string> TranslatableStringSettingOption;
-typedef std::vector<TranslatableStringSettingOption> TranslatableStringSettingOptions;
-typedef std::pair<std::string, std::string> StringSettingOption;
-typedef std::vector<StringSettingOption> StringSettingOptions;
+using TranslatableIntegerSettingOption = std::pair<int, int>;
+using TranslatableIntegerSettingOptions = std::vector<TranslatableIntegerSettingOption>;
+using IntegerSettingOption = std::pair<std::string, int>;
+using IntegerSettingOptions = std::vector<IntegerSettingOption>;
+using TranslatableStringSettingOption = std::pair<int, std::string>;
+using TranslatableStringSettingOptions = std::vector<TranslatableStringSettingOption>;
+using StringSettingOption = std::pair<std::string, std::string>;
+using StringSettingOptions = std::vector<StringSettingOption>;
 
 class CSetting;
-typedef void (*IntegerSettingOptionsFiller)(std::shared_ptr<const CSetting> setting, IntegerSettingOptions &list, int &current, void *data);
-typedef void (*StringSettingOptionsFiller)(std::shared_ptr<const CSetting> setting, StringSettingOptions &list, std::string &current, void *data);
+using IntegerSettingOptionsFiller = void (*)(std::shared_ptr<const CSetting> setting, IntegerSettingOptions &list, int &current, void *data);
+using StringSettingOptionsFiller = void (*)(std::shared_ptr<const CSetting> setting, StringSettingOptions &list, std::string &current, void *data);

--- a/xbmc/settings/lib/SettingDependency.h
+++ b/xbmc/settings/lib/SettingDependency.h
@@ -26,38 +26,38 @@
 #include "SettingConditions.h"
 #include "utils/BooleanLogic.h"
 
-typedef enum {
-  SettingDependencyTypeNone   = 0,
-  SettingDependencyTypeEnable,
-  SettingDependencyTypeUpdate,
-  SettingDependencyTypeVisible
-} SettingDependencyType;
+enum class SettingDependencyType {
+  Unknown = 0,
+  Enable,
+  Update,
+  Visible
+};
 
-typedef enum {
-  SettingDependencyOperatorNone     = 0,
-  SettingDependencyOperatorEquals,
-  SettingDependencyOperatorLessThan,
-  SettingDependencyOperatorGreaterThan,
-  SettingDependencyOperatorContains
-} SettingDependencyOperator;
+enum class SettingDependencyOperator {
+  Unknown = 0,
+  Equals,
+  LessThan,
+  GreaterThan,
+  Contains
+};
 
-typedef enum {
-  SettingDependencyTargetNone     = 0,
-  SettingDependencyTargetSetting,
-  SettingDependencyTargetProperty
-} SettingDependencyTarget;
+enum class SettingDependencyTarget {
+  Unknown = 0,
+  Setting,
+  Property
+};
 
 class CSettingDependencyCondition : public CSettingConditionItem
 {
 public:
-  explicit CSettingDependencyCondition(CSettingsManager *settingsManager = NULL);
+  explicit CSettingDependencyCondition(CSettingsManager *settingsManager = nullptr);
   CSettingDependencyCondition(const std::string &setting, const std::string &value,
                               SettingDependencyOperator op, bool negated = false,
-                              CSettingsManager *settingsManager = NULL);
+                              CSettingsManager *settingsManager = nullptr);
   CSettingDependencyCondition(const std::string &strProperty, const std::string &value,
                               const std::string &setting = "", bool negated = false,
-                              CSettingsManager *settingsManager = NULL);
-  virtual ~CSettingDependencyCondition() { }
+                              CSettingsManager *settingsManager = nullptr);
+  virtual ~CSettingDependencyCondition() = default;
 
   virtual bool Deserialize(const TiXmlNode *node);
   virtual bool Check() const;
@@ -71,27 +71,27 @@ private:
   bool setTarget(const std::string &target);
   bool setOperator(const std::string &op);
   
-  SettingDependencyTarget m_target;
-  SettingDependencyOperator m_operator;
+  SettingDependencyTarget m_target = SettingDependencyTarget::Unknown;
+  SettingDependencyOperator m_operator = SettingDependencyOperator::Equals;
 };
 
-typedef std::shared_ptr<CSettingDependencyCondition> CSettingDependencyConditionPtr;
+using CSettingDependencyConditionPtr = std::shared_ptr<CSettingDependencyCondition>;
 
 class CSettingDependencyConditionCombination;
-typedef std::shared_ptr<CSettingDependencyConditionCombination> CSettingDependencyConditionCombinationPtr;
+using CSettingDependencyConditionCombinationPtr = std::shared_ptr<CSettingDependencyConditionCombination>;
 
 class CSettingDependencyConditionCombination : public CSettingConditionCombination
 {
 public:
-  explicit CSettingDependencyConditionCombination(CSettingsManager *settingsManager = NULL)
+  explicit CSettingDependencyConditionCombination(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionCombination(settingsManager)
   { }
-  CSettingDependencyConditionCombination(BooleanLogicOperation op, CSettingsManager *settingsManager = NULL)
+  CSettingDependencyConditionCombination(BooleanLogicOperation op, CSettingsManager *settingsManager = nullptr)
     : CSettingConditionCombination(settingsManager)
   {
     SetOperation(op);
   }
-  virtual ~CSettingDependencyConditionCombination() { }
+  virtual ~CSettingDependencyConditionCombination() = default;
 
   virtual bool Deserialize(const TiXmlNode *node);
 
@@ -110,9 +110,9 @@ private:
 class CSettingDependency : public CSettingCondition
 {
 public:
-  explicit CSettingDependency(CSettingsManager *settingsManager = NULL);
-  CSettingDependency(SettingDependencyType type, CSettingsManager *settingsManager = NULL);
-  virtual ~CSettingDependency() { }
+  explicit CSettingDependency(CSettingsManager *settingsManager = nullptr);
+  CSettingDependency(SettingDependencyType type, CSettingsManager *settingsManager = nullptr);
+  virtual ~CSettingDependency() = default;
 
   virtual bool Deserialize(const TiXmlNode *node);
 
@@ -125,8 +125,8 @@ public:
 private:
   bool setType(const std::string &type);
 
-  SettingDependencyType m_type;
+  SettingDependencyType m_type = SettingDependencyType::Unknown;
 };
 
-typedef std::list<CSettingDependency> SettingDependencies;
-typedef std::map<std::string, SettingDependencies> SettingDependencyMap;
+using SettingDependencies = std::list<CSettingDependency>;
+using SettingDependencyMap = std::map<std::string, SettingDependencies>;

--- a/xbmc/settings/lib/SettingLevel.h
+++ b/xbmc/settings/lib/SettingLevel.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2013 Team XBMC
+ *      Copyright (C) 2017 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,25 +19,14 @@
  *
  */
 
-#include <memory>
-#include <string>
-
-class ISettingControl;
-
 /*!
  \ingroup settings
- \brief Interface for creating a new setting control of a custom setting control type.
+ \brief Levels which every setting is assigned to.
  */
-class ISettingControlCreator
-{
-public:
-  virtual ~ISettingControlCreator() = default;
-
-  /*!
-   \brief Creates a new setting control of the given custom setting control type.
-
-   \param controlType string representation of the setting control type
-   \return A new setting control object of the given (custom) setting control type or nullptr if the setting control type is unknown
-   */
-  virtual std::shared_ptr<ISettingControl> CreateControl(const std::string &controlType) const = 0;
+enum class SettingLevel {
+  Basic = 0,
+  Standard,
+  Advanced,
+  Expert,
+  Internal
 };

--- a/xbmc/settings/lib/SettingRequirement.cpp
+++ b/xbmc/settings/lib/SettingRequirement.cpp
@@ -23,7 +23,7 @@
 
 bool CSettingRequirementCondition::Check() const
 {
-  if (m_settingsManager == NULL)
+  if (m_settingsManager == nullptr)
     return false;
 
   bool found = m_settingsManager->GetConditions().Check("IsDefined", m_value);
@@ -41,7 +41,7 @@ bool CSettingRequirementConditionCombination::Check() const
   return CSettingConditionCombination::Check();
 }
 
-CSettingRequirement::CSettingRequirement(CSettingsManager *settingsManager /* = NULL */)
+CSettingRequirement::CSettingRequirement(CSettingsManager *settingsManager /* = nullptr */)
   : CSettingCondition(settingsManager)
 {
   m_operation = CBooleanLogicOperationPtr(new CSettingRequirementConditionCombination(m_settingsManager));

--- a/xbmc/settings/lib/SettingRequirement.h
+++ b/xbmc/settings/lib/SettingRequirement.h
@@ -27,10 +27,10 @@
 class CSettingRequirementCondition : public CSettingConditionItem
 {
 public:
-  CSettingRequirementCondition(CSettingsManager *settingsManager = NULL)
+  CSettingRequirementCondition(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionItem(settingsManager)
   { }
-  virtual ~CSettingRequirementCondition() { }
+  virtual ~CSettingRequirementCondition() = default;
 
   virtual bool Check() const;
 };
@@ -38,10 +38,10 @@ public:
 class CSettingRequirementConditionCombination : public CSettingConditionCombination
 {
 public:
-  CSettingRequirementConditionCombination(CSettingsManager *settingsManager = NULL)
+  CSettingRequirementConditionCombination(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionCombination(settingsManager)
   { }
-  virtual ~CSettingRequirementConditionCombination() { }
+  virtual ~CSettingRequirementConditionCombination() = default;
 
   virtual bool Check() const;
 
@@ -53,6 +53,6 @@ private:
 class CSettingRequirement : public CSettingCondition
 {
 public:
-  CSettingRequirement(CSettingsManager *settingsManager = NULL);
-  virtual ~CSettingRequirement() { }
+  CSettingRequirement(CSettingsManager *settingsManager = nullptr);
+  virtual ~CSettingRequirement() = default;
 };

--- a/xbmc/settings/lib/SettingSection.h
+++ b/xbmc/settings/lib/SettingSection.h
@@ -43,8 +43,8 @@ public:
    \param id Identifier of the setting group
    \param settingsManager Reference to the settings manager
    */
-  CSettingGroup(const std::string &id, CSettingsManager *settingsManager = NULL);
-  ~CSettingGroup();
+  CSettingGroup(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  ~CSettingGroup() = default;
 
   // implementation of ISetting
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -79,8 +79,8 @@ private:
   std::shared_ptr<ISettingControl> m_control;
 };
 
-typedef std::shared_ptr<CSettingGroup> SettingGroupPtr;
-typedef std::vector<SettingGroupPtr> SettingGroupList;
+using SettingGroupPtr = std::shared_ptr<CSettingGroup>;
+using SettingGroupList = std::vector<SettingGroupPtr>;
 
 /*!
  \ingroup settings
@@ -97,8 +97,8 @@ public:
    \param id Identifier of the setting category
    \param settingsManager Reference to the settings manager
    */
-  CSettingCategory(const std::string &id, CSettingsManager *settingsManager = NULL);
-  ~CSettingCategory();
+  CSettingCategory(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  ~CSettingCategory() = default;
 
   // implementation of ISetting
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -135,8 +135,8 @@ private:
   CSettingCategoryAccess m_accessCondition;
 };
 
-typedef std::shared_ptr<CSettingCategory> SettingCategoryPtr;
-typedef std::vector<SettingCategoryPtr> SettingCategoryList;
+using SettingCategoryPtr = std::shared_ptr<CSettingCategory>;
+using SettingCategoryList = std::vector<SettingCategoryPtr>;
 
 /*!
  \ingroup settings
@@ -153,8 +153,8 @@ public:
    \param id Identifier of the setting section
    \param settingsManager Reference to the settings manager
    */
-  CSettingSection(const std::string &id, CSettingsManager *settingsManager = NULL);
-  ~CSettingSection();
+  CSettingSection(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  ~CSettingSection() = default;
 
   // implementation of ISetting
   virtual bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -183,5 +183,5 @@ private:
   SettingCategoryList m_categories;
 };
 
-typedef std::shared_ptr<CSettingSection> SettingSectionPtr;
-typedef std::vector<SettingSectionPtr> SettingSectionList;
+using SettingSectionPtr = std::shared_ptr<CSettingSection>;
+using SettingSectionList = std::vector<SettingSectionPtr>;

--- a/xbmc/settings/lib/SettingType.h
+++ b/xbmc/settings/lib/SettingType.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2013 Team XBMC
+ *      Copyright (C) 2017 Team XBMC
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,25 +19,17 @@
  *
  */
 
-#include <memory>
-#include <string>
-
-class ISettingControl;
-
 /*!
  \ingroup settings
- \brief Interface for creating a new setting control of a custom setting control type.
+ \brief Basic setting types available in the settings system.
  */
-class ISettingControlCreator
-{
-public:
-  virtual ~ISettingControlCreator() = default;
-
-  /*!
-   \brief Creates a new setting control of the given custom setting control type.
-
-   \param controlType string representation of the setting control type
-   \return A new setting control object of the given (custom) setting control type or nullptr if the setting control type is unknown
-   */
-  virtual std::shared_ptr<ISettingControl> CreateControl(const std::string &controlType) const = 0;
+enum class SettingType {
+  Unknown = 0,
+  Boolean,
+  Integer,
+  Number,
+  String,
+  Action,
+  List,
+  Reference
 };

--- a/xbmc/settings/lib/SettingUpdate.cpp
+++ b/xbmc/settings/lib/SettingUpdate.cpp
@@ -24,34 +24,25 @@
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 
-CSettingUpdate::CSettingUpdate()
-  : m_type(SettingUpdateTypeNone)
-{ }
-
-bool CSettingUpdate::operator<(const CSettingUpdate& rhs) const
-{
-  return m_type < rhs.m_type && m_value < rhs.m_value;
-}
-
 bool CSettingUpdate::Deserialize(const TiXmlNode *node)
 {
-  if (node == NULL)
+  if (node == nullptr)
     return false;
 
-  const TiXmlElement *elem = node->ToElement();
-  if (elem == NULL)
+  auto elem = node->ToElement();
+  if (elem == nullptr)
     return false;
   
-  const char *strType = elem->Attribute(SETTING_XML_ATTR_TYPE);
-  if (strType == NULL || strlen(strType) <= 0 || !setType(strType))
+  auto strType = elem->Attribute(SETTING_XML_ATTR_TYPE);
+  if (strType == nullptr || strlen(strType) <= 0 || !setType(strType))
   {
     CLog::Log(LOGWARNING, "CSettingUpdate: missing or unknown update type definition");
     return false;
   }
 
-  if (m_type == SettingUpdateTypeRename)
+  if (m_type == SettingUpdateType::Rename)
   {
-    if (node->FirstChild() == NULL || node->FirstChild()->Type() != TiXmlNode::TINYXML_TEXT)
+    if (node->FirstChild() == nullptr || node->FirstChild()->Type() != TiXmlNode::TINYXML_TEXT)
     {
       CLog::Log(LOGWARNING, "CSettingUpdate: missing or invalid setting id for rename update definition");
       return false;
@@ -66,9 +57,9 @@ bool CSettingUpdate::Deserialize(const TiXmlNode *node)
 bool CSettingUpdate::setType(const std::string &type)
 {
   if (StringUtils::EqualsNoCase(type, "change"))
-    m_type = SettingUpdateTypeChange;
+    m_type = SettingUpdateType::Change;
   else if (StringUtils::EqualsNoCase(type, "rename"))
-    m_type = SettingUpdateTypeRename;
+    m_type = SettingUpdateType::Rename;
   else
     return false;
 

--- a/xbmc/settings/lib/SettingUpdate.h
+++ b/xbmc/settings/lib/SettingUpdate.h
@@ -23,19 +23,22 @@
 
 class TiXmlNode;
 
-typedef enum {
-  SettingUpdateTypeNone   = 0,
-  SettingUpdateTypeRename,
-  SettingUpdateTypeChange
-} SettingUpdateType;
+enum class SettingUpdateType {
+  Unknown = 0,
+  Rename,
+  Change
+};
 
 class CSettingUpdate
 {
 public:
-  CSettingUpdate();
-  virtual ~CSettingUpdate() { }
+  CSettingUpdate() = default;
+  virtual ~CSettingUpdate() = default;
 
-  bool operator<(const CSettingUpdate& rhs) const;
+  inline bool operator<(const CSettingUpdate& rhs) const
+  {
+    return m_type < rhs.m_type && m_value < rhs.m_value;
+  }
 
   virtual bool Deserialize(const TiXmlNode *node);
 
@@ -45,6 +48,6 @@ public:
 private:
   bool setType(const std::string &type);
 
-  SettingUpdateType m_type;
+  SettingUpdateType m_type = SettingUpdateType::Unknown;
   std::string m_value;
 };

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -48,21 +48,21 @@ class TiXmlNode;
  all settings.
  */
 class CSettingsManager : public ISettingCreator, public ISettingControlCreator,
-                         private ISettingCallback,
-                         private ISettingsHandler, private ISubSettings
+                         private ISettingCallback, private ISettingsHandler,
+                         private ISubSettings
 {
 public:
   /*!
    \brief Creates a new (uninitialized) settings manager.
    */
-  CSettingsManager();
+  CSettingsManager() = default;
   virtual ~CSettingsManager();
 
   static const uint32_t Version = 1;
   static const uint32_t MinimumSupportedVersion = 0;
 
   // implementation of ISettingCreator
-  virtual std::shared_ptr<CSetting> CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = NULL) const override;
+  virtual std::shared_ptr<CSetting> CreateSetting(const std::string &settingType, const std::string &settingId, CSettingsManager *settingsManager = nullptr) const override;
 
   // implementation of ISettingControlCreator
   virtual std::shared_ptr<ISettingControl> CreateControl(const std::string &controlType) const override;
@@ -92,7 +92,7 @@ public:
    \param loadedSettings A list to fill with all the successfully loaded settings
    \return True if the setting values were successfully loaded, false otherwise
    */
-  bool Load(const TiXmlElement *root, bool &updated, bool triggerEvents = true, std::map<std::string, std::shared_ptr<CSetting>> *loadedSettings = NULL);
+  bool Load(const TiXmlElement *root, bool &updated, bool triggerEvents = true, std::map<std::string, std::shared_ptr<CSetting>> *loadedSettings = nullptr);
   /*!
    \brief Saves the setting values to the given XML node.
 
@@ -289,7 +289,7 @@ public:
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier
-   \return Setting object with the given identifier or NULL if the identifier is unknown
+   \return Setting object with the given identifier or nullptr if the identifier is unknown
    */
   std::shared_ptr<CSetting> GetSetting(const std::string &id) const;
   /*!
@@ -302,9 +302,9 @@ public:
    \brief Gets the setting section with the given identifier.
 
    \param section Setting section identifier
-   \return Setting section with the given identifier or NULL if the identifier is unknown
+   \return Setting section with the given identifier or nullptr if the identifier is unknown
    */
-  std::shared_ptr<CSettingSection> GetSection(const std::string &section) const;
+  std::shared_ptr<CSettingSection> GetSection(std::string section) const;
   /*!
    \brief Gets a map of settings (and their dependencies) which depend on
    the setting with the given identifier.
@@ -452,7 +452,7 @@ public:
    \param condition Implementation of the dynamic condition
    \param data Opaque data pointer, will be passed back to SettingConditionCheck function
    */
-  void AddCondition(const std::string &identifier, SettingConditionCheck condition, void *data = NULL);
+  void AddCondition(const std::string &identifier, SettingConditionCheck condition, void *data = nullptr);
 
 private:
   // implementation of ISettingCallback
@@ -474,7 +474,7 @@ private:
   virtual bool Load(const TiXmlNode *settings) override;
 
   bool Serialize(TiXmlNode *parent) const;
-  bool Deserialize(const TiXmlNode *node, bool &updated, std::map<std::string, std::shared_ptr<CSetting>> *loadedSettings = NULL);
+  bool Deserialize(const TiXmlNode *node, bool &updated, std::map<std::string, std::shared_ptr<CSetting>> *loadedSettings = nullptr);
 
   bool LoadSetting(const TiXmlNode *node, std::shared_ptr<CSetting> setting, bool &updated);
   bool UpdateSetting(const TiXmlNode *node, std::shared_ptr<CSetting> setting, const CSettingUpdate& update);
@@ -486,55 +486,55 @@ private:
   void ResolveReferenceSettings(std::shared_ptr<CSettingSection> section);
   void CleanupIncompleteSettings();
 
-  typedef enum {
-    SettingOptionsFillerTypeNone = 0,
-    SettingOptionsFillerTypeInteger,
-    SettingOptionsFillerTypeString
-  } SettingOptionsFillerType;
+  enum class SettingOptionsFillerType {
+    Unknown = 0,
+    Integer,
+    String
+  };
 
   void RegisterSettingOptionsFiller(const std::string &identifier, void *filler, SettingOptionsFillerType type);
 
-  typedef std::set<ISettingCallback *> CallbackSet;
-  typedef struct {
+  using CallbackSet = std::set<ISettingCallback *>;
+  struct Setting {
     std::shared_ptr<CSetting> setting;
     SettingDependencyMap dependencies;
     std::set<std::string> children;
     CallbackSet callbacks;
-  } Setting;
+  };
 
-  typedef std::map<std::string, Setting> SettingMap;
+  using SettingMap = std::map<std::string, Setting>;
 
   void ResolveSettingDependencies(std::shared_ptr<CSetting> setting);
-  void ResolveSettingDependencies(SettingMap::iterator settingIterator);
+  void ResolveSettingDependencies(const Setting& setting);
 
   SettingMap::const_iterator FindSetting(std::string settingId) const;
   SettingMap::iterator FindSetting(std::string settingId);
   std::pair<SettingMap::iterator, bool> InsertSetting(std::string settingId, const Setting& setting);
 
-  bool m_initialized;
-  bool m_loaded;
+  bool m_initialized = false;
+  bool m_loaded = false;
 
   SettingMap m_settings;
-  typedef std::map<std::string, std::shared_ptr<CSettingSection>> SettingSectionMap;
+  using SettingSectionMap = std::map<std::string, std::shared_ptr<CSettingSection>>;
   SettingSectionMap m_sections;
 
-  typedef std::map<std::string, ISettingCreator*> SettingCreatorMap;
+  using SettingCreatorMap = std::map<std::string, ISettingCreator*>;
   SettingCreatorMap m_settingCreators;
 
-  typedef std::map<std::string, ISettingControlCreator*> SettingControlCreatorMap;
+  using SettingControlCreatorMap = std::map<std::string, ISettingControlCreator*>;
   SettingControlCreatorMap m_settingControlCreators;
 
   std::set<ISubSettings*> m_subSettings;
-  typedef std::vector<ISettingsHandler*> SettingsHandlers;
+  using SettingsHandlers = std::vector<ISettingsHandler*>;
   SettingsHandlers m_settingsHandlers;
 
   CSettingConditionsManager m_conditions;
 
-  typedef struct {
+  struct SettingOptionsFiller {
     void *filler;
     SettingOptionsFillerType type;
-  } SettingOptionsFiller;
-  typedef std::map<std::string, SettingOptionsFiller> SettingOptionsFillerMap;
+  };
+  using SettingOptionsFillerMap = std::map<std::string, SettingOptionsFiller>;
   SettingOptionsFillerMap m_optionsFillers;
 
   CSharedSection m_critical;

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -77,15 +77,15 @@ static CFileItemPtr GetFileItem(const std::string& label, const TValueType& valu
 static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& options, std::set<int>& selectedOptions, ILocalizer* localizer)
 {
   std::shared_ptr<const CSettingInt> pSettingInt = NULL;
-  if (setting->GetType() == SettingTypeInteger)
+  if (setting->GetType() == SettingType::Integer)
   {
     pSettingInt = std::static_pointer_cast<const CSettingInt>(setting);
     selectedOptions.insert(pSettingInt->GetValue());
   }
-  else if (setting->GetType() == SettingTypeList)
+  else if (setting->GetType() == SettingType::List)
   {
     std::shared_ptr<const CSettingList> settingList = std::static_pointer_cast<const CSettingList>(setting);
-    if (settingList->GetElementType() != SettingTypeInteger)
+    if (settingList->GetElementType() != SettingType::Integer)
       return false;
 
     pSettingInt = std::static_pointer_cast<const CSettingInt>(settingList->GetDefinition());
@@ -102,7 +102,7 @@ static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& op
 
   switch (pSettingInt->GetOptionsType())
   {
-    case SettingOptionsTypeStaticTranslatable:
+    case SettingOptionsType::StaticTranslatable:
     {
       const TranslatableIntegerSettingOptions& settingOptions = pSettingInt->GetTranslatableOptions();
       for (const auto& option : settingOptions)
@@ -110,21 +110,21 @@ static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& op
       break;
     }
 
-    case SettingOptionsTypeStatic:
+    case SettingOptionsType::Static:
     {
       const IntegerSettingOptions& settingOptions = pSettingInt->GetOptions();
       options.insert(options.end(), settingOptions.begin(), settingOptions.end());
       break;
     }
 
-    case SettingOptionsTypeDynamic:
+    case SettingOptionsType::Dynamic:
     {
       IntegerSettingOptions settingOptions = std::const_pointer_cast<CSettingInt>(pSettingInt)->UpdateDynamicOptions();
       options.insert(options.end(), settingOptions.begin(), settingOptions.end());
       break;
     }
 
-    case SettingOptionsTypeNone:
+    case SettingOptionsType::Unknown:
     default:
     {
       std::shared_ptr<const CSettingControlFormattedRange> control = std::static_pointer_cast<const CSettingControlFormattedRange>(pSettingInt->GetControl());
@@ -151,15 +151,15 @@ static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& op
 static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& options, std::set<std::string>& selectedOptions)
 {
   std::shared_ptr<const CSettingString> pSettingString = NULL;
-  if (setting->GetType() == SettingTypeString)
+  if (setting->GetType() == SettingType::String)
   {
     pSettingString = std::static_pointer_cast<const CSettingString>(setting);
     selectedOptions.insert(pSettingString->GetValue());
   }
-  else if (setting->GetType() == SettingTypeList)
+  else if (setting->GetType() == SettingType::List)
   {
     std::shared_ptr<const CSettingList>settingList = std::static_pointer_cast<const CSettingList>(setting);
-    if (settingList->GetElementType() != SettingTypeString)
+    if (settingList->GetElementType() != SettingType::String)
       return false;
 
     pSettingString = std::static_pointer_cast<const CSettingString>(settingList->GetDefinition());
@@ -176,7 +176,7 @@ static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& opti
 
   switch (pSettingString->GetOptionsType())
   {
-    case SettingOptionsTypeStaticTranslatable:
+    case SettingOptionsType::StaticTranslatable:
     {
       const TranslatableStringSettingOptions& settingOptions = pSettingString->GetTranslatableOptions();
       for (const auto& option : settingOptions)
@@ -184,21 +184,21 @@ static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& opti
       break;
     }
 
-    case SettingOptionsTypeStatic:
+    case SettingOptionsType::Static:
     {
       const StringSettingOptions& settingOptions = pSettingString->GetOptions();
       options.insert(options.end(), settingOptions.begin(), settingOptions.end());
       break;
     }
 
-    case SettingOptionsTypeDynamic:
+    case SettingOptionsType::Dynamic:
     {
       StringSettingOptions settingOptions = std::const_pointer_cast<CSettingString>(pSettingString)->UpdateDynamicOptions();
       options.insert(options.end(), settingOptions.begin(), settingOptions.end());
       break;
     }
 
-    case SettingOptionsTypeNone:
+    case SettingOptionsType::Unknown:
     default:
       return false;
   }
@@ -291,15 +291,15 @@ bool CGUIControlSpinExSetting::OnClick()
 
   switch (m_pSetting->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
       SetValid(std::static_pointer_cast<CSettingInt>(m_pSetting)->SetValue(m_pSpin->GetValue()));
       break;
 
-    case SettingTypeNumber:
+    case SettingType::Number:
       SetValid(std::static_pointer_cast<CSettingNumber>(m_pSetting)->SetValue(m_pSpin->GetFloatValue()));
       break;
     
-    case SettingTypeString:
+    case SettingType::String:
       SetValid(std::static_pointer_cast<CSettingString>(m_pSetting)->SetValue(m_pSpin->GetStringValue()));
       break;
     
@@ -350,9 +350,9 @@ void CGUIControlSpinExSetting::FillControl()
   {
     m_pSpin->SetType(SPIN_CONTROL_TYPE_TEXT);
 
-    if (m_pSetting->GetType() == SettingTypeInteger)
+    if (m_pSetting->GetType() == SettingType::Integer)
       FillIntegerSettingControl();
-    else if (m_pSetting->GetType() == SettingTypeString)
+    else if (m_pSetting->GetType() == SettingType::String)
     {
       StringSettingOptions options;
       std::set<std::string> selectedValues;
@@ -438,19 +438,19 @@ bool CGUIControlListSetting::OnClick()
   bool ret = false;
   switch (m_pSetting->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
       if (values.size() > 1)
         return false;
       ret = std::static_pointer_cast<CSettingInt>(m_pSetting)->SetValue((int)values.at(0).asInteger());
       break;
 
-    case SettingTypeString:
+    case SettingType::String:
       if (values.size() > 1)
         return false;
       ret = std::static_pointer_cast<CSettingString>(m_pSetting)->SetValue(values.at(0).asString());
       break;
 
-    case SettingTypeList:
+    case SettingType::List:
       ret = CSettingUtils::SetList(std::static_pointer_cast<CSettingList>(m_pSetting), values);
       break;
     
@@ -517,11 +517,11 @@ bool CGUIControlListSetting::GetItems(SettingConstPtr setting, CFileItemList &it
     return GetIntegerItems(setting, items);
   else if (controlFormat == "string")
   {
-    if (setting->GetType() == SettingTypeInteger ||
-       (setting->GetType() == SettingTypeList && std::static_pointer_cast<const CSettingList>(setting)->GetElementType() == SettingTypeInteger))
+    if (setting->GetType() == SettingType::Integer ||
+       (setting->GetType() == SettingType::List && std::static_pointer_cast<const CSettingList>(setting)->GetElementType() == SettingType::Integer))
       return GetIntegerItems(setting, items);
-    else if (setting->GetType() == SettingTypeString ||
-            (setting->GetType() == SettingTypeList && std::static_pointer_cast<const CSettingList>(setting)->GetElementType() == SettingTypeString))
+    else if (setting->GetType() == SettingType::String ||
+            (setting->GetType() == SettingType::List && std::static_pointer_cast<const CSettingList>(setting)->GetElementType() == SettingType::String))
       return GetStringItems(setting, items);
   }
   else
@@ -636,7 +636,7 @@ bool CGUIControlButtonSetting::OnClick()
   else if (controlType == "slider")
   {
     float value, min, step, max;
-    if (m_pSetting->GetType() == SettingTypeInteger)
+    if (m_pSetting->GetType() == SettingType::Integer)
     {
       std::shared_ptr<CSettingInt> settingInt = std::static_pointer_cast<CSettingInt>(m_pSetting);
       value = (float)settingInt->GetValue();
@@ -644,7 +644,7 @@ bool CGUIControlButtonSetting::OnClick()
       step = (float)settingInt->GetStep();
       max = (float)settingInt->GetMaximum();
     }
-    else if (m_pSetting->GetType() == SettingTypeNumber)
+    else if (m_pSetting->GetType() == SettingType::Number)
     {
       std::shared_ptr<CSettingNumber> settingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
       value = (float)settingNumber->GetValue();
@@ -684,7 +684,7 @@ void CGUIControlButtonSetting::Update(bool updateDisplayOnly /* = false */)
     {
       switch (m_pSetting->GetType())
       {
-      case SettingTypeString:
+      case SettingType::String:
       {
         std::string strValue = std::static_pointer_cast<CSettingString>(m_pSetting)->GetValue();
         if (controlFormat == "addon")
@@ -713,7 +713,7 @@ void CGUIControlButtonSetting::Update(bool updateDisplayOnly /* = false */)
         break;
       }
 
-      case SettingTypeAction:
+      case SettingType::Action:
       {
         // CSettingAction. 
         // Note: This can be removed once all settings use a proper control & format combination.
@@ -732,7 +732,7 @@ void CGUIControlButtonSetting::Update(bool updateDisplayOnly /* = false */)
   {
     switch (m_pSetting->GetType())
     {
-      case SettingTypeInteger:
+      case SettingType::Integer:
       {
         std::shared_ptr<const CSettingInt> settingInt = std::static_pointer_cast<CSettingInt>(m_pSetting);
         strText = CGUIControlSliderSetting::GetText(std::static_pointer_cast<const CSettingControlSlider>(m_pSetting->GetControl()),
@@ -740,7 +740,7 @@ void CGUIControlButtonSetting::Update(bool updateDisplayOnly /* = false */)
         break;
       }
 
-      case SettingTypeNumber:
+      case SettingType::Number:
       {
         std::shared_ptr<const CSettingNumber> settingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
         strText = CGUIControlSliderSetting::GetText(std::static_pointer_cast<const CSettingControlSlider>(m_pSetting->GetControl()),
@@ -806,7 +806,7 @@ void CGUIControlButtonSetting::OnSliderChange(void *data, CGUISliderControl *sli
   std::string strText;
   switch (m_pSetting->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
     {
       std::shared_ptr<CSettingInt> settingInt = std::static_pointer_cast<CSettingInt>(m_pSetting);
       if (settingInt->SetValue(slider->GetIntValue()))
@@ -815,7 +815,7 @@ void CGUIControlButtonSetting::OnSliderChange(void *data, CGUISliderControl *sli
       break;
     }
 
-    case SettingTypeNumber:
+    case SettingType::Number:
     {
       std::shared_ptr<CSettingNumber> settingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
       if (settingNumber->SetValue(static_cast<double>(slider->GetFloatValue())))
@@ -939,7 +939,7 @@ CGUIControlSliderSetting::CGUIControlSliderSetting(CGUISettingsSliderControl *pS
   
   switch (m_pSetting->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
     {
       std::shared_ptr<CSettingInt> settingInt = std::static_pointer_cast<CSettingInt>(m_pSetting);
       if (m_pSetting->GetControl()->GetFormat() == "percentage")
@@ -953,7 +953,7 @@ CGUIControlSliderSetting::CGUIControlSliderSetting(CGUISettingsSliderControl *pS
       break;
     }
 
-    case SettingTypeNumber:
+    case SettingType::Number:
     {
       std::shared_ptr<CSettingNumber> settingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
       m_pSlider->SetType(SLIDER_CONTROL_TYPE_FLOAT);
@@ -979,11 +979,11 @@ bool CGUIControlSliderSetting::OnClick()
 
   switch (m_pSetting->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
       SetValid(std::static_pointer_cast<CSettingInt>(m_pSetting)->SetValue(m_pSlider->GetIntValue()));
       break;
 
-    case SettingTypeNumber:
+    case SettingType::Number:
       SetValid(std::static_pointer_cast<CSettingNumber>(m_pSetting)->SetValue(m_pSlider->GetFloatValue()));
       break;
     
@@ -1004,7 +1004,7 @@ void CGUIControlSliderSetting::Update(bool updateDisplayOnly /* = false */)
   std::string strText;
   switch (m_pSetting->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
     {
       std::shared_ptr<const CSettingInt> settingInt = std::static_pointer_cast<CSettingInt>(m_pSetting);
       int value;
@@ -1021,7 +1021,7 @@ void CGUIControlSliderSetting::Update(bool updateDisplayOnly /* = false */)
       break;
     }
 
-    case SettingTypeNumber:
+    case SettingType::Number:
     {
       std::shared_ptr<const CSettingNumber> settingNumber = std::static_pointer_cast<CSettingNumber>(m_pSetting);
       double value;
@@ -1076,13 +1076,13 @@ CGUIControlRangeSetting::CGUIControlRangeSetting(CGUISettingsSliderControl *pSli
   m_pSlider->SetID(id);
   m_pSlider->SetRangeSelection(true);
   
-  if (m_pSetting->GetType() == SettingTypeList)
+  if (m_pSetting->GetType() == SettingType::List)
   {
     std::shared_ptr<CSettingList> settingList = std::static_pointer_cast<CSettingList>(m_pSetting);
     SettingConstPtr listDefintion = settingList->GetDefinition();
     switch (listDefintion->GetType())
     {
-      case SettingTypeInteger:
+      case SettingType::Integer:
       {
         std::shared_ptr<const CSettingInt> listDefintionInt = std::static_pointer_cast<const CSettingInt>(listDefintion);
         if (m_pSetting->GetControl()->GetFormat() == "percentage")
@@ -1096,7 +1096,7 @@ CGUIControlRangeSetting::CGUIControlRangeSetting(CGUISettingsSliderControl *pSli
         break;
       }
 
-      case SettingTypeNumber:
+      case SettingType::Number:
       {
         std::shared_ptr<const CSettingNumber> listDefinitionNumber = std::static_pointer_cast<const CSettingNumber>(listDefintion);
         m_pSlider->SetType(SLIDER_CONTROL_TYPE_FLOAT);
@@ -1119,7 +1119,7 @@ CGUIControlRangeSetting::~CGUIControlRangeSetting()
 bool CGUIControlRangeSetting::OnClick()
 {
   if (m_pSlider == NULL ||
-      m_pSetting->GetType() != SettingTypeList)
+      m_pSetting->GetType() != SettingType::List)
     return false;
 
   std::shared_ptr<CSettingList> settingList = std::static_pointer_cast<CSettingList>(m_pSetting);
@@ -1131,12 +1131,12 @@ bool CGUIControlRangeSetting::OnClick()
   SettingConstPtr listDefintion = settingList->GetDefinition();
   switch (listDefintion->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
       values.push_back(m_pSlider->GetIntValue(CGUISliderControl::RangeSelectorLower));
       values.push_back(m_pSlider->GetIntValue(CGUISliderControl::RangeSelectorUpper));
       break;
 
-    case SettingTypeNumber:
+    case SettingType::Number:
       values.push_back(m_pSlider->GetFloatValue(CGUISliderControl::RangeSelectorLower));
       values.push_back(m_pSlider->GetFloatValue(CGUISliderControl::RangeSelectorUpper));
       break;
@@ -1155,7 +1155,7 @@ bool CGUIControlRangeSetting::OnClick()
 void CGUIControlRangeSetting::Update(bool updateDisplayOnly /* = false */)
 {
   if (m_pSlider == NULL ||
-      m_pSetting->GetType() != SettingTypeList)
+      m_pSetting->GetType() != SettingType::List)
     return;
 
   CGUIControlBaseSetting::Update();
@@ -1178,7 +1178,7 @@ void CGUIControlRangeSetting::Update(bool updateDisplayOnly /* = false */)
 
   switch (listDefintion->GetType())
   {
-    case SettingTypeInteger:
+    case SettingType::Integer:
     {
       int valueLower, valueUpper;
       if (updateDisplayOnly)
@@ -1234,7 +1234,7 @@ void CGUIControlRangeSetting::Update(bool updateDisplayOnly /* = false */)
       break;
     }
 
-    case SettingTypeNumber:
+    case SettingType::Number:
     {
       double valueLower, valueUpper;
       if (updateDisplayOnly)

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -249,7 +249,7 @@ void CGUIDialogAudioSubtitleSettings::OnSettingAction(std::shared_ptr<const CSet
 
 void CGUIDialogAudioSubtitleSettings::Save()
 {
-  if (!g_passwordManager.CheckSettingLevelLock(SettingLevelExpert) &&
+  if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
       CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
@@ -325,9 +325,9 @@ void CGUIDialogAudioSubtitleSettings::InitializeSettings()
   // register IsPlayingPassthrough condition
   GetSettingsManager()->AddCondition("IsPlayingPassthrough", IsPlayingPassthrough);
 
-  CSettingDependency dependencyAudioOutputPassthroughDisabled(SettingDependencyTypeEnable, GetSettingsManager());
+  CSettingDependency dependencyAudioOutputPassthroughDisabled(SettingDependencyType::Enable, GetSettingsManager());
   dependencyAudioOutputPassthroughDisabled.Or()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_AUDIO_PASSTHROUGH, "false", SettingDependencyOperatorEquals, false, GetSettingsManager())))
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_AUDIO_PASSTHROUGH, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())))
     ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition("IsPlayingPassthrough", "", "", true, GetSettingsManager())));
   SettingDependencies depsAudioOutputPassthroughDisabled;
   depsAudioOutputPassthroughDisabled.push_back(dependencyAudioOutputPassthroughDisabled);
@@ -337,24 +337,24 @@ void CGUIDialogAudioSubtitleSettings::InitializeSettings()
   // audio settings
   // audio volume setting
   m_volume = g_application.GetVolume(false);
-  std::shared_ptr<CSettingNumber> settingAudioVolume = AddSlider(groupAudio, SETTING_AUDIO_VOLUME, 13376, 0, m_volume, 14054, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM);
+  std::shared_ptr<CSettingNumber> settingAudioVolume = AddSlider(groupAudio, SETTING_AUDIO_VOLUME, 13376, SettingLevel::Basic, m_volume, 14054, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM);
   settingAudioVolume->SetDependencies(depsAudioOutputPassthroughDisabled);
   std::static_pointer_cast<CSettingControlSlider>(settingAudioVolume->GetControl())->SetFormatter(SettingFormatterPercentAsDecibel);
 
   if (m_dspEnabled)
-    AddButton(groupAudio, SETTING_AUDIO_DSP, 24136, 0);
+    AddButton(groupAudio, SETTING_AUDIO_DSP, 24136, SettingLevel::Basic);
 
   // audio volume amplification setting
   if (SupportsAudioFeature(IPC_AUD_AMP) && !m_dspEnabled)
   {
-    std::shared_ptr<CSettingNumber> settingAudioVolumeAmplification = AddSlider(groupAudio, SETTING_AUDIO_VOLUME_AMPLIFICATION, 660, 0, videoSettings.m_VolumeAmplification, 14054, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 6000.0f, VOLUME_DRC_MAXIMUM * 0.01f);
+    std::shared_ptr<CSettingNumber> settingAudioVolumeAmplification = AddSlider(groupAudio, SETTING_AUDIO_VOLUME_AMPLIFICATION, 660, SettingLevel::Basic, videoSettings.m_VolumeAmplification, 14054, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 6000.0f, VOLUME_DRC_MAXIMUM * 0.01f);
     settingAudioVolumeAmplification->SetDependencies(depsAudioOutputPassthroughDisabled);
   }
 
   // audio delay setting
   if (SupportsAudioFeature(IPC_AUD_OFFSET) && !m_dspEnabled)
   {
-    std::shared_ptr<CSettingNumber> settingAudioDelay = AddSlider(groupAudio, SETTING_AUDIO_DELAY, 297, 0, videoSettings.m_AudioDelay, 0, -g_advancedSettings.m_videoAudioDelayRange, 0.025f, g_advancedSettings.m_videoAudioDelayRange, 297, usePopup);
+    std::shared_ptr<CSettingNumber> settingAudioDelay = AddSlider(groupAudio, SETTING_AUDIO_DELAY, 297, SettingLevel::Basic, videoSettings.m_AudioDelay, 0, -g_advancedSettings.m_videoAudioDelayRange, 0.025f, g_advancedSettings.m_videoAudioDelayRange, 297, usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingAudioDelay->GetControl())->SetFormatter(SettingFormatterDelay);
   }
   
@@ -365,24 +365,24 @@ void CGUIDialogAudioSubtitleSettings::InitializeSettings()
   // audio output to all speakers setting
   //! @todo remove this setting
   if (SupportsAudioFeature(IPC_AUD_OUTPUT_STEREO) && !m_dspEnabled)
-    AddToggle(groupAudio, SETTING_AUDIO_OUTPUT_TO_ALL_SPEAKERS, 252, 0, videoSettings.m_OutputToAllSpeakers);
+    AddToggle(groupAudio, SETTING_AUDIO_OUTPUT_TO_ALL_SPEAKERS, 252, SettingLevel::Basic, videoSettings.m_OutputToAllSpeakers);
 
   // audio digital/analog setting
   if (SupportsAudioFeature(IPC_AUD_SELECT_OUTPUT))
   {
     m_passthrough = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
-    AddToggle(groupAudio, SETTING_AUDIO_PASSTHROUGH, 348, 0, m_passthrough);
+    AddToggle(groupAudio, SETTING_AUDIO_PASSTHROUGH, 348, SettingLevel::Basic, m_passthrough);
   }
 
   // subtitle settings
   m_subtitleVisible = g_application.m_pPlayer->GetSubtitleVisible();
   // subtitle enabled setting
-  AddToggle(groupSubtitles, SETTING_SUBTITLE_ENABLE, 13397, 0, m_subtitleVisible);
+  AddToggle(groupSubtitles, SETTING_SUBTITLE_ENABLE, 13397, SettingLevel::Basic, m_subtitleVisible);
 
   // subtitle delay setting
   if (SupportsSubtitleFeature(IPC_SUBS_OFFSET))
   {
-    std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, 0, videoSettings.m_SubtitleDelay, 0, -g_advancedSettings.m_videoSubsDelayRange, 0.1f, g_advancedSettings.m_videoSubsDelayRange, 22006, usePopup);
+    std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, SettingLevel::Basic, videoSettings.m_SubtitleDelay, 0, -g_advancedSettings.m_videoSubsDelayRange, 0.1f, g_advancedSettings.m_videoSubsDelayRange, 22006, usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingSubtitleDelay->GetControl())->SetFormatter(SettingFormatterDelay);
   }
 
@@ -392,10 +392,10 @@ void CGUIDialogAudioSubtitleSettings::InitializeSettings()
 
   // subtitle browser setting
   if (SupportsSubtitleFeature(IPC_SUBS_EXTERNAL))
-    AddButton(groupSubtitles, SETTING_SUBTITLE_BROWSER, 13250, 0);
+    AddButton(groupSubtitles, SETTING_SUBTITLE_BROWSER, 13250, SettingLevel::Basic);
 
   // subtitle stream setting
-  AddButton(groupSaveAsDefault, SETTING_AUDIO_MAKE_DEFAULT, 12376, 0);
+  AddButton(groupSaveAsDefault, SETTING_AUDIO_MAKE_DEFAULT, 12376, SettingLevel::Basic);
 }
 
 bool CGUIDialogAudioSubtitleSettings::SupportsAudioFeature(int feature)
@@ -429,7 +429,7 @@ void CGUIDialogAudioSubtitleSettings::AddAudioStreams(std::shared_ptr<CSettingGr
   if (m_audioStream < 0)
     m_audioStream = 0;
 
-  AddList(group, settingId, 460, 0, m_audioStream, AudioStreamsOptionFiller, 460);
+  AddList(group, settingId, 460, SettingLevel::Basic, m_audioStream, AudioStreamsOptionFiller, 460);
 }
 
 void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(std::shared_ptr<CSettingGroup> group, const std::string &settingId)
@@ -441,7 +441,7 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(std::shared_ptr<CSettin
   if (m_subtitleStream < 0)
     m_subtitleStream = 0;
 
-  AddList(group, settingId, 462, 0, m_subtitleStream, SubtitleStreamsOptionFiller, 462);
+  AddList(group, settingId, 462, SettingLevel::Basic, m_subtitleStream, SubtitleStreamsOptionFiller, 462);
 }
 
 bool CGUIDialogAudioSubtitleSettings::IsPlayingPassthrough(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -94,39 +94,39 @@ void CGUIDialogCMSSettings::InitializeSettings()
   TranslatableIntegerSettingOptions entries;
 
   // create "depsCmsEnabled" for settings depending on CMS being enabled
-  CSettingDependency dependencyCmsEnabled(SettingDependencyTypeEnable, GetSettingsManager());
+  CSettingDependency dependencyCmsEnabled(SettingDependencyType::Enable, GetSettingsManager());
   dependencyCmsEnabled.Or()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSENABLE, "true", SettingDependencyOperatorEquals, false, GetSettingsManager())));
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSENABLE, "true", SettingDependencyOperator::Equals, false, GetSettingsManager())));
   SettingDependencies depsCmsEnabled;
   depsCmsEnabled.push_back(dependencyCmsEnabled);
 
   // create "depsCms3dlut" for 3dlut settings
-  CSettingDependency dependencyCms3dlut(SettingDependencyTypeVisible, GetSettingsManager());
+  CSettingDependency dependencyCms3dlut(SettingDependencyType::Visible, GetSettingsManager());
   dependencyCms3dlut.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_3DLUT), SettingDependencyOperatorEquals, false, GetSettingsManager())));
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_3DLUT), SettingDependencyOperator::Equals, false, GetSettingsManager())));
   SettingDependencies depsCms3dlut;
   depsCms3dlut.push_back(dependencyCmsEnabled);
   depsCms3dlut.push_back(dependencyCms3dlut);
 
   // create "depsCmsIcc" for display settings with icc profile
-  CSettingDependency dependencyCmsIcc(SettingDependencyTypeVisible, GetSettingsManager());
+  CSettingDependency dependencyCmsIcc(SettingDependencyType::Visible, GetSettingsManager());
   dependencyCmsIcc.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_PROFILE), SettingDependencyOperatorEquals, false, GetSettingsManager())));
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_PROFILE), SettingDependencyOperator::Equals, false, GetSettingsManager())));
   SettingDependencies depsCmsIcc;
   depsCmsIcc.push_back(dependencyCmsEnabled);
   depsCmsIcc.push_back(dependencyCmsIcc);
 
   // create "depsCmsGamma" for effective gamma adjustment (not available with bt.1886)
-  CSettingDependency dependencyCmsGamma(SettingDependencyTypeVisible, GetSettingsManager());
+  CSettingDependency dependencyCmsGamma(SettingDependencyType::Visible, GetSettingsManager());
   dependencyCmsGamma.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSGAMMAMODE, std::to_string(CMS_TRC_BT1886), SettingDependencyOperatorEquals, true, GetSettingsManager())));
+    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSGAMMAMODE, std::to_string(CMS_TRC_BT1886), SettingDependencyOperator::Equals, true, GetSettingsManager())));
   SettingDependencies depsCmsGamma;
   depsCmsGamma.push_back(dependencyCmsEnabled);
   depsCmsGamma.push_back(dependencyCmsIcc);
   depsCmsGamma.push_back(dependencyCmsGamma);
 
   // color management settings
-  AddToggle(groupColorManagement, SETTING_VIDEO_CMSENABLE, 36560, 0, CServiceBroker::GetSettings().GetBool(SETTING_VIDEO_CMSENABLE));
+  AddToggle(groupColorManagement, SETTING_VIDEO_CMSENABLE, 36560, SettingLevel::Basic, CServiceBroker::GetSettings().GetBool(SETTING_VIDEO_CMSENABLE));
 
   int currentMode = CServiceBroker::GetSettings().GetInt(SETTING_VIDEO_CMSMODE);
   entries.clear();
@@ -135,11 +135,11 @@ void CGUIDialogCMSSettings::InitializeSettings()
 #ifdef HAVE_LCMS2
   entries.push_back(std::make_pair(36581, CMS_MODE_PROFILE));
 #endif
-  std::shared_ptr<CSettingInt> settingCmsMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSMODE, 36562, 0, currentMode, entries);
+  std::shared_ptr<CSettingInt> settingCmsMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSMODE, 36562, SettingLevel::Basic, currentMode, entries);
   settingCmsMode->SetDependencies(depsCmsEnabled);
 
   std::string current3dLUT = CServiceBroker::GetSettings().GetString(SETTING_VIDEO_CMS3DLUT);
-  std::shared_ptr<CSettingString> settingCms3dlut = AddList(groupColorManagement, SETTING_VIDEO_CMS3DLUT, 36564, 0, current3dLUT, Cms3dLutsFiller, 36564);
+  std::shared_ptr<CSettingString> settingCms3dlut = AddList(groupColorManagement, SETTING_VIDEO_CMS3DLUT, 36564, SettingLevel::Basic, current3dLUT, Cms3dLutsFiller, 36564);
   settingCms3dlut->SetDependencies(depsCms3dlut);
 
   // display settings
@@ -147,7 +147,7 @@ void CGUIDialogCMSSettings::InitializeSettings()
   entries.clear();
   entries.push_back(std::make_pair(36586, CMS_WHITEPOINT_D65));
   entries.push_back(std::make_pair(36587, CMS_WHITEPOINT_D93));
-  std::shared_ptr<CSettingInt> settingCmsWhitepoint = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSWHITEPOINT, 36568, 0, currentWhitepoint, entries);
+  std::shared_ptr<CSettingInt> settingCmsWhitepoint = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSWHITEPOINT, 36568, SettingLevel::Basic, currentWhitepoint, entries);
   settingCmsWhitepoint->SetDependencies(depsCmsIcc);
 
   int currentPrimaries = CServiceBroker::GetSettings().GetInt(SETTING_VIDEO_CMSPRIMARIES);
@@ -158,7 +158,7 @@ void CGUIDialogCMSSettings::InitializeSettings()
   entries.push_back(std::make_pair(36591, CMS_PRIMARIES_BT470M));
   entries.push_back(std::make_pair(36592, CMS_PRIMARIES_BT470BG));
   entries.push_back(std::make_pair(36593, CMS_PRIMARIES_240M));
-  std::shared_ptr<CSettingInt> settingCmsPrimaries = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSPRIMARIES, 36570, 0, currentPrimaries, entries);
+  std::shared_ptr<CSettingInt> settingCmsPrimaries = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSPRIMARIES, 36570, SettingLevel::Basic, currentPrimaries, entries);
   settingCmsPrimaries->SetDependencies(depsCmsIcc);
 
   int currentGammaMode = CServiceBroker::GetSettings().GetInt(SETTING_VIDEO_CMSGAMMAMODE);
@@ -167,12 +167,12 @@ void CGUIDialogCMSSettings::InitializeSettings()
   entries.push_back(std::make_pair(36583, CMS_TRC_INPUT_OFFSET));
   entries.push_back(std::make_pair(36584, CMS_TRC_OUTPUT_OFFSET));
   entries.push_back(std::make_pair(36585, CMS_TRC_ABSOLUTE));
-  std::shared_ptr<CSettingInt> settingCmsGammaMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSGAMMAMODE, 36572, 0, currentGammaMode, entries);
+  std::shared_ptr<CSettingInt> settingCmsGammaMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSGAMMAMODE, 36572, SettingLevel::Basic, currentGammaMode, entries);
   settingCmsGammaMode->SetDependencies(depsCmsIcc);
 
   float currentGamma = CServiceBroker::GetSettings().GetInt(SETTING_VIDEO_CMSGAMMA)/100.0f;
   if (currentGamma == 0.0) currentGamma = 2.20;
-  std::shared_ptr<CSettingNumber> settingCmsGamma = AddSlider(groupColorManagement, SETTING_VIDEO_CMSGAMMA, 36574, 0, currentGamma, 36597, 1.6, 0.05, 2.8, 36574, usePopup);
+  std::shared_ptr<CSettingNumber> settingCmsGamma = AddSlider(groupColorManagement, SETTING_VIDEO_CMSGAMMA, 36574, SettingLevel::Basic, currentGamma, 36597, 1.6, 0.05, 2.8, 36574, usePopup);
   settingCmsGamma->SetDependencies(depsCmsGamma);
 
   int currentLutSize = CServiceBroker::GetSettings().GetInt(SETTING_VIDEO_CMSLUTSIZE);
@@ -180,7 +180,7 @@ void CGUIDialogCMSSettings::InitializeSettings()
   entries.push_back(std::make_pair(36594, 4));
   entries.push_back(std::make_pair(36595, 6));
   entries.push_back(std::make_pair(36596, 8));
-  std::shared_ptr<CSettingInt> settingCmsLutSize = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSLUTSIZE, 36576, 0, currentLutSize, entries);
+  std::shared_ptr<CSettingInt> settingCmsLutSize = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSLUTSIZE, 36576, SettingLevel::Basic, currentLutSize, entries);
   settingCmsLutSize->SetDependencies(depsCmsIcc);
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -177,7 +177,7 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
 void CGUIDialogVideoSettings::Save()
 {
   if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-      !g_passwordManager.CheckSettingLevelLock(::SettingLevelExpert))
+      !g_passwordManager.CheckSettingLevelLock(::SettingLevel::Expert))
     return;
 
   // prompt user if they are sure
@@ -295,7 +295,7 @@ void CGUIDialogVideoSettings::InitializeSettings()
     {
       videoSettings.m_InterlaceMethod = g_application.m_pPlayer->GetDeinterlacingMethodDefault();
     }
-    AddSpinner(groupVideo, SETTING_VIDEO_INTERLACEMETHOD, 16038, 0, static_cast<int>(videoSettings.m_InterlaceMethod), entries);
+    AddSpinner(groupVideo, SETTING_VIDEO_INTERLACEMETHOD, 16038, SettingLevel::Basic, static_cast<int>(videoSettings.m_InterlaceMethod), entries);
   }
 
   entries.clear();
@@ -325,35 +325,35 @@ void CGUIDialogVideoSettings::InitializeSettings()
       it = entries.erase(it);
   }
 
-  AddSpinner(groupVideo, SETTING_VIDEO_SCALINGMETHOD, 16300, 0, static_cast<int>(videoSettings.m_ScalingMethod), entries);
+  AddSpinner(groupVideo, SETTING_VIDEO_SCALINGMETHOD, 16300, SettingLevel::Basic, static_cast<int>(videoSettings.m_ScalingMethod), entries);
 
 #ifdef HAS_VIDEO_PLAYBACK
   AddVideoStreams(groupVideoStream, SETTING_VIDEO_STREAM);
 
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_STRETCH) || g_application.m_pPlayer->Supports(RENDERFEATURE_PIXEL_RATIO))
   {
-    AddList(groupVideo, SETTING_VIDEO_VIEW_MODE, 629, 0, videoSettings.m_ViewMode, CViewModeSettings::ViewModesFiller, 629);
+    AddList(groupVideo, SETTING_VIDEO_VIEW_MODE, 629, SettingLevel::Basic, videoSettings.m_ViewMode, CViewModeSettings::ViewModesFiller, 629);
   }
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_ZOOM))
-    AddSlider(groupVideo, SETTING_VIDEO_ZOOM, 216, 0, videoSettings.m_CustomZoomAmount, "%2.2f", 0.5f, 0.01f, 2.0f, 216, usePopup);
+    AddSlider(groupVideo, SETTING_VIDEO_ZOOM, 216, SettingLevel::Basic, videoSettings.m_CustomZoomAmount, "%2.2f", 0.5f, 0.01f, 2.0f, 216, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_VERTICAL_SHIFT))
-    AddSlider(groupVideo, SETTING_VIDEO_VERTICAL_SHIFT, 225, 0, videoSettings.m_CustomVerticalShift, "%2.2f", -2.0f, 0.01f, 2.0f, 225, usePopup);
+    AddSlider(groupVideo, SETTING_VIDEO_VERTICAL_SHIFT, 225, SettingLevel::Basic, videoSettings.m_CustomVerticalShift, "%2.2f", -2.0f, 0.01f, 2.0f, 225, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_PIXEL_RATIO))
-    AddSlider(groupVideo, SETTING_VIDEO_PIXEL_RATIO, 217, 0, videoSettings.m_CustomPixelRatio, "%2.2f", 0.5f, 0.01f, 2.0f, 217, usePopup);
+    AddSlider(groupVideo, SETTING_VIDEO_PIXEL_RATIO, 217, SettingLevel::Basic, videoSettings.m_CustomPixelRatio, "%2.2f", 0.5f, 0.01f, 2.0f, 217, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_POSTPROCESS))
-    AddToggle(groupVideo, SETTING_VIDEO_POSTPROCESS, 16400, 0, videoSettings.m_PostProcess);
+    AddToggle(groupVideo, SETTING_VIDEO_POSTPROCESS, 16400, SettingLevel::Basic, videoSettings.m_PostProcess);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_BRIGHTNESS))
-    AddPercentageSlider(groupVideoPlayback, SETTING_VIDEO_BRIGHTNESS, 464, 0, static_cast<int>(videoSettings.m_Brightness), 14047, 1, 464, usePopup);
+    AddPercentageSlider(groupVideoPlayback, SETTING_VIDEO_BRIGHTNESS, 464, SettingLevel::Basic, static_cast<int>(videoSettings.m_Brightness), 14047, 1, 464, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_CONTRAST))
-    AddPercentageSlider(groupVideoPlayback, SETTING_VIDEO_CONTRAST, 465, 0, static_cast<int>(videoSettings.m_Contrast), 14047, 1, 465, usePopup);
+    AddPercentageSlider(groupVideoPlayback, SETTING_VIDEO_CONTRAST, 465, SettingLevel::Basic, static_cast<int>(videoSettings.m_Contrast), 14047, 1, 465, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_GAMMA))
-    AddPercentageSlider(groupVideoPlayback, SETTING_VIDEO_GAMMA, 466, 0, static_cast<int>(videoSettings.m_Gamma), 14047, 1, 466, usePopup);
+    AddPercentageSlider(groupVideoPlayback, SETTING_VIDEO_GAMMA, 466, SettingLevel::Basic, static_cast<int>(videoSettings.m_Gamma), 14047, 1, 466, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_NOISE))
-    AddSlider(groupVideoPlayback, SETTING_VIDEO_VDPAU_NOISE, 16312, 0, videoSettings.m_NoiseReduction, "%2.2f", 0.0f, 0.01f, 1.0f, 16312, usePopup);
+    AddSlider(groupVideoPlayback, SETTING_VIDEO_VDPAU_NOISE, 16312, SettingLevel::Basic, videoSettings.m_NoiseReduction, "%2.2f", 0.0f, 0.01f, 1.0f, 16312, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_SHARPNESS))
-    AddSlider(groupVideoPlayback, SETTING_VIDEO_VDPAU_SHARPNESS, 16313, 0, videoSettings.m_Sharpness, "%2.2f", -1.0f, 0.02f, 1.0f, 16313, usePopup);
+    AddSlider(groupVideoPlayback, SETTING_VIDEO_VDPAU_SHARPNESS, 16313, SettingLevel::Basic, videoSettings.m_Sharpness, "%2.2f", -1.0f, 0.02f, 1.0f, 16313, usePopup);
   if (g_application.m_pPlayer->Supports(RENDERFEATURE_NONLINSTRETCH))
-    AddToggle(groupVideoPlayback, SETTING_VIDEO_NONLIN_STRETCH, 659, 0, videoSettings.m_CustomNonLinStretch);
+    AddToggle(groupVideoPlayback, SETTING_VIDEO_NONLIN_STRETCH, 659, SettingLevel::Basic, videoSettings.m_CustomNonLinStretch);
 #endif
 
   // stereoscopic settings
@@ -361,12 +361,12 @@ void CGUIDialogVideoSettings::InitializeSettings()
   entries.push_back(std::make_pair(16316, RENDER_STEREO_MODE_OFF));
   entries.push_back(std::make_pair(36503, RENDER_STEREO_MODE_SPLIT_HORIZONTAL));
   entries.push_back(std::make_pair(36504, RENDER_STEREO_MODE_SPLIT_VERTICAL));
-  AddSpinner(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICMODE  , 36535, 0, videoSettings.m_StereoMode, entries);
-  AddToggle(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICINVERT, 36536, 0, videoSettings.m_StereoInvert);
+  AddSpinner(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICMODE, 36535, SettingLevel::Basic, videoSettings.m_StereoMode, entries);
+  AddToggle(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICINVERT, 36536, SettingLevel::Basic, videoSettings.m_StereoInvert);
 
   // general settings
-  AddButton(groupSaveAsDefault, SETTING_VIDEO_MAKE_DEFAULT, 12376, 0);
-  AddButton(groupSaveAsDefault, SETTING_VIDEO_CALIBRATION, 214, 0);
+  AddButton(groupSaveAsDefault, SETTING_VIDEO_MAKE_DEFAULT, 12376, SettingLevel::Basic);
+  AddButton(groupSaveAsDefault, SETTING_VIDEO_CALIBRATION, 214, SettingLevel::Basic);
 }
 
 void CGUIDialogVideoSettings::AddVideoStreams(std::shared_ptr<CSettingGroup> group, const std::string &settingId)
@@ -378,7 +378,7 @@ void CGUIDialogVideoSettings::AddVideoStreams(std::shared_ptr<CSettingGroup> gro
   if (m_videoStream < 0)
     m_videoStream = 0;
 
-  AddList(group, settingId, 38031, 0, m_videoStream, VideoStreamsOptionFiller, 38031);
+  AddList(group, settingId, 38031, SettingLevel::Basic, m_videoStream, VideoStreamsOptionFiller, 38031);
 }
 
 void CGUIDialogVideoSettings::VideoStreamsOptionFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -41,7 +41,7 @@
 #define XML_EVENTLOG_LEVEL_HIGHER   "showhigherlevels"
 
 CViewStateSettings::CViewStateSettings()
-  : m_settingLevel(SettingLevelStandard),
+  : m_settingLevel(SettingLevel::Standard),
     m_eventLevel(EventLevel::Basic),
     m_eventShowHigherLevels(true)
 {
@@ -126,10 +126,10 @@ bool CViewStateSettings::Load(const TiXmlNode *settings)
   if (pElement != NULL)
   {
     int settingLevel;
-    if (XMLUtils::GetInt(pElement, XML_SETTINGLEVEL, settingLevel, (const int)SettingLevelBasic, (const int)SettingLevelExpert))
+    if (XMLUtils::GetInt(pElement, XML_SETTINGLEVEL, settingLevel, (const int)SettingLevel::Basic, (const int)SettingLevel::Expert))
       m_settingLevel = (SettingLevel)settingLevel;
     else
-      m_settingLevel = SettingLevelStandard;
+      m_settingLevel = SettingLevel::Standard;
 
     const TiXmlNode* pEventLogNode = pElement->FirstChild(XML_EVENTLOG);
     if (pEventLogNode != NULL)
@@ -204,7 +204,7 @@ bool CViewStateSettings::Save(TiXmlNode *settings) const
 
 void CViewStateSettings::Clear()
 {
-  m_settingLevel = SettingLevelStandard;
+  m_settingLevel = SettingLevel::Standard;
 }
 
 const CViewState* CViewStateSettings::Get(const std::string &viewState) const
@@ -229,10 +229,10 @@ CViewState* CViewStateSettings::Get(const std::string &viewState)
 
 void CViewStateSettings::SetSettingLevel(SettingLevel settingLevel)
 {
-  if (settingLevel < SettingLevelBasic)
-    m_settingLevel = SettingLevelBasic;
-  if (settingLevel > SettingLevelExpert)
-    m_settingLevel = SettingLevelExpert;
+  if (settingLevel < SettingLevel::Basic)
+    m_settingLevel = SettingLevel::Basic;
+  if (settingLevel > SettingLevel::Expert)
+    m_settingLevel = SettingLevel::Expert;
   else
     m_settingLevel = settingLevel;
 }
@@ -245,8 +245,8 @@ void CViewStateSettings::CycleSettingLevel()
 SettingLevel CViewStateSettings::GetNextSettingLevel() const
 {
   SettingLevel level = (SettingLevel)((int)m_settingLevel + 1);
-  if (level > SettingLevelExpert)
-    level = SettingLevelBasic;
+  if (level > SettingLevel::Expert)
+    level = SettingLevel::Basic;
   return level;
 }
 


### PR DESCRIPTION
After the huge add-on settings work I figured it's finally time to move the settings related code to C++11 by
* using `nullptr` instead of `NULL`
* using the `default` keyword for ctors and dtors
* initializing member variables in the class definition
* using `enum class` instead of just `enum` where it makes sense
* using `using` instead of `typedef`

## Motivation and Context
Easier to read and maintain code

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
