### PR TITLE
[utils] Variant: return matching iterators for (begin|end)_(array|map)

### DIFF
--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -135,6 +135,8 @@ CVariant::CVariant()
 }
 
 CVariant CVariant::ConstNullVariant = CVariant::VariantTypeConstNull;
+CVariant::VariantArray CVariant::EMPTY_ARRAY;
+CVariant::VariantMap CVariant::EMPTY_MAP;
 
 CVariant::CVariant(VariantType type)
 {
@@ -754,7 +756,7 @@ CVariant::iterator_array CVariant::begin_array()
   if (m_type == VariantTypeArray)
     return m_data.array->begin();
   else
-    return iterator_array();
+    return EMPTY_ARRAY.begin();
 }
 
 CVariant::const_iterator_array CVariant::begin_array() const
@@ -762,7 +764,7 @@ CVariant::const_iterator_array CVariant::begin_array() const
   if (m_type == VariantTypeArray)
     return m_data.array->begin();
   else
-    return const_iterator_array();
+    return EMPTY_ARRAY.begin();
 }
 
 CVariant::iterator_array CVariant::end_array()
@@ -770,7 +772,7 @@ CVariant::iterator_array CVariant::end_array()
   if (m_type == VariantTypeArray)
     return m_data.array->end();
   else
-    return iterator_array();
+    return EMPTY_ARRAY.end();
 }
 
 CVariant::const_iterator_array CVariant::end_array() const
@@ -778,7 +780,7 @@ CVariant::const_iterator_array CVariant::end_array() const
   if (m_type == VariantTypeArray)
     return m_data.array->end();
   else
-    return const_iterator_array();
+    return EMPTY_ARRAY.end();
 }
 
 CVariant::iterator_map CVariant::begin_map()
@@ -786,7 +788,7 @@ CVariant::iterator_map CVariant::begin_map()
   if (m_type == VariantTypeObject)
     return m_data.map->begin();
   else
-    return iterator_map();
+    return EMPTY_MAP.begin();
 }
 
 CVariant::const_iterator_map CVariant::begin_map() const
@@ -794,7 +796,7 @@ CVariant::const_iterator_map CVariant::begin_map() const
   if (m_type == VariantTypeObject)
     return m_data.map->begin();
   else
-    return const_iterator_map();
+    return EMPTY_MAP.begin();
 }
 
 CVariant::iterator_map CVariant::end_map()
@@ -802,7 +804,7 @@ CVariant::iterator_map CVariant::end_map()
   if (m_type == VariantTypeObject)
     return m_data.map->end();
   else
-    return iterator_map();
+    return EMPTY_MAP.end();
 }
 
 CVariant::const_iterator_map CVariant::end_map() const
@@ -810,7 +812,7 @@ CVariant::const_iterator_map CVariant::end_map() const
   if (m_type == VariantTypeObject)
     return m_data.map->end();
   else
-    return const_iterator_map();
+    return EMPTY_MAP.end();
 }
 
 unsigned int CVariant::size() const

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -161,4 +161,7 @@ private:
 
   VariantType m_type;
   VariantUnion m_data;
+
+  static VariantArray EMPTY_ARRAY;
+  static VariantMap EMPTY_MAP;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
[utils] Variant: return matching iterators for (begin|end)_(array|map), if type is not array or map

With this change std::distance(...) is also correct if the type isn't an array or map.
Without this change there needs to be a check for isArray respectively isObject before iterating over the elements.
<!--- Describe your change in detail -->

## Motivation and Context
Incorrect usage of CVariant at #12244.
@Montellese I don't know if you like this idea of the static array and map.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled and runtime tested on Windows and OSX
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
