### PR TITLE
Fix GUIControlGroupList focus / fix crash on kodi shutdown with open …

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -189,18 +189,16 @@ void CGUIDialogContextMenu::SetPosition(float posX, float posY)
 
 float CGUIDialogContextMenu::GetHeight() const
 {
-  const CGUIControl *backMain = GetControl(BACKGROUND_IMAGE);
-  if (backMain)
-    return backMain->GetHeight();
+  if (m_backgroundImage)
+    return m_backgroundImage->GetHeight();
   else
     return CGUIDialog::GetHeight();
 }
 
 float CGUIDialogContextMenu::GetWidth() const
 {
-  const CGUIControl *pControl = GetControl(BACKGROUND_IMAGE);
-  if (pControl)
-    return pControl->GetWidth();
+  if (m_backgroundImage)
+    return m_backgroundImage->GetWidth();
   else
     return CGUIDialog::GetWidth();
 }
@@ -535,13 +533,13 @@ void CGUIDialogContextMenu::OnWindowLoaded()
   m_coordY = m_posY;
   
   const CGUIControlGroupList* pGroupList = dynamic_cast<const CGUIControlGroupList *>(GetControl(GROUP_LIST));
-  const CGUIControl *pControl = GetControl(BACKGROUND_IMAGE);
-  if (pControl && pGroupList)
+  m_backgroundImage = GetControl(BACKGROUND_IMAGE);
+  if (m_backgroundImage && pGroupList)
   {
     if (pGroupList->GetOrientation() == VERTICAL)
-      m_backgroundImageSize = pControl->GetHeight();
+      m_backgroundImageSize = m_backgroundImage->GetHeight();
     else
-      m_backgroundImageSize = pControl->GetWidth();
+      m_backgroundImageSize = m_backgroundImage->GetWidth();
   }
 
   CGUIDialog::OnWindowLoaded();

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -161,4 +161,5 @@ private:
   float m_backgroundImageSize;
   int m_clickedButton;
   CContextButtons m_buttons;
+  const CGUIControl *m_backgroundImage = nullptr;
 };

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -929,6 +929,12 @@ void CGUIControl::SaveStates(std::vector<CControlState> &states)
   // empty for now - do nothing with the majority of controls
 }
 
+CGUIControl *CGUIControl::GetControl(int iControl, std::vector<CGUIControl*> *idCollector)
+{
+  return (iControl == m_controlID) ? this : nullptr;
+}
+
+
 void CGUIControl::UpdateControlStats()
 {
   if (m_controlStats)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -256,6 +256,8 @@ public:
   void SetParentControl(CGUIControl *control) { m_parentControl = control; };
   CGUIControl *GetParentControl(void) const { return m_parentControl; };
   virtual void SaveStates(std::vector<CControlState> &states);
+  virtual CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr);
+
 
   void SetControlStats(GUICONTROLSTATS *controlStats) { m_controlStats = controlStats; };
   virtual void UpdateControlStats();

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -264,7 +264,7 @@ bool CGUIControlGroup::OnMessage(CGUIMessage& message)
 
 bool CGUIControlGroup::SendControlMessage(CGUIMessage &message)
 {
-  CGUIControl *ctrl = GetControl(message.GetControlId(), &m_idCollector);
+  CGUIControl *ctrl(GetControl(message.GetControlId(), &m_idCollector));
   // see if a child matches, and send to the child control if so
   if (ctrl && ctrl->OnMessage(message))
     return true;
@@ -405,36 +405,17 @@ CGUIControl *CGUIControlGroup::GetControl(int iControl, std::vector<CGUIControl*
 
   CGUIControl* pPotential(nullptr);
 
-  LookupMap::iterator first = m_lookup.find(iControl);
-  if (first != m_lookup.end())
-  {
-    LookupMap::iterator last = m_lookup.upper_bound(iControl);
-    for (LookupMap::iterator i = first; i != last; ++i)
-    {
-      CGUIControl *control = i->second;
-      if (control->IsVisible())
-        return control;
-      else if (idCollector)
-        idCollector->push_back(control);
-      else if (!pPotential)
-        pPotential = control;
-    }
-  }
-  return pPotential;
-}
-
-const CGUIControl* CGUIControlGroup::GetControl(int iControl) const
-{
-  const CGUIControl *pPotential = NULL;
   LookupMap::const_iterator first = m_lookup.find(iControl);
   if (first != m_lookup.end())
   {
     LookupMap::const_iterator last = m_lookup.upper_bound(iControl);
     for (LookupMap::const_iterator i = first; i != last; ++i)
     {
-      const CGUIControl *control = i->second;
+      CGUIControl *control = i->second;
       if (control->IsVisible())
         return control;
+      else if (idCollector)
+        idCollector->push_back(control);
       else if (!pPotential)
         pPotential = control;
     }

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -67,8 +67,7 @@ public:
 
   int GetFocusedControlID() const;
   CGUIControl *GetFocusedControl() const;
-  const CGUIControl *GetControl(int id) const;
-  CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr);
+  virtual CGUIControl *GetControl(int id, std::vector<CGUIControl*> *idCollector = nullptr);
   virtual CGUIControl *GetFirstFocusableControl(int id);
 
   virtual void AddControl(CGUIControl *control, int position = -1);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -154,7 +154,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
         CGUIControl *control = *it;
         if (!control->IsVisible())
           continue;
-        if (control->GetID() == message.GetControlId())
+        if (control->GetControl(message.GetControlId()))
         {
           // find out whether this is the first or last control
           if (IsFirstFocusableControl(control))
@@ -183,7 +183,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
         CGUIControl *control = *it;
         if (!control->IsVisible())
           continue;
-        if (control->GetID() == m_focusedControl)
+        if (control->GetControl(m_focusedControl))
         {
           if (IsControlOnScreen(offset, control))
             return CGUIControlGroup::OnMessage(message);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1231,7 +1231,10 @@ void CGUIWindowManager::SetCallback(IWindowManagerCallback& callback)
 void CGUIWindowManager::DeInitialize()
 {
   CSingleLock lock(g_graphicsContext);
-  for (const auto& entry : m_mapWindows)
+
+  // Need a copy bacause addon-dialogs remove itself on Close()
+  std::unordered_map<int, CGUIWindow*> closeMap(m_mapWindows);
+  for (const auto& entry : closeMap)
   {
     CGUIWindow* pWindow = entry.second;
     if (IsWindowActive(entry.first, false))


### PR DESCRIPTION
…addon-dialog

Fix focus issue introduced with PR 12213

## Description
1.) Focus can leave window because GUIControGroupList does not scroll
2.) kodi segfaults on exit with open addon-dialog

## How Has This Been Tested?
extendedInfo.script: 

1.) choose actor and move focus with button down -> focus will leave window
2.) open extendedInfo.script and close kodi (press "s") - segfault

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
