### PR TITLE
[Krypton] FTPParse.cpp: use std::string

### DIFF
--- a/xbmc/filesystem/FTPParse.cpp
+++ b/xbmc/filesystem/FTPParse.cpp
@@ -34,7 +34,7 @@ CFTPParse::CFTPParse()
   m_time = 0;
 }
 
-string CFTPParse::getName()
+std::string CFTPParse::getName()
 {
   return m_name;
 }
@@ -59,16 +59,16 @@ time_t CFTPParse::getTime()
   return m_time;
 }
 
-void CFTPParse::setTime(string str)
+void CFTPParse::setTime(std::string str)
 {
   /* Variables used to capture patterns via the regexes */
-  string month;
-  string day;
-  string year;
-  string hour;
-  string minute;
-  string second;
-  string am_or_pm;
+  std::string month;
+  std::string day;
+  std::string year;
+  std::string hour;
+  std::string minute;
+  std::string second;
+  std::string am_or_pm;
 
   /* time struct used to set the time_t variable */
   struct tm time_struct = {};
@@ -338,21 +338,21 @@ int CFTPParse::getDayOfWeek(int month, int date, int year)
   return day_of_week;
 }
 
-int CFTPParse::FTPParse(string str)
+int CFTPParse::FTPParse(std::string str)
 {
   /* Various variable to capture patterns via the regexes */
-  string permissions;
-  string link_count;
-  string owner;
-  string group;
-  string size;
-  string date;
-  string name;
-  string type;
-  string stuff;
-  string facts;
-  string version;
-  string file_id;
+  std::string permissions;
+  std::string link_count;
+  std::string owner;
+  std::string group;
+  std::string size;
+  std::string date;
+  std::string name;
+  std::string type;
+  std::string stuff;
+  std::string facts;
+  std::string version;
+  std::string file_id;
 
   /* Regex for standard Unix listing formats */
   pcrecpp::RE unix_re("^([-bcdlps])" // type


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Simple rebase of #12067 on the Krypton branch. It would be really nice to have this build failure fixed on the current release branch.
 
## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
