### PR TITLE
[cmake] fix FindSndio module

### DIFF
--- a/cmake/modules/FindSndio.cmake
+++ b/cmake/modules/FindSndio.cmake
@@ -1,34 +1,41 @@
-# sndio check, based on FindAlsa.cmake
+#
+# FindSndio
+# ---------
+# Finds the Sndio Library
+#
+# This will will define the following variables:
+#
+# SNDIO_FOUND - system has sndio
+# SNDIO_INCLUDE_DIRS - sndio include directory
+# SNDIO_DEFINITIONS - sndio definitions
+#
+# and the following imported targets::
+#
+#  Sndio::Sndio    - the sndio library
 #
 
-# Copyright (c) 2006, David Faure, <faure@kde.org>
-# Copyright (c) 2007, Matthias Kretz <kretz@kde.org>
-# Copyright (c) 2009, Jacob Meuser <jakemsr@sdf.lonestar.org>
-#
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
-
-include(CheckIncludeFiles)
-include(CheckIncludeFileCXX)
-include(CheckLibraryExists)
-
-# Already done by toplevel
+find_path(SNDIO_INCLUDE_DIR sndio.h)
 find_library(SNDIO_LIBRARY sndio)
-set(SNDIO_LIBRARY_DIR "")
-if(SNDIO_LIBRARY)
-   get_filename_component(SNDIO_LIBRARY_DIR ${SNDIO_LIBRARY} PATH)
-endif(SNDIO_LIBRARY)
 
-check_library_exists(sndio sio_open "${SNDIO_LIBRARY_DIR}" HAVE_SNDIO)
-if(HAVE_SNDIO)
-  message(STATUS "Found sndio: ${SNDIO_LIBRARY}")
-  set(SNDIO_DEFINITIONS -DHAVE_SNDIO=1)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Sndio
+                                  REQUIRED_VARS SNDIO_LIBRARY SNDIO_INCLUDE_DIR)
+
+if(SNDIO_FOUND)
+  set(SNDIO_INCLUDE_DIRS ${SNDIO_INCLUDE_DIR})
   set(SNDIO_LIBRARIES ${SNDIO_LIBRARY})
-else(HAVE_SNDIO)
-    message(STATUS "sndio not found")
-endif(HAVE_SNDIO)
-set(SNDIO_FOUND ${HAVE_SNDIO})
+  set(SNDIO_DEFINITIONS -DHAVE_SNDIO=1)
 
-find_path(SNDIO_INCLUDES sndio.h)
+  if(NOT TARGET Sndio::Sndio)
+    add_library(Sndio::Sndio UNKNOWN IMPORTED)
+    set_target_properties(Sndio::Sndio PROPERTIES
+                                       IMPORTED_LOCATION "${SNDIO_LIBRARY}"
+                                       INTERFACE_INCLUDE_DIRECTORIES "${SNDIO_INCLUDE_DIR}")
+    set_target_properties(Sndio::Sndio PROPERTIES
+                                       INTERFACE_COMPILE_DEFINITIONS -DHAVE_SNDIO=1)
+  endif()
+endif()
 
-mark_as_advanced(SNDIO_INCLUDES SNDIO_LIBRARY)
+
+mark_as_advanced(SNDIO_INCLUDE_DIR SNDIO_LIBRARY)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->


## Description
fix FindSndio module

## Motivation and Context
Cmake would generate an error on linux if sndio wasn't found

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
