### PR TITLE
Fix crash on test suite teardown

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -135,11 +135,6 @@ void CInputManager::Deinitialize()
 {
 }
 
-void CInputManager::SetEnabledJoystick(bool enabled /* = true */)
-{
-  //! @todo
-}
-
 bool CInputManager::ProcessRemote(int windowId)
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -109,6 +109,8 @@ CInputManager::CInputManager(const CAppParamParser &params) :
 
 CInputManager::~CInputManager()
 {
+  Deinitialize();
+
   // Unregister settings
   CServiceBroker::GetSettings().UnregisterCallback(this);
 
@@ -133,6 +135,9 @@ void CInputManager::InitializeInputs()
 
 void CInputManager::Deinitialize()
 {
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  m_RemoteControl.Disconnect();
+#endif
 }
 
 bool CInputManager::ProcessRemote(int windowId)

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -139,13 +139,6 @@ public:
    */
   void Deinitialize();
 
-  /*! \brief Enable or disable the joystick
-   *
-   * \param enabled true to enable joystick, false to disable
-   * \return void
-   */
-  void SetEnabledJoystick(bool enabled = true);
-
   /*! \brief Handle an input event
    * 
    * \param newEvent event details

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -38,7 +38,7 @@ CRemoteControl::CRemoteControl()
 
 CRemoteControl::~CRemoteControl()
 {
-  Close();
+  Disconnect();
 }
 
 void CRemoteControl::Disconnect()


### PR DESCRIPTION
Remote control failed to stop its thread on application shutdown.

## Motivation and Context
Latent bug was uncovered when I fixed the order of service initialization/deinitialization. I broke it, I fix it :)

## How Has This Been Tested?
Test suite on Windows no longer crashes on teardown.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
