### PR TITLE
changed: Default libcurl timeout value to 30

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -320,7 +320,7 @@ void CAdvancedSettings::Initialize()
   m_screenAlign_xStretchFactor = 1.0;
   m_screenAlign_yStretchFactor = 1.0;
 
-  m_curlconnecttimeout = 10;
+  m_curlconnecttimeout = 30;
   m_curllowspeedtime = 20;
   m_curlretries = 2;
   m_curlDisableIPV6 = false;      //Certain hardware/OS combinations have trouble

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -263,7 +263,7 @@ void CAdvancedSettings::Initialize()
   m_imageRes = 720;
   m_imageScalingAlgorithm = CPictureScalingAlgorithm::Default;
 
-  m_sambaclienttimeout = 10;
+  m_sambaclienttimeout = 30;
   m_sambadoscodepage = "";
   m_sambastatfiles = true;
 


### PR DESCRIPTION
Ages ago when libcurl still had several issues with timeout handling and we also didn't have the ability to abort the opening of a (new) connection, I lowered this value to 10 to make it more user friendly. Fortunately much has improved ever since, and now the value of 10 is actually too low for some scenarios. Mainly for setups with poor (wifi) connections or NAS systems which have HDD spindown enabled, the value should be much higher. According to docs one can assume a harddisk will at max take 30 seconds to spinup, so let's use this as our timeout default as well.
