### PR TITLE
Fix Settings::FadeButton / initial scrollbar display

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -35,7 +35,7 @@ CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float po
   m_totalSize = 0;
   m_orientation = orientation;
   m_alignment = alignment;
-  m_lastScrollerValue = 0;
+  m_lastScrollerValue = -1;
   m_useControlPositions = useControlPositions;
   ControlType = GUICONTROL_GROUPLIST;
   m_minSize = 0;
@@ -356,6 +356,13 @@ float CGUIControlGroupList::Size(const CGUIControl *control) const
 inline float CGUIControlGroupList::Size() const
 {
   return (m_orientation == VERTICAL) ? m_height : m_width;
+}
+
+void CGUIControlGroupList::SetInvalid()
+{
+  CGUIControl::SetInvalid();
+  // Force a message to the scrollbar
+  m_lastScrollerValue = -1;
 }
 
 void CGUIControlGroupList::ScrollTo(float offset)

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -41,6 +41,7 @@ public:
   float GetWidth() const override;
   float GetHeight() const override;
   virtual float Size() const;
+  virtual void SetInvalid() override;
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.h
@@ -183,4 +183,5 @@ protected:
   CTimer m_delayedTimer;                  ///< Delayed setting timer
 
   bool m_confirmed;
+  int m_focusedControl, m_fadedControl;
 };


### PR DESCRIPTION
Fix Settings::FadeButton / initial scrollbar display

## Description
- Moving focus in settings from menu into settings::grouplist shoud fade the category button
- Selecting new category in settings should update the scrollbar

Both issues broke with PR 12213, this PR fixes them

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
