### PR TITLE
[PVR] Fix calculation of 'yesterdayPlusOneYear' in PVR timer settings dialog

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -880,8 +880,8 @@ void CGUIDialogPVRTimerSettings::DaysFiller(
     // Data range: "today" until "yesterday next year"
     const CDateTime now(CDateTime::GetCurrentDateTime());
     CDateTime time(now.GetYear(), now.GetMonth(), now.GetDay(), 0, 0, 0);
-    const CDateTime yesterdayPlusOneYear(
-      time.GetYear() + 1, time.GetMonth(), time.GetDay() - 1, time.GetHour(), time.GetMinute(), time.GetSecond());
+    const CDateTime yesterdayPlusOneYear(CDateTime(time.GetYear() + 1, time.GetMonth(), time.GetDay(), time.GetHour(), time.GetMinute(), time.GetSecond())
+		- CDateTimeSpan(1, 0, 0, 0));
 
     CDateTime oldCDateTime;
     if (setting->GetId() == SETTING_TMR_FIRST_DAY)


### PR DESCRIPTION
## Description
The calculation used to determine the date range to show in the PVR Timer Settings dialog was flawed and didn't work properly on the first day of a month.  It is not correct to subtract 1 from the current day of a month, a calculated 24 hour time span must be subtracted instead.

## Motivation and Context
When debugging PVR code on July 1st I noticed that any selection of an "Add Timer" UI element appeared to deadlock. Upon investigation the root cause was that it was looping thousands of years into the future attempting to build a date range based off an invalid CDateTime instance.

## How Has This Been Tested?
I tested this change on Windows (Win32), local build of master branch, overwriting the .EXE and .PDB installed from the most recent nightly.  To confirm the change I temporarily added a number of local variables to extract the year, month and day values of all CDateTime elements and inspected them via the debugger.  I also confirmed that the "Add Timer" UI elements respond quickly and no longer appear to deadlock.

There should be no impact outside of the PVR Timer Settings dialog, this code is local to that function.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
