### PR TITLE
[AddonVideoCodec] Set aspect / fps in processInfo

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -135,6 +135,9 @@ bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamI
   m_height = hints.height;
 
   m_processInfo.SetVideoDimensions(hints.width, hints.height);
+  m_processInfo.SetVideoDAR(m_displayAspect);
+  if (hints.fpsscale)
+    m_processInfo.SetVideoFps(static_cast<float>(hints.fpsrate) / hints.fpsscale);
 
   return true;
 }


### PR DESCRIPTION
[AddonVideoCodec] Set aspect / fps in processInfo

## Motivation and Context
Aspect ratio is displayed as 0.0 currently if you press "o"

## How Has This Been Tested?
amazon prime addon

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
