### PR TITLE
VideoPlayer, PVR: remove deprecated streamURL related functions

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDFactoryDemuxer.cpp
@@ -81,25 +81,9 @@ CDVDDemux* CDVDFactoryDemuxer::CreateDemuxer(CDVDInputStream* pInputStream, bool
   bool streaminfo = true; /* Look for streams before playback */
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
   {
-    CDVDInputStreamPVRManager* pInputStreamPVR = (CDVDInputStreamPVRManager*)pInputStream;
-    CDVDInputStream* pOtherStream = pInputStreamPVR->GetOtherStream();
-
     /* Don't parse the streaminfo for some cases of streams to reduce the channel switch time */
     bool useFastswitch = URIUtils::IsUsingFastSwitch(pInputStream->GetFileName());
     streaminfo = !useFastswitch;
-
-    if (pOtherStream)
-    {
-      /* Used for MediaPortal PVR addon (uses PVR otherstream for playback of rtsp streams) */
-      if (pOtherStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
-      {
-        std::unique_ptr<CDVDDemuxFFmpeg> demuxer(new CDVDDemuxFFmpeg());
-        if(demuxer->Open(pOtherStream, streaminfo))
-          return demuxer.release();
-        else
-          return nullptr;
-      }
-    }
   }
 
   if (pInputStream->IsStreamType(DVDSTREAM_TYPE_FFMPEG))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -48,10 +48,8 @@ CDVDInputStreamPVRManager::CDVDInputStreamPVRManager(IVideoPlayer* pPlayer, cons
   : CDVDInputStream(DVDSTREAM_TYPE_PVRMANAGER, fileitem)
 {
   m_pPlayer = pPlayer;
-  m_pOtherStream = nullptr;
   m_eof = true;
   m_ScanTimeout.Set(0);
-  m_isOtherStreamHack = false;
   m_demuxActive = false;
 
   m_StreamProps = new PVR_STREAM_PROPERTIES;
@@ -79,10 +77,7 @@ bool CDVDInputStreamPVRManager::IsEOF()
   if (!m_ScanTimeout.IsTimePast())
     return false;
 
-  if (m_pOtherStream)
-    return m_pOtherStream->IsEOF();
-  else
-    return m_eof;
+  return m_eof;
 }
 
 bool CDVDInputStreamPVRManager::Open()
@@ -142,158 +137,68 @@ bool CDVDInputStreamPVRManager::Open()
 
   m_eof = false;
 
-  /*
-   * Translate the "pvr://....." entry.
-   * The PVR Client can use http or whatever else is supported by VideoPlayer.
-   * to access streams.
-   * If after translation the file protocol is still "pvr://" use this class
-   * to read the stream data over the CPVRFile class and the PVR Library itself.
-   * Otherwise call CreateInputStream again with the translated filename and looks again
-   * for the right protocol stream handler and swap every call to this input stream
-   * handler.
-   */
-  m_isOtherStreamHack = false;
-  std::string transFile = ThisIsAHack(m_item.GetPath());
-  if(transFile.substr(0, 6) != "pvr://")
+  if (URIUtils::IsPVRChannel(url.Get()))
   {
-    m_isOtherStreamHack = true;
-    
-    m_item.SetPath(transFile);
-    m_item.SetMimeTypeForInternetFile();
-
-    m_pOtherStream = CDVDFactoryInputStream::CreateInputStream(m_pPlayer, m_item);
-    if (!m_pOtherStream)
-    {
-      CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - unable to create input stream for [%s]", CURL::GetRedacted(transFile).c_str());
-      return false;
-    }
-
-    if (!m_pOtherStream->Open())
-    {
-      CLog::Log(LOGERROR, "CDVDInputStreamPVRManager::Open - error opening [%s]", CURL::GetRedacted(transFile).c_str());
-      delete m_pOtherStream;
-      m_pOtherStream = NULL;
-      return false;
-    }
-  }
-  else
-  {
-    if (URIUtils::IsPVRChannel(url.Get()))
-    {
-      std::shared_ptr<CPVRClient> client;
-      if (CServiceBroker::GetPVRManager().Clients()->GetPlayingClient(client) &&
-          client->GetClientCapabilities().HandlesDemuxing())
-        m_demuxActive = true;
-    }
+    std::shared_ptr<CPVRClient> client;
+    if (CServiceBroker::GetPVRManager().Clients()->GetPlayingClient(client) &&
+        client->GetClientCapabilities().HandlesDemuxing())
+      m_demuxActive = true;
   }
 
   ResetScanTimeout((unsigned int) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
-  CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", CURL::GetRedacted(transFile).c_str());
+  CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", CURL::GetRedacted(m_item.GetPath()).c_str());
 
   m_StreamProps->iStreamCount = 0;
   return true;
 }
 
-std::string CDVDInputStreamPVRManager::ThisIsAHack(const std::string& pathFile)
-{
-  std::string FileName = pathFile;
-  if (FileName.substr(0, 14) == "pvr://channels")
-  {
-    CFileItemPtr channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetByPath(FileName);
-    if (channel && channel->HasPVRChannelInfoTag())
-    {
-      std::string stream = channel->GetPVRChannelInfoTag()->StreamURL();
-      if(!stream.empty())
-      {
-        if (stream.compare(6, 7, "stream/") == 0)
-        {
-          // pvr://stream
-          // This function was added to retrieve the stream URL for this item
-          // Is is used for the MediaPortal (ffmpeg) PVR addon
-          // see PVRManager.cpp
-          return CServiceBroker::GetPVRManager().Clients()->GetStreamURL(channel->GetPVRChannelInfoTag());
-        }
-        else
-        {
-          return stream;
-        }
-      }
-    }
-  }
-  return FileName;
-}
-
 // close file and reset everything
 void CDVDInputStreamPVRManager::Close()
 {
-  if (m_pOtherStream)
-  {
-    m_pOtherStream->Close();
-    delete m_pOtherStream;
-  }
-
   CServiceBroker::GetPVRManager().CloseStream();
 
   CDVDInputStream::Close();
 
-  m_pOtherStream    = NULL;
-  m_eof             = true;
+  m_eof = true;
 
   CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Close - stream closed");
 }
 
 int CDVDInputStreamPVRManager::Read(uint8_t* buf, int buf_size)
 {
-  if (m_pOtherStream)
-  {
-    return m_pOtherStream->Read(buf, buf_size);
-  }
-  else
-  {
-    int ret = CServiceBroker::GetPVRManager().Clients()->ReadStream((BYTE*)buf, buf_size);
-    if (ret < 0)
-      ret = -1;
+  int ret = CServiceBroker::GetPVRManager().Clients()->ReadStream((BYTE*)buf, buf_size);
+  if (ret < 0)
+    ret = -1;
 
-    /* we currently don't support non completing reads */
-    if( ret == 0 )
-      m_eof = true;
+  /* we currently don't support non completing reads */
+  if( ret == 0 )
+    m_eof = true;
 
-    return ret;
-  }
+  return ret;
 }
 
 int64_t CDVDInputStreamPVRManager::Seek(int64_t offset, int whence)
 {
-  if (m_pOtherStream)
+  if (whence == SEEK_POSSIBLE)
   {
-    return m_pOtherStream->Seek(offset, whence);
+    if (CServiceBroker::GetPVRManager().Clients()->CanSeekStream())
+      return 1;
+    else
+      return 0;
   }
-  else
-  {
-    if (whence == SEEK_POSSIBLE)
-    {
-      if (CServiceBroker::GetPVRManager().Clients()->CanSeekStream())
-        return 1;
-      else
-        return 0;
-    }
 
-    int64_t ret = CServiceBroker::GetPVRManager().Clients()->SeekStream(offset, whence);
+  int64_t ret = CServiceBroker::GetPVRManager().Clients()->SeekStream(offset, whence);
 
-    // if we succeed, we are not eof anymore
-    if( ret >= 0 )
-      m_eof = false;
+  // if we succeed, we are not eof anymore
+  if( ret >= 0 )
+    m_eof = false;
 
-    return ret;
-  }
+  return ret;
 }
 
 int64_t CDVDInputStreamPVRManager::GetLength()
 {
-  if (m_pOtherStream)
-    return m_pOtherStream->GetLength();
-  else
-    return CServiceBroker::GetPVRManager().Clients()->GetStreamLength();
+  return CServiceBroker::GetPVRManager().Clients()->GetStreamLength();
 }
 
 int CDVDInputStreamPVRManager::GetTotalTime()
@@ -324,10 +229,7 @@ CDVDInputStream::ENextStream CDVDInputStreamPVRManager::NextStream()
 {
   m_eof = IsEOF();
 
-  CDVDInputStream::ENextStream next;
-  if (m_pOtherStream && ((next = m_pOtherStream->NextStream()) != NEXTSTREAM_NONE))
-    return next;
-  else if(!m_isRecording)
+  if(!m_isRecording)
   {
     if (m_eof)
       return NEXTSTREAM_OPEN;
@@ -371,27 +273,7 @@ void CDVDInputStreamPVRManager::Pause(bool bPaused)
 
 std::string CDVDInputStreamPVRManager::GetInputFormat()
 {
-  if (!m_pOtherStream)
-    return CServiceBroker::GetPVRManager().Clients()->GetCurrentInputFormat();
-  return "";
-}
-
-bool CDVDInputStreamPVRManager::CloseAndOpen(const std::string& strFile)
-{
-  Close();
-
-  m_item.SetPath(strFile);
-  if (Open())
-  {
-    return true;
-  }
-
-  return false;
-}
-
-bool CDVDInputStreamPVRManager::IsOtherStreamHack(void)
-{
-  return m_isOtherStreamHack;
+  return CServiceBroker::GetPVRManager().Clients()->GetCurrentInputFormat();
 }
 
 bool CDVDInputStreamPVRManager::IsRealtime()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -57,7 +57,6 @@ public:
   ENextStream NextStream() override;
   bool IsRealtime() override;
 
-  bool IsOtherStreamHack(void);
   PVR::CPVRChannelPtr GetSelectedChannel();
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
@@ -84,9 +83,6 @@ public:
    */
   std::string GetInputFormat();
 
-  /* returns m_pOtherStream */
-  CDVDInputStream* GetOtherStream();
-
   void ResetScanTimeout(unsigned int iTimeoutMs) override;
 
   // Demux interface
@@ -104,17 +100,13 @@ public:
   void OpenStream(int iStreamId) override {};
 
 protected:
-  bool CloseAndOpen(const std::string& strFile);
   void UpdateStreamMap();
-  std::string ThisIsAHack(const std::string& pathFile);
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);
   IVideoPlayer* m_pPlayer;
-  CDVDInputStream* m_pOtherStream;
   bool m_eof;
   bool m_demuxActive;
   std::string m_strContent;
   XbmcThreads::EndTime m_ScanTimeout;
-  bool m_isOtherStreamHack;
   PVR_STREAM_PROPERTIES *m_StreamProps;
   std::map<int, std::shared_ptr<CDemuxStream>> m_streamMap;
   bool m_isRecording;
@@ -123,14 +115,6 @@ protected:
 
 inline bool CDVDInputStreamPVRManager::IsStreamType(DVDStreamType type) const
 {
-  if (m_pOtherStream)
-    return m_pOtherStream->IsStreamType(type);
-
   return m_streamType == type;
 }
-
-inline CDVDInputStream* CDVDInputStreamPVRManager::GetOtherStream()
-{
-  return m_pOtherStream;
-};
 


### PR DESCRIPTION
Drops streamURL as announced more than a year ago:
https://forum.kodi.tv/showthread.php?tid=259830

This is a necessary step in mirgrating pvr streaming relevant functions to inputstream API.