### PR TITLE
[database] correctly closing video and music databases

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -508,10 +508,12 @@ bool CAutorun::CanResumePlayDVD(const std::string& path)
   if (!strUniqueId.empty())
   {
     CVideoDatabase dbs;
-    dbs.Open();
     CBookmark bookmark;
-    if (dbs.GetResumeBookMark(strUniqueId, bookmark))
+    if (dbs.Open() && dbs.GetResumeBookMark(strUniqueId, bookmark))
+    {
+      dbs.Close();
       return true;
+    }
   }
   return false;
 }

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -444,6 +444,7 @@ void CPartyModeManager::Add(CFileItemPtr &pItem)
     CMusicDatabase database;
     database.Open();
     database.SetPropertiesForFileItem(*pItem);
+    database.Close();
   }
 
   CPlayList& playlist = g_playlistPlayer.GetPlaylist(iPlaylist);
@@ -630,6 +631,7 @@ bool CPartyModeManager::AddInitialSongs(std::vector< std::pair<int,int > > &song
       CMusicDatabase database;
       database.Open();
       database.GetSongsFullByWhere("musicdb://songs/", sqlWhereMusic, items, SortDescription(), true);
+      database.Close();
     }
     if (sqlWhereVideo.size() > 19)
     {
@@ -637,6 +639,7 @@ bool CPartyModeManager::AddInitialSongs(std::vector< std::pair<int,int > > &song
       CVideoDatabase database;
       database.Open();
       database.GetMusicVideosByWhere("videodb://musicvideos/titles/", sqlWhereVideo, items);
+      database.Close();
     }
 
     m_history = chosenSongIDs;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -404,13 +404,19 @@ bool CScraper::IsInUse() const
   { // music scraper
     CMusicDatabase db;
     if (db.Open() && db.ScraperInUse(ID()))
+    {
+      db.Close();
       return true;
+    }
   }
   else
   { // video scraper
     CVideoDatabase db;
     if (db.Open() && db.ScraperInUse(ID()))
+    {
+      db.Close();
       return true;
+    }
   }
   return false;
 }

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -664,6 +664,8 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
       videodb.GetMusicVideoAlbumsNav(m_dbUrl->ToString(), selectItems, -1, dbfilter, countOnly);
     else if (filter.field == FieldTag)
       videodb.GetTagsNav(m_dbUrl->ToString(), selectItems, type, dbfilter, countOnly);
+    
+    videodb.Close();
   }
   else if (m_mediaType == "artists" || m_mediaType == "albums" || m_mediaType == "songs")
   {
@@ -685,6 +687,8 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
       musicdb.GetAlbumTypesNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
     else if (filter.field == FieldMusicLabel)
       musicdb.GetMusicLabelsNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
+    
+    musicdb.Close();
   }
 
   int size = selectItems.Size();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -321,6 +321,8 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
       m_rule.m_parameter.emplace_back(std::move(path));
 
     UpdateButtons();
+    videodatabase.Close();
+    database.Close();
     return;
   }
   else if (m_rule.m_field == FieldSet)
@@ -337,7 +339,11 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     else if (m_type == "musicvideos")
       type = VIDEODB_CONTENT_MUSICVIDEOS;
     else if (m_type != "movies")
+    {
+      videodatabase.Close();
+      database.Close();
       return;
+    }
 
     videodatabase.GetTagsNav(basePath + "tags/", items, type);
     iLabel = 20459;
@@ -346,6 +352,9 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   { //! @todo Add browseability in here.
     assert(false);
   }
+  
+  videodatabase.Close();
+  database.Close();
 
   // sort the items
   items.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -166,6 +166,8 @@ bool CMusicDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
       strLabel += " / ";
     strLabel += musicdatabase.GetAlbumById(params.GetAlbumId());
   }
+  
+  musicdatabase.Close();
 
   if (strLabel.empty())
   {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -40,9 +40,13 @@ std::string CDirectoryNodeAlbum::GetLocalizedName() const
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetAlbumById(GetID());
+  db.Close();
+  
+  return name;
 }
 
 bool CDirectoryNodeAlbum::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
@@ -43,9 +43,14 @@ std::string CDirectoryNodeAlbumCompilations::GetLocalizedName() const
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetAlbumById(GetID());
+  db.Close();
+  
+  return name;
+  
 }
 
 bool CDirectoryNodeAlbumCompilations::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -44,9 +44,13 @@ std::string CDirectoryNodeAlbumRecentlyAdded::GetLocalizedName() const
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetAlbumById(GetID());
+  db.Close();
+  return name;
+  
 }
 
 bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -44,9 +44,13 @@ std::string CDirectoryNodeAlbumRecentlyPlayed::GetLocalizedName() const
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetAlbumById(GetID());
+  db.Close();
+  return name;
+  
 }
 
 bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -42,9 +42,13 @@ NODE_TYPE CDirectoryNodeAlbumTop100::GetChildType() const
 std::string CDirectoryNodeAlbumTop100::GetLocalizedName() const
 {
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetAlbumById(GetID());
+  db.Close();
+  return name;
+  
 }
 
 bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -43,8 +43,12 @@ std::string CDirectoryNodeArtist::GetLocalizedName() const
     return g_localizeStrings.Get(15103); // All Artists
   CMusicDatabase db;
   if (db.Open())
-    return db.GetArtistById(GetID());
-  return "";
+    return "";
+  
+  std::string name = db.GetArtistById(GetID());
+  db.Close();
+  return name;
+  
 }
 
 bool CDirectoryNodeArtist::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -38,9 +38,13 @@ NODE_TYPE CDirectoryNodeGrouped::GetChildType() const
 std::string CDirectoryNodeGrouped::GetLocalizedName() const
 {
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetItemById(GetContentType(), GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetItemById(GetContentType(), GetID());
+  db.Close();
+  return name;
+  
 }
 
 bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
@@ -49,7 +53,11 @@ bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
   if (!musicdatabase.Open())
     return false;
 
-  return musicdatabase.GetItems(BuildPath(), GetContentType(), items);
+  bool bSuccess = musicdatabase.GetItems(BuildPath(), GetContentType(), items);
+  
+  musicdatabase.Close();
+  
+  return bSuccess;
 }
 
 std::string CDirectoryNodeGrouped::GetContentType() const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -75,6 +75,8 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 
   bool hasSingles = (musicDatabase.GetSinglesCount() > 0);
   bool hasCompilations = (musicDatabase.GetCompilationAlbumsCount() > 0);
+  
+  musicDatabase.Close();
 
   for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
   {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
@@ -43,9 +43,13 @@ std::string CDirectoryNodeYearAlbum::GetLocalizedName() const
   if (GetID() == -1)
     return g_localizeStrings.Get(15102); // All Albums
   CMusicDatabase db;
-  if (db.Open())
-    return db.GetAlbumById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+  
+  std::string name = db.GetAlbumById(GetID());
+  db.Close();
+  return name;
+  
 }
 
 bool CDirectoryNodeYearAlbum::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/MusicDatabaseFile.cpp
+++ b/xbmc/filesystem/MusicDatabaseFile.cpp
@@ -46,13 +46,20 @@ std::string CMusicDatabaseFile::TranslateUrl(const CURL& url)
   URIUtils::RemoveExtension(strFileName);
 
   if (!StringUtils::IsNaturalNumber(strFileName))
+  {
+    musicDatabase.Close();
     return "";
+  }
 
   long idSong=atol(strFileName.c_str());
 
   CSong song;
   if (!musicDatabase.GetSong(idSong, song))
+  {
+    musicDatabase.Close();
     return "";
+  }
+  musicDatabase.Close();
 
   StringUtils::ToLower(strExtension);
   if (!URIUtils::HasExtension(song.strFileName, strExtension))

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -113,7 +113,10 @@ namespace XFILE
           else if (mediaType == MediaTypeMovie)
             baseDir = "videodb://movies/";
           else
+          {
+            db.Close();
             return false;
+          }
 
           if (!isGrouped)
             baseDir += "titles";
@@ -127,14 +130,20 @@ namespace XFILE
 
         CVideoDbUrl videoUrl;
         if (!videoUrl.FromString(baseDir))
+        {
+          db.Close();
           return false;
+        }
 
         // store the smartplaylist as JSON in the URL as well
         std::string xsp;
         if (!playlist.IsEmpty(filter))
         {
           if (!playlist.SaveAsJson(xsp, !filter))
+          {
+            db.Close();
             return false;
+          }
         }
 
         if (!xsp.empty())
@@ -177,7 +186,10 @@ namespace XFILE
             else if (mediaType == MediaTypeSong)
               baseDir += "songs";
             else
+            {
+              db.Close();
               return false;
+            }
           }
           else
             baseDir += group;
@@ -187,14 +199,20 @@ namespace XFILE
 
         CMusicDbUrl musicUrl;
         if (!musicUrl.FromString(baseDir))
+        {
+          db.Close();
           return false;
+        }
 
         // store the smartplaylist as JSON in the URL as well
         std::string xsp;
         if (!plist.IsEmpty(filter))
         {
           if (!plist.SaveAsJson(xsp, !filter))
+          {
+            db.Close();
             return false;
+          }
         }
 
         if (!xsp.empty())

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -169,6 +169,8 @@ bool CVideoDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
   // get tag
   if (params.GetTagId() != -1)
     strLabel += videodatabase.GetTagById(params.GetTagId());
+  
+  videodatabase.Close();
 
   // get year
   if (params.GetYear() != -1)
@@ -225,7 +227,6 @@ bool CVideoDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
       return false;
     }
   }
-
   return true;
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -51,7 +51,11 @@ std::string CDirectoryNodeGrouped::GetLocalizedName() const
 {
   CVideoDatabase db;
   if (db.Open())
-    return db.GetItemById(GetContentType(), GetID());
+  {
+    std::string name = db.GetItemById(GetContentType(), GetID());
+    db.Close();
+    return name;
+  }
 
   return "";
 }
@@ -73,8 +77,11 @@ bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
   CVideoDbUrl videoUrl;
   if (!videoUrl.FromString(BuildPath()))
     return false;
+  
+  bool result = videodatabase.GetItems(videoUrl.ToString(), (VIDEODB_CONTENT_TYPE)params.GetContentType(), itemType, items);
+  videodatabase.Close();
 
-  return videodatabase.GetItems(videoUrl.ToString(), (VIDEODB_CONTENT_TYPE)params.GetContentType(), itemType, items);
+  return result;
 }
 
 std::string CDirectoryNodeGrouped::GetContentType() const

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
@@ -38,7 +38,11 @@ std::string CDirectoryNodeInProgressTvShows::GetLocalizedName() const
 {
   CVideoDatabase db;
   if (db.Open())
-    return db.GetTvShowTitleById(GetID());
+  {
+    std::string name = db.GetTvShowTitleById(GetID());
+    db.Close();
+    return name;
+  }
   return "";
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -74,7 +74,10 @@ bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
     {
       CVideoDatabase db;
       if (db.Open() && !db.HasSets())
+      {
+        db.Close();
         continue;
+      }
     }
 
     CVideoDbUrl itemUrl = videoUrl;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -112,6 +112,8 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
     pItem->SetCanQueue(false);
     items.Add(pItem);
   }
+  
+  database.Close();
 
   return true;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -38,9 +38,12 @@ NODE_TYPE CDirectoryNodeTitleTvShows::GetChildType() const
 std::string CDirectoryNodeTitleTvShows::GetLocalizedName() const
 {
   CVideoDatabase db;
-  if (db.Open())
-    return db.GetTvShowTitleById(GetID());
-  return "";
+  if (!db.Open())
+    return "";
+
+  std::string name = db.GetTvShowTitleById(GetID());
+  db.Close();
+  return name;
 }
 
 bool CDirectoryNodeTitleTvShows::GetContent(CFileItemList& items) const

--- a/xbmc/filesystem/VideoDatabaseFile.cpp
+++ b/xbmc/filesystem/VideoDatabaseFile.cpp
@@ -55,6 +55,8 @@ CVideoInfoTag CVideoDatabaseFile::GetVideoTag(const CURL& url)
   
   tag = videoDatabase.GetDetailsByTypeAndId(type, idDb);
   
+  videoDatabase.Close();
+  
   return tag;
 }
 
@@ -104,6 +106,7 @@ std::string CVideoDatabaseFile::TranslatePath(const CURL& url)
 
   std::string realFilename;
   videoDatabase.GetFilePathById(idDb, realFilename, type);
+  videoDatabase.Close();
 
   return realFilename;
 }

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -66,7 +66,10 @@ JSONRPC_STATUS CAudioLibrary::GetArtists(const std::string &method, ITransportLa
 
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString("musicdb://artists/"))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   bool allroles = false;
   if (parameterObject["allroles"].isBoolean())
@@ -100,7 +103,10 @@ JSONRPC_STATUS CAudioLibrary::GetArtists(const std::string &method, ITransportLa
   {
     std::string xsp;
     if (!GetXspFiltering("artists", filter, xsp))
+    {
+      musicdatabase.Close();
       return InvalidParams;
+    }
 
     musicUrl.AddOption("xsp", xsp);
   }
@@ -112,12 +118,18 @@ JSONRPC_STATUS CAudioLibrary::GetArtists(const std::string &method, ITransportLa
   SortDescription sorting;
   ParseLimits(parameterObject, sorting.limitStart, sorting.limitEnd);
   if (!ParseSorting(parameterObject, sorting.sortBy, sorting.sortOrder, sorting.sortAttributes))
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   CFileItemList items;
   musicdatabase.SetTranslateBlankArtist(false);  
   if (!musicdatabase.GetArtistsNav(musicUrl.ToString(), items, albumArtistsOnly, genreID, albumID, songID, CDatabase::Filter(), sorting))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   // Add "artist" to "properties" array by default
   CVariant param = parameterObject;
@@ -127,6 +139,7 @@ JSONRPC_STATUS CAudioLibrary::GetArtists(const std::string &method, ITransportLa
 
   //Get roleids, songgenreids etc, if needed
   JSONRPC_STATUS ret = GetAdditionalArtistDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -154,7 +167,10 @@ JSONRPC_STATUS CAudioLibrary::GetArtistDetails(const std::string &method, ITrans
   CFileItemList items;
   CDatabase::Filter filter;
   if (!musicdatabase.GetArtistsByWhere(musicUrl.ToString(), filter, items) || items.Size() != 1)
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   // Add "artist" to "properties" array by default
   CVariant param = parameterObject;
@@ -164,6 +180,7 @@ JSONRPC_STATUS CAudioLibrary::GetArtistDetails(const std::string &method, ITrans
 
   //Get roleids, roles etc. if needed
   JSONRPC_STATUS ret = GetAdditionalArtistDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -179,7 +196,10 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
 
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString("musicdb://albums/"))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   if (parameterObject["includesingles"].asBoolean())
     musicUrl.AddOption("show_singles", true);
@@ -209,7 +229,10 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
   {
     std::string xsp;
     if (!GetXspFiltering("albums", filter, xsp))
+    {
+      musicdatabase.Close();
       return InvalidParams;
+    }
 
     musicUrl.AddOption("xsp", xsp);
   }
@@ -217,12 +240,18 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
   SortDescription sorting;
   ParseLimits(parameterObject, sorting.limitStart, sorting.limitEnd);
   if (!ParseSorting(parameterObject, sorting.sortBy, sorting.sortOrder, sorting.sortAttributes))
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   int total;
   VECALBUMS albums;
   if (!musicdatabase.GetAlbumsByWhere(musicUrl.ToString(), CDatabase::Filter(), albums, total, sorting))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   CFileItemList items;
   items.Reserve(albums.size());
@@ -239,6 +268,7 @@ JSONRPC_STATUS CAudioLibrary::GetAlbums(const std::string &method, ITransportLay
 
   //Get Genre IDs
   JSONRPC_STATUS ret = GetAdditionalAlbumDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -260,11 +290,17 @@ JSONRPC_STATUS CAudioLibrary::GetAlbumDetails(const std::string &method, ITransp
 
   CAlbum album;
   if (!musicdatabase.GetAlbum(albumID, album, false))
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   std::string path;
   if (!musicdatabase.GetAlbumPath(albumID, path))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   CFileItemPtr albumItem;
   FillAlbumItem(album, path, albumItem);
@@ -272,6 +308,7 @@ JSONRPC_STATUS CAudioLibrary::GetAlbumDetails(const std::string &method, ITransp
   CFileItemList items;
   items.Add(albumItem);
   JSONRPC_STATUS ret = GetAdditionalAlbumDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
   
@@ -288,7 +325,10 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
 
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString("musicdb://songs/"))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   if (!parameterObject["includesingles"].asBoolean())
     musicUrl.AddOption("singles", false);
@@ -322,7 +362,10 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
   {
     std::string xsp;
     if (!GetXspFiltering("songs", filter, xsp))
+    {
+      musicdatabase.Close();
       return InvalidParams;
+    }
 
     musicUrl.AddOption("xsp", xsp);
   }
@@ -330,7 +373,10 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
   SortDescription sorting;
   ParseLimits(parameterObject, sorting.limitStart, sorting.limitEnd);
   if (!ParseSorting(parameterObject, sorting.sortBy, sorting.sortOrder, sorting.sortAttributes))
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   // Check if any properties from songartistview wanted, only then query artist data for songs
   // "displayArtist" is held in songview
@@ -348,9 +394,13 @@ JSONRPC_STATUS CAudioLibrary::GetSongs(const std::string &method, ITransportLaye
  
   CFileItemList items;
   if (!musicdatabase.GetSongsFullByWhere(musicUrl.ToString(), CDatabase::Filter(), items, sorting, artistData))
-    return InternalError; 
+  {
+    musicdatabase.Close();
+    return InternalError;
+  }
 
   JSONRPC_STATUS ret = GetAdditionalSongDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -372,7 +422,10 @@ JSONRPC_STATUS CAudioLibrary::GetSongDetails(const std::string &method, ITranspo
 
   CSong song;
   if (!musicdatabase.GetSong(idSong, song))
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   CFileItemList items;
   CFileItemPtr item = CFileItemPtr(new CFileItem(song));
@@ -380,6 +433,7 @@ JSONRPC_STATUS CAudioLibrary::GetSongDetails(const std::string &method, ITranspo
   items.Add(item);
 
   JSONRPC_STATUS ret = GetAdditionalSongDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -395,7 +449,10 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyAddedAlbums(const std::string &method, 
 
   VECALBUMS albums;
   if (!musicdatabase.GetRecentlyAddedAlbums(albums))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   CFileItemList items;
   for (unsigned int index = 0; index < albums.size(); index++)
@@ -408,6 +465,7 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyAddedAlbums(const std::string &method, 
   }
 
   JSONRPC_STATUS ret = GetAdditionalAlbumDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -427,9 +485,13 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyAddedSongs(const std::string &method, I
 
   CFileItemList items;
   if (!musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://songs/", items, (unsigned int)amount))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   JSONRPC_STATUS ret = GetAdditionalSongDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -445,7 +507,10 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyPlayedAlbums(const std::string &method,
 
   VECALBUMS albums;
   if (!musicdatabase.GetRecentlyPlayedAlbums(albums))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   CFileItemList items;
   for (unsigned int index = 0; index < albums.size(); index++)
@@ -458,6 +523,7 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyPlayedAlbums(const std::string &method,
   }
 
   JSONRPC_STATUS ret = GetAdditionalAlbumDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -473,9 +539,13 @@ JSONRPC_STATUS CAudioLibrary::GetRecentlyPlayedSongs(const std::string &method, 
 
   CFileItemList items;
   if (!musicdatabase.GetRecentlyPlayedAlbumSongs("musicdb://songs/", items))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
 
   JSONRPC_STATUS ret = GetAdditionalSongDetails(parameterObject, items, musicdatabase);
+  musicdatabase.Close();
   if (ret != OK)
     return ret;
 
@@ -491,7 +561,11 @@ JSONRPC_STATUS CAudioLibrary::GetGenres(const std::string &method, ITransportLay
 
   CFileItemList items;
   if (!musicdatabase.GetGenresNav("musicdb://genres/", items))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
+  musicdatabase.Close();
 
   /* need to set strTitle in each item*/
   for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
@@ -509,7 +583,11 @@ JSONRPC_STATUS CAudioLibrary::GetRoles(const std::string &method, ITransportLaye
 
   CFileItemList items;
   if (!musicdatabase.GetRolesNav("musicdb://songs/", items))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
+  musicdatabase.Close();
 
   /* need to set strTitle in each item*/
   for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
@@ -529,7 +607,10 @@ JSONRPC_STATUS CAudioLibrary::SetArtistDetails(const std::string &method, ITrans
 
   CArtist artist;
   if (!musicdatabase.GetArtist(id, artist) || artist.idArtist <= 0)
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   if (ParameterNotNull(parameterObject, "artist"))
     artist.strArtist = parameterObject["artist"].asString();
@@ -555,7 +636,11 @@ JSONRPC_STATUS CAudioLibrary::SetArtistDetails(const std::string &method, ITrans
     CopyStringArray(parameterObject["yearsactive"], artist.yearsActive);
 
   if (!musicdatabase.UpdateArtist(artist))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
+  musicdatabase.Close();
 
   CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
@@ -571,7 +656,10 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const std::string &method, ITransp
 
   CAlbum album;
   if (!musicdatabase.GetAlbum(id, album) || album.idAlbum <= 0)
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   if (ParameterNotNull(parameterObject, "title"))
     album.strAlbum = parameterObject["title"].asString();
@@ -605,7 +693,11 @@ JSONRPC_STATUS CAudioLibrary::SetAlbumDetails(const std::string &method, ITransp
     album.iYear = (int)parameterObject["year"].asInteger();
 
   if (!musicdatabase.UpdateAlbum(album))
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
+  musicdatabase.Close();
 
   CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
@@ -621,7 +713,10 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
 
   CSong song;
   if (!musicdatabase.GetSong(id, song) || song.idSong != id)
+  {
+    musicdatabase.Close();
     return InvalidParams;
+  }
 
   if (ParameterNotNull(parameterObject, "title"))
     song.strTitle = parameterObject["title"].asString();
@@ -667,7 +762,11 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
   // Also need to update artist credits and propagate changes
   // to song_artist and song_genre tables.
   if (musicdatabase.UpdateSong(id, song) <= 0)
+  {
+    musicdatabase.Close();
     return InternalError;
+  }
+  musicdatabase.Close();
 
   CJSONRPCUtils::NotifyItemUpdated();
   return ACK;
@@ -743,6 +842,7 @@ bool CAudioLibrary::FillFileItem(const std::string &strFilename, CFileItemPtr &i
       }
     }
   }
+  musicdatabase.Close();
 
   if (item->GetLabel().empty())
   {
@@ -786,6 +886,7 @@ bool CAudioLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
       success = true;
     }
   }
+  musicdatabase.Close();
 
   if (success)
   {
@@ -842,9 +943,6 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalDetails(const CVariant &parameterObje
 
 JSONRPC_STATUS CAudioLibrary::GetAdditionalArtistDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase)
 {
-  if (!musicdatabase.Open())
-    return InternalError;
-
   std::set<std::string> checkProperties;
   checkProperties.insert("roles");
   checkProperties.insert("songgenres");
@@ -882,9 +980,6 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalArtistDetails(const CVariant &paramet
 
 JSONRPC_STATUS CAudioLibrary::GetAdditionalAlbumDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase)
 {
-  if (!musicdatabase.Open())
-    return InternalError;
-
   std::set<std::string> checkProperties;
   checkProperties.insert("genreid");
   std::set<std::string> additionalProperties;
@@ -914,9 +1009,6 @@ JSONRPC_STATUS CAudioLibrary::GetAdditionalAlbumDetails(const CVariant &paramete
 
 JSONRPC_STATUS CAudioLibrary::GetAdditionalSongDetails(const CVariant &parameterObject, CFileItemList &items, CMusicDatabase &musicdatabase)
 {
-  if (!musicdatabase.Open())
-    return InternalError;
-
   std::set<std::string> checkProperties;
   checkProperties.insert("genreid");
   // Query (songview join songartistview) returns song.strAlbumArtists = CMusicInfoTag.m_strAlbumArtistDesc only

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -255,6 +255,7 @@ JSONRPC_STATUS CFileOperations::SetFileDetails(const std::string &method, ITrans
   CVideoLibrary::UpdateResumePoint(parameterObject, infos, videodatabase);
 
   videodatabase.GetFileInfo("", infos, fileId);
+  videodatabase.Close();
   CJSONRPCUtils::NotifyItemUpdated(infos);
   return ACK;
 }

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -52,6 +52,8 @@ CMusicInfoLoader::CMusicInfoLoader()
 CMusicInfoLoader::~CMusicInfoLoader()
 {
   StopThread();
+  if (m_musicDatabase.IsOpen())
+    m_musicDatabase.Close();
   delete m_mapFileItems;
   delete m_thumbLoader;
 }
@@ -105,6 +107,8 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
     CAlbum album;
     if (database.GetAlbum(param.GetAlbumId(), album, false))
       CMusicDatabase::SetPropertiesFromAlbum(*pItem,album);
+    
+    database.Close();
 
     path = pItem->GetMusicInfoTag()->GetURL();
   }

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -38,6 +38,8 @@ CMusicThumbLoader::CMusicThumbLoader() : CThumbLoader()
 
 CMusicThumbLoader::~CMusicThumbLoader()
 {
+  if (m_musicDatabase->IsOpen())
+    m_musicDatabase->Close();
   delete m_musicDatabase;
 }
 

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -190,6 +190,7 @@ void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const std::string &path)
       if (artwork.find("fanart") != artwork.end())
         m_albumItem->SetArt("fanart",artwork["fanart"]);
     }
+    db.Close();
   }
   m_startUserrating = m_album.iUserrating;
   m_hasUpdatedThumb = false;
@@ -268,6 +269,7 @@ void CGUIDialogMusicInfo::SetDiscography() const
 
     m_albumSongs->Add(item);
   }
+  database.Close();
 }
 
 void CGUIDialogMusicInfo::Update()
@@ -387,6 +389,7 @@ void CGUIDialogMusicInfo::OnGetThumb()
     std::string strArtistPath;
     if (database.GetArtistPath(m_artist.idArtist,strArtistPath))
       localThumb = URIUtils::AddFileToFolder(strArtistPath, "folder.jpg");
+    database.Close();
   }
   else
     localThumb = m_albumItem->GetUserMusicThumb();
@@ -483,6 +486,7 @@ void CGUIDialogMusicInfo::OnGetFanart()
   database.Open();
   std::string strArtistPath;
   database.GetArtistPath(m_artist.idArtist,strArtistPath);
+  database.Close();
   CFileItem item(strArtistPath,true);
   std::string strLocal = item.GetLocalFanart();
   if (!strLocal.empty())
@@ -564,6 +568,7 @@ void CGUIDialogMusicInfo::OnSearch(const CFileItem* pItem)
       Update();
     }
   }
+  database.Close();
 }
 
 CFileItemPtr CGUIDialogMusicInfo::GetCurrentListItem(int offset)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -196,6 +196,7 @@ void CGUIDialogSongInfo::OnInitWindow()
       db.GetAlbumFromSong(m_song->GetMusicInfoTag()->GetDatabaseId(), album);
       m_albumId = album.idAlbum;
     }
+    db.Close();
   }
   CONTROL_ENABLE_ON_CONDITION(CONTROL_ALBUMINFO, m_albumId > -1);
 
@@ -273,6 +274,7 @@ void CGUIDialogSongInfo::SetSong(CFileItem *item)
     if (!thumb.empty())
       m_song->SetProperty("artistthumb", thumb);
   }
+  db.Close();
   m_needsUpdate = false;
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1397,6 +1397,7 @@ void CGUIWindowMusicBase::OnRemoveSource(int iItem)
     database.Open();
     database.RemoveSongsFromPath(m_vecItems->Get(iItem)->GetPath(), songs, false);
     database.CleanupOrphanedItems();
+    database.Close();
     g_infoManager.ResetLibraryBools();
     m_vecItems->RemoveDiscCache(GetID());
   }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -555,6 +555,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         database.Open();
         if (database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString()) > -1)
           buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20400);
+        database.Close();
       }
       if (item->HasMusicInfoTag() && !item->GetMusicInfoTag()->GetArtistString().empty() &&
          !item->GetMusicInfoTag()->GetAlbum().empty() &&
@@ -665,6 +666,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       database.Open();
       strPath = StringUtils::Format("videodb://musicvideos/artists/%i/",
         database.GetMatchingMusicVideo(item->GetMusicInfoTag()->GetArtistString()));
+      database.Close();
       g_windowManager.ActivateWindow(WINDOW_VIDEO_NAV,strPath);
       return true;
     }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -322,6 +322,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
                         if (db.GetArtist(params.GetArtistId(), artist, false))
                             item->GetMusicInfoTag()->SetArtist(artist);
                     }
+                    db.Close();
                 }
 
 
@@ -354,6 +355,8 @@ CUPnPServer::Build(CFileItemPtr                  item,
                         db.GetEpisodeInfo((const char*)path, *item->GetVideoInfoTag(), params.GetEpisodeId());
                     else if (params.GetTvShowId() >= 0 )
                         db.GetTvShowInfo((const char*)path, *item->GetVideoInfoTag(), params.GetTvShowId());
+                  
+                    db.Close();
                 }
 
                 if (item->GetVideoInfoTag()->m_type == MediaTypeTvShow || item->GetVideoInfoTag()->m_type == MediaTypeSeason) {
@@ -450,6 +453,7 @@ CUPnPServer::Announce(AnnouncementFlag flag, const char *sender, const char *mes
                 if (!db.Open()) return;
                 int show_id = db.GetTvShowForEpisode(item_id);
                 int season_id = db.GetSeasonForEpisode(item_id);
+                db.Close();
                 UpdateContainer(StringUtils::Format("videodb://tvshows/titles/%d/", show_id));
                 UpdateContainer(StringUtils::Format("videodb://tvshows/titles/%d/%d/?tvshowid=%d", show_id, season_id, show_id));
                 UpdateContainer("videodb://recentlyaddedepisodes/");
@@ -478,6 +482,7 @@ CUPnPServer::Announce(AnnouncementFlag flag, const char *sender, const char *mes
                 UpdateContainer("musicdb://songs/");
                 UpdateContainer("musicdb://recentlyaddedalbums/");
             }
+            db.Close();
         }
     }
 }
@@ -705,6 +710,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
           mvideos->SetLabel(g_localizeStrings.Get(20389));
           items.Add(mvideos);
       }
+      database.Close();
     }
 
     // Don't pass parent_id if action is Search not BrowseDirectChildren, as
@@ -903,6 +909,7 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
                                           database.GetArtistByName((const char*)artist), // will return -1 if no artist
                                           database.GetAlbumByName((const char*)album));  // will return -1 if no album
 
+            database.Close();
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         } else if (artist.GetLength() > 0) {
             // all tracks by artist name filtered by album if passed
@@ -910,14 +917,17 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
                                           database.GetArtistByName((const char*)artist),
                                           database.GetAlbumByName((const char*)album)); // will return -1 if no album
 
+            database.Close();
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         } else if (album.GetLength() > 0) {
             // all tracks by album name
             std::string strPath = StringUtils::Format("musicdb://albums/%i/",
                                                      database.GetAlbumByName((const char*)album));
 
+            database.Close();
             return OnBrowseDirectChildren(action, strPath.c_str(), filter, starting_index, requested_count, sort_criteria, context);
         }
+        database.Close();
 
         // browse all songs
         return OnBrowseDirectChildren(action, "musicdb://songs/", filter, starting_index, requested_count, sort_criteria, context);
@@ -973,6 +983,7 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
 
       if (!database.GetMoviesNav("videodb://movies/titles/", items)) {
         action->SetError(800, "Internal Error");
+        database.Close();
         return NPT_SUCCESS;
       }
       itemsall.Append(items);
@@ -980,6 +991,7 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
 
       if (!database.GetEpisodesByWhere("videodb://tvshows/titles/", "", items)) {
         action->SetError(800, "Internal Error");
+        database.Close();
         return NPT_SUCCESS;
       }
       itemsall.Append(items);
@@ -987,10 +999,12 @@ CUPnPServer::OnSearchContainer(PLT_ActionReference&          action,
 
       if (!database.GetMusicVideosByWhere("videodb://musicvideos/titles/", "", items)) {
         action->SetError(800, "Internal Error");
+        database.Close();
         return NPT_SUCCESS;
       }
       itemsall.Append(items);
       items.Clear();
+      database.Close();
 
       return BuildResponse(action, itemsall, filter, starting_index, requested_count, sort_criteria, context, NULL);
   } else if (NPT_String(search_criteria).Find("object.item.imageItem") >= 0) {
@@ -1097,6 +1111,8 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
             db.LoadVideoInfo(file_path, tag);
             updated.SetFromVideoInfoTag(tag);
         }
+      
+        db.Close();
 
     } else if (updated.IsMusicDb()) {
       //! @todo implement this

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -191,12 +191,13 @@ CVideoThumbLoader::CVideoThumbLoader() :
 CVideoThumbLoader::~CVideoThumbLoader()
 {
   StopThread();
+  if (m_videoDatabase->IsOpen())
+    m_videoDatabase->Close();
   delete m_videoDatabase;
 }
 
 void CVideoThumbLoader::OnLoaderStart()
 {
-  m_videoDatabase->Open();
   m_showArt.clear();
   m_seasonArt.clear();
   CThumbLoader::OnLoaderStart();
@@ -204,7 +205,6 @@ void CVideoThumbLoader::OnLoaderStart()
 
 void CVideoThumbLoader::OnLoaderFinish()
 {
-  m_videoDatabase->Close();
   m_showArt.clear();
   m_seasonArt.clear();
   CThumbLoader::OnLoaderFinish();
@@ -453,6 +453,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
       int idArtist = database.GetArtistByName(item.GetLabel());
       if (database.GetArtForItem(idArtist, MediaTypeArtist, artwork))
         item.SetArt(artwork);
+      database.Close();
     }
     else if (tag.m_type == MediaTypeAlbum)
     { // we retrieve music video art from the music database (no backward compat)

--- a/xbmc/video/jobs/VideoLibraryJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryJob.cpp
@@ -32,6 +32,9 @@ bool CVideoLibraryJob::DoWork()
   CVideoDatabase db;
   if (!db.Open())
     return false;
+  
+  bool result = Work(db);
+  db.Close();
 
-  return Work(db);
+  return result;
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1684,6 +1684,8 @@ void CGUIWindowVideoBase::OnAssignContent(const std::string &path)
     }
     db.SetScraperForPath(path, info, settings);
   }
+  
+  db.Close();
 
   if (bScan)
   {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -909,6 +909,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       CVideoDatabase database;
       database.Open();
       ADDON::ScraperPtr info = database.GetScraperForPath(item->GetPath());
+      database.Close();
 
       if (!item->IsLiveTV() && !item->IsPlugin() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
       {
@@ -934,6 +935,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       database.Open();
       if (database.GetArtistByName(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)) > -1)
         buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20396);
+      database.Close();
     }
     if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_strAlbum.empty())
     {
@@ -1075,6 +1077,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       database.Open();
       strPath = StringUtils::Format("musicdb://artists/%i/",
                                     database.GetArtistByName(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)));
+      database.Close();
       g_windowManager.ActivateWindow(WINDOW_MUSIC_NAV,strPath);
       return true;
     }
@@ -1185,6 +1188,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
       }
     }
 
+    videodb.Close();
     Refresh(true);
     return true;
   }


### PR DESCRIPTION
While rebasing feature_odb branch to current master and debugging some issues, I added correct close handling to all occurrences of the video and music database.

## Description
Every opened video and music database is now closed correctly, even on early returns.

## Motivation and Context
While testing odb I added some open and close code to the music and video database classes. So I had to make sure that close is always called before the datbase object is beeing destroyed. Although this is not that usefull right now, as it is not really needed to close it correctly (afaik), odb may need it. And it is more clear that Close is called all the time, and not only half of the time or not always. And, as I already wrote the code, I thought to create a PR.

## How Has This Been Tested?
I have imported a large movie, tvshow and music database, played various items, used the webinterface and android app, added some stuff to the library and removed some content.

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
