### PR TITLE
[addons] change CAddonInfo usage to a shared_ptr

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -59,12 +59,11 @@ using XFILE::CFile;
 namespace ADDON
 {
 
-CAddon::CAddon(CAddonInfo addonInfo)
-  : m_addonInfo(std::move(addonInfo))
-  , m_userSettingsPath()
+CAddon::CAddon(const AddonInfoPtr& addonInfo)
+  : m_addonInfo(addonInfo)
   , m_loadSettingsFailed(false)
   , m_hasUserSettings(false)
-  , m_profilePath(StringUtils::Format("special://profile/addon_data/%s/", m_addonInfo.ID().c_str()))
+  , m_profilePath(StringUtils::Format("special://profile/addon_data/%s/", m_addonInfo->ID().c_str()))
   , m_settings(nullptr)
 {
   m_userSettingsPath = URIUtils::AddFileToFolder(m_profilePath, "settings.xml");
@@ -104,7 +103,7 @@ bool CAddon::LoadSettings(bool bForce /* = false */)
     GetSettings()->Uninitialize();
 
   // load the settings definition XML file
-  auto addonSettingsDefinitionFile = URIUtils::AddFileToFolder(m_addonInfo.Path(), "resources", "settings.xml");
+  auto addonSettingsDefinitionFile = URIUtils::AddFileToFolder(m_addonInfo->Path(), "resources", "settings.xml");
   CXBMCTinyXML addonSettingsDefinitionDoc;
   if (!addonSettingsDefinitionDoc.LoadFile(addonSettingsDefinitionFile))
   {
@@ -377,9 +376,9 @@ CAddonSettings* CAddon::GetSettings() const
 
 std::string CAddon::LibPath() const
 {
-  if (m_addonInfo.LibName().empty())
+  if (m_addonInfo->LibName().empty())
     return "";
-  return URIUtils::AddFileToFolder(m_addonInfo.Path(), m_addonInfo.LibName());
+  return URIUtils::AddFileToFolder(m_addonInfo->Path(), m_addonInfo->LibName());
 }
 
 AddonVersion CAddon::GetDependencyVersion(const std::string &dependencyID) const

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -53,41 +53,41 @@ void OnPostUnInstall(const AddonPtr& addon);
 class CAddon : public IAddon
 {
 public:
-  explicit CAddon(CAddonInfo addonInfo);
+  explicit CAddon(const AddonInfoPtr& addonInfo);
   virtual ~CAddon() {}
 
-  TYPE Type() const override { return m_addonInfo.MainType(); }
+  TYPE Type() const override { return m_addonInfo->MainType(); }
   TYPE FullType() const override { return Type(); }
-  bool IsType(TYPE type) const override { return type == m_addonInfo.MainType(); }
-  std::string ID() const override{ return m_addonInfo.ID(); }
-  std::string Name() const override { return m_addonInfo.Name(); }
+  bool IsType(TYPE type) const override { return type == m_addonInfo->MainType(); }
+  std::string ID() const override{ return m_addonInfo->ID(); }
+  std::string Name() const override { return m_addonInfo->Name(); }
   bool IsInUse() const override{ return false; };
-  AddonVersion Version() const override { return m_addonInfo.Version(); }
-  AddonVersion MinVersion() const override { return m_addonInfo.MinVersion(); }
-  std::string Summary() const override { return m_addonInfo.Summary(); }
-  std::string Description() const override { return m_addonInfo.Description(); }
-  std::string Path() const override { return m_addonInfo.Path(); }
+  AddonVersion Version() const override { return m_addonInfo->Version(); }
+  AddonVersion MinVersion() const override { return m_addonInfo->MinVersion(); }
+  std::string Summary() const override { return m_addonInfo->Summary(); }
+  std::string Description() const override { return m_addonInfo->Description(); }
+  std::string Path() const override { return m_addonInfo->Path(); }
   std::string Profile() const override { return m_profilePath; }
   std::string LibPath() const override;
-  std::string Author() const override { return m_addonInfo.Author(); }
-  std::string ChangeLog() const override { return m_addonInfo.ChangeLog(); }
-  std::string Icon() const override { return m_addonInfo.Icon(); };
-  ArtMap Art() const override { return m_addonInfo.Art(); }
-  std::vector<std::string> Screenshots() const override { return m_addonInfo.Screenshots(); };
-  std::string Disclaimer() const override { return m_addonInfo.Disclaimer(); }
-  std::string Broken() const override { return m_addonInfo.Broken(); }
-  CDateTime InstallDate() const override { return m_addonInfo.InstallDate(); }
-  CDateTime LastUpdated() const override { return m_addonInfo.LastUpdated(); }
-  CDateTime LastUsed() const override { return m_addonInfo.LastUsed(); }
-  std::string Origin() const override { return m_addonInfo.Origin(); }
-  uint64_t PackageSize() const override { return m_addonInfo.PackageSize(); }
-  const InfoMap& ExtraInfo() const override { return m_addonInfo.extrainfo; }
-  const ADDONDEPS& GetDeps() const override { return m_addonInfo.GetDeps(); }
+  std::string Author() const override { return m_addonInfo->Author(); }
+  std::string ChangeLog() const override { return m_addonInfo->ChangeLog(); }
+  std::string Icon() const override { return m_addonInfo->Icon(); };
+  ArtMap Art() const override { return m_addonInfo->Art(); }
+  std::vector<std::string> Screenshots() const override { return m_addonInfo->Screenshots(); };
+  std::string Disclaimer() const override { return m_addonInfo->Disclaimer(); }
+  std::string Broken() const override { return m_addonInfo->Broken(); }
+  CDateTime InstallDate() const override { return m_addonInfo->InstallDate(); }
+  CDateTime LastUpdated() const override { return m_addonInfo->LastUpdated(); }
+  CDateTime LastUsed() const override { return m_addonInfo->LastUsed(); }
+  std::string Origin() const override { return m_addonInfo->Origin(); }
+  uint64_t PackageSize() const override { return m_addonInfo->PackageSize(); }
+  const InfoMap& ExtraInfo() const override { return m_addonInfo->extrainfo; }
+  const ADDONDEPS& GetDeps() const override { return m_addonInfo->GetDeps(); }
 
   std::string FanArt() const override
   {
-    auto it = m_addonInfo.Art().find("fanart");
-    return it != m_addonInfo.Art().end() ? it->second : "";
+    auto it = m_addonInfo->Art().find("fanart");
+    return it != m_addonInfo->Art().end() ? it->second : "";
   }
 
   /*! \brief Check whether the this addon can be configured or not
@@ -198,7 +198,7 @@ public:
    \param version the version to meet.
    \return true if  min_version <= version <= current_version, false otherwise.
    */
-  bool MeetsVersion(const AddonVersion &version) const override { return m_addonInfo.MeetsVersion(version); }
+  bool MeetsVersion(const AddonVersion &version) const override { return m_addonInfo->MeetsVersion(version); }
   bool ReloadSettings() override;
 
   /*! \brief callback for when this add-on is disabled.
@@ -219,6 +219,8 @@ public:
   void OnPostInstall(bool update, bool modal) override {};
   void OnPreUnInstall() override {};
   void OnPostUnInstall() override {};
+
+  const AddonInfoPtr AddonInfo() const { return m_addonInfo; }
 
 protected:
   /*! \brief Whether or not the settings have been initialized. */
@@ -260,10 +262,10 @@ protected:
    */
   virtual bool SettingsToXML(CXBMCTinyXML &doc) const;
 
-  const CAddonInfo m_addonInfo;
   std::string m_userSettingsPath;
 
 private:
+  const AddonInfoPtr m_addonInfo;
   bool m_loadSettingsFailed;
   bool m_hasUserSettings;
 

--- a/xbmc/addons/AddonBuilder.cpp
+++ b/xbmc/addons/AddonBuilder.cpp
@@ -54,18 +54,18 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
   if (m_built)
     throw std::logic_error("Already built");
 
-  if (m_addonInfo.m_id.empty())
+  if (m_addonInfo->m_id.empty())
     return nullptr;
 
   m_built = true;
 
-  if (m_addonInfo.m_mainType == ADDON_UNKNOWN)
-    return std::make_shared<CAddon>(std::move(m_addonInfo));
+  if (m_addonInfo->m_mainType == ADDON_UNKNOWN)
+    return std::make_shared<CAddon>(m_addonInfo);
 
   if (m_extPoint == nullptr)
-    return FromProps(std::move(m_addonInfo));
+    return FromProps(m_addonInfo);
 
-  const TYPE type(m_addonInfo.m_mainType);
+  const TYPE type(m_addonInfo->m_mainType);
 
   // Handle screensaver special cases
   if (type == ADDON_SCREENSAVER)
@@ -73,7 +73,7 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
     // built in screensaver or python screensaver
     if (StringUtils::StartsWithNoCase(m_extPoint->plugin->identifier, "screensaver.xbmc.builtin.") ||
         URIUtils::HasExtension(CAddonMgr::GetInstance().GetExtValue(m_extPoint->configuration, "@library"), ".py"))
-      return std::make_shared<CAddon>(std::move(m_addonInfo));
+      return std::make_shared<CAddon>(m_addonInfo);
   }
 
   // Handle audio encoder special cases
@@ -81,7 +81,7 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
   {
     // built in audio encoder
     if (StringUtils::StartsWithNoCase(m_extPoint->plugin->identifier, "audioencoder.xbmc.builtin."))
-      return CAudioEncoder::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CAudioEncoder::FromExtension(m_addonInfo, m_extPoint);
   }
 
   // Ensure binary types have a valid library for the platform
@@ -106,63 +106,63 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
   {
     case ADDON_PLUGIN:
     case ADDON_SCRIPT:
-      return CPluginSource::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CPluginSource::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_SCRIPT_LIBRARY:
     case ADDON_SCRIPT_LYRICS:
     case ADDON_SCRIPT_MODULE:
     case ADDON_SUBTITLE_MODULE:
     case ADDON_SCRIPT_WEATHER:
-      return std::make_shared<CAddon>(std::move(m_addonInfo));
+      return std::make_shared<CAddon>(m_addonInfo);
     case ADDON_WEB_INTERFACE:
-      return CWebinterface::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CWebinterface::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_SERVICE:
-      return CService::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CService::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_SCRAPER_ALBUMS:
     case ADDON_SCRAPER_ARTISTS:
     case ADDON_SCRAPER_MOVIES:
     case ADDON_SCRAPER_MUSICVIDEOS:
     case ADDON_SCRAPER_TVSHOWS:
     case ADDON_SCRAPER_LIBRARY:
-      return CScraper::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CScraper::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_VIZ:
     case ADDON_SCREENSAVER:
-      return std::make_shared<CAddonDll>(std::move(m_addonInfo));
+      return std::make_shared<CAddonDll>(m_addonInfo);
 #ifdef HAS_PVRCLIENTS
     case ADDON_PVRDLL:
-      return PVR::CPVRClient::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return PVR::CPVRClient::FromExtension(m_addonInfo, m_extPoint);
 #endif
     case ADDON_ADSPDLL:
-      return std::make_shared<ActiveAE::CActiveAEDSPAddon>(std::move(m_addonInfo));
+      return std::make_shared<ActiveAE::CActiveAEDSPAddon>(m_addonInfo);
     case ADDON_AUDIOENCODER:
-      return CAudioEncoder::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CAudioEncoder::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_AUDIODECODER:
-      return CAudioDecoder::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CAudioDecoder::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_IMAGEDECODER:
-      return CImageDecoder::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CImageDecoder::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_INPUTSTREAM:
-      return CInputStream::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CInputStream::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_PERIPHERALDLL:
-      return PERIPHERALS::CPeripheralAddon::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return PERIPHERALS::CPeripheralAddon::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_GAMEDLL:
-      return GAME::CGameClient::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return GAME::CGameClient::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_VFS:
-      return CVFSEntry::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CVFSEntry::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_SKIN:
-      return CSkinInfo::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CSkinInfo::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_RESOURCE_IMAGES:
-      return CImageResource::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CImageResource::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_RESOURCE_GAMES:
-      return CGameResource::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CGameResource::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_RESOURCE_LANGUAGE:
-      return CLanguageResource::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CLanguageResource::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_RESOURCE_UISOUNDS:
-      return std::make_shared<CUISoundsResource>(std::move(m_addonInfo));
+      return std::make_shared<CUISoundsResource>(m_addonInfo);
     case ADDON_REPOSITORY:
-      return CRepository::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CRepository::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_CONTEXT_ITEM:
-      return CContextMenuAddon::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return CContextMenuAddon::FromExtension(m_addonInfo, m_extPoint);
     case ADDON_GAME_CONTROLLER:
-      return GAME::CController::FromExtension(std::move(m_addonInfo), m_extPoint);
+      return GAME::CController::FromExtension(m_addonInfo, m_extPoint);
     default:
       break;
   }
@@ -170,70 +170,70 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
 }
 
 
-AddonPtr CAddonBuilder::FromProps(CAddonInfo addonInfo)
+AddonPtr CAddonBuilder::FromProps(const AddonInfoPtr& addonInfo)
 {
   // FIXME: there is no need for this as none of the derived classes will contain any useful
   // information. We should return CAddon instances only, however there are several places that
   // down casts, which need to fixed first.
-  switch (addonInfo.m_mainType)
+  switch (addonInfo->m_mainType)
   {
     case ADDON_PLUGIN:
     case ADDON_SCRIPT:
-      return AddonPtr(new CPluginSource(std::move(addonInfo)));
+      return AddonPtr(new CPluginSource(addonInfo));
     case ADDON_SCRIPT_LIBRARY:
     case ADDON_SCRIPT_LYRICS:
     case ADDON_SCRIPT_WEATHER:
     case ADDON_SCRIPT_MODULE:
     case ADDON_SUBTITLE_MODULE:
-      return AddonPtr(new CAddon(std::move(addonInfo)));
+      return AddonPtr(new CAddon(addonInfo));
     case ADDON_WEB_INTERFACE:
-      return AddonPtr(new CWebinterface(std::move(addonInfo)));
+      return AddonPtr(new CWebinterface(addonInfo));
     case ADDON_SERVICE:
-      return AddonPtr(new CService(std::move(addonInfo)));
+      return AddonPtr(new CService(addonInfo));
     case ADDON_SCRAPER_ALBUMS:
     case ADDON_SCRAPER_ARTISTS:
     case ADDON_SCRAPER_MOVIES:
     case ADDON_SCRAPER_MUSICVIDEOS:
     case ADDON_SCRAPER_TVSHOWS:
     case ADDON_SCRAPER_LIBRARY:
-      return AddonPtr(new CScraper(std::move(addonInfo)));
+      return AddonPtr(new CScraper(addonInfo));
     case ADDON_SKIN:
-      return AddonPtr(new CSkinInfo(std::move(addonInfo)));
+      return AddonPtr(new CSkinInfo(addonInfo));
     case ADDON_VIZ:
     case ADDON_SCREENSAVER:
-      return AddonPtr(new CAddonDll(std::move(addonInfo)));
+      return AddonPtr(new CAddonDll(addonInfo));
     case ADDON_PVRDLL:
-      return AddonPtr(new PVR::CPVRClient(std::move(addonInfo)));
+      return AddonPtr(new PVR::CPVRClient(addonInfo));
     case ADDON_ADSPDLL:
-      return AddonPtr(new ActiveAE::CActiveAEDSPAddon(std::move(addonInfo)));
+      return AddonPtr(new ActiveAE::CActiveAEDSPAddon(addonInfo));
     case ADDON_AUDIOENCODER:
-      return AddonPtr(new CAudioEncoder(std::move(addonInfo)));
+      return AddonPtr(new CAudioEncoder(addonInfo));
     case ADDON_AUDIODECODER:
-      return AddonPtr(new CAudioDecoder(std::move(addonInfo)));
+      return AddonPtr(new CAudioDecoder(addonInfo));
     case ADDON_RESOURCE_IMAGES:
-      return AddonPtr(new CImageResource(std::move(addonInfo)));
+      return AddonPtr(new CImageResource(addonInfo));
     case ADDON_RESOURCE_GAMES:
-      return AddonPtr(new CGameResource(std::move(addonInfo)));
+      return AddonPtr(new CGameResource(addonInfo));
     case ADDON_RESOURCE_LANGUAGE:
-      return AddonPtr(new CLanguageResource(std::move(addonInfo)));
+      return AddonPtr(new CLanguageResource(addonInfo));
     case ADDON_RESOURCE_UISOUNDS:
-      return AddonPtr(new CUISoundsResource(std::move(addonInfo)));
+      return AddonPtr(new CUISoundsResource(addonInfo));
     case ADDON_REPOSITORY:
-      return AddonPtr(new CRepository(std::move(addonInfo)));
+      return AddonPtr(new CRepository(addonInfo));
     case ADDON_CONTEXT_ITEM:
-      return AddonPtr(new CContextMenuAddon(std::move(addonInfo)));
+      return AddonPtr(new CContextMenuAddon(addonInfo));
     case ADDON_INPUTSTREAM:
-      return AddonPtr(new CInputStream(std::move(addonInfo)));
+      return AddonPtr(new CInputStream(addonInfo));
     case ADDON_PERIPHERALDLL:
-      return AddonPtr(new PERIPHERALS::CPeripheralAddon(std::move(addonInfo), false, false)); //! @todo implement
+      return AddonPtr(new PERIPHERALS::CPeripheralAddon(addonInfo, false, false)); //! @todo implement
     case ADDON_GAME_CONTROLLER:
-      return AddonPtr(new GAME::CController(std::move(addonInfo)));
+      return AddonPtr(new GAME::CController(addonInfo));
     case ADDON_GAMEDLL:
-      return AddonPtr(new GAME::CGameClient(std::move(addonInfo)));
+      return AddonPtr(new GAME::CGameClient(addonInfo));
     case ADDON_IMAGEDECODER:
-      return AddonPtr(new CImageDecoder(std::move(addonInfo)));
+      return AddonPtr(new CImageDecoder(addonInfo));
     case ADDON_VFS:
-      return AddonPtr(new CVFSEntry(std::move(addonInfo),"","",false,false,false));
+      return AddonPtr(new CVFSEntry(addonInfo,"","",false,false,false));
     default:
       break;
   }

--- a/xbmc/addons/AddonBuilder.h
+++ b/xbmc/addons/AddonBuilder.h
@@ -27,46 +27,46 @@ namespace ADDON
 class CAddonBuilder
 {
 public:
-  CAddonBuilder() : m_built(false), m_extPoint(nullptr) {}
+  CAddonBuilder() : m_built(false), m_extPoint(nullptr), m_addonInfo(std::make_shared<CAddonInfo>()){}
 
   std::shared_ptr<IAddon> Build();
-  void SetId(std::string id) { m_addonInfo.m_id = std::move(id); }
-  void SetName(std::string name) { m_addonInfo.m_name = std::move(name); }
-  void SetLicense(std::string license) { m_addonInfo.m_license = std::move(license); }
-  void SetSummary(std::string summary) { m_addonInfo.m_summary = std::move(summary); }
-  void SetDescription(std::string description) { m_addonInfo.m_description = std::move(description); }
-  void SetDisclaimer(std::string disclaimer) { m_addonInfo.m_disclaimer = std::move(disclaimer); }
-  void SetAuthor(std::string author) { m_addonInfo.m_author = std::move(author); }
-  void SetSource(std::string source) { m_addonInfo.m_source = std::move(source); }
-  void SetIcon(std::string icon) { m_addonInfo.m_icon = std::move(icon); }
-  void SetArt(std::string type, std::string value) { m_addonInfo.m_art[type] = value; }
-  void SetArt(std::map<std::string, std::string> art) { m_addonInfo.m_art = std::move(art); }
-  void SetScreenshots(std::vector<std::string> screenshots) { m_addonInfo.m_screenshots = std::move(screenshots); }
-  void SetChangelog(std::string changelog) { m_addonInfo.m_changelog = std::move(changelog); }
-  void SetBroken(std::string broken) { m_addonInfo.m_broken = std::move(broken); }
-  void SetPath(std::string path) { m_addonInfo.m_path = std::move(path); }
-  void SetLibName(std::string libname) { m_addonInfo.m_libname = std::move(libname); }
-  void SetVersion(AddonVersion version) { m_addonInfo.m_version = std::move(version); }
-  void SetMinVersion(AddonVersion minversion) { m_addonInfo.m_minversion = std::move(minversion); }
-  void SetDependencies(ADDONDEPS dependencies) { m_addonInfo.m_dependencies = std::move(dependencies); }
-  void SetExtrainfo(InfoMap extrainfo) { m_addonInfo.extrainfo = std::move(extrainfo); }
-  void SetType(TYPE type) { m_addonInfo.m_mainType = type; }
+  void SetId(std::string id) { m_addonInfo->m_id = std::move(id); }
+  void SetName(std::string name) { m_addonInfo->m_name = std::move(name); }
+  void SetLicense(std::string license) { m_addonInfo->m_license = std::move(license); }
+  void SetSummary(std::string summary) { m_addonInfo->m_summary = std::move(summary); }
+  void SetDescription(std::string description) { m_addonInfo->m_description = std::move(description); }
+  void SetDisclaimer(std::string disclaimer) { m_addonInfo->m_disclaimer = std::move(disclaimer); }
+  void SetAuthor(std::string author) { m_addonInfo->m_author = std::move(author); }
+  void SetSource(std::string source) { m_addonInfo->m_source = std::move(source); }
+  void SetIcon(std::string icon) { m_addonInfo->m_icon = std::move(icon); }
+  void SetArt(std::string type, std::string value) { m_addonInfo->m_art[type] = value; }
+  void SetArt(std::map<std::string, std::string> art) { m_addonInfo->m_art = std::move(art); }
+  void SetScreenshots(std::vector<std::string> screenshots) { m_addonInfo->m_screenshots = std::move(screenshots); }
+  void SetChangelog(std::string changelog) { m_addonInfo->m_changelog = std::move(changelog); }
+  void SetBroken(std::string broken) { m_addonInfo->m_broken = std::move(broken); }
+  void SetPath(std::string path) { m_addonInfo->m_path = std::move(path); }
+  void SetLibName(std::string libname) { m_addonInfo->m_libname = std::move(libname); }
+  void SetVersion(AddonVersion version) { m_addonInfo->m_version = std::move(version); }
+  void SetMinVersion(AddonVersion minversion) { m_addonInfo->m_minversion = std::move(minversion); }
+  void SetDependencies(ADDONDEPS dependencies) { m_addonInfo->m_dependencies = std::move(dependencies); }
+  void SetExtrainfo(InfoMap extrainfo) { m_addonInfo->extrainfo = std::move(extrainfo); }
+  void SetType(TYPE type) { m_addonInfo->m_mainType = type; }
   void SetExtPoint(cp_extension_t* ext) { m_extPoint = ext; }
-  void SetInstallDate(CDateTime installDate) { m_addonInfo.m_installDate = installDate; }
-  void SetLastUpdated(CDateTime lastUpdated) { m_addonInfo.m_lastUpdated = lastUpdated; }
-  void SetLastUsed(CDateTime lastUsed) { m_addonInfo.m_lastUsed = lastUsed; }
-  void SetOrigin(std::string origin) { m_addonInfo.m_origin = std::move(origin); }
-  void SetPackageSize(uint64_t size) { m_addonInfo.m_packageSize = size; }
+  void SetInstallDate(CDateTime installDate) { m_addonInfo->m_installDate = installDate; }
+  void SetLastUpdated(CDateTime lastUpdated) { m_addonInfo->m_lastUpdated = lastUpdated; }
+  void SetLastUsed(CDateTime lastUsed) { m_addonInfo->m_lastUsed = lastUsed; }
+  void SetOrigin(std::string origin) { m_addonInfo->m_origin = std::move(origin); }
+  void SetPackageSize(uint64_t size) { m_addonInfo->m_packageSize = size; }
 
-  const std::string& GetId() const { return m_addonInfo.m_id; }
-  const AddonVersion& GetVersion() const { return m_addonInfo.m_version; }
+  const std::string& GetId() const { return m_addonInfo->m_id; }
+  const AddonVersion& GetVersion() const { return m_addonInfo->m_version; }
 
 private:
-  static std::shared_ptr<IAddon> FromProps(CAddonInfo addonInfo);
+  static std::shared_ptr<IAddon> FromProps(const AddonInfoPtr& addonInfo);
 
   bool m_built;
-  CAddonInfo m_addonInfo;
   cp_extension_t* m_extPoint;
+  AddonInfoPtr m_addonInfo;
 };
 
 };

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -47,8 +47,8 @@
 namespace ADDON
 {
 
-CAddonDll::CAddonDll(CAddonInfo addonInfo)
-  : CAddon(std::move(addonInfo)),
+CAddonDll::CAddonDll(const AddonInfoPtr& addonInfo)
+  : CAddon(addonInfo),
     m_bIsChild(false)
 {
   m_initialized = false;
@@ -99,7 +99,7 @@ bool CAddonDll::LoadDll()
       libPath = tempbin + libPath;
       if (!XFILE::CFile::Exists(libPath))
       {
-        CLog::Log(LOGERROR, "ADDON: Could not locate %s", m_addonInfo.LibName().c_str());
+        CLog::Log(LOGERROR, "ADDON: Could not locate %s", AddonInfo()->LibName().c_str());
         return false;
       }
     }
@@ -122,7 +122,7 @@ bool CAddonDll::LoadDll()
   if (!XFILE::CFile::Exists(strFileName))
   {
     std::string tempbin = getenv("XBMC_ANDROID_LIBS");
-    strFileName = tempbin + "/" + m_addonInfo.LibName();
+    strFileName = tempbin + "/" + AddonInfo()->LibName();
   }
 #endif
   if (!XFILE::CFile::Exists(strFileName))
@@ -130,7 +130,7 @@ bool CAddonDll::LoadDll()
     std::string altbin = CSpecialProtocol::TranslatePath("special://xbmcaltbinaddons/");
     if (!altbin.empty())
     {
-      strAltFileName = altbin + m_addonInfo.LibName();
+      strAltFileName = altbin + AddonInfo()->LibName();
       if (!XFILE::CFile::Exists(strAltFileName))
       {
         std::string temp = CSpecialProtocol::TranslatePath("special://xbmc/addons/");
@@ -151,7 +151,7 @@ bool CAddonDll::LoadDll()
       strFileName = tempbin + strFileName;
       if (!XFILE::CFile::Exists(strFileName))
       {
-        CLog::Log(LOGERROR, "ADDON: Could not locate %s", m_addonInfo.LibName().c_str());
+        CLog::Log(LOGERROR, "ADDON: Could not locate %s", AddonInfo()->LibName().c_str());
         return false;
       }
     }
@@ -520,7 +520,7 @@ bool CAddonDll::UpdateSettingInActiveDialog(const char* id, const std::string& v
     return false;
 
   CGUIDialogAddonSettings* dialog = g_windowManager.GetWindow<CGUIDialogAddonSettings>(WINDOW_DIALOG_ADDON_SETTINGS);
-  if (dialog->GetCurrentAddonID() != m_addonInfo.ID())
+  if (dialog->GetCurrentAddonID() != AddonInfo()->ID())
     return false;
 
   CGUIMessage message(GUI_MSG_SETTING_UPDATED, 0, 0);

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -33,7 +33,7 @@ namespace ADDON
   class CAddonDll : public CAddon
   {
   public:
-    CAddonDll(CAddonInfo addonInfo);
+    CAddonDll(const AddonInfoPtr& addonInfo);
 
     //FIXME: does shallow pointer copy. no copy assignment op
     CAddonDll(const CAddonDll &rhs);

--- a/xbmc/addons/AddonInfo.h
+++ b/xbmc/addons/AddonInfo.h
@@ -23,6 +23,7 @@
 #include "addons/AddonVersion.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -80,6 +81,9 @@ namespace ADDON
 
     ADDON_MAX
   } TYPE;
+
+  class CAddonInfo;
+  typedef std::shared_ptr<CAddonInfo> AddonInfoPtr;
 
   typedef std::map<std::string, std::pair<const AddonVersion, bool> > ADDONDEPS;
   typedef std::map<std::string, std::string> InfoMap;

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -24,7 +24,7 @@
 namespace ADDON
 {
 
-std::unique_ptr<CAudioDecoder> CAudioDecoder::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CAudioDecoder> CAudioDecoder::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string extension = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@extension");
   std::string mimetype = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@mimetype");
@@ -33,13 +33,13 @@ std::unique_ptr<CAudioDecoder> CAudioDecoder::FromExtension(CAddonInfo addonInfo
   std::string codecName = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@name");
   std::string strExt = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@name") + "stream";
 
-  return std::unique_ptr<CAudioDecoder>(new CAudioDecoder(std::move(addonInfo), std::move(extension),
+  return std::unique_ptr<CAudioDecoder>(new CAudioDecoder(addonInfo, std::move(extension),
       std::move(mimetype), tags, tracks, std::move(codecName), std::move(strExt)));
 }
 
-CAudioDecoder::CAudioDecoder(CAddonInfo addonInfo, std::string extension, std::string mimetype,
+CAudioDecoder::CAudioDecoder(const AddonInfoPtr& addonInfo, std::string extension, std::string mimetype,
     bool tags, bool tracks, std::string codecName, std::string strExt)
-    : CAddonDll(std::move(addonInfo)), m_extension(extension), m_mimetype(mimetype),
+    : CAddonDll(addonInfo), m_extension(extension), m_mimetype(mimetype),
       m_context(nullptr), m_tags(tags), m_tracks(tracks), m_channel(nullptr)
 {
   m_CodecName = std::move(codecName);

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -39,17 +39,17 @@ namespace ADDON
   {
   public:
 
-    static std::unique_ptr<CAudioDecoder> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CAudioDecoder> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CAudioDecoder(CAddonInfo addonInfo)
-      : CAddonDll(std::move(addonInfo))
+    explicit CAudioDecoder(const AddonInfoPtr& addonInfo)
+      : CAddonDll(addonInfo)
       , m_context{nullptr}
       , m_tags{false}
       , m_tracks{false}
       , m_channel{nullptr}
     {}
 
-    CAudioDecoder(CAddonInfo addonInfo, std::string extension, std::string mimetype, bool tags,
+    CAudioDecoder(const AddonInfoPtr& addonInfo, std::string extension, std::string mimetype, bool tags,
         bool tracks, std::string codecName, std::string strExt);
 
     virtual ~CAudioDecoder();

--- a/xbmc/addons/AudioEncoder.cpp
+++ b/xbmc/addons/AudioEncoder.cpp
@@ -21,14 +21,14 @@
 namespace ADDON
 {
 
-std::unique_ptr<CAudioEncoder> CAudioEncoder::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CAudioEncoder> CAudioEncoder::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string extension = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@extension");
-  return std::unique_ptr<CAudioEncoder>(new CAudioEncoder(std::move(addonInfo), std::move(extension)));
+  return std::unique_ptr<CAudioEncoder>(new CAudioEncoder(addonInfo, std::move(extension)));
 }
 
-CAudioEncoder::CAudioEncoder(CAddonInfo addonInfo, std::string _extension)
-    : CAddonDll(std::move(addonInfo)), extension(std::move(_extension)), m_context(nullptr)
+CAudioEncoder::CAudioEncoder(const AddonInfoPtr& addonInfo, std::string _extension)
+    : CAddonDll(addonInfo), extension(std::move(_extension)), m_context(nullptr)
 {
   memset(&m_struct, 0, sizeof(m_struct));
 }

--- a/xbmc/addons/AudioEncoder.h
+++ b/xbmc/addons/AudioEncoder.h
@@ -28,10 +28,10 @@ namespace ADDON
   class CAudioEncoder : public CAddonDll, public IEncoder
   {
   public:
-    static std::unique_ptr<CAudioEncoder> FromExtension(CAddonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CAudioEncoder> FromExtension(const AddonInfoPtr&, const cp_extension_t* ext);
 
-    explicit CAudioEncoder(CAddonInfo addonInfo) : CAddonDll(std::move(addonInfo)), m_context{nullptr} {};
-    CAudioEncoder(CAddonInfo addonInfo, std::string extension);
+    explicit CAudioEncoder(const AddonInfoPtr& addonInfo) : CAddonDll(addonInfo), m_context{nullptr} {};
+    CAudioEncoder(const AddonInfoPtr& addonInfo, std::string extension);
     virtual ~CAudioEncoder() {}
 
     // Things that MUST be supplied by the child classes

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -31,7 +31,7 @@ namespace ADDON
 {
 
 void CContextMenuAddon::ParseMenu(
-    const CAddonInfo& addonInfo,
+    const AddonInfoPtr& addonInfo,
     cp_cfg_element_t* elem,
     const std::string& parent,
     int& anonGroupCount,
@@ -40,17 +40,17 @@ void CContextMenuAddon::ParseMenu(
   auto menuId = CAddonMgr::GetInstance().GetExtValue(elem, "@id");
   auto menuLabel = CAddonMgr::GetInstance().GetExtValue(elem, "label");
   if (StringUtils::IsNaturalNumber(menuLabel))
-    menuLabel = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(menuLabel.c_str()));
+    menuLabel = g_localizeStrings.GetAddonString(addonInfo->ID(), atoi(menuLabel.c_str()));
 
   if (menuId.empty())
   {
     //anonymous group. create a new unique internal id.
     std::stringstream ss;
-    ss << addonInfo.ID() << ++anonGroupCount;
+    ss << addonInfo->ID() << ++anonGroupCount;
     menuId = ss.str();
   }
 
-  items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, addonInfo.ID()));
+  items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, addonInfo->ID()));
 
   ELEMENTS subMenus;
   if (CAddonMgr::GetInstance().GetExtElements(elem, "menu", subMenus))
@@ -66,19 +66,19 @@ void CContextMenuAddon::ParseMenu(
       auto library = CAddonMgr::GetInstance().GetExtValue(elem, "@library");
       auto label = CAddonMgr::GetInstance().GetExtValue(elem, "label");
       if (StringUtils::IsNaturalNumber(label))
-        label = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(label.c_str()));
+        label = g_localizeStrings.GetAddonString(addonInfo->ID(), atoi(label.c_str()));
 
       if (!label.empty() && !library.empty() && !visCondition.empty())
       {
         auto menu = CContextMenuItem::CreateItem(label, menuId,
-            URIUtils::AddFileToFolder(addonInfo.Path(), library), visCondition, addonInfo.ID());
+            URIUtils::AddFileToFolder(addonInfo->Path(), library), visCondition, addonInfo->ID());
         items.push_back(menu);
       }
     }
   }
 }
 
-std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::vector<CContextMenuItem> items;
 
@@ -105,20 +105,20 @@ std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(CAddonInfo a
 
       auto label = CAddonMgr::GetInstance().GetExtValue(elem, "label");
       if (StringUtils::IsNaturalNumber(label))
-        label = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(label.c_str()));
+        label = g_localizeStrings.GetAddonString(addonInfo->ID(), atoi(label.c_str()));
 
       CContextMenuItem menuItem = CContextMenuItem::CreateItem(label, parent,
-          URIUtils::AddFileToFolder(addonInfo.Path(), addonInfo.LibName()), visCondition, addonInfo.ID());
+          URIUtils::AddFileToFolder(addonInfo->Path(), addonInfo->LibName()), visCondition, addonInfo->ID());
 
       items.push_back(menuItem);
     }
   }
 
-  return std::unique_ptr<CContextMenuAddon>(new CContextMenuAddon(std::move(addonInfo), std::move(items)));
+  return std::unique_ptr<CContextMenuAddon>(new CContextMenuAddon(addonInfo, std::move(items)));
 }
 
-CContextMenuAddon::CContextMenuAddon(CAddonInfo addonInfo, std::vector<CContextMenuItem> items)
-    : CAddon(std::move(addonInfo)), m_items(std::move(items))
+CContextMenuAddon::CContextMenuAddon(const AddonInfoPtr& addonInfo, std::vector<CContextMenuItem> items)
+    : CAddon(addonInfo), m_items(std::move(items))
 {
 }
 

--- a/xbmc/addons/ContextMenuAddon.h
+++ b/xbmc/addons/ContextMenuAddon.h
@@ -35,15 +35,15 @@ namespace ADDON
   class CContextMenuAddon : public CAddon
   {
   public:
-    static std::unique_ptr<CContextMenuAddon> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CContextMenuAddon> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CContextMenuAddon(CAddonInfo addonInfo) : CAddon(std::move(addonInfo)) {}
-    CContextMenuAddon(CAddonInfo addonInfo, std::vector<CContextMenuItem> items);
+    explicit CContextMenuAddon(const AddonInfoPtr& addonInfo) : CAddon(addonInfo) {}
+    CContextMenuAddon(const AddonInfoPtr& addonInfo, std::vector<CContextMenuItem> items);
 
     const std::vector<CContextMenuItem>& GetItems() const { return m_items; };
 
   private:
-    static void ParseMenu(const CAddonInfo& addonInfo, cp_cfg_element_t* elem, const std::string& parent,
+    static void ParseMenu(const AddonInfoPtr& addonInfo, cp_cfg_element_t* elem, const std::string& parent,
         int& anonGroupCount, std::vector<CContextMenuItem>& items);
 
     std::vector<CContextMenuItem> m_items;

--- a/xbmc/addons/GameResource.cpp
+++ b/xbmc/addons/GameResource.cpp
@@ -24,12 +24,12 @@
 
 using namespace ADDON;
 
-CGameResource::CGameResource(CAddonInfo addonInfo) :
-  CResource(std::move(addonInfo))
+CGameResource::CGameResource(const AddonInfoPtr& addonInfo) :
+  CResource(addonInfo)
 {
 }
 
-std::unique_ptr<CGameResource> CGameResource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CGameResource> CGameResource::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
-  return std::unique_ptr<CGameResource>(new CGameResource(std::move(addonInfo)));
+  return std::unique_ptr<CGameResource>(new CGameResource(addonInfo));
 }

--- a/xbmc/addons/GameResource.h
+++ b/xbmc/addons/GameResource.h
@@ -29,10 +29,10 @@ namespace ADDON
 class CGameResource : public CResource
 {
 public:
-  CGameResource(CAddonInfo addonInfo);
+  CGameResource(const AddonInfoPtr& addonInfo);
   virtual ~CGameResource() = default;
 
-  static std::unique_ptr<CGameResource> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CGameResource> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
   // implementation of CResource
   virtual bool IsAllowed(const std::string& file) const override { return true; }

--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -29,17 +29,17 @@ namespace ADDON
 {
 
 std::unique_ptr<CImageDecoder>
-CImageDecoder::FromExtension(CAddonInfo&& addonInfo, const cp_extension_t* ext)
+CImageDecoder::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string mime = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@mimetype");
   std::string extension = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@extension");
-  return std::unique_ptr<CImageDecoder>(new CImageDecoder(std::move(addonInfo),
+  return std::unique_ptr<CImageDecoder>(new CImageDecoder(addonInfo,
                                                           std::move(mime),
                                                           std::move(extension)));
 }
 
-CImageDecoder::CImageDecoder(CAddonInfo&& addonInfo, std::string mime, std::string extension) :
-  CAddonDll(std::move(addonInfo)),
+CImageDecoder::CImageDecoder(const AddonInfoPtr& addonInfo, std::string mime, std::string extension) :
+  CAddonDll(addonInfo),
   m_mimetype(std::move(mime)),
   m_extension(std::move(extension))
 {

--- a/xbmc/addons/ImageDecoder.h
+++ b/xbmc/addons/ImageDecoder.h
@@ -28,13 +28,13 @@ namespace ADDON
                         public IImage
   {
   public:
-    static std::unique_ptr<CImageDecoder> FromExtension(CAddonInfo&&,
+    static std::unique_ptr<CImageDecoder> FromExtension(const AddonInfoPtr& addonInfo,
                                                         const cp_extension_t* ext);
-    explicit CImageDecoder(CAddonInfo addonInfo) :
-      CAddonDll(std::move(addonInfo))
+    explicit CImageDecoder(const AddonInfoPtr& addonInfo) :
+      CAddonDll(addonInfo)
     {}
 
-    CImageDecoder(CAddonInfo&& addonInfo, std::string mimetypes, std::string extensions);
+    CImageDecoder(const AddonInfoPtr& addonInfo, std::string mimetypes, std::string extensions);
     virtual ~CImageDecoder();
 
     bool Create(const std::string& mimetype);

--- a/xbmc/addons/ImageResource.cpp
+++ b/xbmc/addons/ImageResource.cpp
@@ -28,14 +28,14 @@
 namespace ADDON
 {
 
-std::unique_ptr<CImageResource> CImageResource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CImageResource> CImageResource::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string type = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@type");
-  return std::unique_ptr<CImageResource>(new CImageResource(std::move(addonInfo), std::move(type)));
+  return std::unique_ptr<CImageResource>(new CImageResource(addonInfo, std::move(type)));
 }
 
-CImageResource::CImageResource(CAddonInfo addonInfo, std::string type)
-    : CResource(std::move(addonInfo)), m_type(std::move(type))
+CImageResource::CImageResource(const AddonInfoPtr& addonInfo, std::string type)
+    : CResource(addonInfo), m_type(std::move(type))
 {
 }
 

--- a/xbmc/addons/ImageResource.h
+++ b/xbmc/addons/ImageResource.h
@@ -32,10 +32,10 @@ namespace ADDON
 class CImageResource : public CResource
 {
 public:
-  static std::unique_ptr<CImageResource> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CImageResource> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-  explicit CImageResource(CAddonInfo addonInfo) : CResource(std::move(addonInfo)) {};
-  CImageResource(CAddonInfo addonInfo, std::string type);
+  explicit CImageResource(const AddonInfoPtr& addonInfo) : CResource(addonInfo) {};
+  CImageResource(const AddonInfoPtr& addonInfo, std::string type);
 
   virtual void OnPreUnInstall();
 

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -33,7 +33,7 @@ namespace ADDON
 std::map<std::string, CInputStream::Config> CInputStream::m_configMap;
 CCriticalSection CInputStream::m_parentSection;
 
-std::unique_ptr<CInputStream> CInputStream::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CInputStream> CInputStream::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string listitemprops = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@listitemprops");
   std::string extensions = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@extension");
@@ -41,17 +41,17 @@ std::unique_ptr<CInputStream> CInputStream::FromExtension(CAddonInfo addonInfo, 
   std::string name(ext->plugin->identifier);
   std::unique_ptr<CInputStream> istr(new CInputStream(addonInfo, name, listitemprops,
                                                       extensions, protocols));
-  if (!CAddonMgr::GetInstance().IsAddonDisabled(addonInfo.ID()))
+  if (!CAddonMgr::GetInstance().IsAddonDisabled(addonInfo->ID()))
     istr->CheckConfig();
   return istr;
 }
 
-CInputStream::CInputStream(const CAddonInfo& addonInfo,
+CInputStream::CInputStream(const AddonInfoPtr& addonInfo,
                            const std::string& name,
                            const std::string& listitemprops,
                            const std::string& extensions,
                            const std::string& protocols)
-: CAddonDll(std::move(addonInfo))
+: CAddonDll(addonInfo)
 {
   m_fileItemProps = StringUtils::Tokenize(listitemprops, "|");
   for (auto &key : m_fileItemProps)

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -35,12 +35,12 @@ namespace ADDON
   {
   public:
 
-    static std::unique_ptr<CInputStream> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CInputStream> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CInputStream(CAddonInfo addonInfo)
-      : CAddonDll(std::move(addonInfo))
+    explicit CInputStream(const AddonInfoPtr& addonInfo)
+      : CAddonDll(addonInfo)
     {};
-    CInputStream(const CAddonInfo& addonInfo,
+    CInputStream(const AddonInfoPtr& addonInfo,
                  const std::string& name,
                  const std::string& listitemprops,
                  const std::string& extensions,

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -38,7 +38,7 @@ using KODI::MESSAGING::HELPERS::DialogResponse;
 namespace ADDON
 {
 
-std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   // parse <extension> attributes
   CLocale locale = CLocale::FromString(CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@locale"));
@@ -96,7 +96,7 @@ std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(CAddonInfo a
     }
   }
   return std::unique_ptr<CLanguageResource>(new CLanguageResource(
-      std::move(addonInfo),
+      addonInfo,
       locale,
       charsetGui,
       forceUnicodeFont,
@@ -108,7 +108,7 @@ std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(CAddonInfo a
 }
 
 CLanguageResource::CLanguageResource(
-    CAddonInfo addonInfo,
+    const AddonInfoPtr& addonInfo,
     const CLocale& locale,
     const std::string& charsetGui,
     bool forceUnicodeFont,
@@ -117,7 +117,7 @@ CLanguageResource::CLanguageResource(
     const std::string& dvdLanguageAudio,
     const std::string& dvdLanguageSubtitle,
     const std::set<std::string>& sortTokens)
-  : CResource(std::move(addonInfo)),
+  : CResource(addonInfo),
     m_locale(locale),
     m_charsetGui(charsetGui),
     m_forceUnicodeFont(forceUnicodeFont),

--- a/xbmc/addons/LanguageResource.h
+++ b/xbmc/addons/LanguageResource.h
@@ -29,11 +29,11 @@ namespace ADDON
 class CLanguageResource : public CResource
 {
 public:
-  static std::unique_ptr<CLanguageResource> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CLanguageResource> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-  explicit CLanguageResource(CAddonInfo addonInfo) : CResource(std::move(addonInfo)), m_forceUnicodeFont(false) {};
+  explicit CLanguageResource(const AddonInfoPtr& addonInfo) : CResource(addonInfo), m_forceUnicodeFont(false) {};
 
-  CLanguageResource(CAddonInfo addonInfo,
+  CLanguageResource(const AddonInfoPtr& addonInfo,
       const CLocale& locale,
       const std::string& charsetGui,
       bool forceUnicodeFont,

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -58,13 +58,13 @@ namespace PVR
 
 #define DEFAULT_INFO_STRING_VALUE "unknown"
 
-std::unique_ptr<CPVRClient> CPVRClient::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CPVRClient> CPVRClient::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
-  return std::unique_ptr<CPVRClient>(new CPVRClient(std::move(addonInfo)));
+  return std::unique_ptr<CPVRClient>(new CPVRClient(addonInfo));
 }
 
-CPVRClient::CPVRClient(CAddonInfo addonInfo)
-  : CAddonDll(std::move(addonInfo))
+CPVRClient::CPVRClient(const AddonInfoPtr& addonInfo)
+  : CAddonDll(addonInfo)
 {
   ResetProperties();
 }

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -55,9 +55,9 @@ namespace PVR
   class CPVRClient : public ADDON::CAddonDll
   {
   public:
-    static std::unique_ptr<CPVRClient> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CPVRClient> FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CPVRClient(ADDON::CAddonInfo addonInfo);
+    explicit CPVRClient(const ADDON::AddonInfoPtr& addonInfo);
     ~CPVRClient(void);
 
     void OnDisabled() override;

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -28,25 +28,25 @@
 namespace ADDON
 {
 
-std::unique_ptr<CPluginSource> CPluginSource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CPluginSource> CPluginSource::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string provides = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "provides");
   if (!provides.empty())
-    addonInfo.extrainfo.insert(make_pair("provides", provides));
-  return std::unique_ptr<CPluginSource>(new CPluginSource(std::move(addonInfo), provides));
+    addonInfo->extrainfo.insert(make_pair("provides", provides));
+  return std::unique_ptr<CPluginSource>(new CPluginSource(addonInfo, provides));
 }
 
-CPluginSource::CPluginSource(CAddonInfo addonInfo) : CAddon(std::move(addonInfo))
+CPluginSource::CPluginSource(const AddonInfoPtr& addonInfo) : CAddon(addonInfo)
 {
   std::string provides;
-  InfoMap::const_iterator i = m_addonInfo.extrainfo.find("provides");
-  if (i != m_addonInfo.extrainfo.end())
+  InfoMap::const_iterator i = AddonInfo()->extrainfo.find("provides");
+  if (i != AddonInfo()->extrainfo.end())
     provides = i->second;
   SetProvides(provides);
 }
 
-CPluginSource::CPluginSource(CAddonInfo addonInfo, const std::string& provides)
-  : CAddon(std::move(addonInfo))
+CPluginSource::CPluginSource(const AddonInfoPtr& addonInfo, const std::string& provides)
+  : CAddon(addonInfo)
 {
   SetProvides(provides);
 }

--- a/xbmc/addons/PluginSource.h
+++ b/xbmc/addons/PluginSource.h
@@ -30,10 +30,10 @@ public:
 
   enum Content { UNKNOWN, AUDIO, IMAGE, EXECUTABLE, VIDEO, GAME };
 
-  static std::unique_ptr<CPluginSource> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CPluginSource> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-  explicit CPluginSource(CAddonInfo addonInfo);
-  CPluginSource(CAddonInfo addonInfo, const std::string& provides);
+  explicit CPluginSource(const AddonInfoPtr& addonInfo);
+  CPluginSource(const AddonInfoPtr& addonInfo, const std::string& provides);
 
   virtual TYPE FullType() const;
   virtual bool IsType(TYPE type) const;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -54,7 +54,7 @@ using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 
-std::unique_ptr<CRepository> CRepository::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CRepository> CRepository::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   DirList dirs;
   AddonVersion version("0.0.0");
@@ -88,11 +88,11 @@ std::unique_ptr<CRepository> CRepository::FromExtension(CAddonInfo addonInfo, co
     info.hashes = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "hashes") == "true";
     dirs.push_back(std::move(info));
   }
-  return std::unique_ptr<CRepository>(new CRepository(std::move(addonInfo), std::move(dirs)));
+  return std::unique_ptr<CRepository>(new CRepository(addonInfo, std::move(dirs)));
 }
 
-CRepository::CRepository(CAddonInfo addonInfo, DirList dirs)
-    : CAddon(std::move(addonInfo)), m_dirs(std::move(dirs))
+CRepository::CRepository(const AddonInfoPtr& addonInfo, DirList dirs)
+    : CAddon(addonInfo), m_dirs(std::move(dirs))
 {
 }
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -44,10 +44,10 @@ namespace ADDON
 
     typedef std::vector<DirInfo> DirList;
 
-    static std::unique_ptr<CRepository> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CRepository> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CRepository(CAddonInfo addonInfo) : CAddon(std::move(addonInfo)) {};
-    CRepository(CAddonInfo addonInfo, DirList dirs);
+    explicit CRepository(const AddonInfoPtr& addonInfo) : CAddon(addonInfo) {};
+    CRepository(const AddonInfoPtr& addonInfo, DirList dirs);
 
     /*! \brief Get the md5 hash for an addon.
      \param the addon in question.

--- a/xbmc/addons/Resource.h
+++ b/xbmc/addons/Resource.h
@@ -40,7 +40,7 @@ public:
   }
 
 protected:
-  explicit CResource(CAddonInfo addonInfo) : CAddon(std::move(addonInfo)) {}
+  explicit CResource(const AddonInfoPtr& addonInfo) : CAddon(addonInfo) {}
 
   std::string GetResourcePath() const
   {

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -127,7 +127,7 @@ static void CheckScraperError(const TiXmlElement *pxeRoot)
   throw CScraperError(sTitle, sMessage);
 }
 
-std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CScraper> CScraper::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   bool requiressettings = CAddonMgr::GetInstance().GetExtValue(ext->configuration,"@requiressettings") == "true";
 
@@ -137,7 +137,7 @@ std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp
     persistence.SetFromTimeString(tmp);
 
   CONTENT_TYPE pathContent(CONTENT_NONE);
-  switch (addonInfo.MainType())
+  switch (addonInfo->MainType())
   {
     case ADDON_SCRAPER_ALBUMS:
       pathContent = CONTENT_ALBUMS;
@@ -158,11 +158,11 @@ std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp
       break;
   }
 
-  return std::unique_ptr<CScraper>(new CScraper(std::move(addonInfo), requiressettings, persistence, pathContent));
+  return std::unique_ptr<CScraper>(new CScraper(addonInfo, requiressettings, persistence, pathContent));
 }
 
-CScraper::CScraper(CAddonInfo addonInfo)
-  : CAddon(std::move(addonInfo)),
+CScraper::CScraper(const AddonInfoPtr& addonInfo)
+  : CAddon(addonInfo),
     m_fLoaded(false),
     m_requiressettings(false),
     m_pathContent(CONTENT_NONE)
@@ -170,8 +170,8 @@ CScraper::CScraper(CAddonInfo addonInfo)
   m_isPython = URIUtils::GetExtension(LibPath()) == ".py";
 }
 
-CScraper::CScraper(CAddonInfo addonInfo, bool requiressettings, CDateTimeSpan persistence, CONTENT_TYPE pathContent)
-  : CAddon(std::move(addonInfo)),
+CScraper::CScraper(const AddonInfoPtr& addonInfo, bool requiressettings, CDateTimeSpan persistence, CONTENT_TYPE pathContent)
+  : CAddon(addonInfo),
     m_fLoaded(false),
     m_requiressettings(requiressettings),
     m_persistence(persistence),

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -87,10 +87,10 @@ class CScraper : public CAddon
 {
 public:
 
-  static std::unique_ptr<CScraper> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CScraper> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-  explicit CScraper(CAddonInfo addonInfo);
-  CScraper(CAddonInfo addonInfo, bool requiressettings, CDateTimeSpan persistence, CONTENT_TYPE pathContent);
+  explicit CScraper(const AddonInfoPtr& addonInfo);
+  CScraper(const AddonInfoPtr& addonInfo, bool requiressettings, CDateTimeSpan persistence, CONTENT_TYPE pathContent);
 
   /*! \brief Set the scraper settings for a particular path from an XML string
    Loads the default and user settings (if not already loaded) and, if the given XML string is non-empty,

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -26,18 +26,18 @@
 namespace ADDON
 {
 
-std::unique_ptr<CService> CService::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CService> CService::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   START_OPTION startOption(LOGIN);
   std::string start = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@start");
   if (start == "startup")
     startOption = STARTUP;
-  return std::unique_ptr<CService>(new CService(std::move(addonInfo), TYPE(UNKNOWN), startOption));
+  return std::unique_ptr<CService>(new CService(addonInfo, TYPE(UNKNOWN), startOption));
 }
 
 
-CService::CService(CAddonInfo addonInfo, TYPE type, START_OPTION startOption)
-  : CAddon(std::move(addonInfo)), m_type(type), m_startOption(startOption)
+CService::CService(const AddonInfoPtr& addonInfo, TYPE type, START_OPTION startOption)
+  : CAddon(addonInfo), m_type(type), m_startOption(startOption)
 {
   BuildServiceType();
 }

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -39,10 +39,10 @@ namespace ADDON
       LOGIN
     };
 
-    static std::unique_ptr<CService> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CService> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CService(CAddonInfo addonInfo) : CAddon(std::move(addonInfo)), m_type(UNKNOWN), m_startOption(LOGIN) {}
-    CService(CAddonInfo addonInfo, TYPE type, START_OPTION startOption);
+    explicit CService(const AddonInfoPtr& addonInfo) : CAddon(addonInfo), m_type(UNKNOWN), m_startOption(LOGIN) {}
+    CService(const AddonInfoPtr& addonInfo, TYPE type, START_OPTION startOption);
 
     bool Start();
     bool Stop();

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -134,7 +134,7 @@ bool CSkinSettingBool::SerializeSetting(TiXmlElement* element) const
   return true;
 }
 
-std::unique_ptr<CSkinInfo> CSkinInfo::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CSkinInfo> CSkinInfo::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   RESOLUTION_INFO defaultRes = RESOLUTION_INFO();
   std::vector<RESOLUTION_INFO> resolutions;
@@ -178,17 +178,17 @@ std::unique_ptr<CSkinInfo> CSkinInfo::FromExtension(CAddonInfo addonInfo, const 
 
   bool debugging = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@debugging") == "true";
 
-  return std::unique_ptr<CSkinInfo>(new CSkinInfo(std::move(addonInfo), defaultRes, resolutions,
+  return std::unique_ptr<CSkinInfo>(new CSkinInfo(addonInfo, defaultRes, resolutions,
       effectsSlowDown, debugging));
 }
 
 CSkinInfo::CSkinInfo(
-    CAddonInfo addonInfo,
+    const AddonInfoPtr& addonInfo,
     const RESOLUTION_INFO& resolution,
     const std::vector<RESOLUTION_INFO>& resolutions,
     float effectsSlowDown,
     bool debugging)
-    : CAddon(std::move(addonInfo)),
+    : CAddon(addonInfo),
       m_defaultRes(resolution),
       m_resolutions(resolutions),
       m_effectsSlowDown(effectsSlowDown),

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -106,17 +106,17 @@ public:
     std::string m_name;
   };
 
-  static std::unique_ptr<CSkinInfo> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CSkinInfo> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
   //FIXME: CAddonCallbacksGUI/WindowXML hack
-  explicit CSkinInfo(CAddonInfo addonInfo, const RESOLUTION_INFO& resolution = RESOLUTION_INFO())
-      : CAddon(std::move(addonInfo)),
+  explicit CSkinInfo(const AddonInfoPtr& addonInfo, const RESOLUTION_INFO& resolution = RESOLUTION_INFO())
+      : CAddon(addonInfo),
         m_defaultRes(resolution),
         m_effectsSlowDown(1.f),
         m_debugging(false) {}
 
   CSkinInfo(
-      CAddonInfo addonInfo,
+      const AddonInfoPtr& addonInfo,
       const RESOLUTION_INFO& resolution,
       const std::vector<RESOLUTION_INFO>& resolutions,
       float effectsSlowDown,

--- a/xbmc/addons/UISoundsResource.h
+++ b/xbmc/addons/UISoundsResource.h
@@ -27,7 +27,7 @@ namespace ADDON
 class CUISoundsResource : public CResource
 {
 public:
-  CUISoundsResource(CAddonInfo addonInfo) : CResource(std::move(addonInfo)) {};
+  CUISoundsResource(const AddonInfoPtr& addonInfo) : CResource(addonInfo) {};
   virtual bool IsAllowed(const std::string &file) const;
   virtual bool IsInUse() const;
   virtual void OnPostInstall(bool update, bool modal);

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -56,7 +56,7 @@ class CVFSURLWrapper
     std::vector<std::string> m_strings;
 };
 
-std::unique_ptr<CVFSEntry> CVFSEntry::FromExtension(CAddonInfo addonInfo,
+std::unique_ptr<CVFSEntry> CVFSEntry::FromExtension(const AddonInfoPtr& addonInfo,
                                                     const cp_extension_t* ext)
 {
   std::string protocols = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@protocols");
@@ -65,7 +65,7 @@ std::unique_ptr<CVFSEntry> CVFSEntry::FromExtension(CAddonInfo addonInfo,
   bool directories = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@directories") == "true";
   bool filedirectories = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@filedirectories") == "true";
 
-  return std::unique_ptr<CVFSEntry>(new CVFSEntry(std::move(addonInfo),
+  return std::unique_ptr<CVFSEntry>(new CVFSEntry(addonInfo,
                                                   protocols,
                                                   extensions,
                                                   files, directories,
@@ -73,11 +73,11 @@ std::unique_ptr<CVFSEntry> CVFSEntry::FromExtension(CAddonInfo addonInfo,
 }
 
 
-CVFSEntry::CVFSEntry(CAddonInfo addonInfo,
+CVFSEntry::CVFSEntry(const AddonInfoPtr& addonInfo,
                      const std::string& protocols,
                      const std::string& extensions,
                      bool files, bool directories, bool filedirectories)
- : CAddonDll(std::move(addonInfo)),
+ : CAddonDll(addonInfo),
    m_protocols(protocols),
    m_extensions(extensions),
    m_files(files),

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -30,7 +30,7 @@ namespace ADDON
   class CVFSEntry : public CAddonDll
   {
   public:
-    static std::unique_ptr<CVFSEntry> FromExtension(CAddonInfo addonInfo,
+    static std::unique_ptr<CVFSEntry> FromExtension(const AddonInfoPtr& addonInfo,
                                                     const cp_extension_t* ext);
 
     //! \brief Construct from add-on properties.
@@ -40,7 +40,7 @@ namespace ADDON
     //! \param files If true, add-on provides files
     //! \param directories If true, add-on provides directory listings
     //! \param filedirectories If true, add-on provides filedirectories
-    explicit CVFSEntry(CAddonInfo addonInfo,
+    explicit CVFSEntry(const AddonInfoPtr& addonInfo,
                       const std::string& protocols,
                       const std::string& extensions,
                       bool files, bool directories, bool filedirectories);

--- a/xbmc/addons/Webinterface.cpp
+++ b/xbmc/addons/Webinterface.cpp
@@ -26,7 +26,7 @@
 
 using namespace ADDON;
 
-std::unique_ptr<CWebinterface> CWebinterface::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CWebinterface> CWebinterface::FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   // determine the type of the webinterface
   WebinterfaceType type(WebinterfaceTypeStatic);
@@ -34,7 +34,7 @@ std::unique_ptr<CWebinterface> CWebinterface::FromExtension(CAddonInfo addonInfo
   if (StringUtils::EqualsNoCase(webinterfaceType.c_str(), "wsgi"))
     type = WebinterfaceTypeWsgi;
   else if (!webinterfaceType.empty() && !StringUtils::EqualsNoCase(webinterfaceType.c_str(), "static") && !StringUtils::EqualsNoCase(webinterfaceType.c_str(), "html"))
-    CLog::Log(LOGWARNING, "Webinterface addon \"%s\" has specified an unsupported type \"%s\"", addonInfo.ID().c_str(), webinterfaceType.c_str());
+    CLog::Log(LOGWARNING, "Webinterface addon \"%s\" has specified an unsupported type \"%s\"", addonInfo->ID().c_str(), webinterfaceType.c_str());
 
   // determine the entry point of the webinterface
   std::string entryPoint(WEBINTERFACE_DEFAULT_ENTRY_POINT);
@@ -42,11 +42,11 @@ std::unique_ptr<CWebinterface> CWebinterface::FromExtension(CAddonInfo addonInfo
   if (!entry.empty())
     entryPoint = entry;
 
-  return std::unique_ptr<CWebinterface>(new CWebinterface(std::move(addonInfo), type, entryPoint));
+  return std::unique_ptr<CWebinterface>(new CWebinterface(addonInfo, type, entryPoint));
 }
 
-CWebinterface::CWebinterface(ADDON::CAddonInfo addonInfo, WebinterfaceType type,
-    const std::string &entryPoint) : CAddon(std::move(addonInfo)), m_type(type), m_entryPoint(entryPoint)
+CWebinterface::CWebinterface(const AddonInfoPtr& addonInfo, WebinterfaceType type,
+    const std::string &entryPoint) : CAddon(addonInfo), m_type(type), m_entryPoint(entryPoint)
 { }
 
 std::string CWebinterface::GetEntryPoint(const std::string &path) const

--- a/xbmc/addons/Webinterface.h
+++ b/xbmc/addons/Webinterface.h
@@ -34,13 +34,13 @@ namespace ADDON
   class CWebinterface : public CAddon
   {
   public:
-    static std::unique_ptr<CWebinterface> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CWebinterface> FromExtension(const AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    explicit CWebinterface(CAddonInfo addonInfo)
-        : CAddon(std::move(addonInfo)),
+    explicit CWebinterface(const AddonInfoPtr& addonInfo)
+        : CAddon(addonInfo),
           m_type(WebinterfaceTypeStatic),
           m_entryPoint(WEBINTERFACE_DEFAULT_ENTRY_POINT) {}
-    CWebinterface(ADDON::CAddonInfo addonInfo, WebinterfaceType type, const std::string &entryPoint);
+    CWebinterface(const AddonInfoPtr& addonInfo, WebinterfaceType type, const std::string &entryPoint);
 
     WebinterfaceType GetType() const { return m_type; }
     const std::string& EntryPoint() const { return m_entryPoint; }

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -276,8 +276,8 @@ GUIHANDLE CAddonCallbacksGUI::Window_New(void *addonData, const char *xmlFilenam
   {
     //FIXME make this static method of current skin?
     std::string str("none");
-    CAddonInfo addonInfo(str, ADDON_SKIN);
-    addonInfo.SetPath(URIUtils::AddFileToFolder(
+    AddonInfoPtr addonInfo = std::make_shared<CAddonInfo>(str, ADDON_SKIN);
+    addonInfo->SetPath(URIUtils::AddFileToFolder(
       guiHelper->m_addon->Path(),
       "resources",
       "skins",
@@ -285,7 +285,7 @@ GUIHANDLE CAddonCallbacksGUI::Window_New(void *addonData, const char *xmlFilenam
 
     std::shared_ptr<CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo);
     skinInfo->Start();
-    strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res, addonInfo.Path());
+    strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res, addonInfo->Path());
 
     if (!XFILE::CFile::Exists(strSkinPath))
     {

--- a/xbmc/addons/interfaces/GUI/Window.cpp
+++ b/xbmc/addons/interfaces/GUI/Window.cpp
@@ -142,7 +142,7 @@ void* Interface_GUIWindow::create(void* kodiBase, const char* xml_filename,
   if (!XFILE::CFile::Exists(strSkinPath))
   {
     std::string str("none");
-    ADDON::CAddonInfo addonInfo(str, ADDON::ADDON_SKIN);
+    AddonInfoPtr addonInfo = std::make_shared<CAddonInfo>(str, ADDON_SKIN);
 
     // Check for the matching folder for the skin in the fallback skins folder
     std::string fallbackPath = URIUtils::AddFileToFolder(addon->Path(), "resources", "skins");
@@ -153,7 +153,7 @@ void* Interface_GUIWindow::create(void* kodiBase, const char* xml_filename,
     // Check for the matching folder for the skin in the fallback skins folder (if it exists)
     if (XFILE::CFile::Exists(basePath))
     {
-      addonInfo.SetPath(basePath);
+      addonInfo->SetPath(basePath);
       ADDON::CSkinInfo skinInfo(addonInfo, res);
       skinInfo.Start();
       strSkinPath = skinInfo.GetSkinPath(xml_filename, &res);
@@ -162,7 +162,7 @@ void* Interface_GUIWindow::create(void* kodiBase, const char* xml_filename,
     if (!XFILE::CFile::Exists(strSkinPath))
     {
       // Finally fallback to the DefaultSkin as it didn't exist in either the Kodi Skin folder or the fallback skin folder
-      addonInfo.SetPath(URIUtils::AddFileToFolder(fallbackPath, default_skin));
+      addonInfo->SetPath(URIUtils::AddFileToFolder(fallbackPath, default_skin));
       ADDON::CSkinInfo skinInfo(addonInfo, res);
 
       skinInfo.Start();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
@@ -35,8 +35,8 @@ using namespace ActiveAE;
 
 #define DEFAULT_INFO_STRING_VALUE "unknown"
 
-CActiveAEDSPAddon::CActiveAEDSPAddon(CAddonInfo addonInfo) :
-    CAddonDll(std::move(addonInfo))
+CActiveAEDSPAddon::CActiveAEDSPAddon(const AddonInfoPtr& addonInfo) :
+    CAddonDll(addonInfo)
 {
   ResetProperties();
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
@@ -44,7 +44,7 @@ namespace ActiveAE
   class CActiveAEDSPAddon : public ADDON::CAddonDll
   {
   public:
-    explicit CActiveAEDSPAddon(ADDON::CAddonInfo addonInfo);
+    explicit CActiveAEDSPAddon(const ADDON::AddonInfoPtr& addonInfo);
     ~CActiveAEDSPAddon(void);
 
     virtual void OnDisabled();

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -96,7 +96,7 @@ namespace
 
 // --- CGameClient -------------------------------------------------------------
 
-std::unique_ptr<CGameClient> CGameClient::FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CGameClient> CGameClient::FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   using namespace ADDON;
 
@@ -112,14 +112,14 @@ std::unique_ptr<CGameClient> CGameClient::FromExtension(ADDON::CAddonInfo addonI
   {
     std::string strProperty = CAddonMgr::GetInstance().GetExtValue(ext->configuration, property.c_str());
     if (!strProperty.empty())
-      addonInfo.extrainfo[property] = strProperty;
+      addonInfo->extrainfo[property] = strProperty;
   }
 
-  return std::unique_ptr<CGameClient>(new CGameClient(std::move(addonInfo)));
+  return std::unique_ptr<CGameClient>(new CGameClient(addonInfo));
 }
 
-CGameClient::CGameClient(ADDON::CAddonInfo addonInfo) :
-  CAddonDll(std::move(addonInfo)),
+CGameClient::CGameClient(const ADDON::AddonInfoPtr& addonInfo) :
+  CAddonDll(addonInfo),
   m_libraryProps(this, m_struct.props),
   m_bSupportsVFS(false),
   m_bSupportsStandalone(false),
@@ -132,7 +132,7 @@ CGameClient::CGameClient(ADDON::CAddonInfo addonInfo) :
   m_video(nullptr),
   m_region(GAME_REGION_UNKNOWN)
 {
-  const ADDON::InfoMap& extraInfo = m_addonInfo.extrainfo;
+  const ADDON::InfoMap& extraInfo = AddonInfo()->extrainfo;
   ADDON::InfoMap::const_iterator it;
 
   it = extraInfo.find(GAME_PROPERTY_EXTENSIONS);

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -58,9 +58,9 @@ class IGameVideoCallback;
 class CGameClient : public ADDON::CAddonDll
 {
 public:
-  static std::unique_ptr<CGameClient> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CGameClient> FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-  CGameClient(ADDON::CAddonInfo addonInfo);
+  CGameClient(const ADDON::AddonInfoPtr& addonInfo);
 
   virtual ~CGameClient(void);
 

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -30,13 +30,13 @@ using namespace GAME;
 
 const ControllerPtr CController::EmptyPtr;
 
-std::unique_ptr<CController> CController::FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CController> CController::FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
-  return std::unique_ptr<CController>(new CController(std::move(addonInfo)));
+  return std::unique_ptr<CController>(new CController(addonInfo));
 }
 
-CController::CController(ADDON::CAddonInfo addonInfo) :
-  CAddon(std::move(addonInfo)),
+CController::CController(const ADDON::AddonInfoPtr& addonInfo) :
+  CAddon(addonInfo),
   m_bLoaded(false)
 {
 }

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -36,9 +36,9 @@ using JOYSTICK::FEATURE_TYPE;
 class CController : public ADDON::CAddon
 {
 public:
-  static std::unique_ptr<CController> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
+  static std::unique_ptr<CController> FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-  CController(ADDON::CAddonInfo addonInfo);
+  CController(const ADDON::AddonInfoPtr& addonInfo);
 
   virtual ~CController() = default;
 

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -109,7 +109,7 @@ namespace XBMCAddon
       if (!XFILE::CFile::Exists(strSkinPath))
       {
         std::string str("none");
-        ADDON::CAddonInfo addonInfo(str, ADDON::ADDON_SKIN);
+        ADDON::AddonInfoPtr addonInfo = std::make_shared<ADDON::CAddonInfo>(str, ADDON::ADDON_SKIN);
         ADDON::CSkinInfo::TranslateResolution(defaultRes, res);
 
         // Check for the matching folder for the skin in the fallback skins folder
@@ -121,7 +121,7 @@ namespace XBMCAddon
         // Check for the matching folder for the skin in the fallback skins folder (if it exists)
         if (XFILE::CFile::Exists(basePath))
         {
-          addonInfo.SetPath(basePath);
+          addonInfo->SetPath(basePath);
           std::shared_ptr<ADDON::CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
           skinInfo->Start();
           strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res);
@@ -130,7 +130,7 @@ namespace XBMCAddon
         if (!XFILE::CFile::Exists(strSkinPath))
         {
           // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
-          addonInfo.SetPath(URIUtils::AddFileToFolder(fallbackPath, defaultSkin));
+          addonInfo->SetPath(URIUtils::AddFileToFolder(fallbackPath, defaultSkin));
           std::shared_ptr<ADDON::CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
 
           skinInfo->Start();

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -58,7 +58,7 @@ using namespace XFILE;
   #define SAFE_DELETE(p)  do { delete (p); (p) = NULL; } while (0)
 #endif
 
-std::unique_ptr<CPeripheralAddon> CPeripheralAddon::FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CPeripheralAddon> CPeripheralAddon::FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext)
 {
   std::string strProvidesJoysticks = ADDON::CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@provides_joysticks");
   std::string strProvidesButtonMaps = ADDON::CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@provides_buttonmaps");
@@ -66,11 +66,11 @@ std::unique_ptr<CPeripheralAddon> CPeripheralAddon::FromExtension(ADDON::CAddonI
   bool bProvidesJoysticks = StringUtils::EqualsNoCase(strProvidesJoysticks, "true");
   bool bProvidesButtonMaps = StringUtils::EqualsNoCase(strProvidesButtonMaps, "true");
 
-  return std::unique_ptr<CPeripheralAddon>(new CPeripheralAddon(std::move(addonInfo), bProvidesJoysticks, bProvidesButtonMaps));
+  return std::unique_ptr<CPeripheralAddon>(new CPeripheralAddon(addonInfo, bProvidesJoysticks, bProvidesButtonMaps));
 }
 
-CPeripheralAddon::CPeripheralAddon(ADDON::CAddonInfo addonInfo, bool bProvidesJoysticks, bool bProvidesButtonMaps) :
-  CAddonDll(std::move(addonInfo)),
+CPeripheralAddon::CPeripheralAddon(const ADDON::AddonInfoPtr& addonInfo, bool bProvidesJoysticks, bool bProvidesButtonMaps) :
+  CAddonDll(addonInfo),
   m_bProvidesJoysticks(bProvidesJoysticks),
   m_bSupportsJoystickRumble(false),
   m_bSupportsJoystickPowerOff(false),

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -51,9 +51,9 @@ namespace PERIPHERALS
   class CPeripheralAddon : public ADDON::CAddonDll
   {
   public:
-    static std::unique_ptr<CPeripheralAddon> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
+    static std::unique_ptr<CPeripheralAddon> FromExtension(const ADDON::AddonInfoPtr& addonInfo, const cp_extension_t* ext);
 
-    CPeripheralAddon(ADDON::CAddonInfo addonInfo, bool bProvidesJoysticks, bool bProvidesButtonMaps);
+    CPeripheralAddon(const ADDON::AddonInfoPtr& addonInfo, bool bProvidesJoysticks, bool bProvidesButtonMaps);
 
     virtual ~CPeripheralAddon(void);
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This change the on CAddon inserted CAddonInfo who was before static
included as shared_ptr.

To have as shared_ptr is a major requirement to allow several types
on one addon together.

There becomes be on next steps for e.g. CPVRClient the same CAddonInfo given
as for maybe ADDON::CInputStream if on same addon.

Further becomes in future (other requests) the CAddonInfo with this
shared_ptr stored on CAddonManager in a list.
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
