### PR TITLE
[addons] add next step on CAddonInfo to become independent

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -64,15 +64,10 @@ CAddon::CAddon(CAddonInfo addonInfo)
   , m_userSettingsPath()
   , m_loadSettingsFailed(false)
   , m_hasUserSettings(false)
-  , m_profilePath(StringUtils::Format("special://profile/addon_data/%s/", m_addonInfo.id.c_str()))
+  , m_profilePath(StringUtils::Format("special://profile/addon_data/%s/", m_addonInfo.ID().c_str()))
   , m_settings(nullptr)
 {
   m_userSettingsPath = URIUtils::AddFileToFolder(m_profilePath, "settings.xml");
-}
-
-bool CAddon::MeetsVersion(const AddonVersion &version) const
-{
-  return m_addonInfo.minversion <= version && version <= m_addonInfo.version;
 }
 
 /**
@@ -109,7 +104,7 @@ bool CAddon::LoadSettings(bool bForce /* = false */)
     GetSettings()->Uninitialize();
 
   // load the settings definition XML file
-  auto addonSettingsDefinitionFile = URIUtils::AddFileToFolder(m_addonInfo.path, "resources", "settings.xml");
+  auto addonSettingsDefinitionFile = URIUtils::AddFileToFolder(m_addonInfo.Path(), "resources", "settings.xml");
   CXBMCTinyXML addonSettingsDefinitionDoc;
   if (!addonSettingsDefinitionDoc.LoadFile(addonSettingsDefinitionFile))
   {
@@ -382,9 +377,9 @@ CAddonSettings* CAddon::GetSettings() const
 
 std::string CAddon::LibPath() const
 {
-  if (m_addonInfo.libname.empty())
+  if (m_addonInfo.LibName().empty())
     return "";
-  return URIUtils::AddFileToFolder(m_addonInfo.path, m_addonInfo.libname);
+  return URIUtils::AddFileToFolder(m_addonInfo.Path(), m_addonInfo.LibName());
 }
 
 AddonVersion CAddon::GetDependencyVersion(const std::string &dependencyID) const

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -56,38 +56,38 @@ public:
   explicit CAddon(CAddonInfo addonInfo);
   virtual ~CAddon() {}
 
-  TYPE Type() const override { return m_addonInfo.type; }
+  TYPE Type() const override { return m_addonInfo.MainType(); }
   TYPE FullType() const override { return Type(); }
-  bool IsType(TYPE type) const override { return type == m_addonInfo.type; }
-  std::string ID() const override{ return m_addonInfo.id; }
-  std::string Name() const override { return m_addonInfo.name; }
+  bool IsType(TYPE type) const override { return type == m_addonInfo.MainType(); }
+  std::string ID() const override{ return m_addonInfo.ID(); }
+  std::string Name() const override { return m_addonInfo.Name(); }
   bool IsInUse() const override{ return false; };
-  AddonVersion Version() const override { return m_addonInfo.version; }
-  AddonVersion MinVersion() const override { return m_addonInfo.minversion; }
-  std::string Summary() const override { return m_addonInfo.summary; }
-  std::string Description() const override { return m_addonInfo.description; }
-  std::string Path() const override { return m_addonInfo.path; }
+  AddonVersion Version() const override { return m_addonInfo.Version(); }
+  AddonVersion MinVersion() const override { return m_addonInfo.MinVersion(); }
+  std::string Summary() const override { return m_addonInfo.Summary(); }
+  std::string Description() const override { return m_addonInfo.Description(); }
+  std::string Path() const override { return m_addonInfo.Path(); }
   std::string Profile() const override { return m_profilePath; }
   std::string LibPath() const override;
-  std::string Author() const override { return m_addonInfo.author; }
-  std::string ChangeLog() const override { return m_addonInfo.changelog; }
-  std::string Icon() const override { return m_addonInfo.icon; };
-  ArtMap Art() const override { return m_addonInfo.art; }
-  std::vector<std::string> Screenshots() const override { return m_addonInfo.screenshots; };
-  std::string Disclaimer() const override { return m_addonInfo.disclaimer; }
-  std::string Broken() const override { return m_addonInfo.broken; }
-  CDateTime InstallDate() const override { return m_addonInfo.installDate; }
-  CDateTime LastUpdated() const override { return m_addonInfo.lastUpdated; }
-  CDateTime LastUsed() const override { return m_addonInfo.lastUsed; }
-  std::string Origin() const override { return m_addonInfo.origin; }
-  uint64_t PackageSize() const override { return m_addonInfo.packageSize; }
+  std::string Author() const override { return m_addonInfo.Author(); }
+  std::string ChangeLog() const override { return m_addonInfo.ChangeLog(); }
+  std::string Icon() const override { return m_addonInfo.Icon(); };
+  ArtMap Art() const override { return m_addonInfo.Art(); }
+  std::vector<std::string> Screenshots() const override { return m_addonInfo.Screenshots(); };
+  std::string Disclaimer() const override { return m_addonInfo.Disclaimer(); }
+  std::string Broken() const override { return m_addonInfo.Broken(); }
+  CDateTime InstallDate() const override { return m_addonInfo.InstallDate(); }
+  CDateTime LastUpdated() const override { return m_addonInfo.LastUpdated(); }
+  CDateTime LastUsed() const override { return m_addonInfo.LastUsed(); }
+  std::string Origin() const override { return m_addonInfo.Origin(); }
+  uint64_t PackageSize() const override { return m_addonInfo.PackageSize(); }
   const InfoMap& ExtraInfo() const override { return m_addonInfo.extrainfo; }
-  const ADDONDEPS& GetDeps() const override { return m_addonInfo.dependencies; }
+  const ADDONDEPS& GetDeps() const override { return m_addonInfo.GetDeps(); }
 
   std::string FanArt() const override
   {
-    auto it = m_addonInfo.art.find("fanart");
-    return it != m_addonInfo.art.end() ? it->second : "";
+    auto it = m_addonInfo.Art().find("fanart");
+    return it != m_addonInfo.Art().end() ? it->second : "";
   }
 
   /*! \brief Check whether the this addon can be configured or not
@@ -198,7 +198,7 @@ public:
    \param version the version to meet.
    \return true if  min_version <= version <= current_version, false otherwise.
    */
-  bool MeetsVersion(const AddonVersion &version) const override;
+  bool MeetsVersion(const AddonVersion &version) const override { return m_addonInfo.MeetsVersion(version); }
   bool ReloadSettings() override;
 
   /*! \brief callback for when this add-on is disabled.

--- a/xbmc/addons/AddonBuilder.cpp
+++ b/xbmc/addons/AddonBuilder.cpp
@@ -52,18 +52,18 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
   if (m_built)
     throw std::logic_error("Already built");
 
-  if (m_addonInfo.id.empty())
+  if (m_addonInfo.m_id.empty())
     return nullptr;
 
   m_built = true;
 
-  if (m_addonInfo.type == ADDON_UNKNOWN)
+  if (m_addonInfo.m_mainType == ADDON_UNKNOWN)
     return std::make_shared<CAddon>(std::move(m_addonInfo));
 
   if (m_extPoint == nullptr)
     return FromProps(std::move(m_addonInfo));
 
-  const TYPE type(m_addonInfo.type);
+  const TYPE type(m_addonInfo.m_mainType);
 
   // Handle screensaver special cases
   if (type == ADDON_SCREENSAVER)
@@ -176,7 +176,7 @@ AddonPtr CAddonBuilder::FromProps(CAddonInfo addonInfo)
   // FIXME: there is no need for this as none of the derived classes will contain any useful
   // information. We should return CAddon instances only, however there are several places that
   // down casts, which need to fixed first.
-  switch (addonInfo.type)
+  switch (addonInfo.m_mainType)
   {
     case ADDON_PLUGIN:
     case ADDON_SCRIPT:

--- a/xbmc/addons/AddonBuilder.h
+++ b/xbmc/addons/AddonBuilder.h
@@ -30,36 +30,36 @@ public:
   CAddonBuilder() : m_built(false), m_extPoint(nullptr) {}
 
   std::shared_ptr<IAddon> Build();
-  void SetId(std::string id) { m_addonInfo.id = std::move(id); }
-  void SetName(std::string name) { m_addonInfo.name = std::move(name); }
-  void SetLicense(std::string license) { m_addonInfo.license = std::move(license); }
-  void SetSummary(std::string summary) { m_addonInfo.summary = std::move(summary); }
-  void SetDescription(std::string description) { m_addonInfo.description = std::move(description); }
-  void SetDisclaimer(std::string disclaimer) { m_addonInfo.disclaimer = std::move(disclaimer); }
-  void SetAuthor(std::string author) { m_addonInfo.author = std::move(author); }
-  void SetSource(std::string source) { m_addonInfo.source = std::move(source); }
-  void SetIcon(std::string icon) { m_addonInfo.icon = std::move(icon); }
-  void SetArt(std::string type, std::string value) { m_addonInfo.art[type] = value; }
-  void SetArt(std::map<std::string, std::string> art) { m_addonInfo.art = std::move(art); }
-  void SetScreenshots(std::vector<std::string> screenshots) { m_addonInfo.screenshots = std::move(screenshots); }
-  void SetChangelog(std::string changelog) { m_addonInfo.changelog = std::move(changelog); }
-  void SetBroken(std::string broken) { m_addonInfo.broken = std::move(broken); }
-  void SetPath(std::string path) { m_addonInfo.path = std::move(path); }
-  void SetLibName(std::string libname) { m_addonInfo.libname = std::move(libname); }
-  void SetVersion(AddonVersion version) { m_addonInfo.version = std::move(version); }
-  void SetMinVersion(AddonVersion minversion) { m_addonInfo.minversion = std::move(minversion); }
-  void SetDependencies(ADDONDEPS dependencies) { m_addonInfo.dependencies = std::move(dependencies); }
+  void SetId(std::string id) { m_addonInfo.m_id = std::move(id); }
+  void SetName(std::string name) { m_addonInfo.m_name = std::move(name); }
+  void SetLicense(std::string license) { m_addonInfo.m_license = std::move(license); }
+  void SetSummary(std::string summary) { m_addonInfo.m_summary = std::move(summary); }
+  void SetDescription(std::string description) { m_addonInfo.m_description = std::move(description); }
+  void SetDisclaimer(std::string disclaimer) { m_addonInfo.m_disclaimer = std::move(disclaimer); }
+  void SetAuthor(std::string author) { m_addonInfo.m_author = std::move(author); }
+  void SetSource(std::string source) { m_addonInfo.m_source = std::move(source); }
+  void SetIcon(std::string icon) { m_addonInfo.m_icon = std::move(icon); }
+  void SetArt(std::string type, std::string value) { m_addonInfo.m_art[type] = value; }
+  void SetArt(std::map<std::string, std::string> art) { m_addonInfo.m_art = std::move(art); }
+  void SetScreenshots(std::vector<std::string> screenshots) { m_addonInfo.m_screenshots = std::move(screenshots); }
+  void SetChangelog(std::string changelog) { m_addonInfo.m_changelog = std::move(changelog); }
+  void SetBroken(std::string broken) { m_addonInfo.m_broken = std::move(broken); }
+  void SetPath(std::string path) { m_addonInfo.m_path = std::move(path); }
+  void SetLibName(std::string libname) { m_addonInfo.m_libname = std::move(libname); }
+  void SetVersion(AddonVersion version) { m_addonInfo.m_version = std::move(version); }
+  void SetMinVersion(AddonVersion minversion) { m_addonInfo.m_minversion = std::move(minversion); }
+  void SetDependencies(ADDONDEPS dependencies) { m_addonInfo.m_dependencies = std::move(dependencies); }
   void SetExtrainfo(InfoMap extrainfo) { m_addonInfo.extrainfo = std::move(extrainfo); }
-  void SetType(TYPE type) { m_addonInfo.type = type; }
+  void SetType(TYPE type) { m_addonInfo.m_mainType = type; }
   void SetExtPoint(cp_extension_t* ext) { m_extPoint = ext; }
-  void SetInstallDate(CDateTime installDate) { m_addonInfo.installDate = installDate; }
-  void SetLastUpdated(CDateTime lastUpdated) { m_addonInfo.lastUpdated = lastUpdated; }
-  void SetLastUsed(CDateTime lastUsed) { m_addonInfo.lastUsed = lastUsed; }
-  void SetOrigin(std::string origin) { m_addonInfo.origin = std::move(origin); }
-  void SetPackageSize(uint64_t size) { m_addonInfo.packageSize = size; }
+  void SetInstallDate(CDateTime installDate) { m_addonInfo.m_installDate = installDate; }
+  void SetLastUpdated(CDateTime lastUpdated) { m_addonInfo.m_lastUpdated = lastUpdated; }
+  void SetLastUsed(CDateTime lastUsed) { m_addonInfo.m_lastUsed = lastUsed; }
+  void SetOrigin(std::string origin) { m_addonInfo.m_origin = std::move(origin); }
+  void SetPackageSize(uint64_t size) { m_addonInfo.m_packageSize = size; }
 
-  const std::string& GetId() const { return m_addonInfo.id; }
-  const AddonVersion& GetVersion() const { return m_addonInfo.version; }
+  const std::string& GetId() const { return m_addonInfo.m_id; }
+  const AddonVersion& GetVersion() const { return m_addonInfo.m_version; }
 
 private:
   static std::shared_ptr<IAddon> FromProps(CAddonInfo addonInfo);

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -99,7 +99,7 @@ bool CAddonDll::LoadDll()
       libPath = tempbin + libPath;
       if (!XFILE::CFile::Exists(libPath))
       {
-        CLog::Log(LOGERROR, "ADDON: Could not locate %s", m_addonInfo.libname.c_str());
+        CLog::Log(LOGERROR, "ADDON: Could not locate %s", m_addonInfo.LibName().c_str());
         return false;
       }
     }
@@ -122,7 +122,7 @@ bool CAddonDll::LoadDll()
   if (!XFILE::CFile::Exists(strFileName))
   {
     std::string tempbin = getenv("XBMC_ANDROID_LIBS");
-    strFileName = tempbin + "/" + m_addonInfo.libname;
+    strFileName = tempbin + "/" + m_addonInfo.LibName();
   }
 #endif
   if (!XFILE::CFile::Exists(strFileName))
@@ -130,7 +130,7 @@ bool CAddonDll::LoadDll()
     std::string altbin = CSpecialProtocol::TranslatePath("special://xbmcaltbinaddons/");
     if (!altbin.empty())
     {
-      strAltFileName = altbin + m_addonInfo.libname;
+      strAltFileName = altbin + m_addonInfo.LibName();
       if (!XFILE::CFile::Exists(strAltFileName))
       {
         std::string temp = CSpecialProtocol::TranslatePath("special://xbmc/addons/");
@@ -151,7 +151,7 @@ bool CAddonDll::LoadDll()
       strFileName = tempbin + strFileName;
       if (!XFILE::CFile::Exists(strFileName))
       {
-        CLog::Log(LOGERROR, "ADDON: Could not locate %s", m_addonInfo.libname.c_str());
+        CLog::Log(LOGERROR, "ADDON: Could not locate %s", m_addonInfo.LibName().c_str());
         return false;
       }
     }

--- a/xbmc/addons/AddonInfo.cpp
+++ b/xbmc/addons/AddonInfo.cpp
@@ -138,18 +138,25 @@ TYPE CAddonInfo::TranslateSubContent(const std::string& content)
 }
 
 CAddonInfo::CAddonInfo()
-  : type(ADDON_UNKNOWN),
-    packageSize(0)
+  : m_usable(true),
+    m_mainType(ADDON_UNKNOWN),
+    m_packageSize(0)
 {
 
 }
 
 CAddonInfo::CAddonInfo(std::string id, TYPE type)
-  : id(std::move(id)),
-    type(type),
-    packageSize(0)
+  : m_usable(true),
+    m_id(std::move(id)),
+    m_mainType(type),
+    m_packageSize(0)
 {
 
+}
+
+bool CAddonInfo::MeetsVersion(const AddonVersion &version) const
+{
+  return m_minversion <= version && version <= m_version;
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/AddonInfo.h
+++ b/xbmc/addons/AddonInfo.h
@@ -85,11 +85,53 @@ namespace ADDON
   typedef std::map<std::string, std::string> InfoMap;
   typedef std::map<std::string, std::string> ArtMap;
 
+  class CAddonBuilder;
+
   class CAddonInfo
   {
   public:
     CAddonInfo();
     CAddonInfo(std::string id, TYPE type);
+
+    bool IsUsable() const { return m_usable; }
+
+    /*!
+     * @brief Parts used from ADDON::CAddonDatabase
+     */
+    //@{
+    void SetInstallDate(CDateTime installDate) { m_installDate = installDate; }
+    void SetLastUpdated(CDateTime lastUpdated) { m_lastUpdated = lastUpdated; }
+    void SetLastUsed(CDateTime lastUsed) { m_lastUsed = lastUsed; }
+    void SetOrigin(std::string origin) { m_origin = std::move(origin); }
+    //@}
+
+    const std::string& ID() const { return m_id; }
+    TYPE MainType() const { return m_mainType; }
+    const AddonVersion& Version() const { return m_version; }
+    const AddonVersion& MinVersion() const { return m_minversion; }
+    const std::string& Name() const { return m_name; }
+    const std::string& License() const { return m_license; }
+    const std::string& Summary() const { return m_summary; }
+    const std::string& Description() const { return m_description; }
+    const std::string& LibName() const { return m_libname; }
+    const std::string& Author() const { return m_author; }
+    const std::string& Source() const { return m_source; }
+    const std::string& Path() const { return m_path; }
+    void SetPath(const std::string& path) { m_path = path; }
+    const std::string& ChangeLog() const { return m_changelog; }
+    const std::string& Icon() const { return m_icon; }
+    const ArtMap& Art() const { return m_art; }
+    const std::vector<std::string>& Screenshots() const { return m_screenshots; }
+    const std::string& Disclaimer() const { return m_disclaimer; }
+    const ADDONDEPS& GetDeps() const { return m_dependencies; }
+    const std::string& Broken() const { return m_broken; }
+    const CDateTime& InstallDate() const { return m_installDate; }
+    const CDateTime& LastUpdated() const { return m_lastUpdated; }
+    const CDateTime& LastUsed() const { return m_lastUsed; }
+    const std::string& Origin() const { return m_origin; }
+    uint64_t PackageSize() const { return m_packageSize; }
+    const std::string& Language() const { return m_language; }
+    bool MeetsVersion(const AddonVersion &version) const;
 
     /*!
      * @brief Utilities to translate add-on parts to his requested part.
@@ -101,31 +143,40 @@ namespace ADDON
     static TYPE TranslateSubContent(const std::string &content);
     //@}
 
-    std::string id;
-    TYPE type;
-    AddonVersion version{"0.0.0"};
-    AddonVersion minversion{"0.0.0"};
-    std::string name;
-    std::string license;
-    std::string summary;
-    std::string description;
-    std::string libname;
-    std::string author;
-    std::string source;
-    std::string path;
-    std::string changelog;
-    std::string icon;
-    std::map<std::string, std::string> art;
-    std::vector<std::string> screenshots;
-    std::string disclaimer;
-    ADDONDEPS dependencies;
-    std::string broken;
-    InfoMap extrainfo;
-    CDateTime installDate;
-    CDateTime lastUpdated;
-    CDateTime lastUsed;
-    std::string origin;
-    uint64_t packageSize;
+    InfoMap extrainfo; // defined here, but removed in future with cpluff
+
+  private:
+    friend class ADDON::CAddonBuilder;
+
+    bool m_usable;
+
+    std::string m_id;
+    TYPE m_mainType;
+
+    AddonVersion m_version{"0.0.0"};
+    AddonVersion m_minversion{"0.0.0"};
+    std::string m_name;
+    std::string m_license;
+    std::string m_summary;
+    std::string m_description;
+    std::string m_author;
+    std::string m_source;
+    std::string m_path;
+    std::string m_changelog;
+    std::string m_icon;
+    ArtMap m_art;
+    std::vector<std::string> m_screenshots;
+    std::string m_disclaimer;
+    ADDONDEPS m_dependencies;
+    std::string m_broken;
+    CDateTime m_installDate;
+    CDateTime m_lastUpdated;
+    CDateTime m_lastUsed;
+    std::string m_origin;
+    uint64_t m_packageSize;
+    std::string m_language;
+
+    std::string m_libname;
   };
 
 } /* namespace ADDON */

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -40,17 +40,17 @@ void CContextMenuAddon::ParseMenu(
   auto menuId = CAddonMgr::GetInstance().GetExtValue(elem, "@id");
   auto menuLabel = CAddonMgr::GetInstance().GetExtValue(elem, "label");
   if (StringUtils::IsNaturalNumber(menuLabel))
-    menuLabel = g_localizeStrings.GetAddonString(addonInfo.id, atoi(menuLabel.c_str()));
+    menuLabel = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(menuLabel.c_str()));
 
   if (menuId.empty())
   {
     //anonymous group. create a new unique internal id.
     std::stringstream ss;
-    ss << addonInfo.id << ++anonGroupCount;
+    ss << addonInfo.ID() << ++anonGroupCount;
     menuId = ss.str();
   }
 
-  items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, addonInfo.id));
+  items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, addonInfo.ID()));
 
   ELEMENTS subMenus;
   if (CAddonMgr::GetInstance().GetExtElements(elem, "menu", subMenus))
@@ -66,12 +66,12 @@ void CContextMenuAddon::ParseMenu(
       auto library = CAddonMgr::GetInstance().GetExtValue(elem, "@library");
       auto label = CAddonMgr::GetInstance().GetExtValue(elem, "label");
       if (StringUtils::IsNaturalNumber(label))
-        label = g_localizeStrings.GetAddonString(addonInfo.id, atoi(label.c_str()));
+        label = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(label.c_str()));
 
       if (!label.empty() && !library.empty() && !visCondition.empty())
       {
         auto menu = CContextMenuItem::CreateItem(label, menuId,
-            URIUtils::AddFileToFolder(addonInfo.path, library), visCondition, addonInfo.id);
+            URIUtils::AddFileToFolder(addonInfo.Path(), library), visCondition, addonInfo.ID());
         items.push_back(menu);
       }
     }
@@ -105,10 +105,10 @@ std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(CAddonInfo a
 
       auto label = CAddonMgr::GetInstance().GetExtValue(elem, "label");
       if (StringUtils::IsNaturalNumber(label))
-        label = g_localizeStrings.GetAddonString(addonInfo.id, atoi(label.c_str()));
+        label = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(label.c_str()));
 
       CContextMenuItem menuItem = CContextMenuItem::CreateItem(label, parent,
-          URIUtils::AddFileToFolder(addonInfo.path, addonInfo.libname), visCondition, addonInfo.id);
+          URIUtils::AddFileToFolder(addonInfo.Path(), addonInfo.LibName()), visCondition, addonInfo.ID());
 
       items.push_back(menuItem);
     }

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<CInputStream> CInputStream::FromExtension(CAddonInfo addonInfo, 
   std::string name(ext->plugin->identifier);
   std::unique_ptr<CInputStream> istr(new CInputStream(addonInfo, name, listitemprops,
                                                       extensions, protocols));
-  if (!CAddonMgr::GetInstance().IsAddonDisabled(addonInfo.id))
+  if (!CAddonMgr::GetInstance().IsAddonDisabled(addonInfo.ID()))
     istr->CheckConfig();
   return istr;
 }

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp
     persistence.SetFromTimeString(tmp);
 
   CONTENT_TYPE pathContent(CONTENT_NONE);
-  switch (addonInfo.type)
+  switch (addonInfo.MainType())
   {
     case ADDON_SCRAPER_ALBUMS:
       pathContent = CONTENT_ALBUMS;

--- a/xbmc/addons/Webinterface.cpp
+++ b/xbmc/addons/Webinterface.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<CWebinterface> CWebinterface::FromExtension(CAddonInfo addonInfo
   if (StringUtils::EqualsNoCase(webinterfaceType.c_str(), "wsgi"))
     type = WebinterfaceTypeWsgi;
   else if (!webinterfaceType.empty() && !StringUtils::EqualsNoCase(webinterfaceType.c_str(), "static") && !StringUtils::EqualsNoCase(webinterfaceType.c_str(), "html"))
-    CLog::Log(LOGWARNING, "Webinterface addon \"%s\" has specified an unsupported type \"%s\"", addonInfo.id.c_str(), webinterfaceType.c_str());
+    CLog::Log(LOGWARNING, "Webinterface addon \"%s\" has specified an unsupported type \"%s\"", addonInfo.ID().c_str(), webinterfaceType.c_str());
 
   // determine the entry point of the webinterface
   std::string entryPoint(WEBINTERFACE_DEFAULT_ENTRY_POINT);

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -277,15 +277,15 @@ GUIHANDLE CAddonCallbacksGUI::Window_New(void *addonData, const char *xmlFilenam
     //FIXME make this static method of current skin?
     std::string str("none");
     CAddonInfo addonInfo(str, ADDON_SKIN);
-    addonInfo.path = URIUtils::AddFileToFolder(
+    addonInfo.SetPath(URIUtils::AddFileToFolder(
       guiHelper->m_addon->Path(),
       "resources",
       "skins",
-      defaultSkin);
+      defaultSkin));
 
     std::shared_ptr<CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo);
     skinInfo->Start();
-    strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res, addonInfo.path);
+    strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res, addonInfo.Path());
 
     if (!XFILE::CFile::Exists(strSkinPath))
     {

--- a/xbmc/addons/interfaces/GUI/Window.cpp
+++ b/xbmc/addons/interfaces/GUI/Window.cpp
@@ -140,7 +140,7 @@ void* Interface_GUIWindow::create(void* kodiBase, const char* xml_filename,
     // Check for the matching folder for the skin in the fallback skins folder (if it exists)
     if (XFILE::CFile::Exists(basePath))
     {
-      addonInfo.path = basePath;
+      addonInfo.SetPath(basePath);
       ADDON::CSkinInfo skinInfo(addonInfo, res);
       skinInfo.Start();
       strSkinPath = skinInfo.GetSkinPath(xml_filename, &res);
@@ -149,7 +149,7 @@ void* Interface_GUIWindow::create(void* kodiBase, const char* xml_filename,
     if (!XFILE::CFile::Exists(strSkinPath))
     {
       // Finally fallback to the DefaultSkin as it didn't exist in either the Kodi Skin folder or the fallback skin folder
-      addonInfo.path = URIUtils::AddFileToFolder(fallbackPath, default_skin);
+      addonInfo.SetPath(URIUtils::AddFileToFolder(fallbackPath, default_skin));
       ADDON::CSkinInfo skinInfo(addonInfo, res);
 
       skinInfo.Start();

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -121,7 +121,7 @@ namespace XBMCAddon
         // Check for the matching folder for the skin in the fallback skins folder (if it exists)
         if (XFILE::CFile::Exists(basePath))
         {
-          addonInfo.path = basePath;
+          addonInfo.SetPath(basePath);
           std::shared_ptr<ADDON::CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
           skinInfo->Start();
           strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res);
@@ -130,7 +130,7 @@ namespace XBMCAddon
         if (!XFILE::CFile::Exists(strSkinPath))
         {
           // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
-          addonInfo.path = URIUtils::AddFileToFolder(fallbackPath, defaultSkin);
+          addonInfo.SetPath(URIUtils::AddFileToFolder(fallbackPath, defaultSkin));
           std::shared_ptr<ADDON::CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
 
           skinInfo->Start();


### PR DESCRIPTION
## Description
<!--- Describe your change in detail -->
This change all values on CAddonInfo to private and access
them over functions.

Main reason for them is to make the class more safe for next changes
where CAddonInfo is no longer in CAddon, but globally as replacement
for cpluff.

Set of this value becomes in future mainly done from the class constructor
and no more by external parts.

<!--- Provide a general summary of your change in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
