### PR TITLE
[Inputstream] add CryptoSession flags field

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/StreamCrypto.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/StreamCrypto.h
@@ -21,13 +21,17 @@
 
 typedef struct CRYPTO_INFO
 {
-  enum CRYPTO_KEY_SYSTEM : uint16_t
+  enum CRYPTO_KEY_SYSTEM : uint8_t
   {
     CRYPTO_KEY_SYSTEM_NONE = 0,
     CRYPTO_KEY_SYSTEM_WIDEVINE,
     CRYPTO_KEY_SYSTEM_PLAYREADY,
     CRYPTO_KEY_SYSTEM_COUNT
   } m_CryptoKeySystem;                 /*!< @brief keysystem for encrypted media, KEY_SYSTEM_NONE for unencrypted media */
-  const char *m_CryptoSessionId;       /*!< @brief The crypto session key id */
+
+  static const uint8_t FLAG_SECURE_DECODER = 1; /*!< @brief is set in flags if decoding has to be done in TEE environment */
+
+  uint8_t flags;
   uint16_t m_CryptoSessionIdSize;      /*!< @brief The size of the crypto session key id */
+  const char *m_CryptoSessionId;       /*!< @brief The crypto session key id */
 } CRYPTO_INFO;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -102,8 +102,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.0"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.1"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.1"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -391,7 +391,7 @@ std::atomic<bool> CDVDVideoCodecAndroidMediaCodec::m_InstanceGuard(false);
 bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   int num_codecs;
-  bool needSecureDecoder;
+  bool needSecureDecoder(false);
 
   m_opened = false;
   // allow only 1 instance here
@@ -603,6 +603,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       CLog::Log(LOGERROR, "MediaCrypto::ExceptionCheck: <init>");
       goto FAIL;
     }
+    needSecureDecoder = AMediaCrypto_requiresSecureDecoderComponent(m_mime.c_str()) && (m_hints.cryptoSession->flags & DemuxCryptoSession::FLAG_SECURE_DECODER) != 0;
   }
 
   if (m_render_surface)
@@ -630,7 +631,6 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   }
   m_colorFormat = -1;
   num_codecs = CJNIMediaCodecList::getCodecCount();
-  needSecureDecoder = m_crypto && AMediaCrypto_requiresSecureDecoderComponent(m_mime.c_str());
 
   for (int i = 0; i < num_codecs; i++)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxCrypto.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxCrypto.h
@@ -25,7 +25,7 @@
 
 //CryptoSession is usually obtained once per stream, but could change if an key expires
 
-enum CryptoSessionSystem :uint16_t
+enum CryptoSessionSystem :uint8_t
 {
   CRYPTO_SESSION_SYSTEM_NONE,
   CRYPTO_SESSION_SYSTEM_WIDEVINE,
@@ -34,10 +34,11 @@ enum CryptoSessionSystem :uint16_t
 
 struct DemuxCryptoSession
 {
-  DemuxCryptoSession(const CryptoSessionSystem sys, const uint16_t sSize, const char *sData)
+  DemuxCryptoSession(const CryptoSessionSystem sys, const uint16_t sSize, const char *sData, const uint8_t flags)
     : sessionId(new char[sSize])
     , sessionIdSize(sSize)
     , keySystem(sys)
+    , flags(flags)
   {
     memcpy(sessionId, sData, sSize);
   };
@@ -51,6 +52,9 @@ struct DemuxCryptoSession
   char * sessionId;
   uint16_t sessionIdSize;
   CryptoSessionSystem keySystem;
+
+  static const uint8_t FLAG_SECURE_DECODER = 1;
+  uint8_t flags;
 };
 
 //CryptoInfo stores the information to decrypt a sample
@@ -63,7 +67,7 @@ struct DemuxCryptoInfo
     , clearBytes(new uint16_t[numSubs])
     , cipherBytes(new uint32_t[numSubs])
   {};
-  
+
   ~DemuxCryptoInfo()
   {
     delete[] clearBytes;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -484,7 +484,7 @@ void CInputStreamAddon::UpdateStreams()
         CRYPTO_SESSION_SYSTEM_PLAYREADY
       };
       demuxStream->cryptoSession = std::shared_ptr<DemuxCryptoSession>(new DemuxCryptoSession(
-        map[stream.m_cryptoInfo.m_CryptoKeySystem], stream.m_cryptoInfo.m_CryptoSessionIdSize, stream.m_cryptoInfo.m_CryptoSessionId));
+        map[stream.m_cryptoInfo.m_CryptoKeySystem], stream.m_cryptoInfo.m_CryptoSessionIdSize, stream.m_cryptoInfo.m_CryptoSessionId, stream.m_cryptoInfo.flags));
 
       if ((stream.m_features & INPUTSTREAM_INFO::FEATURE_DECODE) != 0)
       {


### PR DESCRIPTION
## Description
- [Inputstream] Add flags field to CryptoSession to be able to pass additinal flags
- [Android] Implement FLAG_SECURE_DECODER in CryptoSession to allow control of the (MediaCodec) decoder type inside kodi

## Motivation and Context
On L3 Android devices encrypted streams do not play with androids .secure decoder

## How Has This Been Tested?
Shield + encrypted content

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
