### PR TITLE
Joysticks: Move to C++11

### DIFF
--- a/xbmc/input/joysticks/IButtonMap.h
+++ b/xbmc/input/joysticks/IButtonMap.h
@@ -39,7 +39,7 @@ namespace JOYSTICK
   class IButtonMap
   {
   public:
-    virtual ~IButtonMap(void) { }
+    virtual ~IButtonMap() = default;
 
     /*!
      * \brief The add-on ID of the game controller associated with this button map

--- a/xbmc/input/joysticks/IButtonMapper.h
+++ b/xbmc/input/joysticks/IButtonMapper.h
@@ -43,7 +43,7 @@ namespace JOYSTICK
   public:
     IButtonMapper() = default;
 
-    virtual ~IButtonMapper(void) { }
+    virtual ~IButtonMapper() = default;
 
     /*!
      * \brief The add-on ID of the game controller associated with this button mapper

--- a/xbmc/input/joysticks/IDriverHandler.h
+++ b/xbmc/input/joysticks/IDriverHandler.h
@@ -32,7 +32,7 @@ namespace JOYSTICK
   class IDriverHandler
   {
   public:
-    virtual ~IDriverHandler(void) { }
+    virtual ~IDriverHandler() = default;
 
     /*!
      * \brief Handle button motion

--- a/xbmc/input/joysticks/IDriverReceiver.h
+++ b/xbmc/input/joysticks/IDriverReceiver.h
@@ -30,7 +30,7 @@ namespace JOYSTICK
   class IDriverReceiver
   {
   public:
-    virtual ~IDriverReceiver(void) { }
+    virtual ~IDriverReceiver() = default;
 
     /*!
      * \brief Set the value of a rumble motor

--- a/xbmc/input/joysticks/IInputHandler.h
+++ b/xbmc/input/joysticks/IInputHandler.h
@@ -38,7 +38,7 @@ namespace JOYSTICK
   public:
     IInputHandler(void) : m_receiver(nullptr) { }
 
-    virtual ~IInputHandler(void) { }
+    virtual ~IInputHandler() = default;
 
     /*!
      * \brief The add-on ID of the game controller associated with this input handler

--- a/xbmc/input/joysticks/IInputReceiver.h
+++ b/xbmc/input/joysticks/IInputReceiver.h
@@ -32,7 +32,7 @@ namespace JOYSTICK
   class IInputReceiver
   {
   public:
-    virtual ~IInputReceiver(void) { }
+    virtual ~IInputReceiver() = default;
 
     /*!
      * \brief Set the value of a rumble motor

--- a/xbmc/input/joysticks/IKeymapHandler.h
+++ b/xbmc/input/joysticks/IKeymapHandler.h
@@ -35,7 +35,7 @@ namespace JOYSTICK
   class IKeymapHandler
   {
   public:
-    virtual ~IKeymapHandler(void) { }
+    virtual ~IKeymapHandler() = default;
 
     /*!
      * \brief Get the type of action mapped to the specified key ID

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -33,7 +33,7 @@ namespace JOYSTICK
   /*!
    * \brief Name of a physical feature belonging to the joystick
    */
-  typedef std::string FeatureName;
+  using FeatureName = std::string;
 
   /*!
    * \brief Types of features used in the joystick library
@@ -89,7 +89,7 @@ namespace JOYSTICK
   /*!
    * \brief Typedef for analog stick directions
    */
-  typedef HAT_DIRECTION  ANALOG_STICK_DIRECTION;
+  using ANALOG_STICK_DIRECTION = HAT_DIRECTION;
 
   /*!
    * \brief States in which a hat can be

--- a/xbmc/input/joysticks/generic/ButtonMapping.h
+++ b/xbmc/input/joysticks/generic/ButtonMapping.h
@@ -215,7 +215,7 @@ namespace JOYSTICK
      */
     CButtonMapping(IButtonMapper* buttonMapper, IButtonMap* buttonMap, IActionMap* actionMap);
 
-    virtual ~CButtonMapping(void) { }
+    virtual ~CButtonMapping() = default;
 
     // implementation of IDriverHandler
     virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;

--- a/xbmc/input/joysticks/generic/DriverReceiving.h
+++ b/xbmc/input/joysticks/generic/DriverReceiving.h
@@ -44,7 +44,7 @@ namespace JOYSTICK
   public:
     CDriverReceiving(IDriverReceiver* receiver, IButtonMap* buttonMap);
 
-    virtual ~CDriverReceiving(void) { }
+    virtual ~CDriverReceiving() = default;
 
     // implementation of IInputReceiver
     virtual bool SetRumbleState(const FeatureName& feature, float magnitude) override;

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -32,7 +32,7 @@ namespace JOYSTICK
   class IButtonMap;
 
   class CJoystickFeature;
-  typedef std::shared_ptr<CJoystickFeature> FeaturePtr;
+  using FeaturePtr = std::shared_ptr<CJoystickFeature>;
 
   /*!
    * \ingroup joystick
@@ -44,7 +44,7 @@ namespace JOYSTICK
   {
   public:
     CJoystickFeature(const FeatureName& name, IInputHandler* handler, IButtonMap* buttonMap);
-    virtual ~CJoystickFeature(void) { }
+    virtual ~CJoystickFeature() = default;
 
     /*!
      * \brief A digital motion has occured
@@ -100,7 +100,7 @@ namespace JOYSTICK
   {
   public:
     CScalarFeature(const FeatureName& name, IInputHandler* handler, IButtonMap* buttonMap);
-    virtual ~CScalarFeature(void) { }
+    virtual ~CScalarFeature() = default;
 
     // implementation of CJoystickFeature
     virtual bool OnDigitalMotion(const CDriverPrimitive& source, bool bPressed) override;
@@ -190,7 +190,7 @@ namespace JOYSTICK
   {
   public:
     CAnalogStick(const FeatureName& name, IInputHandler* handler, IButtonMap* buttonMap);
-    virtual ~CAnalogStick(void) { }
+    virtual ~CAnalogStick() = default;
 
     // implementation of CJoystickFeature
     virtual bool OnDigitalMotion(const CDriverPrimitive& source, bool bPressed) override;
@@ -211,7 +211,7 @@ namespace JOYSTICK
   {
   public:
     CAccelerometer(const FeatureName& name, IInputHandler* handler, IButtonMap* buttonMap);
-    virtual ~CAccelerometer(void) { }
+    virtual ~CAccelerometer() = default;
 
     // implementation of CJoystickFeature
     virtual bool OnDigitalMotion(const CDriverPrimitive& source, bool bPressed) override;

--- a/xbmc/input/keyboard/IKeyboardHandler.h
+++ b/xbmc/input/keyboard/IKeyboardHandler.h
@@ -32,7 +32,7 @@ namespace KEYBOARD
   class IKeyboardHandler
   {
   public:
-    virtual ~IKeyboardHandler(void) { }
+    virtual ~IKeyboardHandler() = default;
 
     /*!
      * \brief A key has been pressed


### PR DESCRIPTION
This adapts the joystick code in the following ways:

* Using the `default` keyword for ctors and dtors
* Using the `using` keyword instead of typedef

Absent is the move of initializers to headers because I don't overload any constructors in the code.

## Motivation and Context
#12251... Someone is trying to make me look bad...

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed (`[  PASSED  ] 581 tests`)
