### PR TITLE
Rework OS screen saver handling

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3348,7 +3348,7 @@
       <group id="1" label="16000">
         <setting id="screensaver.mode" type="addon" label="356" help="36130">
           <level>0</level>
-          <default>screensaver.xbmc.builtin.dim</default>
+          <default>default</default> <!-- will be properly set on startup -->
           <constraints>
             <addontype>xbmc.ui.screensaver</addontype>
             <allowempty>true</allowempty>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -97,10 +97,6 @@
 
 #include "input/KeyboardLayoutManager.h"
 
-#ifdef HAS_SDL
-#include <SDL/SDL.h>
-#endif
-
 #ifdef HAS_UPNP
 #include "network/upnp/UPnP.h"
 #include "filesystem/UPnPDirectory.h"
@@ -677,41 +673,9 @@ bool CApplication::CreateGUI()
   m_frameMoveGuard.lock();
 
   m_renderGUI = true;
-#ifdef HAS_SDL
-  CLog::Log(LOGNOTICE, "Setup SDL");
-
-  /* Clean up on exit, exit on window close and interrupt */
-  atexit(SDL_Quit);
-
-  uint32_t sdlFlags = 0;
-
-#if defined(TARGET_DARWIN_OSX)
-  sdlFlags |= SDL_INIT_VIDEO;
-#endif
-
-  //depending on how it's compiled, SDL periodically calls XResetScreenSaver when it's fullscreen
-  //this might bring the monitor out of standby, so we have to disable it explicitly
-  //by passing 0 for overwrite to setsenv, the user can still override this by setting the environment variable
-#if defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
-  setenv("SDL_VIDEO_ALLOW_SCREENSAVER", "1", 0);
-#endif
-
-#endif // HAS_SDL
 
   m_bSystemScreenSaverEnable = g_Windowing.IsSystemScreenSaverEnabled();
   g_Windowing.EnableSystemScreenSaver(false);
-
-#ifdef HAS_SDL
-  if (SDL_Init(sdlFlags) != 0)
-  {
-    CLog::Log(LOGFATAL, "XBAppEx: Unable to initialize SDL: %s", SDL_GetError());
-    return false;
-  }
-  #if defined(TARGET_DARWIN)
-  // SDL_Init will install a handler for segfaults, restore the default handler.
-  signal(SIGSEGV, SIG_DFL);
-  #endif
-#endif
 
   // Initialize core peripheral port support. Note: If these parameters
   // are 0 and NULL, respectively, then the default number and types of

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -674,17 +674,26 @@ bool CApplication::CreateGUI()
 
   m_renderGUI = true;
 
-  m_bSystemScreenSaverEnable = g_Windowing.IsSystemScreenSaverEnabled();
-  g_Windowing.EnableSystemScreenSaver(false);
-
-  // Initialize core peripheral port support. Note: If these parameters
-  // are 0 and NULL, respectively, then the default number and types of
-  // controllers will be initialized.
   if (!g_Windowing.InitWindowSystem())
   {
     CLog::Log(LOGFATAL, "CApplication::Create: Unable to init windowing system");
     return false;
   }
+
+  // Set default screen saver mode
+  auto screensaverModeSetting = std::static_pointer_cast<CSettingString>(m_ServiceManager->GetSettings().GetSetting(CSettings::SETTING_SCREENSAVER_MODE));
+  // Can only set this after windowing has been initialized since it depends on it
+  if (g_Windowing.GetOSScreenSaver())
+  {
+    // If OS has a screen saver, use it by default
+    screensaverModeSetting->SetDefault("");
+  }
+  else
+  {
+    // If OS has no screen saver, use Kodi one by default
+    screensaverModeSetting->SetDefault("screensaver.xbmc.builtin.dim");
+  }
+  CheckOSScreenSaverInhibitionSetting();
 
   // Retrieve the matching resolution based on GUI settings
   bool sav_res = false;
@@ -1369,6 +1378,10 @@ void CApplication::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   {
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WINDOW_RESIZE);
     g_windowManager.SendThreadMessage(msg);
+  }
+  else if (settingId == CSettings::SETTING_SCREENSAVER_MODE)
+  {
+    CheckOSScreenSaverInhibitionSetting();
   }
   else if (StringUtils::StartsWithNoCase(settingId, "audiooutput."))
   { // AE is master of audio settings and needs to be informed first
@@ -2727,6 +2740,9 @@ bool CApplication::Cleanup()
     // unloading
     CScriptInvocationManager::GetInstance().Uninitialize();
 
+    m_globalScreensaverInhibitor.Release();
+    m_screensaverInhibitor.Release();
+
     g_Windowing.DestroyRenderSystem();
     g_Windowing.DestroyWindow();
     g_Windowing.DestroyWindowSystem();
@@ -2806,9 +2822,6 @@ void CApplication::Stop(int exitCode)
     SaveFileState(true);
 
     g_alarmClock.StopThread();
-
-    if( m_bSystemScreenSaverEnable )
-      g_Windowing.EnableSystemScreenSaver(true);
 
     CLog::Log(LOGNOTICE, "Storing total System Uptime");
     g_sysinfo.SetTotalUptime(g_sysinfo.GetTotalUptime() + (int)(CTimeUtils::GetFrameTime() / 60000));
@@ -3957,18 +3970,50 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
     return false;
 }
 
+void CApplication::CheckOSScreenSaverInhibitionSetting()
+{
+  // Kodi screen saver overrides OS one: always inhibit OS screen saver then
+  if (!m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE).empty() && g_Windowing.GetOSScreenSaver())
+  {
+    if (!m_globalScreensaverInhibitor)
+    {
+      m_globalScreensaverInhibitor = g_Windowing.GetOSScreenSaver()->CreateInhibitor();
+    }
+  }
+  else if (m_globalScreensaverInhibitor)
+  {
+    m_globalScreensaverInhibitor.Release();
+  }
+}
+
 void CApplication::CheckScreenSaverAndDPMS()
 {
-  if (!m_dpmsIsActive)
-    g_Windowing.ResetOSScreensaver();
-
   bool maybeScreensaver =
       !m_dpmsIsActive && !m_screensaverActive
       && !m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE).empty();
   bool maybeDPMS =
       !m_dpmsIsActive && m_dpms->IsSupported()
       && m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF) > 0;
+  // whether the current state of the application should be regarded as active even when there is no
+  // explicit user activity such as input
+  bool haveIdleActivity =
+    // * Are we playing a video and it is not paused?
+    (m_pPlayer->IsPlayingVideo() && !m_pPlayer->IsPaused())
+    // * Are we playing some music in fullscreen vis?
+    || (m_pPlayer->IsPlayingAudio() && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION
+        && !m_ServiceManager->GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty());
 
+  // Handle OS screen saver state
+  if (haveIdleActivity && g_Windowing.GetOSScreenSaver())
+  {
+    // Always inhibit OS screen saver during these kinds of activities
+    m_screensaverInhibitor = g_Windowing.GetOSScreenSaver()->CreateInhibitor();
+  }
+  else if (m_screensaverInhibitor)
+  {
+    m_screensaverInhibitor.Release();
+  }
+  
   // Has the screen saver window become active?
   if (maybeScreensaver && g_windowManager.IsWindowActive(WINDOW_SCREENSAVER))
   {
@@ -3985,11 +4030,7 @@ void CApplication::CheckScreenSaverAndDPMS()
   if (!maybeScreensaver && !maybeDPMS) return;  // Nothing to do.
 
   // See if we need to reset timer.
-  // * Are we playing a video and it is not paused?
-  if ((m_pPlayer->IsPlayingVideo() && !m_pPlayer->IsPaused())
-      // * Are we playing some music in fullscreen vis?
-      || (m_pPlayer->IsPlayingAudio() && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION
-          && !m_ServiceManager->GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty()))
+  if (haveIdleActivity)
   {
     ResetScreenSaverTimer();
     return;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -73,6 +73,7 @@ namespace PLAYLIST
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceStats.h"
 #endif
+#include "windowing/OSScreenSaver.h"
 #include "windowing/XBMC_events.h"
 #include "threads/Thread.h"
 
@@ -407,6 +408,8 @@ protected:
 
   bool LoadSkin(const std::string& skinID);
 
+  void CheckOSScreenSaverInhibitionSetting();
+
   /*!
    \brief Delegates the action to all registered action handlers.
    \param action The action
@@ -430,6 +433,10 @@ protected:
   bool m_screensaverActive;
   std::string m_screensaverIdInUse;
   ADDON::AddonPtr m_pythonScreenSaver; // @warning: Fallback for Python interface, for binaries not needed!
+  // OS screen saver inhibitor that is always active if user selected a Kodi screen saver
+  KODI::WINDOWING::COSScreenSaverInhibitor m_globalScreensaverInhibitor;
+  // Inhibitor that is active e.g. during video playback
+  KODI::WINDOWING::COSScreenSaverInhibitor m_screensaverInhibitor;
 
   // timer information
 #ifdef TARGET_WINDOWS

--- a/xbmc/threads/Timer.cpp
+++ b/xbmc/threads/Timer.cpp
@@ -23,12 +23,16 @@
 #include "Timer.h"
 #include "SystemClock.h"
 
-CTimer::CTimer(ITimerCallback *callback)
+CTimer::CTimer(std::function<void()> const& callback)
   : CThread("Timer"),
     m_callback(callback),
     m_timeout(0),
     m_interval(false),
     m_endTime(0)
+{ }
+
+CTimer::CTimer(ITimerCallback *callback)
+  : CTimer(std::bind(&ITimerCallback::OnTimeout, callback))
 { }
 
 CTimer::~CTimer()
@@ -103,7 +107,7 @@ void CTimer::Process()
       if (m_endTime <= currentTime)
       {
         // execute OnTimeout() callback
-        m_callback->OnTimeout();
+        m_callback();
 
         // continue if this is an interval timer, or if it was restarted during callback
         if (!m_interval && m_endTime <= currentTime)

--- a/xbmc/threads/Timer.h
+++ b/xbmc/threads/Timer.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include <functional>
+
 #include "Event.h"
 #include "Thread.h"
 
@@ -34,6 +36,7 @@ class CTimer : protected CThread
 {
 public:
   CTimer(ITimerCallback *callback);
+  explicit CTimer(std::function<void()> const& callback);
   virtual ~CTimer();
 
   bool Start(uint32_t timeout, bool interval = false);
@@ -50,7 +53,7 @@ protected:
   virtual void Process();
   
 private:
-  ITimerCallback *m_callback;
+  std::function<void()> m_callback;
   uint32_t m_timeout;
   bool m_interval;
   uint32_t m_endTime;

--- a/xbmc/windowing/CMakeLists.txt
+++ b/xbmc/windowing/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(SOURCES WinEvents.cpp
+set(SOURCES OSScreenSaver.cpp
+            WinEvents.cpp
             WinSystem.cpp)
 
-set(HEADERS WindowingFactory.h
+set(HEADERS OSScreenSaver.h
+            WindowingFactory.h
             WinEvents.h
             WinSystem.h
             XBMC_events.h

--- a/xbmc/windowing/OSScreenSaver.cpp
+++ b/xbmc/windowing/OSScreenSaver.cpp
@@ -1,0 +1,110 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "OSScreenSaver.h"
+
+#include "utils/log.h"
+
+using namespace KODI::WINDOWING;
+
+COSScreenSaverManager::COSScreenSaverManager(std::unique_ptr<IOSScreenSaver>&& impl)
+: m_impl(std::move(impl))
+{
+}
+
+COSScreenSaverInhibitor COSScreenSaverManager::CreateInhibitor()
+{
+  COSScreenSaverInhibitor inhibitor(this);
+  if (m_inhibitionCount++ == 0)
+  {
+    // Inhibit if this was first inhibitor
+    CLog::Log(LOGDEBUG, "Inhibiting OS screen saver");
+    m_impl->Inhibit();
+  }
+  return inhibitor;
+}
+
+bool COSScreenSaverManager::IsInhibited()
+{
+  return (m_inhibitionCount > 0);
+}
+
+void COSScreenSaverManager::RemoveInhibitor()
+{
+  if (--m_inhibitionCount == 0)
+  {
+    CLog::Log(LOGDEBUG, "Uninhibiting OS screen saver");
+    // Uninhibit if this was last inhibitor
+    m_impl->Uninhibit();
+  }
+}
+
+COSScreenSaverInhibitor::COSScreenSaverInhibitor()
+: m_active(false), m_manager(nullptr)
+{
+}
+
+COSScreenSaverInhibitor::COSScreenSaverInhibitor(COSScreenSaverManager* manager)
+: m_active(true), m_manager(manager)
+{
+}
+
+COSScreenSaverInhibitor::COSScreenSaverInhibitor(COSScreenSaverInhibitor&& other)
+: m_active(false), m_manager(nullptr)
+{
+  *this = std::move(other);
+}
+
+COSScreenSaverInhibitor& COSScreenSaverInhibitor::operator=(COSScreenSaverInhibitor&& other)
+{
+  Release();
+  m_active = other.m_active;
+  m_manager = other.m_manager;
+  other.m_active = false;
+  other.m_manager = nullptr;
+  return *this;
+}
+
+bool COSScreenSaverInhibitor::IsActive() const
+{
+  return m_active;
+}
+
+COSScreenSaverInhibitor::operator bool() const
+{
+  return IsActive();
+}
+
+void COSScreenSaverInhibitor::Release()
+{
+  if (m_active)
+  {
+    m_manager->RemoveInhibitor();
+    m_active = false;
+  }
+}
+
+COSScreenSaverInhibitor::~COSScreenSaverInhibitor()
+{
+  Release();
+}
+
+
+

--- a/xbmc/windowing/OSScreenSaver.h
+++ b/xbmc/windowing/OSScreenSaver.h
@@ -1,0 +1,119 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <memory>
+#include <utility>
+
+namespace KODI
+{
+namespace WINDOWING
+{
+
+class COSScreenSaverManager;
+
+/**
+ * Inhibit the OS screen saver as long as this object is alive
+ *
+ * Destroy or call \ref Release to stop this inhibitor from being active.
+ * The OS screen saver may still be inhibited as long as other inhibitors are
+ * active though.
+ *
+ * \note Make sure to release or destroy the inhibitor before the \ref
+ *       COSScreenSaverManager is destroyed
+ */
+class COSScreenSaverInhibitor
+{
+public:
+  COSScreenSaverInhibitor();
+  COSScreenSaverInhibitor(COSScreenSaverInhibitor&& other);
+  COSScreenSaverInhibitor& operator=(COSScreenSaverInhibitor&& other);
+  ~COSScreenSaverInhibitor();
+  void Release();
+  bool IsActive() const;
+  operator bool() const;
+
+private:
+  friend class COSScreenSaverManager;
+  COSScreenSaverInhibitor(COSScreenSaverManager* manager);
+  bool m_active;
+  COSScreenSaverManager* m_manager;
+
+  COSScreenSaverInhibitor(COSScreenSaverInhibitor const& other) = delete;
+  COSScreenSaverInhibitor& operator=(COSScreenSaverInhibitor const& other) = delete;
+};
+
+/**
+ * Interface for OS screen saver control implementations
+ */
+class IOSScreenSaver
+{
+public:
+  virtual ~IOSScreenSaver() {}
+  /**
+   * Do not allow the OS screen saver to become active
+   *
+   * Calling this function multiple times without calling \ref Unhibit
+   * MUST NOT produce any side-effects.
+   */
+  virtual void Inhibit() = 0;
+  /**
+   * Allow the OS screen saver to become active again
+   *
+   * Calling this function multiple times or at all without calling \ref Inhibit
+   * MUST NOT produce any side-effects.
+   */
+  virtual void Uninhibit() = 0;
+};
+
+/**
+ * Manage the OS screen saver
+ *
+ * This class keeps track of a number of \ref COSScreenSaverInhibitor instances
+ * and keeps the OS screen saver inhibited as long as at least one of them
+ * exists and is active.
+ */
+class COSScreenSaverManager
+{
+public:
+  /**
+   * Create manager with backing OS-specific implementation
+   */
+  COSScreenSaverManager(std::unique_ptr<IOSScreenSaver>&& impl);
+  /**
+   * Create inhibitor that prevents the OS screen saver from becoming active as
+   * long as it is alive
+   */
+  COSScreenSaverInhibitor CreateInhibitor();
+  /**
+   * Check whether the OS screen saver is currently inhibited
+   */
+  bool IsInhibited();
+
+private:
+  friend class COSScreenSaverInhibitor;
+  void RemoveInhibitor();
+
+  unsigned int m_inhibitionCount = 0;
+  std::unique_ptr<IOSScreenSaver> m_impl;
+};
+
+}
+}

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -60,6 +60,7 @@ bool CWinSystemBase::DestroyWindowSystem()
 #if HAS_GLES
   CGUIFontTTFGL::DestroyStaticVertexBuffers();
 #endif
+  m_screenSaverManager.reset();
   return false;
 }
 
@@ -260,4 +261,18 @@ int CWinSystemBase::NoOfBuffers(void)
 {
   int buffers = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOSCREEN_NOOFBUFFERS);
   return buffers;
+}
+
+KODI::WINDOWING::COSScreenSaverManager* CWinSystemBase::GetOSScreenSaver()
+{
+  if (!m_screenSaverManager)
+  {
+    auto impl = GetOSScreenSaverImpl();
+    if (impl)
+    {
+      m_screenSaverManager.reset(new KODI::WINDOWING::COSScreenSaverManager(std::move(impl)));
+    }
+  }
+
+  return m_screenSaverManager.get();
 }

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -21,6 +21,7 @@
 #ifndef WINDOW_SYSTEM_BASE_H
 #define WINDOW_SYSTEM_BASE_H
 
+#include "OSScreenSaver.h"
 #include "VideoSync.h"
 #include "WinEvents.h"
 #include "guilib/Resolution.h"
@@ -98,6 +99,15 @@ public:
   virtual void EnableSystemScreenSaver(bool bEnable) {};
   virtual bool IsSystemScreenSaverEnabled() {return false;}
   virtual void ResetOSScreensaver() {};
+  /**
+   * Get OS screen saver inhibit implementation if available
+   * 
+   * \return OS screen saver implementation that can be used with this windowing system
+   *         or nullptr if unsupported.
+   *         Lifetime of the returned object will usually end with \ref DestroyWindowSystem, so
+   *         do not use any more after calling that.
+   */
+  KODI::WINDOWING::COSScreenSaverManager* GetOSScreenSaver();
 
   // resolution interfaces
   unsigned int GetWidth() { return m_nWidth; }
@@ -122,6 +132,7 @@ public:
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, int screen, int width, int height, float refreshRate, uint32_t dwFlags = 0);
+  virtual std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() { return nullptr; }
 
   WindowSystemType  m_eWindowSystem;
   int               m_nWidth;
@@ -133,6 +144,7 @@ protected:
   int               m_nScreen;
   bool              m_bBlankOtherDisplay;
   float             m_fRefreshRate;
+  std::unique_ptr<KODI::WINDOWING::COSScreenSaverManager> m_screenSaverManager;
 };
 
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -96,9 +96,6 @@ public:
   virtual void OnMove(int x, int y) {}
 
   // OS System screensaver
-  virtual void EnableSystemScreenSaver(bool bEnable) {};
-  virtual bool IsSystemScreenSaverEnabled() {return false;}
-  virtual void ResetOSScreensaver() {};
   /**
    * Get OS screen saver inhibit implementation if available
    * 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -27,7 +27,7 @@
 #include <memory>
 #include <vector>
 
-typedef enum _WindowSystemType
+enum WindowSystemType
 {
   WINDOW_SYSTEM_WIN32,
   WINDOW_SYSTEM_OSX,
@@ -39,7 +39,7 @@ typedef enum _WindowSystemType
   WINDOW_SYSTEM_RPI,
   WINDOW_SYSTEM_AML,
   WINDOW_SYSTEM_ANDROID
-} WindowSystemType;
+};
 
 struct RESOLUTION_WHR
 {

--- a/xbmc/windowing/X11/CMakeLists.txt
+++ b/xbmc/windowing/X11/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES GLContextEGL.cpp
             GLContextGLX.cpp
             GLContext.cpp
+            OSScreenSaverX11.cpp
             WinEventsX11.cpp
             WinSystemX11.cpp
             WinSystemX11GLContext.cpp
@@ -11,6 +12,7 @@ set(SOURCES GLContextEGL.cpp
 set(HEADERS GLContext.h
             GLContextEGL.h
             GLContextGLX.h
+            OSScreenSaverX11.h
             WinEventsX11.h
             WinSystemX11.h
             WinSystemX11GLContext.h

--- a/xbmc/windowing/X11/OSScreenSaverX11.cpp
+++ b/xbmc/windowing/X11/OSScreenSaverX11.cpp
@@ -1,0 +1,46 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "OSScreenSaverX11.h"
+
+#include <cassert>
+
+COSScreenSaverX11::COSScreenSaverX11(Display* dpy)
+: m_dpy(dpy), m_screensaverResetTimer(std::bind(&COSScreenSaverX11::ResetScreenSaver, this))
+{
+  assert(m_dpy);
+}
+
+void COSScreenSaverX11::Inhibit()
+{
+  // disallow the screensaver by periodically calling XResetScreenSaver(),
+  // for some reason setting a 0 timeout with XSetScreenSaver doesn't work with gnome
+  m_screensaverResetTimer.Start(5000, true);
+}
+
+void COSScreenSaverX11::Uninhibit()
+{
+  m_screensaverResetTimer.Stop(true);
+}
+
+void COSScreenSaverX11::ResetScreenSaver()
+{
+  XResetScreenSaver(m_dpy);
+}

--- a/xbmc/windowing/X11/OSScreenSaverX11.h
+++ b/xbmc/windowing/X11/OSScreenSaverX11.h
@@ -1,0 +1,39 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <X11/Xlib.h>
+
+#include "../OSScreenSaver.h"
+#include "threads/Timer.h"
+
+class COSScreenSaverX11 : public KODI::WINDOWING::IOSScreenSaver
+{
+public:
+  COSScreenSaverX11(Display* dpy);
+  void Inhibit() override;
+  void Uninhibit() override;
+
+private:
+  void ResetScreenSaver();
+
+  Display* m_dpy;
+  CTimer m_screensaverResetTimer;
+};

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -50,8 +50,6 @@ public:
   int  GetNumScreens() override { return 1; }
   int  GetCurrentScreen() override { return m_nScreen; }
   void ShowOSMouse(bool show) override;
-  void ResetOSScreensaver() override;
-  void EnableSystemScreenSaver(bool bEnable) override;
 
   void NotifyAppActiveChange(bool bActivated) override;
   void NotifyAppFocusChange(bool bGaining) override;
@@ -73,6 +71,8 @@ public:
   int GetCrtc() { return m_crtc; }
 
 protected:
+  std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
+
   virtual bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL) = 0;
   virtual XVisualInfo* GetVisual() = 0;
 
@@ -103,6 +103,4 @@ private:
   bool CreateIconPixmap();
   bool HasWindowManager();
   void UpdateCrtc();
-
-  CStopWatch m_screensaverReset;
 };

--- a/xbmc/windowing/osx/CMakeLists.txt
+++ b/xbmc/windowing/osx/CMakeLists.txt
@@ -1,10 +1,12 @@
 if(CORE_SYSTEM_NAME STREQUAL osx)
-  set(SOURCES WinEventsOSX.mm
+  set(SOURCES OSScreenSaverOSX.cpp
+              WinEventsOSX.mm
               WinEventsSDL.cpp
               WinSystemOSX.mm
               WinSystemOSXGL.mm
               VideoSyncOsx.cpp)
-  set(HEADERS WinEventsOSX.h
+  set(HEADERS OSScreenSaverOSX.h
+              WinEventsOSX.h
               WinEventsSDL.h
               WinSystemOSX.h
               WinSystemOSXGL.h

--- a/xbmc/windowing/osx/OSScreenSaverOSX.cpp
+++ b/xbmc/windowing/osx/OSScreenSaverOSX.cpp
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "OSScreenSaverOSX.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+
+COSScreenSaverOSX::COSScreenSaverOSX()
+{
+}
+
+void COSScreenSaverOSX::Inhibit()
+{
+  // see Technical Q&A QA1340
+  if (m_assertionID == 0)
+  {
+    CFStringRef reasonForActivity= CFSTR("XBMC requested disable system screen saver");
+    IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep,
+      kIOPMAssertionLevelOn, reasonForActivity, &m_assertionID);
+  }
+}
+
+void COSScreenSaverOSX::Uninhibit()
+{
+  if (m_assertionID != 0)
+  {
+    IOPMAssertionRelease(m_assertionID);
+    m_assertionID = 0;
+  }
+}

--- a/xbmc/windowing/osx/OSScreenSaverOSX.h
+++ b/xbmc/windowing/osx/OSScreenSaverOSX.h
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#import <IOKit/pwr_mgt/IOPMLib.h>
+
+#include "../OSScreenSaver.h"
+
+class COSScreenSaverOSX : public KODI::WINDOWING::IOSScreenSaver
+{
+public:
+  COSScreenSaverOSX();
+  void Inhibit() override;
+  void Uninhibit() override;
+
+private:
+  IOPMAssertionID m_assertionID = 0;
+};

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -61,10 +61,6 @@ public:
   virtual bool Show(bool raise = true) override;
   virtual void OnMove(int x, int y) override;
 
-  virtual void EnableSystemScreenSaver(bool bEnable) override;
-  virtual bool IsSystemScreenSaverEnabled() override;
-  virtual void ResetOSScreensaver() override;
-
   virtual void EnableTextInput(bool bEnable) override;
   virtual bool IsTextInputEnabled() override;
 
@@ -91,6 +87,8 @@ public:
 
 
 protected:
+  virtual std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
+  
   void  HandlePossibleRefreshrateChange();
   void* CreateWindowedContext(void* shareCtx);
   void* CreateFullScreenContext(int screen_index, void* shareCtx);
@@ -110,7 +108,6 @@ protected:
   bool                         m_obscured;
   unsigned int                 m_obscured_timecheck;
 
-  bool                         m_use_system_screensaver;
   bool                         m_can_display_switch;
   bool                         m_movedToOtherScreen;
   int                          m_lastDisplayNr;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -40,8 +40,10 @@
 #include "platform/darwin/DictionaryUtils.h"
 #include "platform/darwin/DarwinUtils.h"
 
-#import <SDL/SDL_video.h>
-#import <SDL/SDL_events.h>
+#include <cstdlib>
+#include <signal.h>
+
+#import <SDL/SDL.h>
 
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/QuartzCore.h>
@@ -638,6 +640,19 @@ void CWinSystemOSX::OnTimeout()
 
 bool CWinSystemOSX::InitWindowSystem()
 {
+  CLog::LogF(LOGNOTICE, "Setup SDL");
+
+  /* Clean up on exit, exit on window close and interrupt */
+  std::atexit(SDL_Quit);
+
+  if (SDL_Init(SDL_INIT_VIDEO) != 0)
+  {
+    CLog::LogF(LOGFATAL, "Unable to initialize SDL: %s", SDL_GetError());
+    return false;
+  }
+  // SDL_Init will install a handler for segfaults, restore the default handler.
+  signal(SIGSEGV, SIG_DFL);
+
   SDL_EnableUNICODE(1);
 
   // set repeat to 10ms to ensure repeat time < frame time


### PR DESCRIPTION
Replace the WinSystemBase OS screen saver interface

## Description
Current Kodi OS screen saver handling is not adapted to modern desktop windowing systems (which mostly use inhibitors instead of simulated activity) and it's unclear what it's trying to achieve. Some options might have been lost in time, especially on X11. New approach discussed with @FernetMenta:

- Default Kodi screensaver is unset when windowing systems announces support for OS screensaver, `screensaver.xbmc.builtin.dim` otherwise (embedded systems)
- OS screensaver is not reset periodically, but inhibited and uninhibited to match how modern desktop environments handle this
- OS screensaver is inhibited
  - at all times when a Kodi screensaver is set
  - only during video playback or fullscreen music visualization (i.e. when the Kodi screensaver would be inhibited) when no Kodi screensaver is set
- New separate screensaver interface so implementations can be shared between windowing systems (e.g. based on standardized DBus interfaces for x11/mir/wayland on Linux), similar to video clock implementations

from https://github.com/pkerling/xbmc/issues/7#issuecomment-310629584

## Motivation and Context
I looked into screen saver handling for the Wayland windowing implementation and noticed while reading the OSX and X11 code that the current state is quite inconsistent.

## How Has This Been Tested?
X11 backend tested with various setting combinations.

OSX is untested and really not my area of expertise, so any feedback would be much appreciated.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki (not sure)
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
