### PR TITLE
Peripherals: Fix c/p error when Power-Off was added to the Peripheral API

### DIFF
--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -325,5 +325,5 @@ void CPeripheralJoystick::SetSupportsPowerOff(bool bSupportsPowerOff)
   if (!m_supportsPowerOff)
     m_features.erase(std::remove(m_features.begin(), m_features.end(), FEATURE_POWER_OFF), m_features.end());
   else if (std::find(m_features.begin(), m_features.end(), FEATURE_POWER_OFF) == m_features.end())
-    m_features.push_back(FEATURE_RUMBLE);
+    m_features.push_back(FEATURE_POWER_OFF);
 }


### PR DESCRIPTION
This fixes a c/p error introduced in 54620fc from #11707.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
