### PR TITLE
[network] CHTTPJsonRpcHandler: limit any other request method than POST to ReadData permissions on the JSON-RPC API

### DIFF
--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -39,7 +39,7 @@ bool CHTTPJsonRpcHandler::CanHandleRequest(const HTTPRequest &request) const
 
 int CHTTPJsonRpcHandler::HandleRequest()
 {
-  CHTTPClient client;
+  CHTTPClient client(m_request.method);
   bool isRequest = false;
   std::string jsonpCallback;
 
@@ -176,9 +176,12 @@ int CHTTPJsonRpcHandler::CHTTPTransportLayer::GetCapabilities()
   return JSONRPC::Response | JSONRPC::FileDownloadRedirect;
 }
 
-int CHTTPJsonRpcHandler::CHTTPClient::GetPermissionFlags()
+CHTTPJsonRpcHandler::CHTTPClient::CHTTPClient(HTTPMethod method)
+  : m_permissionFlags(JSONRPC::ReadData)
 {
-  return JSONRPC::OPERATION_PERMISSION_ALL;
+  // with a HTTP POST request everything is allowed
+  if (method == POST)
+    m_permissionFlags = JSONRPC::OPERATION_PERMISSION_ALL;
 }
 
 int CHTTPJsonRpcHandler::CHTTPClient::GetAnnouncementFlags()

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -61,7 +61,7 @@ private:
   {
   public:
     CHTTPTransportLayer() = default;
-    ~CHTTPTransportLayer() = default;
+    virtual ~CHTTPTransportLayer() = default;
 
     // implementations of JSONRPC::ITransportLayer
     bool PrepareDownload(const char *path, CVariant &details, std::string &protocol) override;
@@ -73,8 +73,14 @@ private:
   class CHTTPClient : public JSONRPC::IClient
   {
   public:
-    virtual int  GetPermissionFlags();
-    virtual int  GetAnnouncementFlags();
-    virtual bool SetAnnouncementFlags(int flags);
+    CHTTPClient(HTTPMethod method);
+    virtual ~CHTTPClient() = default;
+
+    int GetPermissionFlags() override { return m_permissionFlags; }
+    int GetAnnouncementFlags() override;
+    bool SetAnnouncementFlags(int flags) override;
+
+  private:
+    int m_permissionFlags;
   };
 };


### PR DESCRIPTION
This is an alternative approach to #12265 which still accepts HTTP GET requests to `/jsonrpc` but limits all non-POST requests to `ReadData` permissions. That means that it is still possible to use HTTP GET to `/jsonrpc` to get the whole API definition and it is still possible to call methods like `VideoLibrary.GetMovies`. But when trying to call a modifying JSON-RPC method like `Player.PlayPause` the following error will be returned:
```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32099,
    "message": "Bad client permission."
  },
  "id": 1
}
```
That way it's not possible anymore to perform any modifications using anything but HTTP POST.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
