### PR TITLE
[swig] Partially revert 71151fe2b9. Causes problems with swig < 3.0

### DIFF
--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -80,7 +80,8 @@ namespace XBMCAddon
 
     public:
       Addon(const char* id = NULL);
-      ~Addon() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Addon();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -78,7 +78,8 @@ namespace XBMCAddon
                   iControlRight(0), pGUIControl(NULL) {}
 
     public:
-      ~Control() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Control();
 
 #ifndef SWIG
       virtual CGUIControl* Create();
@@ -651,7 +652,8 @@ namespace XBMCAddon
     class ControlSpin : public Control
     {
     public:
-      ~ControlSpin() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~ControlSpin();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control_spin
@@ -775,7 +777,8 @@ namespace XBMCAddon
                   long alignment = XBFONT_LEFT, 
                   bool hasPath = false, long angle = 0);
 
-      ~ControlLabel() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~ControlLabel();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control_label
@@ -1135,7 +1138,8 @@ namespace XBMCAddon
                   long _itemTextYOffset = CONTROL_TEXT_OFFSET_Y, long _itemHeight = 27, long _space = 2, 
                   long _alignmentY = XBFONT_CENTER_Y);
 
-      ~ControlList() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~ControlList();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control_list

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -60,7 +60,8 @@ namespace XBMCAddon
     public:
 
       inline Dialog() = default;
-      ~Dialog() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Dialog();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -600,12 +601,14 @@ namespace XBMCAddon
       bool                open;
 
     protected:
-      void deallocating() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual void deallocating();
 
     public:
 
       DialogProgress() : dlg(NULL), open(false) {}
-      ~DialogProgress() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~DialogProgress();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -739,12 +742,14 @@ namespace XBMCAddon
       bool open;
 
     protected:
-      void deallocating() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual void deallocating();
 
     public:
 
       DialogBusy() : dlg(NULL), open(false) {}
-      ~DialogBusy() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~DialogBusy();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -847,12 +852,14 @@ namespace XBMCAddon
       bool open;
 
     protected:
-      void deallocating() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual void deallocating();
 
     public:
 
       DialogProgressBG() : dlg(NULL), handle(NULL), open(false) {}
-      ~DialogProgressBG() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~DialogProgressBG();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -71,7 +71,8 @@ namespace XBMCAddon
           file->Open(filepath, XFILE::READ_NO_CACHE);
       }
 
-      inline ~File() override { delete file; }
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      inline virtual ~File() { delete file; }
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -62,7 +62,8 @@ namespace XBMCAddon
       InfoTagMusic(const MUSIC_INFO::CMusicInfoTag& tag);
 #endif
       InfoTagMusic();
-      ~InfoTagMusic() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~InfoTagMusic();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagRadioRDS.h
+++ b/xbmc/interfaces/legacy/InfoTagRadioRDS.h
@@ -64,7 +64,8 @@ namespace XBMCAddon
       InfoTagRadioRDS(const PVR::CPVRRadioRDSInfoTagPtr tag);
 #endif
       InfoTagRadioRDS();
-      ~InfoTagRadioRDS() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~InfoTagRadioRDS();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -63,7 +63,8 @@ namespace XBMCAddon
       InfoTagVideo(const CVideoInfoTag& tag);
 #endif
       InfoTagVideo();
-      ~InfoTagVideo() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~InfoTagVideo();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Keyboard.h
+++ b/xbmc/interfaces/legacy/Keyboard.h
@@ -75,7 +75,8 @@ namespace XBMCAddon
 #endif
 
       Keyboard(const String& line = emptyString, const String& heading = emptyString, bool hidden = false);
-      ~Keyboard() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Keyboard();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -104,7 +104,8 @@ namespace XBMCAddon
       }
 #endif
 
-      ~ListItem() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~ListItem();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -317,7 +317,8 @@ namespace XBMCAddon
 #else
       bool abortRequested();
 #endif
-      ~Monitor() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Monitor();
     };
     /** @} */
   }

--- a/xbmc/interfaces/legacy/PlayList.h
+++ b/xbmc/interfaces/legacy/PlayList.h
@@ -66,7 +66,8 @@ namespace XBMCAddon
 
     public:
       PlayList(int playList);
-      ~PlayList() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~PlayList();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -90,7 +90,8 @@ namespace XBMCAddon
       //  construction of a Player needs to identify whether or not any 
       //  callbacks will be executed asynchronously or not.
       Player(int playerCore = 0);
-      ~Player(void) override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Player(void);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -59,7 +59,8 @@ namespace XBMCAddon
         m_width = 0;
         m_height = 0;
       }
-      inline ~RenderCapture() override
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      inline virtual ~RenderCapture()
       {
         g_application.m_pPlayer->RenderCaptureRelease(m_captureId);
         delete [] m_buffer;

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -267,7 +267,8 @@ namespace XBMCAddon
     public:
       Window(int existingWindowId = -1);
 
-      ~Window() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~Window();
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool    OnMessage(CGUIMessage& message);

--- a/xbmc/interfaces/legacy/WindowDialog.h
+++ b/xbmc/interfaces/legacy/WindowDialog.h
@@ -64,7 +64,8 @@ namespace XBMCAddon
     {
     public:
       WindowDialog();
-      ~WindowDialog() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WindowDialog();
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool OnMessage(CGUIMessage& message) override;

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -119,7 +119,8 @@ namespace XBMCAddon
                 const String& defaultSkin = "Default",
                 const String& defaultRes = "720p",
                 bool isMedia = false);
-      ~WindowXML() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WindowXML();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -538,7 +539,8 @@ namespace XBMCAddon
                       const String& defaultSkin = "Default",
                       const String& defaultRes = "720p");
 
-      ~WindowXMLDialog() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WindowXMLDialog();
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool OnMessage(CGUIMessage &message) override;

--- a/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.h
@@ -45,7 +45,8 @@ namespace XBMCAddon
     {
     public:
       WsgiErrorStream();
-      ~WsgiErrorStream() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WsgiErrorStream();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
@@ -34,7 +34,8 @@ namespace XBMCAddon
     {
     public:
       WsgiInputStreamIterator();
-      ~WsgiInputStreamIterator() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WsgiInputStreamIterator();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcwsgi_WsgiInputStream
@@ -115,7 +116,8 @@ namespace XBMCAddon
     {
     public:
       WsgiInputStream();
-      ~WsgiInputStream() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WsgiInputStream();
 
 #if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
       WsgiInputStreamIterator* begin();

--- a/xbmc/interfaces/legacy/wsgi/WsgiResponse.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiResponse.h
@@ -45,7 +45,8 @@ namespace XBMCAddon
     {
     public:
       WsgiResponse();
-      ~WsgiResponse() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WsgiResponse();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcwsgi_WsgiInputStreamIterator

--- a/xbmc/interfaces/legacy/wsgi/WsgiResponseBody.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiResponseBody.h
@@ -38,7 +38,8 @@ namespace XBMCAddon
     {
     public:
       WsgiResponseBody();
-      ~WsgiResponseBody() override;
+      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
+      virtual ~WsgiResponseBody();
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcwsgi_WsgiInputStreamIterator


### PR DESCRIPTION
## Description
Partially revert 71151fe2b9

14.04 (trusty) ships swig 2.0.11 but swig's [C++11 support was only introduced in 3.0](http://www.swig.org/Doc3.0/CPlusPlus11.html#CPlusPlus11_explicit_overrides_final).
## Motivation and Context
Some team members are still using 14.04 as daily work/build env.

## How Has This Been Tested?
Not at all. No 14.04 here.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Alternatives:
Package and ship 3.0.x in `xbmc-ppa-build-depends` or `xbmc-nightly`. @wsnipex?
Use a backports ppa, e.g. https://launchpad.net/~nschloe/+archive/ubuntu/swig-backports

@peak3d, I have no way to test unless I set up a new build env. Can you take it for a ride?