### PR TITLE
[utils] coverity: ignore uncaught 'fmt::FormatError' exception

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -63,6 +63,7 @@ public:
   template<typename... Args>
   static std::string Format(const std::string& fmt, Args&&... args)
   {
+    // coverity[fun_call_w_exception : FALSE]
     auto result = fmt::format(fmt, std::forward<Args>(args)...);
     if (result == fmt)
       result = fmt::sprintf(fmt, std::forward<Args>(args)...);
@@ -72,6 +73,7 @@ public:
   template<typename... Args>
   static std::wstring Format(const std::wstring& fmt, Args&&... args)
   {
+    // coverity[fun_call_w_exception : FALSE]
     auto result = fmt::format(fmt, std::forward<Args>(args)...);
     if (result == fmt)
       result = fmt::sprintf(fmt, std::forward<Args>(args)...);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Disable an `fmt::FormatError` uncaught exception issue at coverity.
<!--- Describe your change in detail -->

## Motivation and Context
The windows coverity project currently shows 63 warnings because of the exception thrown in fmt.
If fmt throws an exception it should result in a crash as in that case the format string is wrong.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Next coverity after this has been merged will tell if it does what I expect.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
