### PR TITLE
Current clock

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -85,13 +85,13 @@ public:
   // meat and potatoes
   bool                WaitForFrame(int millis);
   // MediaCodec related
-  void                ReleaseOutputBuffer(bool render);
+  void                ReleaseOutputBuffer(bool render, int64_t displayTime);
   // SurfaceTexture released
   int                 GetBufferId() const;
   int                 GetTextureId() const;
   void                GetTransformMatrix(float *textureMatrix);
   void                UpdateTexImage();
-  void                RenderUpdate(const CRect &DestRect);
+  void                RenderUpdate(const CRect &DestRect, int64_t displayTime);
   bool                HasSurfaceTexture() const { return m_surfacetexture.operator bool(); };
 
 private:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -66,7 +66,7 @@ public:
   // Player functions
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) = 0;
   virtual bool IsConfigured() = 0;
-  virtual void AddVideoPicture(const VideoPicture &picture, int index) = 0;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) = 0;
   virtual bool IsPictureHW(const VideoPicture &picture) { return false; };
   virtual void FlipPage(int source) = 0;
   virtual void UnInit() = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -840,7 +840,7 @@ void CMMALRenderer::UpdateFramerateStats(double pts)
     CLog::Log(LOGDEBUG, "%s::%s pts:%.3f diff:%.3f m_frameInterval:%.6f m_frameIntervalDiff:%.6f", CLASSNAME, __func__, pts*1e-6, diff * 1e-6 , m_frameInterval * 1e-6, m_frameIntervalDiff *1e-6);
 }
 
-void CMMALRenderer::AddVideoPicture(const VideoPicture& pic, int id)
+void CMMALRenderer::AddVideoPicture(const VideoPicture& pic, int id, double currentClock)
 {
   CMMALBuffer *buffer = dynamic_cast<CMMALBuffer*>(pic.videoBuffer);
   assert(buffer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -156,7 +156,7 @@ public:
   virtual void         Reset() override; /* resets renderer after seek for example */
   virtual void         Flush() override;
   virtual bool         IsConfigured() override { return m_bConfigured; }
-  virtual void         AddVideoPicture(const VideoPicture& pic, int index) override;
+  virtual void         AddVideoPicture(const VideoPicture& pic, int index, double currentClock) override;
   virtual bool         IsPictureHW(const VideoPicture &picture) override { return false; };
   virtual CRenderInfo GetRenderInfo() override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -94,7 +94,7 @@ bool CRendererAML::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
-void CRendererAML::AddVideoPicture(const VideoPicture &picture, int index)
+void CRendererAML::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   ReleaseBuffer(index);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -37,7 +37,7 @@ public:
   static bool Register();
 
   virtual bool RenderCapture(CRenderCapture* capture) override;
-  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
   virtual void ReleaseBuffer(int idx) override;
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) override;
   virtual bool IsConfigured() override { return m_bConfigured; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererIMX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererIMX.cpp
@@ -51,7 +51,7 @@ bool CRendererIMX::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
-void CRendererIMX::AddVideoPictureHW(DVDVideoPicture &picture, int index)
+void CRendererIMX::AddVideoPictureHW(DVDVideoPicture &picture, int index, double currentClock)
 {
   YUVBUFFER &buf = m_buffers[index];
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererIMX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererIMX.h
@@ -37,7 +37,7 @@ public:
   virtual bool RenderCapture(CRenderCapture* capture) override;
 
   // Player functions
-  virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index);
+  virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index, double currentClock);
   virtual void ReleaseBuffer(int idx);
   virtual bool IsGuiLayer();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -69,7 +69,7 @@ bool CRendererMediaCodec::Register()
   return true;
 }
 
-void CRendererMediaCodec::AddVideoPicture(const VideoPicture &picture, int index)
+void CRendererMediaCodec::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   YUVBUFFER &buf = m_buffers[index];
   CMediaCodecVideoBuffer *videoBuffer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -83,7 +83,7 @@ void CRendererMediaCodec::AddVideoPicture(const VideoPicture &picture, int index
     // releaseOutputBuffer must be in same thread as
     // dequeueOutputBuffer. We are in VideoPlayerVideo
     // thread here, so we are safe.
-    videoBuffer->ReleaseOutputBuffer(true);
+    videoBuffer->ReleaseOutputBuffer(true, 0);
   }
   else
    buf.fields[0][0].id = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h
@@ -37,7 +37,7 @@ public:
   static bool Register();
 
   // Player functions
-  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
   virtual void ReleaseBuffer(int idx) override;
 
   // Feature support

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -95,7 +95,7 @@ bool CRendererMediaCodecSurface::RenderCapture(CRenderCapture* capture)
   return true;
 }
 
-void CRendererMediaCodecSurface::AddVideoPicture(const VideoPicture &picture, int index)
+void CRendererMediaCodecSurface::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   ReleaseBuffer(index);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -38,7 +38,7 @@ public:
   static bool Register();
 
   virtual bool RenderCapture(CRenderCapture* capture) override;
-  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
   virtual void ReleaseBuffer(int idx) override;
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) override;
   virtual bool IsConfigured() override { return m_bConfigured; };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -24,7 +24,6 @@
 
 #include "system.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
-#include <chrono>
 
 class CMediaCodecVideoBuffer;
 
@@ -62,20 +61,7 @@ protected:
   virtual void ReorderDrawPoints() override;
 
 private:
-
-  int m_iRenderBuffer;
-  static const int m_numRenderBuffers = 4;
-
-  struct BUFFER
-  {
-    BUFFER() : videoBuffer(nullptr) {};
-    CMediaCodecVideoBuffer *videoBuffer;
-    int duration;
-  } m_buffers[m_numRenderBuffers];
-
-  std::chrono::time_point<std::chrono::system_clock> m_prevTime;
   bool m_bConfigured;
-  unsigned int m_updateCount;
   CRect m_surfDestRect;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -62,7 +62,7 @@ bool CRendererVAAPI::ConfigChanged(void *hwPic)
   return false;
 }
 
-void CRendererVAAPI::AddVideoPictureHW(VideoPicture &picture, int index)
+void CRendererVAAPI::AddVideoPictureHW(VideoPicture &picture, int index, double currentClock)
 {
   VAAPI::CVaapiRenderPicture *vaapi = static_cast<VAAPI::CVaapiRenderPicture*>(picture.hwPic);
   YUVBUFFER &buf = m_buffers[index];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -34,7 +34,7 @@ public:
   //                       float fps, unsigned flags, ERenderFormat format, void *hwPic, unsigned int orientation) override;
 
   // Player functions
-  //virtual void AddVideoPictureHW(VideoPicture &picture, int index) override;
+  //virtual void AddVideoPictureHW(VideoPicture &picture, int index, double currentClock) override;
   virtual void ReleaseBuffer(int idx) override;
   virtual CRenderInfo GetRenderInfo() override;
   //virtual bool ConfigChanged(void *hwPic) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -316,7 +316,7 @@ int CLinuxRendererGL::NextYV12Texture()
   return (m_iYV12RenderBuffer + 1) % m_NumYV12Buffers;
 }
 
-void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index)
+void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   YUVBUFFER &buf = m_buffers[index];
   buf.videoBuffer = picture.videoBuffer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -107,7 +107,7 @@ public:
   // Player functions
   bool Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) override;
   bool IsConfigured() override { return m_bConfigured; }
-  void AddVideoPicture(const VideoPicture &picture, int index) override;
+  void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
   void FlipPage(int source) override;
   void UnInit() override;
   void Reset() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -197,7 +197,7 @@ int CLinuxRendererGLES::NextYV12Texture()
   return (m_iYV12RenderBuffer + 1) % m_NumYV12Buffers;
 }
 
-void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index)
+void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   YUVBUFFER &buf = m_buffers[index];
   buf.videoBuffer = picture.videoBuffer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -113,7 +113,7 @@ public:
   // Player functions
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) override;
   virtual bool IsConfigured() override { return m_bConfigured; }
-  virtual void AddVideoPicture(const VideoPicture &picture, int index) override;
+  virtual void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
   virtual void FlipPage(int source) override;
   virtual void UnInit() override;
   virtual void Reset() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1004,7 +1004,7 @@ int CRenderManager::AddVideoPicture(const VideoPicture& pic)
   if (!m_pRenderer)
     return -1;
 
-  m_pRenderer->AddVideoPicture(pic, index);
+  m_pRenderer->AddVideoPicture(pic, index, m_dvdClock.GetClock());
 
   return index;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -236,7 +236,7 @@ int CWinRenderer::NextYV12Texture()
     return -1;
 }
 
-void CWinRenderer::AddVideoPicture(const VideoPicture &picture, int index)
+void CWinRenderer::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
   if (m_renderMethod == RENDER_DXVA)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -164,7 +164,7 @@ public:
 
   // Player functions
   bool Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) override;
-  void AddVideoPicture(const VideoPicture &picture, int index) override;
+  void AddVideoPicture(const VideoPicture &picture, int index, double currentClock) override;
   void FlipPage(int source) override;
   void UnInit() override;
   void Reset() override; /* resets renderer after seek for example */


### PR DESCRIPTION
## Description
Android MediaCodecSurface supports Releasing output pictures at a specified time.
Using this function SurfaceFlinger / HWComposer vsync is now under control of Android and leads to better vsync and a/v sync. 25fps on 50hz now play fine.

## Motivation and Context
Remove stutter / smooth playback.

## How Has This Been Tested?
Nvidia shield 2017 / Android 7.01.

## Types of change
- [X] Improvement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
