### PR TITLE
FFmpeg: Bump to 3.1.9-Krypton-17.4 for 17.4 release

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.6-Krypton
+VERSION=3.1.9-Krypton-17.4
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
This bumps our internal ffmpeg from 3.1.6 to 3.1.9 to receive the multiple security bugs fixea in ffmpeg branch. It seems an automated code checker was involved upstream.