### PR TITLE
[depends] bump libbluray to version 1.0.1

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -15,7 +15,7 @@ expat-2.2.0-x64-vc140.7z
 fmt-3.0.1-x64-vc140.7z
 freetype-db5a224-x64-vc140.7z
 libass-d18a5f1-x64-vc140.7z
-libbluray-1.0.0-x64-vc140.7z
+libbluray-1.0.1-x64-vc140.7z
 libcdio-0.94-x64-vc140.7z
 libcec-4.0.2-x64-vc140.7z
 libfribidi-0.19.7-x64-vc140.7z

--- a/tools/depends/target/libbluray/Makefile
+++ b/tools/depends/target/libbluray/Makefile
@@ -3,14 +3,14 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libbluray
-VERSION=0.9.3
+VERSION=1.0.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX) --exec-prefix=$(PREFIX) \
   --disable-examples --disable-doxygen-doc \
-  --disable-bdjava --without-libxml2 --without-freetype
+  --disable-bdjava-jar --without-libxml2 --without-freetype
 
 LIBDYLIB=$(PLATFORM)/src/.libs/libbluray.la
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Bump libbluray to version 1.0.1 for depends and windows x64.
<!--- Describe your change in detail -->

## Motivation and Context
 #11954 bumped version for windows 32 bit.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Windows and OS X
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
