### PR TITLE
Game OSD

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6504,6 +6504,7 @@ msgstr ""
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/Custom_1106_VideoOSDSettings.xml
+#: addons/skin.estuary/xml/GameOSD.xml
 msgctxt "#13395"
 msgid "Video settings"
 msgstr ""
@@ -16958,7 +16959,25 @@ msgctxt "#35220"
 msgid "Game providers"
 msgstr ""
 
-#empty strings from id 35221 to 35249
+#. Title of the game OSD menu
+#: addons/skin.estuary/xml/GameOSD.xml
+msgctxt "#35221"
+msgid "Game Menu"
+msgstr ""
+
+#. Label of button in the in-game menu for stopping game playback
+#: addons/skin.estuary/xml/GameOSD.xml
+msgctxt "#35222"
+msgid "Exit"
+msgstr ""
+
+#. Label of button in the in-game menu for opening the input configuration window
+#: addons/skin.estuary/xml/GameOSD.xml
+msgctxt "#35223"
+msgid "Input settings"
+msgstr ""
+
+#empty strings from id 35224 to 35249
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#35250"

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -9,6 +9,7 @@
 	<controls>
 		<include>PVRChannelNumberInput</include>
 		<control type="group">
+			<visible>!Player.HasGame</visible>
 			<bottom>0</bottom>
 			<height>190</height>
 			<control type="image">

--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<window>
+	<defaultcontrol always="true">11101</defaultcontrol>
+	<include>Animation_DialogPopupOpenClose</include>
+	<controls>
+		<control type="group">
+			<centerleft>50%</centerleft>
+			<height>560</height>
+			<centertop>50%</centertop>
+			<width>700</width>
+			<visible>!Window.IsActive(GameVideoSettings) + !Window.IsActive(GameControllers)</visible>
+			<animation effect="fade" time="200">VisibleChange</animation>
+			<include content="DialogBackgroundCommons">
+				<param name="width" value="700" />
+				<param name="height" value="80" />
+				<param name="header_label" value="$LOCALIZE[35221]" />
+				<param name="header_id" value="1" />
+			</include>
+			<control type="group" id="11000">
+				<left>0</left>
+				<top>80</top>
+				<control type="grouplist" id="11101">
+					<width>700</width>
+					<height>360</height>
+					<itemgap>0</itemgap>
+					<onup>11100</onup>
+					<ondown>11100</ondown>
+					<orientation>vertical</orientation>
+					<control type="button" id="11102">
+						<description>Resume button</description>
+						<width>700</width>
+						<include>DialogSettingButton</include>
+						<label>$LOCALIZE[13404]</label>
+						<label2>Select + X</label2>
+						<onclick>Play</onclick>
+					</control>
+					<control type="button" id="11103">
+						<description>Reset button</description>
+						<width>700</width>
+						<include>DialogSettingButton</include>
+						<label>$LOCALIZE[10035]</label>
+						<label2>Select + B</label2>
+						<onclick>PlayerControl(Reset)</onclick>
+					</control>
+					<control type="button" id="11104">
+						<description>Stop button</description>
+						<width>700</width>
+						<include>DialogSettingButton</include>
+						<label>$LOCALIZE[35222]</label>
+						<label2>Select + Start</label2>
+						<onclick>Stop</onclick>
+					</control>
+					<control type="button" id="11107">
+						<description>Video settings button</description>
+						<width>700</width>
+						<include>DialogSettingButton</include>
+						<label>$LOCALIZE[13395]</label>
+						<onclick>ActivateWindow(gamevideosettings)</onclick>
+					</control>
+					<control type="button" id="11109">
+						<description>Input settings button</description>
+						<width>700</width>
+						<include>DialogSettingButton</include>
+						<label>$LOCALIZE[35223]</label>
+						<onclick>ActivateWindow(gamecontrollers)</onclick>
+					</control>
+				</control>
+			</control>
+		</control>
+	</controls>
+</window>

--- a/cmake/treedata/common/games.txt
+++ b/cmake/treedata/common/games.txt
@@ -7,6 +7,7 @@ xbmc/games/controllers/dialogs     games/controllers/dialogs
 xbmc/games/controllers/guicontrols games/controllers/guicontrols
 xbmc/games/controllers/windows     games/controllers/windows
 xbmc/games/dialogs                 games/dialogs
+xbmc/games/dialogs/osd             games/dialogs/osd
 xbmc/games/ports                   games/ports
 xbmc/games/tags                    games/tags
 xbmc/games/windows                 games/windows

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -33,6 +33,7 @@
 #include "guilib/WindowIDs.h"
 #include "input/Action.h"
 #include "input/ActionIDs.h"
+#include "settings/MediaSettings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/MathUtils.h"
@@ -61,6 +62,14 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
 {
   std::string redactedPath = CURL::GetRedacted(file.GetPath());
   CLog::Log(LOGINFO, "RetroPlayer: Opening: %s", redactedPath.c_str());
+
+  // Reset game settings
+  CMediaSettings::GetInstance().GetCurrentGameSettings() = CMediaSettings::GetInstance().GetDefaultGameSettings();
+
+  //! @todo - Remove this when RetroPlayer has a renderer
+  CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
+  videoSettings.m_ScalingMethod = CMediaSettings::GetInstance().GetCurrentGameSettings().ScalingMethod();
+  videoSettings.m_ViewMode = CMediaSettings::GetInstance().GetCurrentGameSettings().ViewMode();
 
   CSingleLock lock(m_mutex);
 
@@ -428,7 +437,7 @@ void CRetroPlayer::UpdateRenderInfo(CRenderInfo &info)
 
 void CRetroPlayer::CloseOSD()
 {
-  CGUIDialog *pDialog = g_windowManager.GetDialog(WINDOW_DIALOG_VIDEO_OSD);
+  CGUIDialog *pDialog = g_windowManager.GetDialog(WINDOW_DIALOG_GAME_OSD);
   if (pDialog)
     pDialog->Close(true, WINDOW_FULLSCREEN_GAME);
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -120,7 +120,7 @@ namespace RETRO
     //virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) override { return false; }
     //virtual void GetAudioCapabilities(std::vector<int> &audioCaps) override { audioCaps.assign(1,IPC_AUD_ALL); }
     //virtual void GetSubtitleCapabilities(std::vector<int> &subCaps) override { subCaps.assign(1,IPC_SUBS_ALL); }
-    void FrameMove() override { m_renderManager.FrameMove(); }
+    void FrameMove() override;
     void Render(bool clear, uint32_t alpha = 255, bool gui = true) override { m_renderManager.Render(clear, 0, alpha, gui); }
     void FlushRenderer() override { m_renderManager.Flush(); }
     void SetRenderViewMode(int mode) override { m_renderManager.SetViewMode(mode); }
@@ -146,11 +146,25 @@ namespace RETRO
     void UpdateRenderBuffers(int queued, int discard, int free) override {}
 
   private:
+    /*!
+     * \brief Closes the OSD and shows the FullscreenGame window
+     */
+    void CloseOSD();
+
     /**
      * \brief Dump game information (if any) to the debug log.
      */
     void PrintGameInfo(const CFileItem &file) const;
 
+    enum class State
+    {
+      STARTING,
+      FULLSCREEN,
+      BACKGROUND,
+    };
+
+    State                              m_state = State::STARTING;
+    double                             m_priorSpeed = 0.0f; // Speed of gameplay before entering OSD
     CDVDClock                          m_clock;
     CRenderManager                     m_renderManager;
     std::unique_ptr<CProcessInfo>      m_processInfo;

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -114,6 +114,7 @@ namespace RETRO
     //virtual bool HasMenu() const override { return false; }
     //virtual void DoAudioWork() override { }
     //virtual bool OnAction(const CAction &action) override { return false; }
+    bool OnAction(const CAction &action) override;
     std::string GetPlayerState() override;
     bool SetPlayerState(const std::string& state) override;
     //virtual std::string GetPlayingTitle() override { return ""; }

--- a/xbmc/games/addons/CMakeLists.txt
+++ b/xbmc/games/addons/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES GameClient.cpp
+            GameClientHardware.cpp
             GameClientInGameSaves.cpp
             GameClientJoystick.cpp
             GameClientKeyboard.cpp
@@ -9,6 +10,7 @@ set(SOURCES GameClient.cpp
 
 set(HEADERS GameClient.h
             GameClientCallbacks.h
+            GameClientHardware.h
             GameClientInGameSaves.h
             GameClientJoystick.h
             GameClientKeyboard.h

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -41,6 +41,7 @@ namespace KODI
 namespace GAME
 {
 
+class CGameClientHardware;
 class CGameClientInGameSaves;
 class CGameClientJoystick;
 class CGameClientKeyboard;
@@ -81,7 +82,7 @@ public:
   void Unload();
   bool OpenFile(const CFileItem& file, IGameAudioCallback* audio, IGameVideoCallback* video);
   bool OpenStandalone(IGameAudioCallback* audio, IGameVideoCallback* video);
-  void Reset();
+  void Reset(unsigned int port);
   void CloseFile();
   const std::string& GetGamePath() const { return m_gamePath; }
 
@@ -197,6 +198,7 @@ private:
   std::map<int, std::unique_ptr<CGameClientJoystick>> m_ports;
   std::unique_ptr<CGameClientKeyboard> m_keyboard;
   std::unique_ptr<CGameClientMouse> m_mouse;
+  std::unique_ptr<CGameClientHardware> m_hardware;
 
   CCriticalSection m_critSection;
 

--- a/xbmc/games/addons/GameClientHardware.cpp
+++ b/xbmc/games/addons/GameClientHardware.cpp
@@ -1,0 +1,40 @@
+/*
+ *      Copyright (C) 2015-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameClientHardware.h"
+#include "GameClient.h"
+#include "utils/log.h"
+
+#include <assert.h>
+
+using namespace KODI;
+using namespace GAME;
+
+CGameClientHardware::CGameClientHardware(CGameClient* gameClient) :
+  m_gameClient(gameClient)
+{
+  assert(m_gameClient != nullptr);
+}
+
+void CGameClientHardware::OnResetButton(unsigned int port)
+{
+  CLog::Log(LOGDEBUG, "%s: Port %d sending hardware reset", m_gameClient->ID().c_str(), port);
+  m_gameClient->Reset(port);
+}

--- a/xbmc/games/addons/GameClientHardware.h
+++ b/xbmc/games/addons/GameClientHardware.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/hardware/IHardwareInput.h"
+
+namespace KODI
+{
+namespace GAME
+{
+  class CGameClient;
+
+  /*!
+   * \ingroup games
+   * \brief Handles events for hardware such as reset buttons
+   */
+  class CGameClientHardware : public HARDWARE::IHardwareInput
+  {
+  public:
+    /*!
+     * \brief Constructor
+     *
+     * \param gameClient The game client implementation
+     */
+    CGameClientHardware(CGameClient* gameClient);
+
+    virtual ~CGameClientHardware() = default;
+
+    // Implementation of IHardwareInput
+    virtual void OnResetButton(unsigned int port) override;
+
+  private:
+    // Construction parameter
+    CGameClient* const m_gameClient;
+  };
+}
+}

--- a/xbmc/games/dialogs/osd/CMakeLists.txt
+++ b/xbmc/games/dialogs/osd/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(SOURCES DialogGameOSD.cpp
+            DialogGameVideoSettings.cpp
+)
+
+set(HEADERS DialogGameOSD.h
+            DialogGameVideoSettings.h
+)
+
+core_add_library(gameosddialogs)

--- a/xbmc/games/dialogs/osd/DialogGameOSD.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSD.cpp
@@ -1,0 +1,94 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogGameOSD.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIWindowManager.h"
+#include "input/Action.h"
+#include "input/ActionIDs.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CDialogGameOSD::CDialogGameOSD() :
+  CGUIDialog(WINDOW_DIALOG_GAME_OSD, "GameOSD.xml")
+{
+  // Initialize CGUIWindow
+  m_loadType = KEEP_IN_MEMORY;
+}
+
+bool CDialogGameOSD::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+  case ACTION_SHOW_OSD:
+  {
+    Close();
+    return true;
+  }
+  case ACTION_PLAYER_PLAY:
+  case ACTION_PLAYER_RESET:
+  case ACTION_PREV_ITEM:
+  case ACTION_STOP:
+  {
+    Close(true);
+    break;
+  }
+  default:
+    break;
+  }
+
+  return CGUIDialog::OnAction(action);
+}
+
+bool CDialogGameOSD::OnMessage(CGUIMessage& message)
+{
+  switch (message.GetMessage())
+  {
+  case GUI_MSG_WINDOW_DEINIT:  // Fired when OSD is hidden
+  {
+    CloseSubDialogs();
+    break;
+  }
+  default:
+    break;
+  }
+
+  return CGUIDialog::OnMessage(message);
+}
+
+std::vector<int> CDialogGameOSD::GetSubDialogs()
+{
+  return std::vector<int>{
+    WINDOW_DIALOG_GAME_VIDEO_SETTINGS,
+    WINDOW_DIALOG_GAME_CONTROLLERS,
+  };
+}
+
+void CDialogGameOSD::CloseSubDialogs()
+{
+  // Remove our subdialogs if visible
+  for (auto windowId : GetSubDialogs())
+  {
+    CGUIDialog *pDialog = g_windowManager.GetDialog(windowId);
+    if (pDialog)
+      pDialog->Close(true);
+  }
+}

--- a/xbmc/games/dialogs/osd/DialogGameOSD.h
+++ b/xbmc/games/dialogs/osd/DialogGameOSD.h
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "guilib/GUIDialog.h"
+
+#include <vector>
+
+namespace KODI
+{
+namespace GAME
+{
+  class CDialogGameOSD : public CGUIDialog
+  {
+  public:
+    CDialogGameOSD();
+
+    virtual ~CDialogGameOSD() = default;
+
+    // implementation of CGUIControl via CGUIDialog
+    virtual bool OnAction(const CAction &action) override;
+    virtual bool OnMessage(CGUIMessage &message) override;
+
+    static std::vector<int> GetSubDialogs();
+
+  private:
+    void CloseSubDialogs();
+ };
+}
+}

--- a/xbmc/games/dialogs/osd/DialogGameVideoSettings.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSettings.cpp
@@ -1,0 +1,210 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogGameVideoSettings.h"
+#include "dialogs/GUIDialogYesNo.h"
+#include "guilib/GUIDialog.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/WindowIDs.h"
+#include "input/Action.h"
+#include "input/ActionIDs.h"
+#include "profiles/ProfilesManager.h"
+#include "settings/lib/Setting.h"
+#include "settings/lib/SettingsManager.h"
+#include "settings/MediaSettings.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+#include "video/ViewModeSettings.h"
+#include "Application.h"
+#include "ApplicationPlayer.h"
+#include "GUIPassword.h"
+#include "ServiceBroker.h"
+
+using namespace KODI;
+using namespace GAME;
+
+// Video dimensions
+#define SETTING_GAME_SCALINGMETHOD       "game.scalingmethod"
+#define SETTING_GAME_VIEW_MODE           "game.viewmode"
+
+// Video actions
+#define SETTING_GAME_MAKE_DEFAULT        "game.save"
+#define SETTING_GAME_CALIBRATION         "game.calibration"
+
+CDialogGameVideoSettings::CDialogGameVideoSettings() :
+  CGUIDialogSettingsManualBase(WINDOW_DIALOG_GAME_VIDEO_SETTINGS, "DialogSettings.xml")
+{
+  // Initialize CGUIWindow
+  m_loadType = KEEP_IN_MEMORY;
+}
+
+bool CDialogGameVideoSettings::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+  case ACTION_SHOW_OSD:
+  {
+    CGUIDialog *pDialog = g_windowManager.GetDialog(WINDOW_DIALOG_GAME_OSD);
+    if (pDialog)
+      pDialog->Close(true);
+    return true;
+  }
+  default:
+    break;
+  }
+
+  return CGUIDialogSettingsManualBase::OnAction(action);
+}
+
+void CDialogGameVideoSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)
+{
+  if (!setting)
+    return;
+
+  CGUIDialogSettingsManualBase::OnSettingChanged(setting);
+
+  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == SETTING_GAME_SCALINGMETHOD)
+  {
+    gameSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue()));
+
+    //! @todo
+    CVideoSettings &videoSettings = CMediaSettings::GetInstance().GetCurrentVideoSettings();
+    videoSettings.m_ScalingMethod = static_cast<ESCALINGMETHOD>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+  }
+  else if (settingId == SETTING_GAME_VIEW_MODE)
+  {
+    gameSettings.SetViewMode(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+
+    g_application.m_pPlayer->SetRenderViewMode(gameSettings.ViewMode());
+  }
+}
+
+void CDialogGameVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> setting)
+{
+  if (!setting)
+    return;
+
+  CGUIDialogSettingsManualBase::OnSettingChanged(setting);
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == SETTING_GAME_CALIBRATION)
+  {
+    // Launch calibration window
+    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
+        g_passwordManager.CheckSettingLevelLock(CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION)->GetLevel()))
+      return;
+    g_windowManager.ForceActivateWindow(WINDOW_SCREEN_CALIBRATION);
+  }
+  //! @todo implement
+  else if (settingId == SETTING_GAME_MAKE_DEFAULT)
+    Save();
+}
+
+void CDialogGameVideoSettings::Save()
+{
+  if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+      !g_passwordManager.CheckSettingLevelLock(::SettingLevel::Expert))
+    return;
+
+  // Prompt user if they are sure
+  if (CGUIDialogYesNo::ShowAndGetInput(CVariant(12376), CVariant(12377)))
+  {
+    CMediaSettings::GetInstance().GetDefaultGameSettings() = CMediaSettings::GetInstance().GetCurrentGameSettings();
+    CServiceBroker::GetSettings().Save();
+  }
+}
+
+void CDialogGameVideoSettings::SetupView()
+{
+  CGUIDialogSettingsManualBase::SetupView();
+
+  SetHeading(13395);
+  SET_CONTROL_HIDDEN(CONTROL_SETTINGS_OKAY_BUTTON);
+  SET_CONTROL_HIDDEN(CONTROL_SETTINGS_CUSTOM_BUTTON);
+  SET_CONTROL_LABEL(CONTROL_SETTINGS_CANCEL_BUTTON, 15067);
+}
+
+void CDialogGameVideoSettings::InitializeSettings()
+{
+  CGUIDialogSettingsManualBase::InitializeSettings();
+
+  const std::shared_ptr<CSettingCategory> category = AddCategory("gamevideosettings", -1);
+  if (!category)
+  {
+    CLog::Log(LOGERROR, "CDialogGameVideoSettings: unable to setup settings");
+    return;
+  }
+
+  // Get all necessary setting groups
+  const std::shared_ptr<CSettingGroup> groupVideo = AddGroup(category);
+  if (!groupVideo)
+  {
+    CLog::Log(LOGERROR, "CDialogGameVideoSettings: unable to setup settings");
+    return;
+  }
+  const std::shared_ptr<CSettingGroup> groupActions = AddGroup(category);
+  if (!groupActions)
+  {
+    CLog::Log(LOGERROR, "CDialogGameVideoSettings: unable to setup settings");
+    return;
+  }
+
+  CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+  
+  TranslatableIntegerSettingOptions entries;
+  entries.push_back(std::make_pair(16301, VS_SCALINGMETHOD_NEAREST));
+  entries.push_back(std::make_pair(16302, VS_SCALINGMETHOD_LINEAR));
+  entries.push_back(std::make_pair(16303, VS_SCALINGMETHOD_CUBIC ));
+  entries.push_back(std::make_pair(16304, VS_SCALINGMETHOD_LANCZOS2));
+  entries.push_back(std::make_pair(16323, VS_SCALINGMETHOD_SPLINE36_FAST));
+  entries.push_back(std::make_pair(16315, VS_SCALINGMETHOD_LANCZOS3_FAST));
+  entries.push_back(std::make_pair(16322, VS_SCALINGMETHOD_SPLINE36));
+  entries.push_back(std::make_pair(16305, VS_SCALINGMETHOD_LANCZOS3));
+  entries.push_back(std::make_pair(16306, VS_SCALINGMETHOD_SINC8));
+//  entries.push_back(make_pair(?????, VS_SCALINGMETHOD_NEDI));
+  entries.push_back(std::make_pair(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE));
+  entries.push_back(std::make_pair(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE));
+  entries.push_back(std::make_pair(16309, VS_SCALINGMETHOD_SINC_SOFTWARE));
+  entries.push_back(std::make_pair(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE));
+  entries.push_back(std::make_pair(16319, VS_SCALINGMETHOD_DXVA_HARDWARE));
+
+  // Remove unsupported methods
+  for(TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end(); )
+  {
+    if (g_application.m_pPlayer->Supports(static_cast<ESCALINGMETHOD>(it->second)))
+      ++it;
+    else
+      it = entries.erase(it);
+  }
+
+  // Video settings
+  AddSpinner(groupVideo, SETTING_GAME_SCALINGMETHOD, 16300, SettingLevel::Basic, static_cast<int>(gameSettings.ScalingMethod()), entries);
+
+  if (g_application.m_pPlayer->Supports(RENDERFEATURE_STRETCH) || g_application.m_pPlayer->Supports(RENDERFEATURE_PIXEL_RATIO))
+    AddList(groupVideo, SETTING_GAME_VIEW_MODE, 629, SettingLevel::Basic, gameSettings.ViewMode(), CViewModeSettings::ViewModesFiller, 629);
+
+  // General settings
+  AddButton(groupActions, SETTING_GAME_MAKE_DEFAULT, 12376, SettingLevel::Basic);
+  AddButton(groupActions, SETTING_GAME_CALIBRATION, 214, SettingLevel::Basic);
+}

--- a/xbmc/games/dialogs/osd/DialogGameVideoSettings.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSettings.h
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "settings/dialogs/GUIDialogSettingsManualBase.h"
+
+namespace KODI
+{
+namespace GAME
+{
+  class CDialogGameVideoSettings : public CGUIDialogSettingsManualBase
+  {
+  public:
+    CDialogGameVideoSettings();
+    virtual ~CDialogGameVideoSettings() = default;
+
+    // implementation of CGUIControl via CGUIDialogSlider
+    virtual bool OnAction(const CAction &action) override;
+
+  protected:
+    // implementation of ISettingCallback via CGUIDialogSettingsManualBase
+    virtual void OnSettingChanged(std::shared_ptr<const CSetting> setting);
+    virtual void OnSettingAction(std::shared_ptr<const CSetting> setting);
+
+    // specialization of CGUIDialogSettingsBase via CGUIDialogSettingsManualBase
+    virtual bool AllowResettingSettings() const { return false; }
+    virtual void Save();
+    virtual void SetupView();
+
+    // specialization of CGUIDialogSettingsManualBase
+    virtual void InitializeSettings();
+  };
+}
+}

--- a/xbmc/games/ports/PortManager.h
+++ b/xbmc/games/ports/PortManager.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "peripherals/PeripheralTypes.h"
-#include "threads/CriticalSection.h"
+#include "threads/SharedSection.h"
 #include "utils/Observer.h"
 
 #include <map>
@@ -34,6 +34,11 @@ namespace PERIPHERALS
 
 namespace KODI
 {
+namespace HARDWARE
+{
+  class IHardwareInput;
+}
+
 namespace JOYSTICK
 {
   class IInputHandler;
@@ -66,6 +71,7 @@ namespace GAME
      * \param requiredType Used to restrict port to devices of only a certain type
      */
     void OpenPort(JOYSTICK::IInputHandler* handler,
+                  HARDWARE::IHardwareInput *hardwareInput,
                   CGameClient* gameClient,
                   unsigned int port,
                   PERIPHERALS::PeripheralType requiredType = PERIPHERALS::PERIPHERAL_UNKNOWN);
@@ -93,6 +99,14 @@ namespace GAME
     //! @todo Return game client from MapDevices()
     CGameClient* GameClient(JOYSTICK::IInputHandler* handler);
 
+    /*!
+     * \brief Send a hardware reset command for the specified input handler
+     *
+     * \param handler  The handler associated the user who pressed reset, or
+     *                 nullptr if it's unknown who presesd reset
+     */
+    void HardwareReset(JOYSTICK::IInputHandler *handler = nullptr);
+
   private:
     JOYSTICK::IInputHandler* AssignToPort(const PERIPHERALS::PeripheralPtr& device, bool checkPortNumber = true);
 
@@ -101,6 +115,7 @@ namespace GAME
     struct SPort
     {
       JOYSTICK::IInputHandler*    handler; // Input handler for this port
+      HARDWARE::IHardwareInput    *hardwareInput; // Callbacks for hardware input
       unsigned int                port;    // Port number belonging to the game client
       PERIPHERALS::PeripheralType requiredType;
       void*                       device;
@@ -108,7 +123,7 @@ namespace GAME
     };
 
     std::vector<SPort> m_ports;
-    CCriticalSection   m_mutex;
+    CSharedSection     m_mutex;
   };
 }
 }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -683,15 +683,6 @@ void CGUIWindowManager::PreviousWindow()
 
   // ok to go to the previous window now
 
-  // pause game when leaving fullscreen or resume game when entering fullscreen
-  if (g_application.m_pPlayer->IsPlayingGame())
-  {
-    if (previousWindow == WINDOW_FULLSCREEN_VIDEO && g_application.m_pPlayer->IsPaused())
-      g_application.OnAction(ACTION_PAUSE);
-    else if (currentWindow == WINDOW_FULLSCREEN_VIDEO && !g_application.m_pPlayer->IsPaused())
-      g_application.OnAction(ACTION_PAUSE);
-  }
-
   // tell our info manager which window we are going to
   g_infoManager.SetNextWindow(previousWindow);
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -148,6 +148,8 @@
 /* Game related include files */
 #include "games/controllers/windows/GUIControllerWindow.h"
 #include "games/windows/GUIWindowGames.h"
+#include "games/dialogs/osd/DialogGameOSD.h"
+#include "games/dialogs/osd/DialogGameVideoSettings.h"
 
 using namespace KODI;
 using namespace PVR;
@@ -299,6 +301,8 @@ void CGUIWindowManager::CreateWindows()
 
   Add(new GAME::CGUIControllerWindow);
   Add(new GAME::CGUIWindowGames);
+  Add(new GAME::CDialogGameOSD);
+  Add(new GAME::CDialogGameVideoSettings);
 }
 
 bool CGUIWindowManager::DestroyWindows()
@@ -400,6 +404,8 @@ bool CGUIWindowManager::DestroyWindows()
     DestroyWindow(WINDOW_WEATHER);
     DestroyWindow(WINDOW_DIALOG_GAME_CONTROLLERS);
     DestroyWindow(WINDOW_GAMES);
+    DestroyWindow(WINDOW_DIALOG_GAME_OSD);
+    DestroyWindow(WINDOW_DIALOG_GAME_VIDEO_SETTINGS);
 
     Remove(WINDOW_SETTINGS_SERVICE);
     Remove(WINDOW_SETTINGS_MYPVR);

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -146,6 +146,8 @@
 
 #define WINDOW_DIALOG_GAME_CONTROLLERS    10820
 #define WINDOW_GAMES                      10821
+#define WINDOW_DIALOG_GAME_OSD            10822
+#define WINDOW_DIALOG_GAME_VIDEO_SETTINGS 10823
 
 //#define WINDOW_VIRTUAL_KEYBOARD           11000
 // WINDOW_ID's from 11100 to 11199 reserved for Skins

--- a/xbmc/input/ActionIDs.h
+++ b/xbmc/input/ActionIDs.h
@@ -272,6 +272,8 @@
 #define ACTION_VOLUME_SET             245
 #define ACTION_TOGGLE_COMMSKIP        246
 
+#define ACTION_PLAYER_RESET           248 //!< Send a reset command to the active game
+
 // Voice actions
 #define ACTION_VOICE_RECOGNIZE        300
 

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -23,7 +23,8 @@ set(SOURCES Action.cpp
             WindowTranslator.cpp
             XBMC_keytable.cpp)
 
-set(HEADERS Action.h
+set(HEADERS hardware/IHardwareInput.h
+            Action.h
             ActionIDs.h
             ActionTranslator.h
             AppTranslator.h

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -148,7 +148,9 @@ static const std::map<WindowName, WindowID> WindowMapping =
     { "addon"                    , WINDOW_ADDON_START },
     { "eventlog"                 , WINDOW_EVENT_LOG},
     { "tvtimerrules"             , WINDOW_TV_TIMER_RULES},
-    { "radiotimerrules"          , WINDOW_RADIO_TIMER_RULES}
+    { "radiotimerrules"          , WINDOW_RADIO_TIMER_RULES},
+    { "gameosd"                  , WINDOW_DIALOG_GAME_OSD },
+    { "gamevideosettings"        , WINDOW_DIALOG_GAME_VIDEO_SETTINGS },
 };
 
 struct FallbackWindowMapping

--- a/xbmc/input/hardware/IHardwareInput.h
+++ b/xbmc/input/hardware/IHardwareInput.h
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+namespace KODI
+{
+namespace HARDWARE
+{
+  /*!
+   * \ingroup hardware
+   * \brief Handles events for hardware such as reset buttons on a game console
+   */
+  class IHardwareInput
+  {
+  public:
+    virtual ~IHardwareInput() = default;
+    
+    /*!
+     * \brief A hardware reset button has been pressed
+     *
+     * \param port  The port belonging to the user who pressed the reset button,
+     *              or 0 (the default port) if unknown
+     */
+    virtual void OnResetButton(unsigned int port) = 0;
+  };
+}
+}

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -353,6 +353,10 @@ static int PlayerControl(const std::vector<std::string>& params)
       }
     }
   }
+  else if (paramlow == "reset")
+  {
+    g_application.OnAction(CAction(ACTION_PLAYER_RESET));
+  }
 
   return 0;
 }

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES AdvancedSettings.cpp
             AudioDSPSettings.cpp
             DisplaySettings.cpp
+            GameSettings.cpp
             MediaSettings.cpp
             MediaSourceSettings.cpp
             SettingAddon.cpp
@@ -19,6 +20,7 @@ set(HEADERS AdvancedSettings.h
             AudioDSPSettings.h
             DiscSettings.h
             DisplaySettings.h
+            GameSettings.h
             MediaSettings.h
             MediaSourceSettings.h
             SettingAddon.h

--- a/xbmc/settings/GameSettings.cpp
+++ b/xbmc/settings/GameSettings.cpp
@@ -1,0 +1,27 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameSettings.h"
+
+void CGameSettings::Reset()
+{
+  m_scalingMethod = VS_SCALINGMETHOD_NEAREST;
+  m_viewMode = 0;
+}

--- a/xbmc/settings/GameSettings.h
+++ b/xbmc/settings/GameSettings.h
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "cores/IPlayer.h"
+
+class CGameSettings
+{
+public:
+  CGameSettings() { Reset(); }
+
+  // Restore game settings to default
+  void Reset();
+
+  ESCALINGMETHOD ScalingMethod() const { return m_scalingMethod; }
+  void SetScalingMethod(ESCALINGMETHOD scalingMethod) { m_scalingMethod = scalingMethod; }
+  
+  int ViewMode() const { return m_viewMode; }
+  void SetViewMode(int viewMode) { m_viewMode = viewMode; }
+
+private:
+  // Video settings
+  ESCALINGMETHOD m_scalingMethod;
+  int m_viewMode;
+};

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -153,6 +153,19 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
     }
   }
 
+  m_defaultGameSettings.Reset();
+  pElement = settings->FirstChildElement("defaultgamesettings");
+  if (pElement != nullptr)
+  {
+    int scalingMethod;
+    if (XMLUtils::GetInt(pElement, "scalingmethod", scalingMethod, VS_SCALINGMETHOD_NEAREST, VS_SCALINGMETHOD_MAX))
+      m_defaultGameSettings.SetScalingMethod(static_cast<ESCALINGMETHOD>(scalingMethod));
+
+    int viewMode;
+    if (XMLUtils::GetInt(pElement, "viewmode", viewMode, ViewModeNormal, ViewModeZoom110Width))
+      m_defaultGameSettings.SetViewMode(viewMode);
+  }
+
   // mymusic settings
   pElement = settings->FirstChildElement("mymusic");
   if (pElement != NULL)
@@ -253,6 +266,15 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
       XMLUtils::SetInt(pNode, strTag.c_str(), m_defaultAudioSettings.m_MasterModes[type][base]);
     }
   }
+
+  // Default game settings
+  TiXmlElement gameSettingsNode("defaultgamesettings");
+  pNode = settings->InsertEndChild(gameSettingsNode);
+  if (pNode == nullptr)
+    return false;
+
+  XMLUtils::SetInt(pNode, "scalingmethod", m_defaultGameSettings.ScalingMethod());
+  XMLUtils::SetInt(pNode, "viewmode", m_defaultGameSettings.ViewMode());
 
   // mymusic
   pNode = settings->FirstChild("mymusic");

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -26,6 +26,7 @@
 #include "settings/lib/ISettingsHandler.h"
 #include "settings/lib/ISubSettings.h"
 #include "settings/AudioDSPSettings.h"
+#include "settings/GameSettings.h"
 #include "settings/VideoSettings.h"
 #include "threads/CriticalSection.h"
 
@@ -60,6 +61,11 @@ public:
   CAudioSettings& GetDefaultAudioSettings() { return m_defaultAudioSettings; }
   const CAudioSettings& GetCurrentAudioSettings() const { return m_currentAudioSettings; }
   CAudioSettings& GetCurrentAudioSettings() { return m_currentAudioSettings; }
+
+  const CGameSettings& GetDefaultGameSettings() const { return m_defaultGameSettings; }
+  CGameSettings& GetDefaultGameSettings() { return m_defaultGameSettings; }
+  const CGameSettings& GetCurrentGameSettings() const { return m_currentGameSettings; }
+  CGameSettings& GetCurrentGameSettings() { return m_currentGameSettings; }
 
   /*! \brief Retrieve the watched mode for the given content type
    \param content Current content type
@@ -111,6 +117,9 @@ private:
 
   CAudioSettings m_defaultAudioSettings;
   CAudioSettings m_currentAudioSettings;
+
+  CGameSettings m_defaultGameSettings;
+  CGameSettings m_currentGameSettings;
 
   typedef std::map<std::string, WatchedMode> WatchedModes;
   WatchedModes m_watchedModes;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -447,7 +447,7 @@ void CGUIWindowFullScreen::SeekChapter(int iChapter)
 
 void CGUIWindowFullScreen::ToggleOSD()
 {
-  CGUIDialogVideoOSD *pOSD = g_windowManager.GetWindow<CGUIDialogVideoOSD>(WINDOW_DIALOG_VIDEO_OSD);
+  CGUIDialog *pOSD = GetOSD();
   if (pOSD)
   {
     if (pOSD->IsDialogRunning())
@@ -461,10 +461,11 @@ void CGUIWindowFullScreen::ToggleOSD()
 
 void CGUIWindowFullScreen::TriggerOSD()
 {
-  CGUIDialogVideoOSD *pOSD = g_windowManager.GetWindow<CGUIDialogVideoOSD>(WINDOW_DIALOG_VIDEO_OSD);
+  CGUIDialog *pOSD = GetOSD();
   if (pOSD && !pOSD->IsDialogRunning())
   {
-    pOSD->SetAutoClose(3000);
+    if (!g_application.m_pPlayer->IsPlayingGame())
+      pOSD->SetAutoClose(3000);
     pOSD->Open();
   }
 }
@@ -472,4 +473,12 @@ void CGUIWindowFullScreen::TriggerOSD()
 bool CGUIWindowFullScreen::HasVisibleControls()
 {
   return m_controlStats->nCountVisible > 0;
+}
+
+CGUIDialog *CGUIWindowFullScreen::GetOSD()
+{
+  if (g_application.m_pPlayer->IsPlayingGame())
+    return g_windowManager.GetDialog(WINDOW_DIALOG_GAME_OSD);
+  else
+    return g_windowManager.GetDialog(WINDOW_DIALOG_VIDEO_OSD);
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -22,6 +22,8 @@
 
 #include "guilib/GUIWindow.h"
 
+class CGUIDialog;
+
 class CGUIWindowFullScreen : public CGUIWindow
 {
 public:
@@ -44,6 +46,7 @@ private:
   void SeekChapter(int iChapter);
   void ToggleOSD();
   void TriggerOSD();
+  CGUIDialog *GetOSD();
 
   bool m_viewModeChanged;
   unsigned int m_dwShowViewModeTimeout;


### PR DESCRIPTION
This PR adds a Game OSD and greatly improves input handling. The required changes have been split into three PRs so that it can be merged in stages. The first two PRs are:

* #12365 - General improvements to the joystick code
* #12366 - New joystick handling, including button combos in joystick.xml

## Motivation and Context
Needed a way to access the future Video Filters dialog (for GSoC) from within the game.

## How Has This Been Tested?
Still in the early stages of testing.

## Screenshots (if appropriate):
Main menu:
<img width="1261" alt="game osd" src="https://user-images.githubusercontent.com/531482/27528407-1c2aa706-5a05-11e7-8528-5cdf4a29bd93.png">

Video settings:
![Video settings](http://i.imgur.com/BnBlCRo.png)

Input settings:
![Input settings](http://i.imgur.com/bviNyAP.png)


## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
