### PR TITLE
Restore = default constructor for DBusConnectionDeleter

### DIFF
--- a/xbmc/linux/DBusUtil.cpp
+++ b/xbmc/linux/DBusUtil.cpp
@@ -222,6 +222,8 @@ CDBusConnection::operator DBusConnection*()
   return m_connection.get();
 }
 
+CDBusConnection::DBusConnectionDeleter::DBusConnectionDeleter() = default;
+
 void CDBusConnection::DBusConnectionDeleter::operator()(DBusConnection* connection) const
 {
   if (closeBeforeUnref)

--- a/xbmc/linux/DBusUtil.h
+++ b/xbmc/linux/DBusUtil.h
@@ -62,7 +62,7 @@ private:
 
   struct DBusConnectionDeleter
   {
-    DBusConnectionDeleter() {};
+    DBusConnectionDeleter();
     bool closeBeforeUnref = false;
     void operator()(DBusConnection* connection) const;
   };


### PR DESCRIPTION
Proper fix that replaces #12448 

@tamland @candrews please test

## Description
The "= default" was previously removed because it did not work when
in the header file with newer gcc and clang. But it seems to be ok in
the implementation file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
