### PR TITLE
[settings] change XML format of setting values

### DIFF
--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -58,7 +58,7 @@ public:
   CSettingsManager() = default;
   virtual ~CSettingsManager();
 
-  static const uint32_t Version = 1;
+  static const uint32_t Version = 2;
   static const uint32_t MinimumSupportedVersion = 0;
 
   // implementation of ISettingCreator


### PR DESCRIPTION
(This PR is on top of #12276.)

I've always wondered why we stored our settings in `guisettings.xml` split up into categories and settings where the categories were the first part of the settings' identifiers. This can actually cause problems if we e.g. have a setting `foo` and then a setting `foo.bar` the resulting XML will be
```xml
<settings>
  <foo>
    value
    <bar>othervalue</bar>
  </foo>
</settings>
```
which the settings library is unable to parse. With core settings this hasn't happened (yet) but I've seen a few add-ons who suffer from this since #12125. IMO it is much cleaner to just store the settings as
```xml
<settings>
  <foo>value</foo>
  <foo.bar>othervalue</foo.bar>
</settings>
```
because it makes it more obvious what the actual setting identifiers are.

The implementation still supports reading/parsing the old format (which is also used in `advancedsettings.xml`) but always writes settings to XML in the new format.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
