### PR TITLE
Service Manager: Fix order of init/deinit

### DIFF
--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -56,13 +56,13 @@ void CAppParamParser::Parse(const char* const* argv, int nArgs)
         {
           if ((argv[next][0] != '-') && (argv[next][0] == '/'))
           {
-            CServiceBroker::GetInputManager().SetRemoteControlName(argv[next]);
+            m_remoteControlName = argv[next];
             i++;
           }
         }
       }
       else if (strnicmp(argv[i], "-n", 2) == 0 || strnicmp(argv[i], "--nolirc", 8) == 0)
-        CServiceBroker::GetInputManager().DisableRemoteControl();
+        m_remoteControlEnabled = false;
 
       if (stricmp(argv[i], "-d") == 0)
       {

--- a/xbmc/AppParamParser.h
+++ b/xbmc/AppParamParser.h
@@ -25,7 +25,10 @@ class CAppParamParser
   public:
     CAppParamParser();
     void Parse(const char* const* argv, int nArgs);
-    CFileItemList m_playlist;
+
+    const CFileItemList &Playlist() const { return m_playlist; }
+    bool RemoteControlEnabled() const { return m_remoteControlEnabled; }
+    const std::string &RemoteControlName() const { return m_remoteControlName; }
 
   private:
     bool m_testmode;
@@ -33,4 +36,8 @@ class CAppParamParser
     void DisplayHelp();
     void DisplayVersion();
     void EnableDebugMode();
+
+    CFileItemList m_playlist;
+    bool m_remoteControlEnabled = true;
+    std::string m_remoteControlName;
 };

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -418,7 +418,7 @@ bool CApplication::Create()
   m_threadID = CThread::GetCurrentThreadId();
 
   m_ServiceManager.reset(new CServiceManager());
-  if (!m_ServiceManager->Init1())
+  if (!m_ServiceManager->InitStageOne())
   {
     return false;
   }
@@ -622,7 +622,7 @@ bool CApplication::Create()
   // initialize the addon database (must be before the addon manager is init'd)
   CDatabaseManager::GetInstance().Initialize(true);
 
-  if (!m_ServiceManager->Init2())
+  if (!m_ServiceManager->InitStageTwo())
   {
     return false;
   }
@@ -1181,7 +1181,7 @@ bool CApplication::Initialize()
 
       CStereoscopicsManager::GetInstance().Initialize();
 
-      if (!m_ServiceManager->Init3())
+      if (!m_ServiceManager->InitStageThree())
       {
         CLog::Log(LOGERROR, "Application - Init3 failed");
       }
@@ -2725,6 +2725,9 @@ bool CApplication::Cleanup()
 {
   try
   {
+    if (m_ServiceManager)
+      m_ServiceManager->DeinitStageThree();
+
     CLog::Log(LOGNOTICE, "unload skin");
     UnloadSkin();
 
@@ -2765,6 +2768,10 @@ bool CApplication::Cleanup()
 #endif
     DllLoaderContainer::Clear();
     g_playlistPlayer.Clear();
+
+    if (m_ServiceManager)
+      m_ServiceManager->DeinitStageTwo();
+
     m_ServiceManager->GetSettings().Uninitialize();
     g_advancedSettings.Clear();
 
@@ -2786,7 +2793,7 @@ bool CApplication::Cleanup()
     // Cleanup was called more than once on exit during my tests
     if (m_ServiceManager)
     {
-      m_ServiceManager->Deinit();
+      m_ServiceManager->DeinitStageOne();
       m_ServiceManager.reset();
     }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -429,7 +429,7 @@ bool CApplication::Create()
   // here we register all global classes for the CApplicationMessenger,
   // after that we can send messages to the corresponding modules
   CApplicationMessenger::GetInstance().RegisterReceiver(this);
-  CApplicationMessenger::GetInstance().RegisterReceiver(&g_playlistPlayer);
+  CApplicationMessenger::GetInstance().RegisterReceiver(&CServiceBroker::GetPlaylistPlayer());
   CApplicationMessenger::GetInstance().RegisterReceiver(&g_infoManager);
   CApplicationMessenger::GetInstance().SetGUIThread(m_threadID);
 
@@ -1651,7 +1651,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
 
   CLog::Log(LOGINFO, "  initialize new skin...");
   g_windowManager.AddMsgTarget(this);
-  g_windowManager.AddMsgTarget(&g_playlistPlayer);
+  g_windowManager.AddMsgTarget(&CServiceBroker::GetPlaylistPlayer());
   g_windowManager.AddMsgTarget(&g_infoManager);
   g_windowManager.AddMsgTarget(&g_fontManager);
   g_windowManager.AddMsgTarget(&CStereoscopicsManager::GetInstance());
@@ -2100,7 +2100,7 @@ bool CApplication::OnAction(const CAction &action)
   // In case of the action PREV_ITEM, we only allow the playlist player to take it if we're less than 3 seconds into playback.
   if (!(action.GetID() == ACTION_PREV_ITEM && m_pPlayer->CanSeek() && GetTime() > 3) )
   {
-    if (g_playlistPlayer.OnAction(action))
+    if (CServiceBroker::GetPlaylistPlayer().OnAction(action))
       return true;
   }
 
@@ -2329,7 +2329,7 @@ bool CApplication::OnAction(const CAction &action)
   }
   if (action.GetID() == ACTION_SHOW_PLAYLIST)
   {
-    int iPlaylist = g_playlistPlayer.GetCurrentPlaylist();
+    int iPlaylist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
     if (iPlaylist == PLAYLIST_VIDEO && g_windowManager.GetActiveWindow() != WINDOW_VIDEO_PLAYLIST)
       g_windowManager.ActivateWindow(WINDOW_VIDEO_PLAYLIST);
     else if (iPlaylist == PLAYLIST_MUSIC && g_windowManager.GetActiveWindow() != WINDOW_MUSIC_PLAYLIST)
@@ -2767,7 +2767,7 @@ bool CApplication::Cleanup()
     CEventServer::RemoveInstance();
 #endif
     DllLoaderContainer::Clear();
-    g_playlistPlayer.Clear();
+    CServiceBroker::GetPlaylistPlayer().Clear();
 
     if (m_ServiceManager)
       m_ServiceManager->DeinitStageTwo();
@@ -3324,11 +3324,11 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
 
   // this really aught to be inside !bRestart, but since PlayStack
   // uses that to init playback, we have to keep it outside
-  int playlist = g_playlistPlayer.GetCurrentPlaylist();
-  if (item.IsVideo() && playlist == PLAYLIST_VIDEO && g_playlistPlayer.GetPlaylist(playlist).size() > 1)
+  int playlist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+  if (item.IsVideo() && playlist == PLAYLIST_VIDEO && CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
-    options.fullscreen = !g_playlistPlayer.HasPlayedFirstFile() && g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
+    options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() && g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
   }
   else if(m_itemCurrentFile->IsStack() && m_currentStack->Size() > 0)
   {
@@ -3442,7 +3442,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
 #endif
 
     if (item.HasPVRChannelInfoTag())
-      g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
   }
 
   CSingleLock lock(m_playStateMutex);
@@ -3481,8 +3481,8 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
   else if (iResult == PLAYBACK_FAIL)
   {
     // we send this if it isn't playlistplayer that is doing this
-    int next = g_playlistPlayer.GetNextSong();
-    int size = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist()).size();
+    int next = CServiceBroker::GetPlaylistPlayer().GetNextSong();
+    int size = CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size();
     if(next < 0
     || next >= size)
       OnPlayBackStopped();
@@ -3599,7 +3599,7 @@ void CApplication::OnPlayBackPaused()
 
   CVariant param;
   param["player"]["speed"] = 0;
-  param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
+  param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnPause", m_itemCurrentFile, param);
 }
 
@@ -3617,7 +3617,7 @@ void CApplication::OnPlayBackResumed()
 
   CVariant param;
   param["player"]["speed"] = 1;
-  param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
+  param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnPlay", m_itemCurrentFile, param);
 }
 
@@ -3629,7 +3629,7 @@ void CApplication::OnPlayBackSpeedChanged(int iSpeed)
 
   CVariant param;
   param["player"]["speed"] = iSpeed;
-  param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
+  param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnSpeedChanged", m_itemCurrentFile, param);
 }
 
@@ -3642,7 +3642,7 @@ void CApplication::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
   CVariant param;
   CJSONUtils::MillisecondsToTimeObject(iTime, param["player"]["time"]);
   CJSONUtils::MillisecondsToTimeObject(seekOffset, param["player"]["seekoffset"]);
-  param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
+  param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   param["player"]["speed"] = (int)m_pPlayer->GetPlaySpeed();
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnSeek", m_itemCurrentFile, param);
   g_infoManager.SetDisplayAfterSeek(2500, static_cast<int>(seekOffset));
@@ -3699,8 +3699,8 @@ void CApplication::UpdateFileState()
     // and we'd overwrite them with settings for the *previous* item.
     //! @todo these "exceptions" should be removed and the whole logic of saving settings be revisited and
     //! possibly moved out of CApplication.  See PRs 5842, 5958, http://trac.kodi.tv/ticket/15704#comment:3
-    int playlist = g_playlistPlayer.GetCurrentPlaylist();
-    if (!m_progressTrackingItem->IsPVRChannel() && !(playlist == PLAYLIST_VIDEO && g_playlistPlayer.GetPlaylist(playlist).size() > 1))
+    int playlist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    if (!m_progressTrackingItem->IsPVRChannel() && !(playlist == PLAYLIST_VIDEO && CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size() > 1))
       SaveFileState();
 
     // Reset tracking item
@@ -4147,7 +4147,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       if (message.GetParam1()==GUI_MSG_REMOVED_MEDIA)
       {
         // Update general playlist: Remove DVD playlist items
-        int nRemoved = g_playlistPlayer.RemoveDVDItems();
+        int nRemoved = CServiceBroker::GetPlaylistPlayer().RemoveDVDItems();
         if ( nRemoved > 0 )
         {
           CGUIMessage msg( GUI_MSG_PLAYLIST_CHANGED, 0, 0 );
@@ -4190,7 +4190,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #ifdef TARGET_DARWIN_IOS
       CDarwinUtils::SetScheduling(message.GetMessage());
 #endif
-      CPlayList playList = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist());
+      CPlayList playList = CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist());
 
       // Update our infoManager with the new details etc.
       if (m_nextPlaylistItem >= 0)
@@ -4203,11 +4203,11 @@ bool CApplication::OnMessage(CGUIMessage& message)
         // we've started a previously queued item
         CFileItemPtr item = playList[m_nextPlaylistItem];
         // update the playlist manager
-        int currentSong = g_playlistPlayer.GetCurrentSong();
+        int currentSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
         int param = ((currentSong & 0xffff) << 16) | (m_nextPlaylistItem & 0xffff);
-        CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_CHANGED, 0, 0, g_playlistPlayer.GetCurrentPlaylist(), param, item);
+        CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_CHANGED, 0, 0, CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist(), param, item);
         g_windowManager.SendThreadMessage(msg);
-        g_playlistPlayer.SetCurrentSong(m_nextPlaylistItem);
+        CServiceBroker::GetPlaylistPlayer().SetCurrentSong(m_nextPlaylistItem);
         m_itemCurrentFile.reset(new CFileItem(*item));
       }
       g_infoManager.SetCurrentItem(m_itemCurrentFile);
@@ -4215,7 +4215,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
       CVariant param;
       param["player"]["speed"] = 1;
-      param["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
+      param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
       CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnPlay", m_itemCurrentFile, param);
       return true;
     }
@@ -4225,8 +4225,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
     {
       // Check to see if our playlist player has a new item for us,
       // and if so, we check whether our current player wants the file
-      int iNext = g_playlistPlayer.GetNextSong();
-      CPlayList& playlist = g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist());
+      int iNext = CServiceBroker::GetPlaylistPlayer().GetNextSong();
+      CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist());
       if (iNext < 0 || iNext >= playlist.size())
       {
         m_pPlayer->OnNothingToQueueNotify();
@@ -4266,7 +4266,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       {
         /* Player didn't accept next file: *ALWAYS* advance playlist in this case so the player can
             queue the next (if it wants to) and it doesn't keep looping on this song */
-        g_playlistPlayer.SetCurrentSong(iNext);
+        CServiceBroker::GetPlaylistPlayer().SetCurrentSong(iNext);
       }
 
       return true;
@@ -4305,7 +4305,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
       if (message.GetMessage() == GUI_MSG_PLAYBACK_ENDED)
       {
-        g_playlistPlayer.PlayNext(1, true);
+        CServiceBroker::GetPlaylistPlayer().PlayNext(1, true);
       }
       else
       {
@@ -4331,7 +4331,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         }
       }
 
-      if (!m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_NONE && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION)
+      if (!m_pPlayer->IsPlayingAudio() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_NONE && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION)
       {
         m_ServiceManager->GetSettings().Save();  // save vis settings
         WakeUpScreenSaverAndDPMS();
@@ -5119,22 +5119,22 @@ bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlay
     return false;
 
   // setup correct playlist
-  g_playlistPlayer.ClearPlaylist(iPlaylist);
+  CServiceBroker::GetPlaylistPlayer().ClearPlaylist(iPlaylist);
 
   // if the playlist contains an internet stream, this file will be used
   // to generate a thumbnail for musicplayer.cover
   g_application.m_strPlayListFile = strPlayList;
 
   // add the items to the playlist player
-  g_playlistPlayer.Add(iPlaylist, playlist);
+  CServiceBroker::GetPlaylistPlayer().Add(iPlaylist, playlist);
 
   // if we have a playlist
-  if (g_playlistPlayer.GetPlaylist(iPlaylist).size())
+  if (CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).size())
   {
     // start playing it
-    g_playlistPlayer.SetCurrentPlaylist(iPlaylist);
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.Play(track, "");
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlaylist);
+    CServiceBroker::GetPlaylistPlayer().Reset();
+    CServiceBroker::GetPlaylistPlayer().Play(track, "");
     return true;
   }
   return false;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -252,7 +252,6 @@ CApplication::CApplication(void)
   , m_iScreenSaveLock(0)
   , m_bPlaybackStarting(false)
   , m_ePlayState(PLAY_STATE_NONE)
-  , m_ServiceManager(new CServiceManager)
   , m_confirmSkinChange(true)
   , m_ignoreSkinSettingChanges(false)
   , m_saveSkinOnUnloading(true)
@@ -418,6 +417,7 @@ bool CApplication::Create()
   // Grab a handle to our thread to be used later in identifying the render thread.
   m_threadID = CThread::GetCurrentThreadId();
 
+  m_ServiceManager.reset(new CServiceManager());
   if (!m_ServiceManager->Init1())
   {
     return false;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -412,7 +412,7 @@ bool CApplication::SetupNetwork()
   return m_network != NULL;
 }
 
-bool CApplication::Create()
+bool CApplication::Create(const CAppParamParser &params)
 {
   // Grab a handle to our thread to be used later in identifying the render thread.
   m_threadID = CThread::GetCurrentThreadId();
@@ -622,7 +622,7 @@ bool CApplication::Create()
   // initialize the addon database (must be before the addon manager is init'd)
   CDatabaseManager::GetInstance().Initialize(true);
 
-  if (!m_ServiceManager->InitStageTwo())
+  if (!m_ServiceManager->InitStageTwo(params))
   {
     return false;
   }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -135,7 +135,7 @@ public:
   void FrameMove(bool processEvents, bool processGUI = true) override;
   void Render() override;
   virtual void Preflight();
-  bool Create();
+  bool Create(const CAppParamParser &params);
   bool Cleanup() override;
 
   bool CreateGUI();

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -95,7 +95,7 @@ bool CAutorun::PlayDisc(const std::string& path, bool bypassSettings, bool start
   if ( !bypassSettings && CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) != AUTOCD_PLAY && !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_DVDS_AUTORUN))
     return false;
 
-  int nSize = g_playlistPlayer.GetPlaylist( PLAYLIST_MUSIC ).size();
+  int nSize = CServiceBroker::GetPlaylistPlayer().GetPlaylist( PLAYLIST_MUSIC ).size();
   int nAddedToPlaylist = 0;
 
   std::string mediaPath;
@@ -124,9 +124,9 @@ bool CAutorun::PlayDisc(const std::string& path, bool bypassSettings, bool start
   {
     CGUIMessage msg( GUI_MSG_PLAYLIST_CHANGED, 0, 0 );
     g_windowManager.SendMessage( msg );
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_MUSIC);
     // Start playing the items we inserted
-    return g_playlistPlayer.Play(nSize, "");
+    return CServiceBroker::GetPlaylistPlayer().Play(nSize, "");
   }
 
   return bPlaying;
@@ -191,11 +191,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
           if (!startFromBeginning && !item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
             item->m_lStartOffset = STARTOFFSET_RESUME;
 
-          g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-          g_playlistPlayer.SetShuffle (PLAYLIST_VIDEO, false);
-          g_playlistPlayer.Add(PLAYLIST_VIDEO, item);
-          g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-          g_playlistPlayer.Play(0, "");
+          CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+          CServiceBroker::GetPlaylistPlayer().SetShuffle (PLAYLIST_VIDEO, false);
+          CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_VIDEO, item);
+          CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+          CServiceBroker::GetPlaylistPlayer().Play(0, "");
           return true;
         }
 
@@ -212,11 +212,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
           if (!startFromBeginning && !item->GetVideoInfoTag()->m_strFileNameAndPath.empty())
             item->m_lStartOffset = STARTOFFSET_RESUME;
 
-          g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-          g_playlistPlayer.SetShuffle (PLAYLIST_VIDEO, false);
-          g_playlistPlayer.Add(PLAYLIST_VIDEO, item);
-          g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-          g_playlistPlayer.Play(0, "");
+          CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+          CServiceBroker::GetPlaylistPlayer().SetShuffle (PLAYLIST_VIDEO, false);
+          CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_VIDEO, item);
+          CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+          CServiceBroker::GetPlaylistPlayer().Play(0, "");
           return true;
         }
 
@@ -320,11 +320,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
 
           //  internal *.evo playback.
           CLog::Log(LOGINFO,"HD DVD: Internal multifile playback initiated.");
-          g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-          g_playlistPlayer.SetShuffle (PLAYLIST_VIDEO, false);
-          g_playlistPlayer.Add(PLAYLIST_VIDEO, items);
-          g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-          g_playlistPlayer.Play(0, "");
+          CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+          CServiceBroker::GetPlaylistPlayer().SetShuffle (PLAYLIST_VIDEO, false);
+          CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_VIDEO, items);
+          CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+          CServiceBroker::GetPlaylistPlayer().Play(0, "");
           return true;
         }
 				
@@ -344,10 +344,10 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
           if (items.Size())
           {
             items.Sort(SortByLabel, SortOrderAscending);
-            g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-            g_playlistPlayer.Add(PLAYLIST_VIDEO, items);
-            g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-            g_playlistPlayer.Play(0, "");
+            CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+            CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_VIDEO, items);
+            CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+            CServiceBroker::GetPlaylistPlayer().Play(0, "");
             return true;
           }
         }
@@ -403,10 +403,10 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
         if (!g_passwordManager.IsMasterLockUnlocked(true))
           return false;
       }
-      g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-      g_playlistPlayer.Add(PLAYLIST_VIDEO, itemlist);
-      g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-      g_playlistPlayer.Play(0, "");
+      CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+      CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_VIDEO, itemlist);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+      CServiceBroker::GetPlaylistPlayer().Play(0, "");
     }
   }
   // then music
@@ -418,7 +418,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
       if (!pItem->m_bIsFolder && pItem->IsAudio())
       {
         nAddedToPlaylist++;
-        g_playlistPlayer.Add(PLAYLIST_MUSIC, pItem);
+        CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_MUSIC, pItem);
       }
     }
   }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7276,22 +7276,22 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       {
         // requires current playlist be PLAYLIST_MUSIC
         bReturn = false;
-        if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
-          bReturn = (g_playlistPlayer.GetCurrentSong() > 0); // not first song
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
+          bReturn = (CServiceBroker::GetPlaylistPlayer().GetCurrentSong() > 0); // not first song
       }
       break;
     case MUSICPLAYER_HASNEXT:
       {
         // requires current playlist be PLAYLIST_MUSIC
         bReturn = false;
-        if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
-          bReturn = (g_playlistPlayer.GetCurrentSong() < (g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() - 1)); // not last song
+        if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
+          bReturn = (CServiceBroker::GetPlaylistPlayer().GetCurrentSong() < (CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC).size() - 1)); // not last song
       }
       break;
     case MUSICPLAYER_PLAYLISTPLAYING:
       {
         bReturn = false;
-        if (g_application.m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+        if (g_application.m_pPlayer->IsPlayingAudio() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
           bReturn = true;
       }
       break;
@@ -7305,13 +7305,13 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = g_application.m_pPlayer->HasMenu();
     break;
     case PLAYLIST_ISRANDOM:
-      bReturn = g_playlistPlayer.IsShuffled(g_playlistPlayer.GetCurrentPlaylist());
+      bReturn = CServiceBroker::GetPlaylistPlayer().IsShuffled(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist());
     break;
     case PLAYLIST_ISREPEAT:
-      bReturn = g_playlistPlayer.GetRepeat(g_playlistPlayer.GetCurrentPlaylist()) == PLAYLIST::REPEAT_ALL;
+      bReturn = CServiceBroker::GetPlaylistPlayer().GetRepeat(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()) == PLAYLIST::REPEAT_ALL;
     break;
     case PLAYLIST_ISREPEATONE:
-      bReturn = g_playlistPlayer.GetRepeat(g_playlistPlayer.GetCurrentPlaylist()) == PLAYLIST::REPEAT_ONE;
+      bReturn = CServiceBroker::GetPlaylistPlayer().GetRepeat(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()) == PLAYLIST::REPEAT_ONE;
     break;
     case PLAYER_HASDURATION:
       bReturn = g_application.GetTotalTime() > 0;
@@ -7814,14 +7814,14 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
           int index = info.GetData2();
           if (info.GetData1() == 1)
           { // relative index
-            if (g_playlistPlayer.GetCurrentPlaylist() != PLAYLIST_MUSIC)
+            if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != PLAYLIST_MUSIC)
             {
               bReturn = false;
               break;
             }
-            index += g_playlistPlayer.GetCurrentSong();
+            index += CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
           }
-          bReturn = (index >= 0 && index < g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size());
+          bReturn = (index >= 0 && index < CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC).size());
         }
         break;
 
@@ -7829,7 +7829,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         {
           int playlistid = info.GetData1();
           if (playlistid > PLAYLIST_NONE)
-            bReturn = g_playlistPlayer.IsShuffled(playlistid);
+            bReturn = CServiceBroker::GetPlaylistPlayer().IsShuffled(playlistid);
         }
         break;
 
@@ -7837,7 +7837,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         {
           int playlistid = info.GetData1();
           if (playlistid > PLAYLIST_NONE)
-            bReturn = g_playlistPlayer.GetRepeat(playlistid) == PLAYLIST::REPEAT_ALL;
+            bReturn = CServiceBroker::GetPlaylistPlayer().GetRepeat(playlistid) == PLAYLIST::REPEAT_ALL;
         }
         break;
 
@@ -7845,7 +7845,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         {
           int playlistid = info.GetData1();
           if (playlistid > PLAYLIST_NONE)
-            bReturn = g_playlistPlayer.GetRepeat(playlistid) == PLAYLIST::REPEAT_ONE;
+            bReturn = CServiceBroker::GetPlaylistPlayer().GetRepeat(playlistid) == PLAYLIST::REPEAT_ONE;
         }
         break;
       case LIBRARY_HAS_ROLE:
@@ -8311,15 +8311,15 @@ std::string CGUIInfoManager::GetMusicPartyModeLabel(int item)
 
 const std::string CGUIInfoManager::GetMusicPlaylistInfo(const GUIInfo& info)
 {
-  PLAYLIST::CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC);
+  PLAYLIST::CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
   if (playlist.size() < 1)
     return "";
   int index = info.GetData2();
   if (info.GetData1() == 1)
   { // relative index (requires current playlist is PLAYLIST_MUSIC)
-    if (g_playlistPlayer.GetCurrentPlaylist() != PLAYLIST_MUSIC)
+    if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != PLAYLIST_MUSIC)
       return "";
-    index = g_playlistPlayer.GetNextSong(index);
+    index = CServiceBroker::GetPlaylistPlayer().GetNextSong(index);
   }
   if (index < 0 || index >= playlist.size())
     return "";
@@ -8353,30 +8353,30 @@ std::string CGUIInfoManager::GetPlaylistLabel(int item, int playlistid /* = PLAY
   if (playlistid <= PLAYLIST_NONE && !g_application.m_pPlayer->IsPlaying())
     return "";
 
-  int iPlaylist = playlistid == PLAYLIST_NONE ? g_playlistPlayer.GetCurrentPlaylist() : playlistid;
+  int iPlaylist = playlistid == PLAYLIST_NONE ? CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() : playlistid;
   switch (item)
   {
   case PLAYLIST_LENGTH:
     {
-      return StringUtils::Format("%i", g_playlistPlayer.GetPlaylist(iPlaylist).size());
+      return StringUtils::Format("%i", CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).size());
     }
   case PLAYLIST_POSITION:
     {
-      int currentSong = g_playlistPlayer.GetCurrentSong();
+      int currentSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
       if (currentSong > -1)
         return StringUtils::Format("%i", currentSong + 1);
       break;
     }
   case PLAYLIST_RANDOM:
     {
-      if (g_playlistPlayer.IsShuffled(iPlaylist))
+      if (CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist))
         return g_localizeStrings.Get(16041); // 16041: On
       else
         return g_localizeStrings.Get(591); // 591: Off
     }
   case PLAYLIST_REPEAT:
     {
-      PLAYLIST::REPEAT_STATE state = g_playlistPlayer.GetRepeat(iPlaylist);
+      PLAYLIST::REPEAT_STATE state = CServiceBroker::GetPlaylistPlayer().GetRepeat(iPlaylist);
       if (state == PLAYLIST::REPEAT_ONE)
         return g_localizeStrings.Get(592); // 592: One
       else if (state == PLAYLIST::REPEAT_ALL)
@@ -8564,13 +8564,13 @@ std::string CGUIInfoManager::GetMusicLabel(int item)
   {
   case MUSICPLAYER_PLAYLISTLEN:
     {
-      if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
         return GetPlaylistLabel(PLAYLIST_LENGTH);
     }
     break;
   case MUSICPLAYER_PLAYLISTPOS:
     {
-      if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
         return GetPlaylistLabel(PLAYLIST_POSITION);
     }
     break;
@@ -9055,7 +9055,7 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
       }
     }
   }
-  else if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
+  else if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO)
   {
     switch (item)
     {
@@ -10621,7 +10621,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
   else if (condition == LISTITEM_ISPLAYING)
   {
     if (item->HasProperty("playlistposition"))
-      return (int)item->GetProperty("playlisttype").asInteger() == g_playlistPlayer.GetCurrentPlaylist() && (int)item->GetProperty("playlistposition").asInteger() == g_playlistPlayer.GetCurrentSong();
+      return (int)item->GetProperty("playlisttype").asInteger() == CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() && (int)item->GetProperty("playlistposition").asInteger() == CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     else if (item->IsFileItem() && !m_currentFile->GetPath().empty())
     {
       if (!g_application.m_strPlayListFile.empty())

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -186,9 +186,9 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
 
   int iPlaylist = m_bIsVideo ? PLAYLIST_VIDEO : PLAYLIST_MUSIC;
 
-  g_playlistPlayer.ClearPlaylist(iPlaylist);
-  g_playlistPlayer.SetShuffle(iPlaylist, false);
-  g_playlistPlayer.SetRepeat(iPlaylist, PLAYLIST::REPEAT_NONE);
+  CServiceBroker::GetPlaylistPlayer().ClearPlaylist(iPlaylist);
+  CServiceBroker::GetPlaylistPlayer().SetShuffle(iPlaylist, false);
+  CServiceBroker::GetPlaylistPlayer().SetRepeat(iPlaylist, PLAYLIST::REPEAT_NONE);
 
   pDialog->SetLine(0, CVariant{m_bIsVideo ? 20252 : 20124});
   pDialog->Progress();
@@ -202,7 +202,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
             __FUNCTION__, XbmcThreads::SystemClockMillis() - time);
 
   // start playing
-  g_playlistPlayer.SetCurrentPlaylist(iPlaylist);
+  CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlaylist);
   Play(0);
 
   pDialog->Close();
@@ -255,7 +255,7 @@ void CPartyModeManager::AddUserSongs(CPlayList& tempList, bool bPlay /* = false 
   int iPlaylist = PLAYLIST_MUSIC;
   if (m_bIsVideo)
     iPlaylist = PLAYLIST_VIDEO;
-  g_playlistPlayer.GetPlaylist(iPlaylist).Insert(tempList, iAddAt);
+  CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Insert(tempList, iAddAt);
 
   // update last user added song location
   if (m_iLastUserSong < 0)
@@ -285,7 +285,7 @@ void CPartyModeManager::AddUserSongs(CFileItemList& tempList, bool bPlay /* = fa
   if (m_bIsVideo)
     iPlaylist = PLAYLIST_VIDEO;
 
-  g_playlistPlayer.GetPlaylist(iPlaylist).Insert(tempList, iAddAt);
+  CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Insert(tempList, iAddAt);
 
   // update last user added song location
   if (m_iLastUserSong < 0)
@@ -311,7 +311,7 @@ bool CPartyModeManager::AddRandomSongs(int iSongs /* = 0 */)
   if (m_bIsVideo)
     iPlaylist = PLAYLIST_VIDEO;
 
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(iPlaylist);
+  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist);
   int iMissingSongs = QUEUE_DEPTH - playlist.size();
   if (iSongs <= 0)
     iSongs = iMissingSongs;
@@ -446,7 +446,7 @@ void CPartyModeManager::Add(CFileItemPtr &pItem)
     database.SetPropertiesForFileItem(*pItem);
   }
 
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(iPlaylist);
+  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist);
   playlist.Add(pItem);
   CLog::Log(LOGINFO,"PARTY MODE MANAGER: Adding randomly selected song at %i:[%s]", playlist.size() - 1, pItem->GetPath().c_str());
   m_iMatchingSongsPicked++;
@@ -457,13 +457,13 @@ bool CPartyModeManager::ReapSongs()
   int iPlaylist = m_bIsVideo ? PLAYLIST_VIDEO : PLAYLIST_MUSIC;
 
   // reap any played songs
-  int iCurrentSong = g_playlistPlayer.GetCurrentSong();
+  int iCurrentSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
   int i=0;
-  while (i < g_playlistPlayer.GetPlaylist(iPlaylist).size())
+  while (i < CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).size())
   {
     if (i < iCurrentSong)
     {
-      g_playlistPlayer.GetPlaylist(iPlaylist).Remove(i);
+      CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Remove(i);
       iCurrentSong--;
       if (i <= m_iLastUserSong)
         m_iLastUserSong--;
@@ -472,20 +472,20 @@ bool CPartyModeManager::ReapSongs()
       i++;
   }
 
-  g_playlistPlayer.SetCurrentSong(iCurrentSong);
+  CServiceBroker::GetPlaylistPlayer().SetCurrentSong(iCurrentSong);
   return true;
 }
 
 bool CPartyModeManager::MovePlaying()
 {
   // move current song to the top if its not there
-  int iCurrentSong = g_playlistPlayer.GetCurrentSong();
+  int iCurrentSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
   int iPlaylist = m_bIsVideo ? PLAYLIST_MUSIC : PLAYLIST_VIDEO;
 
   if (iCurrentSong > 0)
   {
     CLog::Log(LOGINFO,"PARTY MODE MANAGER: Moving currently playing song from %i to 0", iCurrentSong);
-    CPlayList &playlist = g_playlistPlayer.GetPlaylist(iPlaylist);
+    CPlayList &playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist);
     CPlayList playlistTemp;
     playlistTemp.Add(playlist[iCurrentSong]);
     playlist.Remove(iCurrentSong);
@@ -495,7 +495,7 @@ bool CPartyModeManager::MovePlaying()
     for (int i=0; i<playlistTemp.size(); i++)
       playlist.Add(playlistTemp[i]);
   }
-  g_playlistPlayer.SetCurrentSong(0);
+  CServiceBroker::GetPlaylistPlayer().SetCurrentSong(0);
   return true;
 }
 
@@ -508,7 +508,7 @@ void CPartyModeManager::SendUpdateMessage()
 void CPartyModeManager::Play(int iPos)
 {
   // move current song to the top if its not there
-  g_playlistPlayer.Play(iPos, "");
+  CServiceBroker::GetPlaylistPlayer().Play(iPos, "");
   CLog::Log(LOGINFO,"PARTY MODE MANAGER: Playing song at %i", iPos);
   Process();
 }
@@ -600,7 +600,7 @@ bool CPartyModeManager::AddInitialSongs(std::vector< std::pair<int,int > > &song
 {
   int iPlaylist = m_bIsVideo ? PLAYLIST_VIDEO : PLAYLIST_MUSIC;
 
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(iPlaylist);
+  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist);
   int iMissingSongs = QUEUE_DEPTH - playlist.size();
   if (iMissingSongs > 0)
   {
@@ -714,7 +714,7 @@ void CPartyModeManager::Announce()
   {
     CVariant data;
     
-    data["player"]["playerid"] = g_playlistPlayer.GetCurrentPlaylist();
+    data["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
     data["property"]["partymode"] = m_bEnabled;
     ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
   }

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -607,14 +607,14 @@ void CPlayListPlayer::ReShuffle(int iPlaylist, int iPosition)
       (g_application.m_pPlayer->IsPlayingVideo() && iPlaylist == PLAYLIST_VIDEO)
       )
     {
-      g_playlistPlayer.GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
+      CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
     }
   }
   // otherwise, shuffle from the passed position
   // which is the position of the first new item added
   else
   {
-    g_playlistPlayer.GetPlaylist(iPlaylist).Shuffle(iPosition);
+    CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(iPosition);
   }
 }
 

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -618,7 +618,7 @@ void CPlayListPlayer::ReShuffle(int iPlaylist, int iPosition)
   }
 }
 
-void CPlayListPlayer::Add(int iPlaylist, CPlayList& playlist)
+void CPlayListPlayer::Add(int iPlaylist, const CPlayList& playlist)
 {
   if (iPlaylist != PLAYLIST_MUSIC && iPlaylist != PLAYLIST_VIDEO)
     return;
@@ -640,7 +640,7 @@ void CPlayListPlayer::Add(int iPlaylist, const CFileItemPtr &pItem)
     ReShuffle(iPlaylist, iSize);
 }
 
-void CPlayListPlayer::Add(int iPlaylist, CFileItemList& items)
+void CPlayListPlayer::Add(int iPlaylist, const CFileItemList& items)
 {
   if (iPlaylist != PLAYLIST_MUSIC && iPlaylist != PLAYLIST_VIDEO)
     return;
@@ -651,7 +651,7 @@ void CPlayListPlayer::Add(int iPlaylist, CFileItemList& items)
     ReShuffle(iPlaylist, iSize);
 }
 
-void CPlayListPlayer::Insert(int iPlaylist, CPlayList& playlist, int iIndex)
+void CPlayListPlayer::Insert(int iPlaylist, const CPlayList& playlist, int iIndex)
 {
   if (iPlaylist != PLAYLIST_MUSIC && iPlaylist != PLAYLIST_VIDEO)
     return;
@@ -677,7 +677,7 @@ void CPlayListPlayer::Insert(int iPlaylist, const CFileItemPtr &pItem, int iInde
     m_iCurrentSong++;
 }
 
-void CPlayListPlayer::Insert(int iPlaylist, CFileItemList& items, int iIndex)
+void CPlayListPlayer::Insert(int iPlaylist, const CFileItemList& items, int iIndex)
 {
   if (iPlaylist != PLAYLIST_MUSIC && iPlaylist != PLAYLIST_VIDEO)
     return;

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -169,12 +169,12 @@ public:
   REPEAT_STATE GetRepeat(int iPlaylist) const;
 
   // add items via the playlist player
-  void Add(int iPlaylist, CPlayList& playlist);
+  void Add(int iPlaylist, const CPlayList& playlist);
   void Add(int iPlaylist, const CFileItemPtr &pItem);
-  void Add(int iPlaylist, CFileItemList& items);
-  void Insert(int iPlaylist, CPlayList& playlist, int iIndex);
+  void Add(int iPlaylist, const CFileItemList& items);
+  void Insert(int iPlaylist, const CPlayList& playlist, int iIndex);
   void Insert(int iPlaylist, const CFileItemPtr &pItem, int iIndex);
-  void Insert(int iPlaylist, CFileItemList& items, int iIndex);
+  void Insert(int iPlaylist, const CFileItemList& items, int iIndex);
   void Remove(int iPlaylist, int iPosition);
   void Swap(int iPlaylist, int indexItem1, int indexItem2);
 

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -29,8 +29,6 @@
 #define PLAYLIST_VIDEO   1
 #define PLAYLIST_PICTURE 2
 
-#define g_playlistPlayer CServiceBroker::GetPlaylistPlayer()
-
 class CAction;
 class CFileItem; typedef std::shared_ptr<CFileItem> CFileItemPtr;
 class CFileItemList;

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -85,6 +85,11 @@ CSettings& CServiceBroker::GetSettings()
   return g_application.m_ServiceManager->GetSettings();
 }
 
+GAME::CControllerManager& CServiceBroker::GetGameControllerManager()
+{
+  return g_application.m_ServiceManager->GetGameControllerManager();
+}
+
 GAME::CGameServices& CServiceBroker::GetGameServices()
 {
   return g_application.m_ServiceManager->GetGameServices();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -60,6 +60,7 @@ namespace KODI
 {
 namespace GAME
 {
+  class CControllerManager;
   class CGameServices;
 }
 }
@@ -84,6 +85,7 @@ public:
   static CDataCacheCore& GetDataCacheCore();
   static PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
   static CSettings& GetSettings();
+  static KODI::GAME::CControllerManager& GetGameControllerManager();
   static KODI::GAME::CGameServices& GetGameServices();
   static PERIPHERALS::CPeripherals& GetPeripherals();
   static CFavouritesService& GetFavouritesService();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -40,10 +40,7 @@
 
 using namespace KODI;
 
-CServiceManager::CServiceManager() :
-  m_gameServices(new GAME::CGameServices),
-  m_peripherals(new PERIPHERALS::CPeripherals),
-  m_inputManager(new CInputManager)
+CServiceManager::CServiceManager()
 {
 }
 
@@ -55,6 +52,10 @@ bool CServiceManager::Init1()
 {
   m_announcementManager.reset(new ANNOUNCEMENT::CAnnouncementManager());
   m_announcementManager->Start();
+
+  m_gameServices.reset(new GAME::CGameServices);
+  m_peripherals.reset(new PERIPHERALS::CPeripherals);
+  m_inputManager.reset(new CInputManager);
 
 #ifdef HAS_PYTHON
   m_XBPython.reset(new XBPython());
@@ -152,9 +153,10 @@ bool CServiceManager::Init3()
 void CServiceManager::Deinit()
 {
   m_serviceAddons.reset();
-  m_gameServices->Deinit();
-  m_peripherals.reset();
+
   //m_inputManager->Deinitialize(); //! @todo
+  m_gameServices->Deinit();
+
   m_contextMenuManager.reset();
   m_favouritesService.reset();
   m_binaryAddonCache.reset();
@@ -169,6 +171,11 @@ void CServiceManager::Deinit()
   CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
   m_XBPython.reset();
 #endif
+
+  m_inputManager.reset();
+  m_peripherals.reset();
+  m_gameServices.reset();
+
   m_announcementManager.reset();
   init_level = 0;
 }

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -67,7 +67,7 @@ bool CServiceManager::InitStageOne()
   return true;
 }
 
-bool CServiceManager::InitStageTwo()
+bool CServiceManager::InitStageTwo(const CAppParamParser &params)
 {
   m_Platform.reset(CPlatform::CreateInstance());
   m_Platform->Init();
@@ -105,7 +105,7 @@ bool CServiceManager::InitStageTwo()
 
   m_controllerManager.reset(new GAME::CControllerManager);
 
-  m_inputManager.reset(new CInputManager);
+  m_inputManager.reset(new CInputManager(params));
   m_inputManager->InitializeInputs();
 
   init_level = 2;

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -26,6 +26,7 @@
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
 #include "cores/DataCacheCore.h"
 #include "favourites/FavouritesService.h"
+#include "games/controllers/ControllerManager.h"
 #include "games/GameServices.h"
 #include "peripherals/Peripherals.h"
 #include "PlayListPlayer.h"
@@ -48,21 +49,15 @@ CServiceManager::~CServiceManager()
 {
 }
 
-bool CServiceManager::Init1()
+bool CServiceManager::InitStageOne()
 {
   m_announcementManager.reset(new ANNOUNCEMENT::CAnnouncementManager());
   m_announcementManager->Start();
-
-  m_gameServices.reset(new GAME::CGameServices);
-  m_peripherals.reset(new PERIPHERALS::CPeripherals);
-  m_inputManager.reset(new CInputManager);
 
 #ifdef HAS_PYTHON
   m_XBPython.reset(new XBPython());
   CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(), ".py");
 #endif
-
-  m_Platform.reset(CPlatform::CreateInstance());
 
   m_playlistPlayer.reset(new PLAYLIST::CPlayListPlayer());
 
@@ -72,8 +67,9 @@ bool CServiceManager::Init1()
   return true;
 }
 
-bool CServiceManager::Init2()
+bool CServiceManager::InitStageTwo()
 {
+  m_Platform.reset(CPlatform::CreateInstance());
   m_Platform->Init();
 
   m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager()); /* Need to constructed before, GetRunningInstance() of binary CAddonDll need to call them */
@@ -91,19 +87,25 @@ bool CServiceManager::Init2()
   }
 
   m_repositoryUpdater.reset(new ADDON::CRepositoryUpdater(*m_addonMgr));
+
   m_vfsAddonCache.reset(new ADDON::CVFSAddonCache());
   m_vfsAddonCache->Init();
 
   m_PVRManager.reset(new PVR::CPVRManager());
+  m_PVRManager->Init();
+
   m_dataCacheCore.reset(new CDataCacheCore());
 
   m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
 
   m_favouritesService.reset(new CFavouritesService(CProfilesManager::GetInstance().GetProfileUserDataFolder()));
-  m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));
+
   m_serviceAddons.reset(new ADDON::CServiceAddonManager(*m_addonMgr));
 
+  m_controllerManager.reset(new GAME::CControllerManager);
+
+  m_inputManager.reset(new CInputManager);
   m_inputManager->InitializeInputs();
 
   init_level = 2;
@@ -139,44 +141,57 @@ bool CServiceManager::StartAudioEngine()
   return m_ActiveAE->Initialize();
 }
 
-bool CServiceManager::Init3()
+bool CServiceManager::InitStageThree()
 {
+  m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager));
   m_peripherals->Initialise();
-  m_PVRManager->Init();
+
+  m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));
   m_contextMenuManager->Init();
-  m_gameServices->Init(*m_peripherals);
+
+  m_gameServices.reset(new GAME::CGameServices(*m_controllerManager, *m_peripherals));
 
   init_level = 3;
   return true;
 }
 
-void CServiceManager::Deinit()
+void CServiceManager::DeinitStageThree()
 {
-  m_serviceAddons.reset();
-
-  //m_inputManager->Deinitialize(); //! @todo
-  m_gameServices->Deinit();
-
+  m_gameServices.reset();
   m_contextMenuManager.reset();
+  m_peripherals.reset();
+
+  init_level = 2;
+}
+
+void CServiceManager::DeinitStageTwo()
+{
+  m_peripherals.reset();
+  m_inputManager.reset();
+  m_serviceAddons.reset();
   m_favouritesService.reset();
   m_binaryAddonCache.reset();
-  if (m_PVRManager)
-    m_PVRManager->Deinit();
+  m_dataCacheCore.reset();
   m_PVRManager.reset();
-  m_repositoryUpdater.reset();
   m_vfsAddonCache.reset();
+  m_repositoryUpdater.reset();
   m_binaryAddonManager.reset();
   m_addonMgr.reset();
+  m_Platform.reset();
+
+  init_level = 1;
+}
+
+void CServiceManager::DeinitStageOne()
+{
+  m_settings.reset();
+  m_playlistPlayer.reset();
 #ifdef HAS_PYTHON
   CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
   m_XBPython.reset();
 #endif
-
-  m_inputManager.reset();
-  m_peripherals.reset();
-  m_gameServices.reset();
-
   m_announcementManager.reset();
+
   init_level = 0;
 }
 
@@ -256,6 +271,11 @@ PLAYLIST::CPlayListPlayer& CServiceManager::GetPlaylistPlayer()
 CSettings& CServiceManager::GetSettings()
 {
   return *m_settings;
+}
+
+GAME::CControllerManager& CServiceManager::GetGameControllerManager()
+{
+  return *m_controllerManager;
 }
 
 GAME::CGameServices& CServiceManager::GetGameServices()

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -23,6 +23,8 @@
 #include <memory>
 #include "platform/Platform.h"
 
+class CAppParamParser;
+
 namespace ADDON {
 class CAddonMgr;
 class CBinaryAddonManager;
@@ -83,7 +85,7 @@ public:
   ~CServiceManager();
 
   bool InitStageOne();
-  bool InitStageTwo();
+  bool InitStageTwo(const CAppParamParser &params);
   bool CreateAudioEngine();
   bool DestroyAudioEngine();
   bool StartAudioEngine();

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -64,6 +64,7 @@ namespace KODI
 {
 namespace GAME
 {
+  class CControllerManager;
   class CGameServices;
 }
 }
@@ -81,13 +82,15 @@ public:
   CServiceManager();
   ~CServiceManager();
 
-  bool Init1();
-  bool Init2();
+  bool InitStageOne();
+  bool InitStageTwo();
   bool CreateAudioEngine();
   bool DestroyAudioEngine();
   bool StartAudioEngine();
-  bool Init3();
-  void Deinit();
+  bool InitStageThree();
+  void DeinitStageThree();
+  void DeinitStageTwo();
+  void DeinitStageOne();
   ADDON::CAddonMgr& GetAddonMgr();
   ADDON::CBinaryAddonManager& GetBinaryAddonManager();
   ADDON::CBinaryAddonCache& GetBinaryAddonCache();
@@ -105,6 +108,7 @@ public:
   /**\brief Get the platform object. This is save to be called after Init1() was called
    */
   CPlatform& GetPlatform();
+  KODI::GAME::CControllerManager& GetGameControllerManager();
   KODI::GAME::CGameServices& GetGameServices();
   PERIPHERALS::CPeripherals& GetPeripherals();
 
@@ -153,6 +157,7 @@ protected:
   std::unique_ptr<CPlatform> m_Platform;
   std::unique_ptr<PLAYLIST::CPlayListPlayer> m_playlistPlayer;
   std::unique_ptr<CSettings> m_settings;
+  std::unique_ptr<KODI::GAME::CControllerManager> m_controllerManager;
   std::unique_ptr<KODI::GAME::CGameServices> m_gameServices;
   std::unique_ptr<PERIPHERALS::CPeripherals> m_peripherals;
   std::unique_ptr<CFavouritesService, delete_favouritesService> m_favouritesService;

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -72,8 +72,8 @@ INT CXBApplicationEx::Run(CFileItemList &playlist)
 
   if (playlist.Size() > 0)
   {
-    g_playlistPlayer.Add(0, playlist);
-    g_playlistPlayer.SetCurrentPlaylist(0);
+    CServiceBroker::GetPlaylistPlayer().Add(0, playlist);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(0);
     KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
 

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -34,6 +34,7 @@
 #ifdef TARGET_POSIX
 #include "linux/XTimeUtils.h"
 #endif
+#include "AppParamParser.h"
 
 // Put this here for easy enable and disable
 #ifndef _DEBUG
@@ -62,7 +63,7 @@ VOID CXBApplicationEx::Destroy()
 }
 
 /* Function that runs the application */
-INT CXBApplicationEx::Run(CFileItemList &playlist)
+INT CXBApplicationEx::Run(const CAppParamParser &params)
 {
   CLog::Log(LOGNOTICE, "Running the application..." );
 
@@ -70,9 +71,9 @@ INT CXBApplicationEx::Run(CFileItemList &playlist)
   unsigned int frameTime = 0;
   const unsigned int noRenderFrameTime = 15;  // Simulates ~66fps
 
-  if (playlist.Size() > 0)
+  if (params.Playlist().Size() > 0)
   {
-    CServiceBroker::GetPlaylistPlayer().Add(0, playlist);
+    CServiceBroker::GetPlaylistPlayer().Add(0, params.Playlist());
     CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(0);
     KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }

--- a/xbmc/XBApplicationEx.h
+++ b/xbmc/XBApplicationEx.h
@@ -23,7 +23,7 @@
 
 #include "guilib/IWindowManagerCallback.h"
 
-class CFileItemList;
+class CAppParamParser;
 
 // Do not change the numbering, external scripts depend on them
 enum {
@@ -51,7 +51,7 @@ public:
   virtual void SetRenderGUI(bool renderGUI) {};
 
 public:
-  INT Run(CFileItemList &playlist);
+  INT Run(const CAppParamParser &params);
   VOID Destroy();
 
 private:

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -399,8 +399,11 @@ bool CAddonMgr::Init()
 
 void CAddonMgr::DeInit()
 {
-  m_cpluff->destroy_context(m_cp_context);
-  m_cpluff.reset();
+  if (m_cpluff)
+  {
+    m_cpluff->destroy_context(m_cp_context);
+    m_cpluff.reset();
+  }
   m_database.Close();
 }
 

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -47,7 +47,7 @@ bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (playlistTyp==PLAYLIST_NONE)
     return false;
 
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(playlistTyp);
+  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistTyp);
   items.Reserve(playlist.size());
 
   for (int i = 0; i < playlist.size(); ++i)

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -22,44 +22,32 @@
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/ports/PortManager.h"
+#include "ServiceBroker.h"
 
 using namespace KODI;
 using namespace GAME;
 
-CGameServices::CGameServices() :
-  m_controllerManager(new CControllerManager),
-  m_portManager(new CPortManager)
+CGameServices::CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager) :
+  m_controllerManager(controllerManager),
+  m_portManager(new CPortManager(peripheralManager))
 {
 }
 
-CGameServices::~CGameServices()
-{
-  Deinit();
-}
-
-void CGameServices::Init(PERIPHERALS::CPeripherals& peripheralManager)
-{
-  m_portManager->Initialize(peripheralManager);
-}
-
-void CGameServices::Deinit()
-{
-  m_portManager->Deinitialize();
-}
+CGameServices::~CGameServices() = default;
 
 ControllerPtr CGameServices::GetController(const std::string& controllerId)
 {
-  return m_controllerManager->GetController(controllerId);
+  return m_controllerManager.GetController(controllerId);
 }
 
 ControllerPtr CGameServices::GetDefaultController()
 {
-  return m_controllerManager->GetDefaultController();
+  return m_controllerManager.GetDefaultController();
 }
 
 ControllerVector CGameServices::GetControllers()
 {
-  return m_controllerManager->GetControllers();
+  return m_controllerManager.GetControllers();
 }
 
 CPortManager& CGameServices::PortManager()

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -39,11 +39,8 @@ namespace GAME
   class CGameServices
   {
   public:
-    CGameServices();
+    CGameServices(CControllerManager &controllerManager, PERIPHERALS::CPeripherals& peripheralManager);
     ~CGameServices();
-
-    void Init(PERIPHERALS::CPeripherals& peripheralManager);
-    void Deinit();
 
     ControllerPtr GetController(const std::string& controllerId);
     ControllerPtr GetDefaultController();
@@ -52,7 +49,10 @@ namespace GAME
     CPortManager& PortManager();
 
   private:
-    std::unique_ptr<CControllerManager> m_controllerManager;
+    // Construction parameters
+    CControllerManager &m_controllerManager;
+
+    // Game services
     std::unique_ptr<CPortManager> m_portManager;
   };
 }

--- a/xbmc/games/ports/PortManager.cpp
+++ b/xbmc/games/ports/PortManager.cpp
@@ -49,25 +49,12 @@ namespace
 
 // --- CPortManager -----------------------------------------------------------
 
-CPortManager::CPortManager() :
-  m_portMapper(new CPortMapper)
+CPortManager::CPortManager(PERIPHERALS::CPeripherals& peripheralManager) :
+  m_portMapper(new CPortMapper(peripheralManager, *this))
 {
 }
 
-CPortManager::~CPortManager()
-{
-  Deinitialize();
-}
-
-void CPortManager::Initialize(CPeripherals& peripheralManager)
-{
-  m_portMapper->Initialize(peripheralManager, *this);
-}
-
-void CPortManager::Deinitialize()
-{
-  m_portMapper->Deinitialize();
-}
+CPortManager::~CPortManager() = default;
 
 void CPortManager::OpenPort(IInputHandler* handler,
                             HARDWARE::IHardwareInput *hardwareInput,

--- a/xbmc/games/ports/PortManager.h
+++ b/xbmc/games/ports/PortManager.h
@@ -55,11 +55,8 @@ namespace GAME
   class CPortManager : public Observable
   {
   public:
-    CPortManager();
+    CPortManager(PERIPHERALS::CPeripherals& peripheralManager);
     virtual ~CPortManager();
-
-    void Initialize(PERIPHERALS::CPeripherals& peripheralManager);
-    void Deinitialize();
 
     /*!
      * \brief Request a new port be opened with input on that port sent to the

--- a/xbmc/games/ports/PortMapper.h
+++ b/xbmc/games/ports/PortMapper.h
@@ -39,21 +39,18 @@ namespace GAME
   class CPortMapper : public Observer
   {
   public:
-    CPortMapper();
+    CPortMapper(PERIPHERALS::CPeripherals& peripheralManager, CPortManager& portManager);
 
     virtual ~CPortMapper();
-
-    void Initialize(PERIPHERALS::CPeripherals& peripheralManager, CPortManager& portManager);
-    void Deinitialize();
 
     virtual void Notify(const Observable& obs, const ObservableMessage msg) override;
 
   private:
     void ProcessPeripherals();
 
-    // Initialization parameters
-    PERIPHERALS::CPeripherals* m_peripheralManager;
-    CPortManager* m_portManager;
+    // Construction parameters
+    PERIPHERALS::CPeripherals &m_peripheralManager;
+    CPortManager &m_portManager;
 
     // Port paremters
     std::map<PERIPHERALS::PeripheralPtr, PortPtr> m_portMap;

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -62,6 +62,7 @@
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "settings/Settings.h"
+#include "AppParamParser.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
@@ -78,7 +79,7 @@ using EVENTSERVER::CEventServer;
 using namespace KODI;
 using namespace MESSAGING;
 
-CInputManager::CInputManager() :
+CInputManager::CInputManager(const CAppParamParser &params) :
   m_keymapEnvironment(new CKeymapEnvironment),
   m_buttonTranslator(new CButtonTranslator),
   m_irTranslator(new CIRTranslator),
@@ -93,6 +94,12 @@ CInputManager::CInputManager() :
   m_buttonTranslator->RegisterMapper("joystick", m_joystickTranslator.get());
 
   RegisterKeyboardHandler(m_keyboardEasterEgg.get());
+
+  if (!params.RemoteControlName().empty())
+    SetRemoteControlName(params.RemoteControlName());
+
+  if (!params.RemoteControlEnabled())
+    DisableRemoteControl();
 }
 
 CInputManager::~CInputManager()

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -42,6 +42,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
+class CAppParamParser;
 class CButtonTranslator;
 class CCustomControllerTranslator;
 class CIRTranslator;
@@ -86,7 +87,7 @@ class CInputManager : public ISettingCallback,
                       public Observable
 {
 public:
-  CInputManager();
+  CInputManager(const CAppParamParser &params);
   CInputManager(const CInputManager&) = delete;
   CInputManager const& operator=(CInputManager const&) = delete;
   ~CInputManager() override;

--- a/xbmc/input/joysticks/RumbleGenerator.cpp
+++ b/xbmc/input/joysticks/RumbleGenerator.cpp
@@ -20,7 +20,7 @@
 
 #include "RumbleGenerator.h"
 #include "games/controllers/Controller.h"
-#include "games/GameServices.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/joysticks/IInputReceiver.h"
 #include "input/joysticks/JoystickIDs.h"
 #include "ServiceBroker.h"
@@ -130,7 +130,8 @@ std::vector<std::string> CRumbleGenerator::GetMotors(const std::string& controll
 
   std::vector<std::string> motors;
 
-  ControllerPtr controller = CServiceBroker::GetGameServices().GetController(controllerId);
+  CControllerManager& controllerManager = CServiceBroker::GetGameControllerManager();
+  ControllerPtr controller = controllerManager.GetController(controllerId);
   if (controller)
     controller->GetFeatures(motors, FEATURE_TYPE::MOTOR);
  

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -19,9 +19,9 @@
  */
 
 #include "ButtonMapping.h"
-#include "games/GameServices.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/IButtonMapper.h"
@@ -261,8 +261,8 @@ CButtonMapping::CButtonMapping(IButtonMapper* buttonMapper, IButtonMap* buttonMa
   {
     using namespace GAME;
 
-    CGameServices& gameServices = CServiceBroker::GetGameServices();
-    ControllerPtr controller = gameServices.GetController(m_keymap->ControllerID());
+    CControllerManager& controllerManager = CServiceBroker::GetGameControllerManager();
+    ControllerPtr controller = controllerManager.GetController(m_keymap->ControllerID());
 
     const auto& features = controller->Layout().Features();
     for (const auto& feature : features)

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -20,7 +20,7 @@
 
 #include "FeatureHandling.h"
 #include "games/controllers/Controller.h"
-#include "games/GameServices.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/IInputHandler.h"
@@ -71,7 +71,7 @@ CScalarFeature::CScalarFeature(const FeatureName& name, IInputHandler* handler, 
   m_bActivated(false),
   m_bDiscrete(true)
 {
-  GAME::ControllerPtr controller = CServiceBroker::GetGameServices().GetController(handler->ControllerID());
+  GAME::ControllerPtr controller = CServiceBroker::GetGameControllerManager().GetController(handler->ControllerID());
   if (controller)
     m_inputType = controller->GetInputType(name);
 }

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -53,7 +53,7 @@
  */
 static int ClearPlaylist(const std::vector<std::string>& params)
 {
-  g_playlistPlayer.Clear();
+  CServiceBroker::GetPlaylistPlayer().Clear();
 
   return 0;
 }
@@ -90,21 +90,21 @@ static int PlayOffset(const std::vector<std::string>& params)
     }
 
     // user wants to play the 'other' playlist
-    if (iPlaylist != g_playlistPlayer.GetCurrentPlaylist())
+    if (iPlaylist != CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist())
     {
       g_application.StopPlaying();
-      g_playlistPlayer.Reset();
-      g_playlistPlayer.SetCurrentPlaylist(iPlaylist);
+      CServiceBroker::GetPlaylistPlayer().Reset();
+      CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlaylist);
     }
   }
   // play the desired offset
   int pos = atol(strPos.c_str());
   // playlist is already playing
   if (g_application.m_pPlayer->IsPlaying())
-    g_playlistPlayer.PlayNext(pos);
+    CServiceBroker::GetPlaylistPlayer().PlayNext(pos);
   // we start playing the 'other' playlist so we need to use play to initialize the player state
   else
-    g_playlistPlayer.Play(pos, "");
+    CServiceBroker::GetPlaylistPlayer().Play(pos, "");
 
   return 0;
 }
@@ -263,40 +263,40 @@ static int PlayerControl(const std::vector<std::string>& params)
   else if (paramlow == "random" || paramlow == "randomoff" || paramlow == "randomon")
   {
     // get current playlist
-    int iPlaylist = g_playlistPlayer.GetCurrentPlaylist();
+    int iPlaylist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
 
     // reverse the current setting
-    bool shuffled = g_playlistPlayer.IsShuffled(iPlaylist);
+    bool shuffled = CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist);
     if ((shuffled && paramlow == "randomon") || (!shuffled && paramlow == "randomoff"))
       return 0;
 
     // check to see if we should notify the user
     bool notify = (params.size() == 2 && StringUtils::EqualsNoCase(params[1], "notify"));
-    g_playlistPlayer.SetShuffle(iPlaylist, !shuffled, notify);
+    CServiceBroker::GetPlaylistPlayer().SetShuffle(iPlaylist, !shuffled, notify);
 
     // save settings for now playing windows
     switch (iPlaylist)
     {
       case PLAYLIST_MUSIC:
-        CMediaSettings::GetInstance().SetMusicPlaylistShuffled(g_playlistPlayer.IsShuffled(iPlaylist));
+        CMediaSettings::GetInstance().SetMusicPlaylistShuffled(CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist));
         CServiceBroker::GetSettings().Save();
         break;
       case PLAYLIST_VIDEO:
-        CMediaSettings::GetInstance().SetVideoPlaylistShuffled(g_playlistPlayer.IsShuffled(iPlaylist));
+        CMediaSettings::GetInstance().SetVideoPlaylistShuffled(CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist));
         CServiceBroker::GetSettings().Save();
       default:
         break;
     }
 
     // send message
-    CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_RANDOM, 0, 0, iPlaylist, g_playlistPlayer.IsShuffled(iPlaylist));
+    CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_RANDOM, 0, 0, iPlaylist, CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist));
     g_windowManager.SendThreadMessage(msg);
   }
   else if (StringUtils::StartsWithNoCase(params[0], "repeat"))
   {
     // get current playlist
-    int iPlaylist = g_playlistPlayer.GetCurrentPlaylist();
-    PLAYLIST::REPEAT_STATE previous_state = g_playlistPlayer.GetRepeat(iPlaylist);
+    int iPlaylist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    PLAYLIST::REPEAT_STATE previous_state = CServiceBroker::GetPlaylistPlayer().GetRepeat(iPlaylist);
 
     std::string paramlow(params[0]);
     StringUtils::ToLower(paramlow);
@@ -320,7 +320,7 @@ static int PlayerControl(const std::vector<std::string>& params)
 
     // check to see if we should notify the user
     bool notify = (params.size() == 2 && StringUtils::EqualsNoCase(params[1], "notify"));
-    g_playlistPlayer.SetRepeat(iPlaylist, state, notify);
+    CServiceBroker::GetPlaylistPlayer().SetRepeat(iPlaylist, state, notify);
 
     // save settings for now playing windows
     switch (iPlaylist)
@@ -469,13 +469,13 @@ static int PlayMedia(const std::vector<std::string>& params)
       }
     }
 
-    g_playlistPlayer.ClearPlaylist(playlist);
-    g_playlistPlayer.Add(playlist, items);
-    g_playlistPlayer.SetCurrentPlaylist(playlist);
-    g_playlistPlayer.Play(playOffset, "");
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
+    CServiceBroker::GetPlaylistPlayer().Add(playlist, items);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
+    CServiceBroker::GetPlaylistPlayer().Play(playOffset, "");
   }
   else if (item.IsAudio() || item.IsVideo())
-    g_playlistPlayer.Play(std::make_shared<CFileItem>(item), "");
+    CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
   else
     g_application.PlayMedia(item, "", PLAYLIST_NONE);
 

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -513,10 +513,10 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     {
       // Apply the "shuffled" option if available
       if (optionShuffled.isBoolean())
-        g_playlistPlayer.SetShuffle(playlistid, optionShuffled.asBoolean(), false);
+        CServiceBroker::GetPlaylistPlayer().SetShuffle(playlistid, optionShuffled.asBoolean(), false);
       // Apply the "repeat" option if available
       if (!optionRepeat.isNull())
-        g_playlistPlayer.SetRepeat(playlistid, (REPEAT_STATE)ParseRepeatState(optionRepeat), false);
+        CServiceBroker::GetPlaylistPlayer().SetRepeat(playlistid, (REPEAT_STATE)ParseRepeatState(optionRepeat), false);
     }
 
     int playlistStartPosition = (int)parameterObject["item"]["position"].asInteger();
@@ -775,7 +775,7 @@ JSONRPC_STATUS CPlayerOperations::SetShuffle(const std::string &method, ITranspo
         return FailedToExecute;
 
       int playlistid = GetPlaylist(GetPlayer(parameterObject["playerid"]));
-      if (g_playlistPlayer.IsShuffled(playlistid))
+      if (CServiceBroker::GetPlaylistPlayer().IsShuffled(playlistid))
       {
         if ((shuffle.isBoolean() && !shuffle.asBoolean()) ||
             (shuffle.isString() && shuffle.asString() == "toggle"))
@@ -834,7 +834,7 @@ JSONRPC_STATUS CPlayerOperations::SetRepeat(const std::string &method, ITranspor
       int playlistid = GetPlaylist(GetPlayer(parameterObject["playerid"]));
       if (parameterObject["repeat"].asString() == "cycle")
       {
-        REPEAT_STATE repeatPrev = g_playlistPlayer.GetRepeat(playlistid);
+        REPEAT_STATE repeatPrev = CServiceBroker::GetPlaylistPlayer().GetRepeat(playlistid);
         if (repeatPrev == REPEAT_NONE)
           repeat = REPEAT_ALL;
         else if (repeatPrev == REPEAT_ALL)
@@ -1114,7 +1114,7 @@ PlayerType CPlayerOperations::GetPlayer(const CVariant &player)
 
 int CPlayerOperations::GetPlaylist(PlayerType player)
 {
-  int playlist = g_playlistPlayer.GetCurrentPlaylist();
+  int playlist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   if (playlist == PLAYLIST_NONE) // No active playlist, try guessing
     playlist = g_application.m_pPlayer->GetPreferredPlaylist();
 
@@ -1344,8 +1344,8 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
     {
       case Video:
       case Audio: /* Return the position of current item if there is an active playlist */
-        if (!IsPVRChannel() && g_playlistPlayer.GetCurrentPlaylist() == playlist)
-          result = g_playlistPlayer.GetCurrentSong();
+        if (!IsPVRChannel() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist)
+          result = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
         else
           result = -1;
         break;
@@ -1375,7 +1375,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
           break;
         }
 
-        switch (g_playlistPlayer.GetRepeat(playlist))
+        switch (CServiceBroker::GetPlaylistPlayer().GetRepeat(playlist))
         {
         case REPEAT_ONE:
           result = "one";
@@ -1408,7 +1408,7 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
           break;
         }
 
-        result = g_playlistPlayer.IsShuffled(playlist);
+        result = CServiceBroker::GetPlaylistPlayer().IsShuffled(playlist);
         break;
 
       case Picture:

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -180,7 +180,7 @@ JSONRPC_STATUS CPlaylistOperations::Remove(const std::string &method, ITransport
     return FailedToExecute;
   
   int position = (int)parameterObject["position"].asInteger();
-  if (g_playlistPlayer.GetCurrentPlaylist() == playlist && g_playlistPlayer.GetCurrentSong() == position)
+  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist && CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == position)
     return InvalidParams;
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_REMOVE, playlist, position);

--- a/xbmc/interfaces/legacy/PlayList.cpp
+++ b/xbmc/interfaces/legacy/PlayList.cpp
@@ -40,7 +40,7 @@ namespace XBMCAddon
           iPlayList != PLAYLIST_VIDEO)
         throw PlayListException("PlayList does not exist");
 
-      pPlayList = &g_playlistPlayer.GetPlaylist(playList);
+      pPlayList = &CServiceBroker::GetPlaylistPlayer().GetPlaylist(playList);
       iPlayList = playList;
     }
 
@@ -89,7 +89,7 @@ namespace XBMCAddon
             return false;
 
           // clear current playlist
-          g_playlistPlayer.ClearPlaylist(this->iPlayList);
+          CServiceBroker::GetPlaylistPlayer().ClearPlaylist(this->iPlayList);
 
           // add each item of the playlist to the playlistplayer
           for (int i=0; i < (int)pPlayList->size(); ++i)
@@ -136,7 +136,7 @@ namespace XBMCAddon
 
     int PlayList::getposition()
     {
-      return g_playlistPlayer.GetCurrentSong();
+      return CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     }
 
     XBMCAddon::xbmcgui::ListItem* PlayList::operator [](long i)

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -115,9 +115,9 @@ namespace XBMCAddon
       CMediaSettings::GetInstance().SetVideoStartWindowed(windowed);
 
       // play current file in playlist
-      if (g_playlistPlayer.GetCurrentPlaylist() != iPlayList)
-        g_playlistPlayer.SetCurrentPlaylist(iPlayList);
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, g_playlistPlayer.GetCurrentSong());
+      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != iPlayList)
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
+      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, CServiceBroker::GetPlaylistPlayer().GetCurrentSong());
     }
 
     void Player::playPlaylist(const PlayList* playlist, bool windowed, int startpos)
@@ -131,9 +131,9 @@ namespace XBMCAddon
 
         // play a python playlist (a playlist from playlistplayer.cpp)
         iPlayList = playlist->getPlayListId();
-        g_playlistPlayer.SetCurrentPlaylist(iPlayList);
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
         if (startpos > -1)
-          g_playlistPlayer.SetCurrentSong(startpos);
+          CServiceBroker::GetPlaylistPlayer().SetCurrentSong(startpos);
         CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, startpos);
       }
       else
@@ -173,15 +173,15 @@ namespace XBMCAddon
       XBMC_TRACE;
       DelayedCallGuard dc(languageHook);
 
-      if (g_playlistPlayer.GetCurrentPlaylist() != iPlayList)
+      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != iPlayList)
       {
-        g_playlistPlayer.SetCurrentPlaylist(iPlayList);
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
       }
-      g_playlistPlayer.SetCurrentSong(selected);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentSong(selected);
 
       CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, selected);
-      //g_playlistPlayer.Play(selected);
-      //CLog::Log(LOGNOTICE, "Current Song After Play: %i", g_playlistPlayer.GetCurrentSong());
+      //CServiceBroker::GetPlaylistPlayer().Play(selected);
+      //CLog::Log(LOGNOTICE, "Current Song After Play: %i", CServiceBroker::GetPlaylistPlayer().GetCurrentSong());
     }
 
     void Player::OnPlayBackStarted()

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -262,8 +262,8 @@ bool CGUIWindowMusicBase::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_SHOW_PLAYLIST)
   {
-    if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC ||
-        g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).size() > 0)
+    if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC ||
+        CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC).size() > 0)
     {
       g_windowManager.ActivateWindow(WINDOW_MUSIC_PLAYLIST);
       return true;
@@ -593,7 +593,7 @@ void CGUIWindowMusicBase::RetrieveMusicInfo()
 void CGUIWindowMusicBase::OnQueueItem(int iItem)
 {
   // Determine the proper list to queue this element
-  int playlist = g_playlistPlayer.GetCurrentPlaylist();
+  int playlist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   if (playlist == PLAYLIST_NONE)
     playlist = g_application.m_pPlayer->GetPreferredPlaylist();
   if (playlist == PLAYLIST_NONE)
@@ -602,7 +602,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
   // don't re-queue items from playlist window
   if ( iItem < 0 || iItem >= m_vecItems->Size() || GetID() == WINDOW_MUSIC_PLAYLIST) return ;
 
-  int iOldSize=g_playlistPlayer.GetPlaylist(playlist).size();
+  int iOldSize=CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size();
 
   // add item 2 playlist (make a copy as we alter the queuing state)
   CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));
@@ -629,15 +629,15 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
     return;
   }
 
-  g_playlistPlayer.Add(playlist, queuedItems);
-  if (g_playlistPlayer.GetPlaylist(playlist).size() && !g_application.m_pPlayer->IsPlaying())
+  CServiceBroker::GetPlaylistPlayer().Add(playlist, queuedItems);
+  if (CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlist).size() && !g_application.m_pPlayer->IsPlaying())
   {
     if (m_guiState.get())
       m_guiState->SetPlaylistDirectory("playlistmusic://");
 
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.SetCurrentPlaylist(playlist);
-    g_playlistPlayer.Play(iOldSize, ""); // start playing at the first new item
+    CServiceBroker::GetPlaylistPlayer().Reset();
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
+    CServiceBroker::GetPlaylistPlayer().Play(iOldSize, ""); // start playing at the first new item
   }
 }
 
@@ -1036,13 +1036,13 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
     URIUtils::RemoveSlashAtEnd(strPlayListDirectory);
     */
 
-    g_playlistPlayer.ClearPlaylist(PLAYLIST_MUSIC);
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.Add(PLAYLIST_MUSIC, queuedItems);
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_MUSIC);
+    CServiceBroker::GetPlaylistPlayer().Reset();
+    CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_MUSIC, queuedItems);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_MUSIC);
 
     // play!
-    g_playlistPlayer.Play();
+    CServiceBroker::GetPlaylistPlayer().Play();
   }
   else if (pItem->IsPlayList())
   {
@@ -1111,7 +1111,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
       OnQueueItem(iItem);
       return true;
     }
-    g_playlistPlayer.Play(pItem, player);
+    CServiceBroker::GetPlaylistPlayer().Play(pItem, player);
     return true;
   }
   return CGUIMediaWindow::OnPlayMedia(iItem, player);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -123,9 +123,9 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
         SET_CONTROL_FOCUS(m_iLastControl, 0);
       }
 
-      if (g_application.m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+      if (g_application.m_pPlayer->IsPlayingAudio() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
       {
-        int iSong = g_playlistPlayer.GetCurrentSong();
+        int iSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
         if (iSong >= 0 && iSong <= m_vecItems->Size())
           m_viewControl.SetSelectedItem(iSong);
       }
@@ -141,8 +141,8 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
       {
         if (!g_partyModeManager.IsEnabled())
         {
-          g_playlistPlayer.SetShuffle(PLAYLIST_MUSIC, !(g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC)));
-          CMediaSettings::GetInstance().SetMusicPlaylistShuffled(g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC));
+          CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_MUSIC, !(CServiceBroker::GetPlaylistPlayer().IsShuffled(PLAYLIST_MUSIC)));
+          CMediaSettings::GetInstance().SetMusicPlaylistShuffled(CServiceBroker::GetPlaylistPlayer().IsShuffled(PLAYLIST_MUSIC));
           CServiceBroker::GetSettings().Save();
           UpdateButtons();
           Refresh();
@@ -165,34 +165,34 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_BTNPLAY)
       {
         m_guiState->SetPlaylistDirectory("playlistmusic://");
-        g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
-        g_playlistPlayer.Reset();
-        g_playlistPlayer.Play(m_viewControl.GetSelectedItem(), "");
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_MUSIC);
+        CServiceBroker::GetPlaylistPlayer().Reset();
+        CServiceBroker::GetPlaylistPlayer().Play(m_viewControl.GetSelectedItem(), "");
         UpdateButtons();
       }
       else if (iControl == CONTROL_BTNNEXT)
       {
-        g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
-        g_playlistPlayer.PlayNext();
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_MUSIC);
+        CServiceBroker::GetPlaylistPlayer().PlayNext();
       }
       else if (iControl == CONTROL_BTNPREVIOUS)
       {
-        g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
-        g_playlistPlayer.PlayPrevious();
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_MUSIC);
+        CServiceBroker::GetPlaylistPlayer().PlayPrevious();
       }
       else if (iControl == CONTROL_BTNREPEAT)
       {
         // increment repeat state
-        PLAYLIST::REPEAT_STATE state = g_playlistPlayer.GetRepeat(PLAYLIST_MUSIC);
+        PLAYLIST::REPEAT_STATE state = CServiceBroker::GetPlaylistPlayer().GetRepeat(PLAYLIST_MUSIC);
         if (state == PLAYLIST::REPEAT_NONE)
-          g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_ALL);
+          CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_ALL);
         else if (state == PLAYLIST::REPEAT_ALL)
-          g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_ONE);
+          CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_ONE);
         else
-          g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_NONE);
+          CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, PLAYLIST::REPEAT_NONE);
 
         // save settings
-        CMediaSettings::GetInstance().SetMusicPlaylistRepeat(g_playlistPlayer.GetRepeat(PLAYLIST_MUSIC) == PLAYLIST::REPEAT_ALL);
+        CMediaSettings::GetInstance().SetMusicPlaylistRepeat(CServiceBroker::GetPlaylistPlayer().GetRepeat(PLAYLIST_MUSIC) == PLAYLIST::REPEAT_ALL);
         CServiceBroker::GetSettings().Save();
 
         UpdateButtons();
@@ -256,22 +256,22 @@ bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem, int iAction, bo
 
   // is the currently playing item affected?
   bool bFixCurrentSong = false;
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.m_pPlayer->IsPlayingAudio()) &&
-    ((g_playlistPlayer.GetCurrentSong() == iSelected) || (g_playlistPlayer.GetCurrentSong() == iNew)))
+  if ((CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.m_pPlayer->IsPlayingAudio()) &&
+    ((CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == iSelected) || (CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == iNew)))
     bFixCurrentSong = true;
 
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC);
+  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
   if (playlist.Swap(iSelected, iNew))
   {
     // Correct the current playing song in playlistplayer
     if (bFixCurrentSong)
     {
-      int iCurrentSong = g_playlistPlayer.GetCurrentSong();
+      int iCurrentSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
       if (iSelected == iCurrentSong)
         iCurrentSong = iNew;
       else if (iNew == iCurrentSong)
         iCurrentSong = iSelected;
-      g_playlistPlayer.SetCurrentSong(iCurrentSong);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentSong(iCurrentSong);
     }
 
     if (bUpdate)
@@ -331,11 +331,11 @@ void CGUIWindowMusicPlayList::SavePlayList()
 void CGUIWindowMusicPlayList::ClearPlayList()
 {
   ClearFileItems();
-  g_playlistPlayer.ClearPlaylist(PLAYLIST_MUSIC);
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+  CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_MUSIC);
+  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
   {
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+    CServiceBroker::GetPlaylistPlayer().Reset();
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
   }
   Refresh();
   SET_CONTROL_FOCUS(CONTROL_BTNVIEWASICONS, 0);
@@ -346,11 +346,11 @@ void CGUIWindowMusicPlayList::RemovePlayListItem(int iItem)
   if (iItem < 0 || iItem > m_vecItems->Size()) return;
 
   // The current playing song can't be removed
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC && g_application.m_pPlayer->IsPlayingAudio()
-      && g_playlistPlayer.GetCurrentSong() == iItem)
+  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC && g_application.m_pPlayer->IsPlayingAudio()
+      && CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == iItem)
     return ;
 
-  g_playlistPlayer.Remove(PLAYLIST_MUSIC, iItem);
+  CServiceBroker::GetPlaylistPlayer().Remove(PLAYLIST_MUSIC, iItem);
 
   Refresh();
 
@@ -379,7 +379,7 @@ void CGUIWindowMusicPlayList::UpdateButtons()
     CONTROL_ENABLE(CONTROL_BTNREPEAT);
     CONTROL_ENABLE(CONTROL_BTNPLAY);
 
-    if (g_application.m_pPlayer->IsPlayingAudio() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC)
+    if (g_application.m_pPlayer->IsPlayingAudio() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC)
     {
       CONTROL_ENABLE(CONTROL_BTNNEXT);
       CONTROL_ENABLE(CONTROL_BTNPREVIOUS);
@@ -404,11 +404,11 @@ void CGUIWindowMusicPlayList::UpdateButtons()
 
   // update buttons
   CONTROL_DESELECT(CONTROL_BTNSHUFFLE);
-  if (g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC))
+  if (CServiceBroker::GetPlaylistPlayer().IsShuffled(PLAYLIST_MUSIC))
     CONTROL_SELECT(CONTROL_BTNSHUFFLE);
 
   // update repeat button
-  int iRepeat = 595 + g_playlistPlayer.GetRepeat(PLAYLIST_MUSIC);
+  int iRepeat = 595 + CServiceBroker::GetPlaylistPlayer().GetRepeat(PLAYLIST_MUSIC);
   SET_CONTROL_LABEL(CONTROL_BTNREPEAT, g_localizeStrings.Get(iRepeat));
 
   // Update object count label
@@ -430,16 +430,16 @@ bool CGUIWindowMusicPlayList::OnPlayMedia(int iItem, const std::string &player)
       if (m_guiState.get())
         m_guiState->SetPlaylistDirectory(m_vecItems->GetPath());
 
-      g_playlistPlayer.SetCurrentPlaylist( iPlaylist );
-      g_playlistPlayer.Play(iItem, player);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist( iPlaylist );
+      CServiceBroker::GetPlaylistPlayer().Play(iItem, player);
     }
     else
     {
       // Reset Playlistplayer, playback started now does
       // not use the playlistplayer.
       CFileItemPtr pItem=m_vecItems->Get(iItem);
-      g_playlistPlayer.Reset();
-      g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+      CServiceBroker::GetPlaylistPlayer().Reset();
+      CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
       g_application.PlayFile(*pItem, player);
     }
   }
@@ -498,7 +498,7 @@ bool CGUIWindowMusicPlayList::Update(const std::string& strDirectory, bool updat
 void CGUIWindowMusicPlayList::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
   // is this playlist playing?
-  int itemPlaying = g_playlistPlayer.GetCurrentSong();
+  int itemPlaying = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
 
   if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
   {
@@ -675,9 +675,9 @@ void CGUIWindowMusicPlayList::MarkPlaying()
     m_vecItems->Get(i)->Select(false);
 
   // mark the currently playing item
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.m_pPlayer->IsPlayingAudio()))
+  if ((CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_MUSIC) && (g_application.m_pPlayer->IsPlayingAudio()))
   {
-    int iSong = g_playlistPlayer.GetCurrentSong();
+    int iSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     if (iSong >= 0 && iSong <= m_vecItems->Size())
       m_vecItems->Get(iSong)->Select(true);
   }*/

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -578,11 +578,11 @@ CUPnPRenderer::OnSetNextAVTransportURI(PLT_ActionReference& action)
           playlist = PLAYLIST_VIDEO;
 
         {   CSingleLock lock(g_graphicsContext);
-            g_playlistPlayer.ClearPlaylist(playlist);
-            g_playlistPlayer.Add(playlist, item);
+            CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
+            CServiceBroker::GetPlaylistPlayer().Add(playlist, item);
 
-            g_playlistPlayer.SetCurrentSong(-1);
-            g_playlistPlayer.SetCurrentPlaylist(playlist);
+            CServiceBroker::GetPlaylistPlayer().SetCurrentSong(-1);
+            CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
         }
 
         CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -78,7 +78,8 @@ using namespace JOYSTICK;
 using namespace PERIPHERALS;
 using namespace XFILE;
 
-CPeripherals::CPeripherals() :
+CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements) :
+  m_announcements(announcements),
   m_eventScanner(this)
 {
 }
@@ -122,13 +123,13 @@ void CPeripherals::Initialise()
   m_eventScanner.Start();
 
   MESSAGING::CApplicationMessenger::GetInstance().RegisterReceiver(this);
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  m_announcements.AddAnnouncer(this);
 #endif
 }
 
 void CPeripherals::Clear()
 {
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  m_announcements.RemoveAnnouncer(this);
 
   m_eventScanner.Stop();
 

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -47,6 +47,11 @@ namespace JOYSTICK
 }
 }
 
+namespace ANNOUNCEMENT
+{
+  class CAnnouncementManager;
+}
+
 namespace PERIPHERALS
 {
   class CPeripherals :  public ISettingCallback,
@@ -56,7 +61,7 @@ namespace PERIPHERALS
                         public ANNOUNCEMENT::IAnnouncer
   {
   public:
-    CPeripherals();
+    CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements);
 
     ~CPeripherals() override;
 
@@ -315,6 +320,9 @@ namespace PERIPHERALS
     static void GetSettingsFromMappingsFile(TiXmlElement *xmlNode, std::map<std::string, PeripheralDeviceSetting> &m_settings);
 
     void OnDeviceChanged();
+
+    // Construction parameters
+    ANNOUNCEMENT::CAnnouncementManager &m_announcements;
 
 #if !defined(HAVE_LIBCEC)
     bool                                 m_bMissingLibCecWarningDisplayed = false;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -25,9 +25,9 @@
 #include "addons/AddonManager.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
-#include "games/GameServices.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
 #include "input/joysticks/IDriverHandler.h"
@@ -871,8 +871,8 @@ unsigned int CPeripheralAddon::cb_feature_count(void* kodiInstance, const char* 
 
   unsigned int count = 0;
 
-  CGameServices& gameServices = CServiceBroker::GetGameServices();
-  ControllerPtr controller = gameServices.GetController(controllerId);
+  CControllerManager& controllerManager = CServiceBroker::GetGameControllerManager();
+  ControllerPtr controller = controllerManager.GetController(controllerId);
   if (controller)
     count = controller->Layout().FeatureCount(CPeripheralAddonTranslator::TranslateFeatureType(type));
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -417,7 +417,7 @@ void CXBMCApp::run()
   android_printf(" => running XBMC_Run...");
   try
   {
-    status = XBMC_Run(true, appParamParser.m_playlist);
+    status = XBMC_Run(true, appParamParser);
     android_printf(" => XBMC_Run finished with %d", status);
   }
   catch(...)

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -38,6 +38,7 @@
 #import "platform/darwin/ios/XBMCController.h"
 #endif
 #import "utils/Variant.h"
+#include "ServiceBroker.h"
 
 id objectFromVariant(const CVariant &data);
 
@@ -156,11 +157,11 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
     if (duration > 0)
       [item setValue:[NSNumber numberWithDouble:duration] forKey:@"duration"];
     [item setValue:[NSNumber numberWithDouble:g_application.GetTime()] forKey:@"elapsed"];
-    int current = g_playlistPlayer.GetCurrentSong();
+    int current = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     if (current >= 0)
     {
       [item setValue:[NSNumber numberWithInt:current] forKey:@"current"];
-      [item setValue:[NSNumber numberWithInt:g_playlistPlayer.GetPlaylist(g_playlistPlayer.GetCurrentPlaylist()).size()] forKey:@"total"];
+      [item setValue:[NSNumber numberWithInt:CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()] forKey:@"total"];
     }
     if (g_application.CurrentFileItem().HasMusicInfoTag())
     {

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -24,7 +24,6 @@
 
 #include "system.h"
 #include "settings/AdvancedSettings.h"
-#include "FileItem.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
 #include "windowing/WindowingFactory.h"
@@ -32,6 +31,7 @@
 #include "utils/TimeUtils.h"
 #include "Util.h"
 #include "platform/XbmcContext.h"
+#include "AppParamParser.h"
 
 #import <QuartzCore/QuartzCore.h>
 
@@ -395,7 +395,7 @@ using namespace KODI::MESSAGING;
   setlocale(LC_NUMERIC, "C");
 
   g_application.Preflight();
-  if (!g_application.Create())
+  if (!g_application.Create(CAppParamParser()))
   {
     readyToRun = false;
     ELOG(@"%sUnable to create application", __PRETTY_FUNCTION__);
@@ -423,8 +423,7 @@ using namespace KODI::MESSAGING;
     try
     {
       CCocoaAutoPool innerpool;
-      CFileItemList playlist;
-      g_application.Run(playlist);
+      g_application.Run(CAppParamParser());
     }
     catch(...)
     {

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -112,5 +112,5 @@ int main(int argc, char* argv[])
   CAppParamParser appParamParser;
   appParamParser.Parse(argv, argc);
   
-  return XBMC_Run(true, appParamParser.m_playlist);
+  return XBMC_Run(true, appParamParser);
 }

--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -132,9 +132,8 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
     CAppParamParser appParamParser;
     appParamParser.Parse(argv, argc);
     // Create and run the app
-    status = XBMC_Run(true, appParamParser.m_playlist);
+    status = XBMC_Run(true, appParamParser);
   }
-  
 
   for (int i = 0; i < argc; ++i)
     delete[] argv[i];

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -37,7 +37,7 @@
 #include "platform/MessagePrinter.h"
 #include "utils/log.h"
 
-extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist)
+extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
 {
   int status = -1;
 
@@ -46,7 +46,7 @@ extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist)
     g_advancedSettings.Initialize();
   }
 
-  if (!g_application.Create())
+  if (!g_application.Create(params))
   {
     CMessagePrinter::DisplayError("ERROR: Unable to create application. Exiting");
     return status;
@@ -85,7 +85,7 @@ extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist)
 
   try
   {
-    status = g_application.Run(playlist);
+    status = g_application.Run(params);
   }
 #ifdef TARGET_WINDOWS
   catch (const XbmcCommons::UncheckedException &e)

--- a/xbmc/platform/xbmc.h
+++ b/xbmc/platform/xbmc.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-class CFileItemList;
+class CAppParamParser;
 
-extern "C" int XBMC_Run(bool renderGUI, CFileItemList &playlist);
+extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params);
 

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -123,19 +123,19 @@ void CPlayList::Add(const CFileItemPtr &item)
   Add(item, -1, -1);
 }
 
-void CPlayList::Add(CPlayList& playlist)
+void CPlayList::Add(const CPlayList& playlist)
 {
   for (int i = 0; i < (int)playlist.size(); i++)
     Add(playlist[i], -1, -1);
 }
 
-void CPlayList::Add(CFileItemList& items)
+void CPlayList::Add(const CFileItemList& items)
 {
   for (int i = 0; i < (int)items.Size(); i++)
     Add(items[i]);
 }
 
-void CPlayList::Insert(CPlayList& playlist, int iPosition /* = -1 */)
+void CPlayList::Insert(const CPlayList& playlist, int iPosition /* = -1 */)
 {
   // out of bounds so just add to the end
   int iSize = size();
@@ -151,7 +151,7 @@ void CPlayList::Insert(CPlayList& playlist, int iPosition /* = -1 */)
   }
 }
 
-void CPlayList::Insert(CFileItemList& items, int iPosition /* = -1 */)
+void CPlayList::Insert(const CFileItemList& items, int iPosition /* = -1 */)
 {
   // out of bounds so just add to the end
   int iSize = size();

--- a/xbmc/playlists/PlayList.h
+++ b/xbmc/playlists/PlayList.h
@@ -36,13 +36,13 @@ public:
   virtual bool LoadData(const std::string& strData);
   virtual void Save(const std::string& strFileName) const {};
 
-  void Add(CPlayList& playlist);
+  void Add(const CPlayList& playlist);
   void Add(const CFileItemPtr &pItem);
-  void Add(CFileItemList& items);
+  void Add(const CFileItemList& items);
 
   // for Party Mode
-  void Insert(CPlayList& playlist, int iPosition = -1);
-  void Insert(CFileItemList& items, int iPosition = -1);
+  void Insert(const CPlayList& playlist, int iPosition = -1);
+  void Insert(const CFileItemList& items, int iPosition = -1);
   void Insert(const CFileItemPtr& item, int iPosition = -1);
 
   int FindOrder(int iOrder) const;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -209,10 +209,10 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
 
 void CMediaSettings::OnSettingsLoaded()
 {
-  g_playlistPlayer.SetRepeat(PLAYLIST_MUSIC, m_musicPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  g_playlistPlayer.SetShuffle(PLAYLIST_MUSIC, m_musicPlaylistShuffle);
-  g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, m_videoPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  g_playlistPlayer.SetShuffle(PLAYLIST_VIDEO, m_videoPlaylistShuffle);
+  CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, m_musicPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+  CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_MUSIC, m_musicPlaylistShuffle);
+  CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, m_videoPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+  CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_VIDEO, m_videoPlaylistShuffle);
 }
 
 bool CMediaSettings::Save(TiXmlNode *settings) const

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -37,6 +37,7 @@
 #include "addons/BinaryAddonCache.h"
 #include "interfaces/python/XBPython.h"
 #include "pvr/PVRManager.h"
+#include "AppParamParser.h"
 
 #if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
 #include "platform/win32/WIN32Util.h"
@@ -122,7 +123,7 @@ void TestBasicEnvironment::SetUp()
   g_application.m_ServiceManager->CreateAudioEngine();
   CServiceBroker::GetSettings().Initialize();
 
-  if (!g_application.m_ServiceManager->InitStageTwo()
+  if (!g_application.m_ServiceManager->InitStageTwo(CAppParamParser()))
     exit(1);
 
   g_application.m_ServiceManager->StartAudioEngine();

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -52,7 +52,7 @@ void TestBasicEnvironment::SetUp()
   XFILE::CFile *f;
 
   g_application.m_ServiceManager.reset(new CServiceManager());
-  if (!g_application.m_ServiceManager->Init1())
+  if (!g_application.m_ServiceManager->InitStageOne())
     exit(1);
 
   /* NOTE: The below is done to fix memleak warning about uninitialized variable
@@ -105,9 +105,6 @@ void TestBasicEnvironment::SetUp()
   CSpecialProtocol::SetTempPath(tmp);
 #endif
 
-  if (!g_application.m_ServiceManager->Init2())
-	  exit(1);
-
   /* Create and delete a tempfile to initialize the VFS (really to initialize
    * CLibcdio). This is done so that the initialization of the VFS does not
    * affect the performance results of the test cases.
@@ -123,17 +120,22 @@ void TestBasicEnvironment::SetUp()
   }
   g_powerManager.Initialize();
   g_application.m_ServiceManager->CreateAudioEngine();
-  g_application.m_ServiceManager->StartAudioEngine();
   CServiceBroker::GetSettings().Initialize();
+
+  if (!g_application.m_ServiceManager->InitStageTwo()
+    exit(1);
+
+  g_application.m_ServiceManager->StartAudioEngine();
 }
 
 void TestBasicEnvironment::TearDown()
 {
+  g_application.m_ServiceManager->DeinitStageTwo();
   g_application.m_ServiceManager->DestroyAudioEngine();
   std::string xbmcTempPath = CSpecialProtocol::TranslatePath("special://temp/");
   XFILE::CDirectory::Remove(xbmcTempPath);
   CServiceBroker::GetSettings().Uninitialize();
-  g_application.m_ServiceManager->Deinit();
+  g_application.m_ServiceManager->DeinitStageOne();
 }
 
 void TestBasicEnvironment::SetUpError()

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -123,7 +123,7 @@ static void SetPathAndPlay(CFileItem& item)
   if (item.IsLiveTV()) // pvr tv or pvr radio?
     g_application.PlayMedia(item, "", PLAYLIST_NONE);
   else
-    g_playlistPlayer.Play(std::make_shared<CFileItem>(item), "");
+    CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
 }
 
 bool CResume::Execute(const CFileItemPtr& itemIn) const

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -103,8 +103,8 @@ bool CGUIWindowVideoBase::OnAction(const CAction &action)
     return OnContextButton(m_viewControl.GetSelectedItem(),CONTEXT_BUTTON_SCAN);
   else if (action.GetID() == ACTION_SHOW_PLAYLIST)
   {
-    if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO ||
-        g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO).size() > 0)
+    if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO ||
+        CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_VIDEO).size() > 0)
     {
       g_windowManager.ActivateWindow(WINDOW_VIDEO_PLAYLIST);
       return true;
@@ -424,7 +424,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
 void CGUIWindowVideoBase::OnQueueItem(int iItem)
 {
   // Determine the proper list to queue this element
-  int playlist = g_playlistPlayer.GetCurrentPlaylist();
+  int playlist = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
   if (playlist == PLAYLIST_NONE)
     playlist = g_application.m_pPlayer->GetPreferredPlaylist();
   if (playlist == PLAYLIST_NONE)
@@ -452,8 +452,8 @@ void CGUIWindowVideoBase::OnQueueItem(int iItem)
     return;
   }
 
-  g_playlistPlayer.Add(playlist, queuedItems);
-  g_playlistPlayer.SetCurrentPlaylist(playlist);
+  CServiceBroker::GetPlaylistPlayer().Add(playlist, queuedItems);
+  CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
   // video does not auto play on queue like music
   m_viewControl.SetSelectedItem(iItem + 1);
 }
@@ -1081,8 +1081,8 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
 
   // Reset Playlistplayer, playback started now does
   // not use the playlistplayer.
-  g_playlistPlayer.Reset();
-  g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+  CServiceBroker::GetPlaylistPlayer().Reset();
+  CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
 
   CFileItem item(*pItem);
   if (pItem->IsVideoDb())
@@ -1167,8 +1167,8 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr &item, std::str
 {
   // Get the current playlist and make sure it is not shuffled
   int iPlaylist = m_guiState->GetPlaylist();
-  if (iPlaylist != PLAYLIST_NONE && g_playlistPlayer.IsShuffled(iPlaylist))
-     g_playlistPlayer.SetShuffle(iPlaylist, false);
+  if (iPlaylist != PLAYLIST_NONE && CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist))
+     CServiceBroker::GetPlaylistPlayer().SetShuffle(iPlaylist, false);
 
   CFileItemPtr movieItem(new CFileItem(*item));
 
@@ -1182,7 +1182,7 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item, const std::string &pl
   if(m_thumbLoader.IsLoading())
     m_thumbLoader.StopAsync();
 
-  g_playlistPlayer.Play(std::make_shared<CFileItem>(*item), player);
+  CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*item), player);
 
   if(!g_application.m_pPlayer->IsPlayingVideo())
     m_thumbLoader.Load(*m_vecItems);
@@ -1269,11 +1269,11 @@ void CGUIWindowVideoBase::PlayItem(int iItem, const std::string &player)
     CFileItemList queuedItems;
     AddItemToPlayList(item, queuedItems);
 
-    g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.Add(PLAYLIST_VIDEO, queuedItems);
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-    g_playlistPlayer.Play();
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+    CServiceBroker::GetPlaylistPlayer().Reset();
+    CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST_VIDEO, queuedItems);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+    CServiceBroker::GetPlaylistPlayer().Play();
   }
   else if (pItem->IsPlayList())
   {

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -110,9 +110,9 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
         SET_CONTROL_FOCUS(m_iLastControl, 0);
       }
 
-      if (g_application.m_pPlayer->IsPlayingVideo() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
+      if (g_application.m_pPlayer->IsPlayingVideo() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO)
       {
-        int iSong = g_playlistPlayer.GetCurrentSong();
+        int iSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
         if (iSong >= 0 && iSong <= (int)m_vecItems->Size())
           m_viewControl.SetSelectedItem(iSong);
       }
@@ -128,8 +128,8 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
       {
         if (!g_partyModeManager.IsEnabled())
         {
-          g_playlistPlayer.SetShuffle(PLAYLIST_VIDEO, !(g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO)));
-          CMediaSettings::GetInstance().SetVideoPlaylistShuffled(g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO));
+          CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_VIDEO, !(CServiceBroker::GetPlaylistPlayer().IsShuffled(PLAYLIST_VIDEO)));
+          CMediaSettings::GetInstance().SetVideoPlaylistShuffled(CServiceBroker::GetPlaylistPlayer().IsShuffled(PLAYLIST_VIDEO));
           CServiceBroker::GetSettings().Save();
           UpdateButtons();
           Refresh();
@@ -145,34 +145,34 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNPLAY)
       {
-        g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-        g_playlistPlayer.Reset();
-        g_playlistPlayer.Play(m_viewControl.GetSelectedItem(), "");
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+        CServiceBroker::GetPlaylistPlayer().Reset();
+        CServiceBroker::GetPlaylistPlayer().Play(m_viewControl.GetSelectedItem(), "");
         UpdateButtons();
       }
       else if (iControl == CONTROL_BTNNEXT)
       {
-        g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-        g_playlistPlayer.PlayNext();
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+        CServiceBroker::GetPlaylistPlayer().PlayNext();
       }
       else if (iControl == CONTROL_BTNPREVIOUS)
       {
-        g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
-        g_playlistPlayer.PlayPrevious();
+        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
+        CServiceBroker::GetPlaylistPlayer().PlayPrevious();
       }
       else if (iControl == CONTROL_BTNREPEAT)
       {
         // increment repeat state
-        PLAYLIST::REPEAT_STATE state = g_playlistPlayer.GetRepeat(PLAYLIST_VIDEO);
+        PLAYLIST::REPEAT_STATE state = CServiceBroker::GetPlaylistPlayer().GetRepeat(PLAYLIST_VIDEO);
         if (state == PLAYLIST::REPEAT_NONE)
-          g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_ALL);
+          CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_ALL);
         else if (state == PLAYLIST::REPEAT_ALL)
-          g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_ONE);
+          CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_ONE);
         else
-          g_playlistPlayer.SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_NONE);
+          CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, PLAYLIST::REPEAT_NONE);
 
         // save settings
-        CMediaSettings::GetInstance().SetVideoPlaylistRepeat(g_playlistPlayer.GetRepeat(PLAYLIST_VIDEO) == PLAYLIST::REPEAT_ALL);
+        CMediaSettings::GetInstance().SetVideoPlaylistRepeat(CServiceBroker::GetPlaylistPlayer().GetRepeat(PLAYLIST_VIDEO) == PLAYLIST::REPEAT_ALL);
         CServiceBroker::GetSettings().Save();
 
         UpdateButtons();
@@ -235,22 +235,22 @@ bool CGUIWindowVideoPlaylist::MoveCurrentPlayListItem(int iItem, int iAction, bo
 
   // is the currently playing item affected?
   bool bFixCurrentSong = false;
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.m_pPlayer->IsPlayingVideo()) &&
-    ((g_playlistPlayer.GetCurrentSong() == iSelected) || (g_playlistPlayer.GetCurrentSong() == iNew)))
+  if ((CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.m_pPlayer->IsPlayingVideo()) &&
+    ((CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == iSelected) || (CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == iNew)))
     bFixCurrentSong = true;
 
-  CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO);
+  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_VIDEO);
   if (playlist.Swap(iSelected, iNew))
   {
     // Correct the current playing song in playlistplayer
     if (bFixCurrentSong)
     {
-      int iCurrentSong = g_playlistPlayer.GetCurrentSong();
+      int iCurrentSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
       if (iSelected == iCurrentSong)
         iCurrentSong = iNew;
       else if (iNew == iCurrentSong)
         iCurrentSong = iSelected;
-      g_playlistPlayer.SetCurrentSong(iCurrentSong);
+      CServiceBroker::GetPlaylistPlayer().SetCurrentSong(iCurrentSong);
     }
 
     if (bUpdate)
@@ -265,11 +265,11 @@ bool CGUIWindowVideoPlaylist::MoveCurrentPlayListItem(int iItem, int iAction, bo
 void CGUIWindowVideoPlaylist::ClearPlayList()
 {
   ClearFileItems();
-  g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
+  CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO)
   {
-    g_playlistPlayer.Reset();
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+    CServiceBroker::GetPlaylistPlayer().Reset();
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
   }
   m_viewControl.SetItems(*m_vecItems);
   UpdateButtons();
@@ -287,7 +287,7 @@ void CGUIWindowVideoPlaylist::UpdateButtons()
     CONTROL_ENABLE(CONTROL_BTNSHUFFLE);
     CONTROL_ENABLE(CONTROL_BTNREPEAT);
 
-    if (g_application.m_pPlayer->IsPlayingVideo() && g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO)
+    if (g_application.m_pPlayer->IsPlayingVideo() && CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO)
     {
       CONTROL_ENABLE(CONTROL_BTNNEXT);
       CONTROL_ENABLE(CONTROL_BTNPREVIOUS);
@@ -313,11 +313,11 @@ void CGUIWindowVideoPlaylist::UpdateButtons()
 
   // update buttons
   CONTROL_DESELECT(CONTROL_BTNSHUFFLE);
-  if (g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO))
+  if (CServiceBroker::GetPlaylistPlayer().IsShuffled(PLAYLIST_VIDEO))
     CONTROL_SELECT(CONTROL_BTNSHUFFLE);
 
   // update repeat button
-  int iRepeat = 595 + g_playlistPlayer.GetRepeat(PLAYLIST_VIDEO);
+  int iRepeat = 595 + CServiceBroker::GetPlaylistPlayer().GetRepeat(PLAYLIST_VIDEO);
   SET_CONTROL_LABEL(CONTROL_BTNREPEAT, g_localizeStrings.Get(iRepeat));
 
   MarkPlaying();
@@ -332,17 +332,17 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem, const std::string &player)
   {
     CFileItemPtr pItem = m_vecItems->Get(iItem);
     std::string strPath = pItem->GetPath();
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_VIDEO);
     // need to update Playlist FileItem's startOffset and resumePoint based on GUIWindowVideoPlaylist FileItem
     if (pItem->m_lStartOffset == STARTOFFSET_RESUME)
     {
-      CFileItemPtr pPlaylistItem = g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO)[iItem];
+      CFileItemPtr pPlaylistItem = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_VIDEO)[iItem];
       pPlaylistItem->m_lStartOffset = pItem->m_lStartOffset;
       if (pPlaylistItem->HasVideoInfoTag() && pItem->HasVideoInfoTag())
         pPlaylistItem->GetVideoInfoTag()->SetResumePoint(pItem->GetVideoInfoTag()->GetResumePoint());
     }
     // now play item
-    g_playlistPlayer.Play(iItem, player);
+    CServiceBroker::GetPlaylistPlayer().Play(iItem, player);
   }
   return true;
 }
@@ -350,11 +350,11 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem, const std::string &player)
 void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
 {
   // The current playing song can't be removed
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO && g_application.m_pPlayer->IsPlayingVideo()
-      && g_playlistPlayer.GetCurrentSong() == iItem)
+  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO && g_application.m_pPlayer->IsPlayingVideo()
+      && CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == iItem)
     return ;
 
-  g_playlistPlayer.Remove(PLAYLIST_VIDEO, iItem);
+  CServiceBroker::GetPlaylistPlayer().Remove(PLAYLIST_VIDEO, iItem);
 
   Refresh();
 
@@ -394,7 +394,7 @@ void CGUIWindowVideoPlaylist::SavePlayList()
 
 void CGUIWindowVideoPlaylist::GetContextButtons(int itemNumber, CContextButtons &buttons)
 {
-  int itemPlaying = g_playlistPlayer.GetCurrentSong();
+  int itemPlaying = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
   if (m_movingFrom >= 0)
   {
     if (itemNumber != m_movingFrom && (!g_partyModeManager.IsEnabled() || itemNumber > itemPlaying))
@@ -562,9 +562,9 @@ void CGUIWindowVideoPlaylist::MarkPlaying()
     m_vecItems->Get(i)->Select(false);
 
   // mark the currently playing item
-  if ((g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.m_pPlayer->IsPlayingVideo()))
+  if ((CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO) && (g_application.m_pPlayer->IsPlayingVideo()))
   {
-    int iSong = g_playlistPlayer.GetCurrentSong();
+    int iSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     if (iSong >= 0 && iSong <= m_vecItems->Size())
       m_vecItems->Get(iSong)->Select(true);
   }*/

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -417,7 +417,7 @@ void CGUIViewState::SetPlaylistDirectory(const std::string& strDirectory)
 
 bool CGUIViewState::IsCurrentPlaylistDirectory(const std::string& strDirectory)
 {
-  if (g_playlistPlayer.GetCurrentPlaylist()!=GetPlaylist())
+  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()!=GetPlaylist())
     return false;
 
   std::string strDir = strDirectory;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1396,8 +1396,8 @@ bool CGUIMediaWindow::OnPlayMedia(int iItem, const std::string &player)
 {
   // Reset Playlistplayer, playback started now does
   // not use the playlistplayer.
-  g_playlistPlayer.Reset();
-  g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+  CServiceBroker::GetPlaylistPlayer().Reset();
+  CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
   CFileItemPtr pItem=m_vecItems->Get(iItem);
 
   CLog::Log(LOGDEBUG, "%s %s", __FUNCTION__, CURL::GetRedacted(pItem->GetPath()).c_str());
@@ -1428,8 +1428,8 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string 
   int iPlaylist = m_guiState->GetPlaylist();
   if (iPlaylist != PLAYLIST_NONE)
   {
-    g_playlistPlayer.ClearPlaylist(iPlaylist);
-    g_playlistPlayer.Reset();
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(iPlaylist);
+    CServiceBroker::GetPlaylistPlayer().Reset();
     int mediaToPlay = 0;
     
     // first try to find mainDVD file (VIDEO_TS.IFO). 
@@ -1454,11 +1454,11 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string 
         continue;
 
       if (!nItem->IsPlayList() && !nItem->IsZIP() && !nItem->IsRAR() && (!nItem->IsDVDFile() || (URIUtils::GetFileName(nItem->GetPath()) == mainDVD)))
-        g_playlistPlayer.Add(iPlaylist, nItem);
+        CServiceBroker::GetPlaylistPlayer().Add(iPlaylist, nItem);
 
       if (item->IsSamePath(nItem.get()))
       { // item that was clicked
-        mediaToPlay = g_playlistPlayer.GetPlaylist(iPlaylist).size() - 1;
+        mediaToPlay = CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).size() - 1;
       }
     }
 
@@ -1467,16 +1467,16 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string 
       m_guiState->SetPlaylistDirectory(m_vecItems->GetPath());
 
     // figure out where we start playback
-    if (g_playlistPlayer.IsShuffled(iPlaylist))
+    if (CServiceBroker::GetPlaylistPlayer().IsShuffled(iPlaylist))
     {
-      int iIndex = g_playlistPlayer.GetPlaylist(iPlaylist).FindOrder(mediaToPlay);
-      g_playlistPlayer.GetPlaylist(iPlaylist).Swap(0, iIndex);
+      int iIndex = CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).FindOrder(mediaToPlay);
+      CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Swap(0, iIndex);
       mediaToPlay = 0;
     }
 
     // play
-    g_playlistPlayer.SetCurrentPlaylist(iPlaylist);
-    g_playlistPlayer.Play(mediaToPlay, player);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlaylist);
+    CServiceBroker::GetPlaylistPlayer().Play(mediaToPlay, player);
   }
   return true;
 }
@@ -1505,13 +1505,13 @@ void CGUIMediaWindow::UpdateFileList()
   if (m_guiState.get() && m_guiState->IsCurrentPlaylistDirectory(m_vecItems->GetPath()))
   {
     int iPlaylist=m_guiState->GetPlaylist();
-    int nSong = g_playlistPlayer.GetCurrentSong();
+    int nSong = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
     CFileItem playlistItem;
     if (nSong > -1 && iPlaylist > -1)
-      playlistItem=*g_playlistPlayer.GetPlaylist(iPlaylist)[nSong];
+      playlistItem=*CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist)[nSong];
 
-    g_playlistPlayer.ClearPlaylist(iPlaylist);
-    g_playlistPlayer.Reset();
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(iPlaylist);
+    CServiceBroker::GetPlaylistPlayer().Reset();
 
     for (int i = 0; i < m_vecItems->Size(); i++)
     {
@@ -1520,11 +1520,11 @@ void CGUIMediaWindow::UpdateFileList()
         continue;
 
       if (!pItem->IsPlayList() && !pItem->IsZIP() && !pItem->IsRAR())
-        g_playlistPlayer.Add(iPlaylist, pItem);
+        CServiceBroker::GetPlaylistPlayer().Add(iPlaylist, pItem);
 
       if (pItem->GetPath() == playlistItem.GetPath() &&
           pItem->m_lStartOffset == playlistItem.m_lStartOffset)
-        g_playlistPlayer.SetCurrentSong(g_playlistPlayer.GetPlaylist(iPlaylist).size() - 1);
+        CServiceBroker::GetPlaylistPlayer().SetCurrentSong(CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).size() - 1);
     }
   }
 }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -624,7 +624,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
   }
   if (pItem->IsAudio() || pItem->IsVideo())
   {
-    g_playlistPlayer.Play(std::make_shared<CFileItem>(*pItem), player);
+    CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*pItem), player);
     return;
   }
   if (pItem->IsGame())

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -299,9 +299,9 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   if (CProfilesManager::GetInstance().GetLastUsedProfileIndex() != profile)
   {
-    g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
-    g_playlistPlayer.ClearPlaylist(PLAYLIST_MUSIC);
-    g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
+    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_MUSIC);
+    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
   }
 
   // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status


### PR DESCRIPTION
This PR takes #12431 and finishes the task of ordering the individual services in a LIFO manner. Several circular dependencies arose, so some code was split up and refactored.