### PR TITLE
[GUI] Allow recursive usage of idCollector in CGUIControlGroup

### DIFF
--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -268,14 +268,16 @@ bool CGUIControlGroup::OnMessage(CGUIMessage& message)
 
 bool CGUIControlGroup::SendControlMessage(CGUIMessage &message)
 {
-  CGUIControl *ctrl(GetControl(message.GetControlId(), &m_idCollector));
+  IDCollector collector(m_idCollector);
+
+  CGUIControl *ctrl(GetControl(message.GetControlId(), collector.m_collector));
   // see if a child matches, and send to the child control if so
   if (ctrl && ctrl->OnMessage(message))
     return true;
 
   // Unhandled - send to all matching invisible controls as well
   bool handled(false);
-  for (auto *control : m_idCollector)
+  for (auto *control : *collector.m_collector)
     if (control->OnMessage(message))
       handled = true;
 

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -85,7 +85,8 @@ public:
 #endif
 protected:
   // sub controls
-  std::vector<CGUIControl *> m_children, m_idCollector;
+  std::vector<CGUIControl *> m_children;
+
   typedef std::vector<CGUIControl *>::iterator iControls;
   typedef std::vector<CGUIControl *>::const_iterator ciControls;
   typedef std::vector<CGUIControl *>::reverse_iterator rControls;
@@ -95,5 +96,35 @@ protected:
   bool m_defaultAlways;
   int m_focusedControl;
   bool m_renderFocusedLast;
+private:
+  typedef std::vector< std::vector<CGUIControl *> * > COLLECTORTYPE;
+
+  struct IDCollectorList
+  {
+    ~IDCollectorList() { for (auto item : m_items) delete item; };
+
+    std::vector<CGUIControl *> *Get() {
+      if (++m_stackDepth > m_items.size())
+        m_items.push_back(new std::vector<CGUIControl *>());
+      return m_items[m_stackDepth - 1];
+    }
+
+    void Release() { --m_stackDepth; };
+
+    COLLECTORTYPE m_items;
+    size_t m_stackDepth = 0;
+  }m_idCollector;
+
+  struct IDCollector
+  {
+    IDCollector(IDCollectorList &list)
+      : m_list(list)
+      , m_collector(list.Get()) {};
+
+    ~IDCollector() { m_list.Release(); };
+
+    IDCollectorList &m_list;
+    std::vector<CGUIControl *> *m_collector;
+  };
 };
 


### PR DESCRIPTION
[GUI] Allow recursice usage of idlookup in CGUIControlGroup

## Description
CGUIControl::SendControlmessage is can be called recursice (e.g. closing a video with "x")
This leads to reusage of m_idLookup (wich was introduced for performance reasons) member.

## Motivation and Context
Kodi on Win64 segfaults if pressing x during a running video

## How Has This Been Tested?
Win10 / x64 / 7TV addon / starting a stream / press x

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
