### PR TITLE
[addons] add blocked addon call event to prevent problems after disable

### DIFF
--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -71,5 +71,17 @@ namespace ADDON
      * @deprecated Use Enabled, ReInstalled and UnInstalled instead.
      */
     struct InstalledChanged : AddonEvent {};
+
+    struct Load : AddonEvent
+    {
+      std::string id;
+      explicit Load(std::string id) : id(std::move(id)) {}
+    };
+
+    struct Unload : AddonEvent
+    {
+      std::string id;
+      explicit Unload(std::string id) : id(std::move(id)) {}
+    };
   };
 };

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -604,11 +604,17 @@ bool CAddonInstallJob::DoWork()
   // run any pre-install functions
   ADDON::OnPreInstall(m_addon);
 
+  if (!CAddonMgr::GetInstance().UnloadAddon(m_addon))
+  {
+    CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to unload addon.", m_addon->ID().c_str());
+    return false;
+  }
+
   // perform install
   if (!Install(installFrom, m_repo))
     return false;
 
-  if (!CAddonMgr::GetInstance().ReloadAddon(m_addon))
+  if (!CAddonMgr::GetInstance().LoadAddon(m_addon->ID()))
   {
     CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to reload addon", m_addon->ID().c_str());
     return false;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -706,6 +706,10 @@ bool CAddonMgr::UnloadAddon(const AddonPtr& addon)
     if (m_cpluff->uninstall_plugin(m_cp_context, addon->ID().c_str()) == CP_OK)
     {
       CLog::Log(LOGDEBUG, "CAddonMgr: %s unloaded", addon->ID().c_str());
+
+      lock.Leave();
+      AddonEvents::Unload event(addon->ID());
+      m_unloadEvents.HandleEvent(event);
       return true;
     }
   }
@@ -736,6 +740,11 @@ bool CAddonMgr::LoadAddon(const std::string& addonId)
     CLog::Log(LOGERROR, "CAddonMgr: could not load add-on %s. No add-on with that ID is installed.", addon->ID().c_str());
     return false;
   }
+
+  lock.Leave();
+
+  AddonEvents::Load event(addon->ID());
+  m_unloadEvents.HandleEvent(event);
 
   if (IsAddonDisabled(addon->ID()))
   {

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -706,8 +706,6 @@ bool CAddonMgr::UnloadAddon(const AddonPtr& addon)
     if (m_cpluff->uninstall_plugin(m_cp_context, addon->ID().c_str()) == CP_OK)
     {
       CLog::Log(LOGDEBUG, "CAddonMgr: %s unloaded", addon->ID().c_str());
-      m_events.Publish(AddonEvents::InstalledChanged());
-      m_events.Publish(AddonEvents::UnInstalled(addon->ID()));
       return true;
     }
   }
@@ -715,17 +713,16 @@ bool CAddonMgr::UnloadAddon(const AddonPtr& addon)
   return false;
 }
 
-bool CAddonMgr::ReloadAddon(AddonPtr& addon)
+bool CAddonMgr::LoadAddon(const std::string& addonId)
 {
   CSingleLock lock(m_critSection);
-  if (!addon ||!m_cpluff || !m_cp_context)
+  if (!m_cpluff || !m_cp_context)
     return false;
 
-  AddonPtr tmp;
-  bool isReinstall = GetAddon(addon->ID(), tmp, ADDON_UNKNOWN, false);
-  if (isReinstall)
+  AddonPtr addon;
+  if (GetAddon(addonId, addon, ADDON_UNKNOWN, false))
   {
-    m_cpluff->uninstall_plugin(m_cp_context, addon->ID().c_str());
+    return true;
   }
 
   if (!FindAddons())
@@ -734,22 +731,21 @@ bool CAddonMgr::ReloadAddon(AddonPtr& addon)
     return false;
   }
 
-  if (!GetAddon(addon->ID(), addon, ADDON_UNKNOWN, false))
+  if (!GetAddon(addonId, addon, ADDON_UNKNOWN, false))
   {
-    CLog::Log(LOGERROR, "CAddonMgr: could not reload add-on %s. No add-on with that ID is installed.", addon->ID().c_str());
+    CLog::Log(LOGERROR, "CAddonMgr: could not load add-on %s. No add-on with that ID is installed.", addon->ID().c_str());
     return false;
   }
 
-  if (isReinstall)
-    m_events.Publish(AddonEvents::ReInstalled(addon->ID()));
-
-  if (!EnableAddon(addon->ID()))
+  if (IsAddonDisabled(addon->ID()))
   {
-    CLog::Log(LOGERROR, "CAddonMgr: '%s' was installed but could not be enabled", addon->ID().c_str());
-    return false;
+    EnableAddon(addon->ID());
+    return true;
   }
 
-  CLog::Log(LOGDEBUG, "CAddonMgr: %s reloaded", addon->ID().c_str());
+  m_events.Publish(AddonEvents::ReInstalled(addon->ID()));
+  m_events.Publish(AddonEvents::InstalledChanged());
+  CLog::Log(LOGDEBUG, "CAddonMgr: %s successfully loaded", addon->ID().c_str());
   return true;
 }
 
@@ -758,6 +754,8 @@ void CAddonMgr::OnPostUnInstall(const std::string& id)
   CSingleLock lock(m_critSection);
   m_disabled.erase(id);
   m_updateBlacklist.erase(id);
+  m_events.Publish(AddonEvents::InstalledChanged());
+  m_events.Publish(AddonEvents::UnInstalled(id));
 }
 
 bool CAddonMgr::RemoveFromUpdateBlacklist(const std::string& id)

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -178,7 +178,7 @@ namespace ADDON
      *
      * Returns true if the addon was successfully loaded and enabled; otherwise false.
      */
-    bool ReloadAddon(AddonPtr& addon);
+    bool LoadAddon(const std::string& addonId);
 
     /*! @note: should only be called by AddonInstaller
      *

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -82,6 +82,7 @@ namespace ADDON
     virtual ~CAddonMgr();
 
     CEventStream<AddonEvent>& Events() { return m_events; }
+    CEventStream<AddonEvent>& UnloadEvents() { return m_unloadEvents; }
 
     IAddonMgrCallback* GetCallbackForType(TYPE type);
     bool RegisterAddonMgrCallback(TYPE type, IAddonMgrCallback* cb);
@@ -312,6 +313,7 @@ namespace ADDON
     CCriticalSection m_critSection;
     CAddonDatabase m_database;
     CEventSource<AddonEvent> m_events;
+    CBlockingEventSource<AddonEvent> m_unloadEvents;
     std::set<std::string> m_systemAddons;
     std::set<std::string> m_optionalAddons;
   };

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -89,5 +89,7 @@ namespace ADDON
     CCriticalSection m_criticalSection;
     /** add-on id -> script id */
     std::map<std::string, int> m_services;
+
+    std::vector<std::string> m_blacklistedAddons;
   };
 }

--- a/xbmc/utils/EventStream.h
+++ b/xbmc/utils/EventStream.h
@@ -88,3 +88,18 @@ public:
     CJobManager::GetInstance().Submit(std::move(task));
   }
 };
+
+template<typename Event>
+class CBlockingEventSource : public CEventStream<Event>
+{
+public:
+  template<typename A>
+  void HandleEvent(A event)
+  {
+    CSingleLock lock(this->m_criticalSection);
+    for (const auto& subscription : this->m_subscriptions)
+    {
+      subscription->HandleEvent(event);
+    }
+  }
+};


### PR DESCRIPTION
## Description

This add a major part from me to handle binary addon changes in a secure way!

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
