### PR TITLE
Use http cookies AVOption (instead of sticking cookies in the header AVOption)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -681,9 +681,16 @@ AVDictionary *CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
         CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option 'user-agent: %s'", value.c_str());
         hasUserAgent = true;
       }
+      else if (name == "cookies")
+      {
+        // in the plural option expect multiple Set-Cookie values. They are passed \n delimited to FFMPEG
+        av_dict_set(&options, "cookies", value.c_str(), 0);
+        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option 'cookies: %s'", value.c_str());
+        hasCookies = true;
+      }
       else if (name == "cookie")
       {
-        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option 'cookies: %s'", value.c_str());
+        CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg header value 'cookie: %s'", value.c_str());
         headers.append(it->first).append(": ").append(value).append("\r\n");
         hasCookies = true;
       }


### PR DESCRIPTION
## Description
Add an option to pass the ffmpeg cookies http protocol avoption instead of sticking cookie values inside the ffmpeg headers http protocol avoption.

This is preferable (and necessary) for streams that periodically update authentication values (such as a session token) that are stored as cookies. If the cookie values are specified in the headers avoption, it conflicts with the http protocols cookies option, which does get updated properly.

The cookies value format is different than the headers value format. The value used with the headers avoption is just the cookie value, whereas, the cookies avoption expects a newline delimited list of Set-Cookie values (eg: everything after ‘Set-Cookie: ‘).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
FFMPEG http protocol has an AVOption _just for cookies_ -- we shouldn't be forcing people to cram cookies into the headers AVOption. Also, the cookies AVOption is self updating if a server sends back a new Set-Cookie header in a response. As stated above, this is critical for streams that authenticate using cookies and periodically update those authentication values (eg: neulion).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I've tested this in my own sportsnet addon (https://github.com/micahg/plugin.video.snnow/tree/nologon). Basically instead of calling http://whatever.com/whatever.m3u8|Cookie=just_the_cookie_value I would call http://whatever.com/whatever.m3u8|Cookies=whole_set_cookie_value_including_domain_and_expiry. The stream works, and authentication values are properly updated. Without this change the stream plays until a new authentication value is sent down (which doesn't get updated) and then the stream ends.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
