### PR TITLE
Correct spelling of "its"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17528,7 +17528,7 @@ msgstr ""
 #. Description of setting with label #20458 "Group movies in sets"
 #: system/settings/settings.xml
 msgctxt "#36145"
-msgid "When enabled, movies belonging to a \"Movie set\" are grouped together under one entry for the set in the movie library, this entry can then be opened to display the individual movies. When disabled, each movie will have it's own entry in the movie library even if it belongs to a set."
+msgid "When enabled, movies belonging to a \"Movie set\" are grouped together under one entry for the set in the movie library, this entry can then be opened to display the individual movies. When disabled, each movie will have its own entry in the movie library even if it belongs to a set."
 msgstr ""
 
 #. Description of setting with label #22000 "Update library on startup"

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1689,7 +1689,7 @@ std::string CFileItem::GetOpticalMediaPath() const
 * @todo Ideally this (and SetPath) would not be available outside of construction
 * for CFileItem objects, or at least restricted to essentially be equivalent
 * to construction. This would require re-formulating a bunch of CFileItem
-* construction, and also allowing CFileItemList to have it's own (public)
+* construction, and also allowing CFileItemList to have its own (public)
 * SetURL() function, so for now we give direct access.
 */
 void CFileItem::SetURL(const CURL& url)

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -140,7 +140,7 @@ namespace XbmcCommons
      * shares the underlying data buffer with the Buffer it is a copy
      * of. Changes made to the data through this buffer will be seen
      * in the source buffer and vice/vrs. However, each buffer maintains
-     * it's own indexing.
+     * its own indexing.
      */
     inline Buffer(const Buffer& buf) : bufferRef(buf.bufferRef), buffer(buf.buffer), 
       mposition(buf.mposition), mcapacity(buf.mcapacity), mlimit(buf.mlimit) { }
@@ -152,7 +152,7 @@ namespace XbmcCommons
      * shares the underlying data buffer with the Buffer it is a copy
      * of. Changes made to the data through this buffer will be seen
      * in the source buffer and vice/vrs. However, each buffer maintains
-     * it's own indexing.
+     * its own indexing.
      */
     inline Buffer& operator=(const Buffer& buf)
     {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -150,7 +150,7 @@ CAESinkDARWINOSX::CAESinkDARWINOSX()
 {
   // By default, kAudioHardwarePropertyRunLoop points at the process's main thread on SnowLeopard,
   // If your process lacks such a run loop, you can set kAudioHardwarePropertyRunLoop to NULL which
-  // tells the HAL to run it's own thread for notifications (which was the default prior to SnowLeopard).
+  // tells the HAL to run its own thread for notifications (which was the default prior to SnowLeopard).
   // So tell the HAL to use its own thread for similar behavior under all supported versions of OSX.
   CFRunLoopRef theRunLoop = NULL;
   AudioObjectPropertyAddress theAddress = {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -125,7 +125,7 @@ void CRendererMediaCodecSurface::FlipPage(int source)
 
   CDVDMediaCodecInfo *mci = static_cast<CDVDMediaCodecInfo *>(m_buffers[m_iRenderBuffer].hwPic);
 
-  // Android SurfaceFlinger has it's own clock, so we can release frames early.
+  // Android SurfaceFlinger has its own clock, so we can release frames early.
   // Benefit of this place is that it is called from render-thread and not
   // affected by gui stalls when opening overlay dialogs
   if (mci)

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -113,7 +113,7 @@ bool CGUIWindowVisualisation::OnAction(const CAction &action)
       g_infoManager.SetShowInfo(true);
     }
     break;
-    //! @todo These should be mapped to it's own function - at the moment it's overriding
+    //! @todo These should be mapped to its own function - at the moment it's overriding
     //! the global action of fastforward/rewind and OSD.
 /*  case KEY_BUTTON_Y:
     g_application.m_CdgParser.Pause();

--- a/xbmc/utils/test/TestCharsetConverter.cpp
+++ b/xbmc/utils/test/TestCharsetConverter.cpp
@@ -205,7 +205,7 @@ TEST_F(TestCharsetConverter, utf8To_UTF16LE)
 //{
 //  refstra1 = "ｔｅｓｔ＿ｕｔｆ８Ｔｏ：＿ｃｈａｒｓｅｔ＿ＵＴＦ－３２ＬＥ，＿"
 //#ifdef TARGET_DARWIN
-///* OSX has it's own 'special' utf-8 charset which we use (see UTF8_SOURCE in CharsetConverter.cpp)
+///* OSX has its own 'special' utf-8 charset which we use (see UTF8_SOURCE in CharsetConverter.cpp)
 //   which is basically NFD (decomposed) utf-8.  The trouble is, it fails on the COW FACE and MOUSE FACE
 //   characters for some reason (possibly anything over 0x100000, or maybe there's a decomposed form of these
 //   that I couldn't find???)  If UTF8_SOURCE is switched to UTF-8 then this test would pass as-is, but then


### PR DESCRIPTION
## Description

This fixes every occurrence of "it's own" to "its own", both in code
comments and in UI text.

## Motivation and Context

While using Kodi, I noticed the instance of "it's own" that is visible
in the UI and thought I could just as well fix all of the other obvious
ones.

## How Has This Been Tested?

This does not touch code and as such is unlikely to break anything. I
must recognize that I haven't actually run any tests.

## Screenshots (if appropriate):

(none)

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
