### PR TITLE
Split ButtonTranslator into separate classes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4398,7 +4398,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
   {
     // try translating the action from our ButtonTranslator
     unsigned int actionID;
-    if (CActionTranslator::TranslateActionString(actionStr.c_str(), actionID))
+    if (CActionTranslator::TranslateString(actionStr.c_str(), actionID))
     {
       OnAction(CAction(actionID));
       return true;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -58,6 +58,7 @@
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
 #endif
+#include "input/ActionTranslator.h"
 #include "input/ButtonTranslator.h"
 #include "guilib/GUIAudioManager.h"
 #include "GUIPassword.h"
@@ -4396,8 +4397,8 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
   else
   {
     // try translating the action from our ButtonTranslator
-    int actionID;
-    if (CButtonTranslator::TranslateActionString(actionStr.c_str(), actionID))
+    unsigned int actionID;
+    if (CActionTranslator::TranslateActionString(actionStr.c_str(), actionID))
     {
       OnAction(CAction(actionID));
       return true;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -35,7 +35,7 @@
 #include "utils/Weather.h"
 #include "PartyModeManager.h"
 #include "guilib/GUIVisualisationControl.h"
-#include "input/ButtonTranslator.h"
+#include "input/WindowTranslator.h"
 #include "utils/AlarmClock.h"
 #include "LangInfo.h"
 #include "utils/SystemInfo.h"
@@ -5627,7 +5627,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
     {
       if (prop.name == "property" && prop.num_params() == 1)
       { //! @todo this doesn't support foo.xml
-        int winID = cat.param().empty() ? 0 : CButtonTranslator::TranslateWindow(cat.param());
+        int winID = cat.param().empty() ? 0 : CWindowTranslator::TranslateWindow(cat.param());
         if (winID != WINDOW_INVALID)
           return AddMultiInfo(GUIInfo(WINDOW_PROPERTY, winID, ConditionalStringParameter(prop.param())));
       }
@@ -5637,7 +5637,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         { //! @todo The parameter for these should really be on the first not the second property
           if (prop.param().find("xml") != std::string::npos)
             return AddMultiInfo(GUIInfo(window_bools[i].val, 0, ConditionalStringParameter(prop.param())));
-          int winID = prop.param().empty() ? WINDOW_INVALID : CButtonTranslator::TranslateWindow(prop.param());
+          int winID = prop.param().empty() ? WINDOW_INVALID : CWindowTranslator::TranslateWindow(prop.param());
           return winID != WINDOW_INVALID ? AddMultiInfo(GUIInfo(window_bools[i].val, winID, 0)) : window_bools[i].val;
         }
       }

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -21,8 +21,10 @@
 #include "system.h"
 #include "GUIAudioManager.h"
 #include "ServiceBroker.h"
-#include "input/Key.h"
+#include "input/ActionIDs.h"
+#include "input/ActionTranslator.h"
 #include "input/ButtonTranslator.h"
+#include "input/Key.h"
 #include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
@@ -279,10 +281,10 @@ bool CGUIAudioManager::Load()
     while (pAction)
     {
       TiXmlNode* pIdNode = pAction->FirstChild("name");
-      int id = 0;    // action identity
+      unsigned int id = ACTION_NONE;    // action identity
       if (pIdNode && pIdNode->FirstChild())
       {
-        CButtonTranslator::TranslateActionString(pIdNode->FirstChild()->Value(), id);
+        CActionTranslator::TranslateActionString(pIdNode->FirstChild()->Value(), id);
       }
 
       TiXmlNode* pFileNode = pAction->FirstChild("file");
@@ -290,7 +292,7 @@ bool CGUIAudioManager::Load()
       if (pFileNode && pFileNode->FirstChild())
         strFile += pFileNode->FirstChild()->Value();
 
-      if (id > 0 && !strFile.empty())
+      if (id != ACTION_NONE && !strFile.empty())
       {
         std::string filename = URIUtils::AddFileToFolder(m_strMediaDir, strFile);
         IAESound *sound = LoadSound(filename);

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -285,7 +285,7 @@ bool CGUIAudioManager::Load()
       unsigned int id = ACTION_NONE;    // action identity
       if (pIdNode && pIdNode->FirstChild())
       {
-        CActionTranslator::TranslateActionString(pIdNode->FirstChild()->Value(), id);
+        CActionTranslator::TranslateString(pIdNode->FirstChild()->Value(), id);
       }
 
       TiXmlNode* pFileNode = pAction->FirstChild("file");

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -23,9 +23,10 @@
 #include "ServiceBroker.h"
 #include "input/ActionIDs.h"
 #include "input/ActionTranslator.h"
-#include "input/ButtonTranslator.h"
 #include "input/Key.h"
+#include "input/WindowTranslator.h"
 #include "settings/lib/Setting.h"
+#include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -318,7 +319,7 @@ bool CGUIAudioManager::Load()
       if (pIdNode)
       {
         if (pIdNode->FirstChild())
-          id = CButtonTranslator::TranslateWindow(pIdNode->FirstChild()->Value());
+          id = CWindowTranslator::TranslateWindow(pIdNode->FirstChild()->Value());
       }
 
       CWindowSounds sounds;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -31,7 +31,7 @@
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
-#include "input/ButtonTranslator.h"
+#include "input/WindowTranslator.h"
 #include "utils/XMLUtils.h"
 #include "GUIAudioManager.h"
 #include "Application.h"
@@ -210,7 +210,7 @@ bool CGUIWindow::Load(TiXmlElement *pRootElement)
     std::string strValue = pChild->Value();
     if (strValue == "previouswindow" && pChild->FirstChild())
     {
-      m_previousWindow = CButtonTranslator::TranslateWindow(pChild->FirstChild()->Value());
+      m_previousWindow = CWindowTranslator::TranslateWindow(pChild->FirstChild()->Value());
     }
     else if (strValue == "defaultcontrol" && pChild->FirstChild())
     {

--- a/xbmc/input/Action.cpp
+++ b/xbmc/input/Action.cpp
@@ -20,7 +20,7 @@
 
 #include "Action.h"
 #include "ActionIDs.h"
-#include "ButtonTranslator.h"
+#include "ActionTranslator.h"
 #include "Key.h"
 
 CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.0f */, const std::string &name /* = "" */, unsigned int holdTime /*= 0*/)
@@ -149,5 +149,5 @@ bool CAction::IsGesture() const
 
 bool CAction::IsAnalog() const
 {
-  return CButtonTranslator::IsAnalog(m_id);
+  return CActionTranslator::IsAnalog(m_id);
 }

--- a/xbmc/input/ActionTranslator.cpp
+++ b/xbmc/input/ActionTranslator.cpp
@@ -1,0 +1,307 @@
+/*
+ *      Copyright (C) 2005-2015 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ActionTranslator.h"
+#include "ActionIDs.h"
+#include "interfaces/builtins/Builtins.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <map>
+
+namespace
+{
+using ActionName = std::string;
+using ActionID = unsigned int;
+
+static const std::map<ActionName, ActionID> ActionMappings =
+{
+    { "left"                     , ACTION_MOVE_LEFT },
+    { "right"                    , ACTION_MOVE_RIGHT },
+    { "up"                       , ACTION_MOVE_UP },
+    { "down"                     , ACTION_MOVE_DOWN },
+    { "pageup"                   , ACTION_PAGE_UP },
+    { "pagedown"                 , ACTION_PAGE_DOWN },
+    { "select"                   , ACTION_SELECT_ITEM },
+    { "highlight"                , ACTION_HIGHLIGHT_ITEM },
+    { "parentdir"                , ACTION_NAV_BACK },            // backward compatibility
+    { "parentfolder"             , ACTION_PARENT_DIR },
+    { "back"                     , ACTION_NAV_BACK },
+    { "menu"                     , ACTION_MENU},
+    { "previousmenu"             , ACTION_PREVIOUS_MENU },
+    { "info"                     , ACTION_SHOW_INFO },
+    { "pause"                    , ACTION_PAUSE },
+    { "stop"                     , ACTION_STOP },
+    { "skipnext"                 , ACTION_NEXT_ITEM },
+    { "skipprevious"             , ACTION_PREV_ITEM },
+    { "fullscreen"               , ACTION_SHOW_GUI },
+    { "aspectratio"              , ACTION_ASPECT_RATIO },
+    { "stepforward"              , ACTION_STEP_FORWARD },
+    { "stepback"                 , ACTION_STEP_BACK },
+    { "bigstepforward"           , ACTION_BIG_STEP_FORWARD },
+    { "bigstepback"              , ACTION_BIG_STEP_BACK },
+    { "chapterorbigstepforward"  , ACTION_CHAPTER_OR_BIG_STEP_FORWARD },
+    { "chapterorbigstepback"     , ACTION_CHAPTER_OR_BIG_STEP_BACK },
+    { "osd"                      , ACTION_SHOW_OSD },
+    { "showsubtitles"            , ACTION_SHOW_SUBTITLES },
+    { "nextsubtitle"             , ACTION_NEXT_SUBTITLE },
+    { "browsesubtitle"           , ACTION_BROWSE_SUBTITLE },
+    { "cyclesubtitle"            , ACTION_CYCLE_SUBTITLE },
+    { "playerdebug"              , ACTION_PLAYER_DEBUG },
+    { "codecinfo"                , ACTION_PLAYER_PROCESS_INFO },
+    { "playerprocessinfo"        , ACTION_PLAYER_PROCESS_INFO },
+    { "nextpicture"              , ACTION_NEXT_PICTURE },
+    { "previouspicture"          , ACTION_PREV_PICTURE },
+    { "zoomout"                  , ACTION_ZOOM_OUT },
+    { "zoomin"                   , ACTION_ZOOM_IN },
+    { "playlist"                 , ACTION_SHOW_PLAYLIST },
+    { "queue"                    , ACTION_QUEUE_ITEM },
+    { "zoomnormal"               , ACTION_ZOOM_LEVEL_NORMAL },
+    { "zoomlevel1"               , ACTION_ZOOM_LEVEL_1 },
+    { "zoomlevel2"               , ACTION_ZOOM_LEVEL_2 },
+    { "zoomlevel3"               , ACTION_ZOOM_LEVEL_3 },
+    { "zoomlevel4"               , ACTION_ZOOM_LEVEL_4 },
+    { "zoomlevel5"               , ACTION_ZOOM_LEVEL_5 },
+    { "zoomlevel6"               , ACTION_ZOOM_LEVEL_6 },
+    { "zoomlevel7"               , ACTION_ZOOM_LEVEL_7 },
+    { "zoomlevel8"               , ACTION_ZOOM_LEVEL_8 },
+    { "zoomlevel9"               , ACTION_ZOOM_LEVEL_9 },
+    { "nextcalibration"          , ACTION_CALIBRATE_SWAP_ARROWS },
+    { "resetcalibration"         , ACTION_CALIBRATE_RESET },
+    { "analogmove"               , ACTION_ANALOG_MOVE },
+    { "analogmovex"              , ACTION_ANALOG_MOVE_X },
+    { "analogmovey"              , ACTION_ANALOG_MOVE_Y },
+    { "rotate"                   , ACTION_ROTATE_PICTURE_CW },
+    { "rotateccw"                , ACTION_ROTATE_PICTURE_CCW },
+    { "close"                    , ACTION_NAV_BACK },            // backwards compatibility
+    { "subtitledelayminus"       , ACTION_SUBTITLE_DELAY_MIN },
+    { "subtitledelay"            , ACTION_SUBTITLE_DELAY },
+    { "subtitledelayplus"        , ACTION_SUBTITLE_DELAY_PLUS },
+    { "audiodelayminus"          , ACTION_AUDIO_DELAY_MIN },
+    { "audiodelay"               , ACTION_AUDIO_DELAY },
+    { "audiodelayplus"           , ACTION_AUDIO_DELAY_PLUS },
+    { "subtitleshiftup"          , ACTION_SUBTITLE_VSHIFT_UP },
+    { "subtitleshiftdown"        , ACTION_SUBTITLE_VSHIFT_DOWN },
+    { "subtitlealign"            , ACTION_SUBTITLE_ALIGN },
+    { "audionextlanguage"        , ACTION_AUDIO_NEXT_LANGUAGE },
+    { "verticalshiftup"          , ACTION_VSHIFT_UP },
+    { "verticalshiftdown"        , ACTION_VSHIFT_DOWN },
+    { "nextresolution"           , ACTION_CHANGE_RESOLUTION },
+    { "audiotoggledigital"       , ACTION_TOGGLE_DIGITAL_ANALOG },
+    { "number0"                  , REMOTE_0 },
+    { "number1"                  , REMOTE_1 },
+    { "number2"                  , REMOTE_2 },
+    { "number3"                  , REMOTE_3 },
+    { "number4"                  , REMOTE_4 },
+    { "number5"                  , REMOTE_5 },
+    { "number6"                  , REMOTE_6 },
+    { "number7"                  , REMOTE_7 },
+    { "number8"                  , REMOTE_8 },
+    { "number9"                  , REMOTE_9 },
+    { "smallstepback"            , ACTION_SMALL_STEP_BACK },
+    { "fastforward"              , ACTION_PLAYER_FORWARD },
+    { "rewind"                   , ACTION_PLAYER_REWIND },
+    { "play"                     , ACTION_PLAYER_PLAY },
+    { "playpause"                , ACTION_PLAYER_PLAYPAUSE },
+    { "switchplayer"             , ACTION_SWITCH_PLAYER },
+    { "delete"                   , ACTION_DELETE_ITEM },
+    { "copy"                     , ACTION_COPY_ITEM },
+    { "move"                     , ACTION_MOVE_ITEM },
+    { "screenshot"               , ACTION_TAKE_SCREENSHOT },
+    { "rename"                   , ACTION_RENAME_ITEM },
+    { "togglewatched"            , ACTION_TOGGLE_WATCHED },
+    { "scanitem"                 , ACTION_SCAN_ITEM },
+    { "reloadkeymaps"            , ACTION_RELOAD_KEYMAPS },
+    { "volumeup"                 , ACTION_VOLUME_UP },
+    { "volumedown"               , ACTION_VOLUME_DOWN },
+    { "mute"                     , ACTION_MUTE },
+    { "backspace"                , ACTION_BACKSPACE },
+    { "scrollup"                 , ACTION_SCROLL_UP },
+    { "scrolldown"               , ACTION_SCROLL_DOWN },
+    { "analogfastforward"        , ACTION_ANALOG_FORWARD },
+    { "analogrewind"             , ACTION_ANALOG_REWIND },
+    { "moveitemup"               , ACTION_MOVE_ITEM_UP },
+    { "moveitemdown"             , ACTION_MOVE_ITEM_DOWN },
+    { "contextmenu"              , ACTION_CONTEXT_MENU },
+    { "shift"                    , ACTION_SHIFT },
+    { "symbols"                  , ACTION_SYMBOLS },
+    { "cursorleft"               , ACTION_CURSOR_LEFT },
+    { "cursorright"              , ACTION_CURSOR_RIGHT },
+    { "showtime"                 , ACTION_SHOW_OSD_TIME },
+    { "analogseekforward"        , ACTION_ANALOG_SEEK_FORWARD },
+    { "analogseekback"           , ACTION_ANALOG_SEEK_BACK },
+    { "showpreset"               , ACTION_VIS_PRESET_SHOW },
+    { "nextpreset"               , ACTION_VIS_PRESET_NEXT },
+    { "previouspreset"           , ACTION_VIS_PRESET_PREV },
+    { "lockpreset"               , ACTION_VIS_PRESET_LOCK },
+    { "randompreset"             , ACTION_VIS_PRESET_RANDOM },
+    { "increasevisrating"        , ACTION_VIS_RATE_PRESET_PLUS },
+    { "decreasevisrating"        , ACTION_VIS_RATE_PRESET_MINUS },
+    { "showvideomenu"            , ACTION_SHOW_VIDEOMENU },
+    { "enter"                    , ACTION_ENTER },
+    { "increaserating"           , ACTION_INCREASE_RATING },
+    { "decreaserating"           , ACTION_DECREASE_RATING },
+    { "setrating"                , ACTION_SET_RATING },
+    { "togglefullscreen"         , ACTION_TOGGLE_FULLSCREEN },
+    { "nextscene"                , ACTION_NEXT_SCENE },
+    { "previousscene"            , ACTION_PREV_SCENE },
+    { "nextletter"               , ACTION_NEXT_LETTER },
+    { "prevletter"               , ACTION_PREV_LETTER },
+    { "jumpsms2"                 , ACTION_JUMP_SMS2 },
+    { "jumpsms3"                 , ACTION_JUMP_SMS3 },
+    { "jumpsms4"                 , ACTION_JUMP_SMS4 },
+    { "jumpsms5"                 , ACTION_JUMP_SMS5 },
+    { "jumpsms6"                 , ACTION_JUMP_SMS6 },
+    { "jumpsms7"                 , ACTION_JUMP_SMS7 },
+    { "jumpsms8"                 , ACTION_JUMP_SMS8 },
+    { "jumpsms9"                 , ACTION_JUMP_SMS9 },
+    { "filter"                   , ACTION_FILTER },
+    { "filterclear"              , ACTION_FILTER_CLEAR },
+    { "filtersms2"               , ACTION_FILTER_SMS2 },
+    { "filtersms3"               , ACTION_FILTER_SMS3 },
+    { "filtersms4"               , ACTION_FILTER_SMS4 },
+    { "filtersms5"               , ACTION_FILTER_SMS5 },
+    { "filtersms6"               , ACTION_FILTER_SMS6 },
+    { "filtersms7"               , ACTION_FILTER_SMS7 },
+    { "filtersms8"               , ACTION_FILTER_SMS8 },
+    { "filtersms9"               , ACTION_FILTER_SMS9 },
+    { "firstpage"                , ACTION_FIRST_PAGE },
+    { "lastpage"                 , ACTION_LAST_PAGE },
+    { "guiprofile"               , ACTION_GUIPROFILE_BEGIN },
+    { "red"                      , ACTION_TELETEXT_RED },
+    { "green"                    , ACTION_TELETEXT_GREEN },
+    { "yellow"                   , ACTION_TELETEXT_YELLOW },
+    { "blue"                     , ACTION_TELETEXT_BLUE },
+    { "increasepar"              , ACTION_INCREASE_PAR },
+    { "decreasepar"              , ACTION_DECREASE_PAR },
+    { "volampup"                 , ACTION_VOLAMP_UP },
+    { "volampdown"               , ACTION_VOLAMP_DOWN },
+    { "volumeamplification"      , ACTION_VOLAMP },
+    { "createbookmark"           , ACTION_CREATE_BOOKMARK },
+    { "createepisodebookmark"    , ACTION_CREATE_EPISODE_BOOKMARK },
+    { "settingsreset"            , ACTION_SETTINGS_RESET },
+    { "settingslevelchange"      , ACTION_SETTINGS_LEVEL_CHANGE },
+
+    // 3D movie playback/GUI
+    { "stereomode"               , ACTION_STEREOMODE_SELECT },   // cycle 3D modes, for now an alias for next
+    { "nextstereomode"           , ACTION_STEREOMODE_NEXT },
+    { "previousstereomode"       , ACTION_STEREOMODE_PREVIOUS },
+    { "togglestereomode"         , ACTION_STEREOMODE_TOGGLE },
+    { "stereomodetomono"         , ACTION_STEREOMODE_TOMONO },
+
+    // PVR actions
+    { "channelup"                , ACTION_CHANNEL_UP },
+    { "channeldown"              , ACTION_CHANNEL_DOWN },
+    { "previouschannelgroup"     , ACTION_PREVIOUS_CHANNELGROUP },
+    { "nextchannelgroup"         , ACTION_NEXT_CHANNELGROUP },
+    { "playpvr"                  , ACTION_PVR_PLAY },
+    { "playpvrtv"                , ACTION_PVR_PLAY_TV },
+    { "playpvrradio"             , ACTION_PVR_PLAY_RADIO },
+    { "record"                   , ACTION_RECORD },
+    { "togglecommskip"           , ACTION_TOGGLE_COMMSKIP },
+    { "showtimerrule"            , ACTION_PVR_SHOW_TIMER_RULE },
+
+    // Mouse actions
+    { "leftclick"                , ACTION_MOUSE_LEFT_CLICK },
+    { "rightclick"               , ACTION_MOUSE_RIGHT_CLICK },
+    { "middleclick"              , ACTION_MOUSE_MIDDLE_CLICK },
+    { "doubleclick"              , ACTION_MOUSE_DOUBLE_CLICK },
+    { "longclick"                , ACTION_MOUSE_LONG_CLICK },
+    { "wheelup"                  , ACTION_MOUSE_WHEEL_UP },
+    { "wheeldown"                , ACTION_MOUSE_WHEEL_DOWN },
+    { "mousedrag"                , ACTION_MOUSE_DRAG },
+    { "mousemove"                , ACTION_MOUSE_MOVE },
+
+    // Touch
+    { "tap"                      , ACTION_TOUCH_TAP },
+    { "longpress"                , ACTION_TOUCH_LONGPRESS },
+    { "pangesture"               , ACTION_GESTURE_PAN },
+    { "zoomgesture"              , ACTION_GESTURE_ZOOM },
+    { "rotategesture"            , ACTION_GESTURE_ROTATE },
+    { "swipeleft"                , ACTION_GESTURE_SWIPE_LEFT },
+    { "swiperight"               , ACTION_GESTURE_SWIPE_RIGHT },
+    { "swipeup"                  , ACTION_GESTURE_SWIPE_UP },
+    { "swipedown"                , ACTION_GESTURE_SWIPE_DOWN },
+
+    // Voice
+    { "voicerecognizer"          , ACTION_VOICE_RECOGNIZE },
+
+    // Do nothing / error action
+    { "error"                    , ACTION_ERROR },
+    { "noop"                     , ACTION_NOOP }
+};
+}
+
+void CActionTranslator::GetActions(std::vector<std::string> &actionList)
+{
+  actionList.reserve(ActionMappings.size());
+  for (auto& actionMapping : ActionMappings)
+    actionList.push_back(actionMapping.first);
+}
+
+bool CActionTranslator::IsAnalog(unsigned int actionID)
+{
+  switch (actionID)
+  {
+  case ACTION_ANALOG_SEEK_FORWARD:
+  case ACTION_ANALOG_SEEK_BACK:
+  case ACTION_SCROLL_UP:
+  case ACTION_SCROLL_DOWN:
+  case ACTION_ANALOG_FORWARD:
+  case ACTION_ANALOG_REWIND:
+  case ACTION_ANALOG_MOVE:
+  case ACTION_ANALOG_MOVE_X:
+  case ACTION_ANALOG_MOVE_Y:
+  case ACTION_CURSOR_LEFT:
+  case ACTION_CURSOR_RIGHT:
+  case ACTION_VOLUME_UP:
+  case ACTION_VOLUME_DOWN:
+  case ACTION_ZOOM_IN:
+  case ACTION_ZOOM_OUT:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool CActionTranslator::TranslateActionString(const char *szAction, unsigned int &actionId)
+{
+  actionId = ACTION_NONE;
+
+  if (szAction == nullptr)
+    return false;
+
+  std::string strAction = szAction;
+  StringUtils::ToLower(strAction);
+
+  auto it = ActionMappings.find(strAction);
+  if (it != ActionMappings.end())
+    actionId = it->second;
+  else if (CBuiltins::GetInstance().HasCommand(strAction))
+    actionId = ACTION_BUILT_IN_FUNCTION;
+
+  if (actionId == ACTION_NONE)
+  {
+    CLog::Log(LOGERROR, "Keymapping error: no such action '%s' defined", szAction);
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/input/ActionTranslator.cpp
+++ b/xbmc/input/ActionTranslator.cpp
@@ -281,7 +281,7 @@ bool CActionTranslator::IsAnalog(unsigned int actionID)
   }
 }
 
-bool CActionTranslator::TranslateActionString(const char *szAction, unsigned int &actionId)
+bool CActionTranslator::TranslateString(const char *szAction, unsigned int &actionId)
 {
   actionId = ACTION_NONE;
 

--- a/xbmc/input/ActionTranslator.h
+++ b/xbmc/input/ActionTranslator.h
@@ -19,37 +19,13 @@
  */
 #pragma once
 
-#include <map>
-#include <memory>
 #include <string>
+#include <vector>
 
-class TiXmlNode;
-
-class CIRTranslator
+class CActionTranslator
 {
 public:
-  CIRTranslator() = default;
-
-  /*!
-   * \brief Loads Lircmap.xml/IRSSmap.xml
-   */
-  void Load();
-
-  /*!
-   * \brief Clears the map
-   */
-  void Clear();
-
-  unsigned int TranslateIRRemoteString(const char* szDevice, const char *szButton);
-
-  static uint32_t TranslateRemoteString(const char *szButton);
-  static uint32_t TranslateUniversalRemoteString(const char *szButton);
-
-private:
-  bool LoadIRMap(const std::string &irMapPath);
-  void MapRemote(TiXmlNode *pRemote, const char* szDevice);
-
-  using IRButtonMap = std::map<std::string, std::string>;
-
-  std::map<std::string, std::shared_ptr<IRButtonMap>> m_irRemotesMap;
+  static void GetActions(std::vector<std::string> &actionList);
+  static bool IsAnalog(unsigned int actionId);
+  static bool TranslateActionString(const char *szAction, unsigned int &actionId);
 };

--- a/xbmc/input/ActionTranslator.h
+++ b/xbmc/input/ActionTranslator.h
@@ -27,5 +27,5 @@ class CActionTranslator
 public:
   static void GetActions(std::vector<std::string> &actionList);
   static bool IsAnalog(unsigned int actionId);
-  static bool TranslateActionString(const char *szAction, unsigned int &actionId);
+  static bool TranslateString(const char *szAction, unsigned int &actionId);
 };

--- a/xbmc/input/AppTranslator.cpp
+++ b/xbmc/input/AppTranslator.cpp
@@ -1,0 +1,80 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AppTranslator.h"
+#include "Key.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <map>
+
+namespace
+{
+
+using ActionName = std::string;
+using CommandID = uint32_t;
+
+#ifdef TARGET_WINDOWS
+static const std::map<ActionName, CommandID> AppCommands =
+{
+    { "browser_back"             , APPCOMMAND_BROWSER_BACKWARD },
+    { "browser_forward"          , APPCOMMAND_BROWSER_FORWARD },
+    { "browser_refresh"          , APPCOMMAND_BROWSER_REFRESH },
+    { "browser_stop"             , APPCOMMAND_BROWSER_STOP },
+    { "browser_search"           , APPCOMMAND_BROWSER_SEARCH },
+    { "browser_favorites"        , APPCOMMAND_BROWSER_FAVORITES },
+    { "browser_home"             , APPCOMMAND_BROWSER_HOME },
+    { "volume_mute"              , APPCOMMAND_VOLUME_MUTE },
+    { "volume_down"              , APPCOMMAND_VOLUME_DOWN },
+    { "volume_up"                , APPCOMMAND_VOLUME_UP },
+    { "next_track"               , APPCOMMAND_MEDIA_NEXTTRACK },
+    { "prev_track"               , APPCOMMAND_MEDIA_PREVIOUSTRACK },
+    { "stop"                     , APPCOMMAND_MEDIA_STOP },
+    { "play_pause"               , APPCOMMAND_MEDIA_PLAY_PAUSE },
+    { "launch_mail"              , APPCOMMAND_LAUNCH_MAIL },
+    { "launch_media_select"      , APPCOMMAND_LAUNCH_MEDIA_SELECT },
+    { "launch_app1"              , APPCOMMAND_LAUNCH_APP1 },
+    { "launch_app2"              , APPCOMMAND_LAUNCH_APP2 },
+    { "play"                     , APPCOMMAND_MEDIA_PLAY },
+    { "pause"                    , APPCOMMAND_MEDIA_PAUSE },
+    { "fastforward"              , APPCOMMAND_MEDIA_FAST_FORWARD },
+    { "rewind"                   , APPCOMMAND_MEDIA_REWIND },
+    { "channelup"                , APPCOMMAND_MEDIA_CHANNEL_UP },
+    { "channeldown"              , APPCOMMAND_MEDIA_CHANNEL_DOWN }
+};
+#endif
+
+} // anonymous namespace
+
+uint32_t CAppTranslator::TranslateAppCommand(const char *szButton)
+{
+#ifdef TARGET_WINDOWS
+  std::string strAppCommand = szButton;
+  StringUtils::ToLower(strAppCommand);
+
+  auto it = AppCommands.find(strAppCommand);
+  if (it != AppCommands.end())
+    return it->second | KEY_APPCOMMAND;
+
+  CLog::Log(LOGERROR, "%s: Can't find appcommand %s", __FUNCTION__, szButton);
+#endif
+
+  return 0;
+}

--- a/xbmc/input/AppTranslator.h
+++ b/xbmc/input/AppTranslator.h
@@ -1,0 +1,28 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+
+class CAppTranslator
+{
+public:
+  static uint32_t TranslateAppCommand(const char *szButton);
+};

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -26,6 +26,7 @@
 #include "ActionTranslator.h"
 #include "AppTranslator.h"
 #include "CustomControllerTranslator.h"
+#include "GamepadTranslator.h"
 #include "IRTranslator.h"
 #include "MouseTranslator.h"
 #include "TouchTranslator.h"
@@ -471,7 +472,7 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
         unsigned int holdtimeMs = 0;
 
         if (type == "gamepad")
-            buttonCode = TranslateGamepadString(pButton->Value());
+            buttonCode = CGamepadTranslator::TranslateGamepadString(pButton->Value());
         else if (type == "remote")
             buttonCode = CIRTranslator::TranslateRemoteString(pButton->Value());
         else if (type == "universalremote")
@@ -536,45 +537,6 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
     }
   }
 
-}
-
-uint32_t CButtonTranslator::TranslateGamepadString(const char *szButton)
-{
-  if (!szButton) 
-    return 0;
-  uint32_t buttonCode = 0;
-  std::string strButton = szButton;
-  StringUtils::ToLower(strButton);
-  if (strButton == "a") buttonCode = KEY_BUTTON_A;
-  else if (strButton == "b") buttonCode = KEY_BUTTON_B;
-  else if (strButton == "x") buttonCode = KEY_BUTTON_X;
-  else if (strButton == "y") buttonCode = KEY_BUTTON_Y;
-  else if (strButton == "white") buttonCode = KEY_BUTTON_WHITE;
-  else if (strButton == "black") buttonCode = KEY_BUTTON_BLACK;
-  else if (strButton == "start") buttonCode = KEY_BUTTON_START;
-  else if (strButton == "back") buttonCode = KEY_BUTTON_BACK;
-  else if (strButton == "leftthumbbutton") buttonCode = KEY_BUTTON_LEFT_THUMB_BUTTON;
-  else if (strButton == "rightthumbbutton") buttonCode = KEY_BUTTON_RIGHT_THUMB_BUTTON;
-  else if (strButton == "leftthumbstick") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK;
-  else if (strButton == "leftthumbstickup") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_UP;
-  else if (strButton == "leftthumbstickdown") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_DOWN;
-  else if (strButton == "leftthumbstickleft") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_LEFT;
-  else if (strButton == "leftthumbstickright") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_RIGHT;
-  else if (strButton == "rightthumbstick") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK;
-  else if (strButton == "rightthumbstickup") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_UP;
-  else if (strButton == "rightthumbstickdown") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_DOWN;
-  else if (strButton == "rightthumbstickleft") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_LEFT;
-  else if (strButton == "rightthumbstickright") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_RIGHT;
-  else if (strButton == "lefttrigger") buttonCode = KEY_BUTTON_LEFT_TRIGGER;
-  else if (strButton == "righttrigger") buttonCode = KEY_BUTTON_RIGHT_TRIGGER;
-  else if (strButton == "leftanalogtrigger") buttonCode = KEY_BUTTON_LEFT_ANALOG_TRIGGER;
-  else if (strButton == "rightanalogtrigger") buttonCode = KEY_BUTTON_RIGHT_ANALOG_TRIGGER;
-  else if (strButton == "dpadleft") buttonCode = KEY_BUTTON_DPAD_LEFT;
-  else if (strButton == "dpadright") buttonCode = KEY_BUTTON_DPAD_RIGHT;
-  else if (strButton == "dpadup") buttonCode = KEY_BUTTON_DPAD_UP;
-  else if (strButton == "dpaddown") buttonCode = KEY_BUTTON_DPAD_DOWN;
-  else CLog::Log(LOGERROR, "Gamepad Translator: Can't find button %s", strButton.c_str());
-  return buttonCode;
 }
 
 uint32_t CButtonTranslator::TranslateKeyboardString(const char *szButton)

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "ActionTranslator.h"
 #include "IRTranslator.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
@@ -31,7 +32,6 @@
 #include "input/Key.h"
 #include "input/MouseStat.h"
 #include "input/XBMC_keytable.h"
-#include "interfaces/builtins/Builtins.h"
 #include "Util.h"
 #include "utils/log.h"
 #include "utils/RegExp.h"
@@ -51,248 +51,6 @@ typedef struct
   int origin;
   int target;
 } WindowMapping;
-
-static const ActionMapping actions[] =
-{
-    { "left"                     , ACTION_MOVE_LEFT },
-    { "right"                    , ACTION_MOVE_RIGHT },
-    { "up"                       , ACTION_MOVE_UP },
-    { "down"                     , ACTION_MOVE_DOWN },
-    { "pageup"                   , ACTION_PAGE_UP },
-    { "pagedown"                 , ACTION_PAGE_DOWN },
-    { "select"                   , ACTION_SELECT_ITEM },
-    { "highlight"                , ACTION_HIGHLIGHT_ITEM },
-    { "parentdir"                , ACTION_NAV_BACK },                   // backward compatibility
-    { "parentfolder"             , ACTION_PARENT_DIR },
-    { "back"                     , ACTION_NAV_BACK },
-    { "menu"                     , ACTION_MENU},
-    { "previousmenu"             , ACTION_PREVIOUS_MENU },
-    { "info"                     , ACTION_SHOW_INFO },
-    { "pause"                    , ACTION_PAUSE },
-    { "stop"                     , ACTION_STOP },
-    { "skipnext"                 , ACTION_NEXT_ITEM },
-    { "skipprevious"             , ACTION_PREV_ITEM },
-    { "fullscreen"               , ACTION_SHOW_GUI },
-    { "aspectratio"              , ACTION_ASPECT_RATIO },
-    { "stepforward"              , ACTION_STEP_FORWARD },
-    { "stepback"                 , ACTION_STEP_BACK },
-    { "bigstepforward"           , ACTION_BIG_STEP_FORWARD },
-    { "bigstepback"              , ACTION_BIG_STEP_BACK },
-    { "chapterorbigstepforward"  , ACTION_CHAPTER_OR_BIG_STEP_FORWARD },
-    { "chapterorbigstepback"     , ACTION_CHAPTER_OR_BIG_STEP_BACK },
-    { "osd"                      , ACTION_SHOW_OSD },
-    { "showsubtitles"            , ACTION_SHOW_SUBTITLES },
-    { "nextsubtitle"             , ACTION_NEXT_SUBTITLE },
-    { "browsesubtitle"           , ACTION_BROWSE_SUBTITLE },
-    { "cyclesubtitle"            , ACTION_CYCLE_SUBTITLE },
-    { "playerdebug"              , ACTION_PLAYER_DEBUG },
-    { "codecinfo"                , ACTION_PLAYER_PROCESS_INFO },
-    { "playerprocessinfo"        , ACTION_PLAYER_PROCESS_INFO },
-    { "nextpicture"              , ACTION_NEXT_PICTURE },
-    { "previouspicture"          , ACTION_PREV_PICTURE },
-    { "zoomout"                  , ACTION_ZOOM_OUT },
-    { "zoomin"                   , ACTION_ZOOM_IN },
-    { "playlist"                 , ACTION_SHOW_PLAYLIST },
-    { "queue"                    , ACTION_QUEUE_ITEM },
-    { "zoomnormal"               , ACTION_ZOOM_LEVEL_NORMAL },
-    { "zoomlevel1"               , ACTION_ZOOM_LEVEL_1 },
-    { "zoomlevel2"               , ACTION_ZOOM_LEVEL_2 },
-    { "zoomlevel3"               , ACTION_ZOOM_LEVEL_3 },
-    { "zoomlevel4"               , ACTION_ZOOM_LEVEL_4 },
-    { "zoomlevel5"               , ACTION_ZOOM_LEVEL_5 },
-    { "zoomlevel6"               , ACTION_ZOOM_LEVEL_6 },
-    { "zoomlevel7"               , ACTION_ZOOM_LEVEL_7 },
-    { "zoomlevel8"               , ACTION_ZOOM_LEVEL_8 },
-    { "zoomlevel9"               , ACTION_ZOOM_LEVEL_9 },
-    { "nextcalibration"          , ACTION_CALIBRATE_SWAP_ARROWS },
-    { "resetcalibration"         , ACTION_CALIBRATE_RESET },
-    { "analogmove"               , ACTION_ANALOG_MOVE },
-    { "analogmovex"              , ACTION_ANALOG_MOVE_X },
-    { "analogmovey"              , ACTION_ANALOG_MOVE_Y },
-    { "rotate"                   , ACTION_ROTATE_PICTURE_CW },
-    { "rotateccw"                , ACTION_ROTATE_PICTURE_CCW },
-    { "close"                    , ACTION_NAV_BACK },                    // backwards compatibility
-    { "subtitledelayminus"       , ACTION_SUBTITLE_DELAY_MIN },
-    { "subtitledelay"            , ACTION_SUBTITLE_DELAY },
-    { "subtitledelayplus"        , ACTION_SUBTITLE_DELAY_PLUS },
-    { "audiodelayminus"          , ACTION_AUDIO_DELAY_MIN },
-    { "audiodelay"               , ACTION_AUDIO_DELAY },
-    { "audiodelayplus"           , ACTION_AUDIO_DELAY_PLUS },
-    { "subtitleshiftup"          , ACTION_SUBTITLE_VSHIFT_UP },
-    { "subtitleshiftdown"        , ACTION_SUBTITLE_VSHIFT_DOWN },
-    { "subtitlealign"            , ACTION_SUBTITLE_ALIGN },
-    { "audionextlanguage"        , ACTION_AUDIO_NEXT_LANGUAGE },
-    { "verticalshiftup"          , ACTION_VSHIFT_UP },
-    { "verticalshiftdown"        , ACTION_VSHIFT_DOWN },
-    { "nextresolution"           , ACTION_CHANGE_RESOLUTION },
-    { "audiotoggledigital"       , ACTION_TOGGLE_DIGITAL_ANALOG },
-    { "number0"                  , REMOTE_0 },
-    { "number1"                  , REMOTE_1 },
-    { "number2"                  , REMOTE_2 },
-    { "number3"                  , REMOTE_3 },
-    { "number4"                  , REMOTE_4 },
-    { "number5"                  , REMOTE_5 },
-    { "number6"                  , REMOTE_6 },
-    { "number7"                  , REMOTE_7 },
-    { "number8"                  , REMOTE_8 },
-    { "number9"                  , REMOTE_9 },
-    { "smallstepback"            , ACTION_SMALL_STEP_BACK },
-    { "fastforward"              , ACTION_PLAYER_FORWARD },
-    { "rewind"                   , ACTION_PLAYER_REWIND },
-    { "play"                     , ACTION_PLAYER_PLAY },
-    { "playpause"                , ACTION_PLAYER_PLAYPAUSE },
-    { "switchplayer"             , ACTION_SWITCH_PLAYER },
-    { "delete"                   , ACTION_DELETE_ITEM },
-    { "copy"                     , ACTION_COPY_ITEM },
-    { "move"                     , ACTION_MOVE_ITEM },
-    { "screenshot"               , ACTION_TAKE_SCREENSHOT },
-    { "rename"                   , ACTION_RENAME_ITEM },
-    { "togglewatched"            , ACTION_TOGGLE_WATCHED },
-    { "scanitem"                 , ACTION_SCAN_ITEM },
-    { "reloadkeymaps"            , ACTION_RELOAD_KEYMAPS },
-    { "volumeup"                 , ACTION_VOLUME_UP },
-    { "volumedown"               , ACTION_VOLUME_DOWN },
-    { "mute"                     , ACTION_MUTE },
-    { "backspace"                , ACTION_BACKSPACE },
-    { "scrollup"                 , ACTION_SCROLL_UP },
-    { "scrolldown"               , ACTION_SCROLL_DOWN },
-    { "analogfastforward"        , ACTION_ANALOG_FORWARD },
-    { "analogrewind"             , ACTION_ANALOG_REWIND },
-    { "moveitemup"               , ACTION_MOVE_ITEM_UP },
-    { "moveitemdown"             , ACTION_MOVE_ITEM_DOWN },
-    { "contextmenu"              , ACTION_CONTEXT_MENU },
-    { "shift"                    , ACTION_SHIFT },
-    { "symbols"                  , ACTION_SYMBOLS },
-    { "cursorleft"               , ACTION_CURSOR_LEFT },
-    { "cursorright"              , ACTION_CURSOR_RIGHT },
-    { "showtime"                 , ACTION_SHOW_OSD_TIME },
-    { "analogseekforward"        , ACTION_ANALOG_SEEK_FORWARD },
-    { "analogseekback"           , ACTION_ANALOG_SEEK_BACK },
-    { "showpreset"               , ACTION_VIS_PRESET_SHOW },
-    { "nextpreset"               , ACTION_VIS_PRESET_NEXT },
-    { "previouspreset"           , ACTION_VIS_PRESET_PREV },
-    { "lockpreset"               , ACTION_VIS_PRESET_LOCK },
-    { "randompreset"             , ACTION_VIS_PRESET_RANDOM },
-    { "increasevisrating"        , ACTION_VIS_RATE_PRESET_PLUS },
-    { "decreasevisrating"        , ACTION_VIS_RATE_PRESET_MINUS },
-    { "showvideomenu"            , ACTION_SHOW_VIDEOMENU },
-    { "enter"                    , ACTION_ENTER },
-    { "increaserating"           , ACTION_INCREASE_RATING },
-    { "decreaserating"           , ACTION_DECREASE_RATING },
-    { "setrating"                , ACTION_SET_RATING },
-    { "togglefullscreen"         , ACTION_TOGGLE_FULLSCREEN },
-    { "nextscene"                , ACTION_NEXT_SCENE },
-    { "previousscene"            , ACTION_PREV_SCENE },
-    { "nextletter"               , ACTION_NEXT_LETTER },
-    { "prevletter"               , ACTION_PREV_LETTER },
-    { "jumpsms2"                 , ACTION_JUMP_SMS2 },
-    { "jumpsms3"                 , ACTION_JUMP_SMS3 },
-    { "jumpsms4"                 , ACTION_JUMP_SMS4 },
-    { "jumpsms5"                 , ACTION_JUMP_SMS5 },
-    { "jumpsms6"                 , ACTION_JUMP_SMS6 },
-    { "jumpsms7"                 , ACTION_JUMP_SMS7 },
-    { "jumpsms8"                 , ACTION_JUMP_SMS8 },
-    { "jumpsms9"                 , ACTION_JUMP_SMS9 },
-    { "filter"                   , ACTION_FILTER },
-    { "filterclear"              , ACTION_FILTER_CLEAR },
-    { "filtersms2"               , ACTION_FILTER_SMS2 },
-    { "filtersms3"               , ACTION_FILTER_SMS3 },
-    { "filtersms4"               , ACTION_FILTER_SMS4 },
-    { "filtersms5"               , ACTION_FILTER_SMS5 },
-    { "filtersms6"               , ACTION_FILTER_SMS6 },
-    { "filtersms7"               , ACTION_FILTER_SMS7 },
-    { "filtersms8"               , ACTION_FILTER_SMS8 },
-    { "filtersms9"               , ACTION_FILTER_SMS9 },
-    { "firstpage"                , ACTION_FIRST_PAGE },
-    { "lastpage"                 , ACTION_LAST_PAGE },
-    { "guiprofile"               , ACTION_GUIPROFILE_BEGIN },
-    { "red"                      , ACTION_TELETEXT_RED },
-    { "green"                    , ACTION_TELETEXT_GREEN },
-    { "yellow"                   , ACTION_TELETEXT_YELLOW },
-    { "blue"                     , ACTION_TELETEXT_BLUE },
-    { "increasepar"              , ACTION_INCREASE_PAR },
-    { "decreasepar"              , ACTION_DECREASE_PAR },
-    { "volampup"                 , ACTION_VOLAMP_UP },
-    { "volampdown"               , ACTION_VOLAMP_DOWN },
-    { "volumeamplification"      , ACTION_VOLAMP },
-    { "createbookmark"           , ACTION_CREATE_BOOKMARK },
-    { "createepisodebookmark"    , ACTION_CREATE_EPISODE_BOOKMARK },
-    { "settingsreset"            , ACTION_SETTINGS_RESET },
-    { "settingslevelchange"      , ACTION_SETTINGS_LEVEL_CHANGE },
-
-    // 3D movie playback/GUI
-    { "stereomode"               , ACTION_STEREOMODE_SELECT },          // cycle 3D modes, for now an alias for next
-    { "nextstereomode"           , ACTION_STEREOMODE_NEXT },
-    { "previousstereomode"       , ACTION_STEREOMODE_PREVIOUS },
-    { "togglestereomode"         , ACTION_STEREOMODE_TOGGLE },
-    { "stereomodetomono"         , ACTION_STEREOMODE_TOMONO },
-
-    // PVR actions
-    { "channelup"                , ACTION_CHANNEL_UP },
-    { "channeldown"              , ACTION_CHANNEL_DOWN },
-    { "previouschannelgroup"     , ACTION_PREVIOUS_CHANNELGROUP },
-    { "nextchannelgroup"         , ACTION_NEXT_CHANNELGROUP },
-    { "playpvr"                  , ACTION_PVR_PLAY },
-    { "playpvrtv"                , ACTION_PVR_PLAY_TV },
-    { "playpvrradio"             , ACTION_PVR_PLAY_RADIO },
-    { "record"                   , ACTION_RECORD },
-    { "togglecommskip"           , ACTION_TOGGLE_COMMSKIP },
-    { "showtimerrule"            , ACTION_PVR_SHOW_TIMER_RULE },
-
-    // Mouse actions
-    { "leftclick"                , ACTION_MOUSE_LEFT_CLICK },
-    { "rightclick"               , ACTION_MOUSE_RIGHT_CLICK },
-    { "middleclick"              , ACTION_MOUSE_MIDDLE_CLICK },
-    { "doubleclick"              , ACTION_MOUSE_DOUBLE_CLICK },
-    { "longclick"                , ACTION_MOUSE_LONG_CLICK },
-    { "wheelup"                  , ACTION_MOUSE_WHEEL_UP },
-    { "wheeldown"                , ACTION_MOUSE_WHEEL_DOWN },
-    { "mousedrag"                , ACTION_MOUSE_DRAG },
-    { "mousemove"                , ACTION_MOUSE_MOVE },
-
-    // Touch
-    { "tap"                      , ACTION_TOUCH_TAP },
-    { "longpress"                , ACTION_TOUCH_LONGPRESS },
-    { "pangesture"               , ACTION_GESTURE_PAN },
-    { "zoomgesture"              , ACTION_GESTURE_ZOOM },
-    { "rotategesture"            , ACTION_GESTURE_ROTATE },
-    { "swipeleft"                , ACTION_GESTURE_SWIPE_LEFT },
-    { "swiperight"               , ACTION_GESTURE_SWIPE_RIGHT },
-    { "swipeup"                  , ACTION_GESTURE_SWIPE_UP },
-    { "swipedown"                , ACTION_GESTURE_SWIPE_DOWN },
-
-    // Voice
-    { "voicerecognizer"          , ACTION_VOICE_RECOGNIZE },
-
-    // Do nothing / error action
-    { "error"                    , ACTION_ERROR },
-    { "noop"                     , ACTION_NOOP }
-};
-
-bool CButtonTranslator::IsAnalog(int actionID)
-{
-  switch (actionID)
-  {
-  case ACTION_ANALOG_SEEK_FORWARD:
-  case ACTION_ANALOG_SEEK_BACK:
-  case ACTION_SCROLL_UP:
-  case ACTION_SCROLL_DOWN:
-  case ACTION_ANALOG_FORWARD:
-  case ACTION_ANALOG_REWIND:
-  case ACTION_ANALOG_MOVE:
-  case ACTION_ANALOG_MOVE_X:
-  case ACTION_ANALOG_MOVE_Y:
-  case ACTION_CURSOR_LEFT:
-  case ACTION_CURSOR_RIGHT:
-  case ACTION_VOLUME_UP:
-  case ACTION_VOLUME_DOWN:
-  case ACTION_ZOOM_IN:
-  case ACTION_ZOOM_OUT:
-    return true;
-  default:
-    return false;
-  }
-}
 
 static const ActionMapping windows[] =
 {
@@ -648,7 +406,7 @@ int CButtonTranslator::TranslateLircRemoteString(const char* szDevice, const cha
 
 int CButtonTranslator::GetCustomControllerActionCode(int windowId, int buttonId, const CustomControllerWindowMap *windowMap, std::string& strAction) const
 {
-  int action = 0;
+  unsigned int action = ACTION_NONE;
   
   auto it = windowMap->find(windowId);
   if (it != windowMap->end())
@@ -658,7 +416,7 @@ int CButtonTranslator::GetCustomControllerActionCode(int windowId, int buttonId,
     if (it2 != buttonMap.end())
     {
       strAction = it2->second;
-      TranslateActionString(strAction.c_str(), action);
+      CActionTranslator::TranslateActionString(strAction.c_str(), action);
     }
   }
   
@@ -727,15 +485,6 @@ int CButtonTranslator::GetActionCode(int window, int action)
     return 0;
 
   return it2->second.id;
-}
-
-void CButtonTranslator::GetActions(std::vector<std::string> &actionList)
-{
-  unsigned int size = sizeof(actions) / sizeof(ActionMapping);
-  actionList.clear();
-  actionList.reserve(size);
-  for (unsigned int index = 0; index < size; index++)
-    actionList.push_back(actions[index].name);
 }
 
 void CButtonTranslator::GetWindows(std::vector<std::string> &windowList)
@@ -908,8 +657,8 @@ int CButtonTranslator::GetActionCode(int window, const CKey &key, std::string &s
 
 void CButtonTranslator::MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map)
 {
-  int action = ACTION_NONE;
-  if (!TranslateActionString(szAction, action) || !buttonCode)
+  unsigned int action = ACTION_NONE;
+  if (!CActionTranslator::TranslateActionString(szAction, action) || buttonCode == 0)
     return;   // no valid action, or an invalid buttoncode
 
   // have a valid action, and a valid button - map it.
@@ -1070,32 +819,6 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
     }
   }
 
-}
-
-bool CButtonTranslator::TranslateActionString(const char *szAction, int &action)
-{
-  action = ACTION_NONE;
-  std::string strAction = szAction;
-  StringUtils::ToLower(strAction);
-  if (CBuiltins::GetInstance().HasCommand(strAction))
-    action = ACTION_BUILT_IN_FUNCTION;
-
-  for (unsigned int index=0;index < ARRAY_SIZE(actions);++index)
-  {
-    if (strAction == actions[index].name)
-    {
-      action = actions[index].action;
-      break;
-    }
-  }
-
-  if (action == ACTION_NONE)
-  {
-    CLog::Log(LOGERROR, "Keymapping error: no such action '%s' defined", strAction.c_str());
-    return false;
-  }
-
-  return true;
 }
 
 std::string CButtonTranslator::TranslateWindow(int windowID)
@@ -1367,7 +1090,7 @@ uint32_t CButtonTranslator::TranslateTouchCommand(TiXmlElement *pButton, CButton
   }
 
   action.strID = szAction;
-  if (!TranslateActionString(szAction, action.id) || action.id <= ACTION_NONE)
+  if (!CActionTranslator::TranslateActionString(szAction, action.id) || action.id <= ACTION_NONE)
     return ACTION_NONE;
 
   return actionId | KEY_TOUCH;

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "ActionTranslator.h"
+#include "AppTranslator.h"
 #include "CustomControllerTranslator.h"
 #include "IRTranslator.h"
 #include "MouseTranslator.h"
@@ -42,42 +43,6 @@
 #include "utils/XBMCTinyXML.h"
 
 using namespace XFILE;
-
-typedef struct
-{
-  const char* name;
-  int action;
-} ActionMapping;
-
-#ifdef TARGET_WINDOWS
-static const ActionMapping appcommands[] =
-{
-    { "browser_back"             , APPCOMMAND_BROWSER_BACKWARD },
-    { "browser_forward"          , APPCOMMAND_BROWSER_FORWARD },
-    { "browser_refresh"          , APPCOMMAND_BROWSER_REFRESH },
-    { "browser_stop"             , APPCOMMAND_BROWSER_STOP },
-    { "browser_search"           , APPCOMMAND_BROWSER_SEARCH },
-    { "browser_favorites"        , APPCOMMAND_BROWSER_FAVORITES },
-    { "browser_home"             , APPCOMMAND_BROWSER_HOME },
-    { "volume_mute"              , APPCOMMAND_VOLUME_MUTE },
-    { "volume_down"              , APPCOMMAND_VOLUME_DOWN },
-    { "volume_up"                , APPCOMMAND_VOLUME_UP },
-    { "next_track"               , APPCOMMAND_MEDIA_NEXTTRACK },
-    { "prev_track"               , APPCOMMAND_MEDIA_PREVIOUSTRACK },
-    { "stop"                     , APPCOMMAND_MEDIA_STOP },
-    { "play_pause"               , APPCOMMAND_MEDIA_PLAY_PAUSE },
-    { "launch_mail"              , APPCOMMAND_LAUNCH_MAIL },
-    { "launch_media_select"      , APPCOMMAND_LAUNCH_MEDIA_SELECT },
-    { "launch_app1"              , APPCOMMAND_LAUNCH_APP1 },
-    { "launch_app2"              , APPCOMMAND_LAUNCH_APP2 },
-    { "play"                     , APPCOMMAND_MEDIA_PLAY },
-    { "pause"                    , APPCOMMAND_MEDIA_PAUSE },
-    { "fastforward"              , APPCOMMAND_MEDIA_FAST_FORWARD },
-    { "rewind"                   , APPCOMMAND_MEDIA_REWIND },
-    { "channelup"                , APPCOMMAND_MEDIA_CHANNEL_UP },
-    { "channeldown"              , APPCOMMAND_MEDIA_CHANNEL_DOWN }
-};
-#endif
 
 CButtonTranslator& CButtonTranslator::GetInstance()
 {
@@ -516,7 +481,7 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
         else if (type == "mouse")
             buttonCode = CMouseTranslator::TranslateMouseCommand(pButton);
         else if (type == "appcommand")
-            buttonCode = TranslateAppCommand(pButton->Value());
+            buttonCode = CAppTranslator::TranslateAppCommand(pButton->Value());
         else if (type == "joystick")
         {
           std::string controllerId = DEFAULT_CONTROLLER_ID;
@@ -691,22 +656,6 @@ uint32_t CButtonTranslator::TranslateKeyboardButton(TiXmlElement *pButton)
   }
 
   return button_id;
-}
-
-uint32_t CButtonTranslator::TranslateAppCommand(const char *szButton)
-{
-#ifdef TARGET_WINDOWS
-  std::string strAppCommand = szButton;
-  StringUtils::ToLower(strAppCommand);
-
-  for (int i = 0; i < ARRAY_SIZE(appcommands); i++)
-    if (strAppCommand == appcommands[i].name)
-      return appcommands[i].action | KEY_APPCOMMAND;
-
-  CLog::Log(LOGERROR, "%s: Can't find appcommand %s", __FUNCTION__, szButton);
-#endif
-
-  return 0;
 }
 
 void CButtonTranslator::Clear()

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -27,6 +27,7 @@
 #include "CustomControllerTranslator.h"
 #include "IRTranslator.h"
 #include "TouchTranslator.h"
+#include "WindowTranslator.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
 #include "guilib/WindowIDs.h"
@@ -48,131 +49,6 @@ typedef struct
   int action;
 } ActionMapping;
 
-typedef struct
-{
-  int origin;
-  int target;
-} WindowMapping;
-
-static const ActionMapping windows[] =
-{
-    { "home"                     , WINDOW_HOME },
-    { "programs"                 , WINDOW_PROGRAMS },
-    { "pictures"                 , WINDOW_PICTURES },
-    { "filemanager"              , WINDOW_FILES },
-    { "settings"                 , WINDOW_SETTINGS_MENU },
-    { "music"                    , WINDOW_MUSIC_NAV },
-    { "videos"                   , WINDOW_VIDEO_NAV },
-    { "tvchannels"               , WINDOW_TV_CHANNELS },
-    { "tvrecordings"             , WINDOW_TV_RECORDINGS },
-    { "tvguide"                  , WINDOW_TV_GUIDE },
-    { "tvtimers"                 , WINDOW_TV_TIMERS },
-    { "tvsearch"                 , WINDOW_TV_SEARCH },
-    { "radiochannels"            , WINDOW_RADIO_CHANNELS },
-    { "radiorecordings"          , WINDOW_RADIO_RECORDINGS },
-    { "radioguide"               , WINDOW_RADIO_GUIDE },
-    { "radiotimers"              , WINDOW_RADIO_TIMERS },
-    { "radiosearch"              , WINDOW_RADIO_SEARCH },
-    { "gamecontrollers"          , WINDOW_DIALOG_GAME_CONTROLLERS },
-    { "games"                    , WINDOW_GAMES },
-    { "pvrguideinfo"             , WINDOW_DIALOG_PVR_GUIDE_INFO },
-    { "pvrrecordinginfo"         , WINDOW_DIALOG_PVR_RECORDING_INFO },
-    { "pvrradiordsinfo"          , WINDOW_DIALOG_PVR_RADIO_RDS_INFO },
-    { "pvrtimersetting"          , WINDOW_DIALOG_PVR_TIMER_SETTING },
-    { "pvrgroupmanager"          , WINDOW_DIALOG_PVR_GROUP_MANAGER },
-    { "pvrchannelmanager"        , WINDOW_DIALOG_PVR_CHANNEL_MANAGER },
-    { "pvrguidesearch"           , WINDOW_DIALOG_PVR_GUIDE_SEARCH },
-    { "pvrchannelscan"           , WINDOW_DIALOG_PVR_CHANNEL_SCAN },
-    { "pvrupdateprogress"        , WINDOW_DIALOG_PVR_UPDATE_PROGRESS },
-    { "pvrosdchannels"           , WINDOW_DIALOG_PVR_OSD_CHANNELS },
-    { "pvrchannelguide"          , WINDOW_DIALOG_PVR_CHANNEL_GUIDE },
-    { "pvrosdguide"              , WINDOW_DIALOG_PVR_CHANNEL_GUIDE }, // backward compatibility to v17
-    { "pvrosdteletext"           , WINDOW_DIALOG_OSD_TELETEXT },
-    { "systeminfo"               , WINDOW_SYSTEM_INFORMATION },
-    { "testpattern"              , WINDOW_TEST_PATTERN },
-    { "screencalibration"        , WINDOW_SCREEN_CALIBRATION },
-    { "systemsettings"           , WINDOW_SETTINGS_SYSTEM },
-    { "servicesettings"          , WINDOW_SETTINGS_SERVICE },
-    { "pvrsettings"              , WINDOW_SETTINGS_MYPVR },
-    { "playersettings"           , WINDOW_SETTINGS_PLAYER },
-    { "mediasettings"            , WINDOW_SETTINGS_MEDIA },
-    { "interfacesettings"        , WINDOW_SETTINGS_INTERFACE },
-    { "appearancesettings"       , WINDOW_SETTINGS_INTERFACE },	// backward compatibility to v16
-    { "gamesettings"             , WINDOW_SETTINGS_MYGAMES },
-    { "videoplaylist"            , WINDOW_VIDEO_PLAYLIST },
-    { "loginscreen"              , WINDOW_LOGIN_SCREEN },
-    { "profiles"                 , WINDOW_SETTINGS_PROFILES },
-    { "skinsettings"             , WINDOW_SKIN_SETTINGS },
-    { "addonbrowser"             , WINDOW_ADDON_BROWSER },
-    { "yesnodialog"              , WINDOW_DIALOG_YES_NO },
-    { "progressdialog"           , WINDOW_DIALOG_PROGRESS },
-    { "virtualkeyboard"          , WINDOW_DIALOG_KEYBOARD },
-    { "volumebar"                , WINDOW_DIALOG_VOLUME_BAR },
-    { "submenu"                  , WINDOW_DIALOG_SUB_MENU },
-    { "favourites"               , WINDOW_DIALOG_FAVOURITES },
-    { "contextmenu"              , WINDOW_DIALOG_CONTEXT_MENU },
-    { "notification"             , WINDOW_DIALOG_KAI_TOAST },
-    { "numericinput"             , WINDOW_DIALOG_NUMERIC },
-    { "gamepadinput"             , WINDOW_DIALOG_GAMEPAD },
-    { "shutdownmenu"             , WINDOW_DIALOG_BUTTON_MENU },
-    { "playercontrols"           , WINDOW_DIALOG_PLAYER_CONTROLS },
-    { "playerprocessinfo"        , WINDOW_DIALOG_PLAYER_PROCESS_INFO },
-    { "seekbar"                  , WINDOW_DIALOG_SEEK_BAR },
-    { "musicosd"                 , WINDOW_DIALOG_MUSIC_OSD },
-    { "addonsettings"            , WINDOW_DIALOG_ADDON_SETTINGS },
-    { "visualisationpresetlist"  , WINDOW_DIALOG_VIS_PRESET_LIST },
-    { "osdcmssettings"           , WINDOW_DIALOG_CMS_OSD_SETTINGS },
-    { "osdvideosettings"         , WINDOW_DIALOG_VIDEO_OSD_SETTINGS },
-    { "osdaudiosettings"         , WINDOW_DIALOG_AUDIO_OSD_SETTINGS },
-    { "audiodspmanager"          , WINDOW_DIALOG_AUDIO_DSP_MANAGER },
-    { "osdaudiodspsettings"      , WINDOW_DIALOG_AUDIO_DSP_OSD_SETTINGS },
-    { "videobookmarks"           , WINDOW_DIALOG_VIDEO_BOOKMARKS },
-    { "filebrowser"              , WINDOW_DIALOG_FILE_BROWSER },
-    { "networksetup"             , WINDOW_DIALOG_NETWORK_SETUP },
-    { "mediasource"              , WINDOW_DIALOG_MEDIA_SOURCE },
-    { "profilesettings"          , WINDOW_DIALOG_PROFILE_SETTINGS },
-    { "locksettings"             , WINDOW_DIALOG_LOCK_SETTINGS },
-    { "contentsettings"          , WINDOW_DIALOG_CONTENT_SETTINGS },
-    { "songinformation"          , WINDOW_DIALOG_SONG_INFO },
-    { "smartplaylisteditor"      , WINDOW_DIALOG_SMART_PLAYLIST_EDITOR },
-    { "smartplaylistrule"        , WINDOW_DIALOG_SMART_PLAYLIST_RULE },
-    { "busydialog"               , WINDOW_DIALOG_BUSY },
-    { "pictureinfo"              , WINDOW_DIALOG_PICTURE_INFO },
-    { "accesspoints"             , WINDOW_DIALOG_ACCESS_POINTS },
-    { "fullscreeninfo"           , WINDOW_DIALOG_FULLSCREEN_INFO },
-    { "sliderdialog"             , WINDOW_DIALOG_SLIDER },
-    { "addoninformation"         , WINDOW_DIALOG_ADDON_INFO },
-    { "subtitlesearch"           , WINDOW_DIALOG_SUBTITLES },
-    { "musicplaylist"            , WINDOW_MUSIC_PLAYLIST },
-    { "musicplaylisteditor"      , WINDOW_MUSIC_PLAYLIST_EDITOR },
-    { "teletext"                 , WINDOW_DIALOG_OSD_TELETEXT },
-    { "selectdialog"             , WINDOW_DIALOG_SELECT },
-    { "musicinformation"         , WINDOW_DIALOG_MUSIC_INFO },
-    { "okdialog"                 , WINDOW_DIALOG_OK },
-    { "movieinformation"         , WINDOW_DIALOG_VIDEO_INFO },
-    { "textviewer"               , WINDOW_DIALOG_TEXT_VIEWER },
-    { "fullscreenvideo"          , WINDOW_FULLSCREEN_VIDEO },
-    { "fullscreenlivetv"         , WINDOW_FULLSCREEN_LIVETV },         // virtual window/keymap section for PVR specific bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
-    { "fullscreenradio"          , WINDOW_FULLSCREEN_RADIO },          // virtual window for fullscreen radio, uses WINDOW_VISUALISATION as fallback
-    { "fullscreengame"           , WINDOW_FULLSCREEN_GAME },           // virtual window for fullscreen games, uses WINDOW_FULLSCREEN_VIDEO as fallback
-    { "visualisation"            , WINDOW_VISUALISATION },
-    { "slideshow"                , WINDOW_SLIDESHOW },
-    { "weather"                  , WINDOW_WEATHER },
-    { "screensaver"              , WINDOW_SCREENSAVER },
-    { "videoosd"                 , WINDOW_DIALOG_VIDEO_OSD },
-    { "videomenu"                , WINDOW_VIDEO_MENU },
-    { "videotimeseek"            , WINDOW_VIDEO_TIME_SEEK },
-    { "startwindow"              , WINDOW_START },
-    { "startup"                  , WINDOW_STARTUP_ANIM },
-    { "peripheralsettings"       , WINDOW_DIALOG_PERIPHERAL_SETTINGS },
-    { "extendedprogressdialog"   , WINDOW_DIALOG_EXT_PROGRESS },
-    { "mediafilter"              , WINDOW_DIALOG_MEDIA_FILTER },
-    { "addon"                    , WINDOW_ADDON_START },
-    { "eventlog"                 , WINDOW_EVENT_LOG},
-    { "tvtimerrules"             , WINDOW_TV_TIMER_RULES},
-    { "radiotimerrules"          , WINDOW_RADIO_TIMER_RULES}
-};
-
 static const ActionMapping mousekeys[] =
 {
     { "click"                    , KEY_MOUSE_CLICK },
@@ -190,13 +66,6 @@ static const ActionMapping mousekeys[] =
     { "mouserdrag"               , KEY_MOUSE_RDRAG },
     { "mouserdragstart"          , KEY_MOUSE_RDRAG_START },
     { "mouserdragend"            , KEY_MOUSE_RDRAG_END }
-};
-
-static const WindowMapping fallbackWindows[] =
-{
-    { WINDOW_FULLSCREEN_LIVETV   , WINDOW_FULLSCREEN_VIDEO },
-    { WINDOW_FULLSCREEN_RADIO    , WINDOW_VISUALISATION },
-    { WINDOW_FULLSCREEN_GAME     , WINDOW_FULLSCREEN_VIDEO }
 };
 
 #ifdef TARGET_WINDOWS
@@ -381,7 +250,7 @@ bool CButtonTranslator::LoadKeymap(const std::string &keymapPath)
         if (strcmpi(szWindow, "global") == 0)
           windowID = -1;
         else
-          windowID = TranslateWindow(szWindow);
+          windowID = CWindowTranslator::TranslateWindow(szWindow);
       }
       MapWindowActions(pWindow, windowID);
     }
@@ -404,7 +273,7 @@ bool CButtonTranslator::TranslateCustomControllerString(int windowId, const std:
   if (!m_customControllerTranslator->TranslateCustomControllerString(windowId, controllerName, buttonId, actionId, strAction))
   {
     // If it's invalid, try to get it from a fallback window or the global map
-    int fallbackWindow = GetFallbackWindow(windowId);
+    int fallbackWindow = CWindowTranslator::GetFallbackWindow(windowId);
     if (fallbackWindow > -1)
       m_customControllerTranslator->TranslateCustomControllerString(fallbackWindow, controllerName, buttonId, actionId, strAction);
 
@@ -431,7 +300,7 @@ bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int to
 
   if (!m_touchTranslator->TranslateTouchAction(window, touchAction, touchPointers, actionId, actionString))
   {
-    int fallbackWindow = GetFallbackWindow(window);
+    int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
     if (fallbackWindow > -1)
       m_touchTranslator->TranslateTouchAction(fallbackWindow, touchAction, touchPointers, actionId, actionString);
 
@@ -456,29 +325,6 @@ int CButtonTranslator::GetActionCode(int window, int action)
   return it2->second.id;
 }
 
-void CButtonTranslator::GetWindows(std::vector<std::string> &windowList)
-{
-  unsigned int size = sizeof(windows) / sizeof(ActionMapping);
-  windowList.clear();
-  windowList.reserve(size);
-  for (unsigned int index = 0; index < size; index++)
-    windowList.push_back(windows[index].name);
-}
-
-int CButtonTranslator::GetFallbackWindow(int windowID)
-{
-  for (unsigned int index = 0; index < ARRAY_SIZE(fallbackWindows); ++index)
-  {
-    if (fallbackWindows[index].origin == windowID)
-      return fallbackWindows[index].target;
-  }
-  // for addon windows use WINDOW_ADDON_START because id is dynamic
-  if (windowID > WINDOW_ADDON_START && windowID <= WINDOW_ADDON_END)
-    return WINDOW_ADDON_START;
-
-  return -1;
-}
-
 CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
 {
   std::string strAction;
@@ -488,7 +334,7 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
   if (actionID == 0 && fallback)
   {
     //! @todo Refactor fallback logic
-    int fallbackWindow = GetFallbackWindow(window);
+    int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
     if (fallbackWindow > -1)
       actionID = GetActionCode(fallbackWindow, key, strAction);
     // still no valid action? use global map
@@ -533,7 +379,7 @@ bool CButtonTranslator::HasLongpressMapping(int window, const CKey &key)
   if (window > -1)
   {
     // first check if we have a fallback for the window
-    int fallbackWindow = GetFallbackWindow(window);
+    int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
     if (fallbackWindow > -1 && HasLongpressMapping(fallbackWindow, key))
       return true;
 
@@ -562,7 +408,7 @@ unsigned int CButtonTranslator::GetHoldTimeMs(int window, const CKey &key, bool 
     else if (fallback)
     {
       //! @todo Refactor fallback logic
-      int fallbackWindow = GetFallbackWindow(window);
+      int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
       if (fallbackWindow > -1)
         holdtimeMs = GetHoldTimeMs(fallbackWindow, key, false);
       else
@@ -575,7 +421,7 @@ unsigned int CButtonTranslator::GetHoldTimeMs(int window, const CKey &key, bool 
   else if (fallback)
   {
     //! @todo Refactor fallback logic
-    int fallbackWindow = GetFallbackWindow(window);
+    int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
     if (fallbackWindow > -1)
       holdtimeMs = GetHoldTimeMs(fallbackWindow, key, false);
     else
@@ -744,51 +590,6 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
     }
   }
 
-}
-
-std::string CButtonTranslator::TranslateWindow(int windowID)
-{
-  for (unsigned int index = 0; index < ARRAY_SIZE(windows); ++index)
-  {
-    if (windows[index].action == windowID)
-      return windows[index].name;
-  }
-  return "";
-}
-
-int CButtonTranslator::TranslateWindow(const std::string &window)
-{
-  std::string strWindow(window);
-  if (strWindow.empty()) 
-    return WINDOW_INVALID;
-  StringUtils::ToLower(strWindow);
-  // eliminate .xml
-  if (StringUtils::EndsWith(strWindow, ".xml"))
-    strWindow = strWindow.substr(0, strWindow.size() - 4);
-
-  // window12345, for custom window to be keymapped
-  if (strWindow.length() > 6 && StringUtils::StartsWithNoCase(strWindow, "window"))
-    strWindow = strWindow.substr(6);
-  if (StringUtils::StartsWithNoCase(strWindow, "my"))  // drop "my" prefix
-    strWindow = strWindow.substr(2);
-  if (StringUtils::IsNaturalNumber(strWindow))
-  {
-    // allow a full window id or a delta id
-    int iWindow = atoi(strWindow.c_str());
-    if (iWindow > WINDOW_INVALID)
-      return iWindow;
-    return WINDOW_HOME + iWindow;
-  }
-
-  // run through the window structure
-  for (unsigned int index = 0; index < ARRAY_SIZE(windows); ++index)
-  {
-    if (strWindow == windows[index].name)
-      return windows[index].action;
-  }
-
-  CLog::Log(LOGERROR, "Window Translator: Can't find window %s", strWindow.c_str());
-  return WINDOW_INVALID;
 }
 
 uint32_t CButtonTranslator::TranslateGamepadString(const char *szButton)

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -28,6 +28,7 @@
 #include "CustomControllerTranslator.h"
 #include "GamepadTranslator.h"
 #include "IRTranslator.h"
+#include "JoystickTranslator.h"
 #include "KeyboardTranslator.h"
 #include "MouseTranslator.h"
 #include "TouchTranslator.h"
@@ -35,12 +36,10 @@
 #include "FileItem.h"
 #include "filesystem/Directory.h"
 #include "guilib/WindowIDs.h"
-#include "input/joysticks/JoystickIDs.h"
 #include "input/Key.h"
 #include "Util.h"
 #include "utils/log.h"
 #include "utils/RegExp.h"
-#include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 
 using namespace XFILE;
@@ -484,15 +483,7 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
         else if (type == "appcommand")
             buttonCode = CAppTranslator::TranslateAppCommand(pButton->Value());
         else if (type == "joystick")
-        {
-          std::string controllerId = DEFAULT_CONTROLLER_ID;
-
-          TiXmlElement* deviceElem = pDevice->ToElement();
-          if (deviceElem != nullptr)
-            deviceElem->QueryValueAttribute("profile", &controllerId);
-
-          buttonCode = TranslateJoystickCommand(pButton, controllerId, holdtimeMs);
-        }
+          buttonCode = CJoystickTranslator::TranslateJoystickCommand(pDevice, pButton, holdtimeMs);
 
         if (buttonCode)
         {
@@ -548,73 +539,4 @@ void CButtonTranslator::Clear()
   m_touchTranslator->Clear();
 
   m_Loaded = false;
-}
-
-uint32_t CButtonTranslator::TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs)
-{
-  holdtimeMs = 0;
-
-  const char *szButton = pButton->Value();
-  if (!szButton)
-    return 0;
-
-  uint32_t buttonCode = 0;
-  std::string strButton = szButton;
-  StringUtils::ToLower(strButton);
-
-  if (controllerId == DEFAULT_CONTROLLER_ID)
-  {
-    if (strButton == "a") buttonCode = KEY_JOYSTICK_BUTTON_A;
-    else if (strButton == "b") buttonCode = KEY_JOYSTICK_BUTTON_B;
-    else if (strButton == "x") buttonCode = KEY_JOYSTICK_BUTTON_X;
-    else if (strButton == "y") buttonCode = KEY_JOYSTICK_BUTTON_Y;
-    else if (strButton == "start") buttonCode = KEY_JOYSTICK_BUTTON_START;
-    else if (strButton == "back") buttonCode = KEY_JOYSTICK_BUTTON_BACK;
-    else if (strButton == "left") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_LEFT;
-    else if (strButton == "right") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_RIGHT;
-    else if (strButton == "up") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_UP;
-    else if (strButton == "down") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_DOWN;
-    else if (strButton == "leftthumb") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_STICK_BUTTON;
-    else if (strButton == "rightthumb") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_STICK_BUTTON;
-    else if (strButton == "leftstickup") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_UP;
-    else if (strButton == "leftstickdown") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_DOWN;
-    else if (strButton == "leftstickleft") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_LEFT;
-    else if (strButton == "leftstickright") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_RIGHT;
-    else if (strButton == "rightstickup") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_UP;
-    else if (strButton == "rightstickdown") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_DOWN;
-    else if (strButton == "rightstickleft") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_LEFT;
-    else if (strButton == "rightstickright") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_RIGHT;
-    else if (strButton == "lefttrigger") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_TRIGGER;
-    else if (strButton == "righttrigger") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_TRIGGER;
-    else if (strButton == "leftbumper") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_SHOULDER;
-    else if (strButton == "rightbumper") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_SHOULDER;
-    else if (strButton == "guide") buttonCode = KEY_JOYSTICK_BUTTON_GUIDE;
-  }
-  else if (controllerId == DEFAULT_REMOTE_ID)
-  {
-    if (strButton == "ok") buttonCode = KEY_REMOTE_BUTTON_OK;
-    else if (strButton == "back") buttonCode = KEY_REMOTE_BUTTON_BACK;
-    else if (strButton == "up") buttonCode = KEY_REMOTE_BUTTON_UP;
-    else if (strButton == "down") buttonCode = KEY_REMOTE_BUTTON_DOWN;
-    else if (strButton == "left") buttonCode = KEY_REMOTE_BUTTON_LEFT;
-    else if (strButton == "right") buttonCode = KEY_REMOTE_BUTTON_RIGHT;
-    else if (strButton == "home") buttonCode = KEY_REMOTE_BUTTON_HOME;
-  }
-
-  if (buttonCode == 0)
-  {
-    CLog::Log(LOGERROR, "Joystick Translator: Can't find button %s for controller %s", strButton.c_str(), controllerId.c_str());
-  }
-  else
-  {
-    // Process holdtime parameter
-    std::string strHoldTime;
-    if (pButton->QueryValueAttribute("holdtime", &strHoldTime) == TIXML_SUCCESS)
-    {
-      std::stringstream ss(strHoldTime);
-      ss >> holdtimeMs;
-    }
-  }
-
-  return buttonCode;
 }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -26,6 +26,7 @@
 #include "ActionTranslator.h"
 #include "CustomControllerTranslator.h"
 #include "IRTranslator.h"
+#include "MouseTranslator.h"
 #include "TouchTranslator.h"
 #include "WindowTranslator.h"
 #include "FileItem.h"
@@ -33,7 +34,6 @@
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/JoystickIDs.h"
 #include "input/Key.h"
-#include "input/MouseStat.h"
 #include "input/XBMC_keytable.h"
 #include "Util.h"
 #include "utils/log.h"
@@ -48,25 +48,6 @@ typedef struct
   const char* name;
   int action;
 } ActionMapping;
-
-static const ActionMapping mousekeys[] =
-{
-    { "click"                    , KEY_MOUSE_CLICK },
-    { "leftclick"                , KEY_MOUSE_CLICK },
-    { "rightclick"               , KEY_MOUSE_RIGHTCLICK },
-    { "middleclick"              , KEY_MOUSE_MIDDLECLICK },
-    { "doubleclick"              , KEY_MOUSE_DOUBLE_CLICK },
-    { "longclick"                , KEY_MOUSE_LONG_CLICK },
-    { "wheelup"                  , KEY_MOUSE_WHEEL_UP },
-    { "wheeldown"                , KEY_MOUSE_WHEEL_DOWN },
-    { "mousemove"                , KEY_MOUSE_MOVE },
-    { "mousedrag"                , KEY_MOUSE_DRAG },
-    { "mousedragstart"           , KEY_MOUSE_DRAG_START },
-    { "mousedragend"             , KEY_MOUSE_DRAG_END },
-    { "mouserdrag"               , KEY_MOUSE_RDRAG },
-    { "mouserdragstart"          , KEY_MOUSE_RDRAG_START },
-    { "mouserdragend"            , KEY_MOUSE_RDRAG_END }
-};
 
 #ifdef TARGET_WINDOWS
 static const ActionMapping appcommands[] =
@@ -533,7 +514,7 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
         else if (type == "keyboard")
             buttonCode = TranslateKeyboardButton(pButton);
         else if (type == "mouse")
-            buttonCode = TranslateMouseCommand(pButton);
+            buttonCode = CMouseTranslator::TranslateMouseCommand(pButton);
         else if (type == "appcommand")
             buttonCode = TranslateAppCommand(pButton->Value());
         else if (type == "joystick")
@@ -726,42 +707,6 @@ uint32_t CButtonTranslator::TranslateAppCommand(const char *szButton)
 #endif
 
   return 0;
-}
-
-uint32_t CButtonTranslator::TranslateMouseCommand(TiXmlElement *pButton)
-{
-  uint32_t buttonId = 0;
-
-  if (pButton)
-  {
-    std::string szKey = pButton->ValueStr();
-    if (!szKey.empty())
-    {
-      StringUtils::ToLower(szKey);
-      for (unsigned int i = 0; i < ARRAY_SIZE(mousekeys); i++)
-      {
-        if (szKey == mousekeys[i].name)
-        {
-          buttonId = mousekeys[i].action;
-          break;
-        }
-      }
-      if (!buttonId)
-      {
-        CLog::Log(LOGERROR, "Unknown mouse action (%s), skipping", pButton->Value());
-      }
-      else
-      {
-        int id = 0;
-        if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS) && id>=0 && id<MOUSE_MAX_BUTTON)
-        {
-          buttonId += id;
-        }
-      }
-    }
-  }
-
-  return buttonId;
 }
 
 void CButtonTranslator::Clear()

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -198,7 +198,7 @@ bool CButtonTranslator::LoadKeymap(const std::string &keymapPath)
 
 int CButtonTranslator::TranslateLircRemoteString(const char* szDevice, const char *szButton)
 {
-  return m_irTranslator->TranslateIRRemoteString(szDevice, szButton);
+  return m_irTranslator->TranslateButton(szDevice, szButton);
 }
 
 bool CButtonTranslator::TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, int& action, std::string& strAction)
@@ -206,16 +206,16 @@ bool CButtonTranslator::TranslateCustomControllerString(int windowId, const std:
   unsigned int actionId = ACTION_NONE;
 
   // Try to get the action from the current window
-  if (!m_customControllerTranslator->TranslateCustomControllerString(windowId, controllerName, buttonId, actionId, strAction))
+  if (!m_customControllerTranslator->TranslateString(windowId, controllerName, buttonId, actionId, strAction))
   {
     // If it's invalid, try to get it from a fallback window or the global map
     int fallbackWindow = CWindowTranslator::GetFallbackWindow(windowId);
     if (fallbackWindow > -1)
-      m_customControllerTranslator->TranslateCustomControllerString(fallbackWindow, controllerName, buttonId, actionId, strAction);
+      m_customControllerTranslator->TranslateString(fallbackWindow, controllerName, buttonId, actionId, strAction);
 
     // Still no valid action? Use global map
     if (action == ACTION_NONE)
-      m_customControllerTranslator->TranslateCustomControllerString(-1, controllerName, buttonId, actionId, strAction);
+      m_customControllerTranslator->TranslateString(-1, controllerName, buttonId, actionId, strAction);
   }
 
   if (actionId != ACTION_NONE)
@@ -234,14 +234,14 @@ bool CButtonTranslator::TranslateTouchAction(int window, int touchAction, int to
 
   unsigned int actionId = ACTION_NONE;
 
-  if (!m_touchTranslator->TranslateTouchAction(window, touchAction, touchPointers, actionId, actionString))
+  if (!m_touchTranslator->TranslateAction(window, touchAction, touchPointers, actionId, actionString))
   {
     int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
     if (fallbackWindow > -1)
-      m_touchTranslator->TranslateTouchAction(fallbackWindow, touchAction, touchPointers, actionId, actionString);
+      m_touchTranslator->TranslateAction(fallbackWindow, touchAction, touchPointers, actionId, actionString);
 
     if (actionId == ACTION_NONE)
-      m_touchTranslator->TranslateTouchAction(-1, touchAction, touchPointers, actionId, actionString);
+      m_touchTranslator->TranslateAction(-1, touchAction, touchPointers, actionId, actionString);
   }
 
   action = actionId;
@@ -404,7 +404,7 @@ unsigned int CButtonTranslator::GetActionCode(int window, const CKey &key, std::
 void CButtonTranslator::MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map)
 {
   unsigned int action = ACTION_NONE;
-  if (!CActionTranslator::TranslateActionString(szAction, action) || buttonCode == 0)
+  if (!CActionTranslator::TranslateString(szAction, action) || buttonCode == 0)
     return;   // no valid action, or an invalid buttoncode
 
   // have a valid action, and a valid button - map it.
@@ -455,19 +455,19 @@ void CButtonTranslator::MapWindowActions(const TiXmlNode *pWindow, int windowID)
         unsigned int holdtimeMs = 0;
 
         if (type == "gamepad")
-            buttonCode = CGamepadTranslator::TranslateGamepadString(pButton->Value());
+            buttonCode = CGamepadTranslator::TranslateString(pButton->Value());
         else if (type == "remote")
-            buttonCode = CIRTranslator::TranslateRemoteString(pButton->Value());
+            buttonCode = CIRTranslator::TranslateString(pButton->Value());
         else if (type == "universalremote")
             buttonCode = CIRTranslator::TranslateUniversalRemoteString(pButton->Value());
         else if (type == "keyboard")
-            buttonCode = CKeyboardTranslator::TranslateKeyboardButton(pButton);
+            buttonCode = CKeyboardTranslator::TranslateButton(pButton);
         else if (type == "mouse")
-            buttonCode = CMouseTranslator::TranslateMouseCommand(pButton);
+            buttonCode = CMouseTranslator::TranslateCommand(pButton);
         else if (type == "appcommand")
             buttonCode = CAppTranslator::TranslateAppCommand(pButton->Value());
         else if (type == "joystick")
-          buttonCode = CJoystickTranslator::TranslateJoystickCommand(pDevice, pButton, holdtimeMs);
+          buttonCode = CJoystickTranslator::TranslateButton(pDevice, pButton, holdtimeMs);
 
         if (buttonCode != 0)
         {
@@ -496,7 +496,7 @@ void CButtonTranslator::MapWindowActions(const TiXmlNode *pWindow, int windowID)
   pDevice = pWindow->FirstChild("touch");
   while (pDevice != nullptr)
   {
-    m_touchTranslator->MapTouchActions(windowID, pDevice);
+    m_touchTranslator->MapActions(windowID, pDevice);
     pDevice = pDevice->NextSibling("touch");
   }
 
@@ -504,7 +504,7 @@ void CButtonTranslator::MapWindowActions(const TiXmlNode *pWindow, int windowID)
   pDevice = pWindow->FirstChild("customcontroller");
   while (pDevice != nullptr)
   {
-    m_customControllerTranslator->MapCustomControllerActions(windowID, pDevice);
+    m_customControllerTranslator->MapActions(windowID, pDevice);
     pDevice = pDevice->NextSibling("customcontroller");
   }
 }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -119,7 +119,6 @@ private:
   int GetActionCode(int window, int action);
   int GetActionCode(int window, const CKey &key, std::string &strAction) const;
 
-  static uint32_t TranslateGamepadString(const char *szButton);
   static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs);
 
   static uint32_t TranslateKeyboardString(const char *szButton);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -40,7 +40,7 @@ class CIRTranslator;
 
 struct CButtonAction
 {
-  int id;
+  unsigned int id;
   std::string strID; // needed for "ActivateWindow()" type actions
   unsigned int holdtimeMs;
 };
@@ -73,7 +73,6 @@ public:
   /// clears the maps
   void Clear();
 
-  static void GetActions(std::vector<std::string> &actionList);
   static void GetWindows(std::vector<std::string> &windowList);
 
   /*! \brief Finds out if a longpress mapping exists for this key
@@ -104,8 +103,6 @@ public:
    */
   CAction GetGlobalAction(const CKey &key);
 
-  static bool IsAnalog(int actionID);
-
   /*! \brief Translate between a window name and it's id
    \param window name of the window
    \return id of the window, or WINDOW_INVALID if not found
@@ -117,8 +114,6 @@ public:
    \return name of the window, or an empty string if not found
    */
   static std::string TranslateWindow(int window);
-
-  static bool TranslateActionString(const char *szAction, int &action);
 
   int TranslateLircRemoteString(const char* szDevice, const char *szButton);
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -121,9 +121,6 @@ private:
 
   static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs);
 
-  static uint32_t TranslateKeyboardString(const char *szButton);
-  static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);
-
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);
   void MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map);
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -36,6 +36,7 @@ class CKey;
 class CAction;
 class TiXmlNode;
 class CRegExp;
+class CIRTranslator;
 
 struct CButtonAction
 {
@@ -67,7 +68,7 @@ public:
   void AddDevice(std::string& strDevice);
   void RemoveDevice(std::string& strDevice);
 
-  /// loads Lircmap.xml/IRSSmap.xml (if enabled) and Keymap.xml
+  /// loads Keymap.xml
   bool Load(bool AlwaysLoad = false);
   /// clears the maps
   void Clear();
@@ -120,7 +121,7 @@ public:
   static bool TranslateActionString(const char *szAction, int &action);
 
   int TranslateLircRemoteString(const char* szDevice, const char *szButton);
-  
+
   bool TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, int& action, std::string& strAction);
 
   bool TranslateTouchAction(int window, int touchAction, int touchPointers, int &action, std::string &actionString);
@@ -138,8 +139,6 @@ private:
   int GetFallbackWindow(int windowID);
 
   static uint32_t TranslateGamepadString(const char *szButton);
-  static uint32_t TranslateRemoteString(const char *szButton);
-  static uint32_t TranslateUniversalRemoteString(const char *szButton);
   static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs);
 
   static uint32_t TranslateKeyboardString(const char *szButton);
@@ -154,13 +153,6 @@ private:
   void MapCustomControllerActions(int windowID, TiXmlNode *pCustomController);
 
   bool LoadKeymap(const std::string &keymapPath);
-  bool LoadLircMap(const std::string &lircmapPath);
-  void ClearLircButtonMapEntries();
-
-  void MapRemote(TiXmlNode *pRemote, const char* szDevice);
-
-  typedef std::map<std::string, std::string> lircButtonMap;
-  std::map<std::string, lircButtonMap*> lircRemotesMap;
 
   // maps button id to action
   typedef std::map<int, std::string> CustomControllerButtonMap;
@@ -170,7 +162,6 @@ private:
   std::map<std::string, CustomControllerWindowMap> m_customControllersMap;
   int GetCustomControllerActionCode(int windowId, int buttonId, const CustomControllerWindowMap *windowMap, std::string& strAction) const;
 
-  
   void MapTouchActions(int windowID, TiXmlNode *pTouch);
   static uint32_t TranslateTouchCommand(TiXmlElement *pButton, CButtonAction &action);
   int GetTouchActionCode(int window, int action, std::string &actionString);
@@ -178,6 +169,8 @@ private:
   std::map<int, buttonMap> m_touchMap;
 
   bool m_Loaded;
+
+  std::unique_ptr<CIRTranslator> m_irTranslator;
 };
 
 #endif

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -25,7 +25,6 @@
 
 #include <map>
 #include <string>
-#include <vector>
 #include "system.h" // for HAS_EVENT_SERVER
 
 #ifdef HAS_EVENT_SERVER
@@ -75,8 +74,6 @@ public:
   /// clears the maps
   void Clear();
 
-  static void GetWindows(std::vector<std::string> &windowList);
-
   /*! \brief Finds out if a longpress mapping exists for this key
    \param window id of the current window
    \param key to search a mapping for
@@ -105,18 +102,6 @@ public:
    */
   CAction GetGlobalAction(const CKey &key);
 
-  /*! \brief Translate between a window name and it's id
-   \param window name of the window
-   \return id of the window, or WINDOW_INVALID if not found
-   */
-  static int TranslateWindow(const std::string &window);
-
-  /*! \brief Translate between a window id and it's name
-   \param window id of the window
-   \return name of the window, or an empty string if not found
-   */
-  static std::string TranslateWindow(int window);
-
   int TranslateLircRemoteString(const char* szDevice, const char *szButton);
 
   bool TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, int& action, std::string& strAction);
@@ -133,7 +118,6 @@ private:
 
   int GetActionCode(int window, int action);
   int GetActionCode(int window, const CKey &key, std::string &strAction) const;
-  int GetFallbackWindow(int windowID);
 
   static uint32_t TranslateGamepadString(const char *szButton);
   static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -119,8 +119,6 @@ private:
   int GetActionCode(int window, int action);
   int GetActionCode(int window, const CKey &key, std::string &strAction) const;
 
-  static uint32_t TranslateJoystickCommand(const TiXmlElement *pButton, const std::string& controllerId, unsigned int& holdtimeMs);
-
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);
   void MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map);
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -125,8 +125,6 @@ private:
   static uint32_t TranslateKeyboardString(const char *szButton);
   static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);
 
-  static uint32_t TranslateMouseCommand(TiXmlElement *pButton);
-
   static uint32_t TranslateAppCommand(const char *szButton);
 
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -37,6 +37,7 @@ class CAction;
 class TiXmlNode;
 class CRegExp;
 class CIRTranslator;
+class CTouchTranslator;
 
 struct CButtonAction
 {
@@ -157,15 +158,10 @@ private:
   std::map<std::string, CustomControllerWindowMap> m_customControllersMap;
   int GetCustomControllerActionCode(int windowId, int buttonId, const CustomControllerWindowMap *windowMap, std::string& strAction) const;
 
-  void MapTouchActions(int windowID, TiXmlNode *pTouch);
-  static uint32_t TranslateTouchCommand(TiXmlElement *pButton, CButtonAction &action);
-  int GetTouchActionCode(int window, int action, std::string &actionString);
-
-  std::map<int, buttonMap> m_touchMap;
-
   bool m_Loaded;
 
   std::unique_ptr<CIRTranslator> m_irTranslator;
+  std::unique_ptr<CTouchTranslator> m_touchTranslator;
 };
 
 #endif

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -125,8 +125,6 @@ private:
   static uint32_t TranslateKeyboardString(const char *szButton);
   static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);
 
-  static uint32_t TranslateAppCommand(const char *szButton);
-
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);
   void MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map);
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -36,6 +36,7 @@ class CKey;
 class CAction;
 class TiXmlNode;
 class CRegExp;
+class CCustomControllerTranslator;
 class CIRTranslator;
 class CTouchTranslator;
 
@@ -146,20 +147,12 @@ private:
 
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);
   void MapAction(uint32_t buttonCode, const char *szAction, unsigned int holdtimeMs, buttonMap &map);
-  void MapCustomControllerActions(int windowID, TiXmlNode *pCustomController);
 
   bool LoadKeymap(const std::string &keymapPath);
 
-  // maps button id to action
-  typedef std::map<int, std::string> CustomControllerButtonMap;
-  // maps window id to controller button map
-  typedef std::map<int, CustomControllerButtonMap> CustomControllerWindowMap;
-  // maps custom controller name to controller Window map
-  std::map<std::string, CustomControllerWindowMap> m_customControllersMap;
-  int GetCustomControllerActionCode(int windowId, int buttonId, const CustomControllerWindowMap *windowMap, std::string& strAction) const;
-
   bool m_Loaded;
 
+  std::unique_ptr<CCustomControllerTranslator> m_customControllerTranslator;
   std::unique_ptr<CIRTranslator> m_irTranslator;
   std::unique_ptr<CTouchTranslator> m_touchTranslator;
 };

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES Action.cpp
             ActionTranslator.cpp
             ButtonTranslator.cpp
+            CustomControllerTranslator.cpp
             InertialScrollingHandler.cpp
             InputCodingTableBaiduPY.cpp
             InputCodingTableBasePY.cpp
@@ -20,6 +21,7 @@ set(HEADERS Action.h
             ActionIDs.h
             ActionTranslator.h
             ButtonTranslator.h
+            CustomControllerTranslator.h
             InertialScrollingHandler.h
             InputCodingTable.h
             InputCodingTableBaiduPY.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES Action.cpp
             InputCodingTableFactory.cpp
             InputCodingTableKorean.cpp
             InputManager.cpp
+            IRTranslator.cpp
             Key.cpp
             KeyboardLayout.cpp
             KeyboardLayoutManager.cpp
@@ -23,6 +24,7 @@ set(HEADERS Action.h
             InputCodingTableFactory.h
             InputCodingTableKorean.h
             InputManager.h
+            IRTranslator.h
             Key.h
             KeyboardLayout.h
             KeyboardLayoutManager.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES Action.cpp
             KeyboardStat.cpp
             MouseStat.cpp
             TouchTranslator.cpp
+            WindowTranslator.cpp
             XBMC_keytable.cpp)
 
 set(HEADERS Action.h
@@ -36,6 +37,7 @@ set(HEADERS Action.h
             KeyboardStat.h
             MouseStat.h
             TouchTranslator.h
+            WindowTranslator.h
             XBIRRemote.h
             XBMC_keyboard.h
             XBMC_keysym.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES Action.cpp
             ActionTranslator.cpp
+            AppTranslator.cpp
             ButtonTranslator.cpp
             CustomControllerTranslator.cpp
             InertialScrollingHandler.cpp
@@ -22,6 +23,7 @@ set(SOURCES Action.cpp
 set(HEADERS Action.h
             ActionIDs.h
             ActionTranslator.h
+            AppTranslator.h
             ButtonTranslator.h
             CustomControllerTranslator.h
             InertialScrollingHandler.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES Action.cpp
+            ActionTranslator.cpp
             ButtonTranslator.cpp
             InertialScrollingHandler.cpp
             InputCodingTableBaiduPY.cpp
@@ -16,6 +17,7 @@ set(SOURCES Action.cpp
 
 set(HEADERS Action.h
             ActionIDs.h
+            ActionTranslator.h
             ButtonTranslator.h
             InertialScrollingHandler.h
             InputCodingTable.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES Action.cpp
             KeyboardLayout.cpp
             KeyboardLayoutManager.cpp
             KeyboardStat.cpp
+            KeyboardTranslator.cpp
             MouseStat.cpp
             MouseTranslator.cpp
             TouchTranslator.cpp
@@ -40,6 +41,7 @@ set(HEADERS Action.h
             KeyboardLayout.h
             KeyboardLayoutManager.h
             KeyboardStat.h
+            KeyboardTranslator.h
             MouseStat.h
             MouseTranslator.h
             TouchTranslator.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES Action.cpp
             InputCodingTableKorean.cpp
             InputManager.cpp
             IRTranslator.cpp
+            JoystickTranslator.cpp
             Key.cpp
             KeyboardLayout.cpp
             KeyboardLayoutManager.cpp
@@ -37,6 +38,7 @@ set(HEADERS Action.h
             InputCodingTableKorean.h
             InputManager.h
             IRTranslator.h
+            JoystickTranslator.h
             Key.h
             KeyboardLayout.h
             KeyboardLayoutManager.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES Action.cpp
             AppTranslator.cpp
             ButtonTranslator.cpp
             CustomControllerTranslator.cpp
+            GamepadTranslator.cpp
             InertialScrollingHandler.cpp
             InputCodingTableBaiduPY.cpp
             InputCodingTableBasePY.cpp
@@ -26,6 +27,7 @@ set(HEADERS Action.h
             AppTranslator.h
             ButtonTranslator.h
             CustomControllerTranslator.h
+            GamepadTranslator.h
             InertialScrollingHandler.h
             InputCodingTable.h
             InputCodingTableBaiduPY.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES Action.cpp
             KeyboardLayoutManager.cpp
             KeyboardStat.cpp
             MouseStat.cpp
+            TouchTranslator.cpp
             XBMC_keytable.cpp)
 
 set(HEADERS Action.h
@@ -32,6 +33,7 @@ set(HEADERS Action.h
             KeyboardLayoutManager.h
             KeyboardStat.h
             MouseStat.h
+            TouchTranslator.h
             XBIRRemote.h
             XBMC_keyboard.h
             XBMC_keysym.h

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES Action.cpp
             KeyboardLayoutManager.cpp
             KeyboardStat.cpp
             MouseStat.cpp
+            MouseTranslator.cpp
             TouchTranslator.cpp
             WindowTranslator.cpp
             XBMC_keytable.cpp)
@@ -36,6 +37,7 @@ set(HEADERS Action.h
             KeyboardLayoutManager.h
             KeyboardStat.h
             MouseStat.h
+            MouseTranslator.h
             TouchTranslator.h
             WindowTranslator.h
             XBIRRemote.h

--- a/xbmc/input/CustomControllerTranslator.cpp
+++ b/xbmc/input/CustomControllerTranslator.cpp
@@ -24,7 +24,7 @@
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
 
-void CCustomControllerTranslator::MapCustomControllerActions(int windowID, const TiXmlNode *pCustomController)
+void CCustomControllerTranslator::MapActions(int windowID, const TiXmlNode *pCustomController)
 {
   CustomControllerButtonMap buttonMap;
   std::string controllerName;
@@ -73,7 +73,7 @@ void CCustomControllerTranslator::Clear()
   m_customControllersMap.clear();
 }
 
-bool CCustomControllerTranslator::TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction)
+bool CCustomControllerTranslator::TranslateString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction)
 {
   // Resolve the correct custom controller
   auto it = m_customControllersMap.find(controllerName);
@@ -89,7 +89,7 @@ bool CCustomControllerTranslator::TranslateCustomControllerString(int windowId, 
     if (it3 != buttonMap.end())
     {
       strAction = it3->second;
-      CActionTranslator::TranslateActionString(strAction.c_str(), actionId);
+      CActionTranslator::TranslateString(strAction.c_str(), actionId);
     }
   }
 

--- a/xbmc/input/CustomControllerTranslator.cpp
+++ b/xbmc/input/CustomControllerTranslator.cpp
@@ -1,0 +1,97 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "CustomControllerTranslator.h"
+#include "ActionIDs.h"
+#include "ActionTranslator.h"
+#include "utils/log.h"
+#include "utils/XBMCTinyXML.h"
+
+void CCustomControllerTranslator::MapCustomControllerActions(int windowID, const TiXmlNode *pCustomController)
+{
+  CustomControllerButtonMap buttonMap;
+  std::string controllerName;
+
+  const TiXmlElement *pController = pCustomController->ToElement();
+  if (pController != nullptr)
+  {
+    // Transform loose name to new family, including altnames
+    const char *name = pController->Attribute("name");
+    if (name != nullptr)
+      controllerName = name;
+  }
+
+  if (controllerName.empty())
+  {
+    CLog::Log(LOGERROR, "Missing attribute \"name\" for tag \"customcontroller\"");
+    return;
+  }
+
+  // Parse map
+  const TiXmlElement *pButton = pCustomController->FirstChildElement();
+  int id = 0;
+  while (pButton != nullptr)
+  {
+    std::string action;
+    if (!pButton->NoChildren())
+      action = pButton->FirstChild()->ValueStr();
+
+    if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS) && id >= 0)
+    {
+      buttonMap[id] = action;
+    }
+    else
+      CLog::Log(LOGERROR, "Error reading customController map element, Invalid id: %d", id);
+
+    pButton = pButton->NextSiblingElement();
+  }
+
+  // Add/overwrite button with mapped actions
+  for (auto button : buttonMap)
+    m_customControllersMap[controllerName][windowID][button.first] = std::move(button.second);
+}
+
+void CCustomControllerTranslator::Clear()
+{
+  m_customControllersMap.clear();
+}
+
+bool CCustomControllerTranslator::TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction)
+{
+  // Resolve the correct custom controller
+  auto it = m_customControllersMap.find(controllerName);
+  if (it == m_customControllersMap.end())
+    return false;
+
+  const CustomControllerWindowMap &windowMap = it->second;
+  auto it2 = windowMap.find(windowId);
+  if (it2 != windowMap.end())
+  {
+    const CustomControllerButtonMap &buttonMap = it2->second;
+    auto it3 = buttonMap.find(buttonId);
+    if (it3 != buttonMap.end())
+    {
+      strAction = it3->second;
+      CActionTranslator::TranslateActionString(strAction.c_str(), actionId);
+    }
+  }
+
+  return actionId != ACTION_NONE;
+}

--- a/xbmc/input/CustomControllerTranslator.h
+++ b/xbmc/input/CustomControllerTranslator.h
@@ -29,11 +29,11 @@ class CCustomControllerTranslator
 public:
   CCustomControllerTranslator() = default;
 
-  void MapCustomControllerActions(int windowID, const TiXmlNode *pCustomController);
+  void MapActions(int windowID, const TiXmlNode *pCustomController);
 
   void Clear();
 
-  bool TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction);
+  bool TranslateString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction);
 
 private:
   // Maps button id to action

--- a/xbmc/input/CustomControllerTranslator.h
+++ b/xbmc/input/CustomControllerTranslator.h
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <map>
+#include <string>
+
+class TiXmlNode;
+
+class CCustomControllerTranslator
+{
+public:
+  CCustomControllerTranslator() = default;
+
+  void MapCustomControllerActions(int windowID, const TiXmlNode *pCustomController);
+
+  void Clear();
+
+  bool TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction);
+
+private:
+  // Maps button id to action
+  using CustomControllerButtonMap = std::map<int, std::string>;
+
+  // Maps window id to controller button map
+  using CustomControllerWindowMap = std::map<int, CustomControllerButtonMap>;
+
+  // Maps custom controller name to controller Window map
+  std::map<std::string, CustomControllerWindowMap> m_customControllersMap;
+};

--- a/xbmc/input/GamepadTranslator.cpp
+++ b/xbmc/input/GamepadTranslator.cpp
@@ -1,0 +1,68 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GamepadTranslator.h"
+#include "Key.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <string>
+
+uint32_t CGamepadTranslator::TranslateGamepadString(const char *szButton)
+{
+  if (szButton == nullptr)
+    return 0;
+
+  std::string strButton = szButton;
+  StringUtils::ToLower(strButton);
+
+  uint32_t buttonCode = 0;
+  if (strButton == "a") buttonCode = KEY_BUTTON_A;
+  else if (strButton == "b") buttonCode = KEY_BUTTON_B;
+  else if (strButton == "x") buttonCode = KEY_BUTTON_X;
+  else if (strButton == "y") buttonCode = KEY_BUTTON_Y;
+  else if (strButton == "white") buttonCode = KEY_BUTTON_WHITE;
+  else if (strButton == "black") buttonCode = KEY_BUTTON_BLACK;
+  else if (strButton == "start") buttonCode = KEY_BUTTON_START;
+  else if (strButton == "back") buttonCode = KEY_BUTTON_BACK;
+  else if (strButton == "leftthumbbutton") buttonCode = KEY_BUTTON_LEFT_THUMB_BUTTON;
+  else if (strButton == "rightthumbbutton") buttonCode = KEY_BUTTON_RIGHT_THUMB_BUTTON;
+  else if (strButton == "leftthumbstick") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK;
+  else if (strButton == "leftthumbstickup") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_UP;
+  else if (strButton == "leftthumbstickdown") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_DOWN;
+  else if (strButton == "leftthumbstickleft") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_LEFT;
+  else if (strButton == "leftthumbstickright") buttonCode = KEY_BUTTON_LEFT_THUMB_STICK_RIGHT;
+  else if (strButton == "rightthumbstick") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK;
+  else if (strButton == "rightthumbstickup") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_UP;
+  else if (strButton == "rightthumbstickdown") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_DOWN;
+  else if (strButton == "rightthumbstickleft") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_LEFT;
+  else if (strButton == "rightthumbstickright") buttonCode = KEY_BUTTON_RIGHT_THUMB_STICK_RIGHT;
+  else if (strButton == "lefttrigger") buttonCode = KEY_BUTTON_LEFT_TRIGGER;
+  else if (strButton == "righttrigger") buttonCode = KEY_BUTTON_RIGHT_TRIGGER;
+  else if (strButton == "leftanalogtrigger") buttonCode = KEY_BUTTON_LEFT_ANALOG_TRIGGER;
+  else if (strButton == "rightanalogtrigger") buttonCode = KEY_BUTTON_RIGHT_ANALOG_TRIGGER;
+  else if (strButton == "dpadleft") buttonCode = KEY_BUTTON_DPAD_LEFT;
+  else if (strButton == "dpadright") buttonCode = KEY_BUTTON_DPAD_RIGHT;
+  else if (strButton == "dpadup") buttonCode = KEY_BUTTON_DPAD_UP;
+  else if (strButton == "dpaddown") buttonCode = KEY_BUTTON_DPAD_DOWN;
+  else CLog::Log(LOGERROR, "Gamepad Translator: Can't find button %s", strButton.c_str());
+
+  return buttonCode;
+}

--- a/xbmc/input/GamepadTranslator.cpp
+++ b/xbmc/input/GamepadTranslator.cpp
@@ -25,7 +25,7 @@
 
 #include <string>
 
-uint32_t CGamepadTranslator::TranslateGamepadString(const char *szButton)
+uint32_t CGamepadTranslator::TranslateString(const char *szButton)
 {
   if (szButton == nullptr)
     return 0;

--- a/xbmc/input/GamepadTranslator.h
+++ b/xbmc/input/GamepadTranslator.h
@@ -24,5 +24,5 @@
 class CGamepadTranslator
 {
 public:
-  static uint32_t TranslateGamepadString(const char *szButton);
+  static uint32_t TranslateString(const char *szButton);
 };

--- a/xbmc/input/GamepadTranslator.h
+++ b/xbmc/input/GamepadTranslator.h
@@ -1,0 +1,28 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+
+class CGamepadTranslator
+{
+public:
+  static uint32_t TranslateGamepadString(const char *szButton);
+};

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -147,7 +147,7 @@ void CIRTranslator::Clear()
   m_irRemotesMap.clear();
 }
 
-unsigned int CIRTranslator::TranslateIRRemoteString(const char* szDevice, const char *szButton)
+unsigned int CIRTranslator::TranslateButton(const char* szDevice, const char *szButton)
 {
   // Find the device
   auto it = m_irRemotesMap.find(szDevice);
@@ -163,10 +163,10 @@ unsigned int CIRTranslator::TranslateIRRemoteString(const char* szDevice, const 
   if (strnicmp((*it2).second.c_str(), "obc", 3) == 0)
     return TranslateUniversalRemoteString((*it2).second.c_str());
 
-  return TranslateRemoteString((*it2).second.c_str());
+  return TranslateString((*it2).second.c_str());
 }
 
-uint32_t CIRTranslator::TranslateRemoteString(const char *szButton)
+uint32_t CIRTranslator::TranslateString(const char *szButton)
 {
   if (!szButton) 
     return 0;

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -147,7 +147,7 @@ void CIRTranslator::Clear()
   m_irRemotesMap.clear();
 }
 
-int CIRTranslator::TranslateIRRemoteString(const char* szDevice, const char *szButton)
+unsigned int CIRTranslator::TranslateIRRemoteString(const char* szDevice, const char *szButton)
 {
   // Find the device
   auto it = m_irRemotesMap.find(szDevice);

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -1,0 +1,262 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IRTranslator.h"
+#include "filesystem/File.h"
+#include "profiles/ProfilesManager.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "system.h"
+#include "XBIRRemote.h"
+
+#include <stdlib.h>
+#include <vector>
+
+void CIRTranslator::Load()
+{
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  Clear();
+
+  std::string irMapName;
+#ifdef TARGET_POSIX
+  irMapName = "Lircmap.xml";
+#else
+  irMapName = "IRSSmap.xml";
+#endif
+
+  bool success = false;
+
+  std::string irMapPath = URIUtils::AddFileToFolder("special://xbmc/system/", irMapName);
+  if (XFILE::CFile::Exists(irMapPath))
+    success |= LoadIRMap(irMapPath);
+  else
+    CLog::Log(LOGDEBUG, "CIRTranslator::Load - no system %s found, skipping", irMapName.c_str());
+
+  irMapPath = CProfilesManager::GetInstance().GetUserDataItem(irMapName);
+  if (XFILE::CFile::Exists(irMapPath))
+    success |= LoadIRMap(irMapPath);
+  else
+    CLog::Log(LOGDEBUG, "CIRTranslator::Load - no userdata %s found, skipping", irMapName.c_str());
+
+  if (!success)
+    CLog::Log(LOGERROR, "CIRTranslator::Load - unable to load remote map %s", irMapName.c_str());
+#endif
+}
+
+bool CIRTranslator::LoadIRMap(const std::string &irMapPath)
+{
+  std::string remoteMapTag;
+#ifdef TARGET_POSIX
+  remoteMapTag = "irmap";
+#else
+  remoteMapTag = "irssmap";
+#endif
+
+  // Load our xml file, and fill up our mapping tables
+  CXBMCTinyXML xmlDoc;
+
+  // Load the config file
+  CLog::Log(LOGINFO, "Loading %s", irMapPath.c_str());
+  if (!xmlDoc.LoadFile(irMapPath))
+  {
+    CLog::Log(LOGERROR, "%s, Line %d\n%s", irMapPath.c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+    return false;
+  }
+
+  TiXmlElement* pRoot = xmlDoc.RootElement();
+  std::string strValue = pRoot->Value();
+  if (strValue != remoteMapTag)
+  {
+    CLog::Log(LOGERROR, "%sl Doesn't contain <%s>", irMapPath.c_str(), remoteMapTag.c_str());
+    return false;
+  }
+
+  // Run through our window groups
+  TiXmlNode* pRemote = pRoot->FirstChild();
+  while (pRemote != nullptr)
+  {
+    if (pRemote->Type() == TiXmlNode::TINYXML_ELEMENT)
+    {
+      const char *szRemote = pRemote->Value();
+      if (szRemote != nullptr)
+      {
+        TiXmlAttribute* pAttr = pRemote->ToElement()->FirstAttribute();
+        if (pAttr != nullptr)
+          MapRemote(pRemote, pAttr->Value());
+      }
+    }
+    pRemote = pRemote->NextSibling();
+  }
+
+  return true;
+}
+
+void CIRTranslator::MapRemote(TiXmlNode *pRemote, const char* szDevice)
+{
+  CLog::Log(LOGINFO, "* Adding remote mapping for device '%s'", szDevice);
+
+  std::vector<std::string> remoteNames;
+
+  auto it = m_irRemotesMap.find(szDevice);
+  if (it == m_irRemotesMap.end())
+    m_irRemotesMap[szDevice].reset(new IRButtonMap);
+
+  std::shared_ptr<IRButtonMap>& buttons = m_irRemotesMap[szDevice];
+
+  TiXmlElement *pButton = pRemote->FirstChildElement();
+  while (pButton != nullptr)
+  {
+    if (!pButton->NoChildren())
+    {
+      if (pButton->ValueStr() == "altname")
+        remoteNames.push_back(pButton->FirstChild()->ValueStr());
+      else
+        (*buttons)[pButton->FirstChild()->ValueStr()] = pButton->ValueStr();
+    }
+    pButton = pButton->NextSiblingElement();
+  }
+
+  for (const auto& remoteName : remoteNames)
+  {
+    CLog::Log(LOGINFO, "* Linking remote mapping for '%s' to '%s'", szDevice, remoteName.c_str());
+    m_irRemotesMap[remoteName] = buttons;
+  }
+}
+
+void CIRTranslator::Clear()
+{
+  m_irRemotesMap.clear();
+}
+
+int CIRTranslator::TranslateIRRemoteString(const char* szDevice, const char *szButton)
+{
+  // Find the device
+  auto it = m_irRemotesMap.find(szDevice);
+  if (it == m_irRemotesMap.end())
+    return 0;
+
+  // Find the button
+  auto it2 = (*it).second->find(szButton);
+  if (it2 == (*it).second->end())
+    return 0;
+
+  // Convert the button to code
+  if (strnicmp((*it2).second.c_str(), "obc", 3) == 0)
+    return TranslateUniversalRemoteString((*it2).second.c_str());
+
+  return TranslateRemoteString((*it2).second.c_str());
+}
+
+uint32_t CIRTranslator::TranslateRemoteString(const char *szButton)
+{
+  if (!szButton) 
+    return 0;
+
+  uint32_t buttonCode = 0;
+
+  std::string strButton = szButton;
+  StringUtils::ToLower(strButton);
+
+  if (strButton == "left") buttonCode = XINPUT_IR_REMOTE_LEFT;
+  else if (strButton == "right") buttonCode = XINPUT_IR_REMOTE_RIGHT;
+  else if (strButton == "up") buttonCode = XINPUT_IR_REMOTE_UP;
+  else if (strButton == "down") buttonCode = XINPUT_IR_REMOTE_DOWN;
+  else if (strButton == "select") buttonCode = XINPUT_IR_REMOTE_SELECT;
+  else if (strButton == "back") buttonCode = XINPUT_IR_REMOTE_BACK;
+  else if (strButton == "menu") buttonCode = XINPUT_IR_REMOTE_MENU;
+  else if (strButton == "info") buttonCode = XINPUT_IR_REMOTE_INFO;
+  else if (strButton == "display") buttonCode = XINPUT_IR_REMOTE_DISPLAY;
+  else if (strButton == "title") buttonCode = XINPUT_IR_REMOTE_TITLE;
+  else if (strButton == "play") buttonCode = XINPUT_IR_REMOTE_PLAY;
+  else if (strButton == "pause") buttonCode = XINPUT_IR_REMOTE_PAUSE;
+  else if (strButton == "reverse") buttonCode = XINPUT_IR_REMOTE_REVERSE;
+  else if (strButton == "forward") buttonCode = XINPUT_IR_REMOTE_FORWARD;
+  else if (strButton == "skipplus") buttonCode = XINPUT_IR_REMOTE_SKIP_PLUS;
+  else if (strButton == "skipminus") buttonCode = XINPUT_IR_REMOTE_SKIP_MINUS;
+  else if (strButton == "stop") buttonCode = XINPUT_IR_REMOTE_STOP;
+  else if (strButton == "zero") buttonCode = XINPUT_IR_REMOTE_0;
+  else if (strButton == "one") buttonCode = XINPUT_IR_REMOTE_1;
+  else if (strButton == "two") buttonCode = XINPUT_IR_REMOTE_2;
+  else if (strButton == "three") buttonCode = XINPUT_IR_REMOTE_3;
+  else if (strButton == "four") buttonCode = XINPUT_IR_REMOTE_4;
+  else if (strButton == "five") buttonCode = XINPUT_IR_REMOTE_5;
+  else if (strButton == "six") buttonCode = XINPUT_IR_REMOTE_6;
+  else if (strButton == "seven") buttonCode = XINPUT_IR_REMOTE_7;
+  else if (strButton == "eight") buttonCode = XINPUT_IR_REMOTE_8;
+  else if (strButton == "nine") buttonCode = XINPUT_IR_REMOTE_9;
+  // Additional keys from the media center extender for xbox remote
+  else if (strButton == "power") buttonCode = XINPUT_IR_REMOTE_POWER;
+  else if (strButton == "mytv") buttonCode = XINPUT_IR_REMOTE_MY_TV;
+  else if (strButton == "mymusic") buttonCode = XINPUT_IR_REMOTE_MY_MUSIC;
+  else if (strButton == "mypictures") buttonCode = XINPUT_IR_REMOTE_MY_PICTURES;
+  else if (strButton == "myvideo") buttonCode = XINPUT_IR_REMOTE_MY_VIDEOS;
+  else if (strButton == "record") buttonCode = XINPUT_IR_REMOTE_RECORD;
+  else if (strButton == "start") buttonCode = XINPUT_IR_REMOTE_START;
+  else if (strButton == "volumeplus") buttonCode = XINPUT_IR_REMOTE_VOLUME_PLUS;
+  else if (strButton == "volumeminus") buttonCode = XINPUT_IR_REMOTE_VOLUME_MINUS;
+  else if (strButton == "channelplus") buttonCode = XINPUT_IR_REMOTE_CHANNEL_PLUS;
+  else if (strButton == "channelminus") buttonCode = XINPUT_IR_REMOTE_CHANNEL_MINUS;
+  else if (strButton == "pageplus") buttonCode = XINPUT_IR_REMOTE_CHANNEL_PLUS;
+  else if (strButton == "pageminus") buttonCode = XINPUT_IR_REMOTE_CHANNEL_MINUS;
+  else if (strButton == "mute") buttonCode = XINPUT_IR_REMOTE_MUTE;
+  else if (strButton == "recordedtv") buttonCode = XINPUT_IR_REMOTE_RECORDED_TV;
+  else if (strButton == "guide") buttonCode = XINPUT_IR_REMOTE_GUIDE;
+  else if (strButton == "livetv") buttonCode = XINPUT_IR_REMOTE_LIVE_TV;
+  else if (strButton == "liveradio") buttonCode = XINPUT_IR_REMOTE_LIVE_RADIO;
+  else if (strButton == "epgsearch") buttonCode = XINPUT_IR_REMOTE_EPG_SEARCH;
+  else if (strButton == "star") buttonCode = XINPUT_IR_REMOTE_STAR;
+  else if (strButton == "hash") buttonCode = XINPUT_IR_REMOTE_HASH;
+  else if (strButton == "clear") buttonCode = XINPUT_IR_REMOTE_CLEAR;
+  else if (strButton == "enter") buttonCode = XINPUT_IR_REMOTE_ENTER;
+  else if (strButton == "xbox") buttonCode = XINPUT_IR_REMOTE_DISPLAY; // Same as display
+  else if (strButton == "playlist") buttonCode = XINPUT_IR_REMOTE_PLAYLIST;
+  else if (strButton == "teletext") buttonCode = XINPUT_IR_REMOTE_TELETEXT;
+  else if (strButton == "red") buttonCode = XINPUT_IR_REMOTE_RED;
+  else if (strButton == "green") buttonCode = XINPUT_IR_REMOTE_GREEN;
+  else if (strButton == "yellow") buttonCode = XINPUT_IR_REMOTE_YELLOW;
+  else if (strButton == "blue") buttonCode = XINPUT_IR_REMOTE_BLUE;
+  else if (strButton == "subtitle") buttonCode = XINPUT_IR_REMOTE_SUBTITLE;
+  else if (strButton == "language") buttonCode = XINPUT_IR_REMOTE_LANGUAGE;
+  else if (strButton == "eject") buttonCode = XINPUT_IR_REMOTE_EJECT;
+  else if (strButton == "contentsmenu") buttonCode = XINPUT_IR_REMOTE_CONTENTS_MENU;
+  else if (strButton == "rootmenu") buttonCode = XINPUT_IR_REMOTE_ROOT_MENU;
+  else if (strButton == "topmenu") buttonCode = XINPUT_IR_REMOTE_TOP_MENU;
+  else if (strButton == "dvdmenu") buttonCode = XINPUT_IR_REMOTE_DVD_MENU;
+  else if (strButton == "print") buttonCode = XINPUT_IR_REMOTE_PRINT;
+  else CLog::Log(LOGERROR, "Remote Translator: Can't find button %s", strButton.c_str());
+  return buttonCode;
+}
+
+uint32_t CIRTranslator::TranslateUniversalRemoteString(const char *szButton)
+{
+  if (szButton == nullptr || strlen(szButton) < 4 || strnicmp(szButton, "obc", 3)) 
+    return 0;
+
+  const char *szCode = szButton + 3;
+
+  // Button Code is 255 - OBC (Original Button Code) of the button
+  uint32_t buttonCode = 255 - atol(szCode);
+  if (buttonCode > 255) 
+    buttonCode = 0;
+
+  return buttonCode;
+}

--- a/xbmc/input/IRTranslator.h
+++ b/xbmc/input/IRTranslator.h
@@ -1,0 +1,55 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+class TiXmlNode;
+
+class CIRTranslator
+{
+public:
+  CIRTranslator() = default;
+
+  /*!
+   * \brief Loads Lircmap.xml/IRSSmap.xml
+   */
+  void Load();
+
+  /*!
+   * \brief Clears the map
+   */
+  void Clear();
+
+  int TranslateIRRemoteString(const char* szDevice, const char *szButton);
+
+  static uint32_t TranslateRemoteString(const char *szButton);
+  static uint32_t TranslateUniversalRemoteString(const char *szButton);
+
+private:
+  bool LoadIRMap(const std::string &irMapPath);
+  void MapRemote(TiXmlNode *pRemote, const char* szDevice);
+
+  using IRButtonMap = std::map<std::string, std::string>;
+
+  std::map<std::string, std::shared_ptr<IRButtonMap>> m_irRemotesMap;
+};

--- a/xbmc/input/IRTranslator.h
+++ b/xbmc/input/IRTranslator.h
@@ -40,9 +40,9 @@ public:
    */
   void Clear();
 
-  unsigned int TranslateIRRemoteString(const char* szDevice, const char *szButton);
+  unsigned int TranslateButton(const char* szDevice, const char *szButton);
 
-  static uint32_t TranslateRemoteString(const char *szButton);
+  static uint32_t TranslateString(const char *szButton);
   static uint32_t TranslateUniversalRemoteString(const char *szButton);
 
 private:

--- a/xbmc/input/JoystickTranslator.cpp
+++ b/xbmc/input/JoystickTranslator.cpp
@@ -27,7 +27,7 @@
 
 #include <sstream>
 
-uint32_t CJoystickTranslator::TranslateJoystickCommand(const TiXmlNode* pDevice, const TiXmlElement *pButton, unsigned int& holdtimeMs)
+uint32_t CJoystickTranslator::TranslateButton(const TiXmlNode* pDevice, const TiXmlElement *pButton, unsigned int& holdtimeMs)
 {
   std::string controllerId = DEFAULT_CONTROLLER_ID;
 

--- a/xbmc/input/JoystickTranslator.cpp
+++ b/xbmc/input/JoystickTranslator.cpp
@@ -1,0 +1,103 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "JoystickTranslator.h"
+#include "Key.h"
+#include "input/joysticks/JoystickIDs.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <sstream>
+
+uint32_t CJoystickTranslator::TranslateJoystickCommand(const TiXmlNode* pDevice, const TiXmlElement *pButton, unsigned int& holdtimeMs)
+{
+  std::string controllerId = DEFAULT_CONTROLLER_ID;
+
+  const TiXmlElement* deviceElem = pDevice->ToElement();
+  if (deviceElem != nullptr)
+    deviceElem->QueryValueAttribute("profile", &controllerId);
+
+  holdtimeMs = 0;
+
+  const char *szButton = pButton->Value();
+  if (szButton == nullptr)
+    return 0;
+
+  std::string strButton = szButton;
+  StringUtils::ToLower(strButton);
+
+  uint32_t buttonCode = 0;
+  if (controllerId == DEFAULT_CONTROLLER_ID)
+  {
+    if (strButton == "a") buttonCode = KEY_JOYSTICK_BUTTON_A;
+    else if (strButton == "b") buttonCode = KEY_JOYSTICK_BUTTON_B;
+    else if (strButton == "x") buttonCode = KEY_JOYSTICK_BUTTON_X;
+    else if (strButton == "y") buttonCode = KEY_JOYSTICK_BUTTON_Y;
+    else if (strButton == "start") buttonCode = KEY_JOYSTICK_BUTTON_START;
+    else if (strButton == "back") buttonCode = KEY_JOYSTICK_BUTTON_BACK;
+    else if (strButton == "left") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_LEFT;
+    else if (strButton == "right") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_RIGHT;
+    else if (strButton == "up") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_UP;
+    else if (strButton == "down") buttonCode = KEY_JOYSTICK_BUTTON_DPAD_DOWN;
+    else if (strButton == "leftthumb") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_STICK_BUTTON;
+    else if (strButton == "rightthumb") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_STICK_BUTTON;
+    else if (strButton == "leftstickup") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_UP;
+    else if (strButton == "leftstickdown") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_DOWN;
+    else if (strButton == "leftstickleft") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_LEFT;
+    else if (strButton == "leftstickright") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_THUMB_STICK_RIGHT;
+    else if (strButton == "rightstickup") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_UP;
+    else if (strButton == "rightstickdown") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_DOWN;
+    else if (strButton == "rightstickleft") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_LEFT;
+    else if (strButton == "rightstickright") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_THUMB_STICK_RIGHT;
+    else if (strButton == "lefttrigger") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_TRIGGER;
+    else if (strButton == "righttrigger") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_TRIGGER;
+    else if (strButton == "leftbumper") buttonCode = KEY_JOYSTICK_BUTTON_LEFT_SHOULDER;
+    else if (strButton == "rightbumper") buttonCode = KEY_JOYSTICK_BUTTON_RIGHT_SHOULDER;
+    else if (strButton == "guide") buttonCode = KEY_JOYSTICK_BUTTON_GUIDE;
+  }
+  else if (controllerId == DEFAULT_REMOTE_ID)
+  {
+    if (strButton == "ok") buttonCode = KEY_REMOTE_BUTTON_OK;
+    else if (strButton == "back") buttonCode = KEY_REMOTE_BUTTON_BACK;
+    else if (strButton == "up") buttonCode = KEY_REMOTE_BUTTON_UP;
+    else if (strButton == "down") buttonCode = KEY_REMOTE_BUTTON_DOWN;
+    else if (strButton == "left") buttonCode = KEY_REMOTE_BUTTON_LEFT;
+    else if (strButton == "right") buttonCode = KEY_REMOTE_BUTTON_RIGHT;
+    else if (strButton == "home") buttonCode = KEY_REMOTE_BUTTON_HOME;
+  }
+
+  if (buttonCode == 0)
+  {
+    CLog::Log(LOGERROR, "Joystick Translator: Can't find button %s for controller %s", szButton, controllerId.c_str());
+  }
+  else
+  {
+    // Process holdtime parameter
+    std::string strHoldTime;
+    if (pButton->QueryValueAttribute("holdtime", &strHoldTime) == TIXML_SUCCESS)
+    {
+      std::stringstream ss(std::move(strHoldTime));
+      ss >> holdtimeMs;
+    }
+  }
+
+  return buttonCode;
+}

--- a/xbmc/input/JoystickTranslator.h
+++ b/xbmc/input/JoystickTranslator.h
@@ -1,0 +1,32 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+class TiXmlElement;
+class TiXmlNode;
+
+class CJoystickTranslator
+{
+public:
+  static uint32_t TranslateJoystickCommand(const TiXmlNode* pDevice, const TiXmlElement *pButton, unsigned int& holdtimeMs);
+};

--- a/xbmc/input/JoystickTranslator.h
+++ b/xbmc/input/JoystickTranslator.h
@@ -28,5 +28,5 @@ class TiXmlNode;
 class CJoystickTranslator
 {
 public:
-  static uint32_t TranslateJoystickCommand(const TiXmlNode* pDevice, const TiXmlElement *pButton, unsigned int& holdtimeMs);
+  static uint32_t TranslateButton(const TiXmlNode* pDevice, const TiXmlElement *pButton, unsigned int& holdtimeMs);
 };

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -145,9 +145,6 @@
 // 0xD000 -> 0xD0FF is reserved for WM_APPCOMMAND messages
 #define KEY_APPCOMMAND      0xD000
 
-// 0xF000 -> 0xF0FF is reserved for mouse actions
-#define KEY_TOUCH           0xF000
-
 #define KEY_INVALID         0xFFFF
 
 #define ICON_TYPE_NONE          101

--- a/xbmc/input/KeyboardTranslator.cpp
+++ b/xbmc/input/KeyboardTranslator.cpp
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-uint32_t CKeyboardTranslator::TranslateKeyboardButton(const TiXmlElement *pButton)
+uint32_t CKeyboardTranslator::TranslateButton(const TiXmlElement *pButton)
 {
   uint32_t button_id = 0;
   const char *szButton = pButton->Value();
@@ -54,7 +54,7 @@ uint32_t CKeyboardTranslator::TranslateKeyboardButton(const TiXmlElement *pButto
       CLog::Log(LOGERROR, "Keyboard Translator: `key' button has no id");
   }
   else
-    button_id = TranslateKeyboardString(szButton);
+    button_id = TranslateString(szButton);
 
   // Process the ctrl/shift/alt modifiers
   std::string strMod;
@@ -87,7 +87,7 @@ uint32_t CKeyboardTranslator::TranslateKeyboardButton(const TiXmlElement *pButto
   return button_id;
 }
 
-uint32_t CKeyboardTranslator::TranslateKeyboardString(const char *szButton)
+uint32_t CKeyboardTranslator::TranslateString(const char *szButton)
 {
   uint32_t buttonCode = 0;
   XBMCKEYTABLE keytable;

--- a/xbmc/input/KeyboardTranslator.cpp
+++ b/xbmc/input/KeyboardTranslator.cpp
@@ -1,0 +1,109 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "KeyboardTranslator.h"
+#include "Key.h"
+#include "XBMC_keytable.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <string>
+#include <vector>
+
+uint32_t CKeyboardTranslator::TranslateKeyboardButton(const TiXmlElement *pButton)
+{
+  uint32_t button_id = 0;
+  const char *szButton = pButton->Value();
+
+  if (szButton == nullptr)
+    return 0;
+
+  const std::string strKey = szButton;
+  if (strKey == "key")
+  {
+    std::string strID;
+    if (pButton->QueryValueAttribute("id", &strID) == TIXML_SUCCESS)
+    {
+      const char *str = strID.c_str();
+      char *endptr;
+      long int id = strtol(str, &endptr, 0);
+      if (endptr - str != (int)strlen(str) || id <= 0 || id > 0x00FFFFFF)
+        CLog::Log(LOGDEBUG, "%s - invalid key id %s", __FUNCTION__, strID.c_str());
+      else
+        button_id = (uint32_t)id;
+    }
+    else
+      CLog::Log(LOGERROR, "Keyboard Translator: `key' button has no id");
+  }
+  else
+    button_id = TranslateKeyboardString(szButton);
+
+  // Process the ctrl/shift/alt modifiers
+  std::string strMod;
+  if (pButton->QueryValueAttribute("mod", &strMod) == TIXML_SUCCESS)
+  {
+    StringUtils::ToLower(strMod);
+
+    std::vector<std::string> modArray = StringUtils::Split(strMod, ",");
+    for (auto substr : modArray)
+    {
+      StringUtils::Trim(substr);
+
+      if (substr == "ctrl" || substr == "control")
+        button_id |= CKey::MODIFIER_CTRL;
+      else if (substr == "shift")
+        button_id |= CKey::MODIFIER_SHIFT;
+      else if (substr == "alt")
+        button_id |= CKey::MODIFIER_ALT;
+      else if (substr == "super" || substr == "win")
+        button_id |= CKey::MODIFIER_SUPER;
+      else if (substr == "meta" || substr == "cmd")
+        button_id |= CKey::MODIFIER_META;
+      else if (substr == "longpress")
+        button_id |= CKey::MODIFIER_LONG;
+      else
+        CLog::Log(LOGERROR, "Keyboard Translator: Unknown key modifier %s in %s", substr.c_str(), strMod.c_str());
+    }
+  }
+
+  return button_id;
+}
+
+uint32_t CKeyboardTranslator::TranslateKeyboardString(const char *szButton)
+{
+  uint32_t buttonCode = 0;
+  XBMCKEYTABLE keytable;
+
+  // Look up the key name
+  if (KeyTableLookupName(szButton, &keytable))
+  {
+    buttonCode = keytable.vkey;
+  }
+  else
+  {
+    // The lookup failed i.e. the key name wasn't found
+    CLog::Log(LOGERROR, "Keyboard Translator: Can't find button %s", szButton);
+  }
+
+  buttonCode |= KEY_VKEY;
+
+  return buttonCode;
+}

--- a/xbmc/input/KeyboardTranslator.h
+++ b/xbmc/input/KeyboardTranslator.h
@@ -26,6 +26,6 @@ class TiXmlElement;
 class CKeyboardTranslator
 {
 public:
-  static uint32_t TranslateKeyboardButton(const TiXmlElement *pButton);
-  static uint32_t TranslateKeyboardString(const char *szButton);
+  static uint32_t TranslateButton(const TiXmlElement *pButton);
+  static uint32_t TranslateString(const char *szButton);
 };

--- a/xbmc/input/KeyboardTranslator.h
+++ b/xbmc/input/KeyboardTranslator.h
@@ -1,0 +1,31 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+
+class TiXmlElement;
+
+class CKeyboardTranslator
+{
+public:
+  static uint32_t TranslateKeyboardButton(const TiXmlElement *pButton);
+  static uint32_t TranslateKeyboardString(const char *szButton);
+};

--- a/xbmc/input/MouseTranslator.cpp
+++ b/xbmc/input/MouseTranslator.cpp
@@ -1,0 +1,87 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MouseTranslator.h"
+#include "Key.h"
+#include "MouseStat.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+
+namespace
+{
+
+using ActionName = std::string;
+using KeyID = uint32_t;
+
+static const std::map<ActionName, KeyID> MouseKeys =
+{
+    { "click"                    , KEY_MOUSE_CLICK },
+    { "leftclick"                , KEY_MOUSE_CLICK },
+    { "rightclick"               , KEY_MOUSE_RIGHTCLICK },
+    { "middleclick"              , KEY_MOUSE_MIDDLECLICK },
+    { "doubleclick"              , KEY_MOUSE_DOUBLE_CLICK },
+    { "longclick"                , KEY_MOUSE_LONG_CLICK },
+    { "wheelup"                  , KEY_MOUSE_WHEEL_UP },
+    { "wheeldown"                , KEY_MOUSE_WHEEL_DOWN },
+    { "mousemove"                , KEY_MOUSE_MOVE },
+    { "mousedrag"                , KEY_MOUSE_DRAG },
+    { "mousedragstart"           , KEY_MOUSE_DRAG_START },
+    { "mousedragend"             , KEY_MOUSE_DRAG_END },
+    { "mouserdrag"               , KEY_MOUSE_RDRAG },
+    { "mouserdragstart"          , KEY_MOUSE_RDRAG_START },
+    { "mouserdragend"            , KEY_MOUSE_RDRAG_END }
+};
+
+} // anonymous namespace
+
+uint32_t CMouseTranslator::TranslateMouseCommand(const TiXmlElement *pButton)
+{
+  uint32_t buttonId = 0;
+
+  if (pButton != nullptr)
+  {
+    std::string szKey = pButton->ValueStr();
+    if (!szKey.empty())
+    {
+      StringUtils::ToLower(szKey);
+
+      auto it = MouseKeys.find(szKey);
+      if (it != MouseKeys.end())
+        buttonId = it->second;
+
+      if (buttonId == 0)
+      {
+        CLog::Log(LOGERROR, "Unknown mouse action (%s), skipping", pButton->Value());
+      }
+      else
+      {
+        int id = 0;
+        if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS))
+        {
+          if (0 <= id && id < MOUSE_MAX_BUTTON)
+            buttonId += id;
+        }
+      }
+    }
+  }
+
+  return buttonId;
+}

--- a/xbmc/input/MouseTranslator.cpp
+++ b/xbmc/input/MouseTranslator.cpp
@@ -52,7 +52,7 @@ static const std::map<ActionName, KeyID> MouseKeys =
 
 } // anonymous namespace
 
-uint32_t CMouseTranslator::TranslateMouseCommand(const TiXmlElement *pButton)
+uint32_t CMouseTranslator::TranslateCommand(const TiXmlElement *pButton)
 {
   uint32_t buttonId = 0;
 

--- a/xbmc/input/MouseTranslator.h
+++ b/xbmc/input/MouseTranslator.h
@@ -1,0 +1,30 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+
+class TiXmlElement;
+
+class CMouseTranslator
+{
+public:
+  static uint32_t TranslateMouseCommand(const TiXmlElement *pButton);
+};

--- a/xbmc/input/MouseTranslator.h
+++ b/xbmc/input/MouseTranslator.h
@@ -26,5 +26,5 @@ class TiXmlElement;
 class CMouseTranslator
 {
 public:
-  static uint32_t TranslateMouseCommand(const TiXmlElement *pButton);
+  static uint32_t TranslateCommand(const TiXmlElement *pButton);
 };

--- a/xbmc/input/TouchTranslator.cpp
+++ b/xbmc/input/TouchTranslator.cpp
@@ -45,7 +45,7 @@ static const std::map<ActionName, TouchCommandID> TouchCommands =
     { "swipedown"                , ACTION_GESTURE_SWIPE_DOWN }
 };
 
-void CTouchTranslator::MapTouchActions(int windowID, const TiXmlNode *pTouch)
+void CTouchTranslator::MapActions(int windowID, const TiXmlNode *pTouch)
 {
   if (pTouch == nullptr)
     return;
@@ -95,7 +95,7 @@ void CTouchTranslator::Clear()
   m_touchMap.clear();
 }
 
-bool CTouchTranslator::TranslateTouchAction(int window, unsigned int touchCommand, int touchPointers, unsigned int &actionId, std::string &actionString)
+bool CTouchTranslator::TranslateAction(int window, unsigned int touchCommand, int touchPointers, unsigned int &actionId, std::string &actionString)
 {
   unsigned int touchActionKey = GetTouchActionKey(touchCommand, touchPointers);
 
@@ -157,7 +157,7 @@ unsigned int CTouchTranslator::TranslateTouchCommand(const TiXmlElement *pButton
   unsigned int touchActionKey = GetTouchActionKey(touchCommandId, pointers);
 
   action.strAction = szAction;
-  if (!CActionTranslator::TranslateActionString(szAction, action.actionId) || action.actionId == ACTION_NONE)
+  if (!CActionTranslator::TranslateString(szAction, action.actionId) || action.actionId == ACTION_NONE)
     return ACTION_NONE;
 
   return touchActionKey;

--- a/xbmc/input/TouchTranslator.cpp
+++ b/xbmc/input/TouchTranslator.cpp
@@ -1,0 +1,172 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "TouchTranslator.h"
+#include "ActionIDs.h"
+#include "ActionTranslator.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <map>
+
+using ActionName = std::string;
+using TouchCommandID = unsigned int;
+
+#define TOUCH_COMMAND_NONE  0
+
+static const std::map<ActionName, TouchCommandID> TouchCommands =
+{
+    { "tap"                      , ACTION_TOUCH_TAP },
+    { "longpress"                , ACTION_TOUCH_LONGPRESS },
+    { "pan"                      , ACTION_GESTURE_PAN },
+    { "zoom"                     , ACTION_GESTURE_ZOOM },
+    { "rotate"                   , ACTION_GESTURE_ROTATE },
+    { "swipeleft"                , ACTION_GESTURE_SWIPE_LEFT },
+    { "swiperight"               , ACTION_GESTURE_SWIPE_RIGHT },
+    { "swipeup"                  , ACTION_GESTURE_SWIPE_UP },
+    { "swipedown"                , ACTION_GESTURE_SWIPE_DOWN }
+};
+
+void CTouchTranslator::MapTouchActions(int windowID, const TiXmlNode *pTouch)
+{
+  if (pTouch == nullptr)
+    return;
+
+  TouchActionMap map;
+
+  // Check if there already is a touch map for the window ID
+  auto it = m_touchMap.find(windowID);
+  if (it != m_touchMap.end())
+  {
+    // Get the existing touch map and remove it from the window mapping as it
+    // will be inserted later on
+    map = std::move(it->second);
+    m_touchMap.erase(it);
+  }
+
+  const TiXmlElement *pTouchElem = pTouch->ToElement();
+  if (pTouchElem == nullptr)
+    return;
+
+  const TiXmlElement *pButton = pTouchElem->FirstChildElement();
+  while (pButton != nullptr)
+  {
+    CTouchAction action;
+    unsigned int touchActionKey = TranslateTouchCommand(pButton, action);
+    if (touchActionKey != ACTION_NONE)
+    {
+      // check if there already is a mapping for the parsed action
+      // and remove it if necessary
+      TouchActionMap::iterator actionIt = map.find(touchActionKey);
+      if (actionIt != map.end())
+        map.erase(actionIt);
+
+      map.insert(std::make_pair(touchActionKey, std::move(action)));
+    }
+
+    pButton = pButton->NextSiblingElement();
+  }
+
+  // add the modified touch map with the window ID
+  if (!map.empty())
+    m_touchMap.insert(std::make_pair(windowID, std::move(map)));
+}
+
+void CTouchTranslator::Clear()
+{
+  m_touchMap.clear();
+}
+
+bool CTouchTranslator::TranslateTouchAction(int window, unsigned int touchCommand, int touchPointers, unsigned int &actionId, std::string &actionString)
+{
+  unsigned int touchActionKey = GetTouchActionKey(touchCommand, touchPointers);
+
+  actionId = GetActionID(window, touchActionKey, actionString);
+
+  return actionId != ACTION_NONE;
+}
+
+unsigned int CTouchTranslator::GetActionID(WindowID window, TouchActionKey touchActionKey, std::string &actionString)
+{
+  auto windowIt = m_touchMap.find(window);
+  if (windowIt == m_touchMap.end())
+    return ACTION_NONE;
+
+  auto touchIt = windowIt->second.find(touchActionKey);
+  if (touchIt == windowIt->second.end())
+    return ACTION_NONE;
+
+  actionString = touchIt->second.strAction;
+  return touchIt->second.actionId;
+}
+
+unsigned int CTouchTranslator::TranslateTouchCommand(const TiXmlElement *pButton, CTouchAction &action)
+{
+  const char *szButton = pButton->Value();
+  if (szButton == nullptr || pButton->FirstChild() == nullptr)
+    return ACTION_NONE;
+
+  const char *szAction = pButton->FirstChild()->Value();
+  if (szAction == nullptr)
+    return ACTION_NONE;
+
+  std::string strTouchCommand = szButton;
+  StringUtils::ToLower(strTouchCommand);
+
+  // Handle direction
+  const char *attrVal = pButton->Attribute("direction");
+  if (attrVal != nullptr)
+    strTouchCommand += attrVal;
+
+  // Lookup command
+  unsigned int touchCommandId = TOUCH_COMMAND_NONE;
+  auto it = TouchCommands.find(strTouchCommand);
+  if (it != TouchCommands.end())
+    touchCommandId = it->second;
+
+  if (touchCommandId == TOUCH_COMMAND_NONE)
+  {
+    CLog::Log(LOGERROR, "%s: Can't find touch command %s", __FUNCTION__, szButton);
+    return ACTION_NONE;
+  }
+
+  // Handle pointers
+  int pointers = 1;
+  attrVal = pButton->Attribute("pointers");
+  if (attrVal != nullptr)
+    pointers = (int)strtol(attrVal, nullptr, 0);
+
+  unsigned int touchActionKey = GetTouchActionKey(touchCommandId, pointers);
+
+  action.strAction = szAction;
+  if (!CActionTranslator::TranslateActionString(szAction, action.actionId) || action.actionId == ACTION_NONE)
+    return ACTION_NONE;
+
+  return touchActionKey;
+}
+
+unsigned int CTouchTranslator::GetTouchActionKey(unsigned int touchCommandId, int touchPointers)
+{
+  if (touchPointers <= 0)
+    touchPointers = 1;
+
+  return touchCommandId + touchPointers - 1;
+}

--- a/xbmc/input/TouchTranslator.h
+++ b/xbmc/input/TouchTranslator.h
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <map>
+#include <string>
+
+class TiXmlElement;
+class TiXmlNode;
+
+class CTouchTranslator
+{
+public:
+  CTouchTranslator() = default;
+
+  void MapTouchActions(int windowID, const TiXmlNode *pTouch);
+
+  void Clear();
+
+  bool TranslateTouchAction(int window, unsigned int touchCommand, int touchPointers, unsigned int &actionId, std::string &actionString);
+
+private:
+  struct CTouchAction
+  {
+    unsigned int actionId;
+    std::string strAction; // Needed for "ActivateWindow()" type actions
+  };
+
+  using TouchActionKey = unsigned int;
+  using TouchActionMap = std::map<TouchActionKey, CTouchAction>;
+
+  using WindowID = int;
+  using TouchMap = std::map<WindowID, TouchActionMap>;
+
+  unsigned int GetActionID(WindowID window, TouchActionKey touchActionKey, std::string &actionString);
+
+  static unsigned int TranslateTouchCommand(const TiXmlElement *pButton, CTouchAction &action);
+
+  static unsigned int GetTouchActionKey(unsigned int touchCommandId, int touchPointers);
+
+  TouchMap m_touchMap;
+};

--- a/xbmc/input/TouchTranslator.h
+++ b/xbmc/input/TouchTranslator.h
@@ -30,11 +30,11 @@ class CTouchTranslator
 public:
   CTouchTranslator() = default;
 
-  void MapTouchActions(int windowID, const TiXmlNode *pTouch);
+  void MapActions(int windowID, const TiXmlNode *pTouch);
 
   void Clear();
 
-  bool TranslateTouchAction(int window, unsigned int touchCommand, int touchPointers, unsigned int &actionId, std::string &actionString);
+  bool TranslateAction(int window, unsigned int touchCommand, int touchPointers, unsigned int &actionId, std::string &actionString);
 
 private:
   struct CTouchAction

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -1,0 +1,253 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "WindowTranslator.h"
+#include "guilib/WindowIDs.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#include <algorithm>
+#include <map>
+#include <stdlib.h>
+
+namespace
+{
+using WindowName = std::string;
+using WindowID = int;
+
+static const std::map<WindowName, WindowID> WindowMapping =
+{
+    { "home"                     , WINDOW_HOME },
+    { "programs"                 , WINDOW_PROGRAMS },
+    { "pictures"                 , WINDOW_PICTURES },
+    { "filemanager"              , WINDOW_FILES },
+    { "settings"                 , WINDOW_SETTINGS_MENU },
+    { "music"                    , WINDOW_MUSIC_NAV },
+    { "videos"                   , WINDOW_VIDEO_NAV },
+    { "tvchannels"               , WINDOW_TV_CHANNELS },
+    { "tvrecordings"             , WINDOW_TV_RECORDINGS },
+    { "tvguide"                  , WINDOW_TV_GUIDE },
+    { "tvtimers"                 , WINDOW_TV_TIMERS },
+    { "tvsearch"                 , WINDOW_TV_SEARCH },
+    { "radiochannels"            , WINDOW_RADIO_CHANNELS },
+    { "radiorecordings"          , WINDOW_RADIO_RECORDINGS },
+    { "radioguide"               , WINDOW_RADIO_GUIDE },
+    { "radiotimers"              , WINDOW_RADIO_TIMERS },
+    { "radiosearch"              , WINDOW_RADIO_SEARCH },
+    { "gamecontrollers"          , WINDOW_DIALOG_GAME_CONTROLLERS },
+    { "games"                    , WINDOW_GAMES },
+    { "pvrguideinfo"             , WINDOW_DIALOG_PVR_GUIDE_INFO },
+    { "pvrrecordinginfo"         , WINDOW_DIALOG_PVR_RECORDING_INFO },
+    { "pvrradiordsinfo"          , WINDOW_DIALOG_PVR_RADIO_RDS_INFO },
+    { "pvrtimersetting"          , WINDOW_DIALOG_PVR_TIMER_SETTING },
+    { "pvrgroupmanager"          , WINDOW_DIALOG_PVR_GROUP_MANAGER },
+    { "pvrchannelmanager"        , WINDOW_DIALOG_PVR_CHANNEL_MANAGER },
+    { "pvrguidesearch"           , WINDOW_DIALOG_PVR_GUIDE_SEARCH },
+    { "pvrchannelscan"           , WINDOW_DIALOG_PVR_CHANNEL_SCAN },
+    { "pvrupdateprogress"        , WINDOW_DIALOG_PVR_UPDATE_PROGRESS },
+    { "pvrosdchannels"           , WINDOW_DIALOG_PVR_OSD_CHANNELS },
+    { "pvrchannelguide"          , WINDOW_DIALOG_PVR_CHANNEL_GUIDE },
+    { "pvrosdguide"              , WINDOW_DIALOG_PVR_CHANNEL_GUIDE }, // backward compatibility to v17
+    { "pvrosdteletext"           , WINDOW_DIALOG_OSD_TELETEXT },
+    { "systeminfo"               , WINDOW_SYSTEM_INFORMATION },
+    { "testpattern"              , WINDOW_TEST_PATTERN },
+    { "screencalibration"        , WINDOW_SCREEN_CALIBRATION },
+    { "systemsettings"           , WINDOW_SETTINGS_SYSTEM },
+    { "servicesettings"          , WINDOW_SETTINGS_SERVICE },
+    { "pvrsettings"              , WINDOW_SETTINGS_MYPVR },
+    { "playersettings"           , WINDOW_SETTINGS_PLAYER },
+    { "mediasettings"            , WINDOW_SETTINGS_MEDIA },
+    { "interfacesettings"        , WINDOW_SETTINGS_INTERFACE },
+    { "appearancesettings"       , WINDOW_SETTINGS_INTERFACE },	// backward compatibility to v16
+    { "gamesettings"             , WINDOW_SETTINGS_MYGAMES },
+    { "videoplaylist"            , WINDOW_VIDEO_PLAYLIST },
+    { "loginscreen"              , WINDOW_LOGIN_SCREEN },
+    { "profiles"                 , WINDOW_SETTINGS_PROFILES },
+    { "skinsettings"             , WINDOW_SKIN_SETTINGS },
+    { "addonbrowser"             , WINDOW_ADDON_BROWSER },
+    { "yesnodialog"              , WINDOW_DIALOG_YES_NO },
+    { "progressdialog"           , WINDOW_DIALOG_PROGRESS },
+    { "virtualkeyboard"          , WINDOW_DIALOG_KEYBOARD },
+    { "volumebar"                , WINDOW_DIALOG_VOLUME_BAR },
+    { "submenu"                  , WINDOW_DIALOG_SUB_MENU },
+    { "favourites"               , WINDOW_DIALOG_FAVOURITES },
+    { "contextmenu"              , WINDOW_DIALOG_CONTEXT_MENU },
+    { "notification"             , WINDOW_DIALOG_KAI_TOAST },
+    { "numericinput"             , WINDOW_DIALOG_NUMERIC },
+    { "gamepadinput"             , WINDOW_DIALOG_GAMEPAD },
+    { "shutdownmenu"             , WINDOW_DIALOG_BUTTON_MENU },
+    { "playercontrols"           , WINDOW_DIALOG_PLAYER_CONTROLS },
+    { "playerprocessinfo"        , WINDOW_DIALOG_PLAYER_PROCESS_INFO },
+    { "seekbar"                  , WINDOW_DIALOG_SEEK_BAR },
+    { "musicosd"                 , WINDOW_DIALOG_MUSIC_OSD },
+    { "addonsettings"            , WINDOW_DIALOG_ADDON_SETTINGS },
+    { "visualisationpresetlist"  , WINDOW_DIALOG_VIS_PRESET_LIST },
+    { "osdcmssettings"           , WINDOW_DIALOG_CMS_OSD_SETTINGS },
+    { "osdvideosettings"         , WINDOW_DIALOG_VIDEO_OSD_SETTINGS },
+    { "osdaudiosettings"         , WINDOW_DIALOG_AUDIO_OSD_SETTINGS },
+    { "audiodspmanager"          , WINDOW_DIALOG_AUDIO_DSP_MANAGER },
+    { "osdaudiodspsettings"      , WINDOW_DIALOG_AUDIO_DSP_OSD_SETTINGS },
+    { "videobookmarks"           , WINDOW_DIALOG_VIDEO_BOOKMARKS },
+    { "filebrowser"              , WINDOW_DIALOG_FILE_BROWSER },
+    { "networksetup"             , WINDOW_DIALOG_NETWORK_SETUP },
+    { "mediasource"              , WINDOW_DIALOG_MEDIA_SOURCE },
+    { "profilesettings"          , WINDOW_DIALOG_PROFILE_SETTINGS },
+    { "locksettings"             , WINDOW_DIALOG_LOCK_SETTINGS },
+    { "contentsettings"          , WINDOW_DIALOG_CONTENT_SETTINGS },
+    { "songinformation"          , WINDOW_DIALOG_SONG_INFO },
+    { "smartplaylisteditor"      , WINDOW_DIALOG_SMART_PLAYLIST_EDITOR },
+    { "smartplaylistrule"        , WINDOW_DIALOG_SMART_PLAYLIST_RULE },
+    { "busydialog"               , WINDOW_DIALOG_BUSY },
+    { "pictureinfo"              , WINDOW_DIALOG_PICTURE_INFO },
+    { "accesspoints"             , WINDOW_DIALOG_ACCESS_POINTS },
+    { "fullscreeninfo"           , WINDOW_DIALOG_FULLSCREEN_INFO },
+    { "sliderdialog"             , WINDOW_DIALOG_SLIDER },
+    { "addoninformation"         , WINDOW_DIALOG_ADDON_INFO },
+    { "subtitlesearch"           , WINDOW_DIALOG_SUBTITLES },
+    { "musicplaylist"            , WINDOW_MUSIC_PLAYLIST },
+    { "musicplaylisteditor"      , WINDOW_MUSIC_PLAYLIST_EDITOR },
+    { "teletext"                 , WINDOW_DIALOG_OSD_TELETEXT },
+    { "selectdialog"             , WINDOW_DIALOG_SELECT },
+    { "musicinformation"         , WINDOW_DIALOG_MUSIC_INFO },
+    { "okdialog"                 , WINDOW_DIALOG_OK },
+    { "movieinformation"         , WINDOW_DIALOG_VIDEO_INFO },
+    { "textviewer"               , WINDOW_DIALOG_TEXT_VIEWER },
+    { "fullscreenvideo"          , WINDOW_FULLSCREEN_VIDEO },
+    { "fullscreenlivetv"         , WINDOW_FULLSCREEN_LIVETV },         // virtual window/keymap section for PVR specific bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
+    { "fullscreenradio"          , WINDOW_FULLSCREEN_RADIO },          // virtual window for fullscreen radio, uses WINDOW_VISUALISATION as fallback
+    { "fullscreengame"           , WINDOW_FULLSCREEN_GAME },           // virtual window for fullscreen games, uses WINDOW_FULLSCREEN_VIDEO as fallback
+    { "visualisation"            , WINDOW_VISUALISATION },
+    { "slideshow"                , WINDOW_SLIDESHOW },
+    { "weather"                  , WINDOW_WEATHER },
+    { "screensaver"              , WINDOW_SCREENSAVER },
+    { "videoosd"                 , WINDOW_DIALOG_VIDEO_OSD },
+    { "videomenu"                , WINDOW_VIDEO_MENU },
+    { "videotimeseek"            , WINDOW_VIDEO_TIME_SEEK },
+    { "startwindow"              , WINDOW_START },
+    { "startup"                  , WINDOW_STARTUP_ANIM },
+    { "peripheralsettings"       , WINDOW_DIALOG_PERIPHERAL_SETTINGS },
+    { "extendedprogressdialog"   , WINDOW_DIALOG_EXT_PROGRESS },
+    { "mediafilter"              , WINDOW_DIALOG_MEDIA_FILTER },
+    { "addon"                    , WINDOW_ADDON_START },
+    { "eventlog"                 , WINDOW_EVENT_LOG},
+    { "tvtimerrules"             , WINDOW_TV_TIMER_RULES},
+    { "radiotimerrules"          , WINDOW_RADIO_TIMER_RULES}
+};
+
+struct FallbackWindowMapping
+{
+  int origin;
+  int target;
+};
+
+static const std::vector<FallbackWindowMapping> FallbackWindows =
+{
+    { WINDOW_FULLSCREEN_LIVETV   , WINDOW_FULLSCREEN_VIDEO },
+    { WINDOW_FULLSCREEN_RADIO    , WINDOW_VISUALISATION },
+    { WINDOW_FULLSCREEN_GAME     , WINDOW_FULLSCREEN_VIDEO }
+};
+} // anonymous namespace
+
+void CWindowTranslator::GetWindows(std::vector<std::string> &windowList)
+{
+  windowList.clear();
+  windowList.reserve(WindowMapping.size());
+  for (auto itMapping : WindowMapping)
+    windowList.push_back(itMapping.first);
+}
+
+int CWindowTranslator::TranslateWindow(const std::string &window)
+{
+  std::string strWindow(window);
+  if (strWindow.empty())
+    return WINDOW_INVALID;
+
+  StringUtils::ToLower(strWindow);
+
+  // Eliminate .xml
+  if (StringUtils::EndsWith(strWindow, ".xml"))
+    strWindow = strWindow.substr(0, strWindow.size() - 4);
+
+  // window12345, for custom window to be keymapped
+  if (strWindow.length() > 6 && StringUtils::StartsWith(strWindow, "window"))
+    strWindow = strWindow.substr(6);
+
+  // Drop "my" prefix
+  if (StringUtils::StartsWith(strWindow, "my"))
+    strWindow = strWindow.substr(2);
+
+  if (StringUtils::IsNaturalNumber(strWindow))
+  {
+    // Allow a full window ID or a delta ID
+    int iWindow = atoi(strWindow.c_str());
+    if (iWindow > WINDOW_INVALID)
+      return iWindow;
+
+    return WINDOW_HOME + iWindow;
+  }
+
+  // Run through the window structure
+  auto it = WindowMapping.find(strWindow);
+  if (it != WindowMapping.end())
+    return it->second;
+
+  CLog::Log(LOGERROR, "Window Translator: Can't find window %s", window.c_str());
+
+  return WINDOW_INVALID;
+}
+
+std::string CWindowTranslator::TranslateWindow(int windowId)
+{
+  static auto reverseWindowMapping = CreateReverseWindowMapping();
+
+  auto it = reverseWindowMapping.find(windowId);
+  if (it != reverseWindowMapping.end())
+    return it->second;
+
+  return "";
+}
+
+int CWindowTranslator::GetFallbackWindow(int windowId)
+{
+  auto it = std::find_if(FallbackWindows.begin(), FallbackWindows.end(),
+    [windowId](const FallbackWindowMapping& mapping)
+    {
+      return mapping.origin == windowId;
+    });
+
+  if (it != FallbackWindows.end())
+    return it->target;
+
+  // For add-on windows use WINDOW_ADDON_START because ID is dynamic
+  if (WINDOW_ADDON_START < windowId && windowId <= WINDOW_ADDON_END)
+    return WINDOW_ADDON_START;
+
+  return -1;
+}
+
+std::map<int, const char*> CWindowTranslator::CreateReverseWindowMapping()
+{
+  std::map<WindowID, const char*> reverseWindowMapping;
+
+  for (auto itMapping : WindowMapping)
+    reverseWindowMapping.insert(std::make_pair(itMapping.second, itMapping.first.c_str()));
+
+  return reverseWindowMapping;
+}

--- a/xbmc/input/WindowTranslator.h
+++ b/xbmc/input/WindowTranslator.h
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+class CWindowTranslator
+{
+public:
+  /*!
+   * \brief Get a list of all known window names
+   */
+  static void GetWindows(std::vector<std::string> &windowList);
+
+  /*!
+   * \brief Translate between a window name and its ID
+   * \param window The name of the window
+   * \return ID of the window, or WINDOW_INVALID if not found
+   */
+  static int TranslateWindow(const std::string &window);
+
+  /*!
+   * \brief Translate between a window id and it's name
+   * \param window id of the window
+   * \return name of the window, or an empty string if not found
+   */
+  static std::string TranslateWindow(int windowId);
+
+  /*!
+   * \brief Get the window ID that should be used as fallback for keymap input
+   * \return The fallback window, or -1 for no fallback window
+   */
+  static int GetFallbackWindow(int windowId);
+
+private:
+  static std::map<int, const char*> CreateReverseWindowMapping();
+};

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -25,6 +25,8 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
+#include "input/ActionTranslator.h"
+#include "input/ButtonTranslator.h"
 #include "input/Key.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -51,8 +53,8 @@ using namespace KODI::MESSAGING;
 static int Action(const std::vector<std::string>& params)
 {
   // try translating the action from our ButtonTranslator
-  int actionID;
-  if (CButtonTranslator::TranslateActionString(params[0].c_str(), actionID))
+  unsigned int actionID;
+  if (CActionTranslator::TranslateActionString(params[0].c_str(), actionID))
   {
     int windowID = params.size() == 2 ? CButtonTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
     CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, windowID, -1, static_cast<void*>(new CAction(actionID)));

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -54,7 +54,7 @@ static int Action(const std::vector<std::string>& params)
 {
   // try translating the action from our ButtonTranslator
   unsigned int actionID;
-  if (CActionTranslator::TranslateActionString(params[0].c_str(), actionID))
+  if (CActionTranslator::TranslateString(params[0].c_str(), actionID))
   {
     int windowID = params.size() == 2 ? CWindowTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
     CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, windowID, -1, static_cast<void*>(new CAction(actionID)));

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -26,8 +26,8 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
 #include "input/ActionTranslator.h"
-#include "input/ButtonTranslator.h"
 #include "input/Key.h"
+#include "input/WindowTranslator.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
@@ -56,7 +56,7 @@ static int Action(const std::vector<std::string>& params)
   unsigned int actionID;
   if (CActionTranslator::TranslateActionString(params[0].c_str(), actionID))
   {
-    int windowID = params.size() == 2 ? CButtonTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
+    int windowID = params.size() == 2 ? CWindowTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
     CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, windowID, -1, static_cast<void*>(new CAction(actionID)));
   }
 
@@ -84,7 +84,7 @@ static int ActivateWindow(const std::vector<std::string>& params2)
   }
 
   // confirm the window destination is valid prior to switching
-  int iWindow = CButtonTranslator::TranslateWindow(strWindow);
+  int iWindow = CWindowTranslator::TranslateWindow(strWindow);
   if (iWindow != WINDOW_INVALID)
   {
     // compare the given directory param with the current active directory
@@ -127,7 +127,7 @@ static int ActivateAndFocus(const std::vector<std::string>& params)
   std::string strWindow = params[0];
 
   // confirm the window destination is valid prior to switching
-  int iWindow = CButtonTranslator::TranslateWindow(strWindow);
+  int iWindow = CWindowTranslator::TranslateWindow(strWindow);
   if (iWindow != WINDOW_INVALID)
   {
     if (iWindow != g_windowManager.GetActiveWindow())
@@ -229,7 +229,7 @@ static int CancelAlarm(const std::vector<std::string>& params)
  */
 static int ClearProperty(const std::vector<std::string>& params)
 {
-  CGUIWindow *window = g_windowManager.GetWindow(params.size() > 1 ? CButtonTranslator::TranslateWindow(params[1]) : g_windowManager.GetFocusedWindow());
+  CGUIWindow *window = g_windowManager.GetWindow(params.size() > 1 ? CWindowTranslator::TranslateWindow(params[1]) : g_windowManager.GetFocusedWindow());
   if (window)
     window->SetProperty(params[0],"");
 
@@ -252,7 +252,7 @@ static int CloseDialog(const std::vector<std::string>& params)
   }
   else
   {
-    int id = CButtonTranslator::TranslateWindow(params[0]);
+    int id = CWindowTranslator::TranslateWindow(params[0]);
     CGUIWindow *window = g_windowManager.GetWindow(id);
     if (window && window->IsDialog())
       ((CGUIDialog *)window)->Close(bForce);
@@ -379,7 +379,7 @@ static int SetResolution(const std::vector<std::string>& params)
  */
 static int SetProperty(const std::vector<std::string>& params)
 {
-  CGUIWindow *window = g_windowManager.GetWindow(params.size() > 2 ? CButtonTranslator::TranslateWindow(params[2]) : g_windowManager.GetFocusedWindow());
+  CGUIWindow *window = g_windowManager.GetWindow(params.size() > 2 ? CWindowTranslator::TranslateWindow(params[2]) : g_windowManager.GetFocusedWindow());
   if (window)
     window->SetProperty(params[0],params[1]);
 

--- a/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIControlBuiltins.cpp
@@ -21,7 +21,7 @@
 #include "GUIControlBuiltins.h"
 
 #include "guilib/GUIWindowManager.h"
-#include "input/ButtonTranslator.h"
+#include "input/WindowTranslator.h"
 #include "utils/StringUtils.h"
 
 /*! \brief Send a move event to a GUI control.
@@ -48,7 +48,7 @@ static int SendClick(const std::vector<std::string>& params)
   if (params.size() == 2)
   {
     // have a window - convert it
-    int windowID = CButtonTranslator::TranslateWindow(params[0]);
+    int windowID = CWindowTranslator::TranslateWindow(params[0]);
     CGUIMessage message(GUI_MSG_CLICKED, atoi(params[1].c_str()), windowID);
     g_windowManager.SendMessage(message);
   }
@@ -70,7 +70,7 @@ static int SendClick(const std::vector<std::string>& params)
 static int SendMessage(const std::vector<std::string>& params)
 {
   int controlID = atoi(params[0].c_str());
-  int windowID = (params.size() == 3) ? CButtonTranslator::TranslateWindow(params[2]) : g_windowManager.GetActiveWindow();
+  int windowID = (params.size() == 3) ? CWindowTranslator::TranslateWindow(params[2]) : g_windowManager.GetActiveWindow();
   if (params[1] == "moveup")
     g_windowManager.SendMessage(GUI_MSG_MOVE_OFFSET, windowID, controlID, 1);
   else if (params[1] == "movedown")

--- a/xbmc/interfaces/json-rpc/FavouritesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FavouritesOperations.cpp
@@ -20,12 +20,14 @@
 
 #include "FavouritesOperations.h"
 #include "favourites/FavouritesService.h"
-#include "input/ButtonTranslator.h"
+#include "input/WindowTranslator.h"
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "guilib/WindowIDs.h"
+#include "ServiceBroker.h"
+
 #include <vector>
 
 using namespace JSONRPC;
@@ -65,7 +67,7 @@ JSONRPC_STATUS CFavouritesOperations::GetFavourites(const std::string &method, I
       if (fields.find("window") != fields.end())
       {
         if (StringUtils::IsNaturalNumber(parameters[0]))
-          object["window"] = CButtonTranslator::TranslateWindow(strtol(parameters[0].c_str(), NULL, 10));
+          object["window"] = CWindowTranslator::TranslateWindow(strtol(parameters[0].c_str(), NULL, 10));
         else
           object["window"] = parameters[0];
       }
@@ -135,7 +137,7 @@ JSONRPC_STATUS CFavouritesOperations::AddFavourite(const std::string &method, IT
   if (type.compare("window") == 0)
   {
     item = CFileItem(parameterObject["windowparameter"].asString(), true);
-    contextWindow = CButtonTranslator::TranslateWindow(parameterObject["window"].asString());
+    contextWindow = CWindowTranslator::TranslateWindow(parameterObject["window"].asString());
     if (contextWindow == WINDOW_INVALID)
       return InvalidParams;
   } 

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -89,7 +89,7 @@ JSONRPC_STATUS CInputOperations::SendText(const std::string &method, ITransportL
 JSONRPC_STATUS CInputOperations::ExecuteAction(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
   unsigned int action;
-  if (!CActionTranslator::TranslateActionString(parameterObject["action"].asString().c_str(), action))
+  if (!CActionTranslator::TranslateString(parameterObject["action"].asString().c_str(), action))
     return InvalidParams;
 
   return SendAction(action);

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -25,7 +25,7 @@
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "input/ButtonTranslator.h"
+#include "input/ActionTranslator.h"
 #include "input/Key.h"
 #include "utils/Variant.h"
 #include "input/XBMC_keyboard.h"
@@ -88,8 +88,8 @@ JSONRPC_STATUS CInputOperations::SendText(const std::string &method, ITransportL
 
 JSONRPC_STATUS CInputOperations::ExecuteAction(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  int action;
-  if (!CButtonTranslator::TranslateActionString(parameterObject["action"].asString().c_str(), action))
+  unsigned int action;
+  if (!CActionTranslator::TranslateActionString(parameterObject["action"].asString().c_str(), action))
     return InvalidParams;
 
   return SendAction(action);

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -26,7 +26,7 @@
 #include "addons/IAddon.h"
 #include "dbwrappers/DatabaseQuery.h"
 #include "input/ActionTranslator.h"
-#include "input/ButtonTranslator.h"
+#include "input/WindowTranslator.h"
 #include "interfaces/AnnouncementManager.h"
 #include "playlists/SmartPlayList.h"
 #include "settings/AdvancedSettings.h"
@@ -56,7 +56,7 @@ void CJSONRPC::Initialize()
   CJSONServiceDescription::AddEnum("Input.Action", enumList);
 
   enumList.clear();
-  CButtonTranslator::GetWindows(enumList);
+  CWindowTranslator::GetWindows(enumList);
   CJSONServiceDescription::AddEnum("GUI.Window", enumList);
 
   // filter-related enums

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -25,6 +25,7 @@
 #include "addons/Addon.h"
 #include "addons/IAddon.h"
 #include "dbwrappers/DatabaseQuery.h"
+#include "input/ActionTranslator.h"
 #include "input/ButtonTranslator.h"
 #include "interfaces/AnnouncementManager.h"
 #include "playlists/SmartPlayList.h"
@@ -51,7 +52,7 @@ void CJSONRPC::Initialize()
   CJSONServiceDescription::AddEnum("Addon.Types", enumList);
 
   enumList.clear();
-  CButtonTranslator::GetActions(enumList);
+  CActionTranslator::GetActions(enumList);
   CJSONServiceDescription::AddEnum("Input.Action", enumList);
 
   enumList.clear();

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -27,6 +27,7 @@
 #include "EventPacket.h"
 #include "threads/SingleLock.h"
 #include "input/ButtonTranslator.h"
+#include "input/GamepadTranslator.h"
 #include "input/IRTranslator.h"
 #include <map>
 #include <queue>
@@ -77,7 +78,7 @@ void CEventButtonState::Load()
       }
       else if  ( m_mapName.compare("XG") == 0 ) // xbox gamepad map
       {
-        m_iKeyCode = CButtonTranslator::TranslateGamepadString( m_buttonName.c_str() );
+        m_iKeyCode = CGamepadTranslator::TranslateGamepadString( m_buttonName.c_str() );
       }
       else if  ( m_mapName.compare("R1") == 0 ) // xbox remote map
       {

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -27,6 +27,7 @@
 #include "EventPacket.h"
 #include "threads/SingleLock.h"
 #include "input/ButtonTranslator.h"
+#include "input/IRTranslator.h"
 #include <map>
 #include <queue>
 #include "filesystem/File.h"
@@ -80,11 +81,11 @@ void CEventButtonState::Load()
       }
       else if  ( m_mapName.compare("R1") == 0 ) // xbox remote map
       {
-        m_iKeyCode = CButtonTranslator::TranslateRemoteString( m_buttonName.c_str() );
+        m_iKeyCode = CIRTranslator::TranslateRemoteString( m_buttonName.c_str() );
       }
       else if  ( m_mapName.compare("R2") == 0 ) // xbox universal remote map
       {
-        m_iKeyCode = CButtonTranslator::TranslateUniversalRemoteString( m_buttonName.c_str() );
+        m_iKeyCode = CIRTranslator::TranslateUniversalRemoteString( m_buttonName.c_str() );
       }
       else if ( (m_mapName.length() > 3) &&
                 (StringUtils::StartsWith(m_mapName, "LI:")) ) // starts with LI: ?

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -75,15 +75,15 @@ void CEventButtonState::Load()
     {
       if ( m_mapName.compare("KB") == 0 ) // standard keyboard map
       {
-        m_iKeyCode = CKeyboardTranslator::TranslateKeyboardString( m_buttonName.c_str() );
+        m_iKeyCode = CKeyboardTranslator::TranslateString( m_buttonName.c_str() );
       }
       else if  ( m_mapName.compare("XG") == 0 ) // xbox gamepad map
       {
-        m_iKeyCode = CGamepadTranslator::TranslateGamepadString( m_buttonName.c_str() );
+        m_iKeyCode = CGamepadTranslator::TranslateString( m_buttonName.c_str() );
       }
       else if  ( m_mapName.compare("R1") == 0 ) // xbox remote map
       {
-        m_iKeyCode = CIRTranslator::TranslateRemoteString( m_buttonName.c_str() );
+        m_iKeyCode = CIRTranslator::TranslateString( m_buttonName.c_str() );
       }
       else if  ( m_mapName.compare("R2") == 0 ) // xbox universal remote map
       {

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -29,6 +29,7 @@
 #include "input/ButtonTranslator.h"
 #include "input/GamepadTranslator.h"
 #include "input/IRTranslator.h"
+#include "input/KeyboardTranslator.h"
 #include <map>
 #include <queue>
 #include "filesystem/File.h"
@@ -74,7 +75,7 @@ void CEventButtonState::Load()
     {
       if ( m_mapName.compare("KB") == 0 ) // standard keyboard map
       {
-        m_iKeyCode = CButtonTranslator::TranslateKeyboardString( m_buttonName.c_str() );
+        m_iKeyCode = CKeyboardTranslator::TranslateKeyboardString( m_buttonName.c_str() );
       }
       else if  ( m_mapName.compare("XG") == 0 ) // xbox gamepad map
       {

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -30,7 +30,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "interfaces/builtins/Builtins.h"
-#include "input/ButtonTranslator.h"
+#include "input/ActionTranslator.h"
 #include "threads/SingleLock.h"
 #include "Zeroconf.h"
 #include "guilib/GUIAudioManager.h"
@@ -348,8 +348,8 @@ bool CEventServer::ExecuteNextAction()
 
       case AT_BUTTON:
         {
-          int actionID;
-          CButtonTranslator::TranslateActionString(actionEvent.actionName.c_str(), actionID);
+          unsigned int actionID;
+          CActionTranslator::TranslateActionString(actionEvent.actionName.c_str(), actionID);
           CAction action(actionID, 1.0f, 0.0f, actionEvent.actionName);
           g_audioManager.PlayActionSound(action);
           g_application.OnAction(action);

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -349,7 +349,7 @@ bool CEventServer::ExecuteNextAction()
       case AT_BUTTON:
         {
           unsigned int actionID;
-          CActionTranslator::TranslateActionString(actionEvent.actionName.c_str(), actionID);
+          CActionTranslator::TranslateString(actionEvent.actionName.c_str(), actionID);
           CAction action(actionID, 1.0f, 0.0f, actionEvent.actionName);
           g_audioManager.PlayActionSound(action);
           g_application.OnAction(action);

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -25,7 +25,7 @@
 #include "utils/log.h"
 #include "CompileInfo.h"
 #include "filesystem/SpecialProtocol.h"
-#include "input/ButtonTranslator.h"
+#include "input/WindowTranslator.h"
 #include "guilib/GUIControlFactory.h"
 #include "guilib/GUIFontManager.h"
 #include "guilib/GUITextLayout.h"
@@ -136,7 +136,7 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
       point = CPoint(pointer->GetXPosition(), pointer->GetYPosition());
     if (window)
     {
-      std::string windowName = CButtonTranslator::TranslateWindow(window->GetID());
+      std::string windowName = CWindowTranslator::TranslateWindow(window->GetID());
       if (!windowName.empty())
         windowName += " (" + std::string(window->GetProperty("xmlfile").asString()) + ")";
       else


### PR DESCRIPTION
This refactors CButtonTranslator into separate classes for each type of input. Some classes own an instance of their keymap, others are fully static and CButtonTranslator uses its own keymap to translate the input type.

Needs testing:
- [x] LIRC and IRServerSuite
- [ ] Touch
- [ ] Custom controller (Apple Remote and Harmony Remote)
- [ ] EventServer gamepad
- [x] Joystick
- [x] Keyboard
- [x] Mouse
- [ ] Media commands on Windows for media keys

## Motivation and Context
I need to extend the joystick keymapper, but couldn't bring myself to add more code to CButtonTranslator.cpp. This gives me a separate file to stick the new code in.

Also ButtonTranslator.cpp shorted from 1700 lines to 500 lines. 'nuff said.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
