### PR TITLE
[PVR] Add Info support to recently played channel widget.

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -35,6 +35,7 @@
 #include "music/MusicThumbLoader.h"
 #include "pictures/PictureThumbLoader.h"
 #include "pvr/PVRManager.h"
+#include "pvr/dialogs/GUIDialogPVRGuideInfo.h"
 #include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
@@ -394,6 +395,11 @@ bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
   else if (fileItem->HasPVRRecordingInfoTag())
   {
     CGUIDialogPVRRecordingInfo::ShowFor(fileItem);
+    return true;
+  }
+  else if (fileItem->HasPVRChannelInfoTag())
+  {
+    CGUIDialogPVRGuideInfo::ShowFor(fileItem);
     return true;
   }
   else if (fileItem->HasVideoInfoTag())

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -257,3 +257,8 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
   if (bHideAddTimer)
     SET_CONTROL_HIDDEN(CONTROL_BTN_ADD_TIMER);
 }
+
+void CGUIDialogPVRGuideInfo::ShowFor(const CFileItemPtr& item)
+{
+  CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(item);
+}

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -37,6 +37,8 @@ namespace PVR
 
     void SetProgInfo(const CPVREpgInfoTagPtr &tag);
 
+    static void ShowFor(const CFileItemPtr& item);
+
   protected:
     void OnInitWindow() override;
 


### PR DESCRIPTION
The recently played channel widget (can be founf for example on Estuary home screen) now reacts on info action, usually mapped to "i" on keyboards or "info" key on remote controls, by opening a dialog with information for the running show.

This has been runtime tested on macOS, latest Kodi master.

@Jalle19 mind taking a look? Mostly a nobrainer.