### PR TITLE
[depends][win32] Hopefully fix a dnssd crash

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win32.list
@@ -9,7 +9,7 @@
 cpluff-ed7874fc-win32-vc140.7z
 crossguid-8f399e-win32-vc140-v3.7z
 curl-7.48-win32-vc140.7z
-dnssd-541-win32.zip
+dnssd-765.50.9-win32-vc140-v2.7z
 easyhook-2.7.5870.0-win32-vc140-v2.7z
 expat-2.2.0-win32-vc140.7z
 fmt-3.0.1-win32-vc140.7z

--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -9,7 +9,7 @@
 cpluff-0.1.3-x64-vc140.7z
 crossguid-fef89a4-x64-vc140.7z
 curl-7.52.1-x64-vc140.7z
-dnssd-765.50.9-x64-vc140.7z
+dnssd-765.50.9-x64-vc140-v2.7z
 easyhook-2.7.6035.0-x64-vc140.7z
 expat-2.2.0-x64-vc140.7z
 fmt-3.0.1-x64-vc140.7z


### PR DESCRIPTION
win32 version was built against msvcr100
if it's missing load fail and we crash.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
