### PR TITLE
Fix AddonVideoCodec plane swap

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -210,10 +210,13 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
 
     pVideoPicture->videoBuffer = static_cast<CVideoBuffer*>(picture.buffer);
 
-    int strides[YuvImage::MAX_PLANES];
+    int strides[YuvImage::MAX_PLANES], planeOffsets[YuvImage::MAX_PLANES];
     for (int i = 0; i<YuvImage::MAX_PLANES; ++i)
       strides[i] = picture.stride[i];
-    pVideoPicture->videoBuffer->SetDimensions(picture.width, picture.height, strides);
+    for (int i = 0; i<YuvImage::MAX_PLANES; ++i)
+      planeOffsets[i] = picture.planeOffsets[i];
+
+    pVideoPicture->videoBuffer->SetDimensions(picture.width, picture.height, strides, planeOffsets);
 
     pVideoPicture->iDisplayWidth = pVideoPicture->iWidth;
     pVideoPicture->iDisplayHeight = pVideoPicture->iHeight;

--- a/xbmc/cores/VideoPlayer/Process/VideoBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/Process/VideoBuffer.cpp
@@ -266,6 +266,15 @@ void CVideoBufferSysMem::SetDimensions(int width, int height, const int (&stride
   m_image.plane[2] = m_image.plane[1] + m_image.planesize[1];
 }
 
+void CVideoBufferSysMem::SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES])
+{
+  SetDimensions(width, height, strides);
+
+  m_image.plane[0] = m_data + planeOffsets[0];
+  m_image.plane[1] = m_data + planeOffsets[1];
+  m_image.plane[2] = m_data + planeOffsets[2];
+}
+
 bool CVideoBufferSysMem::Alloc()
 {
   m_data = new uint8_t[m_size];

--- a/xbmc/cores/VideoPlayer/Process/VideoBuffer.h
+++ b/xbmc/cores/VideoPlayer/Process/VideoBuffer.h
@@ -100,6 +100,7 @@ public:
   virtual void GetPlanes(uint8_t*(&planes)[YuvImage::MAX_PLANES]) {};
   virtual void GetStrides(int(&strides)[YuvImage::MAX_PLANES]) {};
   virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) {};
+  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) {};
 
   static bool CopyPicture(YuvImage* pDst, YuvImage *pSrc);
   static bool CopyNV12Picture(YuvImage* pDst, YuvImage *pSrc);
@@ -122,6 +123,7 @@ public:
   void GetPlanes(uint8_t*(&planes)[YuvImage::MAX_PLANES]) override;
   void GetStrides(int(&strides)[YuvImage::MAX_PLANES]) override;
   void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) override;
+  void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) override;
   bool Alloc();
 
 protected:


### PR DESCRIPTION
## Description
some decoders provide relative offsets to the  start in memory of the planes (YUV)
We need to transport and respect this information in VideoBuffer.

## Motivation and Context
An unnamed addon schows red as blue

## How Has This Been Tested?
Linux x86_64 / N*****x addon

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
