### PR TITLE
[Android] Map SL/SR channels to BL/BR for audiotrack

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=4c1dc017a1b695fd5976fc3e700d466b89e1a778
+VERSION=072eb4622d223e5a28c06c5e0402538583e75cf6
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -143,6 +143,15 @@ static int AEChannelMapToAUDIOTRACKChannelMask(CAEChannelInfo info)
 {
   info.ResolveChannels(KnownChannels);
 
+  // Detect layouts with 6 channels including one LFE channel
+  // We currently support the following layouts:
+  // 5.1            FL+FR+FC+LFE+BL+BR
+  // 5.1(side)      FL+FR+FC+LFE+SL+SR
+  // According to CEA-861-D only RR and RL are defined
+  // Therefore we let Android decide about the 5.1 mapping
+  if (info.Count() == 6 && info.HasChannel(AE_CH_LFE))
+    return CJNIAudioFormat::CHANNEL_OUT_5POINT1;
+
   int atMask = 0;
 
   for (unsigned int i = 0; i < info.Count(); i++)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -149,8 +149,13 @@ static int AEChannelMapToAUDIOTRACKChannelMask(CAEChannelInfo info)
   // 5.1(side)      FL+FR+FC+LFE+SL+SR
   // According to CEA-861-D only RR and RL are defined
   // Therefore we let Android decide about the 5.1 mapping
+  // For 8 channel layouts including one LFE channel
+  // we leave the same decision to Android
   if (info.Count() == 6 && info.HasChannel(AE_CH_LFE))
     return CJNIAudioFormat::CHANNEL_OUT_5POINT1;
+
+  if (info.Count() == 8 && info.HasChannel(AE_CH_LFE))
+    return CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND;
 
   int atMask = 0;
 


### PR DESCRIPTION
[Android] Map SL/SR channels to BL/BR for audiotrack

## Description
5.1 streams with Channel Layout: FL, FR, FC, LFE, SL, SR PCM do not play dolby on some AVR (e.g. denon). Instead they fall back to stereo. Mapping to Channel Layout: FL, FR, FC, LFE, BL, BR solve the issue.

## How Has This Been Tested?
NVIDIA shield 2017 / denon AVR 2310 / several dolby streams

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Credits to @fritsch !!!!