### PR TITLE
DVDDemuxFFmpeg: Discard repair track from GoPro recordings

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1443,6 +1443,10 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       {
         stream = new CDemuxStream();
         stream->type = STREAM_DATA;
+        // Video (mp4) from GoPro cameras can had a 'meta' track used for a file repair containing
+        //  'fdsc' data, this is also called the SOS track. Ignore it or we will glitch bad on startup.
+        if (pStream->codec->codec_tag == MKTAG('f','d','s','c'))
+          pStream->discard = AVDISCARD_ALL;
         break;
       }
     case AVMEDIA_TYPE_SUBTITLE:


### PR DESCRIPTION
GoPro video files always stutter at the start (e.g. for 20 seconds) and then resume fine.
https://forum.kodi.tv/showthread.php?tid=259292
https://trac.kodi.tv/ticket/17371
https://trac.kodi.tv/ticket/17373

MrMC had a fix and in testing that resolves the reported issue.
https://forum.kodi.tv/showthread.php?tid=259292&pid=2622828#pid2622828

<!--- Provide a general summary of your change in the Title above -->

## Description
Video (mp4) from GoPro cameras can have a 'meta' track used for a file repair containing
'fdsc' data, this is also called the SOS track. Ignore it or we will glitch bad on startup.

<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
