### PR TITLE
[jenkins] - ensure that depends are rebuilt when darwim arm arch is changing

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -88,7 +88,7 @@ function getBuildHash ()
   checkPath="$1"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $checkPath)"
-  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $XBMC_DEPENDS_ROOT"
+  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $XBMC_DEPENDS_ROOT $DARWIN_ARM_CPU"
   echo $hashStr
 }
 


### PR DESCRIPTION
When changing between armv7 and arm64 on the ios job - depends were not cleaned.

@MartijnKaijser i think that might be the reason why you had success with master and ios-arm64 - i cleared the workspace and can see that it doesn't build for arm64 actually (because of the missing fix in ffmpeg).

@Rechi fyi ping as you had arm64 fixes in before too:

this is the printout https://pastebin.com/dBBG1C01

where i think only the first one is the cause and the others are follow up errors. We are missing this commit from ffmpeg upstream:

https://github.com/FFmpeg/FFmpeg/commit/2425d7329fdccfa9954faba748f3865151354f0c

@FernetMenta fyi