### PR TITLE
Fix "VMSF_DELTA filter in unrar allows arbitrary memory write"

### DIFF
--- a/lib/UnrarXLib/rarvm.cpp
+++ b/lib/UnrarXLib/rarvm.cpp
@@ -873,14 +873,16 @@ void RarVM::ExecuteStandardFilter(VM_StandardFilters FilterType)
       break;
     case VMSF_DELTA:
       {
-        int DataSize=R[4],Channels=R[0],SrcPos=0,Border=DataSize*2;
-        SET_VALUE(false,&Mem[VM_GLOBALMEMADDR+0x20],DataSize);
-        if (DataSize>=VM_GLOBALMEMADDR/2)
+        uint DataSize=R[4],Channels=R[0],SrcPos=0,Border=DataSize*2;
+        if (DataSize>VM_MEMSIZE/2 || Channels>MAX3_UNPACK_CHANNELS || Channels==0)
           break;
-        for (int CurChannel=0;CurChannel<Channels;CurChannel++)
+
+        // Bytes from same channels are grouped to continual data blocks,
+        // so we need to place them back to their interleaving positions.
+        for (uint CurChannel=0;CurChannel<Channels;CurChannel++)
         {
           byte PrevByte=0;
-          for (int DestPos=DataSize+CurChannel;DestPos<Border;DestPos+=Channels)
+          for (uint DestPos=DataSize+CurChannel;DestPos<Border;DestPos+=Channels)
             Mem[DestPos]=(PrevByte-=Mem[SrcPos++]);
         }
       }

--- a/lib/UnrarXLib/unpack.hpp
+++ b/lib/UnrarXLib/unpack.hpp
@@ -1,6 +1,12 @@
 #ifndef _RAR_UNPACK_
 #define _RAR_UNPACK_
 
+// Limit maximum number of channels in RAR3 delta filter to some reasonable
+// value to prevent too slow processing of corrupt archives with invalid
+// channels number. Must be equal or larger than v3_MAX_FILTER_CHANNELS.
+// No need to provide it for RAR5, which uses only 5 bits to store channels.
+#define MAX3_UNPACK_CHANNELS      1024
+
 enum BLOCK_TYPES {BLOCK_LZ,BLOCK_PPM};
 
 struct Decode


### PR DESCRIPTION
See https://bugs.chromium.org/p/project-zero/issues/detail?id=1286

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

Addresses the "VMSF_DELTA filter in unrar allows arbitrary memory write" vulnerability. This code was taken from the unrar 5.5.5 release at http://www.rarlab.com/rar/unrarsrc-5.5.5.tar.gz

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
There's a security issue - reported in trac at https://trac.kodi.tv/ticket/17510

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
