### PR TITLE
[Music]Fix change of information provider for albums and artists 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -792,6 +792,7 @@ msgctxt "#180"
 msgid "Duration"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#181"
 msgid "Select album"
 msgstr ""
@@ -1170,10 +1171,12 @@ msgctxt "#254"
 msgid "DTS capable receiver"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#255"
 msgid "CDDB"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#256"
 msgid "Fetching CD information"
 msgstr ""
@@ -1464,46 +1467,57 @@ msgctxt "#317"
 msgid "Cleaned database successfully"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#318"
 msgid "Cleaning songs..."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#319"
 msgid "Error cleaning songs"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#320"
 msgid "Cleaning artists..."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#321"
 msgid "Error cleaning artists"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#322"
-msgid "Cleaning genres..."
+msgid "Cleaning genres, roles etc...."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#323"
-msgid "Error cleaning genres"
+msgid "Error cleaning genres, roles etc."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#324"
 msgid "Cleaning paths..."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#325"
 msgid "Error cleaning paths"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#326"
 msgid "Cleaning albums..."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#327"
 msgid "Error cleaning albums"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#328"
 msgid "Writing changes..."
 msgstr ""
@@ -1512,10 +1526,12 @@ msgctxt "#329"
 msgid "Error writing changes"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#330"
 msgid "This may take some time..."
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#331"
 msgid "Compressing database..."
 msgstr ""
@@ -2942,10 +2958,12 @@ msgctxt "#648"
 msgid "Import video library"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#649"
 msgid "Importing"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#650"
 msgid "Exporting"
 msgstr ""
@@ -3099,10 +3117,12 @@ msgstr ""
 
 #empty strings from id 682 to 699
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#700"
 msgid "Cleaning up library"
 msgstr ""
 
+#: xbmc/music/MusicDatabase.cpp
 msgctxt "#701"
 msgid "Removing old songs from the library"
 msgstr ""
@@ -12147,6 +12167,7 @@ msgctxt "#20194"
 msgid "Default provider for artist information"
 msgstr ""
 
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
 msgctxt "#20195"
 msgid "Change information provider"
 msgstr ""
@@ -20379,6 +20400,7 @@ msgid "All roles"
 msgstr ""
 
 #empty strings from id 38047 to 38059
+#strings 38047 to 38059 reserved for music library roles
 
 #. Question when forced rescan of music tags needed after upgrade from previous version of Kodi
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -20398,7 +20420,74 @@ msgctxt "#38062"
 msgid "Do full tag scan even when music files are unchanged?"
 msgstr ""
 
-#empty strings from id 38063 to 38099
+#. Label for a context submenu entry to change the default addon used to fetch artist or album information, related to #20195, #20193 and #20194
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38063"
+msgid "Set default information provider"
+msgstr ""
+
+#. Label for a context submenu entry to change the information provider for a specific artist, related to #20195
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38064"
+msgid "Set for this artist"
+msgstr ""
+
+#. Label for a context submenu entry to change the information provider for all artists in node, related to #20195
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38065"
+msgid "Set for all artists shown"
+msgstr ""
+
+#. Label for a context submenu entry to change the information provider for a specific album, related to #20195
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38066"
+msgid "Set for this album"
+msgstr ""
+
+#. Label for a context submenu entry to change the information provider for all albums in node, related to #20195
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38067"
+msgid "Set for all albums shown"
+msgstr ""
+
+#. Dialog message asking for confirmation of change the information provider for all artists shown in node, after #38065
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38068"
+msgid "Use this information provider for all the artists shown here?"
+msgstr ""
+
+#. Dialog message asking for confirmation of change the information provider for all albums shown in node, after #38067
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38069"
+msgid "Use this information provider for all the albums shown here?"
+msgstr ""
+
+#. Dialog message asking for confirmation of change to the default artist information provider, after #38063
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38070"
+msgid "Use this information provider for all artists, clearing any previous settings for specific artists?"
+msgstr ""
+
+#. Dialog message asking for confirmation of change to the default album information provider, after #38063
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38071"
+msgid "Use this information provider for all albums, clearing any previous settings for specific albums?"
+msgstr ""
+
+#. Dialog message asking for confirmation to get additional info for all the artists or albums in the node immediately
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38072"
+msgid "Do you want to refresh information for all these items now?"
+msgstr ""
+
+#. Dialog message asking for confirmation to get additional info for the current artist or album immediately
+#: xbmc/music/windows/GUIWindowMusicNav.cpp
+msgctxt "#38073"
+msgid "Do you want to refresh information for this item now?"
+msgstr ""
+
+#empty strings from id 38074 to 38099
+#strings 38074 to 38099 reserved for music library
 
 #. Description of section #14200 "Player""
 #: system/settings/settings.xml

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -121,7 +121,9 @@ void CMusicDatabaseDirectory::ClearDirectoryCache(const std::string& strDirector
 
 bool CMusicDatabaseDirectory::IsAllItem(const std::string& strDirectory)
 {
-  if (StringUtils::EndsWith(strDirectory, "/-1/"))
+  //Last query parameter, ignoring any appended options, is -1
+  CURL url(strDirectory);
+  if (StringUtils::EndsWith(url.GetWithoutOptions(), "/-1/"))
     return true;
   return false;
 }

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -81,8 +81,8 @@ public:
     dateAdded.Reset();
     lastPlayed.Reset();
     songs.clear();
-    infoSongs.clear();
     releaseType = Album;
+    strLastScraped.clear();
     bScrapedMBID = false;
     bArtistSongMerge = false;
   }
@@ -165,8 +165,8 @@ public:
   CDateTime dateAdded;
   CDateTime lastPlayed;
   VECSONGS songs;     ///< Local songs
-  VECSONGS infoSongs; ///< Scraped songs
   ReleaseType releaseType;
+  std::string strLastScraped;
   bool bScrapedMBID;
   bool bArtistSongMerge;
 };

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -74,6 +74,7 @@ public:
     strPath.clear();
     dateAdded.Reset();
     bScrapedMBID = false;
+    strLastScraped.clear();
   }
 
   /*! \brief Load artist information from an XML file.
@@ -107,6 +108,7 @@ public:
   std::vector<std::pair<std::string,std::string> > discography;
   CDateTime dateAdded;
   bool bScrapedMBID;
+  std::string strLastScraped;
 };
 
 class CArtistCredit

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -50,8 +50,7 @@ namespace dbiplus
 #define ERROR_DATABASE    315
 #define ERROR_REORG_SONGS   319
 #define ERROR_REORG_ARTIST   321
-#define ERROR_REORG_GENRE   323
-#define ERROR_REORG_ROLE   324
+#define ERROR_REORG_OTHER   323
 #define ERROR_REORG_PATH   325
 #define ERROR_REORG_ALBUM   327
 #define ERROR_WRITING_CHANGES  329
@@ -213,7 +212,7 @@ public:
   */
   bool AddAlbum(CAlbum& album);
 
-  /*! \brief Update an album and all its nested entities (artists, songs, infoSongs, etc)
+  /*! \brief Update an album and all its nested entities (artists, songs etc)
    \param album the album to update
    \return true or false
    */
@@ -261,8 +260,6 @@ public:
                    bool bScrapedMBID);
   bool ClearAlbumLastScrapedTime(int idAlbum);
   bool HasAlbumBeenScraped(int idAlbum);
-  bool HasScrapedAlbumMBID(int idArtist);
-  int  AddAlbumInfoSong(int idAlbum, const CSong& song);
 
   /////////////////////////////////////////////////
   // Audiobook
@@ -307,7 +304,6 @@ public:
   void SetTranslateBlankArtist(bool translate) { m_translateBlankArtist = translate; }
   bool HasArtistBeenScraped(int idArtist);
   bool ClearArtistLastScrapedTime(int idArtist);
-  bool HasScrapedArtistMBID(int idArtist);
   int  AddArtistDiscography(int idArtist, const std::string& strAlbum, const std::string& strYear);
   bool DeleteArtistDiscography(int idArtist);
 
@@ -429,8 +425,9 @@ public:
   /////////////////////////////////////////////////
   // Scraper
   /////////////////////////////////////////////////
-  bool SetScraperForPath(const std::string& strPath, const ADDON::ScraperPtr& info);
-  bool GetScraperForPath(const std::string& strPath, ADDON::ScraperPtr& info, const ADDON::TYPE &type);
+  bool SetScraper(int id, const CONTENT_TYPE &content, const ADDON::ScraperPtr scraper);
+  bool SetScraperAll(const std::string& strBaseDir, const ADDON::ScraperPtr scraper);
+  bool GetScraper(int id, const CONTENT_TYPE &content, ADDON::ScraperPtr& scraper);
   
   /*! \brief Check whether a given scraper is in use.
    \param scraperID the scraper to check for.
@@ -574,13 +571,13 @@ private:
   void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl &baseUrl);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CMusicDbUrl &baseUrl);
   void GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item);
-  CSong GetAlbumInfoSongFromDataset(const dbiplus::sql_record* const record, int offset = 0);
   bool CleanupSongs();
   bool CleanupSongsByIds(const std::string &strSongIds);
   bool CleanupPaths();
   bool CleanupAlbums();
   bool CleanupArtists();
   bool CleanupGenres();
+  bool CleanupInfoSettings();
   bool CleanupRoles();
   void UpdateTables(int version) override;
   bool SearchArtists(const std::string& search, CFileItemList &artists);
@@ -632,6 +629,7 @@ private:
     album_idAlbum=0,
     album_strAlbum,
     album_strMusicBrainzAlbumID,
+    album_strReleaseGroupMBID,
     album_strArtists,
     album_strArtistSort,
     album_strGenres,
@@ -647,6 +645,8 @@ private:
     album_iUserrating,
     album_iVotes,
     album_bCompilation,
+    album_bScrapedMBID,
+    album_lastScraped,
     album_iTimesPlayed,
     album_strReleaseType,
     album_dtDateAdded,
@@ -690,17 +690,10 @@ private:
     artist_strYearsActive,
     artist_strImage,
     artist_strFanart,
+    artist_bScrapedMBID,
+    artist_lastScraped,
     artist_dtDateAdded,
     artist_enumCount // end of the enum, do not add past here
   } ArtistFields;
 
-  static enum _AlbumInfoSongFields
-  {
-    albumInfoSong_idAlbumInfoSong=0,
-    albumInfoSong_idAlbumInfo,
-    albumInfoSong_iTrack,
-    albumInfoSong_strTitle,
-    albumInfoSong_iDuration,
-    albumInfoSong_enumCount // end of the enum, do not add past here
-  } AlbumInfoSongFields;
 };

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -169,7 +169,7 @@ bool CGUIDialogMusicInfo::OnAction(const CAction &action)
 void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const std::string &path)
 {
   m_album = album;
-  SetSongs(m_album.infoSongs);
+  SetSongs(m_album.songs);
   *m_albumItem = CFileItem(path, true);
   m_albumItem->GetMusicInfoTag()->SetAlbum(m_album);
   CMusicDatabase::SetPropertiesFromAlbum(*m_albumItem,m_album);

--- a/xbmc/music/infoscanner/MusicAlbumInfo.h
+++ b/xbmc/music/infoscanner/MusicAlbumInfo.h
@@ -44,7 +44,6 @@ public:
   const CAlbum &GetAlbum() const { return m_album; }
   CAlbum& GetAlbum() { return m_album; }
   void SetAlbum(CAlbum& album);
-  const VECSONGS &GetSongs() const { return m_album.infoSongs; }
   const std::string& GetTitle2() const { return m_strTitle2; }
   void SetTitle(const std::string& strTitle) { m_album.strAlbum = strTitle; }
   const CScraperUrl& GetAlbumURL() const { return m_albumURL; }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -280,17 +280,12 @@ bool CGUIWindowMusicBase::OnAction(const CAction &action)
   return CGUIMediaWindow::OnAction(action);
 }
 
-void CGUIWindowMusicBase::OnItemInfoAll(int iItem, bool bCurrent /* = false */, bool refresh /* = false */)
+void CGUIWindowMusicBase::OnItemInfoAll(const std::string strPath, bool refresh )
 {
-  CMusicDatabaseDirectory dir;
-  std::string strPath = m_vecItems->GetPath();
-  if (bCurrent)
-    strPath = m_vecItems->Get(iItem)->GetPath();
-  
   if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "albums"))
-    g_application.StartMusicAlbumScan(strPath,refresh);
+    g_application.StartMusicAlbumScan(strPath, refresh);
   else if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "artists"))
-    g_application.StartMusicArtistScan(strPath,refresh);
+    g_application.StartMusicArtistScan(strPath, refresh);
 }
 
 /// \brief Retrieves music info for albums from allmusic.com and displays them in CGUIDialogMusicInfo
@@ -367,13 +362,12 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
   CDirectoryNode::GetDatabaseInfo(pItem->GetPath(), params);
 
   ADDON::ScraperPtr scraper;
-  if (!m_musicdatabase.GetScraperForPath(pItem->GetPath(), scraper, ADDON::ADDON_SCRAPER_ARTISTS))
+  if (!m_musicdatabase.GetScraper(params.GetArtistId(), CONTENT_ARTISTS, scraper))
     return;
 
   CArtist artist;
   if (!m_musicdatabase.GetArtist(params.GetArtistId(), artist))
       return;
-  artist.bScrapedMBID = m_musicdatabase.HasScrapedArtistMBID(artist.idArtist);
   m_musicdatabase.GetArtistPath(params.GetArtistId(), artist.strPath);
   bool refresh = false;
   while (1)
@@ -440,13 +434,12 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
   CDirectoryNode::GetDatabaseInfo(pItem->GetPath(), params);
 
   ADDON::ScraperPtr scraper;
-  if (!m_musicdatabase.GetScraperForPath(pItem->GetPath(), scraper, ADDON::ADDON_SCRAPER_ALBUMS))
+  if (!m_musicdatabase.GetScraper(params.GetAlbumId(), CONTENT_ALBUMS, scraper))
     return false;
 
   CAlbum album;
   if (!m_musicdatabase.GetAlbum(params.GetAlbumId(), album))
     return false;
-  album.bScrapedMBID = m_musicdatabase.HasScrapedAlbumMBID(album.idAlbum);
   m_musicdatabase.GetAlbumPath(params.GetAlbumId(), album.strPath);
   bool refresh = false;
   while (1)

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -90,7 +90,7 @@ protected:
 
   void RetrieveMusicInfo();
   void OnItemInfo(int iItem, bool bShowInfo = true);
-  void OnItemInfoAll(int iItem, bool bCurrent=false, bool refresh=false);
+  void OnItemInfoAll(const std::string strPath, bool refresh = false);
   virtual void OnQueueItem(int iItem);
   enum ALLOW_SELECTION { SELECTION_ALLOWED = 0, SELECTION_AUTO, SELECTION_FORCED };
   bool FindAlbumInfo(const CFileItem* album, MUSIC_GRABBER::CMusicAlbumInfo& albumInfo, ALLOW_SELECTION allowSelection);

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -51,6 +51,7 @@ protected:
 
   bool GetSongsFromPlayList(const std::string& strPlayList, CFileItemList &items);
   std::string GetQuickpathName(const std::string& strPath) const;
+  bool ManageInfoProvider(const CFileItemPtr item);
 
   VECSOURCES m_shares;
 


### PR DESCRIPTION
A follow up from #12120,  the improvements to scraping additional artist and album information, that fixes flaws in how changes to artist and album information providers are selected and applied. 

Music DB schema changes include:
- Remove albuminfosong table, as storing scraped tracks is deprecated.
- Adding the release group MBID, scrapedMBID flag and lastScraped to album and artist views. This fixes loss of release group MBID when refreshing with a scraper that does not return release group id e.g. TADB scraper or from NFO files, and needed for JSON API exposure of properties.
- Replacing the  content table with (more accurately named) infosetting table and store idSetting in artist and album tables. 

The "Change Info provider" context menu action  was truely broken, especially on saying saying yes to the subsequent "Do you want to refresh information for all items within this path?".  For example:
- doing so for an album it used the _song_ ids as if they were album ids and refreshed the info for those.
- doing it on "*all albums" set the _artist_ scraper, and again used _song_ ids.
- doing it on a parent folder could hang.
- from genres node, a path and settings were stored, but these settings were not applied when adding artists, or albums with songs of that genre, or "Query info for all".
Also "content" (if anyone did use this feature) was not cleaned up when orphaned.

The user access to set/clear these settings was also so limited as to be useless. 
- If a user had set scraper settings for an artist or album, then there was no way to reset them to default. The only way to know they were non-default was to look at the settings for each item at a time, and then they could not be reset, only set something else specifically.
- There was no practical way to set the setting for more than one artist or album  at a time (genre did not work, and anyway what or those with more than one genre). 
- The only way **to set the default settings** themselves was to go to System > Settings > Media > Music and change the addon used, then go to System >addons > My Addons > Information Providers > Album (or artist) and change the addon settings.
I suspect that all users have done in the past is to set the default settings, and then apply them to everything uniformly.

This PR addresses both aspects, to do this there is a **UX/UI change**
- "Change information provider"  is only on the context menu when the current item is an album or artist (from any "artists" or "albums" node or smart playlist)
- The action is followed by submenu offering to set information provider for 
a) current item, 
b) all items on node, filtered by criteria
c) default (for all).
This is followed by the `CGUIDialogContentSetting` dialog to select the info provider addon to use and change settings. Then a comfirmation message is displayed before the setting change is applied. Finally the user is asked if they want to query for additional information using these settings immediately (otherwise they can use "Query Info For all" later).

This gives the facility to set information provider for multiple artists or albums, and to reset to default, without cluttering ordinary music library use.
