### PR TITLE
fixed: Crash when we're unable to retrieve info from remote server

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -406,12 +406,17 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     if (!CVideoLibraryQueue::GetInstance().RefreshItemModal(item, needsRefresh, pDlgInfo->RefreshAll()))
       return listNeedsUpdating;
 
-    // remove directory caches and reload images
-    CUtil::DeleteVideoDatabaseDirectoryCache();
-    CGUIMessage reload(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-    OnMessage(reload);
+    // Make sure item has a videoinfotag else we'll crash and burn
+    if (item->HasVideoInfoTag())
+    {
+      // remove directory caches and reload images
+      CUtil::DeleteVideoDatabaseDirectoryCache();
+      CGUIMessage reload(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
+      OnMessage(reload);
 
-    pDlgInfo->SetMovie(item.get());
+      pDlgInfo->SetMovie(item.get());
+    }
+
     pDlgInfo->Open();
     item->SetArt("thumb", pDlgInfo->GetThumbnail());
     needsRefresh = pDlgInfo->NeedRefresh();


### PR DESCRIPTION
Fix for the crash mentioned in my team-email. If ok'ed, I'll prepare a backport for Krypton.