### PR TITLE
Fix missing member initialization

### DIFF
--- a/xbmc/interfaces/info/InfoBool.cpp
+++ b/xbmc/interfaces/info/InfoBool.cpp
@@ -28,7 +28,7 @@ namespace INFO
       m_context(context),
       m_listItemDependent(false),
       m_expression(expression),
-      m_refeshCounter(0),
+      m_refreshCounter(0),
       m_parentRefreshCounter(refreshCounter)
   {
     StringUtils::ToLower(m_expression);

--- a/xbmc/interfaces/info/InfoBool.cpp
+++ b/xbmc/interfaces/info/InfoBool.cpp
@@ -28,6 +28,7 @@ namespace INFO
       m_context(context),
       m_listItemDependent(false),
       m_expression(expression),
+      m_refeshCounter(0),
       m_parentRefreshCounter(refreshCounter)
   {
     StringUtils::ToLower(m_expression);

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -47,10 +47,10 @@ public:
   {
     if (item && m_listItemDependent)
       Update(item);
-    else if (m_refeshCounter != m_parentRefreshCounter)
+    else if (m_refreshCounter != m_parentRefreshCounter)
     {
       Update(NULL);
-      m_refeshCounter = m_parentRefreshCounter;
+      m_refreshCounter = m_parentRefreshCounter;
     }
     return m_value;
   }
@@ -86,7 +86,7 @@ protected:
   std::string  m_expression;   ///< original expression
 
 private:
-  unsigned int m_refeshCounter;
+  unsigned int m_refreshCounter;
   unsigned int &m_parentRefreshCounter;
 };
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -891,7 +891,7 @@ void MUSIC_INFO::CMusicInfoScanner::ScrapeInfoAddedAlbums()
     return;
 
   std::set<int> artists;
-  for (auto i = 0; i < m_albumsAdded.size(); ++i)
+  for (auto i = 0u; i < m_albumsAdded.size(); ++i)
   {
     if (m_bStop)
       break;


### PR DESCRIPTION
Ran into this while trying to use valgrind for something useful. tons of things like

 ==7579== Conditional jump or move depends on uninitialised value(s)
==7579==    at 0x198DA74: INFO::InfoBool::Get(CGUIListItem const*) (InfoBool.h:50)

also fixes a variable name and a rather amusing use of auto.