### PR TITLE
[xbmc][win32] Fix a crash for subtitle rendering in 4k on amd cards

### DIFF
--- a/project/BuildDependencies/scripts/0_package.list
+++ b/project/BuildDependencies/scripts/0_package.list
@@ -16,7 +16,7 @@ expat-2.2.0-win32-vc140.7z
 freetype-db5a22-win32-vc140.7z
 giflib-5.1.4-win32-vc140.7z
 jsonschemabuilder-1.0.0-win32-3.7z
-libass-d18a5f1-win32-vc140.7z
+libass-317313-win32-vc140.7z
 libbluray-0.9.3-win32-vc140.7z
 libcdio-0.9.3-win32-vc140.7z
 libcec-4.0.1-win32-vc140-2.7z

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -81,7 +81,7 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, int width, int height)
   m_count  = 0;
 
   SQuads quads;
-  if(!convert_quad(images, quads))
+  if(!convert_quad(images, quads, width))
     return;
   
   float u, v;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -301,7 +301,7 @@ COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, int width, int height)
   m_texture = 0;
 
   SQuads quads;
-  if(!convert_quad(images, quads))
+  if(!convert_quad(images, quads, width))
     return;
 
   glGenTextures(1, &m_texture);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.cpp
@@ -182,7 +182,7 @@ uint32_t* convert_rgba(CDVDOverlaySpu* o, bool mergealpha
   return rgba;
 }
 
-bool convert_quad(ASS_Image* images, SQuads& quads)
+bool convert_quad(ASS_Image* images, SQuads& quads, int max_x)
 {
   ASS_Image* img;
 
@@ -204,8 +204,8 @@ bool convert_quad(ASS_Image* images, SQuads& quads)
   if (quads.count == 0)
     return false;
 
-  if (quads.size_x > (int)g_Windowing.GetMaxTextureSize())
-    quads.size_x = g_Windowing.GetMaxTextureSize();
+  if (quads.size_x > max_x)
+    quads.size_x = max_x;
 
   int curr_x = 0;
   int curr_y = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
@@ -63,7 +63,7 @@ namespace OVERLAY {
   uint32_t* convert_rgba(CDVDOverlaySpu*   o, bool mergealpha
                        , int& min_x, int& max_x
                        , int& min_y, int& max_y);
-  bool      convert_quad(ASS_Image* images, SQuads& quads);
+  bool      convert_quad(ASS_Image* images, SQuads& quads, int max_x);
   int       GetStereoscopicDepth();
 
 }


### PR DESCRIPTION
AMD drivers crashes when we try to allocate a texture
5073 pixels wide. This caps our texture to the screen width.
Bump libass to 0.1.3.7 which includes a 4k fix

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
