### PR TITLE
Fix broken virtual keyboard when using a controller

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -296,7 +296,8 @@
   </VideoPlaylist>
   <VirtualKeyboard>
     <joystick profile="game.controller.default">
-      <a>Shift</a>
+      <a>Select</a>
+      <a holdtime="500">Shift</a>
       <b>BackSpace</b>
       <y>Symbols</y>
       <leftbumper>Shift</leftbumper>


### PR DESCRIPTION
By setting "a" to the Shift action, the correct Select actions were being blocked, making the virtual keyboard unusable.