### PR TITLE
VideoBuffer: Avoid unsafe race when resetting pool

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/VideoBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/Process/VideoBuffer.cpp
@@ -48,8 +48,9 @@ void CVideoBuffer::Release()
   m_refCount--;
   if (m_refCount <= 0)
   {
-    m_pool->Return(m_id);
+    std::shared_ptr<IVideoBufferPool> pool = m_pool->GetPtr();
     m_pool = nullptr;
+    pool->Return(m_id);
   }
 }
 


### PR DESCRIPTION
Currently we are resetting the m_pool variable after Returning the buffer.
As the pool will add the buffer back to the free list there is a danger it
will be reallocated and m_pool assigned before the reset to nullptr occurs.

That leaves you with a live buffer with an invalid pool pointer.
So, make sure we don't touch m_pool after returning the buffer.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
