### PR TITLE
[addons/settings] fix loading scraper settings from the database

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -88,7 +88,7 @@ bool CAddon::SettingsLoaded() const
   return m_settings != nullptr && m_settings->IsLoaded();
 }
 
-bool CAddon::LoadSettings(bool bForce /* = false */)
+bool CAddon::LoadSettings(bool bForce, bool loadUserSettings /* = true */)
 {
   if (SettingsInitialized() && !bForce)
     return true;
@@ -128,7 +128,8 @@ bool CAddon::LoadSettings(bool bForce /* = false */)
   m_loadSettingsFailed = false;
 
   // load user settings / values
-  LoadUserSettings();
+  if (loadUserSettings)
+    LoadUserSettings();
 
   return true;
 }

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -229,10 +229,11 @@ protected:
 
   /*! \brief Load the default settings and override these with any previously configured user settings
    \param bForce force the load of settings even if they are already loaded (reload)
+   \param loadUserSettings whether or not to load user settings
    \return true if settings exist, false otherwise
    \sa LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  bool LoadSettings(bool bForce);
+  bool LoadSettings(bool bForce, bool loadUserSettings = true);
 
   /*! \brief Load the user settings
    \return true if user settings exist, false otherwise

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -188,7 +188,7 @@ bool CScraper::Supports(const CONTENT_TYPE &content) const
 bool CScraper::SetPathSettings(CONTENT_TYPE content, const std::string& xml)
 {
   m_pathContent = content;
-  if (!LoadSettings(false))
+  if (!LoadSettings(false, false))
     return false;
 
   if (xml.empty())


### PR DESCRIPTION
This fixes a problem reported by @DaveTBlake with loading scraper settings from the database using the new add-on settings system.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
