### PR TITLE
Explicitly initialize VIS_INFO structure; may be bypassed

### DIFF
--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -442,7 +442,7 @@ void CGUIVisualisationControl::CreateBuffers()
   ClearBuffers();
 
   // Get the number of buffers from the current vis
-  VIS_INFO info;
+  VIS_INFO info { false, 0 };
 
   if (m_instance && m_alreadyStarted)
     m_instance->GetInfo(&info);


### PR DESCRIPTION
## Description
The initialization of the VIS_INFO structure in CGUIVisualisationControl::CreateBuffers() may be bypassed, this causes a runtime error when debugging through Visual Studio.

## Motivation and Context
Running a DEBUG build of the master branch through Visual Studio stops frequently at this location due to the VIS_INFO structure members being accessed prior to initialization when the member variable m_alreadyStarted is set to false.  This happens every time a PVR Live TV channel is opened, for example.

## How Has This Been Tested?
I tested this change on Windows (Win32) using a local build of the master branch.  The resultant binaries (.dll, .pdb) were copied over a recently installed nightly build.  The only non-default add-on installed was my own PVR, and the only non-default settings are PVR related.  I stepped through the code via a breakpoint set by Visual Studio while executing tests against a custom PVR client and opening channels.  No adverse side-effects have been noted after the change.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
