### PR TITLE
[pvr] change setting continue last channel to yes and always

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10076,12 +10076,6 @@ msgctxt "#19189"
 msgid "Continue last channel on startup"
 msgstr ""
 
-#. pvr settings "automatically start last played channel after Kodi startup" setting value
-#: system/settings/settings.xml
-msgctxt "#19190"
-msgid "Background"
-msgstr ""
-
 #: addons/skin.estuary/xml/SettingsSystemInfo.xml
 msgctxt "#19191"
 msgid "PVR service"
@@ -10635,12 +10629,6 @@ msgstr ""
 #: xbmc/pvr/channels/PVRChannelGroupInternal.cpp
 msgctxt "#19287"
 msgid "All channels"
-msgstr ""
-
-#. pvr settings 'continue last channel on startup' setting value label.
-#: system/settings/settings.xml
-msgctxt "#19288"
-msgid "Foreground"
 msgstr ""
 
 #. Label for button to hide a group in the group manager
@@ -16315,6 +16303,7 @@ msgid "Only when playback stopped"
 msgstr ""
 
 #. play GUI sounds
+#. pvr settings "automatically start last played channel after Kodi startup" setting value
 #: system/settings/settings.xml
 msgctxt "#34122"
 msgid "Always"
@@ -18057,7 +18046,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36228"
-msgid "Continue with the last viewed channel on startup."
+msgid "Continue with the last viewed channel on startup. \"Yes\" will only continue with the last viewed channel if it was playing on app quit. \"Always\" will continue with the last viewed channel no matter if it was playing on app quit."
 msgstr ""
 
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1386,9 +1386,9 @@
           <default>0</default> <!-- CONTINUE_LAST_CHANNEL_OFF -->
           <constraints>
             <options>
-              <option label="106">0</option>   <!-- CONTINUE_LAST_CHANNEL_OFF -->
-              <option label="19190">1</option> <!-- CONTINUE_LAST_CHANNEL_IN_BACKGROUND -->
-              <option label="19288">2</option> <!-- CONTINUE_LAST_CHANNEL_IN_FOREGROUND -->
+              <option label="106">0</option> <!-- CONTINUE_LAST_CHANNEL_OFF -->
+              <option label="107">1</option> <!-- CONTINUE_LAST_CHANNEL_ON -->
+              <option label="34122">2</option> <!-- CONTINUE_LAST_CHANNEL_ALWAYS -->
             </options>
           </constraints>
           <control type="list" format="string" />

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1232,12 +1232,13 @@ namespace PVR
     if (iPlayMode == CONTINUE_LAST_CHANNEL_OFF)
       return false;
 
-    // Only switch to the channel if it was playing on last app quit.
-    if (bWasPlaying)
+    // switch to the channel if it was playing on last app quit or
+    // setting is always that means no matter if the channel was playing on last app quit
+    if (bWasPlaying || iPlayMode == CONTINUE_LAST_CHANNEL_ALWAYS)
     {
       CLog::Log(LOGNOTICE, "PVRGUIActions - %s - continue playback on channel '%s'", __FUNCTION__, channel->ChannelName().c_str());
       CServiceBroker::GetPVRManager().SetPlayingGroup(CServiceBroker::GetPVRManager().ChannelGroups()->GetLastPlayedGroup(channel->ChannelID()));
-      return SwitchToChannel(item, true, iPlayMode == CONTINUE_LAST_CHANNEL_IN_FOREGROUND);
+      return SwitchToChannel(item, true, true);
     }
 
     return false;

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1238,7 +1238,7 @@ namespace PVR
     {
       CLog::Log(LOGNOTICE, "PVRGUIActions - %s - continue playback on channel '%s'", __FUNCTION__, channel->ChannelName().c_str());
       CServiceBroker::GetPVRManager().SetPlayingGroup(CServiceBroker::GetPVRManager().ChannelGroups()->GetLastPlayedGroup(channel->ChannelID()));
-      return SwitchToChannel(item, true, true);
+      return SwitchToChannel(item, true, m_settings.GetBoolValue(CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN));
     }
 
     return false;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -53,9 +53,9 @@ namespace PVR
 
   enum ContinueLastChannelOnStartup
   {
-    CONTINUE_LAST_CHANNEL_OFF  = 0,
-    CONTINUE_LAST_CHANNEL_IN_BACKGROUND,
-    CONTINUE_LAST_CHANNEL_IN_FOREGROUND
+    CONTINUE_LAST_CHANNEL_OFF = 0,
+    CONTINUE_LAST_CHANNEL_ON,       // continue with the last viewed channel if it was playing on app quit
+    CONTINUE_LAST_CHANNEL_ALWAYS    // continue with the last viewed channel no matter if it was playing on app quit.
   };
 
   class CPVRManagerJobQueue


### PR DESCRIPTION
This PR change the setting "Continue last channel" and drop the values "foreground" and "background" in favor of "Yes", which means it will only playback the last viewed channel if it was playing on app quit, and "Always" which always continue the last viewed channel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Not many users differ between foreground and background, but want Kodi to playback TV on startup no matter if they played a channel on app quit. They use Kodi as TV receiver replacement (me too). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested on MacOS

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
