### PR TITLE
RetroPlayer: Fix black screen when playing games

### DIFF
--- a/xbmc/cores/RetroPlayer/PixelConverter.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverter.cpp
@@ -45,7 +45,7 @@ class CPixelBufferFFmpeg : public CVideoBuffer
 {
 public:
   CPixelBufferFFmpeg(IVideoBufferPool &pool, int id);
-  virtual ~CPixelBufferFFmpeg();
+  ~CPixelBufferFFmpeg() override;
   virtual void GetPlanes(uint8_t*(&planes)[YuvImage::MAX_PLANES]) override;
   virtual void GetStrides(int(&strides)[YuvImage::MAX_PLANES]) override;
 
@@ -98,7 +98,7 @@ void CPixelBufferFFmpeg::Unref()
 class CPixelBufferPoolFFmpeg : public IVideoBufferPool
 {
 public:
-  virtual ~CPixelBufferPoolFFmpeg();
+  ~CPixelBufferPoolFFmpeg() override;
   virtual void Return(int id) override;
   virtual CVideoBuffer* Get() override;
 
@@ -162,18 +162,13 @@ void CPixelBufferPoolFFmpeg::Return(int id)
 // main class
 //------------------------------------------------------------------------------
 
-void CPixelConverter::delete_buffer_pool::operator()(CPixelBufferPoolFFmpeg *p) const
-{
-  delete p;
-}
-
 CPixelConverter::CPixelConverter() :
   m_targetFormat(AV_PIX_FMT_NONE),
   m_width(0),
   m_height(0),
   m_swsContext(nullptr),
   m_pFrame(nullptr),
-  m_pixelBufferPool(new CPixelBufferPoolFFmpeg)
+  m_pixelBufferPool(std::make_shared<CPixelBufferPoolFFmpeg>())
 {
 }
 

--- a/xbmc/cores/RetroPlayer/PixelConverter.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverter.cpp
@@ -245,7 +245,7 @@ void CPixelConverter::GetPicture(VideoPicture& dvdVideoPicture)
   }
 
   dvdVideoPicture.dts            = DVD_NOPTS_VALUE;
-  dvdVideoPicture.pts            = DVD_NOPTS_VALUE;
+  dvdVideoPicture.pts            = 0.0; // Show immediately
   dvdVideoPicture.iFlags         = 0;
   dvdVideoPicture.color_matrix   = 4; // CONF_FLAGS_YUVCOEF_BT601
   dvdVideoPicture.color_range    = 0; // *not* CONF_FLAGS_YUV_FULLRANGE

--- a/xbmc/cores/RetroPlayer/PixelConverter.h
+++ b/xbmc/cores/RetroPlayer/PixelConverter.h
@@ -44,15 +44,10 @@ public:
 protected:
   bool AllocateBuffers(AVFrame *pFrame) const;
 
-  struct delete_buffer_pool
-  {
-    void operator()(CPixelBufferPoolFFmpeg *p) const;
-  };
-
   AVPixelFormat m_targetFormat;
   unsigned int m_width;
   unsigned int m_height;
   SwsContext* m_swsContext;
   AVFrame *m_pFrame;
-  std::unique_ptr<CPixelBufferPoolFFmpeg, delete_buffer_pool> m_pixelBufferPool;
+  std::shared_ptr<CPixelBufferPoolFFmpeg> m_pixelBufferPool;
 };

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -473,6 +473,11 @@ void CRetroPlayer::UpdateRenderInfo(CRenderInfo &info)
   m_processInfo->UpdateRenderInfo(info);
 }
 
+void CRetroPlayer::UpdateRenderBuffers(int queued, int discard, int free)
+{
+  m_processInfo->UpdateRenderBuffers(queued, discard, free);
+}
+
 void CRetroPlayer::UpdateGuiRender(bool gui)
 {
   m_processInfo->SetGuiRender(gui);

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -142,7 +142,7 @@ namespace RETRO
     virtual void GetDebugInfo(std::string &audio, std::string &video, std::string &general) override { }
     virtual void UpdateClockSync(bool enabled) override;
     virtual void UpdateRenderInfo(CRenderInfo &info) override;
-    virtual void UpdateRenderBuffers(int queued, int discard, int free) override {}
+    virtual void UpdateRenderBuffers(int queued, int discard, int free) override;
     virtual void UpdateGuiRender(bool gui) override;
     virtual void UpdateVideoRender(bool video) override;
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -128,8 +128,6 @@ namespace RETRO
     float GetRenderAspectRatio() override { return m_renderManager.GetAspectRatio(); }
     void TriggerUpdateResolution() override { m_renderManager.TriggerUpdateResolution(0.0f, 0, 0); }
     bool IsRenderingVideo() override { return m_renderManager.IsConfigured(); }
-//    bool IsRenderingGuiLayer() { return m_renderManager.IsGuiLayer(); }
-//    bool IsRenderingVideoLayer() override { return m_renderManager.IsVideoLayer(); }
     bool Supports(EINTERLACEMETHOD method) override;
     EINTERLACEMETHOD GetDeinterlacingMethodDefault() override;
     bool Supports(ESCALINGMETHOD method) override { return m_renderManager.Supports(method); }

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -119,6 +119,8 @@ void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
 
   if (GetPicture(data, size, picture))
   {
+    picture.iDuration = 1.0 / m_framerate;
+
     if (!Configure(picture))
     {
       CLog::Log(LOGERROR, "RetroPlayerVideo: Failed to configure renderer");


### PR DESCRIPTION
This contains two fixes for two separate bugs causing a black screen during gameplay. It also contains some minor improvements that shouldn't affect playback.