### PR TITLE
[Win32 BufferPool] Remove decoder locks

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1168,15 +1168,12 @@ void CDecoder::FFReleaseBuffer(void* opaque, uint8_t* data)
 
 void CDecoder::ReleaseBuffer(uint8_t *data)
 {
+  ID3D11VideoDecoderOutputView* view = reinterpret_cast<ID3D11VideoDecoderOutputView*>(data);
+  if (!m_bufferPool->IsValid(view))
   {
-    CSingleLock lock(m_section);
-    ID3D11VideoDecoderOutputView* view = reinterpret_cast<ID3D11VideoDecoderOutputView*>(data);
-    if (!m_bufferPool->IsValid(view))
-    {
-      CLog::LogFunction(LOGWARNING, __FUNCTION__, "return of invalid surface.");
-    }
-    m_bufferPool->ReturnView(view);
+    CLog::LogFunction(LOGWARNING, __FUNCTION__, "return of invalid surface.");
   }
+  m_bufferPool->ReturnView(view);
 
   IHardwareDecoder::Release();
 }
@@ -1191,8 +1188,6 @@ int CDecoder::FFGetBuffer(AVCodecContext* avctx, AVFrame* pic, int flags)
 
 int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic)
 {
-  CSingleLock lock(m_section);
-
   if (!m_decoder)
     return -1;
 


### PR DESCRIPTION
Remove DXVA Decoder::SingleLock for GetBuffer / ReleaseBuffer because they are already locked in BufferPool

## Motivation and Context
Deadlock when playing videos

## How Has This Been Tested?
pvr.zattoohiq from kodinerds repo, play first channel.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
