### PR TITLE
[addons] show update all entry also if only one addon update is available

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -509,7 +509,7 @@ static void OutdatedAddons(const CURL& path, CFileItemList &items)
   VECADDONS addons = CAddonMgr::GetInstance().GetAvailableUpdates();
   CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24043));
 
-  if (items.Size() > 1)
+  if (!items.IsEmpty())
   {
     CFileItemPtr item(new CFileItem("addons://update_all/", false));
     item->SetLabel(g_localizeStrings.Get(24122));


### PR DESCRIPTION
See title.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
It's really annoying that you need to open the addon info dialog to update the addon if only one addon is listed under available updates.

## How Has This Been Tested?
Runtime tested on MacOS

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
