### PR TITLE
[Python] Fix xbmcgui.Window methods to get the actual size of a Window

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
@@ -45,6 +45,18 @@ namespace XBMCAddon
       return g_windowManager.GetTopMostModalDialogID();
     }
 
+    long getScreenHeight()
+    {
+      XBMC_TRACE;
+      return g_graphicsContext.GetHeight();
+    }
+
+    long getScreenWidth()
+    {
+      XBMC_TRACE;
+      return g_graphicsContext.GetWidth();
+    }
+
     const char* getNOTIFICATION_INFO()    { return NOTIFICATION_INFO; }
     const char* getNOTIFICATION_WARNING() { return NOTIFICATION_WARNING; }
     const char* getNOTIFICATION_ERROR()   { return NOTIFICATION_ERROR; }

--- a/xbmc/interfaces/legacy/ModuleXbmcgui.h
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.h
@@ -83,6 +83,40 @@ namespace XBMCAddon
 #else
     long getCurrentWindowDialogId();
 #endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcgui_window
+    /// @brief \python_func{ getScreenHeight() }
+    ///-------------------------------------------------------------------------
+    /// Returns the height of this screen.
+    ///
+    /// @return                       Screen height
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v18 New function added.
+    ///
+    getScreenHeight();
+#else
+    long getScreenHeight();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmcgui_window
+    /// @brief \python_func{ getScreenWidth() }
+    ///-------------------------------------------------------------------------
+    /// Returns the width of this screen.
+    ///
+    /// @return                       Screen width
+    ///
+    ///-------------------------------------------------------------------------
+    /// @python_v18 New function added.
+    ///
+    getScreenWidth();
+#else
+    long getScreenWidth();
+#endif
     ///@}
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -319,7 +319,7 @@ namespace XBMCAddon
         break;
       case CGUIControl::GUICONTROL_SLIDER:
         pControl = new ControlSlider();
-        break;			
+        break;
       case CGUIControl::GUICONTAINER_LIST:
       case CGUIControl::GUICONTAINER_WRAPLIST:
       case CGUIControl::GUICONTAINER_FIXEDLIST:
@@ -594,13 +594,17 @@ namespace XBMCAddon
     long Window::getHeight()
     {
       XBMC_TRACE;
-      return g_graphicsContext.GetHeight();
+      SingleLockWithDelayGuard gslock(g_graphicsContext, languageHook);
+      RESOLUTION_INFO resInfo = ref(window)->GetCoordsRes();
+      return resInfo.iHeight;
     }
 
     long Window::getWidth()
     {
       XBMC_TRACE;
-      return g_graphicsContext.GetWidth();
+      SingleLockWithDelayGuard gslock(g_graphicsContext, languageHook);
+      RESOLUTION_INFO resInfo = ref(window)->GetCoordsRes();
+      return resInfo.iWidth;
     }
 
     long Window::getResolution()

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -640,9 +640,12 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_window
       /// @brief \python_func{ getHeight() }
       ///-----------------------------------------------------------------------
-      /// Returns the height of this screen.
+      /// Returns the height of this Window instance.
       ///
-      /// @return                       Screen height
+      /// @return                       Window height in pixels
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 Function changed
       ///
       getHeight();
 #else
@@ -654,9 +657,12 @@ namespace XBMCAddon
       /// \ingroup python_xbmcgui_window
       /// @brief \python_func{ getWidth() }
       ///-----------------------------------------------------------------------
-      /// Returns the width of this screen.
+      /// Returns the width of this Window instance.
       ///
-      /// @return                       Screen width
+      /// @return                       Window width in pixels
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 Function changed
       ///
       getWidth();
 #else

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -691,6 +691,9 @@ namespace XBMCAddon
       ///  |   8   | PAL60 4:3  (720x480)
       ///  |   9   | PAL60 16:9 (720x480)
       ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 Deprecated.
+      ///
       getResolution();
 #else
       SWIGHIDDENVIRTUAL long getResolution();
@@ -733,6 +736,9 @@ namespace XBMCAddon
       /// win.setCoordinateResolution(0)
       /// ..
       /// ~~~~~~~~~~~~~
+      ///-----------------------------------------------------------------------
+      /// @python_v18 Deprecated.
+      ///
       setCoordinateResolution(...);
 #else
       SWIGHIDDENVIRTUAL void setCoordinateResolution(long res);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This PR fixes `xbmcgui.Window.getWidth()` and `xbmcgui.Window.getHeight()` methods so that they return the actual pixel size of a Window instance instead of the current display resolution.
Display resolution can now be obtained using `xbmcgui.getScreenWidth()` and `xbmcgui.getScreenHeight()` free functions.
Also this PR adds deprecation information to `Window.getResolution()` and `Window.setCoordinateResolution()` methods because currently they are practically useless.

## Motivation and Context
xbmcgui Controls are placed using pixel coordinates from the top left corner. However, currently there is no way to determine the the actual pixel size of the visible area (pixel coordinate grid) of a Window instance. Existing `getWidth` and `getHeight` methods return the current display resolution which is not the same as Window's coordinate grid resolution. The fixed methods will help to correctly place Controls on the screen, especially if the Controls are placed in a Window with existing ID, e.g. over a fullscreen video, and display resolution can still be obtained using the new free functions.

## How Has This Been Tested?
I compiled the code in Vusial Studio 2015 on Windows 10. Then I built a Windows installer and installed Kodi from it. After that I ran a simple testing addon and checked if those fixed methods and new functions actually work using an interactive Python debugger.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed