### PR TITLE
revert explicitly defaulted constructor

### DIFF
--- a/xbmc/linux/DBusUtil.h
+++ b/xbmc/linux/DBusUtil.h
@@ -62,7 +62,7 @@ private:
 
   struct DBusConnectionDeleter
   {
-    DBusConnectionDeleter() = default;
+    DBusConnectionDeleter() {};
     bool closeBeforeUnref = false;
     void operator()(DBusConnection* connection) const;
   };


### PR DESCRIPTION
Causes compilation error on newer compilers for some reason. Revering this temporarily so people can compile. See on-going discussion in #12371