### PR TITLE
CHG: simplify emu_msvcrt FILE* handling

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -480,7 +480,7 @@ extern "C"
       int nmode = convert_fmode(mode);
       if( (o->mode & nmode) != nmode)
         CLog::Log(LOGWARNING, "dll_fdopen - mode 0x%x differs from fd mode 0x%x", nmode, o->mode);
-      return &o->file_emu;
+      return reinterpret_cast<FILE*>(o);
     }
     else if (!IS_STD_DESCRIPTOR(fd))
     {
@@ -543,7 +543,8 @@ extern "C"
         return -1;
       }
       object->mode = iMode;
-      return g_emuFileWrapper.GetDescriptorByStream(&object->file_emu);
+      FILE* f = reinterpret_cast<FILE*>(object);
+      return g_emuFileWrapper.GetDescriptorByStream(f);
     }
     delete pFile;
     return -1;

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.h
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.h
@@ -45,13 +45,7 @@ typedef void ( *PFV)(void);
 #define IS_STDIN_STREAM(stream)     (stream != NULL && __IS_STDIN_STREAM(stream))
 #define IS_STDOUT_STREAM(stream)    (stream != NULL && __IS_STDOUT_STREAM(stream))
 #define IS_STDERR_STREAM(stream)    (stream != NULL && __IS_STDERR_STREAM(stream))
-#if defined(TARGET_WINDOWS) && (_MSC_VER < 1900)
-#define IS_VALID_STREAM(stream)     (stream != NULL && (stream->_ptr != NULL))
-#elif defined(TARGET_WINDOWS) && (_MSC_VER >= 1900)
-#define IS_VALID_STREAM(stream)     (stream != nullptr && (stream->_Placeholder != nullptr))
-#else
-#define IS_VALID_STREAM(stream)     true
-#endif
+#define IS_VALID_STREAM(stream)     (stream != nullptr)
 
 
 #define IS_STD_STREAM(stream)       (stream != NULL && (__IS_STDIN_STREAM(stream) || __IS_STDOUT_STREAM(stream) || __IS_STDERR_STREAM(stream)))

--- a/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.h
+++ b/xbmc/cores/DllLoader/exports/util/EmuFileWrapper.h
@@ -39,20 +39,14 @@ namespace XFILE
   class CFile;
 }
 
-#if defined(TARGET_WINDOWS) && _MSC_VER >= 1900
-struct kodi_iobuf {
-  int   _file;
-};
-#endif
-
 typedef struct stEmuFileObject
 {
-  FILE    file_emu;
   XFILE::CFile*  file_xbmc;
   CCriticalSection *file_lock;
   int mode;
   //Stick this last to avoid 3-7 bytes of padding
   bool    used;
+  int     fd;
 } EmuFileObject;
 
 class CEmuFileWrapper


### PR DESCRIPTION
Context:
The latest Android NDK "opacifies" the FILE struct (making it `char[nn]`) which left me with 2 options:
1) Add an additional ifdef and find another hack
2) Do something else

This is 2). It takes advantage of the fact that the FILE* are completely ours, and, being supposidely opaque, can be anything.
So, rather than keeping track of an actual, platform-dependent, FILE, we return a "reinterpret_cast"ed pointer to our own structure.

This allows the code to be platform/compiler-independent (removing the ifdefs)

Limitation:
If the client lib takes a copy of the actual FILE struct, this will crash badly, as their definition and ours will be different, but there is no reason to do such thing.

Tested by me on Android arm32.
AFAIK, the only actual remaining way to test is to extract a DVD on the file system, and read the IFO.


