### PR TITLE
FIX: ensure real filename from videodb in playlists

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -25,7 +25,6 @@
 #include "input/Key.h"
 #include "URL.h"
 #include "messaging/ApplicationMessenger.h"
-#include "filesystem/VideoDatabaseFile.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "ServiceBroker.h"
 
@@ -296,9 +295,6 @@ bool CPlayListPlayer::Play(int iSong, std::string player, bool bAutoPlay /* = fa
 
   m_iCurrentSong = iSong;
   CFileItemPtr item = playlist[m_iCurrentSong];
-  if (item->IsVideoDb() && !item->HasVideoInfoTag())
-    *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetPath()));
-
   playlist.SetPlayed(true);
 
   m_bPlaybackStarted = false;

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -83,6 +83,9 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
   else
     item->m_iprogramCount = iOrder;
 
+  if (item->IsVideoDb())
+    item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
+
   // increment the playable counter
   item->ClearProperty("unplayable");
   if (m_iPlayableItems < 0)


### PR DESCRIPTION
fixes issue when downloading subtitles side-by-side