### PR TITLE
Revert "[droid] packaging: don't delete pil libs from script.module.pil"

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -88,7 +88,7 @@ shared:
 	mkdir -p assets
 	cp -rfp $(PREFIX)/share/@APP_NAME_LC@/* ./assets
 	find `pwd`/assets/ -depth -name ".git" -exec rm -rf {} \;
-	find `pwd`/assets/ -name "*.so" -not -name "*imaging*.so" -exec rm {} \;
+	find `pwd`/assets/ -name "*.so" -exec rm {} \;
 	find `pwd`/assets/addons/skin.*/media/* -depth -not -iname "Textures.xbt" -exec rm -rf {} \;
 	cd `pwd`/assets/addons; rm -rf $(EXCLUDED_ADDONS)
 	mkdir -p assets/system/certs


### PR DESCRIPTION
This reverts commit a59e00f619e179cdea5d205e2ec0a3ae5a7bd4d2.

The PIL libraries are alredy globbed in https://github.com/xbmc/xbmc/blob/Krypton/tools/android/packaging/Makefile.in#L135