### PR TITLE
[ios11] - fix native keyboard

### DIFF
--- a/xbmc/platform/darwin/ios/IOSKeyboard.mm
+++ b/xbmc/platform/darwin/ios/IOSKeyboard.mm
@@ -58,7 +58,7 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
   m_pCharCallback = pCallback;
 
   // init keyboard stuff
-  [g_pIosKeyboard setDefault:[NSString stringWithUTF8String:initialString.c_str()]];
+  SetTextToKeyboard(initialString);
   [g_pIosKeyboard setHidden:bHiddenInput];
   [g_pIosKeyboard setHeading:[NSString stringWithUTF8String:heading.c_str()]];
   [g_pIosKeyboard registerKeyboard:this]; // for calling back

--- a/xbmc/platform/darwin/ios/IOSKeyboard.mm
+++ b/xbmc/platform/darwin/ios/IOSKeyboard.mm
@@ -53,8 +53,12 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
     g_pIosKeyboard = [[KeyboardView alloc] initWithFrame:keyboardFrame];
     if (!g_pIosKeyboard)
       return false;
-  }
 
+    // inform the controller that the native keyboard is active
+    // basically as long as g_pIosKeyboard exists...
+    [g_xbmcController nativeKeyboardActive:true];
+  }
+  
   m_pCharCallback = pCallback;
 
   // init keyboard stuff
@@ -76,6 +80,7 @@ bool CIOSKeyboard::ShowAndGetInput(char_callback_t pCallback, const std::string 
   @synchronized([KeyboardView class])
   {
     g_pIosKeyboard = nil;
+    [g_xbmcController nativeKeyboardActive:false];
   }
   return confirmed;
 }

--- a/xbmc/platform/darwin/ios/IOSKeyboardView.h
+++ b/xbmc/platform/darwin/ios/IOSKeyboardView.h
@@ -38,7 +38,6 @@
 @property (getter = isConfirmed) BOOL _confirmed;
 @property (assign, setter = registerKeyboard:) CIOSKeyboard *_iosKeyboard;
 
-- (void) setDefault:(NSString *)defaultText;
 - (void) setHeading:(NSString *)heading;
 - (void) setHidden:(BOOL)hidden;
 - (void) activate;

--- a/xbmc/platform/darwin/ios/IOSKeyboardView.mm
+++ b/xbmc/platform/darwin/ios/IOSKeyboardView.mm
@@ -321,6 +321,18 @@ static CEvent keyboardFinishedEvent;
 
 - (void) setHeading:(NSString *)heading
 {
+  if([NSThread currentThread] != [NSThread mainThread])
+  {
+    [self performSelectorOnMainThread:@selector(setHeadingInternal:) withObject:heading  waitUntilDone:YES];
+  }
+  else
+  {
+    [self setHeadingInternal:heading];
+  }
+}
+
+- (void) setHeadingInternal:(NSString *)heading
+{
   if (heading && heading.length > 0) {
     _heading.text = [NSString stringWithFormat:@" %@:", heading];
   }
@@ -335,9 +347,24 @@ static CEvent keyboardFinishedEvent;
   [self textChanged:nil];
 }
 
+- (void) setHiddenInternal:(NSNumber *)hidden
+{
+  BOOL hiddenBool = [hidden boolValue];
+  [_textField setSecureTextEntry:hiddenBool];
+}
+
 - (void) setHidden:(BOOL)hidden
 {
-  [_textField setSecureTextEntry:hidden];
+  NSNumber *passedValue = [NSNumber numberWithBool:hidden];
+
+  if([NSThread currentThread] != [NSThread mainThread])
+  {
+    [self performSelectorOnMainThread:@selector(setHiddenInternal:) withObject:passedValue  waitUntilDone:YES];
+  }
+  else
+  {
+    [self setHiddenInternal:passedValue];
+  }
 }
 
 - (void) textChanged:(NSNotification*)aNotification; {

--- a/xbmc/platform/darwin/ios/XBMCController.h
+++ b/xbmc/platform/darwin/ios/XBMCController.h
@@ -55,6 +55,7 @@ typedef enum
   NSTimer *m_networkAutoSuspendTimer;
   IOSPlaybackState m_playbackState;
   NSDictionary *nowPlayingInfo;
+  bool nativeKeyboardActive;
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property CGPoint lastGesturePoint;
@@ -64,6 +65,7 @@ typedef enum
 @property CGSize screensize;
 @property (nonatomic, retain) NSTimer *m_networkAutoSuspendTimer;
 @property (nonatomic, retain) NSDictionary *nowPlayingInfo;
+@property bool nativeKeyboardActive;
 
 // message from which our instance is obtained
 - (void) pauseAnimation;
@@ -84,6 +86,7 @@ typedef enum
 - (void) createGestureRecognizers;
 - (void) activateKeyboard:(UIView *)view;
 - (void) deactivateKeyboard:(UIView *)view;
+- (void) nativeKeyboardActive: (bool)active;
 
 - (void) disableNetworkAutoSuspend;
 - (void) enableNetworkAutoSuspend:(id)obj;

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -91,6 +91,7 @@ XBMCController *g_xbmcController;
 @synthesize screensize;
 @synthesize m_networkAutoSuspendTimer;
 @synthesize nowPlayingInfo;
+@synthesize nativeKeyboardActive;
 //--------------------------------------------------------------
 - (void) sendKeypressEvent: (XBMC_Event) event
 {
@@ -109,6 +110,15 @@ XBMCController *g_xbmcController;
 
 - (void)insertText:(NSString *)text
 {
+  // in case the native touch keyboard is active
+  // don't do anything here
+  // we are only supposed to be called when
+  // using an external bt keyboard...
+  if (nativeKeyboardActive)
+  {
+    return;
+  }
+
   XBMC_Event newEvent;
   memset(&newEvent, 0, sizeof(newEvent));
   unichar currentKey = [text characterAtIndex:0];
@@ -350,6 +360,11 @@ XBMCController *g_xbmcController;
   [view removeFromSuperview];
   m_glView.userInteractionEnabled = YES;
   [self becomeFirstResponder];
+}
+//--------------------------------------------------------------
+- (void) nativeKeyboardActive: (bool)active;
+{
+  nativeKeyboardActive = active;
 }
 //--------------------------------------------------------------
 -(void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event


### PR DESCRIPTION
Users reported that the native keyboard wouldn't appear on ios 11 beta. I bit the apple (haha) and installed the ios beta and fixed the bug.  

## Description
There was a wrong inter thread access to an ui object in the keyboard view which didn't crash in older ios versions but is not allowed anyway.

## How Has This Been Tested?
Tested on ipad mini retina running ios 11 beta 2 and iphone se running ios10 (regression test).
## Types of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
