### PR TITLE
[addons] add gui control classes to new addon interface

### DIFF
--- a/xbmc/addons/interfaces/GUI/General.cpp
+++ b/xbmc/addons/interfaces/GUI/General.cpp
@@ -20,6 +20,17 @@
 
 #include "General.h"
 #include "controls/Button.h"
+#include "controls/Edit.h"
+#include "controls/FadeLabel.h"
+#include "controls/Image.h"
+#include "controls/Label.h"
+#include "controls/Progress.h"
+#include "controls/RadioButton.h"
+#include "controls/Rendering.h"
+#include "controls/SettingsSlider.h"
+#include "controls/Slider.h"
+#include "controls/Spin.h"
+#include "controls/TextBox.h"
 #include "dialogs/ContextMenu.h"
 #include "dialogs/ExtendedProgressBar.h"
 #include "dialogs/FileBrowser.h"
@@ -58,6 +69,17 @@ void Interface_GUIGeneral::Init(AddonGlobalInterface* addonInterface)
   addonInterface->toKodi->kodi_gui = static_cast<AddonToKodiFuncTable_kodi_gui*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui)));
 
   Interface_GUIControlButton::Init(addonInterface);
+  Interface_GUIControlEdit::Init(addonInterface);
+  Interface_GUIControlFadeLabel::Init(addonInterface);
+  Interface_GUIControlImage::Init(addonInterface);
+  Interface_GUIControlLabel::Init(addonInterface);
+  Interface_GUIControlProgress::Init(addonInterface);
+  Interface_GUIControlRadioButton::Init(addonInterface);
+  Interface_GUIControlAddonRendering::Init(addonInterface);
+  Interface_GUIControlSettingsSlider::Init(addonInterface);
+  Interface_GUIControlSlider::Init(addonInterface);
+  Interface_GUIControlSpin::Init(addonInterface);
+  Interface_GUIControlTextBox::Init(addonInterface);
   Interface_GUIDialogContextMenu::Init(addonInterface);
   Interface_GUIDialogExtendedProgress::Init(addonInterface);
   Interface_GUIDialogFileBrowser::Init(addonInterface);
@@ -88,6 +110,17 @@ void Interface_GUIGeneral::DeInit(AddonGlobalInterface* addonInterface)
       addonInterface->toKodi->kodi_gui)
   {
     Interface_GUIControlButton::DeInit(addonInterface);
+    Interface_GUIControlEdit::DeInit(addonInterface);
+    Interface_GUIControlFadeLabel::DeInit(addonInterface);
+    Interface_GUIControlImage::DeInit(addonInterface);
+    Interface_GUIControlLabel::DeInit(addonInterface);
+    Interface_GUIControlProgress::DeInit(addonInterface);
+    Interface_GUIControlRadioButton::DeInit(addonInterface);
+    Interface_GUIControlAddonRendering::DeInit(addonInterface);
+    Interface_GUIControlSettingsSlider::DeInit(addonInterface);
+    Interface_GUIControlSlider::DeInit(addonInterface);
+    Interface_GUIControlSpin::DeInit(addonInterface);
+    Interface_GUIControlTextBox::DeInit(addonInterface);
     Interface_GUIDialogContextMenu::DeInit(addonInterface);
     Interface_GUIDialogExtendedProgress::DeInit(addonInterface);
     Interface_GUIDialogFileBrowser::DeInit(addonInterface);

--- a/xbmc/addons/interfaces/GUI/Window.h
+++ b/xbmc/addons/interfaces/GUI/Window.h
@@ -107,9 +107,21 @@ namespace ADDON
 
     /* GUI control access functions */
     static void* get_control_button(void* kodiBase, void* handle, int control_id);
+    static void* get_control_edit(void* kodiBase, void* handle, int control_id);
+    static void* get_control_fade_label(void* kodiBase, void* handle, int control_id);
+    static void* get_control_image(void* kodiBase, void* handle, int control_id);
+    static void* get_control_label(void* kodiBase, void* handle, int control_id);
+    static void* get_control_radio_button(void* kodiBase, void* handle, int control_id);
+    static void* get_control_progress(void* kodiBase, void* handle, int control_id);
+    static void* get_control_render_addon(void* kodiBase, void* handle, int control_id);
+    static void* get_control_settings_slider(void* kodiBase, void* handle, int control_id);
+    static void* get_control_slider(void* kodiBase, void* handle, int control_id);
+    static void* get_control_spin(void* kodiBase, void* handle, int control_id);
+    static void* get_control_text_box(void* kodiBase, void* handle, int control_id);
     //@}
 
   private:
+    static void* GetControl(void* kodiBase, void* handle, int control_id, const char* function, CGUIControl::GUICONTROLTYPES type, const std::string& typeName);
     static int GetNextAvailableWindowId();
   };
 
@@ -140,7 +152,7 @@ namespace ADDON
     void SetContainerProperty(const std::string& key, const std::string& value);
     void SetContainerContent(const std::string& value);
     int GetCurrentContainerControlId();
-    CGUIControl* GetAddonControl(int controlId, CGUIControl::GUICONTROLTYPES type, std::string typeName);
+    CGUIControl* GetAddonControl(int controlId, CGUIControl::GUICONTROLTYPES type, const std::string& typeName);
 
   protected:
     void GetContextButtons(int itemNumber, CContextButtons &buttons) override;

--- a/xbmc/addons/interfaces/GUI/controls/CMakeLists.txt
+++ b/xbmc/addons/interfaces/GUI/controls/CMakeLists.txt
@@ -1,5 +1,27 @@
-set(SOURCES Button.cpp)
+set(SOURCES Button.cpp
+            Edit.cpp
+            FadeLabel.cpp
+            Image.cpp
+            Label.cpp
+            Progress.cpp
+            RadioButton.cpp
+            Rendering.cpp
+            SettingsSlider.cpp
+            Slider.cpp
+            Spin.cpp
+            TextBox.cpp)
 
-set(HEADERS Button.h)
+set(HEADERS Button.h
+            Edit.h
+            FadeLabel.h
+            Image.h
+            Label.h
+            Progress.h
+            RadioButton.h
+            Rendering.h
+            SettingsSlider.h
+            Slider.h
+            Spin.h
+            TextBox.h)
 
 core_add_library(addons_interfaces_gui_controls)

--- a/xbmc/addons/interfaces/GUI/controls/Edit.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Edit.cpp
@@ -1,0 +1,219 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Edit.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Edit.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIEditControl.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlEdit::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_edit = static_cast<AddonToKodiFuncTable_kodi_gui_control_edit*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_edit)));
+
+  addonInterface->toKodi->kodi_gui->control_edit->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_edit->set_enabled = set_enabled;
+  addonInterface->toKodi->kodi_gui->control_edit->set_input_type = set_input_type;
+  addonInterface->toKodi->kodi_gui->control_edit->set_label = set_label;
+  addonInterface->toKodi->kodi_gui->control_edit->get_label = get_label;
+  addonInterface->toKodi->kodi_gui->control_edit->set_text = set_text;
+  addonInterface->toKodi->kodi_gui->control_edit->get_text = get_text;
+  addonInterface->toKodi->kodi_gui->control_edit->set_cursor_position = set_cursor_position;
+  addonInterface->toKodi->kodi_gui->control_edit->get_cursor_position = get_cursor_position;
+}
+
+void Interface_GUIControlEdit::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_edit);
+}
+
+void Interface_GUIControlEdit::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlEdit::set_enabled(void* kodiBase, void* handle, bool enable)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetEnabled(enable);
+}
+
+void Interface_GUIControlEdit::set_input_type(void* kodiBase, void* handle, int type, const char *heading)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control || !heading)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p', heading='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, heading, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIEditControl::INPUT_TYPE kodiType;
+  switch (static_cast<AddonGUIInputType>(type))
+  {
+    case ADDON_INPUT_TYPE_TEXT:
+      kodiType = CGUIEditControl::INPUT_TYPE_TEXT;
+      break;
+    case ADDON_INPUT_TYPE_NUMBER:
+      kodiType = CGUIEditControl::INPUT_TYPE_NUMBER;
+      break;
+    case ADDON_INPUT_TYPE_SECONDS:
+      kodiType = CGUIEditControl::INPUT_TYPE_SECONDS;
+      break;
+    case ADDON_INPUT_TYPE_TIME:
+      kodiType = CGUIEditControl::INPUT_TYPE_TIME;
+      break;
+    case ADDON_INPUT_TYPE_DATE:
+      kodiType = CGUIEditControl::INPUT_TYPE_DATE;
+      break;
+    case ADDON_INPUT_TYPE_IPADDRESS:
+      kodiType = CGUIEditControl::INPUT_TYPE_IPADDRESS;
+      break;
+    case ADDON_INPUT_TYPE_PASSWORD:
+      kodiType = CGUIEditControl::INPUT_TYPE_PASSWORD;
+      break;
+    case ADDON_INPUT_TYPE_PASSWORD_MD5:
+      kodiType = CGUIEditControl::INPUT_TYPE_PASSWORD_MD5;
+      break;
+    case ADDON_INPUT_TYPE_SEARCH:
+      kodiType = CGUIEditControl::INPUT_TYPE_SEARCH;
+      break;
+    case ADDON_INPUT_TYPE_FILTER:
+      kodiType = CGUIEditControl::INPUT_TYPE_FILTER;
+      break;
+    case ADDON_INPUT_TYPE_READONLY:
+    default:
+      kodiType = CGUIEditControl::INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW;
+  }
+ 
+  control->SetInputType(kodiType, heading);
+}
+
+void Interface_GUIControlEdit::set_label(void* kodiBase, void* handle, const char *label)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control || !label)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p', label='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, label, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetLabel(label);
+}
+
+char* Interface_GUIControlEdit::get_label(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetLabel().c_str());
+}
+
+void Interface_GUIControlEdit::set_text(void* kodiBase, void* handle, const char* text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p', text='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, text, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetLabel2(text);
+}
+
+char* Interface_GUIControlEdit::get_text(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetLabel2().c_str());
+}
+
+void Interface_GUIControlEdit::set_cursor_position(void* kodiBase, void* handle, unsigned int position)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetCursorPosition(position);
+}
+
+unsigned int Interface_GUIControlEdit::get_cursor_position(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIEditControl* control = static_cast<CGUIEditControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlEdit::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0;
+  }
+
+  return control->GetCursorPosition();
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Edit.h
+++ b/xbmc/addons/interfaces/GUI/controls/Edit.h
@@ -1,0 +1,71 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Edit.h"
+   */
+  struct Interface_GUIControlEdit
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_enabled(void* kodiBase, void* handle, bool enabled);
+
+    static void set_input_type(void* kodiBase, void* handle, int type, const char* heading);
+
+    static void set_label(void* kodiBase, void* handle, const char* label);
+    static char* get_label(void* kodiBase, void* handle);
+
+    static void set_text(void* kodiBase, void* handle, const char* text);
+    static char* get_text(void* kodiBase, void* handle);
+
+    static void set_cursor_position(void* kodiBase, void* handle, unsigned int position);
+    static unsigned int get_cursor_position(void* kodiBase, void* handle);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/FadeLabel.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/FadeLabel.cpp
@@ -1,0 +1,127 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FadeLabel.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/FadeLabel.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIFadeLabelControl.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlFadeLabel::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_fade_label = static_cast<AddonToKodiFuncTable_kodi_gui_control_fade_label*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_fade_label)));
+
+  addonInterface->toKodi->kodi_gui->control_fade_label->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_fade_label->add_label = add_label;
+  addonInterface->toKodi->kodi_gui->control_fade_label->get_label = get_label;
+  addonInterface->toKodi->kodi_gui->control_fade_label->set_scrolling = set_scrolling;
+  addonInterface->toKodi->kodi_gui->control_fade_label->reset = reset;
+}
+
+void Interface_GUIControlFadeLabel::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_fade_label);
+}
+
+void Interface_GUIControlFadeLabel::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlFadeLabel::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlFadeLabel::add_label(void* kodiBase, void* handle, const char *label)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  if (!addon || !control | !label)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlFadeLabel::%s - invalid handler data (kodiBase='%p', handle='%p', label='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, label, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_ADD, control->GetParentID(), control->GetID());
+  msg.SetLabel(label);
+  control->OnMessage(msg);
+}
+
+char* Interface_GUIControlFadeLabel::get_label(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlFadeLabel::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  CGUIMessage msg(GUI_MSG_ITEM_SELECTED, control->GetParentID(), control->GetID());
+  control->OnMessage(msg);
+  std::string text = msg.GetLabel();
+  return strdup(text.c_str());
+}
+
+void Interface_GUIControlFadeLabel::set_scrolling(void* kodiBase, void* handle, bool scroll)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlFadeLabel::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetScrolling(scroll);
+}
+
+void Interface_GUIControlFadeLabel::reset(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIFadeLabelControl* control = static_cast<CGUIFadeLabelControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlFadeLabel::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
+  control->OnMessage(msg);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/FadeLabel.h
+++ b/xbmc/addons/interfaces/GUI/controls/FadeLabel.h
@@ -1,0 +1,66 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/FadeLabel.h"
+   */
+  struct Interface_GUIControlFadeLabel
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_enabled(void* kodiBase, void* handle, bool enabled);
+    static void set_selected(void* kodiBase, void* handle, bool selected);
+
+    static void add_label(void* kodiBase, void* handle, const char* label);
+    static char* get_label(void* kodiBase, void* handle);
+    static void set_scrolling(void* kodiBase, void* handle, bool scroll);
+    static void reset(void* kodiBase, void* handle);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Image.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Image.cpp
@@ -1,0 +1,90 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Image.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Image.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIImage.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlImage::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_image = static_cast<AddonToKodiFuncTable_kodi_gui_control_image*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_image)));
+
+  addonInterface->toKodi->kodi_gui->control_image->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_image->set_filename = set_filename;
+  addonInterface->toKodi->kodi_gui->control_image->set_color_diffuse = set_color_diffuse;
+}
+
+void Interface_GUIControlImage::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_image);
+}
+
+void Interface_GUIControlImage::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIImage* control = static_cast<CGUIImage*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlImage::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlImage::set_filename(void* kodiBase, void* handle, const char* filename, bool use_cache)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIImage* control = static_cast<CGUIImage*>(handle);
+  if (!addon || !control || !filename)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlImage::%s - invalid handler data (kodiBase='%p', handle='%p', filename='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, filename, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetFileName(filename, false, use_cache);
+}
+
+void Interface_GUIControlImage::set_color_diffuse(void* kodiBase, void* handle, uint32_t colorDiffuse)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIImage* control = static_cast<CGUIImage*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlImage::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetColorDiffuse(colorDiffuse);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Image.h
+++ b/xbmc/addons/interfaces/GUI/controls/Image.h
@@ -1,0 +1,63 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdint.h>
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Image.h"
+   */
+  struct Interface_GUIControlImage
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_filename(void* kodiBase, void* handle, const char* filename, bool use_cache);
+    static void set_color_diffuse(void* kodiBase, void* handle, uint32_t color_diffuse);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Label.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Label.cpp
@@ -1,0 +1,93 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Label.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Label.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUILabelControl.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlLabel::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_label = static_cast<AddonToKodiFuncTable_kodi_gui_control_label*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_label)));
+
+  addonInterface->toKodi->kodi_gui->control_label->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_label->set_label = set_label;
+  addonInterface->toKodi->kodi_gui->control_label->get_label = get_label;
+}
+
+void Interface_GUIControlLabel::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_label);
+}
+
+void Interface_GUIControlLabel::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUILabelControl* control = static_cast<CGUILabelControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlLabel::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlLabel::set_label(void* kodiBase, void* handle, const char *label)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUILabelControl* control = static_cast<CGUILabelControl*>(handle);
+  if (!addon || !control || !label)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlLabel::%s - invalid handler data (kodiBase='%p', handle='%p', label='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, label, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
+  msg.SetLabel(label);
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+char* Interface_GUIControlLabel::get_label(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUILabelControl* control = static_cast<CGUILabelControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlLabel::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetDescription().c_str());
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Label.h
+++ b/xbmc/addons/interfaces/GUI/controls/Label.h
@@ -1,0 +1,62 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Label.h"
+   */
+  struct Interface_GUIControlLabel
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+
+    static void set_label(void* kodiBase, void* handle, const char* label);
+    static char* get_label(void* kodiBase, void* handle);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Progress.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Progress.cpp
@@ -1,0 +1,91 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Progress.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Progress.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIProgressControl.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlProgress::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_progress = static_cast<AddonToKodiFuncTable_kodi_gui_control_progress*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_progress)));
+
+  addonInterface->toKodi->kodi_gui->control_progress->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_progress->set_percentage = set_percentage;
+  addonInterface->toKodi->kodi_gui->control_progress->get_percentage = get_percentage;
+}
+
+void Interface_GUIControlProgress::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_progress);
+}
+
+void Interface_GUIControlProgress::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIProgressControl* control = static_cast<CGUIProgressControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlProgress::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlProgress::set_percentage(void* kodiBase, void* handle, float percent)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIProgressControl* control = static_cast<CGUIProgressControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlProgress::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetPercentage(percent);
+}
+
+float Interface_GUIControlProgress::get_percentage(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIProgressControl* control = static_cast<CGUIProgressControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlProgress::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0.0f;
+  }
+
+  return control->GetPercentage();
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Progress.h
+++ b/xbmc/addons/interfaces/GUI/controls/Progress.h
@@ -1,0 +1,62 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Progress.h"
+   */
+  struct Interface_GUIControlProgress
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+
+    static void set_percentage(void* kodiBase, void* handle, float percent);
+    static float get_percentage(void* kodiBase, void* handle);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/RadioButton.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/RadioButton.cpp
@@ -1,0 +1,137 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RadioButton.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/RadioButton.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIRadioButtonControl.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlRadioButton::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_radio_button = static_cast<AddonToKodiFuncTable_kodi_gui_control_radio_button*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_radio_button)));
+
+  addonInterface->toKodi->kodi_gui->control_radio_button->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_radio_button->set_enabled = set_enabled;
+
+  addonInterface->toKodi->kodi_gui->control_radio_button->set_label = set_label;
+  addonInterface->toKodi->kodi_gui->control_radio_button->get_label = get_label;
+
+  addonInterface->toKodi->kodi_gui->control_radio_button->set_selected = set_selected;
+  addonInterface->toKodi->kodi_gui->control_radio_button->is_selected = is_selected;
+}
+
+void Interface_GUIControlRadioButton::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_radio_button);
+}
+
+void Interface_GUIControlRadioButton::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlRadioButton::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlRadioButton::set_enabled(void* kodiBase, void* handle, bool enabled)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlRadioButton::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetEnabled(enabled);
+}
+
+void Interface_GUIControlRadioButton::set_label(void* kodiBase, void* handle, const char *label)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  if (!addon || !control || !label)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlRadioButton::%s - invalid handler data (kodiBase='%p', handle='%p', label='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, label, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetLabel(label);
+}
+
+char* Interface_GUIControlRadioButton::get_label(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlRadioButton::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetLabel().c_str());
+}
+
+void Interface_GUIControlRadioButton::set_selected(void* kodiBase, void* handle, bool selected)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlRadioButton::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetSelected(selected);
+}
+
+bool Interface_GUIControlRadioButton::is_selected(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIRadioButtonControl* control = static_cast<CGUIRadioButtonControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlRadioButton::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return false;
+  }
+
+  return control->IsSelected();
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/RadioButton.h
+++ b/xbmc/addons/interfaces/GUI/controls/RadioButton.h
@@ -1,0 +1,66 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/RadioButton.h"
+   */
+  struct Interface_GUIControlRadioButton
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_enabled(void* kodiBase, void* handle, bool enabled);
+
+    static void set_label(void* kodiBase, void* handle, const char* label);
+    static char* get_label(void* kodiBase, void* handle);
+
+    static void set_selected(void* kodiBase, void* handle, bool selected);
+    static bool is_selected(void* kodiBase, void* handle);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Rendering.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Rendering.cpp
@@ -1,0 +1,153 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Rendering.h"
+#include "addons/interfaces/GUI/General.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIRenderingControl.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlAddonRendering::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_rendering = static_cast<AddonToKodiFuncTable_kodi_gui_control_rendering*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_rendering)));
+
+  addonInterface->toKodi->kodi_gui->control_rendering->set_callbacks = set_callbacks;
+  addonInterface->toKodi->kodi_gui->control_rendering->destroy = destroy;
+}
+
+void Interface_GUIControlAddonRendering::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_rendering);
+}
+
+void Interface_GUIControlAddonRendering::set_callbacks(
+                            void* kodiBase, void* handle, void* clienthandle,
+                            bool (*createCB)(void*,int,int,int,int,void*),
+                            void (*renderCB)(void*), void (*stopCB)(void*), bool (*dirtyCB)(void*))
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIAddonRenderingControl* control = static_cast<CGUIAddonRenderingControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlAddonRendering::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  Interface_GUIGeneral::lock();
+  control->m_clientHandle = clienthandle;
+  control->CBCreate = createCB;
+  control->CBRender = renderCB;
+  control->CBStop = stopCB;
+  control->CBDirty = dirtyCB;
+  control->m_addon = addon;
+  Interface_GUIGeneral::unlock();
+
+  control->m_control->InitCallback(control);
+}
+
+void Interface_GUIControlAddonRendering::destroy(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUIAddonRenderingControl* control = static_cast<CGUIAddonRenderingControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlAddonRendering::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  Interface_GUIGeneral::lock();
+  static_cast<CGUIAddonRenderingControl*>(handle)->Delete();
+  Interface_GUIGeneral::unlock();
+}
+
+
+CGUIAddonRenderingControl::CGUIAddonRenderingControl(CGUIRenderingControl *control)
+  : CBCreate{nullptr},
+    CBRender{nullptr},
+    CBStop{nullptr},
+    CBDirty{nullptr},
+    m_clientHandle{nullptr},
+    m_addon{nullptr},
+    m_control{control},
+    m_refCount{1}
+{
+}
+
+bool CGUIAddonRenderingControl::Create(int x, int y, int w, int h, void *device)
+{
+  if (CBCreate)
+  {
+    if (CBCreate(m_clientHandle, x, y, w, h, device))
+    {
+      ++m_refCount;
+      return true;
+    }
+  }
+  return false;
+}
+
+void CGUIAddonRenderingControl::Render()
+{
+  if (CBRender)
+  {
+    CBRender(m_clientHandle);
+  }
+}
+
+void CGUIAddonRenderingControl::Stop()
+{
+  if (CBStop)
+  {
+    CBStop(m_clientHandle);
+  }
+
+  --m_refCount;
+  if (m_refCount <= 0)
+    delete this;
+}
+
+void CGUIAddonRenderingControl::Delete()
+{
+  --m_refCount;
+  if (m_refCount <= 0)
+    delete this;
+}
+
+bool CGUIAddonRenderingControl::IsDirty()
+{
+  bool ret = true;
+  if (CBDirty)
+  {
+    ret = CBDirty(m_clientHandle);
+  }
+  return ret;
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Rendering.h
+++ b/xbmc/addons/interfaces/GUI/controls/Rendering.h
@@ -1,0 +1,106 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "guilib/IRenderingCallback.h"
+
+class CGUIRenderingControl;
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  class CAddonDll;
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h"
+   */
+  struct Interface_GUIControlAddonRendering
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_callbacks(void* kodiBase,
+                             void* handle,
+                             void* clienthandle,
+                             bool (*createCB)(void*,int,int,int,int,void*),
+                             void (*renderCB)(void*),
+                             void (*stopCB)(void*),
+                             bool (*dirtyCB)(void*));
+    static void destroy(void* kodiBase, void* handle);
+    //@}
+  };
+
+  class CGUIAddonRenderingControl : public IRenderingCallback
+  {
+  friend struct Interface_GUIControlAddonRendering;
+  public:
+    CGUIAddonRenderingControl(CGUIRenderingControl *pControl);
+    virtual ~CGUIAddonRenderingControl() {}
+
+    virtual bool Create(int x, int y, int w, int h, void *device);
+    virtual void Render();
+    virtual void Stop();
+    virtual bool IsDirty();
+    virtual void Delete();
+
+  protected:
+    bool (*CBCreate)
+        (void*   cbhdl,
+         int         x,
+         int         y,
+         int         w,
+         int         h,
+         void       *device);
+    void (*CBRender)
+        (void*   cbhdl);
+    void (*CBStop)
+        (void*   cbhdl);
+    bool (*CBDirty)
+        (void*   cbhdl);
+
+    void* m_clientHandle;
+    CAddonDll* m_addon;
+    CGUIRenderingControl* m_control;
+    int m_refCount;
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/SettingsSlider.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/SettingsSlider.cpp
@@ -1,0 +1,268 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SettingsSlider.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/SettingsSlider.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUISettingsSliderControl.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlSettingsSlider::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_settings_slider = static_cast<AddonToKodiFuncTable_kodi_gui_control_settings_slider*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_settings_slider)));
+
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_enabled = set_enabled;
+
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_text = set_text;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->reset = reset;
+
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_int_range = set_int_range;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_int_value = set_int_value;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->get_int_value = get_int_value;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_int_interval = set_int_interval;
+
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_percentage = set_percentage;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->get_percentage = get_percentage;
+
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_float_range = set_float_range;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_float_value = set_float_value;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->get_float_value = get_float_value;
+  addonInterface->toKodi->kodi_gui->control_settings_slider->set_float_interval = set_float_interval;
+}
+
+void Interface_GUIControlSettingsSlider::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_settings_slider);
+}
+
+void Interface_GUIControlSettingsSlider::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlSettingsSlider::set_enabled(void* kodiBase, void* handle, bool enabled)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetEnabled(enabled);
+}
+
+void Interface_GUIControlSettingsSlider::set_text(void* kodiBase, void* handle, const char *text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p', text='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, text, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
+  msg.SetLabel(text);
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+void Interface_GUIControlSettingsSlider::reset(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+void Interface_GUIControlSettingsSlider::set_int_range(void* kodiBase, void* handle, int start, int end)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_INT);
+  control->SetRange(start, end);
+}
+
+void Interface_GUIControlSettingsSlider::set_int_value(void* kodiBase, void* handle, int value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_INT);
+  control->SetIntValue(value);
+}
+
+int Interface_GUIControlSettingsSlider::get_int_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return -1;
+  }
+
+  return control->GetIntValue();
+}
+
+void Interface_GUIControlSettingsSlider::set_int_interval(void* kodiBase, void* handle, int interval)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetIntInterval(interval);
+}
+
+void Interface_GUIControlSettingsSlider::set_percentage(void* kodiBase, void* handle, float percent)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_PERCENTAGE);
+  control->SetPercentage(percent);
+}
+
+float Interface_GUIControlSettingsSlider::get_percentage(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0.0f;
+  }
+
+  return control->GetPercentage();
+}
+
+void Interface_GUIControlSettingsSlider::set_float_range(void* kodiBase, void* handle, float start, float end)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_FLOAT);
+  control->SetFloatRange(start, end);
+}
+
+void Interface_GUIControlSettingsSlider::set_float_value(void* kodiBase, void* handle, float value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_FLOAT);
+  control->SetFloatValue(value);
+}
+
+float Interface_GUIControlSettingsSlider::get_float_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0.0f;
+  }
+
+  return control->GetFloatValue();
+}
+
+void Interface_GUIControlSettingsSlider::set_float_interval(void* kodiBase, void* handle, float interval)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISettingsSliderControl* control = static_cast<CGUISettingsSliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSettingsSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetFloatInterval(interval);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/SettingsSlider.h
+++ b/xbmc/addons/interfaces/GUI/controls/SettingsSlider.h
@@ -1,0 +1,76 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/SettingsSlider.h"
+   */
+  struct Interface_GUIControlSettingsSlider
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_enabled(void* kodiBase, void* handle, bool enabled);
+
+    static void set_text(void* kodiBase, void* handle, const char* text);
+    static void reset(void* kodiBase, void* handle);
+
+    static void set_int_range(void* kodiBase, void* handle, int start, int end);
+    static void set_int_value(void* kodiBase, void* handle, int value);
+    static int get_int_value(void* kodiBase, void* handle);
+    static void set_int_interval(void* kodiBase, void* handle, int interval);
+
+    static void set_percentage(void* kodiBase, void* handle, float percent);
+    static float get_percentage(void* kodiBase, void* handle);
+
+    static void set_float_range(void* kodiBase, void* handle, float start, float end);
+    static void set_float_value(void* kodiBase, void* handle, float value);
+    static float get_float_value(void* kodiBase, void* handle);
+    static void set_float_interval(void* kodiBase, void* handle, float interval);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Slider.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Slider.cpp
@@ -1,0 +1,266 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Slider.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Slider.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUISliderControl.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlSlider::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_slider = static_cast<AddonToKodiFuncTable_kodi_gui_control_slider*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_slider)));
+
+  addonInterface->toKodi->kodi_gui->control_slider->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_slider->set_enabled = set_enabled;
+
+  addonInterface->toKodi->kodi_gui->control_slider->reset = reset;
+  addonInterface->toKodi->kodi_gui->control_slider->get_description = get_description;
+
+  addonInterface->toKodi->kodi_gui->control_slider->set_int_range = set_int_range;
+  addonInterface->toKodi->kodi_gui->control_slider->set_int_value = set_int_value;
+  addonInterface->toKodi->kodi_gui->control_slider->get_int_value = get_int_value;
+  addonInterface->toKodi->kodi_gui->control_slider->set_int_interval = set_int_interval;
+
+  addonInterface->toKodi->kodi_gui->control_slider->set_percentage = set_percentage;
+  addonInterface->toKodi->kodi_gui->control_slider->get_percentage = get_percentage;
+
+  addonInterface->toKodi->kodi_gui->control_slider->set_float_range = set_float_range;
+  addonInterface->toKodi->kodi_gui->control_slider->set_float_value = set_float_value;
+  addonInterface->toKodi->kodi_gui->control_slider->get_float_value = get_float_value;
+  addonInterface->toKodi->kodi_gui->control_slider->set_float_interval = set_float_interval;
+}
+
+void Interface_GUIControlSlider::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_slider);
+}
+
+void Interface_GUIControlSlider::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlSlider::set_enabled(void* kodiBase, void* handle, bool enabled)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetEnabled(enabled);
+}
+
+void Interface_GUIControlSlider::reset(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+char* Interface_GUIControlSlider::get_description(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetDescription().c_str());
+}
+
+void Interface_GUIControlSlider::set_int_range(void* kodiBase, void* handle, int start, int end)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_INT);
+  control->SetRange(start, end);
+}
+
+void Interface_GUIControlSlider::set_int_value(void* kodiBase, void* handle, int value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_INT);
+  control->SetIntValue(value);
+}
+
+int Interface_GUIControlSlider::get_int_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return -1;
+  }
+
+  return control->GetIntValue();
+}
+
+void Interface_GUIControlSlider::set_int_interval(void* kodiBase, void* handle, int interval)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetIntInterval(interval);
+}
+
+void Interface_GUIControlSlider::set_percentage(void* kodiBase, void* handle, float percent)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_PERCENTAGE);
+  control->SetPercentage(percent);
+}
+
+float Interface_GUIControlSlider::get_percentage(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0.0f;
+  }
+
+  return control->GetPercentage();
+}
+
+void Interface_GUIControlSlider::set_float_range(void* kodiBase, void* handle, float start, float end)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_FLOAT);
+  control->SetFloatRange(start, end);
+}
+
+void Interface_GUIControlSlider::set_float_value(void* kodiBase, void* handle, float value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(SLIDER_CONTROL_TYPE_FLOAT);
+  control->SetFloatValue(value);
+}
+
+float Interface_GUIControlSlider::get_float_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0.0f;
+  }
+
+  return control->GetFloatValue();
+}
+
+void Interface_GUIControlSlider::set_float_interval(void* kodiBase, void* handle, float interval)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISliderControl* control = static_cast<CGUISliderControl*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSlider::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetFloatInterval(interval);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Slider.h
+++ b/xbmc/addons/interfaces/GUI/controls/Slider.h
@@ -1,0 +1,77 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Slider.h"
+   */
+  struct Interface_GUIControlSlider
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_enabled(void* kodiBase, void* handle, bool enabled);
+
+    static void reset(void* kodiBase, void* handle);
+
+    static char* get_description(void* kodiBase, void* handle);
+
+    static void set_int_range(void* kodiBase, void* handle, int start, int end);
+    static void set_int_value(void* kodiBase, void* handle, int value);
+    static int get_int_value(void* kodiBase, void* handle);
+    static void set_int_interval(void* kodiBase, void* handle, int interval);
+
+    static void set_percentage(void* kodiBase, void* handle, float percent);
+    static float get_percentage(void* kodiBase, void* handle);
+
+    static void set_float_range(void* kodiBase, void* handle, float start, float end);
+    static void set_float_value(void* kodiBase, void* handle, float value);
+    static float get_float_value(void* kodiBase, void* handle);
+    static void set_float_interval(void* kodiBase, void* handle, float interval);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Spin.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/Spin.cpp
@@ -1,0 +1,293 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Spin.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/Spin.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUISpinControlEx.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlSpin::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_spin = static_cast<AddonToKodiFuncTable_kodi_gui_control_spin*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_spin)));
+
+  addonInterface->toKodi->kodi_gui->control_spin->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_spin->set_enabled = set_enabled;
+
+  addonInterface->toKodi->kodi_gui->control_spin->set_text = set_text;
+  addonInterface->toKodi->kodi_gui->control_spin->reset = reset;
+  addonInterface->toKodi->kodi_gui->control_spin->set_type = set_type;
+
+  addonInterface->toKodi->kodi_gui->control_spin->add_string_label = add_string_label;
+  addonInterface->toKodi->kodi_gui->control_spin->set_string_value = set_string_value;
+  addonInterface->toKodi->kodi_gui->control_spin->get_string_value = get_string_value;
+
+  addonInterface->toKodi->kodi_gui->control_spin->add_int_label = add_int_label;
+  addonInterface->toKodi->kodi_gui->control_spin->set_int_range = set_int_range;
+  addonInterface->toKodi->kodi_gui->control_spin->set_int_value = set_int_value;
+  addonInterface->toKodi->kodi_gui->control_spin->get_int_value = get_int_value;
+
+  addonInterface->toKodi->kodi_gui->control_spin->set_float_range = set_float_range;
+  addonInterface->toKodi->kodi_gui->control_spin->set_float_value = set_float_value;
+  addonInterface->toKodi->kodi_gui->control_spin->get_float_value = get_float_value;
+  addonInterface->toKodi->kodi_gui->control_spin->set_float_interval = set_float_interval;
+}
+
+void Interface_GUIControlSpin::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_spin);
+}
+
+void Interface_GUIControlSpin::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlSpin::set_enabled(void* kodiBase, void* handle, bool enabled)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetEnabled(enabled);
+}
+
+void Interface_GUIControlSpin::set_text(void* kodiBase, void* handle, const char *text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p', text='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, text, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
+  msg.SetLabel(text);
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+void Interface_GUIControlSpin::reset(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+void Interface_GUIControlSpin::set_type(void* kodiBase, void* handle, int type)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetType(type);
+}
+
+void Interface_GUIControlSpin::add_string_label(void* kodiBase, void* handle, const char* label, const char* value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control || !label || !value)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p', label='%p', value='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, label, value, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->AddLabel(std::string(label), std::string(value));
+}
+
+void Interface_GUIControlSpin::set_string_value(void* kodiBase, void* handle, const char* value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control || !value)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p', value='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, value, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetStringValue(std::string(value));
+}
+
+char* Interface_GUIControlSpin::get_string_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetStringValue().c_str());
+}
+
+void Interface_GUIControlSpin::add_int_label(void* kodiBase, void* handle, const char* label, int value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control || !label)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p', label='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, label, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->AddLabel(std::string(label), value);
+}
+
+void Interface_GUIControlSpin::set_int_range(void* kodiBase, void* handle, int start, int end)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetRange(start, end);
+}
+
+void Interface_GUIControlSpin::set_int_value(void* kodiBase, void* handle, int value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetValue(value);
+}
+
+int Interface_GUIControlSpin::get_int_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return -1;
+  }
+
+  return control->GetValue();
+}
+
+void Interface_GUIControlSpin::set_float_range(void* kodiBase, void* handle, float start, float end)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetFloatRange(start, end);
+}
+
+void Interface_GUIControlSpin::set_float_value(void* kodiBase, void* handle, float value)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetFloatValue(value);
+}
+
+float Interface_GUIControlSpin::get_float_value(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return 0.0f;
+  }
+
+  return control->GetFloatValue();
+}
+
+void Interface_GUIControlSpin::set_float_interval(void* kodiBase, void* handle, float interval)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUISpinControlEx* control = static_cast<CGUISpinControlEx*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlSpin::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetFloatInterval(interval);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/Spin.h
+++ b/xbmc/addons/interfaces/GUI/controls/Spin.h
@@ -1,0 +1,79 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Spin.h"
+   */
+  struct Interface_GUIControlSpin
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void set_enabled(void* kodiBase, void* handle, bool enabled);
+
+    static void set_text(void* kodiBase, void* handle, const char *text);
+    static void reset(void* kodiBase, void* handle);
+    static void set_type(void* kodiBase, void* handle, int type);
+
+    static void add_string_label(void* kodiBase, void* handle, const char* label, const char* value);
+    static void add_int_label(void* kodiBase, void* handle, const char* label, int value);
+
+    static void set_string_value(void* kodiBase, void* handle, const char* value);
+    static char* get_string_value(void* kodiBase, void* handle);
+
+    static void set_int_range(void* kodiBase, void* handle, int start, int end);
+    static void set_int_value(void* kodiBase, void* handle, int value);
+    static int get_int_value(void* kodiBase, void* handle);
+
+    static void set_float_range(void* kodiBase, void* handle, float start, float end);
+    static void set_float_value(void* kodiBase, void* handle, float value);
+    static float get_float_value(void* kodiBase, void* handle);
+    static void set_float_interval(void* kodiBase, void* handle, float interval);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/TextBox.cpp
+++ b/xbmc/addons/interfaces/GUI/controls/TextBox.cpp
@@ -1,0 +1,139 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "TextBox.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/controls/TextBox.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUITextBox.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIControlTextBox::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi->kodi_gui->control_text_box = static_cast<AddonToKodiFuncTable_kodi_gui_control_text_box*>(malloc(sizeof(AddonToKodiFuncTable_kodi_gui_control_text_box)));
+
+  addonInterface->toKodi->kodi_gui->control_text_box->set_visible = set_visible;
+  addonInterface->toKodi->kodi_gui->control_text_box->reset = reset;
+  addonInterface->toKodi->kodi_gui->control_text_box->set_text = set_text;
+  addonInterface->toKodi->kodi_gui->control_text_box->get_text = get_text;
+  addonInterface->toKodi->kodi_gui->control_text_box->scroll = scroll;
+  addonInterface->toKodi->kodi_gui->control_text_box->set_auto_scrolling = set_auto_scrolling;
+}
+
+void Interface_GUIControlTextBox::DeInit(AddonGlobalInterface* addonInterface)
+{
+  free(addonInterface->toKodi->kodi_gui->control_text_box);
+}
+
+void Interface_GUIControlTextBox::set_visible(void* kodiBase, void* handle, bool visible)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlTextBox::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetVisible(visible);
+}
+
+void Interface_GUIControlTextBox::reset(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlTextBox::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, control->GetParentID(), control->GetID());
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+void Interface_GUIControlTextBox::set_text(void* kodiBase, void* handle, const char* text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  if (!addon || !control || !text)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlTextBox::%s - invalid handler data (kodiBase='%p', handle='%p', text='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, text, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  CGUIMessage msg(GUI_MSG_LABEL_SET, control->GetParentID(), control->GetID());
+  msg.SetLabel(text);
+  g_windowManager.SendThreadMessage(msg, control->GetParentID());
+}
+
+char* Interface_GUIControlTextBox::get_text(void* kodiBase, void* handle)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlTextBox::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return nullptr;
+  }
+
+  return strdup(control->GetDescription().c_str());
+}
+
+void Interface_GUIControlTextBox::scroll(void* kodiBase, void* handle, unsigned int position)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlTextBox::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->Scroll(position);
+}
+
+void Interface_GUIControlTextBox::set_auto_scrolling(void* kodiBase, void* handle, int delay, int time, int repeat)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  CGUITextBox* control = static_cast<CGUITextBox*>(handle);
+  if (!addon || !control)
+  {
+    CLog::Log(LOGERROR, "Interface_GUIControlTextBox::%s - invalid handler data (kodiBase='%p', handle='%p') on addon '%s'",
+                          __FUNCTION__, addon, control, addon ? addon->ID().c_str() : "unknown");
+    return;
+  }
+
+  control->SetAutoScrolling(delay, time, repeat);
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/GUI/controls/TextBox.h
+++ b/xbmc/addons/interfaces/GUI/controls/TextBox.h
@@ -1,0 +1,65 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/TextBox.h"
+   */
+  struct Interface_GUIControlTextBox
+  {
+
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note To add a new function use the "_" style to directly identify an
+     * add-on callback function. Everything with CamelCase is only to be used
+     * in Kodi.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void set_visible(void* kodiBase, void* handle, bool visible);
+    static void reset(void* kodiBase, void* handle);
+    static void set_text(void* kodiBase, void* handle, const char* text);
+    static char* get_text(void* kodiBase, void* handle);
+    static void scroll(void* kodiBase, void* handle, unsigned int position);
+    static void set_auto_scrolling(void* kodiBase, void* handle, int delay, int time, int repeat);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Edit.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Edit.h
@@ -1,0 +1,276 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CEdit Control Edit
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CEdit }
+  /// **Editable window text control used as an input control for the osd keyboard
+  /// and other input fields**
+  ///
+  /// The edit control  allows a user to  input text in Kodi. You can choose the
+  /// font, size, colour, location and header of the text to be displayed.
+  ///
+  /// It has the header \ref Edit.h "#include <kodi/gui/controls/Edit.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here  you  find  the   needed  skin  part  for  a   \ref skin_Edit_control
+  /// "edit control".
+  ///
+  /// @note The  call of the  control is only possible  from  the  corresponding
+  /// window as its class and identification number is required.
+  ///
+
+  //============================================================================
+  // see gui/definition.h for use of group "cpp_kodi_gui_controls_CEdit_Defs"
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CEdit_Defs Definitions, structures and enumerators
+  /// \ingroup cpp_kodi_gui_controls_CEdit
+  /// @brief **Library definition values**
+  ///
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */
+
+//============================================================================
+///
+/// \ingroup cpp_kodi_gui_controls_CEdit_Defs
+/// @{
+/// @anchor AddonGUIInputType
+/// @brief Text input types used on kodi::gui::controls::CEdit
+enum AddonGUIInputType
+{
+  /// Text inside edit control only readable
+  ADDON_INPUT_TYPE_READONLY = -1,
+  /// Normal text entries
+  ADDON_INPUT_TYPE_TEXT = 0,
+  /// To use on edit control only numeric numbers
+  ADDON_INPUT_TYPE_NUMBER,
+  /// To insert seconds
+  ADDON_INPUT_TYPE_SECONDS,
+  /// To insert time
+  ADDON_INPUT_TYPE_TIME,
+  /// To insert a date
+  ADDON_INPUT_TYPE_DATE,
+  /// Used for write in IP addresses
+  ADDON_INPUT_TYPE_IPADDRESS,
+  /// Text field used as password entry field with not visible text
+  ADDON_INPUT_TYPE_PASSWORD,
+  /// Text field used as password entry field with not visible text but
+  /// returned as MD5 value
+  ADDON_INPUT_TYPE_PASSWORD_MD5,
+  /// Use text field for search purpose
+  ADDON_INPUT_TYPE_SEARCH,
+  /// Text field as filter
+  ADDON_INPUT_TYPE_FILTER,
+  ///
+  ADDON_INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW
+};
+/// @}
+//----------------------------------------------------------------------------
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  class CEdit : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CEdit(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_edit(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::control::CEdit can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Destructor
+    ///
+    virtual ~CEdit() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_edit->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Set's the control's enabled/disabled state
+    ///
+    /// @param[in] enabled              If true enabled, otherwise disabled
+    ///
+    void SetEnabled(bool enabled)
+    {
+      m_interface->kodi_gui->control_edit->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief To set the text string on edit control
+    ///
+    /// @param[in] label                Text to show
+    ///
+    void SetLabel(const std::string& label)
+    {
+      m_interface->kodi_gui->control_edit->set_label(m_interface->kodiBase, m_controlHandle, label.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Returns the text heading for this edit control.
+    ///
+    /// @return                         Heading text
+    ///
+    std::string GetLabel() const
+    {
+      std::string label;
+      char* ret = m_interface->kodi_gui->control_edit->get_label(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          label = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return label;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Set's text heading for this edit control.
+    ///
+    /// @param[in] text                 string or unicode - text string.
+    ///
+    void SetText(const std::string& text)
+    {
+      m_interface->kodi_gui->control_edit->set_text(m_interface->kodiBase, m_controlHandle, text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Returns the text value for this edit control.
+    ///
+    /// @return                         Text value of control
+    ///
+    std::string GetText() const
+    {
+      std::string text;
+      char* ret = m_interface->kodi_gui->control_edit->get_text(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          text = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return text;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief Set the cursor position on text.
+    ///
+    /// @param[in] iPosition            The position to set
+    ///
+    void SetCursorPosition(unsigned int iPosition)
+    {
+      m_interface->kodi_gui->control_edit->set_cursor_position(m_interface->kodiBase, m_controlHandle, iPosition);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief To get current cursor position on text field
+    ///
+    /// @return                         The current cursor position
+    ///
+    unsigned int GetCursorPosition()
+    {
+      return m_interface->kodi_gui->control_edit->get_cursor_position(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CEdit
+    /// @brief To set field input type which are defined on \ref AddonGUIInputType
+    ///
+    /// @param[in] type                 The \ref AddonGUIInputType "Add-on input type"
+    ///                                 to use
+    /// @param[in] heading              The heading text for related keyboard
+    ///                                 dialog
+    ///
+    void SetInputType(AddonGUIInputType type, const std::string& heading)
+    {
+      m_interface->kodi_gui->control_edit->set_input_type(m_interface->kodiBase, m_controlHandle, static_cast<int>(type), heading.c_str());
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/FadeLabel.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/FadeLabel.h
@@ -1,0 +1,159 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CFadeLabel Control Fade Label
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CFadeLabel }
+  /// **Window control used to show multiple pieces of text in the same position,
+  /// by fading from one to the other**
+  ///
+  /// The fade label  control is used for displaying multiple pieces  of text in
+  /// the same  space in  Kodi. You can choose  the font, size, colour, location
+  /// and contents  of the text to be displayed.  The first piece of information
+  /// to display fades in over 50 frames, then scrolls off to the left.  Once it
+  /// is  finished scrolling off screen,  the second piece  of information fades
+  /// in and  the process repeats.  A fade label  control is not  supported in a
+  /// list container.
+  ///
+  /// It has the header \ref FadeLabel.h "#include <kodi/gui/controls/FadeLabel.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Fade_Label_Control "fade label control"
+  ///
+  /// @note The  call of the  control is only  possible from  the  corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CFadeLabel : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief Construct a new control.
+    ///
+    /// @param[in] window     related window control class
+    /// @param[in] controlId  Used skin xml control id
+    ///
+    CFadeLabel(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_fade_label(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CFadeLabel can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief Destructor.
+    ///
+    virtual ~CFadeLabel() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief Set the control on window to visible.
+    ///
+    /// @param[in] visible    If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_fade_label->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief To add additional text string on fade label.
+    ///
+    /// @param[in] label      Text to show
+    ///
+    void AddLabel(const std::string& label)
+    {
+      m_interface->kodi_gui->control_fade_label->add_label(m_interface->kodiBase, m_controlHandle, label.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief Get the used text from button
+    ///
+    /// @return               Text shown
+    ///
+    std::string GetLabel() const
+    {
+      std::string label;
+      char* ret = m_interface->kodi_gui->control_fade_label->get_label(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          label = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return label;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief To enable or disable scrolling on fade label
+    ///
+    /// @param[in] scroll     To  enable scrolling  set  to true,  otherwise  is
+    ///                       disabled
+    ///
+    void SetScrolling(bool scroll)
+    {
+      m_interface->kodi_gui->control_fade_label->set_scrolling(m_interface->kodiBase, m_controlHandle, scroll);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CFadeLabel
+    /// @brief To reset al inserted labels.
+    ///
+    void Reset()
+    {
+      m_interface->kodi_gui->control_fade_label->reset(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Image.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Image.h
@@ -1,0 +1,123 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CImage Control Image
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CImage }
+  /// **Window control used to show an image.**
+  ///
+  /// The  image control is used  for displaying  images in Kodi. You can choose
+  /// the position, size, transparency and contents of the image to be displayed.
+  ///
+  /// It has the header \ref Image.h "#include <kodi/gui/controls/Image.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Image_Control "image control"
+  ///
+  /// @note The  call of  the control is  only possible  from the  corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CImage : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CImage
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CImage(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_image(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CImage can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CImage
+    /// @brief Destructor
+    ///
+    virtual ~CImage() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CImage
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_image->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CImage
+    /// @brief To set the filename used on image control.
+    ///
+    /// @param[in] filename             Image file to use
+    /// @param[in] useCache             To define  storage of image,  default is
+    ///                                 in  cache,  if false  becomes it  loaded
+    ///                                 always on changes again
+    ///
+    void SetFileName(const std::string& filename, bool useCache = true)
+    {
+      m_interface->kodi_gui->control_image->set_filename(m_interface->kodiBase, m_controlHandle, filename.c_str(), useCache);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CImage
+    /// @brief To set set the diffuse color on image.
+    ///
+    /// @param[in] colorDiffuse         Color to use for diffuse
+    ///
+    void SetColorDiffuse(uint32_t colorDiffuse)
+    {
+      m_interface->kodi_gui->control_image->set_color_diffuse(m_interface->kodiBase, m_controlHandle, colorDiffuse);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Label.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Label.h
@@ -1,0 +1,128 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CLabel Control Label
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CLabel }
+  /// **Window control used to show some lines of text.**
+  ///
+  /// The  label control  is used for  displaying text  in Kodi.  You can choose
+  /// the font, size, colour, location and contents of the text to be displayed.
+  ///
+  /// It has the header \ref Label.h "#include <kodi/gui/controls/Label.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Label_Control "label control"
+  ///
+  /// @note The  call  of the control  is only possible  from the  corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CLabel : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CLabel
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CLabel(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_label(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CLabel can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CLabel
+    /// @brief Destructor
+    ///
+    virtual ~CLabel() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CLabel
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_label->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CLabel
+    /// @brief To set the text string on label
+    ///
+    /// @param[in] text                 Text to show
+    ///
+    void SetLabel(const std::string& text)
+    {
+      m_interface->kodi_gui->control_label->set_label(m_interface->kodiBase, m_controlHandle, text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CLabel
+    /// @brief Get the used text from control
+    ///
+    /// @return                         Used text on label control
+    ///
+    std::string GetLabel() const
+    {
+      std::string label;
+      char* ret = m_interface->kodi_gui->control_label->get_label(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          label = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return label;
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Progress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Progress.h
@@ -1,0 +1,121 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CProgress Control Progress
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CProgress }
+  /// **Window control to show the progress of a particular operation**
+  ///
+  /// The progress control is used to show the progress of an item that may take
+  /// a long time,  or to show how far  through a movie you are.  You can choose
+  /// the position, size, and look of the progress control.
+  ///
+  /// It has the header \ref Progress.h "#include <kodi/gui/controls/Progress.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Progress_Control "progress control"
+  ///
+  /// @note The call of the control is only possible from the corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CProgress : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CProgress
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CProgress(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_progress(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CProgress can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CProgress
+    /// @brief Destructor
+    ///
+    virtual ~CProgress() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CProgress
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_progress->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CProgress
+    /// @brief To set Percent position of control
+    ///
+    /// @param[in] percent              The percent position to use
+    ///
+    void SetPercentage(float percent)
+    {
+      m_interface->kodi_gui->control_progress->set_percentage(m_interface->kodiBase, m_controlHandle, percent);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CProgress
+    /// @brief Get the active percent position of progress bar
+    ///
+    /// @return                         Progress position as percent
+    ///
+    float GetPercentage() const
+    {
+      return m_interface->kodi_gui->control_progress->get_percentage(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/RadioButton.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/RadioButton.h
@@ -31,101 +31,103 @@ namespace controls
 
   //============================================================================
   ///
-  /// \defgroup cpp_kodi_gui_controls_CButton Control Button
+  /// \defgroup cpp_kodi_gui_controls_CRadioButton Control Radio Button
   /// \ingroup cpp_kodi_gui
-  /// @brief \cpp_class{ kodi::gui::controls::CButton }
-  /// **Standard push button control for window**
+  /// @brief \cpp_class{ kodi::gui::controls::CRadioButton }
+  /// **Window control for a radio button (as used for on/off settings)**
   ///
-  /// The  button  control  is used for creating push buttons  in Kodi.  You can
-  /// choose the position,  size,  and look of the button,  as well as  choosing
-  /// what action(s) should be performed when pushed.
+  /// The radio  button control is used for creating push button on/off settings
+  /// in Kodi. You can choose the position,  size,  and look of the button. When
+  /// the user clicks on the radio button,  the state will change,  toggling the
+  /// extra  textures  (textureradioon and textureradiooff).  Used  for settings
+  /// controls.
   ///
-  /// It has the header \ref Button.h "#include <kodi/gui/controls/Button.h>"
+  /// It has the header \ref RadioButton.h "#include <kodi/gui/controls/RadioButton.h>"
   /// be included to enjoy it.
   ///
-  /// Here you find the needed skin part for a \ref skin_Button_control "button control"
+  /// Here you find the needed skin part for a \ref Radio_button_control "radio button control"
   ///
-  /// @note The call of the control is  only  possible  from  the  corresponding
+  /// @note The  call  of the  control is  only possible  from the corresponding
   /// window as its class and identification number is required.
   ///
-  class CButton : public CAddonGUIControlBase
+  class CRadioButton : public CAddonGUIControlBase
   {
   public:
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
     /// @brief Construct a new control
     ///
-    /// @param[in] window               related window control class
-    /// @param[in] controlId            Used skin xml control id
+    /// @param[in] window     related window control class
+    /// @param[in] controlId  Used skin xml control id
     ///
-    CButton(CWindow* window, int controlId)
+    CRadioButton(CWindow* window, int controlId)
       : CAddonGUIControlBase(window)
     {
-      m_controlHandle = m_interface->kodi_gui->window->get_control_button(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      m_controlHandle = m_interface->kodi_gui->window->get_control_radio_button(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
       if (!m_controlHandle)
-        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::CButton can't create control class from Kodi !!!");
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CRadioButton can't create control class from Kodi !!!");
     }
     //--------------------------------------------------------------------------
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
     /// @brief Destructor
     ///
-    virtual ~CButton() = default;
+    virtual ~CRadioButton() = default;
     //--------------------------------------------------------------------------
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
     /// @brief Set the control on window to visible
     ///
-    /// @param[in] visible              If true visible, otherwise hidden
+    /// @param[in] visible    If true visible, otherwise hidden
     ///
     void SetVisible(bool visible)
     {
-      m_interface->kodi_gui->control_button->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+      m_interface->kodi_gui->control_radio_button->set_visible(m_interface->kodiBase, m_controlHandle, visible);
     }
     //--------------------------------------------------------------------------
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
     /// @brief Set's the control's enabled/disabled state
     ///
-    /// @param[in] enabled              If true enabled, otherwise disabled
+    /// @param[in] enabled    If true enabled, otherwise disabled
     ///
     void SetEnabled(bool enabled)
     {
-      m_interface->kodi_gui->control_button->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
+      m_interface->kodi_gui->control_radio_button->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
     }
     //--------------------------------------------------------------------------
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief To set the text string on button
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
+    /// @brief To set the text string on radio button
     ///
-    /// @param[in] label                Text to show
+    /// @param[in] label      Text to show
     ///
     void SetLabel(const std::string& label)
     {
-      m_interface->kodi_gui->control_button->set_label(m_interface->kodiBase, m_controlHandle, label.c_str());
+      m_interface->kodi_gui->control_radio_button->set_label(m_interface->kodiBase, m_controlHandle, label.c_str());
     }
     //--------------------------------------------------------------------------
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Get the used text from button
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
+    /// @brief Get the used text from control
     ///
-    /// @return                         Text shown
+    /// @return               Text shown
     ///
     std::string GetLabel() const
     {
       std::string label;
-      char* ret = m_interface->kodi_gui->control_button->get_label(m_interface->kodiBase, m_controlHandle);
+      char* ret = m_interface->kodi_gui->control_radio_button->get_label(m_interface->kodiBase, m_controlHandle);
       if (ret != nullptr)
       {
         if (std::strlen(ret))
@@ -138,35 +140,28 @@ namespace controls
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief If two labels are used for button becomes it set with them
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
+    /// @brief To set radio button condition to on or off
     ///
-    /// @param[in] label                Text for second label
+    /// @param[in] selected   true set radio button to  selection on,  otherwise
+    ///                       off
     ///
-    void SetLabel2(const std::string& label)
+    void SetSelected(bool selected)
     {
-      m_interface->kodi_gui->control_button->set_label2(m_interface->kodiBase, m_controlHandle, label.c_str());
+      m_interface->kodi_gui->control_radio_button->set_selected(m_interface->kodiBase, m_controlHandle, selected);
     }
     //--------------------------------------------------------------------------
 
     //==========================================================================
     ///
-    /// @ingroup cpp_kodi_gui_control_CButton
-    /// @brief Get the second label if present
+    /// \ingroup cpp_kodi_gui_controls_CRadioButton
+    /// @brief Get the current selected condition of radio button
     ///
-    /// @return                         Second label
+    /// @return               Selected condition
     ///
-    std::string GetLabel2() const
+    bool IsSelected() const
     {
-      std::string label;
-      char* ret = m_interface->kodi_gui->control_button->get_label2(m_interface->kodiBase, m_controlHandle);
-      if (ret != nullptr)
-      {
-        if (std::strlen(ret))
-          label = ret;
-        m_interface->free_string(m_interface->kodiBase, ret);
-      }
-      return label;
+      return m_interface->kodi_gui->control_radio_button->is_selected(m_interface->kodiBase, m_controlHandle);
     }
     //--------------------------------------------------------------------------
   };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Rendering.h
@@ -1,0 +1,215 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CRendering Control Rendering
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CRendering }
+  /// **Window control for rendering own parts**
+  ///
+  /// This rendering control is used  when own parts are needed.  You  have  the
+  /// control  over them  to render direct  OpenGL or  DirectX  content  to  the
+  /// screen set by the size of them.
+  ///
+  /// Alternative  can be  the virtual  functions from t his been ignored if the
+  /// callbacks are  defined  by the  \ref CRendering_SetIndependentCallbacks function  and
+  /// class is used as single and not as a parent class.
+  ///
+  /// It has the header \ref Rendering.h "#include <kodi/gui/controls/Rendering.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Addon_Rendering_control "rendering control"
+  ///
+  /// @note The  call of  the control is only  possible  from  the corresponding
+  /// window as its class and identification number is required.
+  ///
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CRendering_Defs Definitions, structures and enumerators
+  /// \ingroup cpp_kodi_gui_controls_CRendering
+  /// @brief **Library definition values**
+  ///
+
+  class CRendering : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CRendering(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_render_addon(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (m_controlHandle)
+        m_interface->kodi_gui->control_rendering->set_callbacks(m_interface->kodiBase, m_controlHandle, this,
+                                                                OnCreateCB, OnRenderCB, OnStopCB, OnDirtyCB);
+      else
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::%s can't create control class from Kodi !!!", __FUNCTION__);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// @brief Destructor
+    ///
+    virtual ~CRendering()
+    {
+      m_interface->kodi_gui->control_rendering->destroy(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// @brief To create rendering control on Add-on
+    ///
+    /// Function  creates the  needed rendering  control for Kodi  which becomes
+    /// handled and processed from Add-on
+    ///
+    /// @note This is  callback  function  from Kodi  to  Add-on and  not to use
+    /// for calls from add-on to this function.
+    ///
+    /// @param[in] x                    Horizontal position
+    /// @param[in] y                    Vertical position
+    /// @param[in] w                    Width of control
+    /// @param[in] h                    Height of control
+    /// @param[in] device               The device to use.  For OpenGL  is empty
+    ///                                 on Direct X is the needed device send.
+    /// @return                         Add-on needs to return true if successed,
+    ///                                 otherwise false.
+    ///
+    virtual bool Create(int x, int y, int w, int h, void* device) { return false; }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// @brief Render process call from Kodi
+    ///
+    /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
+    /// for calls from add-on to this function.
+    ///
+    virtual void Render() { }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// @brief Call from Kodi to stop rendering process
+    ///
+    /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
+    /// for calls from add-on to this function.
+    ///
+    virtual void Stop() { }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// @brief Call from Kodi where add-on  becomes asked about  dirty rendering
+    /// region.
+    ///
+    /// @note This  is callback  function from  Kodi to  Add-on  and not  to use
+    /// for calls from add-on to this function.
+    ///
+    virtual bool Dirty() { return false; }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CRendering
+    /// \anchor CRendering_SetIndependentCallbacks
+    /// @brief If the  class is used  independent (with "new CRendering")
+    /// and not as  parent (with "cCLASS_own : CRendering") from own must
+    /// be the callback from Kodi to add-on overdriven with own functions!
+    ///
+    void SetIndependentCallbacks(
+        GUIHANDLE             cbhdl,
+        bool      (*CBCreate)(GUIHANDLE cbhdl,
+                              int       x,
+                              int       y,
+                              int       w,
+                              int       h,
+                              void*     device),
+        void      (*CBRender)(GUIHANDLE cbhdl),
+        void      (*CBStop)  (GUIHANDLE cbhdl),
+        bool      (*CBDirty) (GUIHANDLE cbhdl))
+    {
+      if (!cbhdl ||
+          !CBCreate || !CBRender || !CBStop || !CBDirty)
+      {
+        kodi::Log(ADDON_LOG_ERROR, "kodi::gui::controls::%s called with nullptr !!!", __FUNCTION__);
+        return;
+      }
+
+      m_interface->kodi_gui->control_rendering->set_callbacks(m_interface->kodiBase, m_controlHandle, cbhdl,
+                                          CBCreate, CBRender, CBStop, CBDirty);
+    }
+    //--------------------------------------------------------------------------
+
+  private:
+    /*
+     * Defined callback functions from Kodi to add-on, for use in parent / child system
+     * (is private)!
+     */
+    static bool OnCreateCB(void* cbhdl, int x, int y, int w, int h, void* device)
+    {
+      return static_cast<CRendering*>(cbhdl)->Create(x, y, w, h, device);
+    }
+
+    static void OnRenderCB(void* cbhdl)
+    {
+      static_cast<CRendering*>(cbhdl)->Render();
+    }
+
+    static void OnStopCB(void* cbhdl)
+    {
+      static_cast<CRendering*>(cbhdl)->Stop();
+    }
+
+    static bool OnDirtyCB(void* cbhdl)
+    {
+      return static_cast<CRendering*>(cbhdl)->Dirty();
+    }
+
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/SettingsSlider.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/SettingsSlider.h
@@ -1,0 +1,323 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CSettingsSlider Control Settings Slider
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CSettingsSlider }
+  /// **Window control for moveable slider with text name**
+  ///
+  /// The settings slider control is  used in the settings  screens for  when an
+  /// option is best  specified on a sliding scale. You can choose the position,
+  /// size, and look of the slider control.  It is basically a cross between the
+  /// button control  and a slider  control.  It has a  label and  focus and non
+  /// focus textures, as well as a slider control on the right.
+  ///
+  /// It has the header \ref SettingsSlider.h "#include <kodi/gui/controls/SettingsSlider.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Settings_Slider_Control "settings slider control"
+  ///
+  /// @note The call  of the control  is only  possible  from the  corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CSettingsSlider : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CSettingsSlider(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_settings_slider(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CSettingsSlider can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Destructor
+    ///
+    virtual ~CSettingsSlider() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Set's the control's enabled/disabled state
+    ///
+    /// @param[in] enabled              If true enabled, otherwise disabled
+    ///
+    void SetEnabled(bool enabled)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To set the text string on settings slider
+    ///
+    /// @param[in] text                 Text to show
+    ///
+    void SetText(const std::string& text)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_text(m_interface->kodiBase, m_controlHandle, text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To reset slider on defaults
+    ///
+    void Reset()
+    {
+      m_interface->kodi_gui->control_settings_slider->reset(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To set the the range as integer of slider, e.g. -10 is the slider
+    /// start and e.g. +10 is  the from here defined position where it reach the
+    /// end.
+    ///
+    /// Ad default is the range from 0 to 100.
+    ///
+    /// The integer interval is as default 1 and can be changed with
+    /// @ref SetIntInterval.
+    ///
+    /// @param[in] start                Integer start value
+    /// @param[in] end                  Integer end value
+    ///
+    /// @note Percent, floating point  or integer are alone possible.  Combining
+    /// these different  values  can be not  together  and can, therefore,  only
+    /// one each can be used.
+    ///
+    void SetIntRange(int start, int end)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_int_range(m_interface->kodiBase, m_controlHandle, start, end);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Set the slider position  with the given integer value.  The Range
+    /// must be defined with a call from \ref SetIntRange before.
+    ///
+    /// @param[in] value                Position in range to set with integer
+    ///
+    /// @note Percent, floating point  or integer are alone possible.  Combining
+    /// these different  values ​​can  be not  together and  can, therefore,  only
+    /// one each can be used.
+    ///
+    void SetIntValue(int value)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_int_value(m_interface->kodiBase, m_controlHandle, value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To get the current position as integer value.
+    ///
+    /// @return                         The position as integer
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different  values ​​can  be not  together and can,  therefore,  only
+    /// one each can be used.
+    ///
+    int GetIntValue() const
+    {
+      return m_interface->kodi_gui->control_settings_slider->get_int_value(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To set the  interval steps of slider,  as default is it 1.  If it
+    /// becomes  changed with  this function  will a step  of the user  with the
+    /// value fixed here be executed.
+    ///
+    /// @param[in] interval             Intervall step to set.
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different values  ​​can  be not  together and can,  therefore,  only
+    /// one each can be used.
+    ///
+    void SetIntInterval(int interval)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_int_interval(m_interface->kodiBase, m_controlHandle, interval);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Sets the percent of the slider.
+    ///
+    /// @param[in] percent              float - Percent value of slide
+    ///
+    /// @note Percent, floating point  or integer are alone possible.  Combining
+    /// these different  values ​​can  be not together  and can,  therefore,  only
+    /// one each can be used.
+    ///
+    void SetPercentage(float percent)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_percentage(m_interface->kodiBase, m_controlHandle, percent);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Returns a float of the percent of the slider.
+    ///
+    /// @return                         float - Percent of slider
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different  values ​​can be  not together  and can,  therefore,  only
+    /// one each can be used.
+    ///
+    float GetPercentage() const
+    {
+      return m_interface->kodi_gui->control_settings_slider->get_percentage(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To set the the range as float of slider, e.g. -25.0 is the slider
+    /// start and  e.g.  +25.0 is the from  here defined position where it reach
+    /// the end.
+    ///
+    /// As default is the range 0.0 to 1.0.
+    ///
+    /// The float interval is as default 0.1 and can be changed with
+    /// @ref SetFloatInterval.
+    ///
+    /// @param[in] start                Integer start value
+    /// @param[in] end                  Integer end value
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different values ​​ can be not  together  and can,  therefore,  only
+    /// one each can be used.
+    ///
+    void SetFloatRange(float start, float end)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_float_range(m_interface->kodiBase, m_controlHandle, start, end);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief Set  the slider position  with the given  float value.  The Range
+    /// can be defined with a  call from \ref SetIntRange before,  as default it
+    /// is 0.0 to 1.0.
+    ///
+    /// @param[in] value                Position in range to set with float
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different  values ​​can be not  together  and can,  therefore,  only
+    /// one each can be used.
+    ///
+    void SetFloatValue(float value)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_float_value(m_interface->kodiBase, m_controlHandle, value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To get the current position as float value.
+    ///
+    /// @return                         The position as float
+    ///
+    float GetFloatValue() const
+    {
+      return m_interface->kodi_gui->control_settings_slider->get_float_value(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSettingsSlider
+    /// @brief To set  the interval steps of slider,  as default is it 0.1 If it
+    /// becomes changed with this function will a step of the user with the
+    /// value fixed here be executed.
+    ///
+    /// @param[in] interval             Intervall step to set.
+    ///
+    /// @note Percent, floating point or  integer are alone possible.  Combining
+    /// these different values ​​can be not together and can, therefore, only
+    /// one each can be used.
+    ///
+    void SetFloatInterval(float interval)
+    {
+      m_interface->kodi_gui->control_settings_slider->set_float_interval(m_interface->kodiBase, m_controlHandle, interval);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Slider.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Slider.h
@@ -1,0 +1,336 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CSlider Control Slider
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CSlider }
+  /// **Window control for moveable slider**
+  ///
+  /// The slider control is used for things where a sliding bar best  represents
+  /// the operation at hand (such as a volume control or seek control).  You can
+  /// choose the position, size, and look of the slider control.
+  ///
+  /// It has the header \ref Slider.h "#include <kodi/gui/controls/Slider.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Slider_Control "slider control"
+  ///
+  /// @note The  call of the  control  is only  possible from  the corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CSlider : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CSlider(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_slider(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CSlider can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Destructor
+    ///
+    virtual ~CSlider() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_slider->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Set's the control's enabled/disabled state
+    ///
+    /// @param[in] enabled              If true enabled, otherwise disabled
+    ///
+    void SetEnabled(bool enabled)
+    {
+      m_interface->kodi_gui->control_slider->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To reset slider on defaults
+    ///
+    void Reset()
+    {
+      m_interface->kodi_gui->control_slider->reset(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief With GetDescription becomes a string value of position returned.
+    ///
+    /// @return                        Text string about current slider position
+    ///
+    /// The following are the text definition returned from this:
+    /// | Value     | Without range selection | With range selection           |
+    /// |:---------:|:------------------------|:-------------------------------|
+    /// | float     | <c>%2.2f</c>            | <c>[%2.2f, %2.2f]</c>          |
+    /// | integer   | <c>%i</c>               | <c>[%i, %i]</c>                |
+    /// | percent   | <c>%i%%</c>             | <c>[%i%%, %i%%]</c>            |
+    ///
+    std::string GetDescription() const
+    {
+      std::string text;
+      char* ret = m_interface->kodi_gui->control_slider->get_description(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          text = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return text;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To set the the range as integer of slider, e.g. -10 is the slider
+    /// start and e.g. +10 is the from here defined position where it  reach the
+    /// end.
+    ///
+    /// Ad default is the range from 0 to 100.
+    ///
+    /// The integer interval is as default 1 and can be changed with
+    /// @ref SetIntInterval.
+    ///
+    /// @param[in] start                Integer start value
+    /// @param[in] end                  Integer end value
+    ///
+    /// @note Percent, floating point or  integer are alone possible.  Combining
+    /// these different values can be not together and can, therefore,  only one
+    /// each can be used.
+    ///
+    void SetIntRange(int start, int end)
+    {
+      m_interface->kodi_gui->control_slider->set_int_range(m_interface->kodiBase, m_controlHandle, start, end);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup CSlider
+    /// @brief Set the slider position  with the given integer value.  The Range
+    /// must be defined with a call from \ref SetIntRange before.
+    ///
+    /// @param[in] value                Position in range to set with integer
+    ///
+    /// @note Percent, floating point or integer  are alone possible.  Combining
+    /// these different values can be not together and can, therefore,  only one
+    /// each can be used.
+    ///
+    void SetIntValue(int value)
+    {
+      m_interface->kodi_gui->control_slider->set_int_value(m_interface->kodiBase, m_controlHandle, value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To get the current position as integer value.
+    ///
+    /// @return                         The position as integer
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these  different  values  can be not together and can,  therefore,  only
+    /// one each can be used.
+    ///
+    int GetIntValue() const
+    {
+      return m_interface->kodi_gui->control_slider->get_int_value(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To set the interval  steps of slider,  as default is it 1.  If it
+    /// becomes  changed  with this function  will a step  of the  user with the
+    /// value fixed here be executed.
+    ///
+    /// @param[in] interval             Intervall step to set.
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different values can be not together and can, therefore,  only one
+    /// each can be used.
+    ///
+    void SetIntInterval(int interval)
+    {
+      m_interface->kodi_gui->control_slider->set_int_interval(m_interface->kodiBase, m_controlHandle, interval);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Sets the percent of the slider.
+    ///
+    /// @param[in] percent              float - Percent value of slide
+    ///
+    /// @note Percent, floating point or  integer are alone possible.  Combining
+    /// these different values can be not together and can, therefore,  only one
+    /// each can be used.
+    ///
+    void SetPercentage(float percent)
+    {
+      m_interface->kodi_gui->control_slider->set_percentage(m_interface->kodiBase, m_controlHandle, percent);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Returns a float of the percent of the slider.
+    ///
+    /// @return                         float - Percent of slider
+    ///
+    /// @note Percent, floating point or integer  are alone possible.  Combining
+    /// these different values can be not together and can, therefore,  only one
+    /// each can be used.
+    ///
+    float GetPercentage() const
+    {
+      return m_interface->kodi_gui->control_slider->get_percentage(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To set the the range as float of slider, e.g. -25.0 is the slider
+    /// start and e.g. +25.0 is  the from here  defined position  where it reach
+    /// the end.
+    ///
+    /// As default is the range 0.0 to 1.0.
+    ///
+    /// The float interval is as default 0.1 and can be changed with
+    /// @ref SetFloatInterval.
+    ///
+    /// @param[in] start                Integer start value
+    /// @param[in] end                  Integer end value
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these  different  values  can be not together and can,  therefore,  only
+    /// one each can be used.
+    ///
+    void SetFloatRange(float start, float end)
+    {
+      m_interface->kodi_gui->control_slider->set_float_range(m_interface->kodiBase, m_controlHandle, start, end);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief Set the slider  position with the  given float value.  The  Range
+    /// can be defined with a call from  \ref SetIntRange before,  as default it
+    /// is 0.0 to 1.0.
+    ///
+    /// @param[in] value                Position in range to set with float
+    ///
+    /// @note Percent, floating  point or integer are alone possible.  Combining
+    /// these different values can be not together and can, therefore,  only one
+    /// each can be used.
+    ///
+    void SetFloatValue(float value)
+    {
+      m_interface->kodi_gui->control_slider->set_float_value(m_interface->kodiBase, m_controlHandle, value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To get the current position as float value.
+    ///
+    /// @return                         The position as float
+    ///
+    float GetFloatValue() const
+    {
+      return m_interface->kodi_gui->control_slider->get_float_value(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSlider
+    /// @brief To set the interval  steps of slider, as default is it 0.1  If it
+    /// becomes changed  with this  function  will a step  of the user  with the
+    /// value fixed here be executed.
+    ///
+    /// @param[in] interval             Intervall step to set.
+    ///
+    /// @note Percent, floating point or integer  are alone possible.  Combining
+    /// these different  values can be  not together  and can,  therefore,  only
+    /// one each can be used.
+    ///
+    void SetFloatInterval(float interval)
+    {
+      m_interface->kodi_gui->control_slider->set_float_interval(m_interface->kodiBase, m_controlHandle, interval);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Spin.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/Spin.h
@@ -1,0 +1,376 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CSpin Control Spin
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CSpin }
+  /// **Window control used for cycling up/down controls**
+  ///
+  /// The settings spin control is used in the settings  screens for when a list
+  /// of options  can be chosen  from using  up/down arrows.  You can choose the
+  /// position,  size,  and look of  the spin control.  It is basically  a cross
+  /// between  the button  control and a spin control.  It has a label and focus
+  /// and non focus textures, as well as a spin control on the right.
+  ///
+  /// It has the header \ref Spin.h "#include <kodi/gui/controls/Spin.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Spin_Control "spin control"
+  ///
+  /// @note The  call of  the  control is  only possible from  the corresponding
+  /// window as its class and identification number is required.
+  ///
+
+
+  //============================================================================
+  ///
+  /// \ingroup cpp_kodi_gui_controls_CSpin
+  /// @anchor AddonGUISpinControlType
+  /// @brief The values here defines the used value format for steps on
+  /// spin control.
+  ///
+  typedef enum AddonGUISpinControlType
+  {
+    /// One spin step interpreted as integer
+    ADDON_SPIN_CONTROL_TYPE_INT    = 1,
+    /// One spin step interpreted as floating point value
+    ADDON_SPIN_CONTROL_TYPE_FLOAT  = 2,
+    /// One spin step interpreted as text string
+    ADDON_SPIN_CONTROL_TYPE_TEXT   = 3,
+    /// One spin step interpreted as a page change value
+    ADDON_SPIN_CONTROL_TYPE_PAGE   = 4
+  } AddonGUISpinControlType;
+  //----------------------------------------------------------------------------
+
+  class CSpin : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CSpin(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_spin(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CSpin can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief Destructor
+    ///
+    virtual ~CSpin() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_spin->set_visible(m_interface->kodiBase, m_controlHandle, visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief Set's the control's enabled/disabled state
+    ///
+    /// @param[in] enabled              If true enabled, otherwise disabled
+    ///
+    void SetEnabled(bool enabled)
+    {
+      m_interface->kodi_gui->control_spin->set_enabled(m_interface->kodiBase, m_controlHandle, enabled);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To set the text string on spin control
+    ///
+    /// @param[in] text                Text to show as name for spin
+    ///
+    void SetText(const std::string& text)
+    {
+      m_interface->kodi_gui->control_spin->set_text(m_interface->kodiBase, m_controlHandle, text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To reset spin control to defaults
+    ///
+    void Reset()
+    {
+      m_interface->kodi_gui->control_spin->reset(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To set the with SpinControlType defined types of spin.
+    ///
+    /// @param[in] type                 The type to use
+    ///
+    /// @note See description of \ref AddonGUISpinControlType for available types.
+    ///
+    void SetType(AddonGUISpinControlType type)
+    {
+      m_interface->kodi_gui->control_spin->set_type(m_interface->kodiBase, m_controlHandle, (int)type);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To add a label entry in spin defined with a value as string.
+    ///
+    /// Format must be set to ADDON_SPIN_CONTROL_TYPE_TEXT to use this function.
+    ///
+    /// @param[in] label                Label string to view on skin
+    /// @param[in] value                String value to use for selection
+    ///                                 of them.
+    ///
+    void AddLabel(const std::string& label, const std::string& value)
+    {
+      m_interface->kodi_gui->control_spin->add_string_label(m_interface->kodiBase, m_controlHandle, label.c_str(), value.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To add a label entry in spin defined with a value as integer.
+    ///
+    /// Format must be set to ADDON_SPIN_CONTROL_TYPE_INT to use this function.
+    ///
+    /// @param[in] label                Label string to view on skin
+    /// @param[in] value                Integer value to use for selection
+    ///                                 of them.
+    ///
+    void AddLabel(const std::string& label, int value)
+    {
+      m_interface->kodi_gui->control_spin->add_int_label(m_interface->kodiBase, m_controlHandle, label.c_str(), value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To change the spin to position with them string as value.
+    ///
+    /// Format must be set to ADDON_SPIN_CONTROL_TYPE_TEXT to use this function.
+    ///
+    /// @param[in] value                 String value to change to
+    ///
+    void SetStringValue(const std::string& value)
+    {
+      m_interface->kodi_gui->control_spin->set_string_value(m_interface->kodiBase, m_controlHandle, value.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To get the current spin control position with text string value.
+    ///
+    /// Format must be set to ADDON_SPIN_CONTROL_TYPE_TEXT to use this function.
+    ///
+    /// @return                         Currently selected string value
+    ///
+    std::string GetStringValue() const
+    {
+      std::string value;
+      char* ret = m_interface->kodi_gui->control_spin->get_string_value(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          value = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return value;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To set the the range as integer of slider, e.g. -10 is the slider
+    /// start and e.g. +10 is the from here defined position where it reach  the
+    /// end.
+    ///
+    /// Ad default is the range from 0 to 100.
+    ///
+    /// @param[in] start                Integer start value
+    /// @param[in] end                  Integer end value
+    ///
+    /// @note Percent, floating point or  integer are alone possible.  Combining
+    /// these  different  values  can be not together and can,  therefore,  only
+    /// one each can be used and must be defined with \ref SetType before.
+    ///
+    void SetIntRange(int start, int end)
+    {
+      m_interface->kodi_gui->control_spin->set_int_range(m_interface->kodiBase, m_controlHandle, start, end);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief Set the slider  position with the given integer value.  The Range
+    /// must be defined with a call from \ref SetIntRange before.
+    ///
+    /// @param[in] value                Position in range to set with integer
+    ///
+    /// @note Percent, floating point or  integer are alone possible.  Combining
+    /// these different  values can  be not  together  and can, therefore,  only
+    /// one each can be used and must be defined with \ref SetType before.
+    ///
+    void SetIntValue(int value)
+    {
+      m_interface->kodi_gui->control_spin->set_int_value(m_interface->kodiBase, m_controlHandle, value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To get the current position as integer value.
+    ///
+    /// @return                         The position as integer
+    ///
+    /// @note Percent,  floating point or integer are alone possible.  Combining
+    /// these different values  can be not  together  and can,  therefore,  only
+    /// one each can be used and must be defined with \ref SetType before.
+    ///
+    int GetIntValue() const
+    {
+      return m_interface->kodi_gui->control_spin->get_int_value(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To set the  the range as  float of spin,  e.g. -25.0 is  the spin
+    /// start and e.g. +25.0 is the from  here defined  position where  it reach
+    /// the end.
+    ///
+    /// As default is the range 0.0 to 1.0.
+    ///
+    /// The float interval is as default 0.1 and can be changed with
+    /// @ref SetFloatInterval.
+    ///
+    /// @param[in] start                Integer start value
+    /// @param[in] end                  Integer end value
+    ///
+    /// @note Percent, floating point  or integer are alone possible.  Combining
+    /// these different  values can be  not together  and can,  therefore,  only
+    /// one each can be used and must be defined with \ref SetType before.
+    ///
+    void SetFloatRange(float start, float end)
+    {
+      m_interface->kodi_gui->control_spin->set_float_range(m_interface->kodiBase, m_controlHandle, start, end);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief Set  the spin  position with  the given float  value.  The  Range
+    /// can be defined with a call from  \ref SetIntRange before, as  default it
+    /// is 0.0 to 1.0.
+    ///
+    /// @param[in] value                Position in range to set with float
+    ///
+    /// @note Percent, floating point or integer are  alone possible.  Combining
+    /// these different  values can  be not together  and can,  therefore,  only
+    /// one each can be used and must be defined with \ref SetType before.
+    ///
+    void SetFloatValue(float value)
+    {
+      m_interface->kodi_gui->control_spin->set_float_value(m_interface->kodiBase, m_controlHandle, value);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To get the current position as float value.
+    ///
+    /// @return                         The position as float
+    ///
+    float GetFloatValue() const
+    {
+      return m_interface->kodi_gui->control_spin->get_float_value(m_interface->kodiBase, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CSpin
+    /// @brief To set the  interval steps of spin,  as default  is it 0.1  If it
+    /// becomes  changed  with this  function will  a step of the  user with the
+    /// value fixed here be executed.
+    ///
+    /// @param[in] interval             Intervall step to set.
+    ///
+    /// @note Percent, floating point  or integer are alone possible.  Combining
+    /// these  different values  can  be not together and can,  therefore,  only
+    /// one each can be used and must be defined with \ref SetType before.
+    ///
+    void SetFloatInterval(float interval)
+    {
+      m_interface->kodi_gui->control_spin->set_float_interval(m_interface->kodiBase, m_controlHandle, interval);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/TextBox.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/controls/TextBox.h
@@ -1,0 +1,176 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+#include "../Window.h"
+
+namespace kodi
+{
+namespace gui
+{
+namespace controls
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_controls_CTextBox Control Text Box
+  /// \ingroup cpp_kodi_gui
+  /// @brief \cpp_class{ kodi::gui::controls::CTextBox }
+  /// **Used to show a multi-page piece of text**
+  ///
+  /// The text box control  can be used to display  descriptions,  help texts or
+  /// other larger texts.  It corresponds to the representation which is also to
+  /// be seen on the CDialogTextViewer.
+  ///
+  /// It has the header \ref TextBox.h "#include <kodi/gui/controls/TextBox.h>"
+  /// be included to enjoy it.
+  ///
+  /// Here you find the needed skin part for a \ref Text_Box "textbox control".
+  ///
+  /// @note The call  of the  control is  only possible  from the  corresponding
+  /// window as its class and identification number is required.
+  ///
+  class CTextBox : public CAddonGUIControlBase
+  {
+  public:
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief Construct a new control
+    ///
+    /// @param[in] window               related window control class
+    /// @param[in] controlId            Used skin xml control id
+    ///
+    CTextBox(CWindow* window, int controlId)
+      : CAddonGUIControlBase(window)
+    {
+      m_controlHandle = m_interface->kodi_gui->window->get_control_text_box(m_interface->kodiBase, m_Window->GetControlHandle(), controlId);
+      if (!m_controlHandle)
+        kodi::Log(ADDON_LOG_FATAL, "kodi::gui::controls::CTextBox can't create control class from Kodi !!!");
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief Destructor
+    ///
+    virtual ~CTextBox() = default;
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief Set the control on window to visible
+    ///
+    /// @param[in] visible              If true visible, otherwise hidden
+    ///
+    void SetVisible(bool visible)
+    {
+      m_interface->kodi_gui->control_text_box->set_visible(m_interface->kodiBase, m_controlHandle,  visible);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief To reset box an remove all the text
+    ///
+    void Reset()
+    {
+      m_interface->kodi_gui->control_text_box->reset(m_controlHandle, m_controlHandle);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief To set the text on box
+    ///
+    /// @param[in] text                 Text to show
+    ///
+    void SetText(const std::string& text)
+    {
+      m_interface->kodi_gui->control_text_box->set_text(m_interface->kodiBase, m_controlHandle,  text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief Get the used text from control
+    ///
+    /// @return                         Text shown
+    ///
+    std::string GetText() const
+    {
+      std::string text;
+      char* ret = m_interface->kodi_gui->control_text_box->get_text(m_interface->kodiBase, m_controlHandle);
+      if (ret != nullptr)
+      {
+        if (std::strlen(ret))
+          text = ret;
+        m_interface->free_string(m_interface->kodiBase, ret);
+      }
+      return text;
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief To scroll text on other position
+    ///
+    /// @param[in] position             The line position to scroll to
+    ///
+    void Scroll(unsigned int position)
+    {
+      m_interface->kodi_gui->control_text_box->scroll(m_interface->kodiBase, m_controlHandle, position);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_controls_CTextBox
+    /// @brief To set automatic scrolling of textbox
+    ///
+    /// Specifies the timing  and conditions of  any autoscrolling  this textbox
+    /// should have. Times are in milliseconds.  The content is delayed  for the
+    /// given delay,  then scrolls at a rate of one line per time interval until
+    /// the end.  If the repeat tag is present,  it then  delays for  the repeat
+    /// time,  fades out over 1 second,  and repeats.  It does not wrap or reset
+    /// to the top at the end of the scroll.
+    ///
+    /// @param[in] delay                Content delay
+    /// @param[in] time                 One line per time interval
+    /// @param[in] repeat               Delays with given time, fades out over 1
+    ///                                 second, and repeats
+    ///
+    void SetAutoScrolling(int delay, int time, int repeat)
+    {
+      m_interface->kodi_gui->control_text_box->set_auto_scrolling(m_interface->kodiBase, m_controlHandle, delay, time, repeat);
+    }
+    //--------------------------------------------------------------------------
+  };
+
+} /* namespace controls */
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
@@ -49,6 +49,135 @@ typedef struct AddonToKodiFuncTable_kodi_gui_control_button
   char* (*get_label2)(void* kodiBase, void* handle);
 } AddonToKodiFuncTable_kodi_gui_control_button;
 
+typedef struct AddonToKodiFuncTable_kodi_gui_control_edit
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_enabled)(void* kodiBase, void* handle, bool enabled);
+  void (*set_label)(void* kodiBase, void* handle, const char* label);
+  char* (*get_label)(void* kodiBase, void* handle);
+  void (*set_text)(void* kodiBase, void* handle, const char* text);
+  char* (*get_text)(void* kodiBase, void* handle);
+  void (*set_cursor_position)(void* kodiBase, void* handle, unsigned int position);
+  unsigned int (*get_cursor_position)(void* kodiBase, void* handle);
+  void (*set_input_type)(void* kodiBase, void* handle, int type, const char* heading);
+} AddonToKodiFuncTable_kodi_gui_control_edit;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_fade_label
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*add_label)(void* kodiBase, void* handle, const char* text);
+  char* (*get_label)(void* kodiBase, void* handle);
+  void (*set_scrolling)(void* kodiBase, void* handle, bool scroll);
+  void (*reset)(void* kodiBase, void* handle);
+} AddonToKodiFuncTable_kodi_gui_control_fade_label;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_image
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_filename)(void* kodiBase, void* handle, const char* filename, bool use_cache);
+  void (*set_color_diffuse)(void* kodiBase, void* handle, uint32_t color_diffuse);
+} AddonToKodiFuncTable_kodi_gui_control_image;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_label
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_label)(void* kodiBase, void* handle, const char* text);
+  char* (*get_label)(void* kodiBase, void* handle);
+} AddonToKodiFuncTable_kodi_gui_control_label;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_progress
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_percentage)(void* kodiBase, void* handle, float percent);
+  float (*get_percentage)(void* kodiBase, void* handle);
+} AddonToKodiFuncTable_kodi_gui_control_progress;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_radio_button
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_enabled)(void* kodiBase, void* handle, bool enabled);
+  void (*set_label)(void* kodiBase, void* handle, const char* text);
+  char* (*get_label)(void* kodiBase, void* handle);
+  void (*set_selected)(void* kodiBase, void* handle, bool selected);
+  bool (*is_selected)(void* kodiBase, void* handle);
+} AddonToKodiFuncTable_kodi_gui_control_radio_button;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_rendering
+{
+  void (*set_callbacks)(void* kodiBase, void* handle, void* clienthandle,
+      bool    (*createCB)(void*,int,int,int,int,void*),
+      void    (*renderCB)(void*),
+      void    (*stopCB)(void*),
+      bool    (*dirtyCB)(void*));
+  void (*destroy)(void *kodiBase, void* handle);
+} AddonToKodiFuncTable_kodi_gui_control_rendering;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_settings_slider
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_enabled)(void* kodiBase, void* handle, bool enabled);
+  void (*set_text)(void* kodiBase, void* handle, const char* label);
+  void (*reset)(void* kodiBase, void* handle);
+  void (*set_int_range)(void* kodiBase, void* handle, int start, int end);
+  void (*set_int_value)(void* kodiBase, void* handle, int value);
+  int (*get_int_value)(void* kodiBase, void* handle);
+  void (*set_int_interval)(void* kodiBase, void* handle, int interval);
+  void (*set_percentage)(void* kodiBase, void* handle, float percent);
+  float (*get_percentage)(void* kodiBase, void* handle);
+  void (*set_float_range)(void* kodiBase, void* handle, float start, float end);
+  void (*set_float_value)(void* kodiBase, void* handle, float value);
+  float (*get_float_value)(void* kodiBase, void* handle);
+  void (*set_float_interval)(void* kodiBase, void* handle, float interval);
+} AddonToKodiFuncTable_kodi_gui_control_settings_slider;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_slider
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_enabled)(void* kodiBase, void* handle, bool enabled);
+  void (*reset)(void* kodiBase, void* handle);
+  char* (*get_description)(void* kodiBase, void* handle);
+  void (*set_int_range)(void* kodiBase, void* handle, int start, int end);
+  void (*set_int_value)(void* kodiBase, void* handle, int value);
+  int (*get_int_value)(void* kodiBase, void* handle);
+  void (*set_int_interval)(void* kodiBase, void* handle, int interval);
+  void (*set_percentage)(void* kodiBase, void* handle, float percent);
+  float (*get_percentage)(void* kodiBase, void* handle);
+  void (*set_float_range)(void* kodiBase, void* handle, float start, float end);
+  void (*set_float_value)(void* kodiBase, void* handle, float value);
+  float (*get_float_value)(void* kodiBase, void* handle);
+  void (*set_float_interval)(void* kodiBase, void* handle, float interval);
+} AddonToKodiFuncTable_kodi_gui_control_slider;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_spin
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*set_enabled)(void* kodiBase, void* handle, bool enabled);
+  void (*set_text)(void* kodiBase, void* handle, const char* text);
+  void (*reset)(void* kodiBase, void* handle);
+  void (*set_type)(void* kodiBase, void* handle, int type);
+  void (*add_string_label)(void* kodiBase, void* handle, const char* label, const char* value);
+  void (*set_string_value)(void* kodiBase, void* handle, const char* value);
+  char* (*get_string_value)(void* kodiBase, void* handle);
+  void (*add_int_label)(void* kodiBase, void* handle, const char* label, int value);
+  void (*set_int_range)(void* kodiBase, void* handle, int start, int end);
+  void (*set_int_value)(void* kodiBase, void* handle, int value);
+  int (*get_int_value)(void* kodiBase, void* handle);
+  void (*set_float_range)(void* kodiBase, void* handle, float start, float end);
+  void (*set_float_value)(void* kodiBase, void* handle, float value);
+  float (*get_float_value)(void* kodiBase, void* handle);
+  void (*set_float_interval)(void* kodiBase, void* handle, float interval);
+} AddonToKodiFuncTable_kodi_gui_control_spin;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_control_text_box
+{
+  void (*set_visible)(void* kodiBase, void* handle, bool visible);
+  void (*reset)(void* kodiBase, void* handle);
+  void (*set_text)(void* kodiBase, void* handle, const char* text);
+  char* (*get_text)(void* kodiBase, void* handle);
+  void (*scroll)(void* kodiBase, void* handle, unsigned int scroll);
+  void (*set_auto_scrolling)(void* kodiBase, void* handle, int delay, int time, int repeat);
+} AddonToKodiFuncTable_kodi_gui_control_text_box;
+
 typedef struct AddonToKodiFuncTable_kodi_gui_dialogContextMenu
 {
   int (*open)(void* kodiBase, const char *heading, const char *entries[], unsigned int size);
@@ -226,12 +355,54 @@ typedef struct AddonToKodiFuncTable_kodi_gui_window
 
   /* GUI control access functions */
   void* (*get_control_button)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_edit)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_fade_label)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_image)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_label)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_progress)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_radio_button)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_render_addon)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_settings_slider)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_slider)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_spin)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_text_box)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy1)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy2)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy3)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy4)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy5)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy6)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy7)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy8)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy9)(void* kodiBase, void* handle, int control_id);
+  void* (*get_control_dummy10)(void* kodiBase, void* handle, int control_id); /* This and above used to add new get_control_* functions */
 } AddonToKodiFuncTable_kodi_gui_window;
 
 typedef struct AddonToKodiFuncTable_kodi_gui
 {
   AddonToKodiFuncTable_kodi_gui_general* general;
   AddonToKodiFuncTable_kodi_gui_control_button* control_button;
+  AddonToKodiFuncTable_kodi_gui_control_edit* control_edit;
+  AddonToKodiFuncTable_kodi_gui_control_fade_label* control_fade_label;
+  AddonToKodiFuncTable_kodi_gui_control_label* control_label;
+  AddonToKodiFuncTable_kodi_gui_control_image* control_image;
+  AddonToKodiFuncTable_kodi_gui_control_progress* control_progress;
+  AddonToKodiFuncTable_kodi_gui_control_radio_button* control_radio_button;
+  AddonToKodiFuncTable_kodi_gui_control_rendering* control_rendering;
+  AddonToKodiFuncTable_kodi_gui_control_settings_slider* control_settings_slider;
+  AddonToKodiFuncTable_kodi_gui_control_slider* control_slider;
+  AddonToKodiFuncTable_kodi_gui_control_spin* control_spin;
+  AddonToKodiFuncTable_kodi_gui_control_text_box* control_text_box;
+  void* control_dummy1;
+  void* control_dummy2;
+  void* control_dummy3;
+  void* control_dummy4;
+  void* control_dummy5;
+  void* control_dummy6;
+  void* control_dummy7;
+  void* control_dummy8;
+  void* control_dummy9;
+  void* control_dummy10; /* This and above used to add new controls */
   AddonToKodiFuncTable_kodi_gui_dialogContextMenu* dialogContextMenu;
   AddonToKodiFuncTable_kodi_gui_dialogExtendedProgress* dialogExtendedProgress;
   AddonToKodiFuncTable_kodi_gui_dialogFileBrowser* dialogFileBrowser;
@@ -242,6 +413,16 @@ typedef struct AddonToKodiFuncTable_kodi_gui
   AddonToKodiFuncTable_kodi_gui_dialogSelect* dialogSelect;
   AddonToKodiFuncTable_kodi_gui_dialogTextViewer* dialogTextViewer;
   AddonToKodiFuncTable_kodi_gui_dialogYesNo* dialogYesNo;
+  void* dialog_dummy1;
+  void* dialog_dummy2;
+  void* dialog_dummy3;
+  void* dialog_dummy4;
+  void* dialog_dummy5;
+  void* dialog_dummy6;
+  void* dialog_dummy7;
+  void* dialog_dummy8;
+  void* dialog_dummy9;
+  void* dialog_dummy10; /* This and above used to add new dialogs */
   AddonToKodiFuncTable_kodi_gui_listItem* listItem;
   AddonToKodiFuncTable_kodi_gui_window* window;
 } AddonToKodiFuncTable_kodi_gui;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Title above -->
This change alow addons to edit all used controls on his processed window.

For the moment is this mostly the last request to create the global addon
interface function.

Most further requests are to change addon types iself to new style.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
