### PR TITLE
Include "fmt/printf.h" if using libfmt 4 or later

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -38,6 +38,10 @@
 
 #include <fmt/format.h>
 
+#if FMT_VERSION >= 40000
+#include <fmt/printf.h>
+#endif
+
 #include "LangInfo.h"
 #include "XBDateTime.h"
 #include "utils/params_check_macros.h"


### PR DESCRIPTION
libfmt 4 requires the inclusion of fmt/printf.h to use fmt::printf,
see https://github.com/fmtlib/fmt/releases/tag/4.0.0

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This simple change allows kodi to compile against either libfmt-3 or libfmt-4.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
As Linux distros and Kod itself upgrade to libfmt 4, this change will allow that change to be painless.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I tested building with libfmt-3.0.2 installed and then again with libfmt-4.0.0 installed.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
