### PR TITLE
Remove casts not required anymore

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2546,7 +2546,7 @@ void CVideoPlayer::HandleMessages()
       if (msg.GetRelative())
         time = (m_clock.GetClock() + m_State.time_offset) / 1000l + time;
 
-      time = msg.GetRestore() ? static_cast<double>(m_Edl.RestoreCutTime(static_cast<int>(time))) : time;
+      time = msg.GetRestore() ? m_Edl.RestoreCutTime(time) : time;
 
       // if input stream doesn't support ISeekTime, convert back to pts
       //! @todo


### PR DESCRIPTION
Followup to https://github.com/xbmc/xbmc/pull/12442

As I tested the change on Kodi v17, I missed these casts introduced in v18. The casts should not be required any more as RestoreCutTime now works with double.