### PR TITLE
RetroPlayer: Remove dependency on IPlayer interface

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -148,7 +148,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   {
     SetSpeed(1);
     m_callback.OnPlayBackStarted();
-    m_autoSave.reset(new CRetroPlayerAutoSave(this));
+    m_autoSave.reset(new CRetroPlayerAutoSave(*m_gameClient));
   }
   else
   {

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -19,8 +19,8 @@
  */
 
 #include "RetroPlayerAutoSave.h"
-#include "cores/IPlayer.h"
-#include "cores/DataCacheCore.h"
+#include "games/addons/GameClient.h"
+#include "games/addons/playback/IGameClientPlayback.h"
 #include "utils/log.h"
 #include "URL.h"
 
@@ -29,12 +29,11 @@ using namespace RETRO;
 
 #define AUTOSAVE_DURATION_SECS    10 // Auto-save every 10 seconds
 
-CRetroPlayerAutoSave::CRetroPlayerAutoSave(IPlayer *player) :
+CRetroPlayerAutoSave::CRetroPlayerAutoSave(GAME::CGameClient &gameClient) :
   CThread("CRetroPlayerAutoSave"),
-  m_player(player)
+  m_gameClient(gameClient)
 {
-  if (m_player != nullptr)
-    Create(false);
+  Create(false);
 }
 
 CRetroPlayerAutoSave::~CRetroPlayerAutoSave() = default;
@@ -48,9 +47,9 @@ void CRetroPlayerAutoSave::Process()
     if (m_bStop)
       break;
 
-    if (CDataCacheCore::GetInstance().GetSpeed() > 0.0f)
+    if (m_gameClient.GetPlayback()->GetSpeed() > 0.0)
     {
-      std::string savePath = m_player->GetPlayerState();
+      std::string savePath = m_gameClient.GetPlayback()->CreateSavestate();
       if (!savePath.empty())
         CLog::Log(LOGDEBUG, "Saved state to %s", CURL::GetRedacted(savePath).c_str());
     }

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
@@ -19,9 +19,8 @@
  */
 #pragma once
 
+#include "games/GameTypes.h"
 #include "threads/Thread.h"
-
-class IPlayer;
 
 namespace KODI
 {
@@ -30,7 +29,7 @@ namespace RETRO
   class CRetroPlayerAutoSave : protected CThread
   {
   public:
-    CRetroPlayerAutoSave(IPlayer *player);
+    CRetroPlayerAutoSave(GAME::CGameClient &gameClient);
 
     ~CRetroPlayerAutoSave() override;
 
@@ -40,7 +39,7 @@ namespace RETRO
 
   private:
     // Construction parameter
-    IPlayer *const m_player;
+    GAME::CGameClient &m_gameClient;
   };
 }
 }


### PR DESCRIPTION
This change removes a layer from the creation of saved states.

## Description
<!--- Describe your change in detail -->

Previously, the autosave subsystem would call out to the IPlayer interface, which would call back in to the internal playback API, IGameClientPlayback:

* Autosave -> IPlayer -> IGameClientPlayback -> Playback API

Now, we call the internal playback API directly:

* Autosave -> IGameClientPlayback -> Playback API

## Motivation and Context
Comment in #12470
