### PR TITLE
[addons] add help for load of shared library and allow use of own addon temp folder

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -323,6 +323,11 @@ void CAddonDll::Destroy()
   /* Unload library file */
   if (m_pDll)
   {
+    /* If temporary directory was used from addon delete them */
+    const std::string tempPath = URIUtils::AddFileToFolder("special://temp/addons", ID());
+    if (XFILE::CDirectory::Exists(tempPath))
+      XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(tempPath));
+
     /* Inform dll to stop all activities */
     if (m_needsavedsettings)  // If the addon supports it we save some settings to settings.xml before stop
     {

--- a/xbmc/addons/interfaces/General.h
+++ b/xbmc/addons/interfaces/General.h
@@ -57,6 +57,7 @@ namespace ADDON
     static char* get_language(void* kodiBase, int format, bool region);
     static bool queue_notification(void* kodiBase, int type, const char* header, const char* message, const char* imageFile, unsigned int displayTime, bool withSound, unsigned int messageTime);
     static void get_md5(void* kodiBase, const char* text, char* md5);
+    static char* get_temp_path(void* kodiBase);
     //@}
   };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -40,6 +40,7 @@ typedef struct AddonToKodiFuncTable_kodi
   char* (*get_language)(void* kodiBase, int format, bool region);
   bool (*queue_notification)(void* kodiBase, int type, const char* header, const char* message, const char* imageFile, unsigned int displayTime, bool withSound, unsigned int messageTime);
   void (*get_md5)(void* kodiBase, const char* text, char* md5);
+  char* (*get_temp_path)(void* kodiBase);
 } AddonToKodiFuncTable_kodi;
 
 //==============================================================================
@@ -407,3 +408,37 @@ inline std::string GetMD5(const std::string& text)
 }
 } /* namespace kodi */
 //----------------------------------------------------------------------------
+
+//==============================================================================
+namespace kodi {
+///
+/// \ingroup cpp_kodi
+/// @brief To get a temporary path for the addon
+///
+/// This gives a temporary path which the addon can use individually for its things.
+///
+/// The content of this folder will be deleted when Kodi is finished!
+///
+/// @param[in] append A string to append to returned temporary path
+/// @return Individual path for the addon
+///
+inline std::string GetTempAddonPath(const std::string& append = "")
+{
+  char* str = ::kodi::addon::CAddonBase::m_interface->toKodi->kodi->get_temp_path(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase);
+  std::string ret = str;
+  ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, str);
+  if (!append.empty())
+  {
+    if (append.at(0) != '\\' &&
+        append.at(0) != '/')
+#ifdef TARGET_WINDOWS
+      ret.append("\\");
+#else
+      ret.append("/");
+#endif
+    ret.append(append);
+  }
+  return ret;
+}
+} /* namespace kodi */
+//------------------------------------------------------------------------------

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/tools/DllHelper.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/tools/DllHelper.h
@@ -1,0 +1,129 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <kodi/AddonBase.h>
+
+#ifdef _WIN32                   // windows
+#include <p8-platform/windows/dlfcn-win32.h>
+#else
+#include <dlfcn.h>              // linux+osx
+#endif
+
+#define REGISTER_DLL_SYMBOL(functionPtr) \
+  CDllHelper::RegisterSymbol(functionPtr, #functionPtr)
+
+/// @brief Class to help with load of shared library functions
+///
+/// You can add them as parent to your class and to help with load of shared
+/// library functions.
+///
+/// @note To use on Windows must you also include p8-platform on your addon!
+///
+///
+/// ----------------------------------------------------------------------------
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.cpp}
+///
+/// #include <kodi/tools/DllHelper.h>
+///
+/// ...
+/// class CMyInstance : public kodi::addon::CInstanceAudioDecoder,
+///                     private CDllHelper
+/// {
+/// public:
+///   CMyInstance(KODI_HANDLE instance);
+///   bool Start();
+///
+///   ...
+///
+///   /* The pointers for on shared library exported functions */
+///   int (*Init)();
+///   void (*Cleanup)();
+///   int (*GetLength)();
+/// };
+///
+/// CMyInstance::CMyInstance(KODI_HANDLE instance)
+///   : CInstanceAudioDecoder(instance)
+/// {
+/// }
+///
+/// bool CMyInstance::Start()
+/// {
+///   std::string lib = kodi::GetAddonPath("myLib.so");
+///   if (!LoadDll(lib)) return false;
+///   if (!REGISTER_DLL_SYMBOL(Init)) return false;
+///   if (!REGISTER_DLL_SYMBOL(Cleanup)) return false;
+///   if (!REGISTER_DLL_SYMBOL(GetLength)) return false;
+///
+///   Init();
+///   return true;
+/// }
+/// ...
+/// ~~~~~~~~~~~~~
+///
+class CDllHelper
+{
+public:
+  CDllHelper() : m_dll(nullptr) { }
+  virtual ~CDllHelper()
+  {
+    if (m_dll)
+      dlclose(m_dll);
+  }
+
+  /// @brief Function to load requested library
+  ///
+  /// @param[in] path         The path with filename of shared library to load
+  /// @return                 true if load was successful done
+  ///
+  bool LoadDll(const std::string& path)
+  {
+    m_dll = dlopen(path.c_str(), RTLD_LAZY);
+    if (m_dll == nullptr)
+    {
+      kodi::Log(ADDON_LOG_ERROR, "Unable to load %s", dlerror());
+      return false;
+    }
+    return true;
+  }
+
+  /// @brief Function to register requested library symbol
+  ///
+  /// @note This function should not be used, use instead the macro
+  /// REGISTER_DLL_SYMBOL to register the symbol pointer.
+  ///
+  template <typename T>
+  bool RegisterSymbol(T& functionPtr, const char* strFunctionPtr)
+  {
+    functionPtr = reinterpret_cast<T>(dlsym(m_dll, strFunctionPtr));
+    if (functionPtr == nullptr)
+    {
+      kodi::Log(ADDON_LOG_ERROR, "Unable to assign function %s", dlerror());
+      return false;
+    }
+    return true;
+  }
+
+private:
+  void* m_dll;
+};

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -50,7 +50,7 @@
                                                       "libXBMC_addon.h" \
                                                       "addon-instance/"
 
-#define ADDON_GLOBAL_VERSION_GENERAL                  "1.0.0"
+#define ADDON_GLOBAL_VERSION_GENERAL                  "1.0.1"
 #define ADDON_GLOBAL_VERSION_GENERAL_MIN              "1.0.0"
 #define ADDON_GLOBAL_VERSION_GENERAL_XML_ID           "kodi.binary.global.general"
 #define ADDON_GLOBAL_VERSION_GENERAL_DEPENDS          "General.h"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This is a part to simplify the load of shared library functions on a
addon.

This part is mainly needed for audio decoder addons.

Further add it a new addon callback function to get a temporary folder for addon itself. This becomes used e.g. on audio decoders to copy temporary a used dll to there.
Will make this way to ensure that temporary things are really erased again and there is no flooding on the disk.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
