### PR TITLE
[PVR] Obtain live stream URL from client addon before starting playba…

### DIFF
--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -648,9 +648,9 @@ namespace PVR
     bool GetDescrambleInfo(PVR_DESCRAMBLE_INFO &descrambleinfo) const;
 
     /*!
-     * @brief Get the stream URL for a channel from the server. Used by the MediaPortal add-on.
+     * @brief Get the stream URL for a channel from the PVR backend.
      * @param channel The channel to get the stream URL for.
-     * @return The requested URL.
+     * @return The requested URL or empty string if not available.
      */
     std::string GetLiveStreamURL(const CPVRChannelPtr &channel);
 

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -989,6 +989,10 @@ namespace PVR
 
   void CPVRGUIActions::StartPlayback(CFileItem *item, bool bFullscreen) const
   {
+    const CPVRChannelPtr channel = item->GetPVRChannelInfoTag();
+    if (channel)
+      item->SetDynPath(CServiceBroker::GetPVRManager().Clients()->GetLiveStreamURL(channel));
+
     CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
     CheckAndSwitchToFullscreen(bFullscreen);
   }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -978,6 +978,15 @@ bool CPVRClients::GetPlayingClient(PVR_CLIENT &client) const
   return GetCreatedClient(GetPlayingClientID(), client);
 }
 
+std::string CPVRClients::GetLiveStreamURL(const CPVRChannelPtr &channel)
+{
+  PVR_CLIENT client;
+  if (GetCreatedClient(channel->ClientID(), client))
+    return client->GetLiveStreamURL(channel);
+
+  return std::string();
+}
+
 bool CPVRClients::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel)
 {
   assert(channel.get());

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -282,6 +282,13 @@ namespace PVR
     bool IsEncrypted(void) const;
 
     /*!
+     * @brief Get the stream URL for a given channel from the respective client.
+     * @param channel The channel to get the stream URL for.
+     * @return The stream URL or empty string if not available.
+     */
+    std::string GetLiveStreamURL(const CPVRChannelPtr &channel);
+
+    /*!
      * @brief Open a stream on the given channel.
      * @param channel The channel to start playing.
      * @param bIsSwitchingChannel True when switching channels, false otherwise.


### PR DESCRIPTION
…ck of tv channels; Store it in the dynamic path of the item passed to the player."

Followup to #12552 and #12550 to provide an interim solution for now broken addons that relay on passing a stream url for channels to kodi.

Now, before starting playback of a channel, PVR API function `GetLiveStreamURL(channel)` will be called. Addons formerly used PVR_CHANNEL::strStreamURL must properly implement GetLiveStreamURL, if they do not already.

Related forum discussion: https://forum.kodi.tv/showthread.php?tid=318996