### PR TITLE
Games: Move to C++11

### DIFF
--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -41,7 +41,7 @@ CGameSettings& CGameSettings::GetInstance()
 
 void CGameSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 {
-  if (setting == NULL)
+  if (setting == nullptr)
     return;
 
   const std::string& settingId = setting->GetId();
@@ -59,7 +59,7 @@ void CGameSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 
 void CGameSettings::OnSettingAction(std::shared_ptr<const CSetting> setting)
 {
-  if (setting == NULL)
+  if (setting == nullptr)
     return;
 
   const std::string& settingId = setting->GetId();

--- a/xbmc/games/GameSettings.h
+++ b/xbmc/games/GameSettings.h
@@ -32,14 +32,14 @@ class CGameSettings : public ISettingCallback,
 {
 public:
   static CGameSettings& GetInstance();
-  virtual ~CGameSettings() { }
+  virtual ~CGameSettings() = default;
 
   // Inherited from ISettingCallback
   virtual void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
   virtual void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
 private:
-  CGameSettings() { }
+  CGameSettings() = default;
 };
 
 } // namespace GAME

--- a/xbmc/games/GameTypes.h
+++ b/xbmc/games/GameTypes.h
@@ -26,7 +26,7 @@ namespace GAME
 {
 
   class CGameClient;
-  typedef std::shared_ptr<CGameClient> GameClientPtr;
-  typedef std::vector<GameClientPtr>   GameClientVector;
+  using GameClientPtr = std::shared_ptr<CGameClient>;
+  using GameClientVector = std::vector<GameClientPtr>;
 
 }

--- a/xbmc/games/addons/GameClientCallbacks.h
+++ b/xbmc/games/addons/GameClientCallbacks.h
@@ -33,7 +33,7 @@ namespace GAME
   class IGameAudioCallback
   {
   public:
-    virtual ~IGameAudioCallback() { }
+    virtual ~IGameAudioCallback() = default;
 
     virtual unsigned int NormalizeSamplerate(unsigned int samplerate) const = 0;
     virtual bool OpenPCMStream(AEDataFormat format, unsigned int samplerate, const CAEChannelInfo& channelLayout) = 0;
@@ -45,7 +45,7 @@ namespace GAME
   class IGameVideoCallback
   {
   public:
-    virtual ~IGameVideoCallback() { }
+    virtual ~IGameVideoCallback() = default;
 
     virtual bool OpenPixelStream(AVPixelFormat pixfmt, unsigned int width, unsigned int height, double framerate, unsigned int orientationDeg) = 0;
     virtual bool OpenEncodedStream(AVCodecID codec) = 0;

--- a/xbmc/games/addons/savestates/DeltaPairMemoryStream.h
+++ b/xbmc/games/addons/savestates/DeltaPairMemoryStream.h
@@ -62,7 +62,7 @@ namespace GAME
       uint32_t delta;
     };
 
-    typedef std::vector<DeltaPair> DeltaPairVector;
+    using DeltaPairVector = std::vector<DeltaPair>;
 
     struct MemoryFrame
     {

--- a/xbmc/games/addons/savestates/Savestate.cpp
+++ b/xbmc/games/addons/savestates/Savestate.cpp
@@ -95,7 +95,7 @@ bool CSavestate::Serialize(const std::string& path) const
 
   TiXmlElement rootElement(SAVESTATE_XML_ROOT);
   TiXmlNode* root = xmlFile.InsertEndChild(rootElement);
-  if (root == NULL)
+  if (root == nullptr)
     return false;
 
   TiXmlElement* pElement = root->ToElement();

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -38,7 +38,7 @@ public:
 
   CController(ADDON::CAddonInfo addonInfo);
 
-  virtual ~CController(void) { }
+  virtual ~CController() = default;
 
   static const ControllerPtr EmptyPtr;
 

--- a/xbmc/games/controllers/ControllerTypes.h
+++ b/xbmc/games/controllers/ControllerTypes.h
@@ -25,6 +25,6 @@
 namespace GAME
 {
   class CController;
-  typedef std::shared_ptr<CController> ControllerPtr;
-  typedef std::vector<ControllerPtr>   ControllerVector;
+  using ControllerPtr = std::shared_ptr<CController>;
+  using ControllerVector = std::vector<ControllerPtr>;
 }

--- a/xbmc/games/controllers/guicontrols/GUIAnalogStickButton.h
+++ b/xbmc/games/controllers/guicontrols/GUIAnalogStickButton.h
@@ -31,7 +31,7 @@ namespace GAME
                           const CControllerFeature& feature,
                           unsigned int index);
 
-    virtual ~CGUIAnalogStickButton(void) { }
+    virtual ~CGUIAnalogStickButton() = default;
 
     // implementation of IFeatureButton
     virtual bool PromptForInput(CEvent& waitEvent) override;

--- a/xbmc/games/controllers/guicontrols/GUIControllerButton.h
+++ b/xbmc/games/controllers/guicontrols/GUIControllerButton.h
@@ -30,6 +30,6 @@ namespace GAME
   public:
     CGUIControllerButton(const CGUIButtonControl& buttonControl, const std::string& label, unsigned int index);
 
-    virtual ~CGUIControllerButton(void) { }
+    virtual ~CGUIControllerButton() = default;
   };
 }

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.h
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.h
@@ -37,7 +37,7 @@ namespace GAME
                       const CControllerFeature& feature,
                       unsigned int index);
 
-    virtual ~CGUIFeatureButton(void) { }
+    virtual ~CGUIFeatureButton() = default;
 
     // implementation of CGUIControl via CGUIButtonControl
     virtual void OnUnFocus(void) override;

--- a/xbmc/games/controllers/guicontrols/GUIFeatureControls.h
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureControls.h
@@ -31,7 +31,7 @@ namespace GAME
   public:
     CGUIFeatureGroupTitle(const CGUILabelControl& groupTitleTemplate, const std::string& groupName, unsigned int featureIndex);
 
-    virtual ~CGUIFeatureGroupTitle(void) { }
+    virtual ~CGUIFeatureGroupTitle() = default;
   };
 
   class CGUIFeatureSeparator : public CGUIImage
@@ -39,6 +39,6 @@ namespace GAME
   public:
     CGUIFeatureSeparator(const CGUIImage& separatorTemplate, unsigned int featureIndex);
 
-    virtual ~CGUIFeatureSeparator(void) { }
+    virtual ~CGUIFeatureSeparator() = default;
   };
 }

--- a/xbmc/games/controllers/guicontrols/GUIGameController.h
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.h
@@ -31,7 +31,7 @@ namespace GAME
     CGUIGameController(int parentID, int controlID, float posX, float posY, float width, float height);
     CGUIGameController(const CGUIGameController &from);
 
-    virtual ~CGUIGameController(void) { }
+    virtual ~CGUIGameController() = default;
 
     // implementation of CGUIControl via CGUIImage
     virtual CGUIGameController* Clone(void) const override;

--- a/xbmc/games/controllers/guicontrols/GUIScalarFeatureButton.h
+++ b/xbmc/games/controllers/guicontrols/GUIScalarFeatureButton.h
@@ -31,7 +31,7 @@ namespace GAME
                             const CControllerFeature& feature,
                             unsigned int index);
 
-    virtual ~CGUIScalarFeatureButton(void) { }
+    virtual ~CGUIScalarFeatureButton() = default;
 
     // implementation of IFeatureButton
     virtual bool PromptForInput(CEvent& waitEvent) override;

--- a/xbmc/games/controllers/windows/IConfigurationWindow.h
+++ b/xbmc/games/controllers/windows/IConfigurationWindow.h
@@ -55,7 +55,7 @@ namespace GAME
   class IControllerList
   {
   public:
-    virtual ~IControllerList(void) { }
+    virtual ~IControllerList() = default;
 
     /*!
      * \brief  Initialize the resource
@@ -105,7 +105,7 @@ namespace GAME
   class IFeatureList
   {
   public:
-    virtual ~IFeatureList(void) { }
+    virtual ~IFeatureList() = default;
 
     /*!
      * \brief  Initialize the resource
@@ -145,7 +145,7 @@ namespace GAME
   class IFeatureButton
   {
   public:
-    virtual ~IFeatureButton(void) { }
+    virtual ~IFeatureButton() = default;
 
     /*!
      * \brief Get the feature represented by this button
@@ -187,7 +187,7 @@ namespace GAME
   class IConfigurationWizard
   {
   public:
-    virtual ~IConfigurationWizard(void) { }
+    virtual ~IConfigurationWizard() = default;
 
     /*!
      * \brief Start the wizard at the specified feature

--- a/xbmc/games/ports/PortTypes.h
+++ b/xbmc/games/ports/PortTypes.h
@@ -25,6 +25,6 @@ namespace GAME
 {
 
 class CPort;
-typedef std::shared_ptr<CPort> PortPtr;
+using PortPtr = std::shared_ptr<CPort>;
 
 }

--- a/xbmc/games/windows/GUIWindowGames.h
+++ b/xbmc/games/windows/GUIWindowGames.h
@@ -30,7 +30,7 @@ namespace GAME
   {
   public:
     CGUIWindowGames();
-    virtual ~CGUIWindowGames() { }
+    virtual ~CGUIWindowGames() = default;
 
     // implementation of CGUIControl via CGUIMediaWindow
     virtual bool OnMessage(CGUIMessage& message) override;


### PR DESCRIPTION
This adapts the games code in the following ways:

* Using nullptr instead of NULL
* Using the `default` keyword for ctors and dtors
* Using the `using` keyword instead of typedef

Absent is the move of initializers to headers because I don't overload any constructors in the code.

## Motivation and Context
#12251... Someone is trying to outdo me...

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed (`[  PASSED  ] 581 tests`)
