### PR TITLE
Ignore FORBIDS_EPG_TAG_ON_CREATE timer types when creating via CreateFromEpg()

### DIFF
--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -816,7 +816,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
     // create epg-based timer rule
     timerType = CPVRTimerType::CreateFromAttributes(
       PVR_TIMER_TYPE_IS_REPEATING,
-      PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES, channel->ClientID());
+      PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES | PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE, channel->ClientID());
 
     if (timerType)
     {
@@ -838,7 +838,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTagPtr &tag, b
     // create one-shot epg-based timer
     timerType = CPVRTimerType::CreateFromAttributes(
       PVR_TIMER_TYPE_ATTRIBUTE_NONE,
-      PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES, channel->ClientID());
+      PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES | PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE, channel->ClientID());
   }
 
   if (!timerType)


### PR DESCRIPTION
## Description
After pull request 11775 [https://github.com/xbmc/xbmc/pull/11775](https://github.com/xbmc/xbmc/pull/11775), selecting "Add Timer" from an EPG context menu will erroneously add a timer(s) that have the PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE attribute set.  

Assuming that pull request 11775 must remain in place to resolve the original problem, my proposed solution is to add filtering for PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE into CPVRTimerInfoTag::CreateFromEpg() such that a timer with this attribute set will never be selected in this context and subsequently passed onto CGUIDialogPVRTimerSettings.

## Motivation and Context
The expectation is that timer(s) created with the PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE attribute set would never appear in the selection dialog when accessed via an EPG element's "Add Timer" context menu.

## How Has This Been Tested?
Testing was performed on Windows, using a debug build of 17.3-Krypton (x86).  The tested PVR module is an unofficial custom PVR [https://github.com/djp952/pvr.hdhomerundvr](https://github.com/djp952/pvr.hdhomerundvr) that defines timers with the PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE.  Prior to the change a timer with that attribute set would appear in the EPG context menu.  After the change the erroneous timer no longer appears.  The PVR has a limited number of timer types implemented (specifically there are no MANUAL timer types), but tests of various other timer integration points appear to be normal afterwards.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
