### PR TITLE
[Estuary] DialogSeekBar: Reintroduce channel number display, like we …

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -200,6 +200,17 @@
 				<texture>$INFO[Player.Art(thumb)]</texture>
 			</control>
 			<control type="label">
+				<left>20</left>
+				<width>220</width>
+				<top>-80</top>
+				<height>25</height>
+				<label>$INFO[VideoPlayer.ChannelNumberLabel]</label>
+				<shadowcolor>black</shadowcolor>
+				<align>center</align>
+				<font>WeatherTemp</font>
+				<aligny>center</aligny>
+			</control>
+			<control type="label">
 				<right>20</right>
 				<width>800</width>
 				<top>190</top>


### PR DESCRIPTION
…had with Krypton (got lost somehow on master).

Screenshot:
![screenshot001](https://user-images.githubusercontent.com/3226626/27300427-f9ac84da-552f-11e7-8db0-07a687793b26.png)

@phil65 good to go (I just copied the Krypton code that got lost)?