### PR TITLE
VideoBuffers: Use YuvImage::MAX_PLANES

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -128,8 +128,8 @@ bool CDVDVideoPPFFmpeg::Process(VideoPicture* pPicture)
   int pict_type = (m_pSource->qscale_type != DVP_QSCALE_MPEG1) ?
                    PP_PICT_TYPE_QP2 : 0;
 
-  uint8_t* srcPlanes[3], *dstPlanes[3];
-  int srcStrides[3], dstStrides[3];
+  uint8_t* srcPlanes[YuvImage::MAX_PLANES], *dstPlanes[YuvImage::MAX_PLANES];
+  int srcStrides[YuvImage::MAX_PLANES], dstStrides[YuvImage::MAX_PLANES];
   m_pSource->videoBuffer->GetPlanes(srcPlanes);
   m_pSource->videoBuffer->GetStrides(srcStrides);
   m_pTarget.videoBuffer->GetPlanes(dstPlanes);

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -269,8 +269,8 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
 
             if (context)
             {
-              uint8_t *planes[3];
-              int stride[3];
+              uint8_t *planes[YuvImage::MAX_PLANES];
+              int stride[YuvImage::MAX_PLANES];
               picture.videoBuffer->GetPlanes(planes);
               picture.videoBuffer->GetStrides(stride);
               uint8_t *src[4]= { planes[0], planes[1], planes[2], 0 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
VideoBuffers: Use YuvImage::MAX_PLANES
so MAX_PLANES can be modified without a build error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
