### PR TITLE
[cmake] FindBluray.cmake: fix version check

### DIFF
--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -14,14 +14,21 @@
 #
 #   Bluray::Bluray   - The libbluray library
 
+set(Bluray_FIND_VERSION 0.9.3)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_BLURAY libbluray>=0.9.3 QUIET)
+  pkg_check_modules(PC_BLURAY libbluray>=${Bluray_FIND_VERSION} QUIET)
+  set(BLURAY_VERSION ${PC_BLURAY_VERSION})
 endif()
 
 find_path(BLURAY_INCLUDE_DIR libbluray/bluray.h
                              PATHS ${PC_BLURAY_INCLUDEDIR})
 
-set(BLURAY_VERSION ${PC_BLURAY_VERSION})
+if(NOT BLURAY_VERSION AND EXISTS ${BLURAY_INCLUDE_DIR}/libbluray/bluray-version.h)
+  file(STRINGS ${BLURAY_INCLUDE_DIR}/libbluray/bluray-version.h _bluray_version_str
+       REGEX "#define[ \t]BLURAY_VERSION_STRING[ \t][\"]?[0-9.]+[\"]?")
+  string(REGEX REPLACE "^.*BLURAY_VERSION_STRING[ \t][\"]?([0-9.]+).*$" "\\1" BLURAY_VERSION ${_bluray_version_str})
+  unset(_bluray_version_str)
+endif()
 
 include(FindPackageHandleStandardArgs)
 if(NOT WIN32)
@@ -29,7 +36,7 @@ if(NOT WIN32)
                               PATHS ${PC_BLURAY_LIBDIR})
 
   find_package_handle_standard_args(Bluray
-                                    REQUIRED_VARS BLURAY_LIBRARY BLURAY_INCLUDE_DIR
+                                    REQUIRED_VARS BLURAY_LIBRARY BLURAY_INCLUDE_DIR BLURAY_VERSION
                                     VERSION_VAR BLURAY_VERSION)
 else()
   # Dynamically loaded DLL


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
properly check libbluray version

## Description


## Motivation and Context
reported by @notspiff 
currently the version check is only done using pkg-config. If pkg-config fails (e.g. because of too low version), we still do the manual search without any further version checks.
The effect is that libbluray <=0.9.2 is accepted, even though the find rule tries to enforce 0.9.3


## How Has This Been Tested?
not really

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

