### PR TITLE
CVideoPlayer: cannot pause if seek is not supported

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3590,14 +3590,14 @@ void CVideoPlayer::SetSpeed(float speed)
   if (speed < 0 && IsInMenu())
     return;
  
-  if(!CanSeek() && !CanPause())
+  if (!CanSeek() && !CanPause())
     return;
   
   int iSpeed = static_cast<int>(speed * DVD_PLAYSPEED_NORMAL);
 
-  if(!CanSeek())
+  if (!CanSeek())
   {
-    if((iSpeed != DVD_PLAYSPEED_NORMAL) && (iSpeed != DVD_PLAYSPEED_PAUSE))
+    if ((iSpeed != DVD_PLAYSPEED_NORMAL) && (iSpeed != DVD_PLAYSPEED_PAUSE))
       return;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3589,10 +3589,10 @@ void CVideoPlayer::SetSpeed(float speed)
   // forward is fine
   if (speed < 0 && IsInMenu())
     return;
- 
+
   if (!CanSeek() && !CanPause())
     return;
-  
+
   int iSpeed = static_cast<int>(speed * DVD_PLAYSPEED_NORMAL);
 
   if (!CanSeek())

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3589,11 +3589,17 @@ void CVideoPlayer::SetSpeed(float speed)
   // forward is fine
   if (speed < 0 && IsInMenu())
     return;
-
-  if (!CanSeek())
+ 
+  if(!CanSeek() && !CanPause())
     return;
   
   int iSpeed = static_cast<int>(speed * DVD_PLAYSPEED_NORMAL);
+
+  if(!CanSeek())
+  {
+    if((iSpeed != DVD_PLAYSPEED_NORMAL) && (iSpeed != DVD_PLAYSPEED_PAUSE))
+      return;
+  }
 
   m_newPlaySpeed = iSpeed;
   if (m_newPlaySpeed != m_playSpeed)


### PR DESCRIPTION
## Description
CVideoPlayer does not allow for a pause operation to occur if seek is not supported.  The call to SetPlaySpeed will be specifically bypassed by a test to CanSeek().

## Motivation and Context
While developing a PVR client I had noted a while back that if the client indicates it supports pausing but it does not support seeking, the player UI control for Pause was present but inoperable.  I ultimately tracked down the problem to CVideoPlayer::SetSpeed disallowing the operation by testing CanSeek().  

The proposed modification checks both CanSeek() and CanPause() up front and returns early if both are false.  Subsequently if CanSeek() is false, implying that CanPause() is true, and the request is for a pause (DVD_PLAYSPEED_PAUSE) or resume (DVD_PLAYSPEED_NORMAL) operation it will be allowed to go through.

## How Has This Been Tested?
I tested this change on Windows (Win32) using a local build of the master branch.  The resultant binaries (.dll, .pdb) were copied over a recently installed nightly build.  I confirmed the change resolves the specific problem I'm trying to resolve with the PVR Client.

Additionally, I temporarily hard-coded CanSeek() to return false and tested the player with a number of different playback mediums - DVD, Blu-Ray, MP4, WMV and M2TS.  Each media type was paused and resumed successfully while disallowing seek and playback speed changes as expected.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
