### PR TITLE
[imdb] fix crash on empty videoInfoTag

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -306,6 +306,11 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
 
   // setup cast list
   ClearCastList();
+  
+  // When the scraper throws an error, the video tag can be null here
+  if (!item->HasVideoInfoTag())
+    return;
+  
   MediaType type = item->GetVideoInfoTag()->m_type;
 
   m_startUserrating = m_movieItem->GetVideoInfoTag()->m_iUserRating;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -398,6 +398,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     CGUIDialogOK::ShowAndGetInput(CVariant{13346}, CVariant{14057});
     return false;
   }
+  
+  // If the scraper failed above and no videoinfotag was created, return
+  if (!item->HasVideoInfoTag())
+    return false;
 
   bool listNeedsUpdating = false;
   // 3. Run a loop so that if we Refresh we re-run this block


### PR DESCRIPTION
Scraping with an invalid api key caused a crash after trying to scrape a few times.

## Description
When cleaning my database to re-scrape everything, I still had the old tmdb addon running, as there was an issue with the update. This caused kodi to crash after trying to scan for content a few times. As I catched the crash in the debugger I added some checks, as it seems in that case the videoInfoTag is not assigned. This should just prevent the crash when it tries to access the info tag.

## Motivation and Context
This prevents the crash I catched in the debugger.

## How Has This Been Tested?
I re-tested scraping a few times with the invalid key and it was not crashing any more. Noticed no issues.

## Screenshots (if appropriate):

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
