### PR TITLE
XBMC_events, cleanup and fix

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -407,12 +407,12 @@ bool CInputManager::OnEvent(XBMC_Event& newEvent)
       }
       else
       {
-        if (newEvent.button.type == XBMC_MOUSEBUTTONDOWN)
+        if (newEvent.type == XBMC_MOUSEBUTTONDOWN)
         {
           if (it->driverHandler->OnButtonPress(newEvent.button.button))
             handled = true;
         }
-        else if (newEvent.button.type == XBMC_MOUSEBUTTONUP)
+        else if (newEvent.type == XBMC_MOUSEBUTTONUP)
         {
           it->driverHandler->OnButtonRelease(newEvent.button.button);
         }

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -67,7 +67,7 @@ void CMouseStat::HandleEvent(XBMC_Event& newEvent)
   m_mouseState.y  = std::max(0, std::min(m_maxY, m_mouseState.y + dy));
 
   // Fill in the public members
-  if (newEvent.button.type == XBMC_MOUSEBUTTONDOWN)
+  if (newEvent.type == XBMC_MOUSEBUTTONDOWN)
   {
     if (newEvent.button.button == XBMC_BUTTON_LEFT) m_mouseState.button[MOUSE_LEFT_BUTTON] = true;
     if (newEvent.button.button == XBMC_BUTTON_RIGHT) m_mouseState.button[MOUSE_RIGHT_BUTTON] = true;
@@ -79,7 +79,7 @@ void CMouseStat::HandleEvent(XBMC_Event& newEvent)
     if (newEvent.button.button == XBMC_BUTTON_WHEELUP) m_mouseState.dz = 1;
     if (newEvent.button.button == XBMC_BUTTON_WHEELDOWN) m_mouseState.dz = -1;
   }
-  else if (newEvent.button.type == XBMC_MOUSEBUTTONUP)
+  else if (newEvent.type == XBMC_MOUSEBUTTONUP)
   {
     if (newEvent.button.button == XBMC_BUTTON_LEFT) m_mouseState.button[MOUSE_LEFT_BUTTON] = false;
     if (newEvent.button.button == XBMC_BUTTON_RIGHT) m_mouseState.button[MOUSE_RIGHT_BUTTON] = false;

--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -443,7 +443,7 @@ XBMCMod CLinuxInputDevice::UpdateModifiers(XBMC_Event& devt)
     default: break;
   }
 
-  if (devt.key.type == XBMC_KEYDOWN)
+  if (devt.type == XBMC_KEYDOWN)
   {
     m_keyMods |= modifier;
   }
@@ -452,7 +452,7 @@ XBMCMod CLinuxInputDevice::UpdateModifiers(XBMC_Event& devt)
     m_keyMods &= ~modifier;
   }
 
-  if (devt.key.type == XBMC_KEYDOWN)
+  if (devt.type == XBMC_KEYDOWN)
   {
     modifier = XBMCKMOD_NONE;
     switch (devt.key.keysym.sym)
@@ -493,7 +493,6 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
       return false;
 
     devt.type = levt.value ? XBMC_MOUSEBUTTONDOWN : XBMC_MOUSEBUTTONUP;
-    devt.button.type = devt.type;
     devt.button.x = m_mouseX;
     devt.button.y = m_mouseY;
 
@@ -543,7 +542,6 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
     }
 
     devt.type = levt.value ? XBMC_KEYDOWN : XBMC_KEYUP;
-    devt.key.type = devt.type;
     // warning, key.keysym.scancode is unsigned char so 0 - 255 only
     devt.key.keysym.scancode = code;
     devt.key.keysym.sym = key;
@@ -613,14 +611,12 @@ bool CLinuxInputDevice::RelEvent(const struct input_event& levt, XBMC_Event& dev
   if (motion)
   {
     devt.type = XBMC_MOUSEMOTION;
-    devt.motion.type = XBMC_MOUSEMOTION;
     devt.motion.x = m_mouseX;
     devt.motion.y = m_mouseY;
   }
   else if (wheel)
   {
      devt.type = XBMC_MOUSEBUTTONUP;
-     devt.button.type = devt.type;
      devt.button.x = m_mouseX;
      devt.button.y = m_mouseY;
      devt.button.button = (levt.value<0) ? XBMC_BUTTON_WHEELDOWN:XBMC_BUTTON_WHEELUP;
@@ -664,7 +660,6 @@ bool CLinuxInputDevice::AbsEvent(const struct input_event& levt, XBMC_Event& dev
   }
 
   devt.type = XBMC_MOUSEMOTION;
-  devt.motion.type = XBMC_MOUSEMOTION;
   devt.motion.x = m_mouseX;
   devt.motion.y = m_mouseY;
 

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -167,7 +167,6 @@ void CGenericTouchActionHandler::touch(uint8_t type, uint8_t button, uint16_t x,
   memset(&newEvent, 0, sizeof(newEvent));
   
   newEvent.type = type;
-  newEvent.button.type = type;
   newEvent.button.button = button;
   newEvent.button.x = x;
   newEvent.button.y = y;
@@ -181,7 +180,6 @@ void CGenericTouchActionHandler::sendEvent(int actionId, float x, float y, float
   memset(&newEvent, 0, sizeof(newEvent));
   
   newEvent.type = XBMC_TOUCH;
-  newEvent.touch.type = XBMC_TOUCH;
   newEvent.touch.action = actionId;
   newEvent.touch.x = x;
   newEvent.touch.y = y;
@@ -198,7 +196,6 @@ void CGenericTouchActionHandler::focusControl(float x, float y)
   memset(&newEvent, 0, sizeof(newEvent));
 
   newEvent.type = XBMC_SETFOCUS;
-  newEvent.focus.type = XBMC_SETFOCUS;
   newEvent.focus.x = (uint16_t)x;
   newEvent.focus.y = (uint16_t)y;
 

--- a/xbmc/platform/android/activity/AndroidKey.cpp
+++ b/xbmc/platform/android/activity/AndroidKey.cpp
@@ -329,7 +329,6 @@ void CAndroidKey::XBMC_Key(uint8_t code, uint16_t key, uint16_t modifiers, uint1
 
   unsigned char type = up ? XBMC_KEYUP : XBMC_KEYDOWN;
   newEvent.type = type;
-  newEvent.key.type = type;
   newEvent.key.keysym.scancode = code;
   newEvent.key.keysym.sym = (XBMCKey)key;
   newEvent.key.keysym.unicode = unicode;

--- a/xbmc/platform/android/activity/AndroidMouse.cpp
+++ b/xbmc/platform/android/activity/AndroidMouse.cpp
@@ -79,7 +79,6 @@ void CAndroidMouse::MouseMove(float x, float y)
   memset(&newEvent, 0, sizeof(newEvent));
 
   newEvent.type = XBMC_MOUSEMOTION;
-  newEvent.motion.type = XBMC_MOUSEMOTION;
   newEvent.motion.x = x;
   newEvent.motion.y = y;
   CWinEvents::MessagePush(&newEvent);
@@ -99,7 +98,6 @@ void CAndroidMouse::MouseButton(float x, float y, int32_t action, int32_t button
     checkButtons = m_lastButtonState;
 
   newEvent.type = (action ==  AMOTION_EVENT_ACTION_DOWN) ? XBMC_MOUSEBUTTONDOWN : XBMC_MOUSEBUTTONUP;
-  newEvent.button.type = newEvent.type;
   newEvent.button.x = x;
   newEvent.button.y = y;
   if (checkButtons & AMOTION_EVENT_BUTTON_PRIMARY)
@@ -135,14 +133,12 @@ void CAndroidMouse::MouseWheel(float x, float y, float value)
   else
     return;
 
-  newEvent.button.type = newEvent.type;
   newEvent.button.x = x;
   newEvent.button.y = y;
 
   CWinEvents::MessagePush(&newEvent);
 
   newEvent.type = XBMC_MOUSEBUTTONUP;
-  newEvent.button.type = newEvent.type;
 
   CWinEvents::MessagePush(&newEvent);
 }

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -417,7 +417,6 @@ bool CWinEventsX11Imp::MessagePump()
           XLookupString(&xevent.xkey, NULL, 0, &xkeysym, NULL);
           newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
           newEvent.key.keysym.scancode = xevent.xkey.keycode;
-          newEvent.key.type = xevent.xkey.type;
           if (XLookupString(&xevent.xkey, keybuf, sizeof(keybuf), NULL, &state))
           {
             newEvent.key.keysym.unicode = keybuf[0];
@@ -459,7 +458,6 @@ bool CWinEventsX11Imp::MessagePump()
             {
               newEvent.key.keysym.sym = XBMCK_UNKNOWN;
               newEvent.key.keysym.unicode = keys[i];
-              newEvent.key.type = xevent.xkey.type;
               ret |= ProcessKey(newEvent);
             }
             if (keys.length() > 0)
@@ -468,7 +466,6 @@ bool CWinEventsX11Imp::MessagePump()
               XLookupString(&xevent.xkey, NULL, 0, &xkeysym, NULL);
               newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
               newEvent.key.keysym.unicode = keys[keys.length() - 1];
-              newEvent.key.type = xevent.xkey.type;
 
               ret |= ProcessKey(newEvent);
             }
@@ -479,7 +476,6 @@ bool CWinEventsX11Imp::MessagePump()
           {
             newEvent.key.keysym.scancode = xevent.xkey.keycode;
             newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
-            newEvent.key.type = xevent.xkey.type;
             ret |= ProcessKey(newEvent);
             break;
           }
@@ -509,7 +505,6 @@ bool CWinEventsX11Imp::MessagePump()
         xkeysym = XLookupKeysym(&xevent.xkey, 0);
         newEvent.key.keysym.scancode = xevent.xkey.keycode;
         newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
-        newEvent.key.type = xevent.xkey.type;
         ret |= ProcessKey(newEvent);
         break;
       }

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -50,19 +50,16 @@ typedef enum {
 
 /* Keyboard event structure */
 typedef struct XBMC_KeyboardEvent {
-	unsigned char type;	/* XBMC_KEYDOWN or XBMC_KEYUP */
 	XBMC_keysym keysym;
 } XBMC_KeyboardEvent;
 
 /* Mouse motion event structure */
 typedef struct XBMC_MouseMotionEvent {
-	unsigned char type;	/* XBMC_MOUSEMOTION */
 	uint16_t x, y;	/* The X/Y coordinates of the mouse */
 } XBMC_MouseMotionEvent;
 
 /* Mouse button event structure */
 typedef struct XBMC_MouseButtonEvent {
-	unsigned char type;	/* XBMC_MOUSEBUTTONDOWN or XBMC_MOUSEBUTTONUP */
 	unsigned char button;	/* The mouse button index */
 	uint16_t x, y;	/* The X/Y coordinates of the mouse at press time */
 } XBMC_MouseButtonEvent;
@@ -72,25 +69,21 @@ typedef struct XBMC_MouseButtonEvent {
    mode with the new width and height.
  */
 typedef struct XBMC_ResizeEvent {
-	unsigned char type;	/* XBMC_VIDEORESIZE */
 	int w;		/* New width */
 	int h;		/* New height */
 } XBMC_ResizeEvent;
 
 typedef struct XBMC_MoveEvent {
-	unsigned char type;	/* XBMC_VIDEOMOVE */
 	int x;		/* New x position */
 	int y;		/* New y position */
 } XBMC_MoveEvent;
 
 /* The "quit requested" event */
 typedef struct XBMC_QuitEvent {
-	unsigned char type;	/* XBMC_QUIT */
 } XBMC_QuitEvent;
 
 /* A user-defined event type */
 typedef struct XBMC_UserEvent {
-	unsigned char type;	/* XBMC_USEREVENT */
 	int code;	/* User defined event code */
 	void *data1;	/* User defined data pointer */
 	void *data2;	/* User defined data pointer */
@@ -98,13 +91,11 @@ typedef struct XBMC_UserEvent {
 
 /* Multimedia keys on keyboards / remotes are mapped to APPCOMMAND events */
 typedef struct XBMC_AppCommandEvent {
-  unsigned char type; /* XBMC_APPCOMMAND */
-  unsigned int action; /* One of ACTION_... */  
+  unsigned int action; /* One of ACTION_... */
 } XBMC_AppCommandEvent;
 
 /* Mouse motion event structure */
 typedef struct XBMC_TouchEvent {
-  unsigned char type;   /* XBMC_TOUCH */
   int action;           /* action ID */
   float x, y;           /* The X/Y coordinates of the mouse */
   float x2, y2;         /* Additional X/Y coordinates */
@@ -112,23 +103,25 @@ typedef struct XBMC_TouchEvent {
 } XBMC_TouchEvent;
 
 typedef struct XBMC_SetFocusEvent {
-	unsigned char type;	/* XBMC_SETFOCUS */
 	int x;		/* x position */
 	int y;		/* y position */
 } XBMC_SetFocusEvent;
 
 /* General event structure */
-typedef union XBMC_Event {
-  unsigned char type;
-  XBMC_KeyboardEvent key;
-  XBMC_MouseMotionEvent motion;
-  XBMC_MouseButtonEvent button;
-  XBMC_ResizeEvent resize;
-  XBMC_MoveEvent move;
-  XBMC_QuitEvent quit;
-  XBMC_UserEvent user;
-  XBMC_AppCommandEvent appcommand;
-  XBMC_TouchEvent touch;
-  XBMC_SetFocusEvent focus;
+typedef struct XBMC_Event {
+  uint8_t type;
+  union
+  {
+    XBMC_KeyboardEvent key;
+    XBMC_MouseMotionEvent motion;
+    XBMC_MouseButtonEvent button;
+    XBMC_ResizeEvent resize;
+    XBMC_MoveEvent move;
+    XBMC_QuitEvent quit;
+    XBMC_UserEvent user;
+    XBMC_AppCommandEvent appcommand;
+    XBMC_TouchEvent touch;
+    XBMC_SetFocusEvent focus;
+  };
 } XBMC_Event;
 

--- a/xbmc/windowing/mir/WinEventsMir.cpp
+++ b/xbmc/windowing/mir/WinEventsMir.cpp
@@ -183,7 +183,6 @@ void MirHandlePointerButton(MirPointerEvent const* pev, unsigned char type)
   memset(&new_event, 0, sizeof(new_event));
 
   new_event.button.button = xbmc_button;
-  new_event.button.type   = type;
   new_event.button.x = x;
   new_event.button.y = y;
 

--- a/xbmc/windowing/osx/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/WinEventsSDL.cpp
@@ -76,7 +76,6 @@ bool CWinEventsSDL::MessagePump()
         newEvent.key.keysym.scancode = event.key.keysym.scancode;
         newEvent.key.keysym.sym = (XBMCKey) event.key.keysym.sym;
         newEvent.key.keysym.unicode = event.key.keysym.unicode;
-        newEvent.key.type = XBMC_KEYDOWN;
 
         // Check if the Windows keys are down because SDL doesn't flag this.
         uint16_t mod = event.key.keysym.mod;
@@ -99,7 +98,6 @@ bool CWinEventsSDL::MessagePump()
         newEvent.key.keysym.sym = (XBMCKey) event.key.keysym.sym;
         newEvent.key.keysym.mod =(XBMCMod) event.key.keysym.mod;
         newEvent.key.keysym.unicode = event.key.keysym.unicode;
-        newEvent.key.type = XBMC_KEYUP;
 
         ret |= g_application.OnEvent(newEvent);
         break;
@@ -141,7 +139,6 @@ bool CWinEventsSDL::MessagePump()
         }
         XBMC_Event newEvent;
         newEvent.type = XBMC_MOUSEMOTION;
-        newEvent.motion.type = XBMC_MOUSEMOTION;
         newEvent.motion.x = event.motion.x;
         newEvent.motion.y = event.motion.y;
 

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -594,7 +594,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_APPCOMMAND: // MULTIMEDIA keys are mapped to APPCOMMANDS
     {
       CLog::Log(LOGDEBUG, "WinEventsWin32.cpp: APPCOMMAND %d", GET_APPCOMMAND_LPARAM(lParam));
-      newEvent.appcommand.type = XBMC_APPCOMMAND;
+      newEvent.type = XBMC_APPCOMMAND;
       newEvent.appcommand.action = GET_APPCOMMAND_LPARAM(lParam);
       if (m_pEventFunc(newEvent))
         return TRUE;


### PR DESCRIPTION
fixes unwanted overwrites of fields caused by this old SDL union crap. works on OSX. other platforms like X11 need adjustments. then it should fix issue reported by @MilhouseVH 