### PR TITLE
[addons/settings] Fix fallout #3

### DIFF
--- a/xbmc/addons/settings/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.cpp
@@ -139,6 +139,9 @@ void CGUIDialogAddonSettings::SetupView()
 
   CGUIDialogSettingsManagerBase::SetupView();
 
+  // set addon id as window property
+  SetProperty("Addon.ID", m_addon->ID());
+
   // set heading
   SetHeading(StringUtils::Format("$LOCALIZE[10004] - %s", m_addon->Name().c_str())); // "Settings - AddonName"
 

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -96,8 +96,8 @@ bool CSkinSettings::Load(const TiXmlNode *settings)
 
   const TiXmlElement *rootElement = settings->FirstChildElement(XML_SKINSETTINGS);
   
-  //return true in the case skinsettings is missing. It just means that
-  //it's been migrated and it's not an error
+  // return true in the case skinsettings is missing. It just means that
+  // it's been migrated and it's not an error
   if (rootElement == nullptr)
   {
     CLog::Log(LOGDEBUG, "CSkinSettings: no <skinsettings> tag found");
@@ -116,26 +116,7 @@ bool CSkinSettings::Save(TiXmlNode *settings) const
   if (settings == nullptr)
     return false;
 
-  CSingleLock lock(m_critical);
-
-  if (m_settings.empty())
-    return true;
-
-  // add the <skinsettings> tag
-  TiXmlElement xmlSettingsElement(XML_SKINSETTINGS);
-  TiXmlNode* settingsNode = settings->InsertEndChild(xmlSettingsElement);
-  if (settingsNode == nullptr)
-  {
-    CLog::Log(LOGWARNING, "CSkinSettings: could not create <skinsettings> tag");
-    return false;
-  }
-
-  TiXmlElement* settingsElement = settingsNode->ToElement();
-  for (const auto& setting : m_settings)
-  {
-    if (!setting->Serialize(settingsElement))
-      CLog::Log(LOGWARNING, "CSkinSettings: unable to save setting \"%s\"", setting->name.c_str());
-  }
+  // nothing to do here because skin settings saving has been migrated to CSkinInfo
 
   return true;
 }

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -148,7 +148,7 @@ static bool GetIntegerOptions(SettingConstPtr setting, IntegerSettingOptions& op
   return true;
 }
 
-static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& options, std::set<std::string>& selectedOptions)
+static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& options, std::set<std::string>& selectedOptions, ILocalizer* localizer)
 {
   std::shared_ptr<const CSettingString> pSettingString = NULL;
   if (setting->GetType() == SettingType::String)
@@ -180,7 +180,7 @@ static bool GetStringOptions(SettingConstPtr setting, StringSettingOptions& opti
     {
       const TranslatableStringSettingOptions& settingOptions = pSettingString->GetTranslatableOptions();
       for (const auto& option : settingOptions)
-        options.push_back(std::make_pair(g_localizeStrings.Get(option.first), option.second));
+        options.push_back(std::make_pair(Localize(option.first, localizer), option.second));
       break;
     }
 
@@ -389,7 +389,7 @@ void CGUIControlSpinExSetting::FillControl()
       StringSettingOptions options;
       std::set<std::string> selectedValues;
       // get the string options
-      if (!GetStringOptions(m_pSetting, options, selectedValues) || selectedValues.size() != 1)
+      if (!GetStringOptions(m_pSetting, options, selectedValues, m_localizer) || selectedValues.size() != 1)
         return;
 
       // add them to the spinner
@@ -577,12 +577,12 @@ bool CGUIControlListSetting::GetIntegerItems(SettingConstPtr setting, CFileItemL
   return true;
 }
 
-bool CGUIControlListSetting::GetStringItems(SettingConstPtr setting, CFileItemList &items)
+bool CGUIControlListSetting::GetStringItems(SettingConstPtr setting, CFileItemList &items) const
 {
   StringSettingOptions options;
   std::set<std::string> selectedValues;
   // get the string options
-  if (!GetStringOptions(setting, options, selectedValues))
+  if (!GetStringOptions(setting, options, selectedValues, m_localizer))
     return false;
 
   // turn them into CFileItems and add them to the item list

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -941,8 +941,6 @@ void CGUIControlEditSetting::Update(bool updateDisplayOnly /* = false */)
     std::shared_ptr<CSettingUrlEncodedString> urlEncodedSetting = std::static_pointer_cast<CSettingUrlEncodedString>(m_pSetting);
     m_pEdit->SetLabel2(urlEncodedSetting->GetDecodedValue());
   }
-  else if (control->IsHidden() || control->GetFormat() == "md5")
-    m_pEdit->SetLabel2(std::string(m_pSetting->ToString().size(), '*'));
   else
     m_pEdit->SetLabel2(m_pSetting->ToString());
 }

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -147,8 +147,7 @@ public:
 private:
   bool GetItems(std::shared_ptr<const CSetting> setting, CFileItemList &items) const;
   bool GetIntegerItems(std::shared_ptr<const CSetting> setting, CFileItemList &items) const;
-
-  static bool GetStringItems(std::shared_ptr<const CSetting> setting, CFileItemList &items);
+  bool GetStringItems(std::shared_ptr<const CSetting> setting, CFileItemList &items) const;
 
   CGUIButtonControl *m_pButton;
 };


### PR DESCRIPTION
These commits should fix the following problems caused by #12125:
* with my first set of fallout fixes I thought I fixed settings with hidden values (passwords etc) but I actually made it worse. This should fix it for real.
* I noticed that localized strings in spinners weren't properly localized with add-on strings
* I re-added the `Addon.ID` window property to `CGUIDialogAddonSettings` which was broken and reported at https://forum.kodi.tv/showthread.php?tid=316560
* I'm sneaking in a commit which will remove code that still stored skin settings in `guisettings.xml` even though we migrated them to skin-specific add-on settings quite a while ago

There are still other issues that need fixing which I will cover in separate PRs because they are more complex.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
