### PR TITLE
[settings] add "masking" to "path" type

### DIFF
--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -82,6 +82,11 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
         source = source->NextSibling("source");
       }
     }
+
+    // get masking
+    auto masking = constraints->FirstChild("masking");
+    if (masking != nullptr)
+      m_masking = masking->FirstChild()->ValueStr();
   }
 
   return true;


### PR DESCRIPTION

<!--- Provide a general summary of your change in the Title above -->

## Description
If a file selection is needed must be allowed to mask for needed
file extensions.

Before was this only on the old addon settings format possible. This
allow also the use on new.

Is required on some addons to select something.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
