### PR TITLE
[settings] fix seq fault if addon use same setting in different groups

### DIFF
--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1248,7 +1248,9 @@ void CSettingsManager::ResolveReferenceSettings(std::shared_ptr<CSettingSection>
         else
         {
           referencedSetting = itReferencedSetting->second.setting;
-          m_settings.erase(FindSetting(referenceSetting->GetId()));
+          itReferencedSetting = FindSetting(referenceSetting->GetId());
+          if (itReferencedSetting != m_settings.end())
+            m_settings.erase(itReferencedSetting);
         }
 
         group->ReplaceSetting(referenceSetting, referencedSetting);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Related to https://pastebin.com/nEa0TQBc and https://forum.kodi.tv/showthread.php?tid=298462&pid=2610026#pid2610026
<!--- Describe your change in detail -->

Crash was from settings.xml here: https://github.com/Zomboided/service.vpn.manager/blob/master/resources/settings.xml

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
