### PR TITLE
[PlayListM3u] Get Mime-Type from #KODIPROP to avoid mime type checking

### DIFF
--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -194,6 +194,11 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         {
           newItem->SetProperty(prop.first, prop.second);
         }
+
+        newItem->SetMimeType(newItem->GetProperty("mimetype").asString());
+        if (!newItem->GetMimeType().empty())
+          newItem->SetContentLookup(false);
+
         Add(newItem);
 
         // Reset the values just in case there part of the file have the extended marker


### PR DESCRIPTION
[PlayListM3u] Get Mime-Type from #KODIPROP to avoid mime type checking

## Description
Allow passing mime-type in m3u playlists / .strm files:
#KODIPROP:mimetype=application/dash+xml

## Motivation and Context
We arrived content provider where the HEAD request used to validate mime-type invalidates the file to download. Setting mime-type explicite in m3u playlist prevents fireing this HEAD Request.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
