### PR TITLE
[bluray] jvm check is available since libbluray 1.0.1

### DIFF
--- a/lib/DllLibbluray.h
+++ b/lib/DllLibbluray.h
@@ -18,8 +18,6 @@
  *
  */
 #pragma once
-#include "system.h"
-#ifdef HAVE_LIBBLURAY
 
 #include "DynamicDll.h"
 
@@ -196,5 +194,3 @@ public:
   static BD_DIR_H *dir_open(const char* dirname);
   static void      bluray_logger(const char* msg);
 };
-
-#endif

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -18,7 +18,6 @@
  *
  */
 #include "system.h"
-#ifdef HAVE_LIBBLURAY
 
 #include <functional>
 
@@ -1237,5 +1236,3 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
   m_dll->bd_set_player_setting_str(m_bd, BLURAY_PLAYER_CACHE_ROOT, cacheDir.c_str());
 #endif
 }
-
-#endif

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -17,8 +17,6 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#include "system.h"
-#ifdef HAVE_LIBBLURAY
 #include "BlurayDirectory.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -204,4 +202,3 @@ CURL CBlurayDirectory::GetUnderlyingCURL(const CURL& url)
 }
 
 } /* namespace XFILE */
-#endif

--- a/xbmc/filesystem/BlurayFile.cpp
+++ b/xbmc/filesystem/BlurayFile.cpp
@@ -18,9 +18,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAVE_LIBBLURAY
-
 #include "BlurayFile.h"
 #include "URL.h"
 #include <assert.h>
@@ -47,4 +44,3 @@ namespace XFILE
     return host.append(filename);
   }
 } /* namespace XFILE */
-#endif

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(SOURCES AdvancedSettings.cpp
             AudioDSPSettings.cpp
-            DiscSettings.cpp
             DisplaySettings.cpp
             MediaSettings.cpp
             MediaSourceSettings.cpp
@@ -33,5 +32,9 @@ set(HEADERS AdvancedSettings.h
             SettingUtils.h
             SkinSettings.h
             VideoSettings.h)
+
+if(BLURAY_FOUND)
+  list(APPEND SOURCES DiscSettings.cpp)
+endif()
 
 core_add_library(settings)

--- a/xbmc/settings/DiscSettings.cpp
+++ b/xbmc/settings/DiscSettings.cpp
@@ -31,6 +31,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "utils/Variant.h"
 
+#include <libbluray/bluray-version.h>
 
 CDiscSettings::CDiscSettings(void)
 {
@@ -58,7 +59,7 @@ CDiscSettings& CDiscSettings::GetInstance()
 
 void CDiscSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 {
-#ifdef TARGET_WINDOWS
+#if (BLURAY_VERSION >= BLURAY_VERSION_CODE(1,0,1))
   if (setting == NULL)
     return;
 

--- a/xbmc/settings/DiscSettings.cpp
+++ b/xbmc/settings/DiscSettings.cpp
@@ -18,9 +18,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAVE_LIBBLURAY
-
 #include <string>
 
 #include "DiscSettings.h"
@@ -88,4 +85,3 @@ void CDiscSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   }
 #endif
 }
-#endif

--- a/xbmc/settings/DiscSettings.h
+++ b/xbmc/settings/DiscSettings.h
@@ -29,9 +29,6 @@ enum BDPlaybackMode
   BD_PLAYBACK_MAIN_TITLE,
 };
 
-#include "system.h"
-#ifdef HAVE_LIBBLURAY
-
 #include "settings/lib/ISettingCallback.h"
 
 class DllLibbluray;
@@ -51,4 +48,3 @@ protected:
   DllLibbluray*       m_dll;
 
 };
-#endif


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
The jvm check is available since libbluray version 1.0.1 and not windows only.
<!--- Describe your change in detail -->

## Motivation and Context
#11954 added the check for windows only.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested on Windows (with and without libbluray), OS X and Linux (with 0.9.3 and 1.0.1)
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
