### PR TITLE
[pvr] drop channel guide button from info dialog + add channel guide to context menu

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRChannelGuide.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelGuide.xml
@@ -3,6 +3,13 @@
 	<defaultcontrol always="true">11</defaultcontrol>
 	<controls>
 		<control type="group">
+			<animation effect="fade" start="0" end="100" time="100">WindowOpen</animation>
+			<animation effect="fade" start="100" end="0" time="100">WindowClose</animation>
+			<animation effect="fade" start="100" end="75" time="0" condition="true">Conditional</animation>
+			<visible>!Window.IsActive(fullscreenvideo)</visible>
+			<include>ColoredBackgroundImages</include>
+		</control>
+		<control type="group">
 			<depth>DepthOSD</depth>
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<control type="group">

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -56,6 +56,7 @@ namespace PVR
     };
 
     DECL_CONTEXTMENUITEM(ShowInformation);
+    DECL_STATICCONTEXTMENUITEM(ShowChannelGuide);
     DECL_STATICCONTEXTMENUITEM(FindSimilar);
     DECL_STATICCONTEXTMENUITEM(PlayRecording);
     DECL_STATICCONTEXTMENUITEM(StartRecording);
@@ -123,6 +124,23 @@ namespace PVR
         return CServiceBroker::GetPVRManager().GUIActions()->ShowRecordingInfo(item);
 
       return CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(item);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // Show channel guide
+
+    bool ShowChannelGuide::IsVisible(const CFileItem &item) const
+    {
+      const CPVRChannelPtr channel(item.GetPVRChannelInfoTag());
+      if (channel)
+        return channel->GetEPGNow().get() != nullptr;
+
+      return false;
+    }
+
+    bool ShowChannelGuide::Execute(const CFileItemPtr &item) const
+    {
+      return CServiceBroker::GetPVRManager().GUIActions()->ShowChannelEPG(item);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -525,6 +543,7 @@ namespace PVR
     m_items =
     {
       std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
+      std::make_shared<CONTEXTMENUITEM::ShowChannelGuide>(19686), /* Channel guide */
       std::make_shared<CONTEXTMENUITEM::FindSimilar>(19003), /* Find similar */
       std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
       std::make_shared<CONTEXTMENUITEM::ToggleTimerState>(),

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -49,7 +49,6 @@ using namespace KODI::MESSAGING;
 #define CONTROL_BTN_OK                  7
 #define CONTROL_BTN_PLAY_RECORDING      8
 #define CONTROL_BTN_ADD_TIMER           9
-#define CONTROL_BTN_CHANNEL_GUIDE       10
 
 CGUIDialogPVRGuideInfo::CGUIDialogPVRGuideInfo(void)
     : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_INFO, "DialogPVRInfo.xml")
@@ -66,26 +65,6 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonOK(CGUIMessage &message)
   {
     Close();
     bReturn = true;
-  }
-
-  return bReturn;
-}
-
-bool CGUIDialogPVRGuideInfo::OnClickButtonChannelGuide(CGUIMessage &message)
-{
-  bool bReturn = false;
-
-  if (message.GetSenderId() == CONTROL_BTN_CHANNEL_GUIDE)
-  {
-    if (!m_progItem || !m_progItem->HasPVRChannel())
-    {
-      /* invalid channel */
-      CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19136}); // Information, Channel unavailable
-      Close();
-      return bReturn;
-    }
-
-    bReturn = CServiceBroker::GetPVRManager().GUIActions()->ShowChannelEPG(CFileItemPtr(new CFileItem(m_progItem)));
   }
 
   return bReturn;
@@ -187,8 +166,7 @@ bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
            OnClickButtonRecord(message) ||
            OnClickButtonPlay(message) ||
            OnClickButtonFind(message) ||
-           OnClickButtonAddTimer(message) ||
-           OnClickButtonChannelGuide(message);
+           OnClickButtonAddTimer(message);
   }
 
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -48,7 +48,6 @@ namespace PVR
     bool OnClickButtonPlay(CGUIMessage &message);
     bool OnClickButtonFind(CGUIMessage &message);
     bool OnClickButtonAddTimer(CGUIMessage &message);
-    bool OnClickButtonChannelGuide(CGUIMessage &message);
 
     CPVREpgInfoTagPtr m_progItem;
   };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
First, this PR drops the channel guide button (introduced by myself) from the guide info dialog, because normally you open the pvr guide info dialog from within the channel guide dialog not the other way around. In that case it'll end-up in an unsightly UI workflow.

Second, I added a new entry "Channel guide" to the context menu for all channel items with existing EPG data. You can now reach the channel guide from there.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Unsightly UI workflow.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested on MacOS
