### PR TITLE
[depends] bump freetype to 2.8

### DIFF
--- a/tools/depends/target/freetype2/Makefile
+++ b/tools/depends/target/freetype2/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=freetype
-VERSION=2.4.7
+VERSION=2.8
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 
@@ -11,7 +11,7 @@ ARCHIVE=$(SOURCE).tar.bz2
 # force using internal libtool
 export LIBTOOL=builds/unix/libtool
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) builds/unix; \
-          ./configure --prefix=$(PREFIX) --disable-shared
+          ./configure --prefix=$(PREFIX) --disable-shared --with-png=no
 
 LIBDYLIB=$(PLATFORM)/objs/.libs/lib$(LIBNAME).a
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
bump freetype to version 2.8
The feature supporting color embedded bitmaps, which was added in freetype 2.5, is currently disabled.
<!--- Describe your change in detail -->

<!--## Motivation and Context-->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled depends for osx, ios, appletvos and android
compiled kodi for osx
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
