### PR TITLE
Dont force dirtyRegions on parent controls

### DIFF
--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -185,8 +185,8 @@ public:
   virtual float GetWidth() const;
   virtual float GetHeight() const;
 
-  void MarkDirtyRegion();
-  bool IsControlDirty() const { return m_controlIsDirty; };
+  void MarkDirtyRegion(const unsigned int dirtyState = DIRTY_STATE_CONTROL);
+  bool IsControlDirty() const { return m_controlDirtyState != 0; };
 
   /*! \brief return the render region in screen coordinates of this control
    */
@@ -373,7 +373,10 @@ protected:
   TransformMatrix m_transform;
   TransformMatrix m_cachedTransform; // Contains the absolute transform the control
 
-  bool  m_controlIsDirty;
+  static const unsigned int DIRTY_STATE_CONTROL = 1; //This control is dirty
+  static const unsigned int DIRTY_STATE_CHILD = 2; //One / more children are dirty
+
+  unsigned int  m_controlDirtyState;
   CRect m_renderRegion;         // In screen coordinates
 };
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -72,7 +72,6 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   m_menuControlID = 0;
   m_menuLastFocusedControlID = 0;
   m_custom = false;
-  m_forceProcess = true;
 }
 
 CGUIWindow::~CGUIWindow()
@@ -343,10 +342,8 @@ void CGUIWindow::CenterWindow()
 
 void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  if (!m_controlIsDirty && !m_forceProcess && g_advancedSettings.m_guiSmartRedraw)
+  if (!IsControlDirty() && g_advancedSettings.m_guiSmartRedraw)
     return;
-
-  m_forceProcess = false;
 
   g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
   g_graphicsContext.AddGUITransform();
@@ -743,9 +740,9 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
       if (HasID(message.GetSenderId()) || !message.GetSenderId())
       {
         if (message.GetParam1() == GUI_MSG_PAGE_CHANGE ||
-            message.GetParam1() == GUI_MSG_REFRESH_THUMBS ||
-            message.GetParam1() == GUI_MSG_REFRESH_LIST ||
-            message.GetParam1() == GUI_MSG_WINDOW_RESIZE)
+          message.GetParam1() == GUI_MSG_REFRESH_THUMBS ||
+          message.GetParam1() == GUI_MSG_REFRESH_LIST ||
+          message.GetParam1() == GUI_MSG_WINDOW_RESIZE)
         { // alter the message accordingly, and send to all controls
           for (iControls it = m_children.begin(); it != m_children.end(); ++it)
           {
@@ -755,7 +752,7 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
           }
         }
         else if (message.GetParam1() == GUI_MSG_STATE_CHANGED)
-          m_forceProcess = true;
+          MarkDirtyRegion(DIRTY_STATE_CHILD); //Don't force an dirtyRect, we don't know if / what has changed.
       }
     }
     break;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -320,7 +320,6 @@ protected:
 private:
   std::map<std::string, CVariant, icompare> m_mapProperties;
   std::map<INFO::InfoPtr, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
-  bool m_forceProcess;
 };
 
 #endif


### PR DESCRIPTION
Dont force dirtyRegions on parent controls

## Description
Currently we draw visible regions of recursivw parents if a control gets dirty
This  PR changes this behaviour (only Control dirty Rect is displayed)

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@mkortstiege can you pls verify that its working as expected? Thx