### PR TITLE
[addons] fix Service add-on started twice

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -401,12 +401,6 @@ void OnPreInstall(const AddonPtr& addon)
 void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
 {
   AddonPtr localAddon;
-  if (CAddonMgr::GetInstance().ServicesHasStarted())
-  {
-    if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_SERVICE))
-      std::static_pointer_cast<CService>(localAddon)->Start();
-  }
-
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_REPOSITORY))
     CRepositoryUpdater::GetInstance().ScheduleUpdate(); //notify updater there is a new addon or version
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Related to https://trac.kodi.tv/ticket/17502 and https://forum.kodi.tv/showthread.php?tid=307759

Found that during install (from repo and also from zip) the addon was one time
started by CAddon::OnEnabled(...) and then by CAddon::OnPostInstall(...).

The first:
```
#0  0x0000561966062654 in CScriptInvocationManager::ExecuteAsync (this=0x561967a90ea0 <CScriptInvocationManager::GetInstance()::s_instance>, script=..., 
    languageInvoker=std::shared_ptr (count 2, weak 0) 0x7f918417cf40, addon=warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr (count 3, weak 1) 0x7f918417aed0, 
    arguments=std::vector of length 0, capacity 0) at /home/alwin/Development/kodi/xbmc/interfaces/generic/ScriptInvocationManager.cpp:239
#1  0x00005619660624a0 in CScriptInvocationManager::ExecuteAsync (this=0x561967a90ea0 <CScriptInvocationManager::GetInstance()::s_instance>, script=..., 
    addon=warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr (count 3, weak 1) 0x7f918417aed0, arguments=std::vector of length 0, capacity 0)
    at /home/alwin/Development/kodi/xbmc/interfaces/generic/ScriptInvocationManager.cpp:219
#2  0x0000561965b82712 in (anonymous namespace)::CService::Start (this=0x7f918417aed0) at /home/alwin/Development/kodi/xbmc/addons/Service.cpp:52
#3  0x0000561965ad6992 in (anonymous namespace)::OnEnabled (id=...) at /home/alwin/Development/kodi/xbmc/addons/Addon.cpp:404
#4  0x0000561965b18836 in (anonymous namespace)::CAddonMgr::EnableSingle (this=0x561969fea7c0, id=...)
    at /home/alwin/Development/kodi/xbmc/addons/AddonManager.cpp:845
#5  0x0000561965b18c98 in (anonymous namespace)::CAddonMgr::EnableAddon (this=0x561969fea7c0, id=...)
    at /home/alwin/Development/kodi/xbmc/addons/AddonManager.cpp:865
#6  0x0000561965b1791d in (anonymous namespace)::CAddonMgr::ReloadAddon (this=0x561969fea7c0, addon=warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr (count 1, weak 1) 0x7f91840dd790)
    at /home/alwin/Development/kodi/xbmc/addons/AddonManager.cpp:740
#7  0x0000561965b0b61c in CAddonInstallJob::DoWork (this=0x56196c2a2dd0) at /home/alwin/Development/kodi/xbmc/addons/AddonInstaller.cpp:612
#8  0x000056196573407d in CJobWorker::Process (this=0x56196b9b70e0) at /home/alwin/Development/kodi/xbmc/utils/JobManager.cpp:69
#9  0x00005619657eae21 in CThread::Action (this=0x56196b9b70e0) at /home/alwin/Development/kodi/xbmc/threads/Thread.cpp:221
#10 0x00005619657eaab7 in CThread::staticThread (data=0x56196b9b70e0) at /home/alwin/Development/kodi/xbmc/threads/Thread.cpp:131
#11 0x00007f91e74f76da in start_thread (arg=0x7f918bfff700) at pthread_create.c:456
#12 0x00007f91dfee4d7f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105
```

The second:
```
#0  0x00005607fbba3655 in CScriptInvocationManager::ExecuteAsync (this=0x5607fd5d1ea0 <CScriptInvocationManager::GetInstance()::s_instance>, script=..., 
    languageInvoker=std::shared_ptr (count 2, weak 0) 0x7f04ac0b92f0, addon=warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr (count 3, weak 1) 0x7f04ac04ec80, 
    arguments=std::vector of length 0, capacity 0) at /home/alwin/Development/kodi/xbmc/interfaces/generic/ScriptInvocationManager.cpp:239
#1  0x00005607fbba34a0 in CScriptInvocationManager::ExecuteAsync (this=0x5607fd5d1ea0 <CScriptInvocationManager::GetInstance()::s_instance>, script=..., 
    addon=warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr (count 3, weak 1) 0x7f04ac04ec80, arguments=std::vector of length 0, capacity 0)
    at /home/alwin/Development/kodi/xbmc/interfaces/generic/ScriptInvocationManager.cpp:219
#2  0x00005607fb6c3712 in (anonymous namespace)::CService::Start (this=0x7f04ac04ec80) at /home/alwin/Development/kodi/xbmc/addons/Service.cpp:52
#3  0x00005607fb617db4 in (anonymous namespace)::OnPostInstall (addon=warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<ADDON::CService*, std::default_delete<ADDON::CService>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr (count 1, weak 1) 0x7f04ac060040, update=false, modal=false)
    at /home/alwin/Development/kodi/xbmc/addons/Addon.cpp:448
#4  0x00005607fb64c814 in CAddonInstallJob::DoWork (this=0x5608013e0090) at /home/alwin/Development/kodi/xbmc/addons/AddonInstaller.cpp:621
#5  0x00005607fb27507d in CJobWorker::Process (this=0x560800e61030) at /home/alwin/Development/kodi/xbmc/utils/JobManager.cpp:69
#6  0x00005607fb32be21 in CThread::Action (this=0x560800e61030) at /home/alwin/Development/kodi/xbmc/threads/Thread.cpp:221
#7  0x00005607fb32bab7 in CThread::staticThread (data=0x560800e61030) at /home/alwin/Development/kodi/xbmc/threads/Thread.cpp:131
#8  0x00007f0524fbc6da in start_thread (arg=0x7f04c67fc700) at pthread_create.c:456
#9  0x00007f051d9a9d7f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105
```

This remove the service start from `CAddon::OnPostInstall` who becomes also done from `CAddon::OnEnabled` who is always called for them.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
