### PR TITLE
Fix peripherals started before strings are loaded

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -107,9 +107,6 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_inputManager->InitializeInputs();
 
   m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager));
-  m_peripherals->Initialise();
-
-  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager, *m_peripherals));
 
   init_level = 2;
   return true;
@@ -147,6 +144,11 @@ bool CServiceManager::StartAudioEngine()
 // stage 3 is called after successful initialization of WindowManager
 bool CServiceManager::InitStageThree()
 {
+  // Peripherals depends on strings being loaded before stage 3
+  m_peripherals->Initialise();
+
+  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager, *m_peripherals));
+
   m_contextMenuManager->Init();
   m_PVRManager->Init();
 
@@ -158,13 +160,14 @@ void CServiceManager::DeinitStageThree()
 {
   m_PVRManager->Deinit();
   m_contextMenuManager->Deinit();
+  m_gameServices.reset();
+  m_peripherals->Clear();
 
   init_level = 2;
 }
 
 void CServiceManager::DeinitStageTwo()
 {
-  m_gameServices.reset();
   m_peripherals.reset();
   m_inputManager.reset();
   m_gameControllerManager.reset();


### PR DESCRIPTION
This fixes the following error:

![screenshot000](https://user-images.githubusercontent.com/531482/28297028-745f2b0a-6b20-11e7-9fc6-9ccee023240e.png)

## How Has This Been Tested?
The labels show up now.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
