### PR TITLE
RetroPlayer: Fix black screen on playback

### DIFF
--- a/xbmc/cores/RetroPlayer/PixelConverter.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverter.cpp
@@ -245,7 +245,6 @@ void CPixelConverter::GetPicture(VideoPicture& dvdVideoPicture)
   }
 
   dvdVideoPicture.dts            = DVD_NOPTS_VALUE;
-  dvdVideoPicture.pts            = 0.0; // Show immediately
   dvdVideoPicture.iFlags         = 0;
   dvdVideoPicture.color_matrix   = 4; // CONF_FLAGS_YUVCOEF_BT601
   dvdVideoPicture.color_range    = 0; // *not* CONF_FLAGS_YUV_FULLRANGE

--- a/xbmc/cores/RetroPlayer/PixelConverterRBP.cpp
+++ b/xbmc/cores/RetroPlayer/PixelConverterRBP.cpp
@@ -156,7 +156,6 @@ void CPixelConverterRBP::GetPicture(VideoPicture& picture)
   m_renderBuffer = nullptr;
 
   picture.dts            = DVD_NOPTS_VALUE;
-  picture.pts            = DVD_NOPTS_VALUE;
   picture.iFlags         = 0;
   picture.color_matrix   = 4; // CONF_FLAGS_YUVCOEF_BT601
   picture.color_range    = 0; // *not* CONF_FLAGS_YUV_FULLRANGE

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -59,6 +59,8 @@ CRetroPlayer::CRetroPlayer(IPlayerCallback& callback) :
   m_renderManager(m_clock, this),
   m_processInfo(CProcessInfo::CreateInstance())
 {
+  m_processInfo->SetDataCache(&CServiceBroker::GetDataCacheCore());
+  m_processInfo->SetTempo(1.0);
 }
 
 CRetroPlayer::~CRetroPlayer()
@@ -304,10 +306,7 @@ void CRetroPlayer::SeekTime(int64_t iTime /* = 0 */)
   if (m_gameClient)
   {
     m_gameClient->GetPlayback()->SeekTimeMs(static_cast<unsigned int>(iTime));
-    m_audio->Enable(m_gameClient->GetPlayback()->GetSpeed() == 1.0);
-
-    if (m_gameClient->GetPlayback()->GetSpeed() != 0.0)
-      CloseOSD();
+    OnSpeedChange(m_gameClient->GetPlayback()->GetSpeed());
   }
 }
 
@@ -354,12 +353,7 @@ void CRetroPlayer::SetSpeed(float speed)
     }
 
     m_gameClient->GetPlayback()->SetSpeed(speed);
-    m_audio->Enable(m_gameClient->GetPlayback()->GetSpeed() == 1.0);
-
-    if (m_gameClient->GetPlayback()->GetSpeed() != 0.0)
-      CloseOSD();
-
-    CDataCacheCore::GetInstance().SetSpeed(1.0, speed);
+    OnSpeedChange(speed);
   }
 }
 
@@ -371,15 +365,18 @@ bool CRetroPlayer::OnAction(const CAction &action)
   {
     if (m_gameClient)
     {
-      double previousPlaySpeed = m_gameClient->GetPlayback()->GetSpeed();
-      m_gameClient->GetPlayback()->SetSpeed(0.0);
-      CServiceBroker::GetGameServices().PortManager().HardwareReset();
-      if (previousPlaySpeed > 0.0)
-        m_gameClient->GetPlayback()->SetSpeed(previousPlaySpeed);
-      else
-        m_gameClient->GetPlayback()->SetSpeed(1.0f);
+      double speed = m_gameClient->GetPlayback()->GetSpeed();
 
-      CloseOSD();
+      m_gameClient->GetPlayback()->SetSpeed(0.0);
+
+      CServiceBroker::GetGameServices().PortManager().HardwareReset();
+
+      // If rewinding or paused, begin playback
+      if (speed <= 0.0)
+        speed = 1.0;
+
+      m_gameClient->GetPlayback()->SetSpeed(speed);
+      OnSpeedChange(speed);
     }
     return true;
   }
@@ -486,6 +483,14 @@ void CRetroPlayer::UpdateGuiRender(bool gui)
 void CRetroPlayer::UpdateVideoRender(bool video)
 {
   m_processInfo->SetVideoRender(video);
+}
+
+void CRetroPlayer::OnSpeedChange(double newSpeed)
+{
+  m_audio->Enable(newSpeed == 1.0);
+  m_processInfo->SetSpeed(newSpeed);
+  if (newSpeed != 0.0)
+    CloseOSD();
 }
 
 void CRetroPlayer::CloseOSD()

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -96,7 +96,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
     if (m_gameClient->Initialize())
     {
       m_audio.reset(new CRetroPlayerAudio(*m_processInfo));
-      m_video.reset(new CRetroPlayerVideo(m_renderManager, *m_processInfo));
+      m_video.reset(new CRetroPlayerVideo(m_renderManager, *m_processInfo, m_clock));
 
       if (!file.GetPath().empty())
         bSuccess = m_gameClient->OpenFile(file, m_audio.get(), m_video.get());

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -148,6 +148,12 @@ namespace RETRO
 
   private:
     /*!
+     * \brief Called when the speed changes
+     * \param newSpeed The new speed, possibly equal to the previous speed
+     */
+    void OnSpeedChange(double newSpeed);
+
+    /*!
      * \brief Closes the OSD and shows the FullscreenGame window
      */
     void CloseOSD();

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -37,10 +37,11 @@
 using namespace KODI;
 using namespace RETRO;
 
-CRetroPlayerVideo::CRetroPlayerVideo(CRenderManager& renderManager, CProcessInfo& processInfo) :
+CRetroPlayerVideo::CRetroPlayerVideo(CRenderManager& renderManager, CProcessInfo& processInfo, CDVDClock &clock) :
   //CThread("RetroPlayerVideo"),
   m_renderManager(renderManager),
   m_processInfo(processInfo),
+  m_clock(clock),
   m_framerate(0.0),
   m_orientation(0),
   m_bConfigured(false),
@@ -119,6 +120,7 @@ void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
 
   if (GetPicture(data, size, picture))
   {
+    picture.pts = m_clock.GetClock(); // Show immediately
     picture.iDuration = DVD_SEC_TO_TIME(1.0 / m_framerate);
 
     if (!Configure(picture))

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -119,7 +119,7 @@ void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
 
   if (GetPicture(data, size, picture))
   {
-    picture.iDuration = 1.0 / m_framerate;
+    picture.iDuration = DVD_SEC_TO_TIME(1.0 / m_framerate);
 
     if (!Configure(picture))
     {

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
@@ -39,7 +39,7 @@ namespace RETRO
                             //protected CThread
   {
   public:
-    CRetroPlayerVideo(CRenderManager& m_renderManager, CProcessInfo& m_processInfo);
+    CRetroPlayerVideo(CRenderManager& m_renderManager, CProcessInfo& m_processInfo, CDVDClock &clock);
 
     ~CRetroPlayerVideo() override;
 
@@ -63,6 +63,7 @@ namespace RETRO
     // Construction parameters
     CRenderManager& m_renderManager;
     CProcessInfo&   m_processInfo;
+    CDVDClock       &m_clock;
 
     // Stream properties
     double       m_framerate;


### PR DESCRIPTION
If the title of this PR looks familiar, it's because RetroPlayer broke yet again with the last VP update. This fixes the blank screen that shows when playing games.

## How Has This Been Tested?
Games play with video now.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
