### PR TITLE
[Estuary] Add episodename to live tv and recordings osd sub label, cleanup seek bar for live tv.

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -209,21 +209,11 @@
 				<aligny>center</aligny>
 				<visible>VideoPlayer.HasEpg</visible>
 			</control>
-			<control type="label">
-				<left>260</left>
-				<right>50</right>
-				<top>20</top>
-				<height>25</height>
-				<label>$INFO[VideoPlayer.Title]$INFO[VideoPlayer.EpisodeName, (,)]</label>
-				<align>left</align>
-				<font>font36_title</font>
-				<aligny>center</aligny>
-			</control>
 			<control type="textbox">
 				<left>260</left>
-				<top>55</top>
+				<top>20</top>
 				<right>50</right>
-				<height>120</height>
+				<height>155</height>
 				<label fallback="416">$INFO[VideoPlayer.Plot]</label>
 				<align>justify</align>
 				<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -264,7 +264,7 @@
 		<value condition="Window.IsActive(visualisation) + Integer.IsGreater(Playlist.Length,1)">$LOCALIZE[554] $INFO[Playlist.Position] / $INFO[Playlist.Length]</value>
 		<value condition="VideoPlayer.Content(musicvideos)">$INFO[VideoPlayer.Artist]$INFO[VideoPlayer.Album, - ]</value>
 		<value condition="VideoPlayer.Content(episodes)">$INFO[VideoPlayer.Season,[COLOR button_focus]S,[/COLOR]]$INFO[VideoPlayer.Episode,[COLOR button_focus]E,: [/COLOR]]$INFO[VideoPlayer.TVShowTitle]</value>
-		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR=blue],[/COLOR]) ]$INFO[VideoPlayer.ChannelName]</value>
+		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR=blue],[/COLOR]) ]$INFO[VideoPlayer.ChannelName] $INFO[VideoPlayer.EpisodeName, - ]</value>
 		<value>$INFO[VideoPlayer.Genre]</value>
 	</variable>
 	<variable name="AddonsFanartVar">


### PR DESCRIPTION
Add episodename to live tv and recordings osd sub label, because it was nowhere displayed in the osd:

Before:
![screenshot001](https://user-images.githubusercontent.com/3226626/27202120-9d23d8e2-5220-11e7-9d41-00e57940ef6d.png)

After:
![screenshot000](https://user-images.githubusercontent.com/3226626/27202132-a425fc2e-5220-11e7-8021-4fbaf003acaf.png)

Remove show title and episodename from to live tv seek bar dialog, because this info was duplicated in the osd sub label (show title even before this PR):

Before:
![screenshot003](https://user-images.githubusercontent.com/3226626/27203046-4fd00526-5224-11e7-8437-d0e01cc443ee.png)

After:
![screenshot002](https://user-images.githubusercontent.com/3226626/27203052-547cef9e-5224-11e7-8e4f-17a030872897.png)

@phil65 @ronie mind taking a look.