### PR TITLE
Fix crash on startup

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -252,6 +252,7 @@ CApplication::CApplication(void)
   , m_iScreenSaveLock(0)
   , m_bPlaybackStarting(false)
   , m_ePlayState(PLAY_STATE_NONE)
+  , m_ServiceManager(new CServiceManager)
   , m_confirmSkinChange(true)
   , m_ignoreSkinSettingChanges(false)
   , m_saveSkinOnUnloading(true)
@@ -417,7 +418,6 @@ bool CApplication::Create()
   // Grab a handle to our thread to be used later in identifying the render thread.
   m_threadID = CThread::GetCurrentThreadId();
 
-  m_ServiceManager.reset(new CServiceManager());
   if (!m_ServiceManager->Init1())
   {
     return false;


### PR DESCRIPTION
This fixes a crash on startup introduced in commit 26349e1, "Move CInputManager into service manager" from #12366.

Specifically, `CAppParamParser` references `CInputManager` which is owned by `CServiceManager`, which hasn't been created or initialized yet.

To fix this, we create `CServiceManager` before the input manager is accessed. This causes the IR remote commands to be performed on an uninitialized CInputManager, which is perfectly acceptable as these parameters are meant to be set before initialization.