### PR TITLE
Fix crash during close of kodi if vfs and pvr addons are present.

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -87,14 +87,14 @@ bool CServiceManager::Init2()
     return false;
   }
 
+  m_vfsAddonCache.reset(new ADDON::CVFSAddonCache());
+  m_vfsAddonCache->Init();
+
   m_PVRManager.reset(new PVR::CPVRManager());
   m_dataCacheCore.reset(new CDataCacheCore());
 
   m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
-
-  m_vfsAddonCache.reset(new ADDON::CVFSAddonCache());
-  m_vfsAddonCache->Init();
 
   m_favouritesService.reset(new CFavouritesService(CProfilesManager::GetInstance().GetProfileUserDataFolder()));
   m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));
@@ -151,11 +151,11 @@ void CServiceManager::Deinit()
   m_peripherals.reset();
   m_contextMenuManager.reset();
   m_favouritesService.reset();
-  m_vfsAddonCache.reset();
   m_binaryAddonCache.reset();
   if (m_PVRManager)
     m_PVRManager->Deinit();
   m_PVRManager.reset();
+  m_vfsAddonCache.reset();
   m_binaryAddonManager.reset();
   m_addonMgr.reset();
 #ifdef HAS_PYTHON

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -42,7 +42,7 @@ CAudioDecoder::~CAudioDecoder()
 bool CAudioDecoder::CreateDecoder()
 {
   m_struct.toKodi.kodiInstance = this;
-  return CreateInstance(&m_struct);
+  return CreateInstance(&m_struct) == ADDON_STATUS_OK;
 }
 
 bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -323,11 +323,6 @@ void CAddonDll::Destroy()
   /* Unload library file */
   if (m_pDll)
   {
-    /* If temporary directory was used from addon delete them */
-    const std::string tempPath = URIUtils::AddFileToFolder("special://temp/addons", ID());
-    if (XFILE::CDirectory::Exists(tempPath))
-      XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(tempPath));
-
     /* Inform dll to stop all activities */
     if (m_needsavedsettings)  // If the addon supports it we save some settings to settings.xml before stop
     {

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -22,6 +22,8 @@
 #include "BinaryAddonBase.h"
 
 #include "addons/AddonManager.h"
+#include "filesystem/SpecialProtocol.h"
+#include "filesystem/Directory.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 
@@ -29,7 +31,7 @@ using namespace ADDON;
 
 CBinaryAddonManager::~CBinaryAddonManager()
 {
-  CAddonMgr::GetInstance().Events().Unsubscribe(this);
+  DeInit();
 }
 
 bool CBinaryAddonManager::Init()
@@ -49,6 +51,15 @@ bool CBinaryAddonManager::Init()
     AddAddonBaseEntry(addon);
 
   return true;
+}
+
+void CBinaryAddonManager::DeInit()
+{
+  /* If temporary directory was used from addon delete them */
+  if (XFILE::CDirectory::Exists("special://temp/binary-addons"))
+    XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath("special://temp/binary-addons"));
+
+  CAddonMgr::GetInstance().Events().Unsubscribe(this);
 }
 
 bool CBinaryAddonManager::HasInstalledAddons(const TYPE &type) const

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -29,6 +29,11 @@
 
 using namespace ADDON;
 
+CBinaryAddonManager::CBinaryAddonManager()
+  : m_tempAddonBasePath("special://temp/binary-addons")
+{
+}
+
 CBinaryAddonManager::~CBinaryAddonManager()
 {
   DeInit();
@@ -56,8 +61,8 @@ bool CBinaryAddonManager::Init()
 void CBinaryAddonManager::DeInit()
 {
   /* If temporary directory was used from addon delete them */
-  if (XFILE::CDirectory::Exists("special://temp/binary-addons"))
-    XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath("special://temp/binary-addons"));
+  if (XFILE::CDirectory::Exists(m_tempAddonBasePath))
+    XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(m_tempAddonBasePath));
 
   CAddonMgr::GetInstance().Events().Unsubscribe(this);
 }

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -43,6 +43,7 @@ namespace ADDON
     ~CBinaryAddonManager();
 
     bool Init();
+    void DeInit();
 
     /*!
      * @brief Checks system about given type to know related add-on's are

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -39,7 +39,7 @@ namespace ADDON
   class CBinaryAddonManager
   {
   public:
-    CBinaryAddonManager() = default;
+    CBinaryAddonManager();
     ~CBinaryAddonManager();
 
     bool Init();
@@ -129,6 +129,16 @@ namespace ADDON
      */
     AddonPtr GetRunningAddon(const std::string& addonId) const;
 
+    /*!
+     * @brief To get the path where temporary addon parts can be becomes stored
+     *
+     * @return the base path used for temporary addon paths
+     *
+     * @warning the folder and his contents becomes deleted during stop and
+     * close of Kodi
+     */
+    const std::string& GetTempAddonBasePath() { return m_tempAddonBasePath; }
+
   private:
     bool AddAddonBaseEntry(BINARY_ADDON_LIST_ENTRY& entry);
 
@@ -142,6 +152,8 @@ namespace ADDON
     typedef std::map<std::string, BinaryAddonBasePtr> BinaryAddonMgrBaseList;
     BinaryAddonMgrBaseList m_installedAddons;
     BinaryAddonMgrBaseList m_enabledAddons;
+
+    const std::string m_tempAddonBasePath;
   };
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -252,7 +252,7 @@ char* Interface_General::get_temp_path(void* kodiBase)
     return nullptr;
   }
 
-  const std::string tempPath = URIUtils::AddFileToFolder("special://temp/addons", addon->ID());
+  const std::string tempPath = URIUtils::AddFileToFolder("special://temp/binary-addons", addon->ID());
   if (!XFILE::CDirectory::Exists(tempPath))
     XFILE::CDirectory::Create(tempPath);
 

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -23,7 +23,9 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/General.h"
 
 #include "Application.h"
+#include "ServiceBroker.h"
 #include "addons/binary-addons/AddonDll.h"
+#include "addons/binary-addons/BinaryAddonManager.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/Directory.h"
@@ -252,7 +254,7 @@ char* Interface_General::get_temp_path(void* kodiBase)
     return nullptr;
   }
 
-  const std::string tempPath = URIUtils::AddFileToFolder("special://temp/binary-addons", addon->ID());
+  const std::string tempPath = URIUtils::AddFileToFolder(CServiceBroker::GetBinaryAddonManager().GetTempAddonBasePath(), addon->ID());
   if (!XFILE::CDirectory::Exists(tempPath))
     XFILE::CDirectory::Create(tempPath);
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description

Error was coming with https://github.com/xbmc/xbmc/pull/12379. During my test there was no PVR addon active and seen it now. This make the m_vfsAddonCache reset short before the manager, then are the related addons, normally closed.

Related to:
```
Thread 1 "kodi.bin" received signal SIGSEGV, Segmentation fault.

#0  __GI___pthread_mutex_lock (mutex=0x8) at ../nptl/pthread_mutex_lock.c:67
#1  0x0000555d3ee0e0ae in (anonymous namespace)::(anonymous namespace)::RecursiveMutex::lock (this=0x8)
    at /home/alwin/Development/kodi/xbmc/threads/platform/pthreads/CriticalSection.h:49
#2  0x0000555d3ee0f1da in (anonymous namespace)::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock (this=0x8)
    at /home/alwin/Development/kodi/xbmc/threads/Lockables.h:60
#3  0x0000555d3ee0f154 in (anonymous namespace)::UniqueLock<CCriticalSection>::UniqueLock (this=0x7ffe8296b2f0, lockable=...)
    at /home/alwin/Development/kodi/xbmc/threads/Lockables.h:127
#4  0x0000555d3ee0e0f1 in CSingleLock::CSingleLock (this=0x7ffe8296b2f0, cs=...)
    at /home/alwin/Development/kodi/xbmc/threads/SingleLock.h:38
#5  0x0000555d3f752245 in (anonymous namespace)::CVFSAddonCache::GetAddonInstances (this=0x0)
    at /home/alwin/Development/kodi/xbmc/addons/VFSEntry.cpp:49
#6  0x0000555d3fcdd531 in (anonymous namespace)::CFileDirectoryFactory::Create (url=..., pItem=0x7ffe8296bb90, strMask=...)
    at /home/alwin/Development/kodi/xbmc/filesystem/FileDirectoryFactory.cpp:88
#7  0x0000555d3fccad15 in (anonymous namespace)::CDirectoryFactory::Create (url=...)
    at /home/alwin/Development/kodi/xbmc/filesystem/DirectoryFactory.cpp:110
#8  0x0000555d3fcc90f1 in (anonymous namespace)::CDirectory::Exists (url=..., bUseCache=true)
    at /home/alwin/Development/kodi/xbmc/filesystem/Directory.cpp:308
#9  0x0000555d3fcc8fa5 in (anonymous namespace)::CDirectory::Exists (strPath=..., bUseCache=true)
    at /home/alwin/Development/kodi/xbmc/filesystem/Directory.cpp:290
#10 0x0000555d3f68dd15 in (anonymous namespace)::CAddonDll::Destroy (this=0x7fcb8801ce50)
    at /home/alwin/Development/kodi/xbmc/addons/binary-addons/AddonDll.cpp:328
#11 0x0000555d3f70f71f in PVR::CPVRClient::Destroy (this=0x7fcb8801ce50) at /home/alwin/Development/kodi/xbmc/addons/PVRClient.cpp:208
#12 0x0000555d3f9c18b3 in PVR::CPVRClients::Unload (this=0x555d428d1570)
    at /home/alwin/Development/kodi/xbmc/pvr/addons/PVRClients.cpp:153
#13 0x0000555d3f9c10d4 in PVR::CPVRClients::~CPVRClients (this=0x555d428d1570, __in_chrg=<optimized out>)
    at /home/alwin/Development/kodi/xbmc/pvr/addons/PVRClients.cpp:59
#14 0x0000555d3f9c113e in PVR::CPVRClients::~CPVRClients (this=0x555d428d1570, __in_chrg=<optimized out>)
    at /home/alwin/Development/kodi/xbmc/pvr/addons/PVRClients.cpp:60
#15 0x0000555d3f9e191a in std::_Sp_counted_ptr<PVR::CPVRClients*, (__gnu_cxx::_Lock_policy)2>::_M_dispose (this=0x555d42b747f0)
    at /usr/include/c++/6/bits/shared_ptr_base.h:372
#16 0x0000555d3edd139c in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x555d42b747f0)
    at /usr/include/c++/6/bits/shared_ptr_base.h:150
#17 0x0000555d3edd108f in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7ffe8296ca08, 
    __in_chrg=<optimized out>) at /usr/include/c++/6/bits/shared_ptr_base.h:662
#18 0x0000555d3f04f384 in std::__shared_ptr<PVR::CPVRClients, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7ffe8296ca00, 
    __in_chrg=<optimized out>) at /usr/include/c++/6/bits/shared_ptr_base.h:928
#19 0x0000555d3f9dea1a in std::__shared_ptr<PVR::CPVRClients, (__gnu_cxx::_Lock_policy)2>::reset (this=0x555d42ba9760)
    at /usr/include/c++/6/bits/shared_ptr_base.h:1025
#20 0x0000555d3f9d780c in PVR::CPVRManager::Deinit (this=0x555d42ba9430) at /home/alwin/Development/kodi/xbmc/pvr/PVRManager.cpp:386
#21 0x0000555d3f825984 in CServiceManager::Deinit (this=0x555d4289d1a0) at /home/alwin/Development/kodi/xbmc/ServiceManager.cpp:155
#22 0x0000555d3f76809a in CApplication::Cleanup (this=0x555d42810bc0) at /home/alwin/Development/kodi/xbmc/Application.cpp:2796
#23 0x0000555d3f84bbd7 in CXBApplicationEx::Destroy (this=0x555d42810bc0) at /home/alwin/Development/kodi/xbmc/XBApplicationEx.cpp:61
#24 0x0000555d3f84bd5b in CXBApplicationEx::Run (this=0x555d42810bc0, playlist=...)
    at /home/alwin/Development/kodi/xbmc/XBApplicationEx.cpp:164
#25 0x0000555d3f3eea0b in XBMC_Run (renderGUI=true, playlist=...) at /home/alwin/Development/kodi/xbmc/platform/xbmc.cpp:88
#26 0x0000555d3edd0dd6 in main (argc=1, argv=0x7ffe8296d138) at /home/alwin/Development/kodi/xbmc/platform/posix/main.cpp:115
```

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
