### PR TITLE
VideoPlayer: rework speed and tempo

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2180,8 +2180,6 @@ bool CApplication::OnAction(const CAction &action)
       if (action.GetID() == ACTION_PLAYER_FORWARD || action.GetID() == ACTION_PLAYER_REWIND)
       {
         float playSpeed = m_pPlayer->GetPlaySpeed();
-        if (playSpeed >= 0.75 && playSpeed <= 1.55)
-          playSpeed = 1;
 
         if (action.GetID() == ACTION_PLAYER_REWIND && (playSpeed == 1)) // Enables Rewinding
           playSpeed *= -2;

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -122,7 +122,6 @@ PlayBackRet CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOpt
     m_audioStreamUpdate.SetExpired();
     m_videoStreamUpdate.SetExpired();
     m_subtitleStreamUpdate.SetExpired();
-    m_speedUpdate.SetExpired();
   }
   return iResult;
 }
@@ -245,7 +244,6 @@ void CApplicationPlayer::Pause()
   if (player)
   {
     player->Pause();
-    m_speedUpdate.SetExpired();
   }
 }
 
@@ -476,6 +474,13 @@ void CApplicationPlayer::SetSpeed(float speed)
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     player->SetSpeed(speed);
+}
+
+void CApplicationPlayer::SetTempo(float tempo)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetTempo(tempo);
 }
 
 void CApplicationPlayer::DoAudioWork()
@@ -721,20 +726,25 @@ void CApplicationPlayer::SetPlaySpeed(float speed)
     return ;
 
   SetSpeed(speed);
-  m_speedUpdate.SetExpired();
 }
 
 float CApplicationPlayer::GetPlaySpeed()
 {
-  if (!m_speedUpdate.IsTimePast())
-    return m_fPlaySpeed;
-
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
   {
-    m_fPlaySpeed = player->GetSpeed();
-    m_speedUpdate.Set(1000);
-    return m_fPlaySpeed;
+    return CDataCacheCore::GetInstance().GetSpeed();
+  }
+  else
+    return 0;
+}
+
+float CApplicationPlayer::GetPlayTempo()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    return CDataCacheCore::GetInstance().GetTempo();
   }
   else
     return 0;

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -60,8 +60,6 @@ class CApplicationPlayer
   int m_iVideoStream;
   XbmcThreads::EndTime m_subtitleStreamUpdate;
   int m_iSubtitleStream;
-  XbmcThreads::EndTime m_speedUpdate;
-  float m_fPlaySpeed;
 
 public:
   CApplicationPlayer();
@@ -72,10 +70,12 @@ public:
   void ClosePlayerGapless(std::string &playername);
   void CreatePlayer(const std::string &player, IPlayerCallback& callback);
   std::string GetCurrentPlayer();
-  float  GetPlaySpeed();
+  float GetPlaySpeed();
+  float GetPlayTempo();
   bool HasPlayer() const;
   PlayBackRet OpenFile(const CFileItem& item, const CPlayerOptions& options);
   void SetPlaySpeed(float speed);
+  void SetTempo(float tempo);
 
   void FrameMove();
   void Render(bool clear, uint32_t alpha = 255, bool gui = true);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6089,7 +6089,12 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     break;
   case PLAYER_PLAYSPEED:
       if(g_application.m_pPlayer->IsPlaying())
-        strLabel = StringUtils::Format("%.2f", g_application.m_pPlayer->GetPlaySpeed());
+      {
+        float speed = g_application.m_pPlayer->GetPlaySpeed();
+        if (speed == 1.0)
+          speed = g_application.m_pPlayer->GetPlayTempo();
+        strLabel = StringUtils::Format("%.2f", speed);
+      }
       break;
   case MUSICPLAYER_TITLE:
   case MUSICPLAYER_ALBUM:
@@ -7182,7 +7187,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     case PLAYER_PLAYING:
       {
         float speed = g_application.m_pPlayer->GetPlaySpeed();
-        bReturn = (speed >= 0.75 && speed <= 1.55);
+        bReturn = (speed == 1.0);
       }
       break;
     case PLAYER_PAUSED:
@@ -7238,8 +7243,9 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       break;
     case PLAYER_IS_TEMPO:
       {
+        float tempo = g_application.m_pPlayer->GetPlayTempo();
         float speed = g_application.m_pPlayer->GetPlaySpeed();
-        bReturn = (speed >= 0.75 && speed <= 1.55 && speed != 1);
+        bReturn = (speed == 1.0 && tempo != 1.0);
       }
       break;
     case PLAYER_RECORDING:
@@ -7956,8 +7962,9 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
     CDateTime time(CDateTime::GetCurrentDateTime());
     int playTimeRemaining = GetPlayTimeRemaining();
     float speed = g_application.m_pPlayer->GetPlaySpeed();
-    if (speed >= 0.75 && speed <= 1.55)
-      playTimeRemaining /= speed;
+    float tempo = g_application.m_pPlayer->GetPlayTempo();
+    if (speed == 1.0)
+      playTimeRemaining /= tempo;
     time += CDateTimeSpan(0, 0, 0, playTimeRemaining);
     return LocalizeTime(time, (TIME_FORMAT)info.GetData1());
   }
@@ -7971,7 +7978,7 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   {
     std::string strTime;
     float speed = g_application.m_pPlayer->GetPlaySpeed();
-    if (speed < 0.8 || speed > 1.5)
+    if (speed != 1.0)
       strTime = StringUtils::Format("%s (%ix)", GetCurrentPlayTime((TIME_FORMAT)info.GetData1()).c_str(), (int)speed);
     else
       strTime = GetCurrentPlayTime();

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -237,6 +237,28 @@ bool CDataCacheCore::CDataCacheCore::IsSeeking()
   return m_stateInfo.m_stateSeeking;
 }
 
+void CDataCacheCore::SetSpeed(float tempo, float speed)
+{
+  CSingleLock lock(m_stateSection);
+
+  m_stateInfo.m_tempo = tempo;
+  m_stateInfo.m_speed = speed;
+}
+
+float CDataCacheCore::GetSpeed()
+{
+  CSingleLock lock(m_stateSection);
+
+  return m_stateInfo.m_speed;
+}
+
+float CDataCacheCore::GetTempo()
+{
+  CSingleLock lock(m_stateSection);
+
+  return m_stateInfo.m_tempo;
+}
+
 bool CDataCacheCore::IsPlayerStateChanged()
 {
   CSingleLock lock(m_stateSection);

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -66,6 +66,9 @@ public:
   // player states
   void SetStateSeeking(bool active);
   bool IsSeeking();
+  void SetSpeed(float tempo, float speed);
+  float GetSpeed();
+  float GetTempo();
   bool IsPlayerStateChanged();
   void SetGuiRender(bool gui);
   bool GetGuiRender();
@@ -110,5 +113,7 @@ protected:
     bool m_stateSeeking;
     bool m_renderGuiLayer;
     bool m_renderVideoLayer;
+    float m_tempo;
+    float m_speed;
   } m_stateInfo;
 };

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -38,6 +38,7 @@
 #include "utils/Variant.h"
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
+#include "cores/DataCacheCore.h"
 #include "input/InputManager.h"
 #if defined(TARGET_WINDOWS)
   #include "utils/CharsetConverter.h"
@@ -575,11 +576,7 @@ int64_t CExternalPlayer::GetTotalTime() // in milliseconds
 void CExternalPlayer::SetSpeed(float speed)
 {
   m_speed = speed;
-}
-
-float CExternalPlayer::GetSpeed()
-{
-  return m_speed;
+  CDataCacheCore::GetInstance().SetSpeed(1.0, speed);
 }
 
 std::string CExternalPlayer::GetPlayerState()

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -60,7 +60,6 @@ public:
   int64_t GetTime() override;
   int64_t GetTotalTime() override;
   void SetSpeed(float speed) override;
-  float GetSpeed() override;
   void DoAudioWork() override {}
 
   std::string GetPlayerState() override;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -326,7 +326,7 @@ public:
   virtual int GetSourceBitrate(){ return 0;}
   virtual bool GetStreamDetails(CStreamDetails &details){ return false;}
   virtual void SetSpeed(float speed) = 0;
-  virtual float GetSpeed() = 0;
+  virtual void SetTempo(float tempo) { };
   virtual bool SupportsTempo() { return false; }
 
   //Returns true if not playback (paused or stopped being filled)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -23,6 +23,7 @@
 #include "RetroPlayerAutoSave.h"
 #include "RetroPlayerVideo.h"
 #include "addons/AddonManager.h"
+#include "cores/DataCacheCore.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/File.h"
@@ -357,14 +358,9 @@ void CRetroPlayer::SetSpeed(float speed)
 
     if (m_gameClient->GetPlayback()->GetSpeed() != 0.0)
       CloseOSD();
-  }
-}
 
-float CRetroPlayer::GetSpeed()
-{
-  if (m_gameClient)
-    return static_cast<float>(m_gameClient->GetPlayback()->GetSpeed());
-  return 0;
+    CDataCacheCore::GetInstance().SetSpeed(1.0, speed);
+  }
 }
 
 bool CRetroPlayer::OnAction(const CAction &action)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -108,7 +108,6 @@ namespace RETRO
     //virtual int GetSourceBitrate() override { return 0; }
     bool GetStreamDetails(CStreamDetails &details) override;
     void SetSpeed(float speed) override;
-    float GetSpeed() override;
     //virtual bool IsCaching() const override { return false; }
     //virtual int GetCacheLevel() const override { return -1; }
     //virtual bool IsInMenu() const override { return false; }

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -20,6 +20,7 @@
 
 #include "RetroPlayerAutoSave.h"
 #include "cores/IPlayer.h"
+#include "cores/DataCacheCore.h"
 #include "utils/log.h"
 #include "URL.h"
 
@@ -47,7 +48,7 @@ void CRetroPlayerAutoSave::Process()
     if (m_bStop)
       break;
 
-    if (m_player->GetSpeed() > 0.0f)
+    if (CDataCacheCore::GetInstance().GetSpeed() > 0.0f)
     {
       std::string savePath = m_player->GetPlayerState();
       if (!savePath.empty())

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -248,6 +248,29 @@ class CDVDMsgPlayerSeekChapter : public CDVDMsg
     int m_iChapter;
 };
 
+class CDVDMsgPlayerSetSpeed : public CDVDMsg
+{
+public:
+  struct SpeedParams
+  {
+    int m_speed;
+    bool m_isTempo;
+  };
+
+  CDVDMsgPlayerSetSpeed(SpeedParams params)
+  : CDVDMsg(PLAYER_SETSPEED)
+  , m_params(params)
+  {}
+
+  float GetSpeed() const { return m_params.m_speed; }
+  float IsTempo() const { return m_params.m_isTempo; }
+
+private:
+
+  SpeedParams m_params;
+
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 //////
 ////// DEMUXER_ Messages

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -424,6 +424,70 @@ bool CProcessInfo::IsSeeking()
   return m_stateSeeking;
 }
 
+void CProcessInfo::SetSpeed(float speed)
+{
+  CSingleLock lock(m_stateSection);
+
+  m_speed = speed;
+  m_newSpeed = speed;
+
+  if (m_dataCache)
+    m_dataCache->SetSpeed(m_newTempo, speed);
+}
+
+void CProcessInfo::SetNewSpeed(float speed)
+{
+  CSingleLock lock(m_stateSection);
+
+  m_newSpeed = speed;
+
+  if (m_dataCache)
+    m_dataCache->SetSpeed(m_tempo, speed);
+}
+
+float CProcessInfo::GetNewSpeed()
+{
+  CSingleLock lock(m_stateSection);
+
+  return m_newSpeed;
+}
+
+void CProcessInfo::SetTempo(float tempo)
+{
+  CSingleLock lock(m_stateSection);
+
+  m_tempo = tempo;
+  m_newTempo = tempo;
+
+  if (m_dataCache)
+    m_dataCache->SetSpeed(tempo, m_newSpeed);
+}
+
+void CProcessInfo::SetNewTempo(float tempo)
+{
+  CSingleLock lock(m_stateSection);
+
+  m_newTempo = tempo;
+
+  if (m_dataCache)
+    m_dataCache->SetSpeed(tempo, m_speed);
+}
+
+float CProcessInfo::GetNewTempo()
+{
+  CSingleLock lock(m_stateSection);
+
+  return m_newTempo;
+}
+
+bool CProcessInfo::IsTempoAllowed(float tempo)
+{
+  if (tempo > 0.75 && tempo < 1.55)
+    return true;
+
+  return false;
+}
+
 void CProcessInfo::SetLevelVQ(int level)
 {
   m_levelVQ = level;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -87,6 +87,13 @@ public:
   // player states
   void SetStateSeeking(bool active);
   bool IsSeeking();
+  void SetSpeed(float speed);
+  void SetNewSpeed(float speed);
+  float GetNewSpeed();
+  void SetTempo(float tempo);
+  void SetNewTempo(float tempo);
+  float GetNewTempo();
+  virtual bool IsTempoAllowed(float tempo);
 
   void SetLevelVQ(int level);
   int GetLevelVQ();
@@ -135,4 +142,8 @@ protected:
   std::atomic_int m_levelVQ;
   std::atomic_bool m_renderGuiLayer;
   std::atomic_bool m_renderVideoLayer;
+  float m_tempo;
+  float m_newTempo;
+  float m_speed;
+  float m_newSpeed;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -356,7 +356,7 @@ public:
   int64_t GetTime() override;
   int64_t GetTotalTime() override;
   void SetSpeed(float speed) override;
-  float GetSpeed() override;
+  void SetTempo(float tempo) override;
   bool SupportsTempo() override;
   bool OnAction(const CAction &action) override;
 
@@ -513,8 +513,7 @@ protected:
 
   CSelectionStreams m_SelectionStreams;
 
-  std::atomic_int m_playSpeed;
-  std::atomic_int m_newPlaySpeed;
+  int m_playSpeed;
   int m_streamPlayerSpeed;
   struct SSpeedState
   {

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -941,6 +941,7 @@ void PAPlayer::SetDynamicRangeCompression(long drc)
 void PAPlayer::SetSpeed(float speed)
 {
   m_playbackSpeed = static_cast<int>(speed);
+  CDataCacheCore::GetInstance().SetSpeed(1.0, speed);
   if (m_playbackSpeed != 0 && m_isPaused)
   {
     m_isPaused = false;
@@ -954,18 +955,6 @@ void PAPlayer::SetSpeed(float speed)
     m_callback.OnPlayBackPaused();
   }
   m_signalSpeedChange = true;
-}
-
-float PAPlayer::GetSpeed()
-{
-  //! @todo: remove extra member for pause state
-  //! there was inconsistency throughout the entire application on how speed
-  //! and pause were used. Now speed is defined as current playback speed.
-  //! as a result speed must be 0 if player is paused.
-  if (m_isPaused)
-    return 0;
-
-  return m_playbackSpeed;
 }
 
 int64_t PAPlayer::GetTimeInternal()

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -59,7 +59,6 @@ public:
   void SetVolume(float volume) override;
   void SetDynamicRangeCompression(long drc) override;
   void SetSpeed(float speed = 0) override;
-  float GetSpeed() override;
   int GetCacheLevel() const override;
   int64_t GetTotalTime() override;
   void SetTotalTime(int64_t time) override;

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -142,8 +142,6 @@ static int PlayerControl(const std::vector<std::string>& params)
     if (g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
     {
       float playSpeed = g_application.m_pPlayer->GetPlaySpeed();
-      if (playSpeed >= 0.75 && playSpeed <= 1.55)
-        playSpeed = 1;
 
       if (paramlow == "rewind" && playSpeed == 1) // Enables Rewinding
         playSpeed *= -2;
@@ -169,17 +167,13 @@ static int PlayerControl(const std::vector<std::string>& params)
     if (g_application.m_pPlayer->SupportsTempo() &&
         g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
     {
-      float playSpeed = g_application.m_pPlayer->GetPlaySpeed();
-      if (playSpeed >= 0.75 && playSpeed <= 1.55)
-      {
-        if (paramlow == "tempodown" && playSpeed > 0.85)
-          playSpeed -= 0.1;
-        else if (paramlow == "tempoup" && playSpeed < 1.45)
-          playSpeed += 0.1;
+      float playTempo = g_application.m_pPlayer->GetPlayTempo();
+      if (paramlow == "tempodown")
+          playTempo -= 0.1;
+      else if (paramlow == "tempoup")
+          playTempo += 0.1;
 
-        playSpeed = floor(playSpeed * 100 + 0.5) / 100;
-        g_application.m_pPlayer->SetPlaySpeed(playSpeed);
-      }
+      g_application.m_pPlayer->SetTempo(playTempo);
     }
   }
   else if (paramlow == "next")

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -37,6 +37,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "Application.h"
+#include "cores/DataCacheCore.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
@@ -449,14 +450,20 @@ failed:
 void CUPnPPlayer::Pause()
 {
   if(IsPaused())
+  {
     NPT_CHECK_LABEL(m_control->Play(m_delegate->m_device
                                   , m_delegate->m_instance
                                   , "1"
                                   , m_delegate), failed);
+    CDataCacheCore::GetInstance().SetSpeed(1.0, 1.0);
+  }
   else
+  {
     NPT_CHECK_LABEL(m_control->Pause(m_delegate->m_device
                                    , m_delegate->m_instance
                                    , m_delegate), failed);
+    CDataCacheCore::GetInstance().SetSpeed(1.0, 0.0);
+  }
 
   return;
 failed:
@@ -605,12 +612,5 @@ void CUPnPPlayer::SetSpeed(float speed)
 
 }
 
-float CUPnPPlayer::GetSpeed()
-{
-  if (IsPaused())
-    return 0;
-  else
-    return 1;
-}
 
 } /* namespace UPNP */

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -64,7 +64,6 @@ public:
   int64_t GetTime() override;
   int64_t GetTotalTime() override;
   void SetSpeed(float speed = 0) override;
-  float GetSpeed() override;
 
   bool IsCaching() const override { return false; }
   int GetCacheLevel() const override { return -1; }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -313,7 +313,7 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
 void CGUIWindowFullScreen::FrameMove()
 {
   float playspeed = g_application.m_pPlayer->GetPlaySpeed();
-  if (playspeed < 0.75 || playspeed > 1.55)
+  if (playspeed != 1.0)
     g_infoManager.SetDisplayAfterSeek();
 
   if (!g_application.m_pPlayer->HasPlayer())


### PR DESCRIPTION
Rework on tempo and speed. This allows VideoPlayer to continue with tempo set after pause/resume. Tempo range is now defined by ProcessInfo and can be overridden by platforms and set at runtime. 