### PR TITLE
[ios/ios64] - bump xcode and sdk to fix ios64 compilation

### DIFF
--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -99,7 +99,7 @@ function getBuildHash ()
   checkPath="$1"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $checkPath)"
-  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $XBMC_DEPENDS_ROOT"
+  hashStr="$hashStr $SDK_PATH $NDK_PATH $NDK_VERSION $SDK_VERSION $TOOLCHAIN $XBMC_DEPENDS_ROOT $XCODE_APP"
   echo $hashStr
 }
 

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -4,6 +4,7 @@ NDK_VERSION=${NDK_VERSION:-"Default"}
 Configuration=${Configuration:-"Default"}
 XBMC_DEPENDS_ROOT=${XBMC_DEPENDS_ROOT:-"Default"}
 DARWIN_ARM_CPU=${DARWIN_ARM_CPU:-"Default"}
+XCODE_APP=${XCODE_APP:-"Default"}
 PATH_CHANGE_REV_FILENAME=".last_success_revision"
 FAILED_BUILD_FILENAME=".last_failed_revision"
 #TARBALLS ENV-VAR is only used by android scripts atm
@@ -21,12 +22,14 @@ case $XBMC_PLATFORM_DIR in
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     DEFAULT_DARWIN_ARM_CPU="armv7"
+    DEFAULT_XCODE_APP="Xcode6.1.1.app"
     ;;
 
   osx64)
     DEFAULT_SDK_VERSION=10.10
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
+    DEFAULT_XCODE_APP="Xcode6.1.1.app"
     ;;
 
   android)
@@ -67,6 +70,14 @@ if [ "$DARWIN_ARM_CPU" == "Default" ]
 then
   DARWIN_ARM_CPU=$DEFAULT_DARWIN_ARM_CPU  
 fi
+
+if [ "$XCODE_APP" == "Default" ]
+then
+  XCODE_APP=$DEFAULT_XCODE_APP
+fi
+
+# make osx environment aware of the selected xcode app
+DEVELOPER_DIR=/Applications/$XCODE_APP/Contents/Developer
 
 if [ "$Configuration" == "Default" ]
 then

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -18,11 +18,11 @@ DEPLOYED_BINARY_ADDONS="-e /addons"
 #$XBMC_PLATFORM_DIR matches the platform subdirs!
 case $XBMC_PLATFORM_DIR in
   ios)
-    DEFAULT_SDK_VERSION=8.1
+    DEFAULT_SDK_VERSION=9.2
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="Debug"
     DEFAULT_DARWIN_ARM_CPU="armv7"
-    DEFAULT_XCODE_APP="Xcode6.1.1.app"
+    DEFAULT_XCODE_APP="Xcode.app"
     ;;
 
   osx64)


### PR DESCRIPTION
I am already sick of playing the cat and mouse between ffmpeg and xcode6.1.1 - lets bump xcode and ios sdk for finally being able to compile ios64.

@FernetMenta sorry for bothering you - the patch you backported wasn't enought anymore for some reason and it bombed out in some other aarch64 neon code.

Testbuild is already running here:

http://jenkins.kodi.tv/job/IOS-ARM64/14/

and here

http://jenkins.kodi.tv/job/IOS/703/

I will bump to xcode 7.2 for osx aswell when / if the sparkle PR gets merged (as its needed to compile the sparkle framework).

Once that is done i can update the osx version of the slaves to 10.12 sierra aswell (because xcode7.2 runs on sierra, xcode6.1.1 doesn't ...)