### PR TITLE
[win32] cleanup and fix some includes 

### DIFF
--- a/xbmc/addons/Visualization.cpp
+++ b/xbmc/addons/Visualization.cpp
@@ -23,8 +23,8 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/log.h"
-#ifdef HAS_DX
-#include "windowing/windows/WinSystemWin32DX.h"
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
+#include "windowing/WindowingFactory.h"
 #endif
 
 namespace ADDON
@@ -39,7 +39,7 @@ CVisualization::CVisualization(ADDON::BinaryAddonBasePtr addonBase, float x, flo
   m_profilePath = CSpecialProtocol::TranslatePath(Profile());
 
   m_struct = {{0}};
-#ifdef HAS_DX
+#ifdef defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
   m_struct.props.device = g_Windowing.Get3D11Context();
 #else
   m_struct.props.device = nullptr;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -22,7 +22,6 @@
 // which we don't use here
 #define FF_API_OLD_SAMPLE_FMT 0
 
-#include <d3d9.h>
 #include <dxva.h>
 #include <d3d11.h>
 #include <Initguid.h>

--- a/xbmc/cores/VideoPlayer/Process/windows/ProcessInfoWin10.cpp
+++ b/xbmc/cores/VideoPlayer/Process/windows/ProcessInfoWin10.cpp
@@ -18,10 +18,12 @@
  *
  */
 
-#include "ProcessInfoWin.h"
+#include "ProcessInfoWin10.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
+#include "windowing/WindowingFactory.h"
+#include <set>
 
-#if defined(TARGET_WINDOWS) && defined(TARGET_WIN10)
+#if defined(TARGET_WIN10)
 
 using namespace VIDEOPLAYER;
 
@@ -38,6 +40,18 @@ void CProcessInfoWin10::Register()
 EINTERLACEMETHOD CProcessInfoWin10::GetFallbackDeintMethod()
 {
   return EINTERLACEMETHOD::VS_INTERLACEMETHOD_AUTO;
+}
+
+std::vector<AVPixelFormat> CProcessInfoWin10::GetRenderFormats()
+{
+  auto processor = g_Windowing.m_processorFormats;
+  auto shaders = g_Windowing.m_shaderFormats;
+
+  std::set<AVPixelFormat> formats;
+  formats.insert(processor.begin(), processor.end());
+  formats.insert(shaders.begin(), shaders.end());
+
+  return std::vector<AVPixelFormat>(formats.begin(), formats.end());
 }
 
 #endif

--- a/xbmc/cores/VideoPlayer/Process/windows/ProcessInfoWin10.h
+++ b/xbmc/cores/VideoPlayer/Process/windows/ProcessInfoWin10.h
@@ -32,6 +32,7 @@ public:
   static void Register();
 
   EINTERLACEMETHOD GetFallbackDeintMethod() override;
+  std::vector<AVPixelFormat> GetRenderFormats() override;
 };
 
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -25,7 +25,6 @@
 #define FF_API_OLD_SAMPLE_FMT 0
 #define DEFAULT_STREAM_INDEX (0)
 
-#include <dxva2api.h>
 #include <windows.h>
 #include "DXVAHD.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -24,6 +24,7 @@
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h"
 #include "guilib/D3DResource.h"
 #include "guilib/GraphicContext.h"
+#include "guilib/GUIShaderDX.h"
 #include "OverlayRenderer.h"
 #include "OverlayRendererUtil.h"
 #include "OverlayRendererDX.h"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -18,23 +18,23 @@
  *
  */
 
-#ifdef HAS_DX
-
-#include "WinVideoFilter.h"
-#include "windowing/WindowingFactory.h"
-#include "../../../../utils/log.h"
-#include "../../../../FileSystem/File.h"
 #include "ConvolutionKernels.h"
-#include <DirectXPackedVector.h>
-#include "guilib/GraphicContext.h"
-#include "Util.h"
-#include "platform/win32/WIN32Util.h"
-#include "VideoRenderers/WinRenderBuffer.h"
-#include "YUV2RGBShader.h"
-#include <map>
 #include "dither.h"
+#include "filesystem/File.h"
+#include "guilib/GraphicContext.h"
+#include "platform/win32/WIN32Util.h"
+#include "Util.h"
+#include "utils/log.h"
+#include "VideoRenderers/WinRenderBuffer.h"
+#include "windowing/WindowingFactory.h"
+#include "WinVideoFilter.h"
+#include "YUV2RGBShader.h"
+
+#include <DirectXPackedVector.h>
+#include <map>
 
 using namespace DirectX::PackedVector;
+using namespace Microsoft::WRL;
 
 CYUV2RGBMatrix::CYUV2RGBMatrix()
 {
@@ -1178,5 +1178,3 @@ bool CTestShader::Create()
   }
   return true;
 }
-
-#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -20,18 +20,19 @@
  *
  */
 
-#include <vector>
 
-#include "../../guilib/Geometry.h"
-#include "../WinRenderer.h"
+#include "cores/IPlayer.h"
+#include "guilib/Geometry.h"
+#include "guilib/D3DResource.h"
+
 #include <DirectXMath.h>
-#include <wrl.h>
+#include <vector>
+#include <wrl/client.h>
 
 enum EBufferFormat;
 class CRenderBuffer;
 
 using namespace DirectX;
-using namespace Microsoft::WRL;
 
 class CYUV2RGBMatrix
 {
@@ -76,7 +77,7 @@ private:
   CD3DBuffer m_ib;
   unsigned int m_vbsize;
   unsigned int m_vertsize;
-  ComPtr<ID3D11InputLayout> m_inputLayout;
+  Microsoft::WRL::ComPtr<ID3D11InputLayout> m_inputLayout;
 };
 
 class COutputShader : public CWinShader
@@ -116,7 +117,7 @@ private:
   ID3D11ShaderResourceView *m_pCLUTView{ nullptr };
   bool m_useDithering{ false };
   int m_ditherDepth{ 0 };
-  ComPtr<ID3D11ShaderResourceView> m_pDitherView;
+  Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_pDitherView;
 
   struct CUSTOMVERTEX {
     FLOAT x, y, z;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderBuffer.cpp
@@ -25,7 +25,7 @@
 #include "utils/win32/gpu_memcpy_sse4.h"
 #include "utils/CPUInfo.h"
 #include "utils/win32/memcpy_sse2.h"
-#include "windowing/windows/WinSystemWin32DX.h"
+#include "windowing/WindowingFactory.h"
 #include "WinRenderer.h"
 #include "WinRenderBuffer.h"
 

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -19,9 +19,8 @@
  */
 
 #include "filesystem/File.h"
-#ifdef HAS_DX
-
 #include "D3DResource.h"
+#include "GUIShaderDX.h"
 #include "system.h"
 #include "utils/log.h"
 #include "windowing/WindowingFactory.h"
@@ -1224,5 +1223,3 @@ void CD3DPixelShader::OnDestroyDevice(bool fatal)
 {
   ReleaseShader();
 }
-
-#endif

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifdef HAS_DX
-
 #include <map>
 #include <d3dx11effect.h>
 #include <DirectXMath.h>
@@ -286,5 +284,3 @@ private:
   ID3D11PixelShader*        m_PS;
   bool                      m_inited;
 };
-
-#endif

--- a/xbmc/guilib/DirectXGraphics.cpp
+++ b/xbmc/guilib/DirectXGraphics.cpp
@@ -32,23 +32,22 @@ void XPhysicalFree(LPVOID lpAddress)
   free(lpAddress);
 }
 
-D3DFORMAT GetD3DFormat(XB_D3DFORMAT format)
+DWORD GetD3DFormat(XB_D3DFORMAT format)
 {
   switch (format)
   {
   case XB_D3DFMT_A8R8G8B8:
   case XB_D3DFMT_LIN_A8R8G8B8:
-    return D3DFMT_LIN_A8R8G8B8;
-  case XB_D3DFMT_DXT1:
-    return D3DFMT_DXT1;
-  case XB_D3DFMT_DXT2:
-    return D3DFMT_DXT2;
-  case XB_D3DFMT_DXT4:
-    return D3DFMT_DXT4;
   case XB_D3DFMT_P8:
-    return D3DFMT_LIN_A8R8G8B8;
+    return 21;
+  case XB_D3DFMT_DXT1:
+    return MAKEFOURCC('D', 'X', 'T', '1');
+  case XB_D3DFMT_DXT2:
+    return MAKEFOURCC('D', 'X', 'T', '2');
+  case XB_D3DFMT_DXT4:
+    return MAKEFOURCC('D', 'X', 'T', '4');
   default:
-    return D3DFMT_UNKNOWN;
+    return 0;
   }
 }
 

--- a/xbmc/guilib/DirectXGraphics.h
+++ b/xbmc/guilib/DirectXGraphics.h
@@ -130,7 +130,7 @@ typedef enum _XB_D3DFORMAT
   XB_D3DFMT_FORCE_DWORD          =0x7fffffff
 } XB_D3DFORMAT;
 
-D3DFORMAT GetD3DFormat(XB_D3DFORMAT format);
+DWORD GetD3DFormat(XB_D3DFORMAT format);
 DWORD BytesPerPixelFromFormat(XB_D3DFORMAT format);
 bool IsPalettedFormat(XB_D3DFORMAT format);
 void ParseTextureHeader(D3DTexture *tex, XB_D3DFORMAT &fmt, DWORD &width, DWORD &height, DWORD &pitch, DWORD &offset);

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -18,10 +18,9 @@
  *
  */
 
-#ifdef HAS_DX
-
 #include "GUIFontTTFDX.h"
 #include "GUIFontManager.h"
+#include "GUIShaderDX.h"
 #include "Texture.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/log.h"
@@ -358,5 +357,3 @@ void CGUIFontTTFDX::OnDestroyDevice(bool fatal)
 void CGUIFontTTFDX::OnCreateDevice(void)
 {
 }
-
-#endif

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -17,8 +17,6 @@
 *  <http://www.gnu.org/licenses/>.
 *
 */
-#ifdef HAS_DX
-
 #pragma once
 
 #include "Geometry.h"
@@ -150,5 +148,3 @@ private:
   float               m_clipYFactor;
   float               m_clipYOffset;
 };
-
-#endif

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -785,8 +785,6 @@ bool CSlideShowPic::UpdateVertexBuffer(Vertex* vertices)
 void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t color)
 {
 #ifdef HAS_DX
-  static const DWORD FVF_VERTEX = D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1;
-
   Vertex vertex[5];
   for (int i = 0; i < 4; i++)
   {

--- a/xbmc/platform/win32/pch.h
+++ b/xbmc/platform/win32/pch.h
@@ -34,17 +34,14 @@
 #include <comdef.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include "DInput.h"
+#if !defined(TARGET_WIN10)
 #include "DSound.h"
-#ifdef HAS_DX
-#include "d3d9.h"
+#endif
 #include "d3d11_1.h"
 #include "dxgi.h"
 #include "d3dcompiler.h"
 #include "directxmath.h"
 #include "directxcolors.h" 
-#else
-#include <d3d9types.h>
-#endif
 #include <memory>
 // anything below here should be headers that very rarely (hopefully never)
 // change yet are included almost everywhere.

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -19,17 +19,17 @@
  */
 #pragma once
 
+#include <wrl.h>
+#include <wrl/client.h>
 #include <concrt.h>
-#include <d3d11_1.h>
 #if defined(TARGET_WIN10)
+#include <agile.h>
 #include <dxgi1_3.h>
 #else
 #include <dxgi1_2.h>
-#endif
 #include <easyhook/easyhook.h>
+#endif
 #include <memory>
-#include <wrl.h>
-#include <wrl/client.h>
 
 #include "DirectXHelper.h"
 #include "guilib/D3DResource.h"
@@ -92,7 +92,6 @@ namespace DX
     void ResizeBuffers();
 
     bool SetFullScreen(bool fullscreen, RESOLUTION_INFO& res);
-    void SetWindow(HWND window);
 
     // DX resources registration
     void Register(ID3DResource *resource);
@@ -109,10 +108,12 @@ namespace DX
 
     void SetMonitor(HMONITOR monitor) const;
     HMONITOR GetMonitor() const;
-#if defined(TARGET_WIN10)
+#if defined(TARGET_WINDOWS)
+    void SetWindow(HWND window);
+#elif defined(TARGET_WIN10)
     void Trim() const;
-    void SetWindow(Windows::UI::Core::Core​Window^ window;
-#endif
+    void SetWindow(Windows::UI::Core::CoreWindow^ window);
+#endif // TARGET_WIN10
 
   private:
     class CBackBuffer : public CD3DTexture
@@ -133,7 +134,7 @@ namespace DX
 
     HWND m_window{ nullptr };
 #if defined(TARGET_WIN10)
-    Windows::UI::Core::Core​Window^ m_coreWindow;
+    Platform::Agile<Windows::UI::Core::CoreWindow> m_coreWindow;
 #endif
     Microsoft::WRL::ComPtr<IDXGIFactory2> m_dxgiFactory;
     Microsoft::WRL::ComPtr<IDXGIAdapter1> m_adapter;
@@ -160,8 +161,8 @@ namespace DX
     IDeviceNotify* m_deviceNotify;
 
     // scritical section
-    concurrency::critical_section m_criticalSection;
-    concurrency::critical_section m_resourceSection;
+    Concurrency::critical_section m_criticalSection;
+    Concurrency::critical_section m_resourceSection;
     std::vector<ID3DResource*> m_resources;
     bool m_stereoEnabled;
     bool m_bDeviceCreated;

--- a/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
+++ b/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
@@ -26,6 +26,20 @@
   #define M_PI       3.14159265358979323846
 #endif
 
+#ifndef _d3d9TYPES_H_
+#include "DirectXPackedVector.h"
+using namespace DirectX::PackedVector;
+
+DWORD D3DCOLOR_COLORVALUE(float r, float g, float b, float a)
+{
+  XMCOLOR xColor;
+  XMVECTOR xVector = XMVectorSet(r, g, b, a);
+  XMStoreColor(&xColor, xVector);
+  DWORD color = xColor;
+  return color;
+}
+#endif
+
 CGUIWindowTestPatternDX::CGUIWindowTestPatternDX(void) : CGUIWindowTestPattern()
 {
   m_vb = NULL;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -28,7 +28,6 @@
 #include <vector>
 #include <wrl.h>
 
-#include "guilib/GUIShaderDX.h"
 #include "threads/Condition.h"
 #include "threads/CriticalSection.h"
 #include "rendering/dx/DeviceResources.h"
@@ -42,6 +41,7 @@ enum PCI_Vendors
 };
 
 class ID3DResource;
+class CGUIShaderDX;
 enum AVPixelFormat;
 enum AVPixelFormat;
 

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -21,16 +21,15 @@
 #ifndef RENDER_SYSTEM_DX_H
 #define RENDER_SYSTEM_DX_H
 
-#ifdef HAS_DX
-
 #pragma once
 
 #include <vector>
 #include <wrl.h>
+#include <wrl/client.h>
 
+#include "DeviceResources.h"
 #include "threads/Condition.h"
 #include "threads/CriticalSection.h"
-#include "rendering/dx/DeviceResources.h"
 #include "rendering/RenderSystem.h"
 
 enum PCI_Vendors
@@ -115,15 +114,16 @@ protected:
   void CheckDeviceCaps();
 
   CCriticalSection m_resourceSection;
+  CCriticalSection m_decoderSection;
 
   // our adapter could change as we go
   bool m_interlaced;
-  bool m_inScene{false}; ///< True if we're in a BeginScene()/EndScene() block
+  bool m_inScene{ false }; ///< True if we're in a BeginScene()/EndScene() block
   bool m_BlendEnabled{ false };
   bool m_ScissorsEnabled{ false };
   D3D11_VIEWPORT m_viewPort;
   CRect m_scissor;
-  CGUIShaderDX* m_pGUIShader{nullptr};
+  CGUIShaderDX* m_pGUIShader{ nullptr };
   Microsoft::WRL::ComPtr<ID3D11DepthStencilState> m_depthStencilState;
   Microsoft::WRL::ComPtr<ID3D11BlendState> m_BlendEnableState;
   Microsoft::WRL::ComPtr<ID3D11BlendState> m_BlendDisableState;
@@ -132,13 +132,10 @@ protected:
   // stereo interlaced/checkerboard intermediate target
   CD3DTexture m_rightEyeTex;
 
-  CCriticalSection m_decoderSection;
   XbmcThreads::EndTime m_decodingTimer;
   XbmcThreads::ConditionVariable m_decodingEvent;
 
   std::shared_ptr<DX::DeviceResources> m_deviceResources;
 };
-
-#endif
 
 #endif // RENDER_SYSTEM_DX

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -149,25 +149,22 @@
  * Additional platform specific includes
  ****************************************/
 
-#if defined(TARGET_WINDOWS)
+#if defined(TARGET_WINDOWS) || defined(TARGET_WIN10)
 #include <windows.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include "mmsystem.h"
 #include "DInput.h"
+#if !defined(TARGET_WIN10)
 #include "DSound.h"
+#endif
 #define DSSPEAKER_USE_DEFAULT DSSPEAKER_STEREO
 #define LPDIRECTSOUND8 LPDIRECTSOUND
 #undef GetFreeSpace
 #include "PlatformInclude.h"
-#ifdef HAS_DX
-#include "d3d9.h"   // On Win32, we're always using DirectX for something, whether it be the actual rendering
 #include "d3d11_1.h"
 #include "dxgi.h"
 #include "d3dcompiler.h"
 #include "directxmath.h"
-#else
-#include <d3d9types.h>
-#endif
 #ifdef HAS_SDL
 #include "SDL\SDL.h"
 #endif

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -32,7 +32,6 @@
 #endif
 #pragma comment(lib, "dxgi.lib")
 #pragma warning(disable: 4091)
-#include <d3dumddi.h>
 #include <d3d10umddi.h>
 #pragma warning(default: 4091)
 


### PR DESCRIPTION
this is first phase in preparation to include uwp changes into mainline.

this fixes:
- DX::DeviceResources contains errors
- implementation of ProcessInfoWin10
- invalid includes of windowing (include implementation header instead of factory header)
- d3d9 includes isn't used actually
- remove HAS_DX ifdef from windows related files.
