### PR TITLE
[cmake] Exclude *.xml.include files from install/package generation

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -230,7 +230,9 @@ macro (build_addon target prefix libs)
     set(CPACK_COMPONENTS_IGNORE_GROUPS 1)
     list(APPEND CPACK_COMPONENTS_ALL ${target}-${${prefix}_VERSION})
     # Pack files together to create an archive
-    install(DIRECTORY ${target} DESTINATION ./ COMPONENT ${target}-${${prefix}_VERSION} PATTERN "*.xml.in" EXCLUDE)
+    install(DIRECTORY ${target} DESTINATION ./
+                                COMPONENT ${target}-${${prefix}_VERSION}
+                                REGEX ".+\.xml\.in(clude)?$" EXCLUDE)
     if(WIN32)
       if(NOT CPACK_PACKAGE_DIRECTORY)
         # determine the temporary path
@@ -323,7 +325,8 @@ macro (build_addon target prefix libs)
     if (${prefix}_CUSTOM_BINARY)
       install(FILES ${LIBRARY_LOCATION} DESTINATION ${CMAKE_INSTALL_LIBDIR}/addons/${target} RENAME ${LIBRARY_FILENAME})
     endif()
-    install(DIRECTORY ${target} DESTINATION ${CMAKE_INSTALL_DATADIR}/addons PATTERN "*.xml.in" EXCLUDE)
+    install(DIRECTORY ${target} DESTINATION ${CMAKE_INSTALL_DATADIR}/addons
+                                REGEX ".+\.xml\.in(clude)?$" EXCLUDE)
     if(${prefix}_CUSTOM_DATA)
       install(DIRECTORY ${${prefix}_CUSTOM_DATA} DESTINATION ${CMAKE_INSTALL_DATADIR}/addons/${target}/resources)
     endif()


### PR DESCRIPTION
## Description
Skip foo.xml.include files when packaging add-ons

## Motivation and Context
@garbear complained

## How Has This Been Tested?
Zero tests. I'm sure some regex match is possible. Just want to put it here so garbear can test

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)