### PR TITLE
Fix several settings that broke after the last few ServiceManager refactorings

### DIFF
--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -45,7 +45,12 @@ CRepositoryUpdater::CRepositoryUpdater(CAddonMgr& addonMgr) :
   m_timer(this),
   m_doneEvent(true),
   m_addonMgr(addonMgr)
-{}
+{
+  // Register settings
+  std::set<std::string> settingSet;
+  settingSet.insert(CSettings::SETTING_ADDONS_AUTOUPDATES);
+  CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
+}
 
 void CRepositoryUpdater::Start()
 {
@@ -55,6 +60,9 @@ void CRepositoryUpdater::Start()
 
 CRepositoryUpdater::~CRepositoryUpdater()
 {
+  // Unregister settings
+  CServiceBroker::GetSettings().UnregisterCallback(this);
+
   m_addonMgr.Events().Unsubscribe(this);
 }
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -100,10 +100,18 @@ CInputManager::CInputManager(const CAppParamParser &params) :
 
   if (!params.RemoteControlEnabled())
     DisableRemoteControl();
+
+  // Register settings
+  std::set<std::string> settingSet;
+  settingSet.insert(CSettings::SETTING_INPUT_ENABLEMOUSE);
+  CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
 }
 
 CInputManager::~CInputManager()
 {
+  // Unregister settings
+  CServiceBroker::GetSettings().UnregisterCallback(this);
+
   UnregisterKeyboardHandler(m_keyboardEasterEgg.get());
 
   m_buttonTranslator->UnregisterMapper(m_touchTranslator.get());

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -82,10 +82,21 @@ CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements) :
   m_announcements(announcements),
   m_eventScanner(this)
 {
+  // Register settings
+  std::set<std::string> settingSet;
+  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALS);
+  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALLIBRARIES);
+  settingSet.insert(CSettings::SETTING_INPUT_CONTROLLERCONFIG);
+  settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
+  settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
+  CServiceBroker::GetSettings().RegisterCallback(this, settingSet);
 }
 
 CPeripherals::~CPeripherals()
 {
+  // Unregister settings
+  CServiceBroker::GetSettings().UnregisterCallback(this);
+
   Clear();
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -27,7 +27,6 @@
 #include "Util.h"
 #include "events/EventLog.h"
 #include "addons/AddonSystemSettings.h"
-#include "addons/RepositoryUpdater.h"
 #include "addons/Skin.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h"
@@ -823,7 +822,6 @@ void CSettings::UninitializeISettingsHandlers()
   GetSettingsManager()->UnregisterCallback(&CNetworkServices::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);
   GetSettingsManager()->UnregisterCallback(&CRssManager::GetInstance());
-  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetRepositoryUpdater());
 #if defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)
@@ -1027,10 +1025,6 @@ void CSettings::InitializeISettingCallbacks()
 #endif
 
   settingSet.clear();
-  settingSet.insert(CSettings::SETTING_ADDONS_AUTOUPDATES);
-  GetSettingsManager()->RegisterCallback(&CServiceBroker::GetRepositoryUpdater(), settingSet);
-
-  settingSet.clear();
   settingSet.insert(CSettings::SETTING_ADDONS_SHOW_RUNNING);
   settingSet.insert(CSettings::SETTING_ADDONS_MANAGE_DEPENDENCIES);
   settingSet.insert(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES);
@@ -1077,7 +1071,6 @@ void CSettings::UninitializeISettingCallbacks()
   GetSettingsManager()->UnregisterCallback(&CNetworkServices::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);
   GetSettingsManager()->UnregisterCallback(&CRssManager::GetInstance());
-  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetRepositoryUpdater());
   GetSettingsManager()->UnregisterCallback(&GAME::CGameSettings::GetInstance());
 #if defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_timezone);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -84,7 +84,6 @@
 #include "utils/SeekHandler.h"
 #include "utils/Variant.h"
 #include "view/ViewStateSettings.h"
-#include "input/InputManager.h"
 #include "ServiceBroker.h"
 #include "DiscSettings.h"
 
@@ -821,7 +820,6 @@ void CSettings::UninitializeISettingsHandlers()
   GetSettingsManager()->UnregisterCallback(&g_charsetConverter);
   GetSettingsManager()->UnregisterCallback(&g_graphicsContext);
   GetSettingsManager()->UnregisterCallback(&g_langInfo);
-  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetInputManager());
   GetSettingsManager()->UnregisterCallback(&CNetworkServices::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);
   GetSettingsManager()->UnregisterCallback(&CRssManager::GetInstance());
@@ -978,10 +976,6 @@ void CSettings::InitializeISettingCallbacks()
   GetSettingsManager()->RegisterCallback(&g_langInfo, settingSet);
 
   settingSet.clear();
-  settingSet.insert(CSettings::SETTING_INPUT_ENABLEMOUSE);
-  GetSettingsManager()->RegisterCallback(&CServiceBroker::GetInputManager(), settingSet);
-
-  settingSet.clear();
   settingSet.insert(CSettings::SETTING_SERVICES_WEBSERVER);
   settingSet.insert(CSettings::SETTING_SERVICES_WEBSERVERPORT);
   settingSet.insert(CSettings::SETTING_SERVICES_WEBSERVERUSERNAME);
@@ -1080,7 +1074,6 @@ void CSettings::UninitializeISettingCallbacks()
   GetSettingsManager()->UnregisterCallback(&g_charsetConverter);
   GetSettingsManager()->UnregisterCallback(&g_graphicsContext);
   GetSettingsManager()->UnregisterCallback(&g_langInfo);
-  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetInputManager());
   GetSettingsManager()->UnregisterCallback(&CNetworkServices::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);
   GetSettingsManager()->UnregisterCallback(&CRssManager::GetInstance());

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -61,7 +61,6 @@
 #if defined(HAS_LIBAMCODEC)
 #include "utils/AMLUtils.h"
 #endif // defined(HAS_LIBAMCODEC)
-#include "peripherals/Peripherals.h"
 #include "powermanagement/PowerManager.h"
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRSettings.h"
@@ -831,7 +830,6 @@ void CSettings::UninitializeISettingsHandlers()
   GetSettingsManager()->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_weatherManager);
-  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetPeripherals());
 #if defined(TARGET_DARWIN_OSX)
   GetSettingsManager()->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif
@@ -1027,14 +1025,6 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_WEATHER_ADDONSETTINGS);
   GetSettingsManager()->RegisterCallback(&g_weatherManager, settingSet);
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALS);
-  settingSet.insert(CSettings::SETTING_INPUT_PERIPHERALLIBRARIES);
-  settingSet.insert(CSettings::SETTING_INPUT_CONTROLLERCONFIG);
-  settingSet.insert(CSettings::SETTING_INPUT_TESTRUMBLE);
-  settingSet.insert(CSettings::SETTING_LOCALE_LANGUAGE);
-  GetSettingsManager()->RegisterCallback(&CServiceBroker::GetPeripherals(), settingSet);
-
 #if defined(TARGET_DARWIN_OSX)
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEMODE);
@@ -1100,7 +1090,6 @@ void CSettings::UninitializeISettingCallbacks()
   GetSettingsManager()->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_weatherManager);
-GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetPeripherals());
 #if defined(TARGET_DARWIN_OSX)
   GetSettingsManager()->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif


### PR DESCRIPTION
This fixes several settings that have broke over the last few weeks:

* Enable/disable mouse
* Peripherals dialog
* Peripheral drivers dialog
* Controller configuration
* Test rumble
* CEC language locale
* Add-on autoupdates

## How Has This Been Tested?
Enable/disable mouse and controller configuration guaranteed to be working. Haven't tested the add-on autoupdates setting.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
