### PR TITLE
Fix crash on game close introduced in PR 12180

### DIFF
--- a/xbmc/games/ports/Port.h
+++ b/xbmc/games/ports/Port.h
@@ -46,6 +46,8 @@ namespace GAME
     void RegisterDevice(PERIPHERALS::CPeripheral *device);
     void UnregisterDevice(PERIPHERALS::CPeripheral *device);
 
+    JOYSTICK::IInputHandler *InputHandler() { return m_inputHandler; }
+
   private:
     JOYSTICK::IInputHandler* const m_inputHandler;
     std::unique_ptr<JOYSTICK::IInputHandler> m_controller;

--- a/xbmc/games/ports/PortMapper.cpp
+++ b/xbmc/games/ports/PortMapper.cpp
@@ -95,13 +95,13 @@ void CPortMapper::ProcessPeripherals()
     auto itConnectedPort = newPortMap.find(joystick.get());
     auto itDisconnectedPort = m_portMap.find(joystick);
 
-    bool bIsConnected = itConnectedPort != newPortMap.end();
-    bool bWasConnected = itDisconnectedPort != m_portMap.end();
+    IInputHandler* newHandler = itConnectedPort != newPortMap.end() ? itConnectedPort->second : nullptr;
+    IInputHandler* oldHandler = itDisconnectedPort != m_portMap.end() ? itDisconnectedPort->second->InputHandler() : nullptr;
 
-    if (bIsConnected != bWasConnected)
+    if (oldHandler != newHandler)
     {
       // Unregister old handler
-      if (bWasConnected)
+      if (oldHandler != nullptr)
       {
         PortPtr& oldPort = itDisconnectedPort->second;
 
@@ -111,14 +111,12 @@ void CPortMapper::ProcessPeripherals()
       }
 
       // Register new handler
-      if (bIsConnected)
+      if (newHandler != nullptr)
       {
-        IInputHandler *inputHandler = itConnectedPort->second;
-
-        CGameClient *gameClient = m_portManager->GameClient(inputHandler);
+        CGameClient *gameClient = m_portManager->GameClient(newHandler);
         if (gameClient)
         {
-          PortPtr newPort(new CPort(inputHandler, *gameClient));
+          PortPtr newPort(new CPort(newHandler, *gameClient));
 
           newPort->RegisterDevice(joystick.get());
 


### PR DESCRIPTION
The commit 6083eabfc in #12180 contained a small logic refactor that caused a crash when exiting a game with a joystick plugged in. This restores the previous behavior without the crash.

## How Has This Been Tested?
Tested with 1 and 2 joysticks plugged in.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
