### PR TITLE
InputstreamAddon::OpenStream / AddonVideoCodec::VideoBuffers cleanup

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -173,6 +173,7 @@ extern "C" {
     struct INPUTSTREAM_IDS (__cdecl* get_stream_ids)(const AddonInstance_InputStream* instance);
     struct INPUTSTREAM_INFO (__cdecl* get_stream)(const AddonInstance_InputStream* instance, int streamid);
     void (__cdecl* enable_stream)(const AddonInstance_InputStream* instance, int streamid, bool enable);
+    void(__cdecl* open_stream)(const AddonInstance_InputStream* instance, int streamid);
     void (__cdecl* demux_reset)(const AddonInstance_InputStream* instance);
     void (__cdecl* demux_abort)(const AddonInstance_InputStream* instance);
     void (__cdecl* demux_flush)(const AddonInstance_InputStream* instance);
@@ -271,6 +272,13 @@ namespace addon
      * @remarks
      */
     virtual void EnableStream(int streamid, bool enable) = 0;
+
+    /*!
+    * Opens a stream for playback.
+    * @param streamid unique id of stream
+    * @remarks
+    */
+    virtual void OpenStream(int streamid) = 0;
 
     /*!
      * Reset the demultiplexer in the add-on.
@@ -448,6 +456,7 @@ namespace addon
       m_instanceData->toAddon.get_stream_ids = ADDON_GetStreamIds;
       m_instanceData->toAddon.get_stream = ADDON_GetStream;
       m_instanceData->toAddon.enable_stream = ADDON_EnableStream;
+      m_instanceData->toAddon.open_stream = ADDON_OpenStream;
       m_instanceData->toAddon.demux_reset = ADDON_DemuxReset;
       m_instanceData->toAddon.demux_abort = ADDON_DemuxAbort;
       m_instanceData->toAddon.demux_flush = ADDON_DemuxFlush;
@@ -502,6 +511,11 @@ namespace addon
     inline static void ADDON_EnableStream(const AddonInstance_InputStream* instance, int streamid, bool enable)
     {
       instance->toAddon.addonInstance->EnableStream(streamid, enable);
+    }
+
+    inline static void ADDON_OpenStream(const AddonInstance_InputStream* instance, int streamid)
+    {
+      instance->toAddon.addonInstance->OpenStream(streamid);
     }
 
     inline static void ADDON_DemuxReset(const AddonInstance_InputStream* instance)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -91,6 +91,8 @@ extern "C"
     uint32_t stride[VideoPlane::MaxPlanes];
 
     int64_t pts;
+
+    void *buffer; //< will be passed in release_frame_buffer
   };
 
   enum VIDEOCODEC_RETVAL
@@ -137,6 +139,7 @@ extern "C"
   {
     KODI_HANDLE kodiInstance;
     bool(*get_frame_buffer)(void* kodiInstance, VIDEOCODEC_PICTURE *picture);
+    void(*release_frame_buffer)(void* kodiInstance, void *buffer);
   } AddonToKodiFuncTable_VideoCodec;
 
   typedef struct AddonInstance_VideoCodec
@@ -192,6 +195,12 @@ namespace kodi
       bool GetFrameBuffer(VIDEOCODEC_PICTURE &picture)
       {
         return m_instanceData->toKodi.get_frame_buffer(m_instanceData->toKodi.kodiInstance, &picture);
+      }
+
+      //! \copydoc CInstanceVideoCodec::ReleaseFrameBuffer
+      void ReleaseFrameBuffer(void *buffer)
+      {
+        return m_instanceData->toKodi.release_frame_buffer(m_instanceData->toKodi.kodiInstance, buffer);
       }
 
     private:

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -102,8 +102,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.1"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.1"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.2"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.2"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 
@@ -136,8 +136,8 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_XML_ID   "kodi.binary.instance.visualization"
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "1.0.0"
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "1.0.0"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "1.0.1"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "1.0.1"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "addon-instance/VideoCodec.h" \
                                                       "StreamCodec.h" \

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
@@ -51,16 +51,14 @@ private:
    * In case buffer allocation fails, return false.
    */
   bool GetFrameBuffer(VIDEOCODEC_PICTURE &picture);
+  void ReleaseFrameBuffer(void *buffer);
 
   static bool get_frame_buffer(void* kodiInstance, VIDEOCODEC_PICTURE *picture);
+  static void release_frame_buffer(void* kodiInstance, void *buffer);
 
   AddonInstance_VideoCodec m_struct;
   int m_codecFlags;
   VIDEOCODEC_FORMAT m_formats[VIDEOCODEC_FORMAT::MaxVideoFormats + 1];
   float m_displayAspect;
   unsigned int m_width, m_height;
-
-  void * m_lastPictureBuffer;
-
-  std::map<void *,CVideoBuffer *> m_map;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -340,6 +340,11 @@ public:
   virtual void EnableStream(int64_t demuxerId, int id, bool enable) { EnableStream(id, enable); };
 
   /*
+  * opens a demux stream for playback
+  */
+  virtual void OpenStream(int64_t demuxerId, int id) { OpenStream(id); };
+
+  /*
    * sets desired width / height for video stream
    * adaptive demuxers like DASH can use this to choose best fitting video stream
    */
@@ -352,6 +357,7 @@ public:
 
 protected:
   virtual void EnableStream(int id, bool enable) {};
+  virtual void OpenStream(int id) {};
   virtual CDemuxStream* GetStream(int iStreamId) const = 0;
   virtual std::string GetStreamCodecName(int iStreamId) { return ""; };
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -340,7 +340,7 @@ public:
   virtual void EnableStream(int64_t demuxerId, int id, bool enable) { EnableStream(id, enable); };
 
   /*
-  * opens a demux stream for playback
+  * implicitly enable and open a demux stream for playback
   */
   virtual void OpenStream(int64_t demuxerId, int id) { OpenStream(id); };
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -346,219 +346,210 @@ std::vector<CDemuxStream*> CDVDDemuxClient::GetStreams() const
   std::vector<CDemuxStream*> streams;
 
   for (auto &st : m_streams)
-  {
-    // if video stream has no extradata, hide it from player
-    // but continue reading it for parsing
-    if (st.second->type == STREAM_VIDEO && !st.second->ExtraData)
-    {
-      if (m_IDemux)
-        m_IDemux->EnableStream(st.second->uniqueId, true);
-      continue;
-    }
-
     streams.push_back(st.second.get());
-  }
 
   return streams;
 }
 
 void CDVDDemuxClient::RequestStreams()
 {
-  std::map<int, std::shared_ptr<CDemuxStream>> m_newStreamMap;
-
+  std::map<int, std::shared_ptr<CDemuxStream>> newStreamMap;
   for (auto stream : m_IDemux->GetStreams())
+    RequestStream(stream, newStreamMap);
+  m_streams = newStreamMap;
+}
+
+void CDVDDemuxClient::RequestStream(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map)
+{
+  if (!stream)
   {
-    if (!stream)
+    CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid stream");
+    DisposeStreams();
+    return;
+  }
+
+  std::shared_ptr<CDemuxStream> dStream = GetStreamInternal(stream->uniqueId);
+
+  if (stream->type == STREAM_AUDIO)
+  {
+    CDemuxStreamAudio *source = dynamic_cast<CDemuxStreamAudio*>(stream);
+    if (!source)
     {
-      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStreams - invalid stream");
+      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid audio stream with id %d", stream->uniqueId);
       DisposeStreams();
       return;
     }
 
-    std::shared_ptr<CDemuxStream> dStream = GetStreamInternal(stream->uniqueId);
-
-    if (stream->type == STREAM_AUDIO)
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>> streamAudio;
+    if (dStream)
+      streamAudio = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>>(dStream);
+    if (!streamAudio || streamAudio->codec != source->codec)
     {
-      CDemuxStreamAudio *source = dynamic_cast<CDemuxStreamAudio*>(stream);
-      if (!source)
-      {
-        CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStreams - invalid audio stream with id %d", stream->uniqueId);
-        DisposeStreams();
-        return;
-      }
-
-      std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>> streamAudio;
-      if (dStream)
-        streamAudio = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>>(dStream);
-      if (!streamAudio || streamAudio->codec != source->codec)
-      {
-        streamAudio.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamAudio>());
-        streamAudio->m_parser = av_parser_init(source->codec);
-        if (streamAudio->m_parser)
-          streamAudio->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
-      }
-
-      streamAudio->iChannels       = source->iChannels;
-      streamAudio->iSampleRate     = source->iSampleRate;
-      streamAudio->iBlockAlign     = source->iBlockAlign;
-      streamAudio->iBitRate        = source->iBitRate;
-      streamAudio->iBitsPerSample  = source->iBitsPerSample;
-      if (source->ExtraSize > 0 && source->ExtraData)
-      {
-        delete[] streamAudio->ExtraData;
-        streamAudio->ExtraData = new uint8_t[source->ExtraSize];
-        streamAudio->ExtraSize = source->ExtraSize;
-        for (unsigned int j=0; j<source->ExtraSize; j++)
-          streamAudio->ExtraData[j] = source->ExtraData[j];
-      }
-      streamAudio->m_parser_split = true;
-      streamAudio->changes++;
-      m_newStreamMap[stream->uniqueId] = streamAudio;
-      dStream = streamAudio;
-    }
-    else if (stream->type == STREAM_VIDEO)
-    {
-      CDemuxStreamVideo *source = dynamic_cast<CDemuxStreamVideo*>(stream);
-
-      if (!source)
-      {
-        CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStreams - invalid video stream with id %d", stream->uniqueId);
-        DisposeStreams();
-        return;
-      }
-
-      std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>> streamVideo;
-      if (dStream)
-        streamVideo = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>>(dStream);
-      if (!streamVideo || streamVideo->codec != source->codec ||
-          streamVideo->iWidth != source->iWidth || streamVideo->iHeight != source->iHeight)
-      {
-        streamVideo.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamVideo>());
-        streamVideo->m_parser = av_parser_init(source->codec);
-        if (streamVideo->m_parser)
-          streamVideo->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
-      }
-
-      streamVideo->iFpsScale       = source->iFpsScale;
-      streamVideo->iFpsRate        = source->iFpsRate;
-      streamVideo->iHeight         = source->iHeight;
-      streamVideo->iWidth          = source->iWidth;
-      streamVideo->fAspect         = source->fAspect;
-      streamVideo->iBitRate = source->iBitRate;
-      streamVideo->stereo_mode     = "mono";
-      if (source->ExtraSize > 0 && source->ExtraData)
-      {
-        delete[] streamVideo->ExtraData;
-        streamVideo->ExtraData = new uint8_t[source->ExtraSize];
-        streamVideo->ExtraSize = source->ExtraSize;
-        for (unsigned int j=0; j<source->ExtraSize; j++)
-          streamVideo->ExtraData[j] = source->ExtraData[j];
-      }
-      streamVideo->m_parser_split = true;
-      streamVideo->changes++;
-      m_newStreamMap[stream->uniqueId] = streamVideo;
-      dStream = streamVideo;
-    }
-    else if (stream->type == STREAM_SUBTITLE)
-    {
-      CDemuxStreamSubtitle *source = dynamic_cast<CDemuxStreamSubtitle*>(stream);
-
-      if (!source)
-      {
-        CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStreams - invalid subtitle stream with id %d", stream->uniqueId);
-        DisposeStreams();
-        return;
-      }
-
-      std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>> streamSubtitle;
-      if (dStream)
-        streamSubtitle = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>>(dStream);
-      if (!streamSubtitle || streamSubtitle->codec != source->codec)
-      {
-        streamSubtitle.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>());
-        streamSubtitle->m_parser = av_parser_init(source->codec);
-        if (streamSubtitle->m_parser)
-          streamSubtitle->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
-      }
-
-      if (source->ExtraSize == 4)
-      {
-        delete[] streamSubtitle->ExtraData;
-        streamSubtitle->ExtraData = new uint8_t[4];
-        streamSubtitle->ExtraSize = 4;
-        for (int j=0; j<4; j++)
-          streamSubtitle->ExtraData[j] = source->ExtraData[j];
-      }
-      m_newStreamMap[stream->uniqueId] = streamSubtitle;
-      dStream = streamSubtitle;
-    }
-    else if (stream->type == STREAM_TELETEXT)
-    {
-      CDemuxStreamTeletext *source = dynamic_cast<CDemuxStreamTeletext*>(stream);
-
-      if (!source)
-      {
-        CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStreams - invalid teletext stream with id %d", stream->uniqueId);
-        DisposeStreams();
-        return;
-      }
-
-      std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>> streamTeletext;
-      if (dStream)
-        streamTeletext = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>>(dStream);
-      if (!streamTeletext || streamTeletext->codec != source->codec)
-      {
-        streamTeletext.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>());
-      }
-
-      m_newStreamMap[stream->uniqueId] = streamTeletext;
-      dStream = streamTeletext;
-    }
-    else if (stream->type == STREAM_RADIO_RDS)
-    {
-      CDemuxStreamRadioRDS *source = dynamic_cast<CDemuxStreamRadioRDS*>(stream);
-
-      if (!source)
-      {
-        CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStreams - invalid radio-rds stream with id %d", stream->uniqueId);
-        DisposeStreams();
-        return;
-      }
-
-      std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>> streamRDS;
-      if (dStream)
-        streamRDS = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>>(dStream);
-      if (!streamRDS || streamRDS->codec != source->codec)
-      {
-        streamRDS.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>());
-      }
-
-      m_newStreamMap[stream->uniqueId] = streamRDS;
-      dStream = streamRDS;
-    }
-    else
-    {
-      std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStream>> streamGen;
-      streamGen = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStream>>();
-      m_newStreamMap[stream->uniqueId] = streamGen;
-      dStream = streamGen;
+      streamAudio.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamAudio>());
+      streamAudio->m_parser = av_parser_init(source->codec);
+      if (streamAudio->m_parser)
+        streamAudio->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
     }
 
-    dStream->uniqueId = stream->uniqueId;
-    dStream->codec = stream->codec;
-    dStream->codecName = stream->codecName;
-    dStream->cryptoSession = stream->cryptoSession;
-    dStream->externalInterfaces = stream->externalInterfaces;
-    for (int j=0; j<4; j++)
-      dStream->language[j] = stream->language[j];
-
-    dStream->realtime = stream->realtime;
-
-    CLog::Log(LOGDEBUG,"CDVDDemuxClient::RequestStreams(): added/updated stream %d with codec_id %d",
-        dStream->uniqueId,
-        dStream->codec);
+    streamAudio->iChannels       = source->iChannels;
+    streamAudio->iSampleRate     = source->iSampleRate;
+    streamAudio->iBlockAlign     = source->iBlockAlign;
+    streamAudio->iBitRate        = source->iBitRate;
+    streamAudio->iBitsPerSample  = source->iBitsPerSample;
+    if (source->ExtraSize > 0 && source->ExtraData)
+    {
+      delete[] streamAudio->ExtraData;
+      streamAudio->ExtraData = new uint8_t[source->ExtraSize];
+      streamAudio->ExtraSize = source->ExtraSize;
+      for (unsigned int j=0; j<source->ExtraSize; j++)
+        streamAudio->ExtraData[j] = source->ExtraData[j];
+    }
+    streamAudio->m_parser_split = true;
+    streamAudio->changes++;
+    map[stream->uniqueId] = streamAudio;
+    dStream = streamAudio;
   }
-  m_streams = m_newStreamMap;
+  else if (stream->type == STREAM_VIDEO)
+  {
+    CDemuxStreamVideo *source = dynamic_cast<CDemuxStreamVideo*>(stream);
+
+    if (!source)
+    {
+      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid video stream with id %d", stream->uniqueId);
+      DisposeStreams();
+      return;
+    }
+
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>> streamVideo;
+    if (dStream)
+      streamVideo = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>>(dStream);
+    if (!streamVideo || streamVideo->codec != source->codec ||
+        streamVideo->iWidth != source->iWidth || streamVideo->iHeight != source->iHeight)
+    {
+      streamVideo.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamVideo>());
+      streamVideo->m_parser = av_parser_init(source->codec);
+      if (streamVideo->m_parser)
+        streamVideo->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
+    }
+
+    streamVideo->iFpsScale       = source->iFpsScale;
+    streamVideo->iFpsRate        = source->iFpsRate;
+    streamVideo->iHeight         = source->iHeight;
+    streamVideo->iWidth          = source->iWidth;
+    streamVideo->fAspect         = source->fAspect;
+    streamVideo->iBitRate = source->iBitRate;
+    streamVideo->stereo_mode     = "mono";
+    if (source->ExtraSize > 0 && source->ExtraData)
+    {
+      delete[] streamVideo->ExtraData;
+      streamVideo->ExtraData = new uint8_t[source->ExtraSize];
+      streamVideo->ExtraSize = source->ExtraSize;
+      for (unsigned int j=0; j<source->ExtraSize; j++)
+        streamVideo->ExtraData[j] = source->ExtraData[j];
+    }
+    streamVideo->m_parser_split = true;
+    streamVideo->changes++;
+    map[stream->uniqueId] = streamVideo;
+    dStream = streamVideo;
+  }
+  else if (stream->type == STREAM_SUBTITLE)
+  {
+    CDemuxStreamSubtitle *source = dynamic_cast<CDemuxStreamSubtitle*>(stream);
+
+    if (!source)
+    {
+      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid subtitle stream with id %d", stream->uniqueId);
+      DisposeStreams();
+      return;
+    }
+
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>> streamSubtitle;
+    if (dStream)
+      streamSubtitle = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>>(dStream);
+    if (!streamSubtitle || streamSubtitle->codec != source->codec)
+    {
+      streamSubtitle.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>());
+      streamSubtitle->m_parser = av_parser_init(source->codec);
+      if (streamSubtitle->m_parser)
+        streamSubtitle->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
+    }
+
+    if (source->ExtraSize == 4)
+    {
+      delete[] streamSubtitle->ExtraData;
+      streamSubtitle->ExtraData = new uint8_t[4];
+      streamSubtitle->ExtraSize = 4;
+      for (int j=0; j<4; j++)
+        streamSubtitle->ExtraData[j] = source->ExtraData[j];
+    }
+    map[stream->uniqueId] = streamSubtitle;
+    dStream = streamSubtitle;
+  }
+  else if (stream->type == STREAM_TELETEXT)
+  {
+    CDemuxStreamTeletext *source = dynamic_cast<CDemuxStreamTeletext*>(stream);
+
+    if (!source)
+    {
+      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid teletext stream with id %d", stream->uniqueId);
+      DisposeStreams();
+      return;
+    }
+
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>> streamTeletext;
+    if (dStream)
+      streamTeletext = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>>(dStream);
+    if (!streamTeletext || streamTeletext->codec != source->codec)
+    {
+      streamTeletext.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>());
+    }
+
+    map[stream->uniqueId] = streamTeletext;
+    dStream = streamTeletext;
+  }
+  else if (stream->type == STREAM_RADIO_RDS)
+  {
+    CDemuxStreamRadioRDS *source = dynamic_cast<CDemuxStreamRadioRDS*>(stream);
+
+    if (!source)
+    {
+      CLog::Log(LOGERROR, "CDVDDemuxClient::RequestStream - invalid radio-rds stream with id %d", stream->uniqueId);
+      DisposeStreams();
+      return;
+    }
+
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>> streamRDS;
+    if (dStream)
+      streamRDS = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>>(dStream);
+    if (!streamRDS || streamRDS->codec != source->codec)
+    {
+      streamRDS.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>());
+    }
+
+    map[stream->uniqueId] = streamRDS;
+    dStream = streamRDS;
+  }
+  else
+  {
+    std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStream>> streamGen;
+    streamGen = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStream>>();
+    map[stream->uniqueId] = streamGen;
+    dStream = streamGen;
+  }
+
+  dStream->uniqueId = stream->uniqueId;
+  dStream->codec = stream->codec;
+  dStream->codecName = stream->codecName;
+  dStream->cryptoSession = stream->cryptoSession;
+  dStream->externalInterfaces = stream->externalInterfaces;
+  for (int j=0; j<4; j++)
+    dStream->language[j] = stream->language[j];
+
+  dStream->realtime = stream->realtime;
+
+  CLog::Log(LOGDEBUG,"CDVDDemuxClient::RequestStream(): added/updated stream %d with codec_id %d",
+      dStream->uniqueId,
+      dStream->codec);
 }
 
 std::shared_ptr<CDemuxStream> CDVDDemuxClient::GetStreamInternal(int iStreamId)
@@ -641,6 +632,7 @@ void CDVDDemuxClient::OpenStream(int id)
   if (m_IDemux)
   {
     m_IDemux->OpenStream(id);
+    RequestStream(m_IDemux->GetStream(id), m_streams);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -636,6 +636,14 @@ void CDVDDemuxClient::EnableStream(int id, bool enable)
   }
 }
 
+void CDVDDemuxClient::OpenStream(int id)
+{
+  if (m_IDemux)
+  {
+    m_IDemux->OpenStream(id);
+  }
+}
+
 void CDVDDemuxClient::SetVideoResolution(int width, int height)
 {
   if (m_IDemux)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -49,6 +49,7 @@ public:
   std::string GetFileName() override;
   std::string GetStreamCodecName(int iStreamId) override;
   void EnableStream(int id, bool enable) override;
+  void OpenStream(int id) override;
   void SetVideoResolution(int width, int height) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -54,6 +54,7 @@ public:
 
 protected:
   void RequestStreams();
+  void RequestStream(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map);
   bool ParsePacket(DemuxPacket* pPacket);
   void DisposeStream(int iStreamId);
   void DisposeStreams();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -123,6 +123,7 @@ public:
     virtual CDemuxStream* GetStream(int iStreamId) const = 0;
     virtual std::vector<CDemuxStream*> GetStreams() const = 0;
     virtual void EnableStream(int iStreamId, bool enable) = 0;
+    virtual void OpenStream(int iStreamId) = 0;
     virtual int GetNrOfStreams() const = 0;
     virtual void SetSpeed(int iSpeed) = 0;
     virtual bool SeekTime(double time, bool backward = false, double* startpts = NULL) = 0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -105,6 +105,7 @@ public:
   void AbortDemux() override;
   void FlushDemux() override;
   void EnableStream(int iStreamId, bool enable) override {};
+  void OpenStream(int iStreamId) override {};
 
 protected:
   bool CloseAndOpen(const std::string& strFile);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -342,6 +342,18 @@ void CInputStreamAddon::EnableStream(int streamId, bool enable)
   m_struct.toAddon.enable_stream(&m_struct, stream->second->uniqueId, enable);
 }
 
+void CInputStreamAddon::OpenStream(int streamId)
+{
+  if (!m_struct.toAddon.open_stream)
+    return;
+
+  auto stream = m_streams.find(streamId);
+  if (stream == m_streams.end())
+    return;
+
+  m_struct.toAddon.open_stream(&m_struct, stream->second->uniqueId);
+}
+
 int CInputStreamAddon::GetNrOfStreams() const
 {
   return m_streams.size();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -83,6 +83,8 @@ public:
   CDemuxStream* GetStream(int streamId) const override;
   std::vector<CDemuxStream*> GetStreams() const override;
   void EnableStream(int streamId, bool enable) override;
+  void OpenStream(int streamid) override;
+
   int GetNrOfStreams() const override;
   void SetSpeed(int speed) override;
   bool SeekTime(double time, bool backward = false, double* startpts = nullptr) override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -95,16 +95,15 @@ public:
   bool IsRealTimeStream();
 
 protected:
-  void UpdateStreams();
-  void DisposeStreams();
-  int ConvertVideoCodecProfile(STREAMCODEC_PROFILE profile);
+  static int ConvertVideoCodecProfile(STREAMCODEC_PROFILE profile);
 
   IVideoPlayer* m_player;
 
 private:
   std::vector<std::string> m_fileItemProps;
   INPUTSTREAM_CAPABILITIES m_caps;
-  std::map<int, CDemuxStream*> m_streams;
+
+  int m_streamCount = 0;
 
   AddonInstance_InputStream m_struct;
   std::shared_ptr<CInputStreamProvider> m_subAddonProvider;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3685,11 +3685,11 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
     if(!m_pDemuxer)
       return false;
 
-    stream = m_pDemuxer->GetStream(demuxerId, iStream);
-    if(!stream || stream->disabled)
-      return false;
-
     m_pDemuxer->OpenStream(demuxerId, iStream);
+
+    stream = m_pDemuxer->GetStream(demuxerId, iStream);
+    if (!stream || stream->disabled)
+      return false;
 
     hint.Assign(*stream, true);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3689,7 +3689,7 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
     if(!stream || stream->disabled)
       return false;
 
-    m_pDemuxer->EnableStream(demuxerId, iStream, true);
+    m_pDemuxer->OpenStream(demuxerId, iStream);
 
     hint.Assign(*stream, true);
 


### PR DESCRIPTION
Inputstream related fixes / cleanups related to VideoBuffer management

## Description
1.) Inputstream streams are currently enabled or disabled (wich means making it available for selection)
inputstream.adaptive atleast has to know which stream fron enabled  streams is started, for this an OpenStream callback is implemented (called from kodi -> addon)

2.) AddonVideoCodec needs the possibility to release buffers after drain.
AddonToKodi Interface now has an ReleaseFrameBuffer (beside the existing GetFrameBuffer)

In this step VideoBuffer management was cleaned up.

3.) In the past streams from descriptive files (e.g. DASH manifests) without codec extradata needed some workarounds to start. The last commit retrieves possible changed stream infos / codec extradata right after OpenStream again and lets the decoder start directly.

## How Has This Been Tested?
Win32 / amazon prime addon

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
