### PR TITLE
[xbmc][depends][win32] Fix python that broke in #12502

### DIFF
--- a/cmake/installdata/windows/dlls.txt
+++ b/cmake/installdata/windows/dlls.txt
@@ -1,5 +1,4 @@
 system/*.dll .
 project/BuildDependencies/${ARCH}/bin/libbluray*.jar .
-project/Win32BuildSetup/dependencies/python27.dll .
 project/BuildDependencies/${ARCH}/bin/*.dll .
 project/BuildDependencies/mingwlibs/${ARCH}/bin/*.dll .

--- a/cmake/installdata/windows/python.txt
+++ b/cmake/installdata/windows/python.txt
@@ -1,2 +1,1 @@
-system/python/*
 project/BuildDependencies/${ARCH}/bin/Python KEEP_DIR_STRUCTURE system

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -23,12 +23,7 @@ list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependenci
 list(APPEND CMAKE_SYSTEM_LIBRARY_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependencies/mingwlibs/${ARCH}/bin)
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH})
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_SOURCE_DIR}/project/BuildDependencies)
-
-if(${ARCH} STREQUAL win32)
-  set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/include/python)
-else()
-  set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH}/include/python)
-endif()
+set(PYTHON_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/project/BuildDependencies/${ARCH}/include/python)
 
 
 # -------- Compiler options ---------

--- a/project/BuildDependencies/scripts/0_package.target-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win32.list
@@ -37,7 +37,7 @@ openssl-1.0.2g-win32-vc140-v2.7z
 pcre-8.37-win32-vc140-v3.7z
 pillow-3.1.0-win32-vc140.7z
 pycryptodome-3.4.3-win32.7z
-python-2.7.13-win32-vc140-v2.7z
+python-2.7.13-win32-vc140-v3.7z
 rapidjson-1.1.0-win32.7z
 shairplay-0.9.0-win32-vc140-v2.7z
 sqlite-3.10.2-win32-vc140.7z

--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -32,7 +32,7 @@ mini_wdk-10.0.14393.0-x64.7z
 mysql-connector-c-6.1.9-x64-vc140.7z
 openssl-1.0.2k-x64-vc140.7z
 pcre-8.40-x64-vc140.7z
-python-2.7.13-x64-vc140-v2.7z
+python-2.7.13-x64-vc140-v3.7z
 rapidjson-1.1.0-win32.7z
 shairplay-ce80e00-x64-vc140.7z
 sqlite-3.17.0-x64-vc140.7z

--- a/system/python/readme.txt
+++ b/system/python/readme.txt
@@ -1,9 +1,0 @@
-python directory structure
-
-DLLs dir:
-  Library directory used by python.
-  python extensions (.pyd) from cvs can be placed here
-  
-Lib dir:
-  Library directory used by python.
-  Here can new packages or modules be installed by the user.

--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -143,7 +143,6 @@ set WORKSPACE=%base_dir%\kodi-build
   copy %base_dir%\copying.txt BUILD_WIN32\application > NUL
   copy %base_dir%\privacy-policy.txt BUILD_WIN32\application > NUL
   copy %base_dir%\known_issues.txt BUILD_WIN32\application > NUL
-  xcopy dependencies\*.* BUILD_WIN32\application /Q /I /Y /EXCLUDE:exclude.txt  > NUL
 
   xcopy %WORKSPACE%\addons BUILD_WIN32\application\addons /E /Q /I /Y /EXCLUDE:exclude.txt > NUL
   xcopy %WORKSPACE%\*.dll BUILD_WIN32\application /Q /I /Y > NUL


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Missed some build file changes for the new package format
python cmake file packaged the wrong architecture for extensions

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
