### PR TITLE
[addons] add callback to remove slash at end of path

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -906,6 +906,37 @@ namespace vfs
   }
   //----------------------------------------------------------------------------
 
+
+  //============================================================================
+  ///
+  /// @ingroup cpp_kodi_vfs
+  /// @brief Remove the slash on given path name
+  ///
+  /// @param[in,out] path The complete path
+  ///
+  ///
+  /// ------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// #include <kodi/Filesystem.h>
+  /// ...
+  /// std::string dirName = "special://temp/";
+  /// kodi::vfs::RemoveSlashAtEnd(dirName);
+  /// fprintf(stderr, "Directory name is '%s'\n", dirName.c_str());
+  /// ~~~~~~~~~~~~~
+  ///
+  inline void RemoveSlashAtEnd(std::string& path)
+  {
+    if (!path.empty())
+    {
+      char last = path[path.size() - 1];
+      if (last == '/' || last == '\\')
+        path.erase(path.size() - 1);
+    }
+  }
+  //----------------------------------------------------------------------------
+
   //============================================================================
   ///
   /// @ingroup cpp_kodi_vfs


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This add a addon callback to remove a slash on path end if present. Is small but seen on several addons the need of them and thought to add in headers.

This change does not touch Kodi itself and not need changes on addon.

But that also brings a question from me. Can we add a git label with e.g. "Not down-compatible" for cases where a addon need update or recompile?


<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
