### PR TITLE
[xbmc][win32] Fix a crash when rename fails

### DIFF
--- a/xbmc/filesystem/win32/Win32File.cpp
+++ b/xbmc/filesystem/win32/Win32File.cpp
@@ -406,7 +406,7 @@ bool CWin32File::Rename(const CURL& urlCurrentName, const CURL& urlNewName)
   if (!result)
   {
     CLog::LogW(LOGERROR, L"Failed to rename file/directory %s to %s, Error: %s",
-      curNameW.c_str(), newNameW.c_str(), CLog::Win32ErrorToString(GetLastError()));
+      curNameW.c_str(), newNameW.c_str(), CLog::Win32ErrorToString(GetLastError()).c_str());
   }
   if (m_smbFile)
     m_lastSMBFileErr = GetLastError(); // set real error state


### PR DESCRIPTION
CLog obviously doesn't handle a wstring, not sure
how this happened.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
