### PR TITLE
Remove unused parameters on ResetRenderSystem()

### DIFF
--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -98,7 +98,7 @@ public:
 
   virtual bool InitRenderSystem() = 0;
   virtual bool DestroyRenderSystem() = 0;
-  virtual bool ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate) = 0;
+  virtual bool ResetRenderSystem(int width, int height) = 0;
 
   virtual bool BeginRender() = 0;
   virtual bool EndRender() = 0;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -99,7 +99,7 @@ public:
   bool IsExtSupported(const char* extension) override { return false; };
   void ApplyHardwareTransform(const TransformMatrix &matrix) override {};
   void RestoreHardwareTransform() override {};
-  bool ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate) override { return true; };
+  bool ResetRenderSystem(int width, int height) override { return true; };
 
   std::vector<AVPixelFormat> m_processorFormats;
   std::vector<AVPixelFormat> m_sharedFormats;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -167,7 +167,7 @@ bool CRenderSystemGL::InitRenderSystem()
   return true;
 }
 
-bool CRenderSystemGL::ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate)
+bool CRenderSystemGL::ResetRenderSystem(int width, int height)
 {
   m_width = width;
   m_height = height;

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -32,7 +32,7 @@ public:
   void CheckOpenGLQuirks();
   bool InitRenderSystem() override;
   bool DestroyRenderSystem() override;
-  bool ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate) override;
+  bool ResetRenderSystem(int width, int height) override;
 
   bool BeginRender() override;
   bool EndRender() override;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -135,7 +135,7 @@ bool CRenderSystemGLES::InitRenderSystem()
   return true;
 }
 
-bool CRenderSystemGLES::ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate)
+bool CRenderSystemGLES::ResetRenderSystem(int width, int height)
 {
   m_width = width;
   m_height = height;

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -52,7 +52,7 @@ public:
 
   bool InitRenderSystem() override;
   bool DestroyRenderSystem() override;
-  bool ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate) override;
+  bool ResetRenderSystem(int width, int height) override;
 
   bool BeginRender() override;
   bool EndRender() override;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -143,7 +143,7 @@ bool CWinSystemX11GLContext::ResizeWindow(int newWidth, int newHeight, int newLe
 {
   m_newGlContext = false;
   CWinSystemX11::ResizeWindow(newWidth, newHeight, newLeft, newTop);
-  CRenderSystemGL::ResetRenderSystem(newWidth, newHeight, false, 0);
+  CRenderSystemGL::ResetRenderSystem(newWidth, newHeight);
 
   if (m_newGlContext)
     g_application.ReloadSkin();
@@ -155,7 +155,7 @@ bool CWinSystemX11GLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res
 {
   m_newGlContext = false;
   CWinSystemX11::SetFullScreen(fullScreen, res, blankOtherDisplays);
-  CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight);
 
   if (m_newGlContext)
     g_application.ReloadSkin();

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
@@ -89,14 +89,14 @@ bool CWinSystemAmlogicGLESContext::CreateNewWindow(const std::string& name,
 
 bool CWinSystemAmlogicGLESContext::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
-  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, true, 0);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
   return true;
 }
 
 bool CWinSystemAmlogicGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
-  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
   return true;
 }
 

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -84,14 +84,14 @@ bool CWinSystemAndroidGLESContext::CreateNewWindow(const std::string& name,
 
 bool CWinSystemAndroidGLESContext::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
-  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, true, 0);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
   return true;
 }
 
 bool CWinSystemAndroidGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
-  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
   return true;
 }
 

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -349,14 +349,14 @@ bool CWinSystemEGL::DestroyWindow()
 
 bool CWinSystemEGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
-  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, true, 0);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
   return true;
 }
 
 bool CWinSystemEGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
-  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
   return true;
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -124,7 +124,7 @@ bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
   m_pGLContext.SwapBuffers();
 
   CWinSystemGbm::SetFullScreen(fullScreen, res, blankOtherDisplays);
-  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
 
   return true;
 }

--- a/xbmc/windowing/mir/WinSystemMirGLContext.cpp
+++ b/xbmc/windowing/mir/WinSystemMirGLContext.cpp
@@ -58,7 +58,7 @@ bool CWinSystemMirGLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res
   auto ret = CWinSystemMir::SetFullScreen(fullScreen, res, blankOtherDisplays);
   if (ret)
   {
-    CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, 0);
+    CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight);
   }
 
   return ret;

--- a/xbmc/windowing/mir/WinSystemMirGLESContext.cpp
+++ b/xbmc/windowing/mir/WinSystemMirGLESContext.cpp
@@ -59,7 +59,7 @@ bool CWinSystemMirGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
 
   if (ret)
   {
-    return CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, 0);
+    return CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
   }
 
   return ret;

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -144,7 +144,7 @@ bool CWinSystemIOS::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
     m_nHeight = newHeight;
   }
 
-  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, false, 0);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
 
   return true;
 }
@@ -159,7 +159,7 @@ bool CWinSystemIOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   CLog::Log(LOGDEBUG, "About to switch to %i x %i on screen %i",m_nWidth, m_nHeight, res.iScreen);
   SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate, res.iScreen);
-  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
 
   return true;
 }

--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -58,7 +58,7 @@ void CWinSystemOSXGL::SetVSyncImpl(bool enable)
 bool CWinSystemOSXGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
   CWinSystemOSX::ResizeWindow(newWidth, newHeight, newLeft, newTop);
-  CRenderSystemGL::ResetRenderSystem(newWidth, newHeight, false, 0);
+  CRenderSystemGL::ResetRenderSystem(newWidth, newHeight);
 
   if (m_bVSync)
   {
@@ -71,7 +71,7 @@ bool CWinSystemOSXGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int
 bool CWinSystemOSXGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CWinSystemOSX::SetFullScreen(fullScreen, res, blankOtherDisplays);
-  CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight);
 
   if (m_bVSync)
   {

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -102,14 +102,14 @@ bool CWinSystemRpiGLESContext::CreateNewWindow(const std::string& name,
 
 bool CWinSystemRpiGLESContext::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
-  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, true, 0);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
   return true;
 }
 
 bool CWinSystemRpiGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CreateNewWindow("", fullScreen, res);
-  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
   return true;
 }
 


### PR DESCRIPTION
Remove unused parameters

## Description
Removes full screen and refresh rate info that is never used

## Motivation and Context
Unused information complicates flow and is a burden to windowing implementors

## How Has This Been Tested?
Not at all

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
