### PR TITLE
DBus refactoring

### DIFF
--- a/xbmc/linux/DBusMessage.cpp
+++ b/xbmc/linux/DBusMessage.cpp
@@ -32,6 +32,10 @@ CDBusMessage::CDBusMessage(const char *destination, const char *object, const ch
     CLog::Log(LOGDEBUG, "DBus: Creating message to %s on %s with interface %s and method %s\n", destination, object, interface, method);
 }
 
+CDBusMessage::CDBusMessage(const std::string& destination, const std::string& object, const std::string& interface, const std::string& method)
+: CDBusMessage(destination.c_str(), object.c_str(), interface.c_str(), method.c_str())
+{}
+
 CDBusMessage::~CDBusMessage()
 {
   Close();

--- a/xbmc/linux/DBusMessage.cpp
+++ b/xbmc/linux/DBusMessage.cpp
@@ -43,21 +43,15 @@ CDBusMessage::~CDBusMessage()
 
 bool CDBusMessage::AppendObjectPath(const char *object)
 {
-  PrepareArgument();
-  return dbus_message_iter_append_basic(&m_args, DBUS_TYPE_OBJECT_PATH, &object);
+  return AppendWithType(DBUS_TYPE_OBJECT_PATH, &object);
 }
 
-bool CDBusMessage::AppendArgument(const char *string)
+template<>
+bool CDBusMessage::AppendArgument<bool>(const bool arg)
 {
-  PrepareArgument();
-  return dbus_message_iter_append_basic(&m_args, DBUS_TYPE_STRING, &string);
-}
-
-bool CDBusMessage::AppendArgument(const bool b)
-{
-  dbus_bool_t arg = (b == true);
-  PrepareArgument();
-  return dbus_message_iter_append_basic(&m_args, DBUS_TYPE_BOOLEAN, &arg);
+  // dbus_bool_t width might not match C++ bool width
+  dbus_bool_t convArg = (arg == true);
+  return AppendWithType(DBUS_TYPE_BOOLEAN, &convArg);
 }
 
 bool CDBusMessage::AppendArgument(const char **arrayString, unsigned int length)
@@ -72,6 +66,12 @@ bool CDBusMessage::AppendArgument(const char **arrayString, unsigned int length)
   success &= dbus_message_iter_close_container(&m_args, &sub);
 
   return success;
+}
+
+bool CDBusMessage::AppendWithType(int type, const void* value)
+{
+  PrepareArgument();
+  return dbus_message_iter_append_basic(&m_args, type, value);
 }
 
 DBusMessage *CDBusMessage::SendSystem()

--- a/xbmc/linux/DBusMessage.h
+++ b/xbmc/linux/DBusMessage.h
@@ -20,6 +20,8 @@
  */
 #include "system.h"
 #ifdef HAS_DBUS
+#include <string>
+
 #include <dbus/dbus.h>
 
 class CDBusError;
@@ -28,6 +30,7 @@ class CDBusMessage
 {
 public:
   CDBusMessage(const char *destination, const char *object, const char *interface, const char *method);
+  CDBusMessage(std::string const& destination, std::string const& object, std::string const& interface, std::string const& method);
   ~CDBusMessage();
 
   bool AppendObjectPath(const char *object);

--- a/xbmc/linux/DBusMessage.h
+++ b/xbmc/linux/DBusMessage.h
@@ -22,6 +22,8 @@
 #ifdef HAS_DBUS
 #include <dbus/dbus.h>
 
+class CDBusError;
+
 class CDBusMessage
 {
 public:
@@ -35,12 +37,15 @@ public:
 
   DBusMessage *SendSystem();
   DBusMessage *SendSession();
+  DBusMessage *SendSystem(CDBusError& error);
+  DBusMessage *SendSession(CDBusError& error);
 
   bool SendAsyncSystem();
   bool SendAsyncSession();
 
   DBusMessage *Send(DBusBusType type);
-  DBusMessage *Send(DBusConnection *con, DBusError *error);
+  DBusMessage *Send(DBusBusType type, CDBusError& error);
+  DBusMessage *Send(DBusConnection *con, CDBusError& error);
 private:
 
   bool SendAsync(DBusBusType type);

--- a/xbmc/linux/DBusMessage.h
+++ b/xbmc/linux/DBusMessage.h
@@ -48,14 +48,14 @@ public:
   CDBusMessage(std::string const& destination, std::string const& object, std::string const& interface, std::string const& method);
   ~CDBusMessage();
 
-  bool AppendObjectPath(const char *object);
+  void AppendObjectPath(const char *object);
 
   template<typename T>
-  bool AppendArgument(const T arg)
+  void AppendArgument(const T arg)
   {
-    return AppendWithType(ToDBusType<T>::TYPE, &arg);
+    AppendWithType(ToDBusType<T>::TYPE, &arg);
   }
-  bool AppendArgument(const char **arrayString, unsigned int length);
+  void AppendArgument(const char **arrayString, unsigned int length);
 
   DBusMessage *SendSystem();
   DBusMessage *SendSession();
@@ -69,7 +69,7 @@ public:
   DBusMessage *Send(DBusBusType type, CDBusError& error);
   DBusMessage *Send(DBusConnection *con, CDBusError& error);
 private:
-  bool AppendWithType(int type, const void* value);
+  void AppendWithType(int type, const void* value);
   bool SendAsync(DBusBusType type);
 
   void Close();
@@ -82,5 +82,5 @@ private:
 };
 
 template<>
-bool CDBusMessage::AppendArgument<bool>(const bool arg);
+void CDBusMessage::AppendArgument<bool>(const bool arg);
 #endif

--- a/xbmc/linux/DBusReserve.cpp
+++ b/xbmc/linux/DBusReserve.cpp
@@ -35,9 +35,7 @@ CDBusReserve::CDBusReserve()
 {
   CDBusError error;
   
-  m_conn = dbus_bus_get (DBUS_BUS_SESSION, error);
-  if (!m_conn)
-    error.Log("CDBusReserve::CDBusReserve: Failed to get dbus conn");
+  m_conn.Connect(DBUS_BUS_SESSION);
 }
 
 CDBusReserve::~CDBusReserve()
@@ -47,9 +45,6 @@ CDBusReserve::~CDBusReserve()
     std::string buf = *m_devs.begin();
     ReleaseDevice(buf);
   }
-
-  if(m_conn)
-    dbus_connection_unref(m_conn);
 }
 
 bool CDBusReserve::AcquireDevice(const std::string& device)

--- a/xbmc/linux/DBusReserve.h
+++ b/xbmc/linux/DBusReserve.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-struct DBusConnection;
+#include "DBusUtil.h"
 
 class CDBusReserve
 {
@@ -34,7 +34,7 @@ public:
   bool ReleaseDevice(const std::string &device);
 
 private:
-  DBusConnection *m_conn;
+  CDBusConnection m_conn;
   std::vector<std::string> m_devs;
 };
 

--- a/xbmc/linux/DBusUtil.cpp
+++ b/xbmc/linux/DBusUtil.cpp
@@ -166,3 +166,71 @@ CVariant CDBusUtil::ParseType(DBusMessageIter *itr)
 
   return value;
 }
+
+
+CDBusError::CDBusError()
+{
+  dbus_error_init(&m_error);
+}
+
+CDBusError::~CDBusError()
+{
+  Reset();
+}
+
+void CDBusError::Reset()
+{
+ dbus_error_free(&m_error);
+}
+
+CDBusError::operator DBusError*()
+{
+  return &m_error;
+}
+
+bool CDBusError::IsSet() const
+{
+  return dbus_error_is_set(&m_error);
+}
+
+CDBusError::operator bool()
+{
+  return IsSet();
+}
+
+CDBusError::operator bool() const
+{
+  return IsSet();
+}
+
+std::string CDBusError::Name() const
+{
+  if (!IsSet())
+  {
+    throw std::logic_error("Cannot retrieve name of unset DBus error");
+  }
+  return m_error.name;
+}
+
+std::string CDBusError::Message() const
+{
+  if (!IsSet())
+  {
+    throw std::logic_error("Cannot retrieve message of unset DBus error");
+  }
+  return m_error.message;
+}
+
+void CDBusError::Log(std::string const& message) const
+{
+  Log(LOGERROR, message);
+}
+
+void CDBusError::Log(int level, const std::string& message) const
+{
+  if (!IsSet())
+  {
+    throw std::logic_error("Cannot log unset DBus error");
+  }
+  CLog::Log(level, "%s: %s - %s", message.c_str(), m_error.name, m_error.message);
+}

--- a/xbmc/linux/DBusUtil.cpp
+++ b/xbmc/linux/DBusUtil.cpp
@@ -164,6 +164,23 @@ CVariant CDBusUtil::ParseType(DBusMessageIter *itr)
   return value;
 }
 
+bool CDBusUtil::TryMethodCall(DBusBusType bus, const char* destination, const char* object, const char* interface, const char* method)
+{
+  CDBusMessage message(destination, object, interface, method);
+  CDBusError error;
+  message.Send(bus, error);
+  if (error)
+  {
+    error.Log(LOGDEBUG, std::string("DBus method call to ") + interface + "." + method + " at " + object + " of " + destination + " failed");
+  }
+  return !error;
+}
+
+bool CDBusUtil::TryMethodCall(DBusBusType bus, std::string const& destination, std::string const& object, std::string const& interface, std::string const& method)
+{
+  return TryMethodCall(bus, destination.c_str(), object.c_str(), interface.c_str(), method.c_str());
+}
+
 CDBusConnection::CDBusConnection()
 {}
 

--- a/xbmc/linux/DBusUtil.cpp
+++ b/xbmc/linux/DBusUtil.cpp
@@ -26,25 +26,22 @@ CVariant CDBusUtil::GetVariant(const char *destination, const char *object, cons
   CDBusMessage message(destination, object, "org.freedesktop.DBus.Properties", "Get");
   CVariant result;
 
-  if (message.AppendArgument(interface) && message.AppendArgument(property))
+  message.AppendArgument(interface);
+  message.AppendArgument(property);
+  DBusMessage *reply = message.SendSystem();
+
+  if (reply)
   {
-    DBusMessage *reply = message.SendSystem();
+    DBusMessageIter iter;
 
-    if (reply)
+    if (dbus_message_iter_init(reply, &iter))
     {
-      DBusMessageIter iter;
-
-      if (dbus_message_iter_init(reply, &iter))
-      {
-        if (!dbus_message_has_signature(reply, "v"))
-          CLog::Log(LOGERROR, "DBus: wrong signature on Get - should be \"v\" but was %s", dbus_message_iter_get_signature(&iter));
-        else
-          result = ParseVariant(&iter);
-      }
+      if (!dbus_message_has_signature(reply, "v"))
+        CLog::Log(LOGERROR, "DBus: wrong signature on Get - should be \"v\" but was %s", dbus_message_iter_get_signature(&iter));
+      else
+        result = ParseVariant(&iter);
     }
   }
-  else
-    CLog::Log(LOGERROR, "DBus: append arguments failed");
 
   return result;
 }

--- a/xbmc/linux/DBusUtil.h
+++ b/xbmc/linux/DBusUtil.h
@@ -32,8 +32,16 @@ class CDBusUtil
 {
 public:
   static CVariant GetAll(const char *destination, const char *object, const char *interface);
-
   static CVariant GetVariant(const char *destination, const char *object, const char *interface, const char *property);
+  /**
+   * Try to call a DBus method and return whether the call succeeded
+   */
+  static bool TryMethodCall(DBusBusType bus, const char* destination, const char* object, const char* interface, const char* method);
+  /**
+   * Try to call a DBus method and return whether the call succeeded
+   */
+  static bool TryMethodCall(DBusBusType bus, std::string const& destination, std::string const& object, std::string const& interface, std::string const& method);
+
 private:
   static CVariant ParseType(DBusMessageIter *itr);
   static CVariant ParseVariant(DBusMessageIter *itr);

--- a/xbmc/linux/DBusUtil.h
+++ b/xbmc/linux/DBusUtil.h
@@ -20,6 +20,7 @@
  */
 #include "system.h"
 #ifdef HAS_DBUS
+#include <memory>
 #include <string>
 
 #include <dbus/dbus.h>
@@ -37,6 +38,30 @@ private:
   static CVariant ParseType(DBusMessageIter *itr);
   static CVariant ParseVariant(DBusMessageIter *itr);
 };
+
+class CDBusConnection
+{
+public:
+  CDBusConnection();
+  bool Connect(DBusBusType bus, bool openPrivate = false);
+  bool Connect(DBusBusType bus, CDBusError& error, bool openPrivate = false);
+  void Destroy();
+  operator DBusConnection*();
+
+private:
+  CDBusConnection(CDBusConnection const& other) = delete;
+  CDBusConnection& operator=(CDBusConnection const& other) = delete;
+
+  struct DBusConnectionDeleter
+  {
+    DBusConnectionDeleter()
+    {}
+    bool closeBeforeUnref = false;
+    void operator()(DBusConnection* connection) const;
+  };
+  std::unique_ptr<DBusConnection, DBusConnectionDeleter> m_connection;
+};
+
 class CDBusError
 {
 public:

--- a/xbmc/linux/DBusUtil.h
+++ b/xbmc/linux/DBusUtil.h
@@ -20,6 +20,10 @@
  */
 #include "system.h"
 #ifdef HAS_DBUS
+#include <string>
+
+#include <dbus/dbus.h>
+
 #include "DBusMessage.h"
 #include "utils/Variant.h"
 
@@ -33,4 +37,34 @@ private:
   static CVariant ParseType(DBusMessageIter *itr);
   static CVariant ParseVariant(DBusMessageIter *itr);
 };
+class CDBusError
+{
+public:
+  CDBusError();
+  ~CDBusError();
+  operator DBusError*();
+  bool IsSet() const;
+  /**
+   * Reset this error wrapper
+   *
+   * If there was an error, it was handled and this error wrapper should be used
+   * again in a new call, it must be reset before that call.
+   */
+  void Reset();
+  // Keep because operator DBusError* would be used for if-statements on
+  // non-const CDBusError instead
+  operator bool();
+  operator bool() const;
+  std::string Name() const;
+  std::string Message() const;
+  void Log(std::string const& message = "DBus error") const;
+  void Log(int level, std::string const& message = "DBus error") const;
+
+private:
+  CDBusError(CDBusError const& other) = delete;
+  CDBusError& operator=(CDBusError const& other) = delete;
+
+  DBusError m_error;
+};
+
 #endif

--- a/xbmc/powermanagement/linux/ConsoleDeviceKitPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/ConsoleDeviceKitPowerSyscall.cpp
@@ -85,30 +85,8 @@ int CConsoleDeviceKitPowerSyscall::BatteryLevel()
 
 bool CConsoleDeviceKitPowerSyscall::HasDeviceConsoleKit()
 {
-  CDBusMessage consoleKitMessage("org.freedesktop.ConsoleKit", "/org/freedesktop/ConsoleKit/Manager", "org.freedesktop.ConsoleKit.Manager", "CanStop");
-
-  CDBusError error;
-  consoleKitMessage.SendSystem(error);
-  if (error)
-  {
-    error.Log(LOGDEBUG, "ConsoleKit.Manager");
-    return false;
-  }
-
-  error.Reset();
-
-  CDBusMessage deviceKitMessage("org.freedesktop.DeviceKit.Disks", "/org/freedesktop/DeviceKit/Disks", "org.freedesktop.DeviceKit.Disks", "EnumerateDevices");
-  deviceKitMessage.SendSystem(error);
-
-  if (!error)
-  {
-    return true;
-  }
-  else
-  {
-    error.Log(LOGDEBUG, "DeviceKit.Power");
-    return false;
-  }
+  return CDBusUtil::TryMethodCall(DBUS_BUS_SYSTEM, "org.freedesktop.ConsoleKit", "/org/freedesktop/ConsoleKit/Manager", "org.freedesktop.ConsoleKit.Manager", "CanStop")
+    && CDBusUtil::TryMethodCall(DBUS_BUS_SYSTEM, "org.freedesktop.DeviceKit.Disks", "/org/freedesktop/DeviceKit/Disks", "org.freedesktop.DeviceKit.Disks", "EnumerateDevices");
 }
 
 bool CConsoleDeviceKitPowerSyscall::ConsoleKitMethodCall(const char *method)

--- a/xbmc/powermanagement/linux/ConsoleUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/ConsoleUPowerSyscall.cpp
@@ -44,30 +44,20 @@ bool CConsoleUPowerSyscall::Reboot()
 
 bool CConsoleUPowerSyscall::HasConsoleKitAndUPower()
 {
-  bool hasConsoleKitManager = false;
   CDBusMessage consoleKitMessage("org.freedesktop.ConsoleKit", "/org/freedesktop/ConsoleKit/Manager", "org.freedesktop.ConsoleKit.Manager", "CanStop");
 
-  DBusError error;
-  dbus_error_init (&error);
-  DBusConnection *con = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+  CDBusError error;
+  consoleKitMessage.SendSystem(error);
 
-  if (dbus_error_is_set(&error))
+  if (!error)
   {
-    CLog::Log(LOGDEBUG, "ConsoleUPowerSyscall: %s - %s", error.name, error.message);
-    dbus_error_free(&error);
+    return HasUPower();
+  }
+  else
+  {
+    error.Log(LOGDEBUG, "ConsoleKit.Manager");
     return false;
   }
-
-  consoleKitMessage.Send(con, &error);
-
-  if (!dbus_error_is_set(&error))
-    hasConsoleKitManager = true;
-  else
-    CLog::Log(LOGDEBUG, "ConsoleKit.Manager: %s - %s", error.name, error.message);
-
-  dbus_error_free (&error);
-
-  return HasUPower() && hasConsoleKitManager;
 }
 
 bool CConsoleUPowerSyscall::ConsoleKitMethodCall(const char *method)

--- a/xbmc/powermanagement/linux/ConsoleUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/ConsoleUPowerSyscall.cpp
@@ -44,20 +44,8 @@ bool CConsoleUPowerSyscall::Reboot()
 
 bool CConsoleUPowerSyscall::HasConsoleKitAndUPower()
 {
-  CDBusMessage consoleKitMessage("org.freedesktop.ConsoleKit", "/org/freedesktop/ConsoleKit/Manager", "org.freedesktop.ConsoleKit.Manager", "CanStop");
-
-  CDBusError error;
-  consoleKitMessage.SendSystem(error);
-
-  if (!error)
-  {
-    return HasUPower();
-  }
-  else
-  {
-    error.Log(LOGDEBUG, "ConsoleKit.Manager");
-    return false;
-  }
+  return CDBusUtil::TryMethodCall(DBUS_BUS_SYSTEM, "org.freedesktop.ConsoleKit", "/org/freedesktop/ConsoleKit/Manager", "org.freedesktop.ConsoleKit.Manager", "CanStop")
+    && HasUPower();
 }
 
 bool CConsoleUPowerSyscall::ConsoleKitMethodCall(const char *method)

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -61,17 +61,12 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
   if (m_hasUPower)
     UpdateBatteryLevel();
 
-  DBusError error;
-  dbus_error_init(&error);
-  m_connection = dbus_bus_get_private(DBUS_BUS_SYSTEM, &error);
+  CDBusError error;
+  m_connection = dbus_bus_get_private(DBUS_BUS_SYSTEM, error);
 
-  if (dbus_error_is_set(&error))
+  if (!m_connection)
   {
-    CLog::Log(LOGERROR, "LogindUPowerSyscall: Failed to get dbus connection: %s", error.message);
-    dbus_connection_close(m_connection);
-    dbus_connection_unref(m_connection);
-    m_connection = NULL;
-    dbus_error_free(&error);
+    error.Log("LogindUPowerSyscall: Failed to get dbus connection");
     return;
   }
 
@@ -82,7 +77,6 @@ CLogindUPowerSyscall::CLogindUPowerSyscall()
     dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.UPower',member='DeviceChanged'", NULL);
 
   dbus_connection_flush(m_connection);
-  dbus_error_free(&error);
 }
 
 CLogindUPowerSyscall::~CLogindUPowerSyscall()

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.cpp
@@ -212,15 +212,15 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
   if (m_connection)
   {
     dbus_connection_read_write(m_connection, 0);
-    DBusMessage *msg = dbus_connection_pop_message(m_connection);
+    DBusMessagePtr msg(dbus_connection_pop_message(m_connection));
 
     if (msg)
     {
-      if (dbus_message_is_signal(msg, "org.freedesktop.login1.Manager", "PrepareForSleep"))
+      if (dbus_message_is_signal(msg.get(), "org.freedesktop.login1.Manager", "PrepareForSleep"))
       {
         dbus_bool_t arg;
         // the boolean argument defines whether we are going to sleep (true) or just woke up (false)
-        dbus_message_get_args(msg, NULL, DBUS_TYPE_BOOLEAN, &arg, DBUS_TYPE_INVALID);
+        dbus_message_get_args(msg.get(), NULL, DBUS_TYPE_BOOLEAN, &arg, DBUS_TYPE_INVALID);
         CLog::Log(LOGDEBUG, "LogindUPowerSyscall: Received PrepareForSleep with arg %i", (int)arg);
         if (arg)
         {
@@ -235,7 +235,7 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
 
         result = true;
       }
-      else if (dbus_message_is_signal(msg, "org.freedesktop.UPower", "DeviceChanged"))
+      else if (dbus_message_is_signal(msg.get(), "org.freedesktop.UPower", "DeviceChanged"))
       {
         bool lowBattery = m_lowBattery;
         UpdateBatteryLevel();
@@ -245,9 +245,7 @@ bool CLogindUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
         result = true;
       }
       else
-        CLog::Log(LOGDEBUG, "LogindUPowerSyscall - Received unknown signal %s", dbus_message_get_member(msg));
-
-      dbus_message_unref(msg);
+        CLog::Log(LOGDEBUG, "LogindUPowerSyscall - Received unknown signal %s", dbus_message_get_member(msg.get()));
     }
   }
 

--- a/xbmc/powermanagement/linux/LogindUPowerSyscall.h
+++ b/xbmc/powermanagement/linux/LogindUPowerSyscall.h
@@ -42,7 +42,7 @@ public:
   // we don't require UPower because everything except the battery level works fine without it
   static bool HasLogind();  
 private:
-  DBusConnection *m_connection;
+  CDBusConnection m_connection;
   bool m_canPowerdown;
   bool m_canSuspend;
   bool m_canHibernate;

--- a/xbmc/powermanagement/linux/UPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/UPowerSyscall.cpp
@@ -199,33 +199,20 @@ void CUPowerSyscall::EnumeratePowerSources()
 
 bool CUPowerSyscall::HasUPower()
 {
-  DBusError error;
-  DBusConnection *con;
-  bool hasUPower = false;
-  
-  dbus_error_init (&error);
-  con = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-
-  if (dbus_error_is_set(&error))
-  {
-    CLog::Log(LOGDEBUG, "UPowerSyscall: %s - %s", error.name, error.message);
-    dbus_error_free(&error);
-    return false;
-  }
-
   CDBusMessage deviceKitMessage("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "EnumerateDevices");
 
-  deviceKitMessage.Send(con, &error);
+  CDBusError error;
+  deviceKitMessage.SendSystem(error);
 
-  if (!dbus_error_is_set(&error))
-    hasUPower = true;
+  if (!error)
+  {
+    return true;
+  }
   else
-    CLog::Log(LOGDEBUG, "UPower: %s - %s", error.name, error.message);
-
-  dbus_error_free (&error);
-  dbus_connection_unref(con);
-
-  return hasUPower;
+  {
+    error.Log(LOGDEBUG, "UPower");
+    return false;
+  }
 }
 
 bool CUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)

--- a/xbmc/powermanagement/linux/UPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/UPowerSyscall.cpp
@@ -200,20 +200,7 @@ void CUPowerSyscall::EnumeratePowerSources()
 
 bool CUPowerSyscall::HasUPower()
 {
-  CDBusMessage deviceKitMessage("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "EnumerateDevices");
-
-  CDBusError error;
-  deviceKitMessage.SendSystem(error);
-
-  if (!error)
-  {
-    return true;
-  }
-  else
-  {
-    error.Log(LOGDEBUG, "UPower");
-    return false;
-  }
+  return CDBusUtil::TryMethodCall(DBUS_BUS_SYSTEM, "org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "EnumerateDevices");
 }
 
 bool CUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)

--- a/xbmc/powermanagement/linux/UPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/UPowerSyscall.cpp
@@ -193,16 +193,16 @@ bool CUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
   if (m_connection)
   {
     dbus_connection_read_write(m_connection, 0);
-    DBusMessage *msg = dbus_connection_pop_message(m_connection);
+    DBusMessagePtr msg(dbus_connection_pop_message(m_connection));
 
     if (msg)
     {
       result = true;
-      if (dbus_message_is_signal(msg, "org.freedesktop.UPower", "Sleeping"))
+      if (dbus_message_is_signal(msg.get(), "org.freedesktop.UPower", "Sleeping"))
         callback->OnSleep();
-      else if (dbus_message_is_signal(msg, "org.freedesktop.UPower", "Resuming"))
+      else if (dbus_message_is_signal(msg.get(), "org.freedesktop.UPower", "Resuming"))
         callback->OnWake();
-      else if (dbus_message_is_signal(msg, "org.freedesktop.UPower", "Changed"))
+      else if (dbus_message_is_signal(msg.get(), "org.freedesktop.UPower", "Changed"))
       {
         bool lowBattery = m_lowBattery;
         UpdateCapabilities();
@@ -210,9 +210,7 @@ bool CUPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
           callback->OnLowBattery();
       }
       else
-        CLog::Log(LOGDEBUG, "UPower: Received an unknown signal %s", dbus_message_get_member(msg));
-
-      dbus_message_unref(msg);
+        CLog::Log(LOGDEBUG, "UPower: Received an unknown signal %s", dbus_message_get_member(msg.get()));
     }
   }
   return result;

--- a/xbmc/powermanagement/linux/UPowerSyscall.h
+++ b/xbmc/powermanagement/linux/UPowerSyscall.h
@@ -47,7 +47,6 @@ class CUPowerSyscall : public CAbstractPowerSyscall
 {
 public:
   CUPowerSyscall();
-  virtual ~CUPowerSyscall();
   virtual bool Powerdown();
   virtual bool Suspend();
   virtual bool Hibernate();
@@ -68,7 +67,7 @@ protected:
   void UpdateCapabilities();
 private:
   std::list<CUPowerSource> m_powerSources;
-  DBusConnection *m_connection;
+  CDBusConnection m_connection;
 
   bool m_lowBattery;
   void EnumeratePowerSources();

--- a/xbmc/powermanagement/linux/UPowerSyscall.h
+++ b/xbmc/powermanagement/linux/UPowerSyscall.h
@@ -69,7 +69,6 @@ protected:
 private:
   std::list<CUPowerSource> m_powerSources;
   DBusConnection *m_connection;
-  DBusError m_error;
 
   bool m_lowBattery;
   void EnumeratePowerSources();

--- a/xbmc/storage/linux/DeviceKitDisksProvider.cpp
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.cpp
@@ -262,22 +262,21 @@ bool CDeviceKitDisksProvider::PumpDriveChangeEvents(IStorageEventsCallback *call
   if (m_connection)
   {
     dbus_connection_read_write(m_connection, 0);
-    DBusMessage *msg = dbus_connection_pop_message(m_connection);
+    DBusMessagePtr msg(dbus_connection_pop_message(m_connection));
 
     if (msg)
     {
       char *object;
-      if (dbus_message_get_args (msg, NULL, DBUS_TYPE_OBJECT_PATH, &object, DBUS_TYPE_INVALID))
+      if (dbus_message_get_args (msg.get(), NULL, DBUS_TYPE_OBJECT_PATH, &object, DBUS_TYPE_INVALID))
       {
         result = true;
-        if (dbus_message_is_signal(msg, "org.freedesktop.DeviceKit.Disks", "DeviceAdded"))
+        if (dbus_message_is_signal(msg.get(), "org.freedesktop.DeviceKit.Disks", "DeviceAdded"))
           DeviceAdded(object, callback);
-        else if (dbus_message_is_signal(msg, "org.freedesktop.DeviceKit.Disks", "DeviceRemoved"))
+        else if (dbus_message_is_signal(msg.get(), "org.freedesktop.DeviceKit.Disks", "DeviceRemoved"))
           DeviceRemoved(object, callback);
-        else if (dbus_message_is_signal(msg, "org.freedesktop.DeviceKit.Disks", "DeviceChanged"))
+        else if (dbus_message_is_signal(msg.get(), "org.freedesktop.DeviceKit.Disks", "DeviceChanged"))
           DeviceChanged(object, callback);
       }
-      dbus_message_unref(msg);
     }
   }
   return result;

--- a/xbmc/storage/linux/DeviceKitDisksProvider.cpp
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.cpp
@@ -293,26 +293,19 @@ bool CDeviceKitDisksProvider::PumpDriveChangeEvents(IStorageEventsCallback *call
 
 bool CDeviceKitDisksProvider::HasDeviceKitDisks()
 {
-  bool hasDeviceKitDisks = false;
   CDBusMessage message("org.freedesktop.DeviceKit.Disks", "/org/freedesktop/DeviceKit/Disks", "org.freedesktop.DeviceKit.Disks", "EnumerateDevices");
 
-  DBusError error;
-  dbus_error_init (&error);
-  DBusConnection *con = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-
-  if (con)
-    message.Send(con, &error);
-
-  if (!dbus_error_is_set(&error))
-    hasDeviceKitDisks = true;
+  CDBusError error;
+  message.SendSystem(error);
+  if (!error)
+  {
+    return true;
+  }
   else
-    CLog::Log(LOGDEBUG, "DeviceKit.Disks: %s - %s", error.name, error.message);
-
-  dbus_error_free (&error);
-  if (con)
-    dbus_connection_unref(con);
-
-  return hasDeviceKitDisks;
+  {
+    error.Log(LOGDEBUG, "DeviceKit.Disks");
+    return false;
+  }
 }
 
 void CDeviceKitDisksProvider::DeviceAdded(const char *object, IStorageEventsCallback *callback)

--- a/xbmc/storage/linux/DeviceKitDisksProvider.cpp
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.cpp
@@ -194,27 +194,21 @@ std::string CDeviceKitDiskDevice::toString()
 
 CDeviceKitDisksProvider::CDeviceKitDisksProvider()
 {
-  CDBusError error;
   //! @todo do not use dbus_connection_pop_message() that requires the use of a
   //! private connection
-  m_connection = dbus_bus_get_private(DBUS_BUS_SYSTEM, error);
-  if (m_connection)
-  {
-    dbus_connection_set_exit_on_disconnect(m_connection, false);
+  if (!m_connection.Connect(DBUS_BUS_SYSTEM, true))
+    return;
 
-    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.DeviceKit.Disks'", error);
-    dbus_connection_flush(m_connection);
-  }
+  dbus_connection_set_exit_on_disconnect(m_connection, false);
+
+  CDBusError error;
+  dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.DeviceKit.Disks'", error);
+  dbus_connection_flush(m_connection);
 
   if (error)
   {
     error.Log("DeviceKit.Disks: Failed to attach to signal");
-    if (m_connection)
-    {
-      dbus_connection_close(m_connection);
-      dbus_connection_unref(m_connection);
-    }
-    m_connection = NULL;
+    m_connection.Destroy();
   }
 }
 
@@ -226,13 +220,6 @@ CDeviceKitDisksProvider::~CDeviceKitDisksProvider()
     delete m_AvailableDevices[itr->first];
 
   m_AvailableDevices.clear();
-
-  if (m_connection)
-  {
-    dbus_connection_close(m_connection);
-    dbus_connection_unref(m_connection);
-    m_connection = NULL;
-  }
 }
 
 void CDeviceKitDisksProvider::Initialize()

--- a/xbmc/storage/linux/DeviceKitDisksProvider.cpp
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.cpp
@@ -298,19 +298,7 @@ bool CDeviceKitDisksProvider::PumpDriveChangeEvents(IStorageEventsCallback *call
 
 bool CDeviceKitDisksProvider::HasDeviceKitDisks()
 {
-  CDBusMessage message("org.freedesktop.DeviceKit.Disks", "/org/freedesktop/DeviceKit/Disks", "org.freedesktop.DeviceKit.Disks", "EnumerateDevices");
-
-  CDBusError error;
-  message.SendSystem(error);
-  if (!error)
-  {
-    return true;
-  }
-  else
-  {
-    error.Log(LOGDEBUG, "DeviceKit.Disks");
-    return false;
-  }
+  return CDBusUtil::TryMethodCall(DBUS_BUS_SYSTEM, "org.freedesktop.DeviceKit.Disks", "/org/freedesktop/DeviceKit/Disks", "org.freedesktop.DeviceKit.Disks", "EnumerateDevices");
 }
 
 void CDeviceKitDisksProvider::DeviceAdded(const char *object, IStorageEventsCallback *callback)

--- a/xbmc/storage/linux/DeviceKitDisksProvider.h
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.h
@@ -101,6 +101,6 @@ private:
 
   DeviceMap m_AvailableDevices;
 
-  DBusConnection *m_connection;
+  CDBusConnection m_connection;
 };
 #endif

--- a/xbmc/storage/linux/DeviceKitDisksProvider.h
+++ b/xbmc/storage/linux/DeviceKitDisksProvider.h
@@ -102,6 +102,5 @@ private:
   DeviceMap m_AvailableDevices;
 
   DBusConnection *m_connection;
-  DBusError m_error;
 };
 #endif

--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -278,20 +278,7 @@ bool CUDisksProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 
 bool CUDisksProvider::HasUDisks()
 {
-  CDBusMessage message("org.freedesktop.UDisks", "/org/freedesktop/UDisks", "org.freedesktop.UDisks", "EnumerateDevices");
-
-  CDBusError error;
-  message.SendSystem(error);
-
-  if (!error)
-  {
-    return true;
-  }
-  else
-  {
-    error.Log(LOGDEBUG, "UDisks");
-    return false;
-  }
+  return CDBusUtil::TryMethodCall(DBUS_BUS_SYSTEM, "org.freedesktop.UDisks", "/org/freedesktop/UDisks", "org.freedesktop.UDisks", "EnumerateDevices");
 }
 
 void CUDisksProvider::DeviceAdded(const char *object, IStorageEventsCallback *callback)

--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -277,26 +277,20 @@ bool CUDisksProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
 
 bool CUDisksProvider::HasUDisks()
 {
-  bool hasUDisks = false;
   CDBusMessage message("org.freedesktop.UDisks", "/org/freedesktop/UDisks", "org.freedesktop.UDisks", "EnumerateDevices");
 
-  DBusError error;
-  dbus_error_init (&error);
-  DBusConnection *con = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+  CDBusError error;
+  message.SendSystem(error);
 
-  if (con)
-    message.Send(con, &error);
-
-  if (!dbus_error_is_set(&error))
-    hasUDisks = true;
+  if (!error)
+  {
+    return true;
+  }
   else
-    CLog::Log(LOGDEBUG, "UDisks: %s - %s", error.name, error.message);
-
-  dbus_error_free (&error);
-  if (con)
-    dbus_connection_unref(con);
-
-  return hasUDisks;
+  {
+    error.Log(LOGDEBUG, "UDisks");
+    return false;
+  }
 }
 
 void CUDisksProvider::DeviceAdded(const char *object, IStorageEventsCallback *callback)

--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -173,24 +173,27 @@ std::string CUDiskDevice::toString()
 
 CUDisksProvider::CUDisksProvider()
 {
-  dbus_error_init (&m_error);
+  CDBusError error;
   //! @todo do not use dbus_connection_pop_message() that requires the use of a
   //! private connection
-  m_connection = dbus_bus_get_private(DBUS_BUS_SYSTEM, &m_error);
+  m_connection = dbus_bus_get_private(DBUS_BUS_SYSTEM, error);
 
   if (m_connection)
   {
     dbus_connection_set_exit_on_disconnect(m_connection, false);
 
-    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.UDisks'", &m_error);
+    dbus_bus_add_match(m_connection, "type='signal',interface='org.freedesktop.UDisks'", error);
     dbus_connection_flush(m_connection);
   }
 
-  if (dbus_error_is_set(&m_error))
+  if (error)
   {
-    CLog::Log(LOGERROR, "UDisks: Failed to attach to signal %s", m_error.message);
-    dbus_connection_close(m_connection);
-    dbus_connection_unref(m_connection);
+    error.Log("UDisks: Failed to attach to signal");
+    if (m_connection)
+    {
+      dbus_connection_close(m_connection);
+      dbus_connection_unref(m_connection);
+    }
     m_connection = NULL;
   }
 }
@@ -210,8 +213,6 @@ CUDisksProvider::~CUDisksProvider()
     dbus_connection_unref(m_connection);
     m_connection = NULL;
   }
-
-  dbus_error_free (&m_error);
 }
 
 void CUDisksProvider::Initialize()

--- a/xbmc/storage/linux/UDisksProvider.cpp
+++ b/xbmc/storage/linux/UDisksProvider.cpp
@@ -243,22 +243,21 @@ bool CUDisksProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
   if (m_connection)
   {
     dbus_connection_read_write(m_connection, 0);
-    DBusMessage *msg = dbus_connection_pop_message(m_connection);
+    DBusMessagePtr msg(dbus_connection_pop_message(m_connection));
 
     if (msg)
     {
       char *object;
-      if (dbus_message_get_args (msg, NULL, DBUS_TYPE_OBJECT_PATH, &object, DBUS_TYPE_INVALID))
+      if (dbus_message_get_args (msg.get(), NULL, DBUS_TYPE_OBJECT_PATH, &object, DBUS_TYPE_INVALID))
       {
         result = true;
-        if (dbus_message_is_signal(msg, "org.freedesktop.UDisks", "DeviceAdded"))
+        if (dbus_message_is_signal(msg.get(), "org.freedesktop.UDisks", "DeviceAdded"))
           DeviceAdded(object, callback);
-        else if (dbus_message_is_signal(msg, "org.freedesktop.UDisks", "DeviceRemoved"))
+        else if (dbus_message_is_signal(msg.get(), "org.freedesktop.UDisks", "DeviceRemoved"))
           DeviceRemoved(object, callback);
-        else if (dbus_message_is_signal(msg, "org.freedesktop.UDisks", "DeviceChanged"))
+        else if (dbus_message_is_signal(msg.get(), "org.freedesktop.UDisks", "DeviceChanged"))
           DeviceChanged(object, callback);
       }
-      dbus_message_unref(msg);
     }
   }
   return result;

--- a/xbmc/storage/linux/UDisksProvider.h
+++ b/xbmc/storage/linux/UDisksProvider.h
@@ -83,6 +83,6 @@ private:
 
   DeviceMap m_AvailableDevices;
 
-  DBusConnection *m_connection;
+  CDBusConnection m_connection;
 };
 #endif

--- a/xbmc/storage/linux/UDisksProvider.h
+++ b/xbmc/storage/linux/UDisksProvider.h
@@ -84,6 +84,5 @@ private:
   DeviceMap m_AvailableDevices;
 
   DBusConnection *m_connection;
-  DBusError m_error;
 };
 #endif


### PR DESCRIPTION
Refactor the DBus code on Linux to use RAII and have less repetition

## Description
Introduce RAII wrappers for `DBusConnection`, `DBusMessage`, and `DBusError`. The goal is still not to provide full C++ bindings for DBus, but just to make life a bit easier and make use of C++ comfort features.
I've tried not to change Kodi's behavior regarding PM etc.

## Motivation and Context
The DBus code suffers of a great deal of copy&paste because RAII isn't used and simple helpers for common stuff were not added.
Also, `dbus_connection_close` and  `dbus_connection_unref` are potentially called on a `NULL` connection in some places which is illegal.

## How Has This Been Tested?
Compiled for X11, log output checked

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
