### PR TITLE
[backport] exit GIL when calling into GUI

### DIFF
--- a/xbmc/interfaces/legacy/AddonUtils.cpp
+++ b/xbmc/interfaces/legacy/AddonUtils.cpp
@@ -30,11 +30,13 @@
 
 namespace XBMCAddonUtils
 {
-  GuiLock::GuiLock()
+  GuiLock::GuiLock(XBMCAddon::LanguageHook* languageHook)
+    : m_languageHook(languageHook)
   {
-    languageHook = XBMCAddon::LanguageHook::GetLanguageHook();
-    if (languageHook)
-      languageHook->DelayedCallOpen();
+    if (!m_languageHook)
+      m_languageHook = XBMCAddon::LanguageHook::GetLanguageHook();
+    if (m_languageHook)
+      m_languageHook->DelayedCallOpen();
 
     g_application.LockFrameMoveGuard();
   }
@@ -43,8 +45,8 @@ namespace XBMCAddonUtils
   {
     g_application.UnlockFrameMoveGuard();
 
-    if (languageHook)
-      languageHook->DelayedCallClose();
+    if (m_languageHook)
+      m_languageHook->DelayedCallClose();
   }
 
   static char defaultImage[1024];

--- a/xbmc/interfaces/legacy/AddonUtils.h
+++ b/xbmc/interfaces/legacy/AddonUtils.h
@@ -31,6 +31,7 @@
 
 #include "threads/SingleLock.h"
 
+#include <memory>
 #include <vector>
 
 #ifdef TARGET_WINDOWS
@@ -52,11 +53,11 @@ namespace XBMCAddonUtils
   class GuiLock
   {
   public:
-    GuiLock();
+    GuiLock(XBMCAddon::LanguageHook* languageHook);
     ~GuiLock();
 
   protected:
-    XBMCAddon::LanguageHook* languageHook;
+    XBMCAddon::LanguageHook* m_languageHook = nullptr;
   };
 
   class InvertSingleLockGuard
@@ -66,8 +67,6 @@ namespace XBMCAddonUtils
     InvertSingleLockGuard(CSingleLock& _lock) : lock(_lock) { lock.Leave(); }
     ~InvertSingleLockGuard() { lock.Enter(); }
   };
-
-#define LOCKGUI XBMCAddonUtils::GuiLock __gl
 
   /*
    * Looks in references.xml for image name

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -150,7 +150,7 @@ namespace XBMCAddon
     {
       if (!pGUIControl) return NULL;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return ((CGUITextBox*) pGUIControl)->GetDescription();
     }
 
@@ -241,7 +241,7 @@ namespace XBMCAddon
 
       if (pGUIControl)
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ((CGUIButtonControl*)pGUIControl)->PythonSetLabel(strFont, strText, textColor, shadowColor, focusedColor);
         ((CGUIButtonControl*)pGUIControl)->SetLabel2(strText2);
         ((CGUIButtonControl*)pGUIControl)->PythonSetDisabledColor(disabledColor);
@@ -254,7 +254,7 @@ namespace XBMCAddon
 
       if (pGUIControl)
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ((CGUIButtonControl*)pGUIControl)->PythonSetDisabledColor(disabledColor);
       }
     }
@@ -263,7 +263,7 @@ namespace XBMCAddon
     {
       if (!pGUIControl) return NULL;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return ((CGUIButtonControl*) pGUIControl)->GetLabel();
     }
 
@@ -271,7 +271,7 @@ namespace XBMCAddon
     {
       if (!pGUIControl) return NULL;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return ((CGUIButtonControl*) pGUIControl)->GetLabel2();
     }
 
@@ -331,7 +331,7 @@ namespace XBMCAddon
     {
       strFileName = imageFilename;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (pGUIControl)
         ((CGUIImage*)pGUIControl)->SetFileName(strFileName, false, useCache);
     }
@@ -341,7 +341,7 @@ namespace XBMCAddon
       if (cColorDiffuse) sscanf(cColorDiffuse, "%x", &colorDiffuse);
       else colorDiffuse = 0;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (pGUIControl)
         ((CGUIImage *)pGUIControl)->SetColorDiffuse(colorDiffuse);
     }
@@ -547,7 +547,7 @@ namespace XBMCAddon
     {
       if (pGUIControl)
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ((CGUIRadioButtonControl*)pGUIControl)->SetSelected(selected);
       }
     }
@@ -558,7 +558,7 @@ namespace XBMCAddon
 
       if (pGUIControl)
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         isSelected = ((CGUIRadioButtonControl*)pGUIControl)->IsSelected();
       }
       return isSelected;
@@ -581,7 +581,7 @@ namespace XBMCAddon
 
       if (pGUIControl)
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ((CGUIRadioButtonControl*)pGUIControl)->PythonSetLabel(strFont, strText, textColor, shadowColor, focusedColor);
         ((CGUIRadioButtonControl*)pGUIControl)->PythonSetDisabledColor(disabledColor);
       }
@@ -595,7 +595,7 @@ namespace XBMCAddon
       dwHeight = height;
       if (pGUIControl)
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ((CGUIRadioButtonControl*)pGUIControl)->SetRadioDimensions((float)dwPosX, (float)dwPosY, (float)dwWidth, (float)dwHeight);
       }
     }
@@ -659,7 +659,7 @@ namespace XBMCAddon
     void Control::setEnabled(bool enabled)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (pGUIControl)
         pGUIControl->SetEnabled(enabled);
     }
@@ -667,7 +667,7 @@ namespace XBMCAddon
     void Control::setVisible(bool visible)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (pGUIControl)
         pGUIControl->SetVisible(visible);
     }
@@ -675,7 +675,7 @@ namespace XBMCAddon
     void Control::setVisibleCondition(const char* visible, bool allowHiddenFocus)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
 
       if (pGUIControl)
         pGUIControl->SetVisibleCondition(visible, allowHiddenFocus ? "true" : "false");
@@ -684,7 +684,7 @@ namespace XBMCAddon
     void Control::setEnableCondition(const char* enable)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
 
       if (pGUIControl)
         pGUIControl->SetEnableCondition(enable);
@@ -724,7 +724,7 @@ namespace XBMCAddon
       }
 
       const CRect animRect((float)dwPosX, (float)dwPosY, (float)dwPosX + dwWidth, (float)dwPosY + dwHeight);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (pGUIControl)
       {
         CGUIControlFactory::GetAnimations(pRoot, animRect, iParentId, animations);
@@ -735,7 +735,7 @@ namespace XBMCAddon
     void Control::setPosition(long x, long y)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       dwPosX = x;
       dwPosY = y;
       if (pGUIControl)
@@ -745,7 +745,7 @@ namespace XBMCAddon
     void Control::setWidth(long width)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       dwWidth = width;
       if (pGUIControl)
         pGUIControl->SetWidth((float)dwWidth);
@@ -754,7 +754,7 @@ namespace XBMCAddon
     void Control::setHeight(long height)
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       dwHeight = height;
       if (pGUIControl)
         pGUIControl->SetHeight((float)dwHeight);
@@ -767,7 +767,7 @@ namespace XBMCAddon
         throw WindowException("Control has to be added to a window first");
 
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         if (pGUIControl)
         {
           pGUIControl->SetAction(ACTION_MOVE_UP,    up->iControlId);
@@ -784,7 +784,7 @@ namespace XBMCAddon
         throw WindowException("Control has to be added to a window first");
 
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         if (pGUIControl)
           pGUIControl->SetAction(ACTION_MOVE_UP, control->iControlId);
       }
@@ -796,7 +796,7 @@ namespace XBMCAddon
         throw WindowException("Control has to be added to a window first");
 
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         if (pGUIControl)
           pGUIControl->SetAction(ACTION_MOVE_DOWN, control->iControlId);
       }
@@ -808,7 +808,7 @@ namespace XBMCAddon
         throw WindowException("Control has to be added to a window first");
 
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         if (pGUIControl)
           pGUIControl->SetAction(ACTION_MOVE_LEFT, control->iControlId);
       }
@@ -820,7 +820,7 @@ namespace XBMCAddon
         throw WindowException("Control has to be added to a window first");
 
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         if (pGUIControl)
           pGUIControl->SetAction(ACTION_MOVE_RIGHT, control->iControlId);
       }
@@ -1189,7 +1189,7 @@ namespace XBMCAddon
     long ControlList::getSelectedPosition()
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
 
       // create message
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, iParentId, iControlId);
@@ -1208,7 +1208,7 @@ namespace XBMCAddon
     XBMCAddon::xbmcgui::ListItem* ControlList::getSelectedItem()
     {
       DelayedCallGuard dcguard(languageHook);
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
 
       // create message
       CGUIMessage msg(GUI_MSG_ITEM_SELECTED, iParentId, iControlId);

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -72,7 +72,7 @@ namespace XBMCAddon
 
       String ret;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ret = item->GetLabel();
       }
 
@@ -85,7 +85,7 @@ namespace XBMCAddon
 
       String ret;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ret = item->GetLabel2();
       }
 
@@ -97,7 +97,7 @@ namespace XBMCAddon
       if (!item) return;
       // set label
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         item->SetLabel(label);
       }
     }
@@ -107,7 +107,7 @@ namespace XBMCAddon
       if (!item) return;
       // set label
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         item->SetLabel2(label);
       }
     }
@@ -116,7 +116,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         item->SetIconImage(iconImage);
       }
     }
@@ -125,7 +125,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         item->SetArt("thumb", thumbFilename);
       }
     }
@@ -134,7 +134,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         for (Properties::const_iterator it = dictionary.begin(); it != dictionary.end(); ++it)
         {
           std::string artName = it->first;
@@ -151,7 +151,7 @@ namespace XBMCAddon
     {
       if (!item) return;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       CVideoInfoTag& vtag = *item->GetVideoInfoTag();
       for (Properties::const_iterator it = dictionary.begin(); it != dictionary.end(); ++it)
         vtag.SetUniqueID(it->second, it->first);
@@ -161,7 +161,7 @@ namespace XBMCAddon
     {
       if (!item) return;
 
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       item->GetVideoInfoTag()->SetRating(rating, votes, type, defaultt);
     }
 
@@ -169,7 +169,7 @@ namespace XBMCAddon
     {
       if (!item) return;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         item->Select(selected);
       }
     }
@@ -181,7 +181,7 @@ namespace XBMCAddon
 
       bool ret;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         ret = item->IsSelected();
       }
 
@@ -190,7 +190,7 @@ namespace XBMCAddon
 
     void ListItem::setProperty(const char * key, const String& value)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       String lowerKey = key;
       StringUtils::ToLower(lowerKey);
       if (lowerKey == "startoffset")
@@ -221,7 +221,7 @@ namespace XBMCAddon
 
     String ListItem::getProperty(const char* key)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       String lowerKey = key;
       StringUtils::ToLower(lowerKey);
       std::string value;
@@ -244,43 +244,43 @@ namespace XBMCAddon
 
     String ListItem::getArt(const char* key)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return item->GetArt(key);
     }
 
     String ListItem::getUniqueID(const char* key)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return item->GetVideoInfoTag()->GetUniqueID(key);
     }
 
     float ListItem::getRating(const char* key)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return item->GetVideoInfoTag()->GetRating(key).rating;
     }
 
     int ListItem::getVotes(const char* key)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return item->GetVideoInfoTag()->GetRating(key).votes;
     }
 
     void ListItem::setPath(const String& path)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       item->SetPath(path);
     }
 
     void ListItem::setMimeType(const String& mimetype)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       item->SetMimeType(mimetype);
     }
 
     void ListItem::setContentLookup(bool enable)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       item->SetContentLookup(enable);
     }
 
@@ -314,13 +314,13 @@ namespace XBMCAddon
 
     String ListItem::getPath()
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return item->GetPath();
     }
 
     void ListItem::setInfo(const char* type, const InfoLabelDict& infoLabels)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
 
       if (strcmpi(type, "video") == 0)
       {
@@ -598,7 +598,7 @@ namespace XBMCAddon
 
     void ListItem::setCast(const std::vector<Properties>& actors)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       item->GetVideoInfoTag()->m_cast.clear();
       for (const auto& dictionary: actors)
       {
@@ -622,7 +622,7 @@ namespace XBMCAddon
 
     void ListItem::addStreamInfo(const char* cType, const Properties& dictionary)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
 
       if (strcmpi(cType, "video") == 0)
       {
@@ -690,7 +690,7 @@ namespace XBMCAddon
         if (tuple.GetNumValuesSet() != 2)
           throw ListItemException("Must pass in a list of tuples of pairs of strings. One entry in the list only has %d elements.",tuple.GetNumValuesSet());
 
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
         item->SetProperty(StringUtils::Format("contextmenulabel(%zu)", i), tuple.first());
         item->SetProperty(StringUtils::Format("contextmenuaction(%zu)", i), tuple.second());
       }
@@ -698,7 +698,7 @@ namespace XBMCAddon
 
     void ListItem::setSubtitles(const std::vector<String>& paths)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       unsigned int i = 1;
       for (std::vector<String>::const_iterator it = paths.begin(); it != paths.end(); ++it, i++)
       {
@@ -709,7 +709,7 @@ namespace XBMCAddon
 
     xbmc::InfoTagVideo* ListItem::getVideoInfoTag()
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (item->HasVideoInfoTag())
         return new xbmc::InfoTagVideo(*item->GetVideoInfoTag());
       return new xbmc::InfoTagVideo();
@@ -717,7 +717,7 @@ namespace XBMCAddon
 
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       if (item->HasMusicInfoTag())
         return new xbmc::InfoTagMusic(*item->GetMusicInfoTag());
       return new xbmc::InfoTagMusic();

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -351,7 +351,7 @@ namespace XBMCAddon
 
       bool ret;
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(nullptr);
 
         int id = g_windowManager.GetTopMostModalDialogID();
         if (id == WINDOW_INVALID) id = g_windowManager.GetActiveWindow();

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -164,7 +164,7 @@ namespace XBMCAddon
 
       // Tells the window to add the item to FileItem vector
       {
-        LOCKGUI;
+        XBMCAddonUtils::GuiLock lock(languageHook);
 
         //----------------------------------------------------
         // Former AddItem call
@@ -192,7 +192,7 @@ namespace XBMCAddon
     void WindowXML::addItems(const std::vector<Alternative<String, const XBMCAddon::xbmcgui::ListItem* > > & items)
     {
     XBMC_TRACE;
-    LOCKGUI;
+    XBMCAddonUtils::GuiLock lock(languageHook);
     for (auto item : items)
       {
         AddonClass::Ref<ListItem> ritem = item.which() == XBMCAddon::first ? ListItem::fromString(item.former()) : AddonClass::Ref<ListItem>(item.later());
@@ -207,7 +207,7 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       // Tells the window to remove the item at the specified position from the FileItem vector
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       A(m_vecItems)->Remove(position);
       A(m_viewControl).SetItems(*(A(m_vecItems)));
     }
@@ -215,7 +215,7 @@ namespace XBMCAddon
     int WindowXML::getCurrentListPosition()
     {
       XBMC_TRACE;
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       int listPos = A(m_viewControl).GetSelectedItem();
       return listPos;
     }
@@ -223,13 +223,13 @@ namespace XBMCAddon
     void WindowXML::setCurrentListPosition(int position)
     {
       XBMC_TRACE;
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       A(m_viewControl).SetSelectedItem(position);
     }
 
     ListItem* WindowXML::getListItem(int position)
     {
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       //CFileItemPtr fi = pwx->GetListItem(listPos);
       CFileItemPtr fi;
       {
@@ -259,7 +259,7 @@ namespace XBMCAddon
     void WindowXML::clearList()
     {
       XBMC_TRACE;
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       A(ClearFileItems());
 
       A(m_viewControl).SetItems(*(A(m_vecItems)));
@@ -274,7 +274,7 @@ namespace XBMCAddon
     int WindowXML::getCurrentContainerId()
     {
       XBMC_TRACE;
-      LOCKGUI;
+      XBMCAddonUtils::GuiLock lock(languageHook);
       return A(m_viewControl.GetCurrentControl());
     }
 


### PR DESCRIPTION
## Description
backport from https://github.com/xbmc/xbmc/pull/12504
fixes GUI lock issues with the Python GIL

## Motivation and Context
Fixes the issue where Kodi would lockup or even completely crash when a python add-on itself is serving content to Kodi (like e.g. an audio stream streaming through an internal webserver) and another or the same python add-on is reading a property from the Kodi GUI at the exact same time.
Issue is confirmed fixed with the original PR by FernetMenta and as it was not that hard to back port, I consider it useful in the Krypton 17.4 release too.

## How Has This Been Tested?
Tested on my dev machine (Windows x64). Confirm that Python interaction still works as intended and that the original issue is now fixed.


## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
