### PR TITLE
service addons: replace synchronous add-on hooks with event handlers 

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1167,7 +1167,7 @@ bool CApplication::Initialize()
 #ifdef HAS_JSONRPC
       CJSONRPC::Initialize();
 #endif
-      ADDON::CAddonMgr::GetInstance().StartServices(false);
+      CServiceBroker::GetServiceAddons().StartBeforeLogin();
 
       // activate the configured start window
       int firstWindow = g_SkinInfo->GetFirstWindow();
@@ -1195,7 +1195,7 @@ bool CApplication::Initialize()
 #ifdef HAS_JSONRPC
     CJSONRPC::Initialize();
 #endif
-    ADDON::CAddonMgr::GetInstance().StartServices(false);
+    CServiceBroker::GetServiceAddons().StartBeforeLogin();
   }
 
   g_sysinfo.Refresh();
@@ -1211,8 +1211,6 @@ bool CApplication::Initialize()
 
   m_slowTimer.StartZero();
 
-  CAddonMgr::GetInstance().StartServices(true);
-
   // configure seek handler
   CSeekHandler::GetInstance().Configure();
 
@@ -1221,6 +1219,7 @@ bool CApplication::Initialize()
   RegisterActionListener(&CPlayerController::GetInstance());
 
   CRepositoryUpdater::GetInstance().Start();
+  CServiceBroker::GetServiceAddons().Start();
 
   CLog::Log(LOGNOTICE, "initialize done");
 
@@ -2895,7 +2894,7 @@ void CApplication::Stop(int exitCode)
     g_mediaManager.Stop();
 
     // Stop services before unloading Python
-    CAddonMgr::GetInstance().StopServices(false);
+    CServiceBroker::GetServiceAddons().Stop();
 
     // unregister action listeners
     UnregisterActionListener(&CSeekHandler::GetInstance());

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -100,6 +100,11 @@ CFavouritesService& CServiceBroker::GetFavouritesService()
   return g_application.m_ServiceManager->GetFavouritesService();
 }
 
+ADDON::CServiceAddonManager& CServiceBroker::GetServiceAddons()
+{
+  return g_application.m_ServiceManager->GetServiceAddons();
+}
+
 bool CServiceBroker::IsBinaryAddonCacheUp()
 {
   return g_application.m_ServiceManager->init_level > 1;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -25,6 +25,7 @@ class CAddonMgr;
 class CBinaryAddonManager;
 class CBinaryAddonCache;
 class CVFSAddonCache;
+class CServiceAddonManager;
 }
 
 namespace ActiveAE {
@@ -84,5 +85,6 @@ public:
   static KODI::GAME::CGameServices& GetGameServices();
   static PERIPHERALS::CPeripherals& GetPeripherals();
   static CFavouritesService& GetFavouritesService();
+  static ADDON::CServiceAddonManager& GetServiceAddons();
   static bool IsBinaryAddonCacheUp();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -98,6 +98,7 @@ bool CServiceManager::Init2()
 
   m_favouritesService.reset(new CFavouritesService(CProfilesManager::GetInstance().GetProfileUserDataFolder()));
   m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));
+  m_serviceAddons.reset(new ADDON::CServiceAddonManager(*m_addonMgr));
 
   init_level = 2;
   return true;
@@ -145,6 +146,7 @@ bool CServiceManager::Init3()
 
 void CServiceManager::Deinit()
 {
+  m_serviceAddons.reset();
   m_gameServices->Deinit();
   m_peripherals.reset();
   m_contextMenuManager.reset();
@@ -182,6 +184,11 @@ ADDON::CBinaryAddonManager &CServiceManager::GetBinaryAddonManager()
 ADDON::CVFSAddonCache &CServiceManager::GetVFSAddonCache()
 {
   return *m_vfsAddonCache.get();
+}
+
+ADDON::CServiceAddonManager &CServiceManager::GetServiceAddons()
+{
+  return *m_serviceAddons;
 }
 
 ANNOUNCEMENT::CAnnouncementManager& CServiceManager::GetAnnouncementManager()

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -28,6 +28,7 @@ class CAddonMgr;
 class CBinaryAddonManager;
 class CBinaryAddonCache;
 class CVFSAddonCache;
+class CServiceAddonManager;
 }
 
 namespace ActiveAE {
@@ -88,6 +89,7 @@ public:
   ADDON::CBinaryAddonManager& GetBinaryAddonManager();
   ADDON::CBinaryAddonCache& GetBinaryAddonCache();
   ADDON::CVFSAddonCache& GetVFSAddonCache();
+  ADDON::CServiceAddonManager& GetServiceAddons();
   ANNOUNCEMENT::CAnnouncementManager& GetAnnouncementManager();
 #ifdef HAS_PYTHON
   XBPython& GetXBPython();
@@ -133,6 +135,7 @@ protected:
   std::unique_ptr<ADDON::CBinaryAddonManager> m_binaryAddonManager;
   std::unique_ptr<ADDON::CBinaryAddonCache> m_binaryAddonCache;
   std::unique_ptr<ADDON::CVFSAddonCache> m_vfsAddonCache;
+  std::unique_ptr<ADDON::CServiceAddonManager> m_serviceAddons;
   std::unique_ptr<ANNOUNCEMENT::CAnnouncementManager> m_announcementManager;
 #ifdef HAS_PYTHON
   std::unique_ptr<XBPython> m_XBPython;

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -399,12 +399,6 @@ void OnEnabled(const std::string& id)
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_PVRDLL))
     return addon->OnEnabled();
 
-  if (CAddonMgr::GetInstance().ServicesHasStarted())
-  {
-    if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_SERVICE))
-      std::static_pointer_cast<CService>(addon)->Start();
-  }
-
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_REPOSITORY))
     CRepositoryUpdater::GetInstance().ScheduleUpdate(); //notify updater there is a new addon
 }
@@ -415,26 +409,10 @@ void OnDisabled(const std::string& id)
   AddonPtr addon;
   if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_PVRDLL, false))
     return addon->OnDisabled();
-
-  if (CAddonMgr::GetInstance().ServicesHasStarted())
-  {
-    if (CAddonMgr::GetInstance().GetAddon(id, addon, ADDON_SERVICE, false))
-      std::static_pointer_cast<CService>(addon)->Stop();
-  }
 }
 
 void OnPreInstall(const AddonPtr& addon)
 {
-  //Before installing we need to stop/unregister any local addon
-  //that have this id, regardless of what the 'new' addon is.
-  AddonPtr localAddon;
-
-  if (CAddonMgr::GetInstance().ServicesHasStarted())
-  {
-    if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_SERVICE))
-      std::static_pointer_cast<CService>(localAddon)->Stop();
-  }
-
   //Fallback to the pre-install callback in the addon.
   //! @bug If primary extension point have changed we're calling the wrong method.
   addon->OnPreInstall();
@@ -443,11 +421,6 @@ void OnPreInstall(const AddonPtr& addon)
 void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
 {
   AddonPtr localAddon;
-  if (CAddonMgr::GetInstance().ServicesHasStarted())
-  {
-    if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_SERVICE))
-      std::static_pointer_cast<CService>(localAddon)->Start();
-  }
 
   if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_REPOSITORY))
     CRepositoryUpdater::GetInstance().ScheduleUpdate(); //notify updater there is a new addon or version
@@ -457,14 +430,6 @@ void OnPostInstall(const AddonPtr& addon, bool update, bool modal)
 
 void OnPreUnInstall(const AddonPtr& addon)
 {
-  AddonPtr localAddon;
-
-  if (CAddonMgr::GetInstance().ServicesHasStarted())
-  {
-    if (CAddonMgr::GetInstance().GetAddon(addon->ID(), localAddon, ADDON_SERVICE))
-      std::static_pointer_cast<CService>(localAddon)->Stop();
-  }
-
   addon->OnPreUnInstall();
 }
 

--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -48,6 +48,28 @@ namespace ADDON
       MetadataChanged(std::string id) : id(std::move(id)) {}
     };
 
+    /**
+     * Emitted when a different version of the add-on has been installed
+     * to the file system and should be reloaded.
+     */
+    struct ReInstalled: AddonEvent
+    {
+      std::string id;
+      ReInstalled(std::string id) : id(std::move(id)) {}
+    };
+
+    /**
+     * Emitted after the add-on has been uninstalled.
+     */
+    struct UnInstalled : AddonEvent
+    {
+      std::string id;
+      UnInstalled(std::string id) : id(std::move(id)) {}
+    };
+
+    /**
+     * @deprecated Use Enabled, ReInstalled and UnInstalled instead.
+     */
     struct InstalledChanged : AddonEvent {};
   };
 };

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -273,8 +273,7 @@ static bool LoadManifest(std::set<std::string>& system, std::set<std::string>& o
 
 CAddonMgr::CAddonMgr()
   : m_cp_context(nullptr),
-  m_cpluff(nullptr),
-  m_serviceSystemStarted(false)
+  m_cpluff(nullptr)
 { }
 
 CAddonMgr::~CAddonMgr()
@@ -1216,58 +1215,6 @@ bool CAddonMgr::AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::s
   }
   m_cpluff->destroy_context(context);
   return true;
-}
-
-bool CAddonMgr::ServicesHasStarted() const
-{
-  CSingleLock lock(m_critSection);
-  return m_serviceSystemStarted;
-}
-
-bool CAddonMgr::StartServices(const bool beforelogin)
-{
-  CLog::Log(LOGDEBUG, "ADDON: Starting service addons.");
-
-  VECADDONS services;
-  if (!GetAddons(services, ADDON_SERVICE))
-    return false;
-
-  bool ret = true;
-  for (IVECADDONS it = services.begin(); it != services.end(); ++it)
-  {
-    std::shared_ptr<CService> service = std::dynamic_pointer_cast<CService>(*it);
-    if (service)
-    {
-      if ( (beforelogin && service->GetStartOption() == CService::STARTUP)
-        || (!beforelogin && service->GetStartOption() == CService::LOGIN) )
-        ret &= service->Start();
-    }
-  }
-
-  CSingleLock lock(m_critSection);
-  m_serviceSystemStarted = true;
-
-  return ret;
-}
-
-void CAddonMgr::StopServices(const bool onlylogin)
-{
-  CLog::Log(LOGDEBUG, "ADDON: Stopping service addons.");
-
-  VECADDONS services;
-  if (!GetAddons(services, ADDON_SERVICE))
-    return;
-
-  for (IVECADDONS it = services.begin(); it != services.end(); ++it)
-  {
-    std::shared_ptr<CService> service = std::dynamic_pointer_cast<CService>(*it);
-    if (service)
-    {
-      if ( (onlylogin && service->GetStartOption() == CService::LOGIN)
-        || (!onlylogin) )
-        service->Stop();
-    }
-  }
 }
 
 bool CAddonMgr::IsCompatible(const IAddon& addon)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -271,14 +271,6 @@ namespace ADDON
      */
     bool AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::string& xml, VECADDONS& addons);
 
-    /*! \brief Start all services addons.
-        \return True is all addons are started, false otherwise
-    */
-    bool StartServices(const bool beforelogin);
-    /*! \brief Stop all services addons.
-    */
-    void StopServices(const bool onlylogin);
-
     bool ServicesHasStarted() const;
 
     bool IsCompatible(const IAddon& addon);
@@ -311,7 +303,6 @@ namespace ADDON
     CEventSource<AddonEvent> m_events;
     std::set<std::string> m_systemAddons;
     std::set<std::string> m_optionalAddons;
-    bool m_serviceSystemStarted;
   };
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -159,13 +159,24 @@ namespace ADDON
      */
     bool FindAddons();
 
-    /*! Unload addon from the system. Returns true if it was unloaded, otherwise false. */
+    /*!
+     * @note: should only be called by AddonInstaller
+     *
+     * Unload addon from the system. Returns true if it was unloaded, otherwise false.
+     */
     bool UnloadAddon(const AddonPtr& addon);
 
-    /*! Returns true if the addon was successfully loaded and enabled; otherwise false. */
+    /*!
+     * @note: should only be called by AddonInstaller
+     *
+     * Returns true if the addon was successfully loaded and enabled; otherwise false.
+     */
     bool ReloadAddon(AddonPtr& addon);
 
-    /*! Hook for clearing internal state after uninstall. */
+    /*! @note: should only be called by AddonInstaller
+     *
+     * Hook for clearing internal state after uninstall.
+     */
     void OnPostUnInstall(const std::string& id);
 
     /*! \brief Disable an addon. Returns true on success, false on failure. */

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -20,89 +20,148 @@
 #include "Service.h"
 #include "AddonManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
-#include "utils/log.h"
 #include "system.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
 
 namespace ADDON
 {
 
 std::unique_ptr<CService> CService::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {
-  START_OPTION startOption(LOGIN);
+  START_OPTION startOption(START_OPTION::LOGIN);
   std::string start = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@start");
   if (start == "startup")
-    startOption = STARTUP;
-  return std::unique_ptr<CService>(new CService(std::move(addonInfo), TYPE(UNKNOWN), startOption));
+    startOption = START_OPTION::STARTUP;
+  return std::unique_ptr<CService>(new CService(std::move(addonInfo), startOption));
 }
 
-
-CService::CService(CAddonInfo addonInfo, TYPE type, START_OPTION startOption)
-  : CAddon(std::move(addonInfo)), m_type(type), m_startOption(startOption)
+CService::CService(CAddonInfo addonInfo, START_OPTION startOption)
+  : CAddon(std::move(addonInfo)), m_startOption(startOption)
 {
-  BuildServiceType();
 }
 
-bool CService::Start()
+CServiceAddonManager::CServiceAddonManager(CAddonMgr& addonMgr) :
+    m_addonMgr(addonMgr)
 {
-  bool ret = true;
-  switch (m_type)
+}
+
+CServiceAddonManager::~CServiceAddonManager()
+{
+  m_addonMgr.Events().Unsubscribe(this);
+}
+
+void CServiceAddonManager::OnEvent(const ADDON::AddonEvent& event)
+{
+  if (auto enableEvent = dynamic_cast<const AddonEvents::Enabled*>(&event))
   {
-#ifdef HAS_PYTHON
-  case PYTHON:
-    ret = (CScriptInvocationManager::GetInstance().ExecuteAsync(LibPath(), this->shared_from_this()) != -1);
-    break;
-#endif
-
-  case UNKNOWN:
-  default:
-    ret = false;
-    break;
+    Start(enableEvent->id);
   }
-
-  return ret;
-}
-
-bool CService::Stop()
-{
-  bool ret = true;
-
-  switch (m_type)
+  else if (auto disableEvent = dynamic_cast<const AddonEvents::Disabled*>(&event))
   {
-#ifdef HAS_PYTHON
-  case PYTHON:
-    ret = CScriptInvocationManager::GetInstance().Stop(LibPath());
-    break;
-#endif
-
-  case UNKNOWN:
-  default:
-    ret = false;
-    break;
+    Stop(disableEvent->id);
   }
-
-  return ret;
-}
-
-void CService::BuildServiceType()
-{
-  std::string str = LibPath();
-  std::string ext;
-
-  size_t p = str.find_last_of('.');
-  if (p != std::string::npos)
-    ext = str.substr(p + 1);
-
-#ifdef HAS_PYTHON
-  std::string pythonExt = ADDON_PYTHON_EXT;
-  pythonExt.erase(0, 2);
-  if ( ext == pythonExt )
-    m_type = PYTHON;
-  else
-#endif
+  else if (auto uninstallEvent = dynamic_cast<const AddonEvents::UnInstalled*>(&event))
   {
-    m_type = UNKNOWN;
-    CLog::Log(LOGERROR, "ADDON: extension '%s' is not currently supported for service addon", ext.c_str());
+    Stop(uninstallEvent->id);
+  }
+  else if (auto reinstallEvent = dynamic_cast<const AddonEvents::ReInstalled*>(&event))
+  {
+    Stop(reinstallEvent->id);
+    Start(reinstallEvent->id);
   }
 }
 
+void CServiceAddonManager::StartBeforeLogin()
+{
+  VECADDONS addons;
+  if (m_addonMgr.GetAddons(addons, ADDON_SERVICE))
+  {
+    for (const auto& addon : addons)
+    {
+      auto service = std::static_pointer_cast<CService>(addon);
+      if (service->GetStartOption() == START_OPTION::STARTUP)
+      {
+        Start(addon);
+      }
+    }
+  }
+}
+
+void CServiceAddonManager::Start()
+{
+  m_addonMgr.Events().Subscribe(this, &CServiceAddonManager::OnEvent);
+  VECADDONS addons;
+  if (m_addonMgr.GetAddons(addons, ADDON_SERVICE))
+  {
+    for (const auto& addon : addons)
+    {
+      Start(addon);
+    }
+  }
+}
+
+void CServiceAddonManager::Start(const std::string& addonId)
+{
+  AddonPtr addon;
+  if (!m_addonMgr.GetAddon(addonId, addon, ADDON_SERVICE))
+  {
+    CLog::Log(LOGWARNING, "CServiceAddonManager: no service add-on with id %s exist.", addonId.c_str());
+    return;
+  }
+  Start(addon);
+}
+
+void CServiceAddonManager::Start(const AddonPtr& addon)
+{
+  CSingleLock lock(m_criticalSection);
+  if (m_services.find(addon->ID()) != m_services.end())
+  {
+    CLog::Log(LOGDEBUG, "CServiceAddonManager: %s already started.", addon->ID().c_str());
+    return;
+  }
+
+  if (StringUtils::EndsWith(addon->LibPath(), ".py"))
+  {
+    CLog::Log(LOGDEBUG, "CServiceAddonManager: starting %s", addon->ID().c_str());
+    auto handle = CScriptInvocationManager::GetInstance().ExecuteAsync(addon->LibPath(), addon);
+    if (handle == -1)
+    {
+      CLog::Log(LOGERROR, "CServiceAddonManager: %s failed to start", addon->ID().c_str());
+      return;
+    }
+    m_services[addon->ID()] = handle;
+  }
+}
+
+void CServiceAddonManager::Stop()
+{
+  CSingleLock lock(m_criticalSection);
+  for (const auto& service : m_services)
+  {
+    Stop(service);
+  }
+  m_services.clear();
+}
+
+void CServiceAddonManager::Stop(const std::string& addonId)
+{
+  CSingleLock lock(m_criticalSection);
+  auto it = m_services.find(addonId);
+  if (it != m_services.end())
+  {
+    Stop(*it);
+    m_services.erase(it);
+  }
+}
+
+void CServiceAddonManager::Stop(std::map<std::string, int>::value_type service)
+{
+  CLog::Log(LOGDEBUG, "CServiceAddonManager: stopping %s.", service.first.c_str());
+  if (!CScriptInvocationManager::GetInstance().Stop(service.second))
+  {
+    CLog::Log(LOGINFO, "CServiceAddonManager: failed to stop %s (may have ended)", service.first.c_str());
+  }
+}
 }

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -75,8 +75,6 @@ static int LogOff(const std::vector<std::string>& params)
   if (CVideoLibraryQueue::GetInstance().IsRunning())
     CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
-  ADDON::CAddonMgr::GetInstance().StopServices(true);
-
   g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
   CProfilesManager::GetInstance().LoadMasterProfileForLogin();
   g_passwordManager.bMasterUser = false;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -276,8 +276,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 {
   CServiceBroker::GetContextMenuManager().Deinit();
 
-  // stop service addons and give it some time before we start it again
-  ADDON::CAddonMgr::GetInstance().StopServices(true);
+  CServiceBroker::GetServiceAddons().Stop();
 
   // stop PVR related services
   CServiceBroker::GetPVRManager().Unload();
@@ -331,8 +330,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   CServiceBroker::GetFavouritesService().ReInit(CProfilesManager::GetInstance().GetProfileUserDataFolder());
 
-  // start services which should run on login
-  ADDON::CAddonMgr::GetInstance().StartServices(false);
+  CServiceBroker::GetServiceAddons().Start();
 
   int firstWindow = g_SkinInfo->GetFirstWindow();
   // the startup window is considered part of the initialization as it most likely switches to the final window


### PR DESCRIPTION
This should fix the issues with services getting started multiple times.