### PR TITLE
VideoPlayer: flush renderer on channel switch

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2864,6 +2864,7 @@ void CVideoPlayer::HandleMessages()
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER) == 0)
     {
       FlushBuffers(DVD_NOPTS_VALUE, true, true);
+      m_renderManager.Flush();
       CDVDInputStreamPVRManager* input = dynamic_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
       //! @todo find a better solution for the "otherStreamHack"
       //! a stream is not supposed to be terminated before demuxer
@@ -2892,6 +2893,7 @@ void CVideoPlayer::HandleMessages()
              m_messenger.GetPacketCount(CDVDMsg::PLAYER_CHANNEL_SELECT) == 0)
     {
       FlushBuffers(DVD_NOPTS_VALUE, true, true);
+      m_renderManager.Flush();
       CDVDInputStreamPVRManager* input = dynamic_cast<CDVDInputStreamPVRManager*>(m_pInputStream);
       if (input && input->IsOtherStreamHack())
       {
@@ -2926,6 +2928,7 @@ void CVideoPlayer::HandleMessages()
         {
           g_infoManager.SetDisplayAfterSeek(100000);
           FlushBuffers(DVD_NOPTS_VALUE, true, true);
+          m_renderManager.Flush();
           if (input->IsOtherStreamHack())
           {
             CloseDemuxer();


### PR DESCRIPTION
long demanded by users. kicks out the last frame of last channel when switch to a new one.
