### PR TITLE
Implement basic gameplay persistence (autosave)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16969,7 +16969,19 @@ msgctxt "#35216"
 msgid "Support add-ons"
 msgstr ""
 
-#empty strings from id 35217 to 35219
+#. Dialog text asking user to overwrite their savestate file
+#: xbmc/cores/RetroPlayer/RetroPlayer.cpp"
+msgctxt "#35217"
+msgid "The savestate can only be loaded with \"{0:s}\". Erase savestate and continue?"
+msgstr ""
+
+#. Button to erase the savestate
+#: xbmc/cores/RetroPlayer/RetroPlayer.cpp"
+msgctxt "#35218"
+msgid "Erase savestate"
+msgstr ""
+
+#empty string with id 35219
 
 #. Description of add-on category for game providers
 #: xbmc/filesystem/AddonsDirectory.cpp

--- a/xbmc/cores/RetroPlayer/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(SOURCES PixelConverter.cpp
             RetroPlayer.cpp
             RetroPlayerAudio.cpp
+            RetroPlayerAutoSave.cpp
             RetroPlayerVideo.cpp)
 
 set(HEADERS IPixelConverter.h
             PixelConverter.h
             RetroPlayer.h
             RetroPlayerAudio.h
+            RetroPlayerAutoSave.h
             RetroPlayerDefines.h
             RetroPlayerVideo.h)
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -20,9 +20,15 @@
 
 #include "RetroPlayer.h"
 #include "RetroPlayerAudio.h"
+#include "RetroPlayerAutoSave.h"
 #include "RetroPlayerVideo.h"
+#include "addons/AddonManager.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
+#include "dialogs/GUIDialogYesNo.h"
+#include "filesystem/File.h"
 #include "games/addons/playback/IGameClientPlayback.h"
+#include "games/addons/savestates/Savestate.h"
+#include "games/addons/savestates/SavestateUtils.h"
 #include "games/addons/GameClient.h"
 #include "games/ports/PortManager.h"
 #include "games/tags/GameInfoTag.h"
@@ -30,6 +36,7 @@
 #include "games/GameUtils.h"
 #include "guilib/GUIDialog.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/Action.h"
 #include "input/ActionIDs.h"
@@ -106,18 +113,41 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
 
   if (bSuccess)
   {
-    if (file.m_lStartOffset == STARTOFFSET_RESUME && file.HasGameInfoTag())
-    {
-      std::string redactedSavestatePath = CURL::GetRedacted(file.GetGameInfoTag()->GetSavestate());
-      CLog::Log(LOGDEBUG, "RetroPlayer: Loading savestate %s", redactedSavestatePath.c_str());
+    std::string savestatePath = CSavestateUtils::MakeMetadataPath(file.GetPath());
 
-      if (!SetPlayerState(file.GetGameInfoTag()->GetSavestate()))
-        CLog::Log(LOGERROR, "RetroPlayer: Failed to load savestate");
+    CSavestate save;
+    if (save.Deserialize(savestatePath))
+    {
+      // Check if game client is the same
+      if (save.GameClient() != m_gameClient->ID())
+      {
+        ADDON::AddonPtr addon;
+        if (ADDON::CAddonMgr::GetInstance().GetAddon(save.GameClient(), addon))
+        {
+          // Warn the user that continuing with a different game client will
+          // overwrite the save
+          bool dummy;
+          if (!CGUIDialogYesNo::ShowAndGetInput(438, StringUtils::Format(g_localizeStrings.Get(35217), addon->Name()), dummy, 222, 35218, 0))
+            bSuccess = false;
+        }
+      }
     }
 
-    SetSpeed(1);
+    if (bSuccess)
+    {
+      std::string redactedSavestatePath = CURL::GetRedacted(savestatePath);
+      CLog::Log(LOGDEBUG, "RetroPlayer: Loading savestate %s", redactedSavestatePath.c_str());
 
+      if (!SetPlayerState(savestatePath))
+        CLog::Log(LOGERROR, "RetroPlayer: Failed to load savestate");
+    }
+  }
+
+  if (bSuccess)
+  {
+    SetSpeed(1);
     m_callback.OnPlayBackStarted();
+    m_autoSave.reset(new CRetroPlayerAutoSave(this));
   }
   else
   {
@@ -132,6 +162,9 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
 bool CRetroPlayer::CloseFile(bool reopen /* = false */)
 {
   CLog::Log(LOGDEBUG, "RetroPlayer: Closing file");
+
+  m_autoSave.reset();
+  GetPlayerState();
 
   CSingleLock lock(m_mutex);
 
@@ -363,9 +396,18 @@ bool CRetroPlayer::OnAction(const CAction &action)
 
 std::string CRetroPlayer::GetPlayerState()
 {
-  if (m_gameClient)
-    return m_gameClient->GetPlayback()->CreateManualSavestate();
-  return "";
+  std::string savestatePath;
+
+  if (m_gameClient && m_autoSave)
+  {
+    savestatePath = m_gameClient->GetPlayback()->CreateSavestate();
+    if (savestatePath.empty())
+    {
+      CLog::Log(LOGDEBUG, "Continuing without saving");
+      m_autoSave.reset();
+    }
+  }
+  return savestatePath;
 }
 
 bool CRetroPlayer::SetPlayerState(const std::string& state)
@@ -461,7 +503,6 @@ void CRetroPlayer::PrintGameInfo(const CFileItem &file) const
     CLog::Log(LOGDEBUG, "RetroPlayer: Publisher: %s", tag->GetPublisher().c_str());
     CLog::Log(LOGDEBUG, "RetroPlayer: Format: %s", tag->GetFormat().c_str());
     CLog::Log(LOGDEBUG, "RetroPlayer: Cartridge type: %s", tag->GetCartridgeType().c_str());
-    CLog::Log(LOGDEBUG, "RetroPlayer: Save state: %s", tag->GetSavestate().c_str());
     CLog::Log(LOGDEBUG, "RetroPlayer: Game client: %s", tag->GetGameClient().c_str());
     CLog::Log(LOGDEBUG, "RetroPlayer: ---------------------------------------");
   }

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -35,6 +35,7 @@ namespace KODI
 namespace RETRO
 {
   class CRetroPlayerAudio;
+  class CRetroPlayerAutoSave;
   class CRetroPlayerVideo;
 
   class CRetroPlayer : public IPlayer,
@@ -171,6 +172,7 @@ namespace RETRO
     std::unique_ptr<CProcessInfo>      m_processInfo;
     std::unique_ptr<CRetroPlayerAudio> m_audio;
     std::unique_ptr<CRetroPlayerVideo> m_video;
+    std::unique_ptr<CRetroPlayerAutoSave> m_autoSave;
     GAME::GameClientPtr                m_gameClient;
     CCriticalSection                   m_mutex;
   };

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RetroPlayerAutoSave.h"
+#include "cores/IPlayer.h"
+#include "utils/log.h"
+#include "URL.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+#define AUTOSAVE_DURATION_SECS    10 // Auto-save every 10 seconds
+
+CRetroPlayerAutoSave::CRetroPlayerAutoSave(IPlayer *player) :
+  CThread("CRetroPlayerAutoSave"),
+  m_player(player)
+{
+  if (m_player != nullptr)
+    Create(false);
+}
+
+CRetroPlayerAutoSave::~CRetroPlayerAutoSave() = default;
+
+void CRetroPlayerAutoSave::Process()
+{
+  while (!m_bStop)
+  {
+    Sleep(AUTOSAVE_DURATION_SECS * 1000);
+
+    if (m_bStop)
+      break;
+
+    if (m_player->GetSpeed() > 0.0f)
+    {
+      std::string savePath = m_player->GetPlayerState();
+      if (!savePath.empty())
+        CLog::Log(LOGDEBUG, "Saved state to %s", CURL::GetRedacted(savePath).c_str());
+    }
+  }
+}

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2017 Team Kodi
+ *      Copyright (C) 2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -17,23 +17,30 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
-#include "SavestateUtils.h"
-#include "Savestate.h"
-#include "utils/URIUtils.h"
+#include "threads/Thread.h"
 
-#define SAVESTATE_EXTENSION      ".sav"
-#define METADATA_EXTENSION       ".xml"
+class IPlayer;
 
-using namespace KODI;
-using namespace GAME;
-
-std::string CSavestateUtils::MakePath(const CSavestate& save)
+namespace KODI
 {
-  return URIUtils::ReplaceExtension(save.GamePath(), SAVESTATE_EXTENSION);
+namespace RETRO
+{
+  class CRetroPlayerAutoSave : protected CThread
+  {
+  public:
+    CRetroPlayerAutoSave(IPlayer *player);
+
+    ~CRetroPlayerAutoSave() override;
+
+  protected:
+    // implementation of CThread
+    virtual void Process() override;
+
+  private:
+    // Construction parameter
+    IPlayer *const m_player;
+  };
 }
-
-std::string CSavestateUtils::MakeMetadataPath(const std::string &gamePath)
-{
-  return URIUtils::ReplaceExtension(gamePath, METADATA_EXTENSION);
 }

--- a/xbmc/games/addons/playback/GameClientRealtimePlayback.h
+++ b/xbmc/games/addons/playback/GameClientRealtimePlayback.h
@@ -40,7 +40,7 @@ namespace GAME
     virtual void SeekTimeMs(unsigned int timeMs) override { }
     virtual double GetSpeed() const override { return 1.0; }
     virtual void SetSpeed(double speedFactor) override { }
-    virtual std::string CreateManualSavestate() override { return ""; }
+    virtual std::string CreateSavestate() override { return ""; }
     virtual bool LoadSavestate(const std::string& path) override { return false; }
   };
 }

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
@@ -112,7 +112,7 @@ void CGameClientReversiblePlayback::SetSpeed(double speedFactor)
     m_gameLoop.SetSpeed(speedFactor * REWIND_FACTOR);
 }
 
-std::string CGameClientReversiblePlayback::CreateManualSavestate()
+std::string CGameClientReversiblePlayback::CreateSavestate()
 {
   std::string empty;
 

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.h
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.h
@@ -56,7 +56,7 @@ namespace GAME
     virtual void SeekTimeMs(unsigned int timeMs) override;
     virtual double GetSpeed() const override;
     virtual void SetSpeed(double speedFactor) override;
-    virtual std::string CreateManualSavestate() override;
+    virtual std::string CreateSavestate() override;
     virtual bool LoadSavestate(const std::string& path) override;
 
     // implementation of IGameLoopCallback

--- a/xbmc/games/addons/playback/IGameClientPlayback.h
+++ b/xbmc/games/addons/playback/IGameClientPlayback.h
@@ -45,7 +45,7 @@ namespace GAME
     virtual void SetSpeed(double speedFactor) = 0;
 
     // Savestates
-    virtual std::string CreateManualSavestate() = 0; // Returns the path of savestate on success
+    virtual std::string CreateSavestate() = 0; // Returns the path of savestate on success
     virtual bool LoadSavestate(const std::string& path) = 0;
   };
 }

--- a/xbmc/games/addons/savestates/SavestateDatabase.cpp
+++ b/xbmc/games/addons/savestates/SavestateDatabase.cpp
@@ -23,34 +23,25 @@
 #include "SavestateDefines.h"
 #include "SavestateUtils.h"
 #include "addons/AddonManager.h"
-#include "dbwrappers/dataset.h"
-#include "filesystem/File.h"
 #include "games/GameTypes.h"
 #include "games/tags/GameInfoTag.h"
-#include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "FileItem.h"
 
-#include "utils/log.h"
-
 using namespace KODI;
 using namespace GAME;
-
-#define SAVESTATE_OBJECT  "savestate"
 
 CSavestateDatabase::CSavestateDatabase() = default;
 
 bool CSavestateDatabase::AddSavestate(const CSavestate& save)
 {
-  //! @todo
-  return false;
+  return save.Serialize(CSavestateUtils::MakeMetadataPath(save.GamePath()));
 }
 
 bool CSavestateDatabase::GetSavestate(const std::string& path, CSavestate& save)
 {
-  //! @todo
-  return false;
+  return save.Deserialize(path);
 }
 
 bool CSavestateDatabase::GetSavestatesNav(CFileItemList& items, const std::string& gamePath, const std::string& gameClient /* = "" */)

--- a/xbmc/games/addons/savestates/SavestateUtils.h
+++ b/xbmc/games/addons/savestates/SavestateUtils.h
@@ -33,26 +33,17 @@ namespace GAME
     /*!
      * \brief Calculate a path for the specified savestate
      *
-     * Path to savestate is derived from game client and game CRC. Returns empty
-     * if either of these is unknown. Format is
-     *
-     * Autosave (hex is game CRC):
-     *     special://savegames/gameclient.id/feba62c2.sav
-     *
-     * Save type slot (digit after the underscore is slot 1-9):
-     *     special://savegames/gameclient.id/feba62c2_1.sav
-     *
-     * Save type label (hex after the underscore is CRC of the label):
-     *     special://savegames/gameclient.id/feba62c2_8dc22669.sav
+     * The savestate path is the game path with the extension replaced by ".sav".
      */
     static std::string MakePath(const CSavestate& save);
 
     /*!
-     * \brief Calculate the thumbnail path for the specified savestate
+     * \brief Calculate a metadata path for the specified savestate
      *
-     * This is the savestate path with a different extension
+     * The savestate metadata path is the game path with the extension replaced
+     * by ".xml".
      */
-    static std::string MakeThumbPath(const std::string& savePath);
+    static std::string MakeMetadataPath(const std::string &gamePath);
   };
 }
 }

--- a/xbmc/games/tags/GameInfoTag.cpp
+++ b/xbmc/games/tags/GameInfoTag.cpp
@@ -42,7 +42,6 @@ void CGameInfoTag::Reset()
   m_strPublisher.clear();
   m_strFormat.clear();
   m_strCartridgeType.clear();
-  m_strSavestate.clear();
   m_strGameClient.clear();
 }
 
@@ -63,7 +62,6 @@ CGameInfoTag& CGameInfoTag::operator=(const CGameInfoTag& tag)
     m_strPublisher     = tag.m_strPublisher;
     m_strFormat        = tag.m_strFormat;
     m_strCartridgeType = tag.m_strCartridgeType;
-    m_strSavestate     = tag.m_strSavestate;
     m_strGameClient    = tag.m_strGameClient;
   }
   return *this;
@@ -90,7 +88,6 @@ bool CGameInfoTag::operator==(const CGameInfoTag& tag) const
       if (m_strPublisher     != tag.m_strPublisher)     return false;
       if (m_strFormat        != tag.m_strFormat)        return false;
       if (m_strCartridgeType != tag.m_strCartridgeType) return false;
-      if (m_strSavestate     != tag.m_strSavestate)     return false;
       if (m_strGameClient    != tag.m_strGameClient)    return false;
     }
   }
@@ -114,7 +111,6 @@ void CGameInfoTag::Archive(CArchive& ar)
     ar << m_strPublisher;
     ar << m_strFormat;
     ar << m_strCartridgeType;
-    ar << m_strSavestate;
     ar << m_strGameClient;
   }
   else
@@ -132,7 +128,6 @@ void CGameInfoTag::Archive(CArchive& ar)
     ar >> m_strPublisher;
     ar >> m_strFormat;
     ar >> m_strCartridgeType;
-    ar >> m_strSavestate;
     ar >> m_strGameClient;
   }
 }
@@ -152,7 +147,6 @@ void CGameInfoTag::Serialize(CVariant& value) const
   value["publisher"]     = m_strPublisher;
   value["format"]        = m_strFormat;
   value["cartridgetype"] = m_strCartridgeType;
-  value["savestate"]     = m_strSavestate;
   value["gameclient"]    = m_strGameClient;
 }
 

--- a/xbmc/games/tags/GameInfoTag.h
+++ b/xbmc/games/tags/GameInfoTag.h
@@ -94,10 +94,6 @@ namespace GAME
     const std::string& GetCartridgeType() const { return m_strCartridgeType; }
     void SetCartridgeType(const std::string& strCartridgeType) { m_strCartridgeType = strCartridgeType; }
 
-    // Savestate path
-    const std::string& GetSavestate() const { return m_strSavestate; }
-    void SetSavestate(const std::string& strSavestate) { m_strSavestate = strSavestate; }
-
     // Game client add-on ID
     const std::string& GetGameClient() const { return m_strGameClient; }
     void SetGameClient(const std::string& strGameClient) { m_strGameClient = strGameClient; }
@@ -120,7 +116,6 @@ namespace GAME
     std::string m_strPublisher;
     std::string m_strFormat;
     std::string m_strCartridgeType;
-    std::string m_strSavestate;
     std::string m_strGameClient;
   };
 }


### PR DESCRIPTION
This implements a rudimentary autosave/autoload feature. Basically, when you close the game it's saved, and when you open the game the savestate is restored.

The savestate and metadata is stored alongside the ROM:

```
Chrono Trigger (U) [!].smc   (the ROM)
Chrono Trigger (U) [!].sav   (the state)
Chrono Trigger (U) [!].xml   (the metadata)
```

To guard against power loss, the game is autosaved every 10 seconds.

## Screenshots (if appropriate):

If a different game client is used, Kodi will warn the user that it will overwrite their existing save. This is because savestates are incompatible between emulators, and storing more than a single savestate isn't implemented yet:

<img width="1259" alt="screen shot 2017-07-10 at 12 57 00 pm" src="https://user-images.githubusercontent.com/531482/28037179-6b9670d4-656f-11e7-88f3-902b4d32cb74.png">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
