### PR TITLE
[video] Readd mark watched / unwatched to video folder's context menu

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -54,10 +54,12 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
   if (item.IsDeleted()) // e.g. trashed pvr recording
     return false;
 
-  if (item.m_bIsFolder) //Only allow db content and recording folders to be updated recursively
+  if (item.m_bIsFolder) // Only allow video db content, video and recording folders to be updated recursively
   {
     if (item.HasVideoInfoTag())
       return item.IsVideoDb();
+    else if (item.GetProperty("IsVideoFolder").asBoolean())
+      return true;
     else
       return CUtil::IsTVRecording(item.GetPath());
   }
@@ -78,10 +80,12 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
   if (item.IsDeleted()) // e.g. trashed pvr recording
     return false;
 
-  if (item.m_bIsFolder) //Only allow db content and recording folders to be updated recursively
+  if (item.m_bIsFolder) // Only allow video db content, video and recording folders to be updated recursively
   {
     if (item.HasVideoInfoTag())
       return item.IsVideoDb();
+    else if (item.GetProperty("IsVideoFolder").asBoolean())
+      return true;
     else
       return CUtil::IsTVRecording(item.GetPath());
   }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -606,6 +606,13 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
   {
     CFileItemPtr pItem = items[i];
     CFileItemPtr match;
+
+    if (!content.empty() && pItem->m_bIsFolder && !pItem->IsParentFolder())
+    {
+      // we need this for enabling the right context menu entries, like mark watched / unwatched
+      pItem->SetProperty("IsVideoFolder", true);
+    }
+
     if (!content.empty()) /* optical media will be stacked down, so it's path won't match the base path */
     {
       std::string pathToMatch = pItem->IsOpticalMediaFile() ? pItem->GetLocalMetadataPath() : pItem->GetPath();


### PR DESCRIPTION
This is my desperate ( ;-) ) attempt to fix the problem reported here: https://forum.kodi.tv/showthread.php?tid=311447&page=2

It works, but I'm not sure whether the approach to use an item property to transport the type of the folder is okay. Feedback from devs is welcome.

This has been tested on latest master on macOS.

@notspiff fyi