### PR TITLE
Add xbmcgui.Control.isVisible method

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -704,6 +704,16 @@ namespace XBMCAddon
         pGUIControl->SetVisible(visible);
     }
 
+    bool Control::isVisible()
+    {
+      DelayedCallGuard dcguard(languageHook);
+      LOCKGUI;
+      if (pGUIControl)
+        return pGUIControl->IsVisible();
+      else
+        return false;
+    }
+
     void Control::setVisibleCondition(const char* visible, bool allowHiddenFocus)
     {
       DelayedCallGuard dcguard(languageHook);

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -279,6 +279,28 @@ namespace XBMCAddon
       virtual void setVisible(bool visible);
 #endif
 
+      // isVisible() Method
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      /// \ingroup python_xbmcgui_control
+      /// @brief \python_func{ isVisible() }
+      ///-----------------------------------------------------------------------
+      /// Get the control's visible/hidden state.
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// if self.button.isVisible():
+      ///     ...
+      /// ~~~~~~~~~~~~~
+      ///
+      isVisible(...);
+#else
+      virtual bool isVisible();
+#endif
+
       // setVisibleCondition() Method
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control


### PR DESCRIPTION
This method allows to check Control's visible state from Python.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

This PR adds a new `isVisible` method to `xbmcgui.Control` class to check visible state of a Python-based UI Control.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

@a1rwulf asked on Slack if such method exists, and since it does not I decided to add this method because it is easy to implement.

## How Has This Been Tested?
I compiled a Kodi build with this change and run a simple testing addon to test if the new method works and returns correct data.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
