### PR TITLE
Fix 3d mode switching for Wetek HUB on Libreelec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2066,10 +2066,20 @@ void CAMLCodec::SetVideoSaturation(const int saturation)
   SysfsUtils::SetInt("/sys/class/video/saturation", saturation);
 }
 
-void CAMLCodec::SetVideo3dMode(const int mode3d)
+bool CAMLCodec::SetVideo3dMode(const int mode3d)
 {
-  CLog::Log(LOGDEBUG, "CAMLCodec::SetVideo3dMode:mode3d(0x%x)", mode3d);
-  SysfsUtils::SetInt("/sys/class/ppmgr/ppmgr_3d_mode", mode3d);
+  bool result = true;
+  if (SysfsUtils::Has("/sys/class/ppmgr/ppmgr_3d_mode"))
+  {
+    CLog::Log(LOGDEBUG, "CAMLCodec::SetVideo3dMode:mode3d(0x%x)", mode3d);
+    SysfsUtils::SetInt("/sys/class/ppmgr/ppmgr_3d_mode", mode3d);
+  }
+  else
+  {
+    CLog::Log(LOGINFO, "CAMLCodec::SetVideo3dMode: ppmgr_3d support not found in kernel.");
+    result = false;
+  }
+  return result;
 }
 
 std::string CAMLCodec::GetStereoMode()
@@ -2197,13 +2207,41 @@ void CAMLCodec::SetVideoRect(const CRect &SrcRect, const CRect &DestRect)
   {
     std::string mode = GetStereoMode();
     if (mode == "left_right")
-      SetVideo3dMode(MODE_3D_TO_2D_L);
+    {
+      if (!SetVideo3dMode(MODE_3D_TO_2D_L))
+      {
+        // fall back to software scaling if no hw support
+        // was found
+        dst_rect.x2 *= 2.0;
+      }
+    }
     else if (mode == "right_left")
-      SetVideo3dMode(MODE_3D_TO_2D_R);
+    {
+      if (!SetVideo3dMode(MODE_3D_TO_2D_R))
+      {
+        // fall back to software scaling if no hw support
+        // was found
+        dst_rect.x2 *= 2.0;
+      }
+    }
     else if (mode == "top_bottom")
-      SetVideo3dMode(MODE_3D_TO_2D_T);
+    {
+      if (!SetVideo3dMode(MODE_3D_TO_2D_T))
+      {
+        // fall back to software scaling if no hw support
+        // was found
+        dst_rect.y2 *= 2.0;
+      }
+    }
     else if (mode == "bottom_top")
-      SetVideo3dMode(MODE_3D_TO_2D_B);
+    {
+      if (!SetVideo3dMode(MODE_3D_TO_2D_B))
+      {
+        // fall back to software scaling if no hw support
+        // was found
+        dst_rect.y2 *= 2.0;
+      }
+    }
     else
       SetVideo3dMode(MODE_3D_DISABLE);
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -63,7 +63,7 @@ private:
   void          SetVideoContrast(const int contrast);
   void          SetVideoBrightness(const int brightness);
   void          SetVideoSaturation(const int saturation);
-  void          SetVideo3dMode(const int mode3d);
+  bool          SetVideo3dMode(const int mode3d);
   std::string   GetStereoMode();
   bool          OpenAmlVideo(const CDVDStreamInfo &hints);
   void          CloseAmlVideo();

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -20,6 +20,7 @@
  */
 
 #include "guilib/Resolution.h"
+#include "rendering/RenderSystem.h"
 
 enum AML_DEVICE_TYPE
 {
@@ -59,4 +60,5 @@ bool aml_support_hevc_10bit();
 AML_SUPPORT_H264_4K2K aml_support_h264_4k2k();
 void aml_set_audio_passthrough(bool passthrough);
 bool aml_IsHdmiConnected();
+void aml_handle_display_stereo_mode(RENDER_STEREO_MODE stereo_mode);
 bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res);

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "EGLNativeTypeAmlogic.h"
+#include "guilib/GraphicContext.h"
 #include "guilib/gui3d.h"
 #include "utils/AMLUtils.h"
 #include "utils/StringUtils.h"
@@ -133,6 +134,7 @@ bool CEGLNativeTypeAmlogic::GetNativeResolution(RESOLUTION_INFO *res) const
 
 bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
 {
+  bool result = false;
 #if defined(_FBDEV_WINDOW_H_)
   if (m_nativeWindow)
   {
@@ -144,10 +146,14 @@ bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
   // Don't set the same mode as current
   std::string mode;
   SysfsUtils::GetString("/sys/class/display/mode", mode);
-  if (res.strId == mode)
-    return false;
+  
+  if (res.strId != mode)
+    result = SetDisplayResolution(res.strId.c_str());
 
-  return SetDisplayResolution(res.strId.c_str());
+  RENDER_STEREO_MODE stereo_mode = g_graphicsContext.GetStereoMode();
+  aml_handle_display_stereo_mode(stereo_mode);
+  
+  return result;
 }
 
 bool CEGLNativeTypeAmlogic::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)


### PR DESCRIPTION
Backort of #12316

@kszaq in case this makes it in and gets pulled into libreelec 8.2 - this will conflict with this patch:

https://github.com/LibreELEC/LibreELEC.tv/blob/libreelec-8.2/packages/mediacenter/kodi/patches/aarch64/kodi-0003-EGLNativeTypeAmlogic-Enable-GUI-free_scale-when-framebuffer-size-is-less-than-output.patch

Just ensure that the stereo_mode handling i added here is done after the call to "DealWithScale" ...