### PR TITLE
add dynamic URLs to fileItems

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -362,6 +362,7 @@ const CFileItem& CFileItem::operator=(const CFileItem& item)
   m_bLabelPreformatted=item.m_bLabelPreformatted;
   FreeMemory();
   m_strPath = item.GetPath();
+  m_strDynPath = item.GetDynPath();
   m_bIsParentFolder = item.m_bIsParentFolder;
   m_iDriveType = item.m_iDriveType;
   m_bIsShareOrDrive = item.m_bIsShareOrDrive;
@@ -486,6 +487,7 @@ void CFileItem::Reset()
   m_strDVDLabel.clear();
   m_strTitle.clear();
   m_strPath.clear();
+  m_strDynPath.clear();
   m_dateTime.Reset();
   m_strLockCode.clear();
   m_mimetype.clear();
@@ -510,6 +512,7 @@ void CFileItem::Reset()
   SetInvalid();
 }
 
+// do not archive dynamic path
 void CFileItem::Archive(CArchive& ar)
 {
   CGUIListItem::Archive(ar);
@@ -1717,6 +1720,38 @@ bool CFileItem::IsURL(const CURL& url) const
 bool CFileItem::IsPath(const std::string& path, bool ignoreURLOptions /* = false */) const
 {
   return URIUtils::PathEquals(m_strPath, path, false, ignoreURLOptions);
+}
+
+void CFileItem::SetDynURL(const CURL& url)
+{
+  m_strDynPath = url.Get();
+}
+
+const CURL CFileItem::GetDynURL() const
+{
+  if (!m_strDynPath.empty())
+  {
+    CURL url(m_strDynPath);
+    return url;
+  }
+  else
+  {
+    CURL url(m_strPath);
+    return url;
+  }
+}
+
+const std::string &CFileItem::GetDynPath() const
+{
+  if (!m_strDynPath.empty())
+    return m_strDynPath;
+  else
+    return m_strPath;
+}
+
+void CFileItem::SetDynPath(const std::string &path)
+{
+  m_strDynPath = path;
 }
 
 void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -132,6 +132,11 @@ public:
   void SetPath(const std::string &path) { m_strPath = path; };
   bool IsPath(const std::string& path, bool ignoreURLOptions = false) const;
 
+  const CURL GetDynURL() const;
+  void SetDynURL(const CURL& url);
+  const std::string &GetDynPath() const;
+  void SetDynPath(const std::string &path);
+
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize
@@ -568,6 +573,7 @@ private:
   CBookmark GetResumePoint() const;
 
   std::string m_strPath;            ///< complete path to item
+  std::string m_strDynPath;
 
   SortSpecial m_specialSort;
   bool m_bIsParentFolder;

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -52,12 +52,12 @@ bool CAudioDecoder::Init(const CFileItem& file, unsigned int filecache)
 
   // for replaygain
   CTagLoaderTagLib tag;
-  tag.Load(file.GetPath(), XFILE::CMusicFileDirectory::m_tag, NULL);
+  tag.Load(file.GetDynPath(), XFILE::CMusicFileDirectory::m_tag, NULL);
 
   int channels;
   int sampleRate;
 
- bool ret = m_struct.toAddon.init(&m_struct, file.GetPath().c_str(), filecache,
+ bool ret = m_struct.toAddon.init(&m_struct, file.GetDynPath().c_str(), filecache,
                                   &channels, &sampleRate,
                                   &m_bitsPerSample, &m_TotalTime,
                                   &m_bitRate, &m_format.m_dataFormat, &m_channel);

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -332,7 +332,7 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
     strFileNameAndPath = pItem->GetVideoInfoTag()->m_strFileNameAndPath;
 
   if (strFileNameAndPath.empty())
-    strFileNameAndPath = pItem->GetPath();
+    strFileNameAndPath = pItem->GetDynPath();
 
   std::string playablePath = strFileNameAndPath;
   if (URIUtils::IsStack(playablePath))
@@ -417,7 +417,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
         for (int i = 1; i < files.Size(); i++)
         {
            int duration = 0;
-           if (CDVDFileInfo::GetFileDuration(files[i]->GetPath(), duration))
+           if (CDVDFileInfo::GetFileDuration(files[i]->GetDynPath(), duration))
              p->m_iDuration = p->m_iDuration + duration;
         }
       }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -129,12 +129,12 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
   {
     if (finalFileitem.ContentLookup())
     {
-      CURL origUrl(finalFileitem.GetURL());
+      CURL origUrl(finalFileitem.GetDynURL());
       XFILE::CCurlFile curlFile;
       // try opening the url to resolve all redirects if any
       try
       {
-        if (curlFile.Open(finalFileitem.GetURL()))
+        if (curlFile.Open(finalFileitem.GetDynURL()))
         {
           CURL finalUrl(curlFile.GetURL());
           finalUrl.SetProtocolOptions(origUrl.GetProtocolOptions());

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -46,7 +46,7 @@ void CDVDInputStream::Close()
 
 std::string CDVDInputStream::GetFileName()
 {
-  CURL url(m_item.GetPath());
+  CURL url(m_item.GetDynPath());
 
   url.SetProtocolOptions("");
   return url.Get();
@@ -54,5 +54,5 @@ std::string CDVDInputStream::GetFileName()
 
 CURL CDVDInputStream::GetURL()
 {
-  return m_item.GetURL();
+  return m_item.GetDynURL();
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -63,15 +63,15 @@ bool CDVDInputStreamFFmpeg::Open()
   m_can_seek  = true;
   m_aborted   = false;
 
-  if(strnicmp(m_item.GetPath().c_str(), "udp://", 6) == 0 ||
-     strnicmp(m_item.GetPath().c_str(), "rtp://", 6) == 0)
+  if(strnicmp(m_item.GetDynPath().c_str(), "udp://", 6) == 0 ||
+     strnicmp(m_item.GetDynPath().c_str(), "rtp://", 6) == 0)
   {
     m_can_pause = false;
     m_can_seek = false;
     m_realtime = true;
   }
 
-  if(strnicmp(m_item.GetPath().c_str(), "tcp://", 6) == 0)
+  if(strnicmp(m_item.GetDynPath().c_str(), "tcp://", 6) == 0)
   {
     m_can_pause = true;
     m_can_seek  = false;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -66,11 +66,11 @@ bool CDVDInputStreamFile::Open()
    * 3) No buffer
    * 4) Buffer all non-local (remote) filesystems
    */
-  if (!URIUtils::IsOnDVD(m_item.GetPath()) && !URIUtils::IsBluray(m_item.GetPath())) // Never cache these
+  if (!URIUtils::IsOnDVD(m_item.GetDynPath()) && !URIUtils::IsBluray(m_item.GetDynPath())) // Never cache these
   {
-    if ((g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_INTERNET && URIUtils::IsInternetStream(m_item.GetPath(), true))
-     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET && URIUtils::IsInternetStream(m_item.GetPath(), false))
-     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_REMOTE && URIUtils::IsRemote(m_item.GetPath()))
+    if ((g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_INTERNET && URIUtils::IsInternetStream(m_item.GetDynPath(), true))
+     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET && URIUtils::IsInternetStream(m_item.GetDynPath(), false))
+     || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_REMOTE && URIUtils::IsRemote(m_item.GetDynPath()))
      || (g_advancedSettings.m_cacheBufferMode == CACHE_BUFFER_MODE_ALL))
     {
       flags |= READ_CACHED;
@@ -90,7 +90,7 @@ bool CDVDInputStreamFile::Open()
     flags |= READ_MULTI_STREAM;
 
   // open file in binary mode
-  if (!m_pFile->Open(m_item.GetPath(), flags))
+  if (!m_pFile->Open(m_item.GetDynPath(), flags))
   {
     delete m_pFile;
     m_pFile = NULL;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -88,7 +88,7 @@ bool CDVDInputStreamNavigator::Open()
   // libdvdcss fails if the file path contains VIDEO_TS.IFO or VIDEO_TS/VIDEO_TS.IFO
   // libdvdnav is still able to play without, so strip them.
 
-  std::string path = m_item.GetPath();
+  std::string path = m_item.GetDynPath();
   if(URIUtils::GetFileName(path) == "VIDEO_TS.IFO")
     path = URIUtils::GetParentPath(path);
   URIUtils::RemoveSlashAtEnd(path);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -85,7 +85,7 @@ bool CDVDInputStreamPVRManager::Open()
   if (!CDVDInputStream::Open())
     return false;
 
-  CURL url(m_item.GetPath());
+  CURL url(m_item.GetDynPath());
 
   std::string strURL = url.Get();
 
@@ -146,7 +146,7 @@ bool CDVDInputStreamPVRManager::Open()
   }
 
   ResetScanTimeout((unsigned int) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
-  CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", CURL::GetRedacted(m_item.GetPath()).c_str());
+  CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", CURL::GetRedacted(m_item.GetDynPath()).c_str());
 
   m_StreamProps->iStreamCount = 0;
   return true;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.cpp
@@ -53,7 +53,7 @@ bool CDVDInputStreamStack::Open()
   CStackDirectory dir;
   CFileItemList   items;
 
-  const CURL pathToUrl(m_item.GetPath());
+  const CURL pathToUrl(m_item.GetDynPath());
   if(!dir.GetDirectory(pathToUrl, items))
   {
     CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to get list of stacked items");
@@ -67,9 +67,9 @@ bool CDVDInputStreamStack::Open()
   {
     TFile file(new CFile());
 
-    if (!file->Open(items[index]->GetPath(), READ_TRUNCATED))
+    if (!file->Open(items[index]->GetDynPath(), READ_TRUNCATED))
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to open stack part '%s' - skipping", items[index]->GetPath().c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to open stack part '%s' - skipping", items[index]->GetDynPath().c_str());
       continue;
     }
     TSeg segment;
@@ -78,7 +78,7 @@ bool CDVDInputStreamStack::Open()
 
     if(segment.length <= 0)
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to get file length for '%s' - skipping", items[index]->GetPath().c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to get file length for '%s' - skipping", items[index]->GetDynPath().c_str());
       continue;
     }
 

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -88,7 +88,7 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
 
   if (!m_codec || !m_codec->Init(file, filecache * 1024))
   {
-    CLog::Log(LOGERROR, "CAudioDecoder: Unable to Init Codec while loading file %s", file.GetPath().c_str());
+    CLog::Log(LOGERROR, "CAudioDecoder: Unable to Init Codec while loading file %s", file.GetDynPath().c_str());
     Destroy();
     return false;
   }

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -56,7 +56,7 @@ ICodec* CodecFactory::CreateCodec(const std::string &strFileType)
 
 ICodec* CodecFactory::CreateCodecDemux(const CFileItem& file, unsigned int filecache)
 {
-  CURL urlFile(file.GetPath());
+  CURL urlFile(file.GetDynPath());
   std::string content = file.GetMimeType();
   StringUtils::ToLower(content);
   if (!content.empty())


### PR DESCRIPTION
Kodi identifies an item by its path. Hence path must never be changed once a FileItem was created. This adds a dynamic path to fileIIems that is allowed to be changed.

Required i.e. by PVR