### PR TITLE
[addons/settings] CAddonSettings: fix "file" settings not opening the file selection dialog

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -867,6 +867,8 @@ SettingPtr CAddonSettings::InitializeFromOldSettingPath(const std::string& setti
     control->SetFormat("image");
   else
   {
+    control->SetFormat("file");
+
     // parse the options
     const auto options = StringUtils::Split(option, OldSettingValuesSeparator);
     control->SetUseImageThumbs(std::find(options.cbegin(), options.cend(), "usethumbs") != options.cend());


### PR DESCRIPTION
This commit fixes the problem reported by @manuelm in #12125 that when clicking on a file setting created with the old add-on settings format nothing happens. The expected behaviour is that a file selection dialog opens and the user can choose a file.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
