### PR TITLE
Change CVideoSync stop flag from atomic bool to CEvent

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
@@ -48,6 +48,7 @@ CVideoReferenceClock::CVideoReferenceClock() : CThread("RefClock")
 
 CVideoReferenceClock::~CVideoReferenceClock()
 {
+  m_vsyncStopEvent.Set();
   StopThread();
 }
 
@@ -98,8 +99,9 @@ void CVideoReferenceClock::Process()
       m_VblankTime = Now;          //initialize the timestamp of the last vblank
       SingleLock.Leave();
 
+      m_vsyncStopEvent.Reset();
       //run the clock
-      m_pVideoSync->Run(m_bStop);
+      m_pVideoSync->Run(m_vsyncStopEvent);
     }
     else
     {

--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.h
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.h
@@ -19,13 +19,14 @@
  *
  */
 
-#include "threads/Thread.h"
 #include "threads/CriticalSection.h"
+#include "threads/Event.h"
+#include "threads/Thread.h"
 #include <memory>
 
 class CVideoSync;
 
-class CVideoReferenceClock : public CThread
+class CVideoReferenceClock : CThread
 {
   public:
     CVideoReferenceClock();
@@ -58,6 +59,8 @@ class CVideoReferenceClock : public CThread
     int     m_MissedVblanks;     //number of clock updates missed by the vblank clock
     int     m_TotalMissedVblanks;//total number of clock updates missed, used by codec information screen
     int64_t m_VblankTime;        //last time the clock was updated when using vblank as clock
+
+    CEvent m_vsyncStopEvent;
 
     CCriticalSection m_CritSection;
 

--- a/xbmc/windowing/VideoSync.h
+++ b/xbmc/windowing/VideoSync.h
@@ -18,7 +18,8 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#include <atomic>
+
+#include "threads/Event.h"
 
 class CVideoReferenceClock;
 typedef void (*PUPDATECLOCK)(int NrVBlanks, uint64_t time, void *clock);
@@ -29,7 +30,7 @@ public:
   CVideoSync(void *clock) { m_refClock = clock; };
   virtual ~CVideoSync() = default;
   virtual bool Setup(PUPDATECLOCK func) = 0;
-  virtual void Run(std::atomic<bool>& stop) = 0;
+  virtual void Run(CEvent& stop) = 0;
   virtual void Cleanup() = 0;
   virtual float GetFps() = 0;
   virtual void RefreshChanged() {};

--- a/xbmc/windowing/X11/VideoSyncDRM.cpp
+++ b/xbmc/windowing/X11/VideoSyncDRM.cpp
@@ -76,7 +76,7 @@ bool CVideoSyncDRM::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncDRM::Run(std::atomic<bool>& stop)
+void CVideoSyncDRM::Run(CEvent& stopEvent)
 {
   drmVBlank vbl;
   VblInfo info;
@@ -116,7 +116,7 @@ void CVideoSyncDRM::Run(std::atomic<bool>& stop)
   FD_ZERO(&fds);
   FD_SET(m_fd, &fds);
 
-  while (!stop && !m_abort)
+  while (!stopEvent.Signaled() && !m_abort)
   {
     timeout.tv_sec = 1;
     timeout.tv_usec = 0;

--- a/xbmc/windowing/X11/VideoSyncDRM.h
+++ b/xbmc/windowing/X11/VideoSyncDRM.h
@@ -27,7 +27,7 @@ class CVideoSyncDRM : public CVideoSync, IDispResource
 public:
   CVideoSyncDRM(void *clock) : CVideoSync(clock) {};
   bool Setup(PUPDATECLOCK func) override;
-  void Run(std::atomic<bool>& stop) override;
+  void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;
   void OnResetDisplay() override;

--- a/xbmc/windowing/X11/VideoSyncGLX.cpp
+++ b/xbmc/windowing/X11/VideoSyncGLX.cpp
@@ -181,7 +181,7 @@ bool CVideoSyncGLX::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncGLX::Run(std::atomic<bool>& stop)
+void CVideoSyncGLX::Run(CEvent& stopEvent)
 {
   unsigned int  PrevVblankCount;
   unsigned int  VblankCount;
@@ -193,7 +193,7 @@ void CVideoSyncGLX::Run(std::atomic<bool>& stop)
   m_glXGetVideoSyncSGI(&VblankCount);
   PrevVblankCount = VblankCount;
 
-  while(!stop && !m_displayLost && !m_displayReset)
+  while(!stopEvent.Signaled() && !m_displayLost && !m_displayReset)
   {
     //wait for the next vblank
     ReturnV = m_glXWaitVideoSyncSGI(2, (VblankCount + 1) % 2, &VblankCount);
@@ -246,7 +246,7 @@ void CVideoSyncGLX::Run(std::atomic<bool>& stop)
     PrevVblankCount = VblankCount;
   }
   m_lostEvent.Set();
-  while(!stop && m_displayLost && !m_displayReset)
+  while(!stopEvent.Signaled() && m_displayLost && !m_displayReset)
   {
     Sleep(10);
   }

--- a/xbmc/windowing/X11/VideoSyncGLX.h
+++ b/xbmc/windowing/X11/VideoSyncGLX.h
@@ -32,7 +32,7 @@ class CVideoSyncGLX : public CVideoSync, IDispResource
 public:
   CVideoSyncGLX(void *clock) : CVideoSync(clock) {};
   bool Setup(PUPDATECLOCK func) override;
-  void Run(std::atomic<bool>& stop) override;
+  void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;
   void OnLostDisplay() override;

--- a/xbmc/windowing/amlogic/VideoSyncAML.cpp
+++ b/xbmc/windowing/amlogic/VideoSyncAML.cpp
@@ -55,14 +55,14 @@ bool CVideoSyncAML::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncAML::Run(std::atomic<bool>& stop)
+void CVideoSyncAML::Run(CEvent& stopEvent)
 {
   // We use the wall clock for timout handling (no AML h/w, startup)
   std::chrono::time_point<std::chrono::system_clock> now(std::chrono::system_clock::now());
   unsigned int waittime (3000 / m_fps);
   uint64_t numVBlanks (0);
 
-  while (!stop && !m_abort)
+  while (!stopEvent.Signaled() && !m_abort)
   {
     int countVSyncs(1);
     if( !g_aml_sync_event.WaitMSec(waittime))

--- a/xbmc/windowing/amlogic/VideoSyncAML.h
+++ b/xbmc/windowing/amlogic/VideoSyncAML.h
@@ -28,7 +28,7 @@ public:
   CVideoSyncAML(void *clock);
   virtual ~CVideoSyncAML();
   virtual bool Setup(PUPDATECLOCK func)override;
-  virtual void Run(std::atomic<bool>& stop)override;
+  virtual void Run(CEvent& stopEvent)override;
   virtual void Cleanup()override;
   virtual float GetFps()override;
   virtual void OnResetDisplay()override;

--- a/xbmc/windowing/android/VideoSyncAndroid.h
+++ b/xbmc/windowing/android/VideoSyncAndroid.h
@@ -25,11 +25,11 @@
 class CVideoSyncAndroid : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncAndroid(void *clock) : CVideoSync(clock), m_LastVBlankTime(0), m_abort(false){}
+  CVideoSyncAndroid(void *clock) : CVideoSync(clock), m_LastVBlankTime(0) {}
 
   // CVideoSync interface
   virtual bool Setup(PUPDATECLOCK func) override;
-  virtual void Run(std::atomic<bool>& stop) override;
+  virtual void Run(CEvent& stop) override;
   virtual void Cleanup() override;
   virtual float GetFps() override;
 
@@ -41,5 +41,5 @@ public:
 
 private:
   int64_t m_LastVBlankTime;  //timestamp of the last vblank, used for calculating how many vblanks happened
-  volatile bool m_abort;
+  CEvent m_abortEvent;
 };

--- a/xbmc/windowing/egl/VideoSyncIMX.cpp
+++ b/xbmc/windowing/egl/VideoSyncIMX.cpp
@@ -50,11 +50,11 @@ bool CVideoSyncIMX::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncIMX::Run(std::atomic<bool>& stop)
+void CVideoSyncIMX::Run(CEvent& stopEvent)
 {
   int counter;
 
-  while (!stop && !m_abort)
+  while (!stopEvent.Signaled() && !m_abort)
   {
     counter = g_IMX.WaitVsync();
     uint64_t now = CurrentHostCounter();

--- a/xbmc/windowing/egl/VideoSyncIMX.h
+++ b/xbmc/windowing/egl/VideoSyncIMX.h
@@ -30,7 +30,7 @@ public:
   CVideoSyncIMX(CVideoReferenceClock *clock);
   virtual ~CVideoSyncIMX();
   virtual bool Setup(PUPDATECLOCK func);
-  virtual void Run(std::atomic<bool>& stop);
+  virtual void Run(CEvent& stop);
   virtual void Cleanup();
   virtual float GetFps();
   virtual void OnResetDisplay();

--- a/xbmc/windowing/osx/VideoSyncIos.h
+++ b/xbmc/windowing/osx/VideoSyncIos.h
@@ -26,11 +26,11 @@
 class CVideoSyncIos : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncIos(void *clock) : CVideoSync(clock), m_LastVBlankTime(0), m_abort(false){}
+  CVideoSyncIos(void *clock) : CVideoSync(clock), m_LastVBlankTime(0) {}
   
   // CVideoSync interface
   virtual bool Setup(PUPDATECLOCK func) override;
-  virtual void Run(std::atomic<bool>& stop) override;
+  virtual void Run(CEvent& stopEvent) override;
   virtual void Cleanup() override;
   virtual float GetFps() override;
   
@@ -46,7 +46,7 @@ private:
   virtual void DeinitDisplayLink();
 
   int64_t m_LastVBlankTime;  //timestamp of the last vblank, used for calculating how many vblanks happened
-  volatile bool m_abort;
+  CEvent m_abortEvent;
 };
 
 #endif// TARGET_DARWIN_IOS

--- a/xbmc/windowing/osx/VideoSyncOsx.cpp
+++ b/xbmc/windowing/osx/VideoSyncOsx.cpp
@@ -47,19 +47,19 @@ bool CVideoSyncOsx::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncOsx::Run(std::atomic<bool>& stop)
+void CVideoSyncOsx::Run(CEvent& stopEvent)
 {
   InitDisplayLink();
 
   //because cocoa has a vblank callback, we just keep sleeping until we're asked to stop the thread
-  while(!stop && !m_displayLost && !m_displayReset)
+  while(!stopEvent.Signaled() && !m_displayLost && !m_displayReset)
   {
     usleep(100000);
   }
 
   m_lostEvent.Set();
 
-  while(!stop && m_displayLost && !m_displayReset)
+  while(!stopEvent.Signaled() && m_displayLost && !m_displayReset)
   {
     usleep(10000);
   }

--- a/xbmc/windowing/osx/VideoSyncOsx.h
+++ b/xbmc/windowing/osx/VideoSyncOsx.h
@@ -35,7 +35,7 @@ public:
   
   // CVideoSync interface
   virtual bool Setup(PUPDATECLOCK func) override;
-  virtual void Run(std::atomic<bool>& stop) override;
+  virtual void Run(CEvent& stopEvent) override;
   virtual void Cleanup() override;
   virtual float GetFps() override;
   virtual void RefreshChanged() override;

--- a/xbmc/windowing/rpi/VideoSyncPi.cpp
+++ b/xbmc/windowing/rpi/VideoSyncPi.cpp
@@ -37,12 +37,12 @@ bool CVideoSyncPi::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncPi::Run(std::atomic<bool>& stop)
+void CVideoSyncPi::Run(CEvent& stopEvent)
 {
   /* This shouldn't be very busy and timing is important so increase priority */
   CThread::GetCurrentThread()->SetPriority(CThread::GetCurrentThread()->GetPriority()+1);
 
-  while (!stop && !m_abort)
+  while (!stopEvent.Signaled() && !m_abort)
   {
     g_RBP.WaitVsync();
     uint64_t now = CurrentHostCounter();

--- a/xbmc/windowing/rpi/VideoSyncPi.h
+++ b/xbmc/windowing/rpi/VideoSyncPi.h
@@ -28,7 +28,7 @@ class CVideoSyncPi : public CVideoSync, IDispResource
 public:
   CVideoSyncPi(void *clock) : CVideoSync(clock) {};
   virtual bool Setup(PUPDATECLOCK func);
-  virtual void Run(std::atomic<bool>& stop);
+  virtual void Run(CEvent& stopEvent);
   virtual void Cleanup();
   virtual float GetFps();
   virtual void OnResetDisplay();

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -66,7 +66,7 @@ bool CVideoSyncD3D::Setup(PUPDATECLOCK func)
   return true;
 }
 
-void CVideoSyncD3D::Run(std::atomic<bool>& stop)
+void CVideoSyncD3D::Run(CEvent& stopEvent)
 {
   int64_t Now;
   int64_t LastVBlankTime;
@@ -78,7 +78,7 @@ void CVideoSyncD3D::Run(std::atomic<bool>& stop)
   Now = CurrentHostCounter();
   LastVBlankTime = Now;
   m_lastUpdateTime = Now - systemFrequency;
-  while (!stop && !m_displayLost && !m_displayReset)
+  while (!stopEvent.Signaled() && !m_displayLost && !m_displayReset)
   {
     // sleep until vblank
     HRESULT hr = g_Windowing.GetCurrentOutput()->WaitForVBlank();
@@ -111,7 +111,7 @@ void CVideoSyncD3D::Run(std::atomic<bool>& stop)
   }
 
   m_lostEvent.Set();
-  while (!stop && m_displayLost && !m_displayReset)
+  while (!stopEvent.Signaled() && m_displayLost && !m_displayReset)
   {
     Sleep(10);
   }

--- a/xbmc/windowing/windows/VideoSyncD3D.h
+++ b/xbmc/windowing/windows/VideoSyncD3D.h
@@ -28,7 +28,7 @@ class CVideoSyncD3D : public CVideoSync, IDispResource
 public:
   CVideoSyncD3D(void *clock) : CVideoSync(clock) {};
   bool Setup(PUPDATECLOCK func) override;
-  void Run(std::atomic<bool>& stop) override;
+  void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;
   void RefreshChanged() override;


### PR DESCRIPTION
CVideoSync implementers take a bool reference as stop signal for the processing. Change that to a CEvent.

## Description
Some windowing implementations do not need an extra thread to update
the video clock. If they just get a bool to know when to stop the
thread (that does nothing), they have to wake up every few milliseconds
to poll the flag. Each wake-up costs a context switch that is not
needed.
Passing a stop CEvent instead is more flexible: CVideoSync implementers
can still poll the flag if needed, but it is also possible to let
the whole thread sleep until the stop is requested without intermittent
wake-ups.

I've avoided modifying the windowing implementations for which I was not sure how to correctly preserve the previous behavior and could not test myself.

## Motivation and Context
Want to avoid needless context switches and polling if it's easily doable :-)

## How Has This Been Tested?
on X11

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
