### PR TITLE
[PVR] Fix channel preview OSD after #12510

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -142,7 +142,7 @@ void CPVRGUIInfo::ToggleShowInfo(void)
 
   if (m_ToggleShowInfo.IsTimePast())
   {
-    // if preview was active an user did not sekect a channel
+    // if preview was active and user did not select a channel
     // set current item back to playing channel
     
     m_ToggleShowInfo.SetInfinite();

--- a/xbmc/pvr/PVRJobs.cpp
+++ b/xbmc/pvr/PVRJobs.cpp
@@ -45,9 +45,9 @@ bool CPVRSetRecordingOnChannelJob::DoWork()
   return CServiceBroker::GetPVRManager().GUIActions()->SetRecordingOnChannel(m_channel, m_bOnOff);
 }
 
-CPVRChannelEntryTimeoutJob::CPVRChannelEntryTimeoutJob(int timeout)
+CPVRChannelEntryTimeoutJob::CPVRChannelEntryTimeoutJob(int iTimeout)
 {
-  m_delayTimer.Set(timeout);
+  m_delayTimer.Set(iTimeout);
 }
 
 bool CPVRChannelEntryTimeoutJob::DoWork()

--- a/xbmc/pvr/PVRJobs.h
+++ b/xbmc/pvr/PVRJobs.h
@@ -56,10 +56,10 @@ namespace PVR
   class CPVRChannelEntryTimeoutJob : public CJob, public IJobCallback
   {
   public:
-    CPVRChannelEntryTimeoutJob(int timeout);
+    CPVRChannelEntryTimeoutJob(int iTimeout);
     ~CPVRChannelEntryTimeoutJob() override = default;
     const char *GetType() const override { return "pvr-channel-entry-timeout-job"; }
-    void OnJobComplete(unsigned int jobID, bool success, CJob *job) override { }
+    void OnJobComplete(unsigned int iJobID, bool bSuccess, CJob *job) override {}
 
     bool DoWork() override;
   private:

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -156,7 +156,7 @@ CPVRManager::CPVRManager(void) :
     m_progressBar(nullptr),
     m_progressHandle(nullptr),
     m_managerState(ManagerStateStopped),
-    m_isChannelPreview(false),
+    m_bIsChannelPreview(false),
     m_settings({
       CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
       CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
@@ -820,7 +820,7 @@ void CPVRManager::CloseStream(void)
   m_addons->CloseStream();
 
   CSingleLock lock(m_critSection);
-  m_isChannelPreview = false;
+  m_bIsChannelPreview = false;
   m_currentFile.reset();
 }
 
@@ -835,7 +835,7 @@ void CPVRManager::UpdateCurrentChannel(void)
   {
     m_currentFile.reset(new CFileItem(playingChannel));
     UpdateItem(*m_currentFile);
-    m_isChannelPreview = false;
+    m_bIsChannelPreview = false;
   }
 }
 
@@ -863,7 +863,7 @@ bool CPVRManager::UpdateItem(CFileItem& item)
       *m_currentFile->GetPVRChannelInfoTag() == *item.GetPVRChannelInfoTag())
     return false;
 
-  if (!m_isChannelPreview)
+  if (!m_bIsChannelPreview)
     g_application.SetCurrentFileItem(*m_currentFile);
   
   g_infoManager.SetCurrentItem(m_currentFile);
@@ -915,21 +915,29 @@ bool CPVRManager::UpdateItem(CFileItem& item)
   return false;
 }
 
-void CPVRManager::ChannelPreviewUpDown(bool up)
+void CPVRManager::ChannelPreviewUp()
 {
   CSingleLock lock(m_critSection);
-  CPVRChannelPtr currentChannel(m_currentFile->GetPVRChannelInfoTag());
+
+  const CPVRChannelPtr currentChannel(m_currentFile->GetPVRChannelInfoTag());
   if (currentChannel)
   {
-    CPVRChannelGroupPtr group = GetPlayingGroup(currentChannel->IsRadio());
+    const CPVRChannelGroupPtr group = GetPlayingGroup(currentChannel->IsRadio());
     if (group)
-    {
-      CFileItemPtr newChannel = up ?
-      group->GetByChannelUp(currentChannel) :
-      group->GetByChannelDown(currentChannel);
+      ChannelPreview(group->GetByChannelUp(currentChannel));
+  }
+}
 
-      ChannelPreview(newChannel);
-    }
+void CPVRManager::ChannelPreviewDown()
+{
+  CSingleLock lock(m_critSection);
+
+  const CPVRChannelPtr currentChannel(m_currentFile->GetPVRChannelInfoTag());
+  if (currentChannel)
+  {
+    const CPVRChannelGroupPtr group = GetPlayingGroup(currentChannel->IsRadio());
+    if (group)
+      ChannelPreview(group->GetByChannelDown(currentChannel));
   }
 }
 
@@ -950,19 +958,20 @@ void CPVRManager::ChannelPreview(const CFileItemPtr item)
   if (!channel)
     return;
 
-  m_isChannelPreview = !IsPlayingChannel(channel);
+  m_bIsChannelPreview = !IsPlayingChannel(channel);
   g_infoManager.SetCurrentItem(m_currentFile);
   CServiceBroker::GetPVRManager().ShowPlayerInfo(CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO));
 
-  if (m_isChannelPreview)
+  if (m_bIsChannelPreview)
   {
-    int timeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT);
-    if (timeout > 0)
+    int iTimeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT);
+    if (iTimeout > 0)
     {
-      if (m_channelEntryJobId >= 0)
-        CJobManager::GetInstance().CancelJob(m_channelEntryJobId);
-      CPVRChannelEntryTimeoutJob *job = new CPVRChannelEntryTimeoutJob(timeout);
-      m_channelEntryJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
+      if (m_iChannelEntryJobId >= 0)
+        CJobManager::GetInstance().CancelJob(m_iChannelEntryJobId);
+
+      CPVRChannelEntryTimeoutJob *job = new CPVRChannelEntryTimeoutJob(iTimeout);
+      m_iChannelEntryJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
     }
   }
 }
@@ -971,20 +980,20 @@ void CPVRManager::ChannelPreviewSelect()
 {
   CSingleLock lock(m_critSection);
 
-  m_channelEntryJobId = -1;
+  m_iChannelEntryJobId = -1;
 
-  if (m_isChannelPreview)
+  if (m_bIsChannelPreview)
     m_guiActions->SwitchToChannel(m_currentFile, false);
 }
 
-void CPVRManager::SetChannelPreview(bool preview)
+void CPVRManager::SetChannelPreview(bool bPreview)
 {
-  m_isChannelPreview = preview;
+  m_bIsChannelPreview = bPreview;
 }
 
 bool CPVRManager::IsChannelPreview() const
 {
-  return m_isChannelPreview;
+  return m_bIsChannelPreview;
 }
 
 int CPVRManager::GetTotalTime(void) const

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -937,20 +937,25 @@ void CPVRManager::ChannelPreview(const CFileItemPtr item)
 {
   CSingleLock lock(m_critSection);
 
+  if (!g_infoManager.GetShowInfo() && m_settings.GetIntValue(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT) == 0)
+  {
+    // if no info shown and no channel switch delay, just show info for current channel.
+    CServiceBroker::GetPVRManager().ShowPlayerInfo(CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO));
+    return;
+  }
+
   m_currentFile.reset(new CFileItem(*item));
 
   CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
   if (!channel)
     return;
 
-  if (IsPlayingChannel(channel))
-    m_isChannelPreview = false;
-  else
-  {
-    m_isChannelPreview = true;
-    g_infoManager.SetCurrentItem(m_currentFile);
-    CServiceBroker::GetPVRManager().ShowPlayerInfo(CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO));
+  m_isChannelPreview = !IsPlayingChannel(channel);
+  g_infoManager.SetCurrentItem(m_currentFile);
+  CServiceBroker::GetPVRManager().ShowPlayerInfo(CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO));
 
+  if (m_isChannelPreview)
+  {
     int timeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT);
     if (timeout > 0)
     {

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -284,10 +284,6 @@ namespace PVR
      */
     void ResetPlayingTag(void);
 
-    void ChannelPreviewUpDown(bool up);
-
-    void ChannelPreviewSelect();
-
     /*!
      * @brief Close an open PVR stream.
      */
@@ -456,9 +452,25 @@ namespace PVR
     void ConnectionStateChange(CPVRClient *client, std::string connectString, PVR_CONNECTION_STATE state, std::string message);
 
     /*!
-     * @brief Explicitly set the state of channel preview. This is when channel is displayed on OSD without actually switching
+     * @brief Activate channel preview for next channel in current channel group.
      */
-    void SetChannelPreview(bool preview);
+    void ChannelPreviewUp();
+
+    /*!
+     * @brief Activate channel preview for previous channel in current channel group.
+     */
+    void ChannelPreviewDown();
+
+    /*!
+     * @brief Switch to the channel currently previewed.
+     */
+    void ChannelPreviewSelect();
+
+    /*!
+     * @brief Explicitly set the state of channel preview. This is when channel is displayed on OSD without actually switching
+     * @param bPreview true to activate channel preview, false otherwise.
+     */
+    void SetChannelPreview(bool bPreview);
 
     /*!
      * @brief Query the state of channel preview
@@ -551,6 +563,10 @@ namespace PVR
      */
     bool ChannelUpDown(unsigned int *iNewChannelNumber, bool bPreview, bool bUp);
 
+    /*!
+     * @brief Activate preview for a given channel.
+     * @param item the channel the preview is to be activated for.
+     */
     void ChannelPreview(const CFileItemPtr item);
 
     /*!
@@ -604,8 +620,8 @@ namespace PVR
 
     CCriticalSection                m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */
 
-    std::atomic_bool m_isChannelPreview;
-    int m_channelEntryJobId = -1;
+    std::atomic_bool m_bIsChannelPreview;
+    int m_iChannelEntryJobId = -1;
     CEventSource<PVREvent> m_events;
 
     CPVRActionListener m_actionListener;


### PR DESCRIPTION
Fixes some fallout caused by #12510, superseeds #12572.

This has been runtime-tested on macOS, latest Kodi master.