### PR TITLE
[backport][fix][pictures] CID 77607: prevent buffer overflow

### DIFF
--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -1037,7 +1037,8 @@ void CPictureInfoTag::SetInfo(int info, const std::string& value)
     }
   case SLIDE_EXIF_DATE_TIME:
     {
-      strcpy(m_exifInfo.DateTime, value.c_str());
+      strncpy(m_exifInfo.DateTime, value.c_str(), sizeof(m_exifInfo.DateTime) - 1);
+      m_exifInfo.DateTime[sizeof(m_exifInfo.DateTime) - 1] = '\0';
       m_isInfoSetExternally = true; // Set the internal state to show metadata has been set by call to SetInfo
       ConvertDateTime();
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Prevent a buffer overflow by copying maximal sizeof(dest) - 1 chars.
backport of #12369
<!--- Describe your change in detail -->

## Motivation and Context
calling `ListItem.setInfo('pictures', {'exif:exiftime': '<VALUE>'})` from a python addon with a too long value sets other exif info with invalid data.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
above call with a long value
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
