### PR TITLE
[vfs] fix compiler warning

### DIFF
--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -188,7 +188,7 @@ ssize_t CVFSEntry::Read(void* ctx, void* lpBuf, size_t uiBufSize)
   return m_struct.toAddon.read(&m_struct, ctx, lpBuf, uiBufSize);
 }
 
-ssize_t CVFSEntry::Write(void* ctx, void* lpBuf, size_t uiBufSize)
+ssize_t CVFSEntry::Write(void* ctx, const void* lpBuf, size_t uiBufSize)
 {
   if (!m_struct.toAddon.write)
     return 0;
@@ -431,7 +431,7 @@ ssize_t CVFSEntryIFileWrapper::Read(void* lpBuf, size_t uiBufSize)
   return m_addon->Read(m_context, lpBuf, uiBufSize);
 }
 
-ssize_t CVFSEntryIFileWrapper::Write(void* lpBuf, size_t uiBufSize)
+ssize_t CVFSEntryIFileWrapper::Write(const void* lpBuf, size_t uiBufSize)
 {
   if (!m_context)
     return 0;
@@ -439,12 +439,12 @@ ssize_t CVFSEntryIFileWrapper::Write(void* lpBuf, size_t uiBufSize)
   return m_addon->Write(m_context, lpBuf, uiBufSize);
 }
 
-int64_t CVFSEntryIFileWrapper::Seek(int64_t iFilePosition, int iWhence)
+int64_t CVFSEntryIFileWrapper::Seek(int64_t iFilePosition, int whence)
 {
   if (!m_context)
     return 0;
 
-  return m_addon->Seek(m_context, iFilePosition, iWhence);
+  return m_addon->Seek(m_context, iFilePosition, whence);
 }
 
 void CVFSEntryIFileWrapper::Close()

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -63,7 +63,7 @@ namespace ADDON
     bool Exists(const CURL& url);
     int Stat(const CURL& url, struct __stat64* buffer);
     ssize_t Read(void* ctx, void* lpBuf, size_t uiBufSize);
-    ssize_t Write(void* ctx, void* lpBuf, size_t uiBufSize);
+    ssize_t Write(void* ctx, const void* lpBuf, size_t uiBufSize);
     int64_t Seek(void* ctx, int64_t iFilePosition, int iWhence = SEEK_SET);
     int Truncate(void* ctx, int64_t size);
     void Close(void* ctx);
@@ -141,13 +141,13 @@ namespace ADDON
     //! \param[in] lpBuf Data to write.
     //! \param[in] uiBufSize Number of bytes to write.
     //! \returns Number of bytes written.
-    virtual ssize_t Write(void* lpBuf, size_t uiBufSize);
+    ssize_t Write(const void* lpBuf, size_t uiBufSize) override;
 
     //! \brief Seek in file.
     //! \param[in] iFilePosition Position to seek to.
     //! \param[in] whence Origin for position.
     //! \returns New file position.
-    int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET) override;
+    int64_t Seek(int64_t iFilePosition, int whence = SEEK_SET) override;
 
     //! \brief Truncate a file.
     //! \param[in] size Size of new file.


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This fixes a compiler warning where wrongly a "const void*" was defined
on child as "void*".

Also fixed a bit wrong doxygen value name.
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
