### PR TITLE
Fix missing brackets in dbwrappers code

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -399,10 +399,12 @@ const field_value Dataset::get_field_value(int index) {
       return (*edit_object)[index].val;
     }
     else
+    {
       if (index < 0 || index >= field_count())
         throw DbErrors("Field index not found: %d",index);
 
       return (*fields_object)[index].val;
+    }
   }
   throw DbErrors("Dataset state is Inactive");
 }


### PR DESCRIPTION
While hunting down compiler warnings for #12425, I encountered an actual error in the code. Due to the use of early returns this is benign, but a good lesson nonetheless.