### PR TITLE
Valgrind

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -768,7 +768,7 @@ JSONRPC_STATUS JSONSchemaTypeDefinition::Check(const CVariant &value, CVariant &
       // allowed there is no need to check every element
       if (value.size() < items.size() || (value.size() != items.size() && additionalItems.size() == 0))
       {
-        CLog::Log(LOGDEBUG, "JSONRPC: One of the array elements does not match in type {0}", name.c_str());
+        CLog::Log(LOGDEBUG, "JSONRPC: One of the array elements does not match in type %s", name.c_str());
         errorMessage = StringUtils::Format("{0} array elements expected but {1} received", items.size(), value.size());
         errorData["message"] = errorMessage.c_str();
         return InvalidParams;

--- a/xbmc/network/websocket/WebSocket.cpp
+++ b/xbmc/network/websocket/WebSocket.cpp
@@ -242,7 +242,7 @@ CWebSocketFrame::~CWebSocketFrame()
 
   if (m_free && m_data != NULL)
   {
-    delete m_data;
+    delete[] m_data;
     m_data = NULL;
   }
 }


### PR DESCRIPTION
Valgrind complained about those lines.

## Description
First change uses delete[] for an array that was allocated with new[].
Afaik this needs to be done according to the standard, although most platform
can handle it implicitly.

According to our docs StringUtils::Format must get .c_str and cannot get a std::string.
Not sure if this is right.

@Paxxi @Montellese ?

## How Has This Been Tested?
Couldn't find any regressions when having this commits.
I started this investigation because json-rpc and webserver crash sometimes on my machine and
I hoped the crashes would be related.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
