### PR TITLE
IPlayer: rework player times

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -312,7 +312,7 @@ void CApplicationPlayer::SeekTimeRelative(int64_t iTime)
     // use relative seeking if implemented by player
     if (!player->SeekTimeRelative(iTime))
     {
-      int64_t abstime = player->GetTime() + iTime;
+      int64_t abstime = GetTime() + iTime;
       player->SeekTime(abstime);
     }
   }
@@ -331,7 +331,46 @@ int64_t CApplicationPlayer::GetTime() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    return player->GetTime();
+    return CDataCacheCore::GetInstance().GetPlayTime();
+  else
+    return 0;
+}
+
+int64_t CApplicationPlayer::GetMinTime() const
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return CDataCacheCore::GetInstance().GetMinTime();
+  else
+    return 0;
+}
+
+int64_t CApplicationPlayer::GetMaxTime() const
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return CDataCacheCore::GetInstance().GetMaxTime();
+  else
+    return 0;
+}
+
+time_t CApplicationPlayer::GetStartTime() const
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    return CDataCacheCore::GetInstance().GetStartTime();
+  else
+    return 0;
+}
+
+int64_t CApplicationPlayer::GetTotalTime() const
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+  {
+    int64_t total = CDataCacheCore::GetInstance().GetMaxTime() - CDataCacheCore::GetInstance().GetMinTime();
+    return total;
+  }
   else
     return 0;
 }
@@ -446,20 +485,17 @@ std::string CApplicationPlayer::GetRadioText(unsigned int line)
     return "";
 }
 
-int64_t CApplicationPlayer::GetTotalTime() const
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->GetTotalTime();
-  else
-    return 0;
-}
-
 float CApplicationPlayer::GetPercentage() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    return player->GetPercentage();
+  {
+    int64_t iTotalTime = GetTotalTime();
+
+    if (!iTotalTime)
+      return 0.0f;
+    return GetTime() * 100 / static_cast<float>(iTotalTime);
+  }
   else
     return 0.0;
 }

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -124,6 +124,9 @@ public:
   TextCacheStruct_t* GetTeletextCache();
   std::string GetRadioText(unsigned int line);
   int64_t GetTime() const;
+  int64_t GetMinTime() const;
+  int64_t GetMaxTime() const;
+  time_t GetStartTime() const;
   int64_t GetTotalTime() const;
   int   GetVideoStream();
   int   GetVideoStreamCount();

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7970,8 +7970,7 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   }
   else if (info.m_info == PLAYER_START_TIME)
   {
-    CDateTime time(CDateTime::GetCurrentDateTime());
-    time -= CDateTimeSpan(0, 0, 0, static_cast<int>(GetPlayTime()));
+    CDateTime time(g_application.m_pPlayer->GetStartTime());
     return LocalizeTime(time, (TIME_FORMAT)info.GetData1());
   }
   else if (info.m_info == PLAYER_TIME_SPEED)
@@ -9083,13 +9082,8 @@ std::string CGUIInfoManager::GetVideoLabel(int item)
 
 int64_t CGUIInfoManager::GetPlayTime() const
 {
-  if (g_application.m_pPlayer->IsPlaying())
-  {
-    int64_t lPTS = (int64_t)(g_application.GetTime() * 1000);
-    if (lPTS < 0) lPTS = 0;
-    return lPTS;
-  }
-  return 0;
+  int64_t ret = lrint(g_application.GetTime() * 1000);
+  return ret;
 }
 
 std::string CGUIInfoManager::GetCurrentPlayTime(TIME_FORMAT format) const
@@ -9111,7 +9105,7 @@ std::string CGUIInfoManager::GetCurrentSeekTime(TIME_FORMAT format) const
 int CGUIInfoManager::GetTotalPlayTime() const
 {
   int iTotalTime = lrint(g_application.GetTotalTime());
-  return iTotalTime > 0 ? iTotalTime : 0;
+  return iTotalTime;
 }
 
 int CGUIInfoManager::GetPlayTimeRemaining() const

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1489,6 +1489,17 @@ time_t CPVRClient::GetBufferTimeEnd(void) const
   return time;
 }
 
+bool CPVRClient::GetStreamTimes(PVR_STREAM_TIMES *times)
+{
+  bool ret = false;
+  if (IsPlaying())
+  {
+    if (m_struct.toAddon.GetStreamTimes(times) == PVR_ERROR_NO_ERROR)
+      ret = true;
+  }
+  return ret;
+}
+
 bool CPVRClient::IsRealTimeStream(void) const
 {
   bool bReturn(false);

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -786,6 +786,11 @@ namespace PVR
     bool IsRealTimeStream() const;
 
     /*!
+     * @brief Get Stream times (will be moved to inputstream)
+     */
+    bool GetStreamTimes(PVR_STREAM_TIMES *times);
+
+    /*!
      * @brief reads the client's properties
      */
     bool GetAddonProperties(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -630,6 +630,11 @@ extern "C"
   void OnPowerSavingDeactivated();
 
   /*!
+   * Get stream times. Intermediate, will be moved to inputstream
+   */
+  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times);
+
+  /*!
    * Called by XBMC to assign the function pointers of this add-on to pClient.
    * @param ptr The struct to assign the function pointers to.
    */
@@ -724,5 +729,6 @@ extern "C"
     pClient->toAddon.OnSystemWake                   = OnSystemWake;
     pClient->toAddon.OnPowerSavingActivated         = OnPowerSavingActivated;
     pClient->toAddon.OnPowerSavingDeactivated       = OnPowerSavingDeactivated;
+    pClient->toAddon.GetStreamTimes                 = GetStreamTimes;
   };
 };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -572,6 +572,17 @@ extern "C" {
     } data;
   } ATTRIBUTE_PACKED PVR_MENUHOOK_DATA;
 
+  /*!
+   * @brief times of playing stream
+   */
+  typedef struct PVR_STREAM_TIMES
+  {
+    time_t startTime; /*!< @brief time (UTC) time elapsed refers to. Ideally start of tv show */
+    int64_t ptsStart; /*!< @brief pts of startTime */
+    int64_t ptsBegin; /*!< @brief erliest pts player can seek back */
+    int64_t ptsEnd;   /*!< @brief latest pts player can seek forward */
+  } ATTRIBUTE_PACKED PVR_STREAM_TIMES;
+
   typedef struct AddonToKodiFuncTable_PVR
   {
     KODI_HANDLE kodiInstance;
@@ -679,6 +690,7 @@ extern "C" {
     void (__cdecl* OnSystemWake)(void);
     void (__cdecl* OnPowerSavingActivated)(void);
     void (__cdecl* OnPowerSavingDeactivated)(void);
+    PVR_ERROR (__cdecl* GetStreamTimes)(PVR_STREAM_TIMES*);
   } KodiToAddonFuncTable_PVR;
 
   typedef struct AddonInstance_PVR

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -314,3 +314,36 @@ bool CDataCacheCore::CDataCacheCore::GetVideoRender()
 
   return m_stateInfo.m_renderVideoLayer;
 }
+
+void CDataCacheCore::SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max)
+{
+  CSingleLock lock(m_stateSection);
+  m_timeInfo.m_startTime = start;
+  m_timeInfo.m_time = current;
+  m_timeInfo.m_timeMin = min;
+  m_timeInfo.m_timeMax = max;
+}
+
+time_t CDataCacheCore::GetStartTime()
+{
+  CSingleLock lock(m_stateSection);
+  return m_timeInfo.m_startTime;
+}
+
+int64_t CDataCacheCore::GetPlayTime()
+{
+  CSingleLock lock(m_stateSection);
+  return m_timeInfo.m_time;
+}
+
+int64_t CDataCacheCore::GetMinTime()
+{
+  CSingleLock lock(m_stateSection);
+  return m_timeInfo.m_timeMin;
+}
+
+int64_t CDataCacheCore::GetMaxTime()
+{
+  CSingleLock lock(m_stateSection);
+  return m_timeInfo.m_timeMax;
+}

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -76,9 +76,39 @@ public:
   void SetVideoRender(bool video);
   bool GetVideoRender();
   void SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max);
+
+  /*!
+   * \brief Get the start time
+   *
+   * For a typical video this will be zero. For live TV, this is a reference time
+   * in units of time_t (UTC) from which time elapsed starts. Ideally this would
+   * be the start of the tv show but can be any other time as well.
+   */
   time_t GetStartTime();
+
+  /*!
+   * \brief Get the current time of playback
+   *
+   * This is the time elapsed, in ms, since the start time.
+   */
   int64_t GetPlayTime();
+
+  /*!
+   * \brief Get the minumum time
+   *
+   * This will be zero for a typical video. With timeshift, this is the time,
+   * in ms, that the player can go back. This can be before the start time.
+   */
   int64_t GetMinTime();
+
+  /*!
+   * \brief Get the maximum time
+   *
+   * This is the maximun time, in ms, that the player can skip forward. For a
+   * typical video, this will be the total length. For live TV without
+   * timeshift this is zero, and for live TV with timeshift this will be the
+   * buffer ahead.
+   */
   int64_t GetMaxTime();
 
 protected:

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -75,6 +75,11 @@ public:
   bool GetGuiRender();
   void SetVideoRender(bool video);
   bool GetVideoRender();
+  void SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max);
+  time_t GetStartTime();
+  int64_t GetPlayTime();
+  int64_t GetMinTime();
+  int64_t GetMaxTime();
 
 protected:
   std::atomic_bool m_hasAVInfoChanges;
@@ -117,4 +122,12 @@ protected:
     float m_tempo;
     float m_speed;
   } m_stateInfo;
+
+  struct STimeInfo
+  {
+    time_t m_startTime;
+    int64_t m_time;
+    int64_t m_timeMax;
+    int64_t m_timeMin;
+  } m_timeInfo;
 };

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -524,8 +524,8 @@ void CExternalPlayer::SeekPercentage(float iPercent)
 
 float CExternalPlayer::GetPercentage()
 {
-  int64_t iTime = GetTime();
-  int64_t iTotalTime = GetTotalTime();
+  int64_t iTime = 0;
+  int64_t iTotalTime = 0;
 
   if (iTotalTime != 0)
   {
@@ -556,21 +556,6 @@ float CExternalPlayer::GetSubTitleDelay()
 
 void CExternalPlayer::SeekTime(int64_t iTime)
 {
-}
-
-int64_t CExternalPlayer::GetTime() // in millis
-{
-  if ((XbmcThreads::SystemClockMillis() - m_playbackStartTime) / 1000 > m_playCountMinTime)
-  {
-    m_time = m_totalTime * 1000;
-  }
-
-  return m_time;
-}
-
-int64_t CExternalPlayer::GetTotalTime() // in milliseconds
-{
-  return (int64_t)m_totalTime * 1000;
 }
 
 void CExternalPlayer::SetSpeed(float speed)

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -44,7 +44,6 @@ public:
   bool CanSeek() override;
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   void SeekPercentage(float iPercent) override;
-  float GetPercentage() override;
   void SetVolume(float volume) override {}
   void SetDynamicRangeCompression(long drc) override {}
   bool CanRecord() override { return false; }
@@ -57,8 +56,6 @@ public:
   float GetSubTitleDelay() override;
 
   void SeekTime(int64_t iTime) override;
-  int64_t GetTime() override;
-  int64_t GetTotalTime() override;
   void SetSpeed(float speed) override;
   void DoAudioWork() override {}
 
@@ -77,6 +74,7 @@ public:
 private:
   void GetCustomRegexpReplacers(TiXmlElement *pRootElement, std::vector<std::string>& settings);
   void Process() override;
+  float GetPercentage();
 
   bool m_bAbortRequest;
   bool m_bIsPlaying;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -244,7 +244,6 @@ public:
   virtual void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) = 0;
   virtual bool SeekScene(bool bPlus = true) {return false;}
   virtual void SeekPercentage(float fPercent = 0){}
-  virtual float GetPercentage(){ return 0;}
   virtual float GetCachePercentage(){ return 0;}
   virtual void SetMute(bool bOnOff){}
   virtual void SetVolume(float volume){}
@@ -300,10 +299,7 @@ public:
    \return True if the player supports relative seeking, otherwise false
    */
   virtual bool SeekTimeRelative(int64_t iTime) { return false; }
-  /*!
-   \brief current time in milliseconds
-   */
-  virtual int64_t GetTime() { return 0; }
+
   /*!
    \brief Sets the current time. This 
    can be used for injecting the current time. 
@@ -312,10 +308,7 @@ public:
    tracks in reality (like with airtunes)
    */
   virtual void SetTime(int64_t time) { }
-  /*!
-   \brief total time in milliseconds
-   */
-  virtual int64_t GetTotalTime() { return 0; }
+
   /*!
    \brief Set the total time  in milliseconds
    this can be used for injecting the duration in case

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -260,23 +260,9 @@ void CRetroPlayer::SeekPercentage(float fPercent /* = 0 */)
   else if (fPercent > 100.0f)
     fPercent = 100.0f;
 
-  int64_t totalTime = GetTotalTime();
+  uint64_t totalTime = GetTotalTime();
   if (totalTime != 0)
     SeekTime(static_cast<int64_t>(totalTime * fPercent / 100.0f));
-}
-
-float CRetroPlayer::GetPercentage()
-{
-  if (m_gameClient)
-  {
-    const float timeMs = static_cast<float>(m_gameClient->GetPlayback()->GetTimeMs());
-    const float totalMs = static_cast<float>(m_gameClient->GetPlayback()->GetTotalTimeMs());
-
-    if (totalMs != 0.0f)
-      return timeMs / totalMs * 100.0f;
-  }
-
-  return 0.0f;
 }
 
 float CRetroPlayer::GetCachePercentage()
@@ -320,14 +306,14 @@ bool CRetroPlayer::SeekTimeRelative(int64_t iTime)
   return true;
 }
 
-int64_t CRetroPlayer::GetTime()
+uint64_t CRetroPlayer::GetTime()
 {
   if (m_gameClient)
     return m_gameClient->GetPlayback()->GetTimeMs();
   return 0;
 }
 
-int64_t CRetroPlayer::GetTotalTime()
+uint64_t CRetroPlayer::GetTotalTime()
 {
   if (m_gameClient)
     return m_gameClient->GetPlayback()->GetTotalTimeMs();
@@ -447,6 +433,8 @@ void CRetroPlayer::FrameMove()
       break;
     }
     }
+
+    m_processInfo->SetPlayTimes(0, GetTime(), 0, GetTotalTime());
   }
 }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -159,9 +159,8 @@ namespace RETRO
      */
     void PrintGameInfo(const CFileItem &file) const;
 
-    int64_t GetTime();
-    int64_t GetTotalTime();
-    float GetPercentage();
+    uint64_t GetTime();
+    uint64_t GetTotalTime();
 
     enum class State
     {

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -63,7 +63,6 @@ namespace RETRO
     void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) override;
     //virtual bool SeekScene(bool bPlus = true) override { return false; }
     void SeekPercentage(float fPercent = 0) override;
-    float GetPercentage() override;
     float GetCachePercentage() override;
     void SetMute(bool bOnOff) override;
     //virtual void SetVolume(float volume) override { }
@@ -101,9 +100,6 @@ namespace RETRO
     //virtual float GetActualFPS() override { return 0.0f; }
     void SeekTime(int64_t iTime = 0) override;
     bool SeekTimeRelative(int64_t iTime) override;
-    int64_t GetTime() override;
-    //virtual void SetTime(int64_t time) override { } // Only used by Air Tunes Server
-    int64_t GetTotalTime() override;
     //virtual void SetTotalTime(int64_t time) override { } // Only used by Air Tunes Server
     //virtual int GetSourceBitrate() override { return 0; }
     bool GetStreamDetails(CStreamDetails &details) override;
@@ -162,6 +158,10 @@ namespace RETRO
      * \brief Dump game information (if any) to the debug log.
      */
     void PrintGameInfo(const CFileItem &file) const;
+
+    int64_t GetTime();
+    int64_t GetTotalTime();
+    float GetPercentage();
 
     enum class State
     {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -64,7 +64,7 @@ public:
 
   class IDisplayTime
   {
-    public:
+  public:
     virtual ~IDisplayTime() = default;
     virtual int GetTotalTime() = 0;
     virtual int GetTime() = 0;
@@ -72,14 +72,14 @@ public:
 
   class IPosTime
   {
-    public:
+  public:
     virtual ~IPosTime() = default;
     virtual bool PosTime(int ms) = 0;
   };
 
   class IChapter
   {
-    public:
+  public:
     virtual ~IChapter() = default;
     virtual int  GetChapter() = 0;
     virtual int  GetChapterCount() = 0;
@@ -90,7 +90,7 @@ public:
 
   class IMenus
   {
-    public:
+  public:
     virtual ~IMenus() = default;
     virtual void ActivateButton() = 0;
     virtual void SelectButton(int iButton) = 0;
@@ -116,7 +116,7 @@ public:
 
   class IDemux
   {
-    public:
+  public:
     virtual ~IDemux() = default;
     virtual bool OpenDemux() = 0;
     virtual DemuxPacket* ReadDemux() = 0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -70,6 +70,20 @@ public:
     virtual int GetTime() = 0;
   };
 
+  class ITimes
+  {
+  public:
+    struct Times
+    {
+      time_t startTime;
+      double ptsStart;
+      double ptsBegin;
+      double ptsEnd;
+    };
+    virtual ~ITimes() = default;
+    virtual bool GetTimes(Times &times) = 0;
+  };
+
   class IPosTime
   {
   public:
@@ -182,6 +196,7 @@ public:
   virtual IDemux* GetIDemux() { return nullptr; }
   virtual IPosTime* GetIPosTime() { return nullptr; }
   virtual IDisplayTime* GetIDisplayTime() { return nullptr; }
+  virtual ITimes* GetITimes() { return nullptr; }
 
   const CVariant &GetProperty(const std::string key){ return m_item.GetProperty(key); }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -215,6 +215,24 @@ int CDVDInputStreamPVRManager::GetTime()
   return 0;
 }
 
+bool CDVDInputStreamPVRManager::GetTimes(Times &times)
+{
+  if (m_isRecording)
+    return false;
+
+  PVR_STREAM_TIMES streamTimes;
+  bool ret = CServiceBroker::GetPVRManager().Clients()->GetStreamTimes(&streamTimes);
+  if (ret)
+  {
+    times.startTime = streamTimes.startTime;
+    times.ptsStart = streamTimes.ptsStart;
+    times.ptsBegin = streamTimes.ptsBegin;
+    times.ptsEnd = streamTimes.ptsEnd;
+  }
+
+  return ret;
+}
+
 CPVRChannelPtr CDVDInputStreamPVRManager::GetSelectedChannel()
 {
   return CServiceBroker::GetPVRManager().GetCurrentChannel();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -40,6 +40,7 @@ class IDemux;
 
 class CDVDInputStreamPVRManager
   : public CDVDInputStream
+  , public CDVDInputStream::ITimes
   , public CDVDInputStream::IDisplayTime
   , public CDVDInputStream::IDemux
 {
@@ -59,6 +60,10 @@ public:
 
   PVR::CPVRChannelPtr GetSelectedChannel();
 
+  CDVDInputStream::ITimes* GetITimes() override { return this; }
+  bool GetTimes(Times &times) override;
+
+  // deprecated
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
   int GetTotalTime() override;
   int GetTime() override;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -562,3 +562,23 @@ bool CProcessInfo::GetVideoRender()
 
   return m_renderVideoLayer;
 }
+
+void CProcessInfo::SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max)
+{
+  CSingleLock lock(m_stateSection);
+  m_startTime = start;
+  m_time = current;
+  m_timeMin = min;
+  m_timeMax = max;
+
+  if (m_dataCache)
+  {
+    m_dataCache->SetPlayTimes(start, current, min, max);
+  }
+}
+
+int64_t CProcessInfo::GetMaxTime()
+{
+  CSingleLock lock(m_stateSection);
+  return m_timeMax;
+}

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -96,13 +96,15 @@ public:
   void SetNewTempo(float tempo);
   float GetNewTempo();
   virtual bool IsTempoAllowed(float tempo);
-
   void SetLevelVQ(int level);
   int GetLevelVQ();
   void SetGuiRender(bool gui);
   bool GetGuiRender();
   void SetVideoRender(bool video);
   bool GetVideoRender();
+
+  void SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max);
+  int64_t GetMaxTime();
 
 protected:
   CProcessInfo() = default;
@@ -149,4 +151,8 @@ protected:
   float m_newTempo;
   float m_speed;
   float m_newSpeed;
+  time_t m_startTime;
+  int64_t m_time;
+  int64_t m_timeMax;
+  int64_t m_timeMin;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3057,7 +3057,7 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   }
 
   int64_t seekTarget;
-  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000*g_advancedSettings.m_videoTimeSeekForwardBig)
+  if (g_advancedSettings.m_videoUseTimeSeeking && m_processInfo->GetMaxTime() > 2000*g_advancedSettings.m_videoTimeSeekForwardBig)
   {
     if (bLargeStep)
       seekTarget = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig :
@@ -3075,14 +3075,14 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
       percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
     else
       percent = bPlus ? g_advancedSettings.m_videoPercentSeekForward : g_advancedSettings.m_videoPercentSeekBackward;
-    seekTarget = (int64_t)(GetTotalTime()*(GetPercentage()+percent)/100);
+    seekTarget = (int64_t)(m_processInfo->GetMaxTime()*(GetPercentage()+percent)/100);
   }
 
   bool restore = true;
 
   int64_t time = GetTime();
   if(g_application.CurrentFileItem().IsStack() &&
-     (seekTarget > GetTotalTime() || seekTarget < 0))
+     (seekTarget > m_processInfo->GetMaxTime() || seekTarget < 0))
   {
     g_application.SeekTime((seekTarget - time) * 0.001 + g_application.GetTime());
     // warning, don't access any VideoPlayer variables here as
@@ -3201,7 +3201,7 @@ void CVideoPlayer::GetGeneralInfo(std::string& strGeneralInfo)
 
 void CVideoPlayer::SeekPercentage(float iPercent)
 {
-  int64_t iTotalTime = GetTotalTime();
+  int64_t iTotalTime = m_processInfo->GetMaxTime();
 
   if (!iTotalTime)
     return;
@@ -3211,7 +3211,7 @@ void CVideoPlayer::SeekPercentage(float iPercent)
 
 float CVideoPlayer::GetPercentage()
 {
-  int64_t iTotalTime = GetTotalTime();
+  int64_t iTotalTime = m_processInfo->GetMaxTime();
 
   if (!iTotalTime)
     return 0.0f;
@@ -3458,13 +3458,6 @@ int64_t CVideoPlayer::GetTime()
 {
   CSingleLock lock(m_StateSection);
   return llrint(m_State.time);
-}
-
-// return length in msec
-int64_t CVideoPlayer::GetTotalTime()
-{
-  CSingleLock lock(m_StateSection);
-  return llrint(m_State.time_total);
 }
 
 void CVideoPlayer::SetSpeed(float speed)
@@ -4773,6 +4766,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   else if (m_CurrentAudio.startpts != DVD_NOPTS_VALUE)
     state.dts = m_CurrentAudio.startpts;
 
+  state.startTime = 0;
+  state.timeMin = 0;
+
   if (m_pDemuxer)
   {
     if (IsInMenuInternal())
@@ -4792,7 +4788,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     }
 
     state.time = DVD_TIME_TO_MSEC(m_clock.GetClock(false));
-    state.time_total = m_pDemuxer->GetStreamLength();
+    state.timeMax = m_pDemuxer->GetStreamLength();
   }
 
   state.canpause = true;
@@ -4824,7 +4820,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         state.time_offset = DVD_MSEC_TO_TIME(dispTime) - state.dts;
       }
       state.time += DVD_TIME_TO_MSEC(state.time_offset);
-      state.time_total = pDisplayTime->GetTotalTime();
+      state.timeMax = pDisplayTime->GetTotalTime();
     }
     else
     {
@@ -4839,7 +4835,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       if (m_dvd.state == DVDSTATE_STILL)
       {
         state.time = XbmcThreads::SystemClockMillis() - m_dvd.iDVDStillStartTime;
-        state.time_total = m_dvd.iDVDStillTime;
+        state.timeMax = m_dvd.iDVDStillTime;
         state.isInMenu = true;
       }
       else if (IsInMenuInternal())
@@ -4858,10 +4854,10 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   if (m_Edl.HasCut())
   {
     state.time        = (double) m_Edl.RemoveCutTime(llrint(state.time));
-    state.time_total  = (double) m_Edl.RemoveCutTime(llrint(state.time_total));
+    state.timeMax  = (double) m_Edl.RemoveCutTime(llrint(state.timeMax));
   }
 
-  if (state.time_total <= 0)
+  if (state.timeMax <= 0)
     state.canseek  = false;
 
   if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)
@@ -4880,21 +4876,23 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   {
     state.cache_delay  = 0.0;
     state.cache_level  = std::min(1.0, GetQueueTime() / 8000.0);
-    state.cache_offset = GetQueueTime() / state.time_total;
+    state.cache_offset = GetQueueTime() / state.timeMax;
   }
 
   XFILE::SCacheStatus status;
   if (m_pInputStream && m_pInputStream->GetCacheStatus(&status))
   {
     state.cache_bytes = status.forward;
-    if(state.time_total)
-      state.cache_bytes += m_pInputStream->GetLength() * (int64_t) (GetQueueTime() / state.time_total);
+    if(state.timeMax)
+      state.cache_bytes += m_pInputStream->GetLength() * (int64_t) (GetQueueTime() / state.timeMax);
   }
   else
     state.cache_bytes = 0;
 
   state.timestamp = m_clock.GetAbsoluteClock();
 
+  m_processInfo->SetPlayTimes(state.startTime, state.time, state.timeMin, state.timeMax);
+  
   CSingleLock lock(m_StateSection);
   m_State = state;
 }
@@ -4973,7 +4971,7 @@ bool CVideoPlayer::GetStreamDetails(CStreamDetails &details)
       if (aspect > 0.0f)
         ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_fAspect = aspect;
 
-      int64_t duration = GetTotalTime() / 1000;
+      int64_t duration = m_processInfo->GetMaxTime() / 1000;
       if (duration > 0)
         ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_iDuration = (int) duration;
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4806,8 +4806,19 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       state.recording = pvrStream->IsRecording();
     }
 
+    CDVDInputStream::ITimes* pTimes = m_pInputStream->GetITimes();
     CDVDInputStream::IDisplayTime* pDisplayTime = m_pInputStream->GetIDisplayTime();
-    if (pDisplayTime && pDisplayTime->GetTotalTime() > 0)
+
+    CDVDInputStream::ITimes::Times times;
+    if (pTimes && pTimes->GetTimes(times))
+    {
+      state.startTime = times.startTime;
+      state.time = (m_clock.GetClock(false) - times.ptsStart) * 1000 / DVD_TIME_BASE;
+      state.timeMax = (times.ptsEnd - times.ptsStart) * 1000 / DVD_TIME_BASE;
+      state.timeMin = (times.ptsBegin - times.ptsStart) * 1000 / DVD_TIME_BASE;
+      state.time_offset = 0;
+    }
+    else if (pDisplayTime && pDisplayTime->GetTotalTime() > 0)
     {
       if (state.dts != DVD_NOPTS_VALUE)
       {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3075,14 +3075,14 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
       percent = bPlus ? g_advancedSettings.m_videoPercentSeekForwardBig : g_advancedSettings.m_videoPercentSeekBackwardBig;
     else
       percent = bPlus ? g_advancedSettings.m_videoPercentSeekForward : g_advancedSettings.m_videoPercentSeekBackward;
-    seekTarget = (int64_t)(GetTotalTimeInMsec()*(GetPercentage()+percent)/100);
+    seekTarget = (int64_t)(GetTotalTime()*(GetPercentage()+percent)/100);
   }
 
   bool restore = true;
 
   int64_t time = GetTime();
   if(g_application.CurrentFileItem().IsStack() &&
-     (seekTarget > GetTotalTimeInMsec() || seekTarget < 0))
+     (seekTarget > GetTotalTime() || seekTarget < 0))
   {
     g_application.SeekTime((seekTarget - time) * 0.001 + g_application.GetTime());
     // warning, don't access any VideoPlayer variables here as
@@ -3201,7 +3201,7 @@ void CVideoPlayer::GetGeneralInfo(std::string& strGeneralInfo)
 
 void CVideoPlayer::SeekPercentage(float iPercent)
 {
-  int64_t iTotalTime = GetTotalTimeInMsec();
+  int64_t iTotalTime = GetTotalTime();
 
   if (!iTotalTime)
     return;
@@ -3211,7 +3211,7 @@ void CVideoPlayer::SeekPercentage(float iPercent)
 
 float CVideoPlayer::GetPercentage()
 {
-  int64_t iTotalTime = GetTotalTimeInMsec();
+  int64_t iTotalTime = GetTotalTime();
 
   if (!iTotalTime)
     return 0.0f;
@@ -3472,16 +3472,10 @@ int64_t CVideoPlayer::GetTime()
 }
 
 // return length in msec
-int64_t CVideoPlayer::GetTotalTimeInMsec()
+int64_t CVideoPlayer::GetTotalTime()
 {
   CSingleLock lock(m_StateSection);
   return llrint(m_State.time_total);
-}
-
-// return length in seconds.. this should be changed to return in milliseconds throughout xbmc
-int64_t CVideoPlayer::GetTotalTime()
-{
-  return GetTotalTimeInMsec();
 }
 
 void CVideoPlayer::SetSpeed(float speed)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -454,8 +454,6 @@ protected:
 
   void SetCaching(ECacheState state);
 
-  int64_t GetTotalTimeInMsec();
-
   double GetQueueTime();
   bool GetCachingTimes(double& play_left, double& cache_left, double& file_offset);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -93,7 +93,9 @@ struct SPlayerState
   {
     timestamp = 0;
     time = 0;
-    time_total = 0;
+    startTime = 0;
+    timeMin = 0;
+    timeMax = 0;
     time_offset = 0;
     dts = DVD_NOPTS_VALUE;
     player_state  = "";
@@ -118,7 +120,9 @@ struct SPlayerState
   double time_offset;       // difference between time and pts
 
   double time;              // current playback time
-  double time_total;        // total playback time
+  double timeMax;
+  double timeMin;
+  time_t startTime;
   double dts;               // last known dts
 
   std::string player_state; // full player state
@@ -306,7 +310,6 @@ public:
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   bool SeekScene(bool bPlus = true) override;
   void SeekPercentage(float iPercent) override;
-  float GetPercentage() override;
   float GetCachePercentage() override;
 
   void SetVolume(float nVolume) override;
@@ -353,8 +356,6 @@ public:
 
   void SeekTime(int64_t iTime) override;
   bool SeekTimeRelative(int64_t iTime) override;
-  int64_t GetTime() override;
-  int64_t GetTotalTime() override;
   void SetSpeed(float speed) override;
   void SetTempo(float tempo) override;
   bool SupportsTempo() override;
@@ -487,6 +488,8 @@ protected:
   void UpdateStreamInfos();
   void GetGeneralInfo(std::string& strVideoInfo);
   int64_t GetUpdatedTime();
+  int64_t GetTime();
+  float GetPercentage();
 
   bool m_players_created;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -486,6 +486,7 @@ protected:
   void UpdatePlayState(double timeout);
   void UpdateStreamInfos();
   void GetGeneralInfo(std::string& strVideoInfo);
+  int64_t GetUpdatedTime();
 
   bool m_players_created;
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -764,6 +764,7 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
       si->m_seekFrame  = -1;
       m_playerGUIData.m_time = time; //update for GUI
       si->m_seekNextAtFrame = 0;
+      CDataCacheCore::GetInstance().SetPlayTimes(0, time, 0, m_playerGUIData.m_totalTime);
     }
     /* if its FF/RW */
     else
@@ -969,6 +970,7 @@ int64_t PAPlayer::GetTimeInternal()
   time = time * 1000.0;
 
   m_playerGUIData.m_time = (int64_t)time; //update for GUI
+  CDataCacheCore::GetInstance().SetPlayTimes(0, time, 0, m_playerGUIData.m_totalTime);
 
   return (int64_t)time;
 }
@@ -1000,11 +1002,6 @@ void PAPlayer::SetTime(int64_t time)
   m_newForcedPlayerTime = time;
 }
 
-int64_t PAPlayer::GetTime()
-{
-  return m_playerGUIData.m_time;
-}
-
 int64_t PAPlayer::GetTotalTime64()
 {
   CSingleLock lock(m_streamsLock);
@@ -1021,11 +1018,6 @@ int64_t PAPlayer::GetTotalTime64()
 void PAPlayer::SetTotalTime(int64_t time)
 {
   m_newForcedTotalTime = time;
-}
-
-int64_t PAPlayer::GetTotalTime()
-{
-  return m_playerGUIData.m_totalTime;
 }
 
 int PAPlayer::GetCacheLevel() const
@@ -1052,14 +1044,14 @@ void PAPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   if (!CanSeek()) return;
 
   __int64 seek;
-  if (g_advancedSettings.m_musicUseTimeSeeking && GetTotalTime() > 2 * g_advancedSettings.m_musicTimeSeekForwardBig)
+  if (g_advancedSettings.m_musicUseTimeSeeking && m_playerGUIData.m_totalTime > 2 * g_advancedSettings.m_musicTimeSeekForwardBig)
   {
     if (bLargeStep)
       seek = bPlus ? g_advancedSettings.m_musicTimeSeekForwardBig : g_advancedSettings.m_musicTimeSeekBackwardBig;
     else
       seek = bPlus ? g_advancedSettings.m_musicTimeSeekForward : g_advancedSettings.m_musicTimeSeekBackward;
     seek *= 1000;
-    seek += GetTime();
+    seek += m_playerGUIData.m_time;
   }
   else
   {

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -55,15 +55,12 @@ public:
   bool CanSeek() override;
   void Seek(bool bPlus = true, bool bLargeStep = false, bool bChapterOverride = false) override;
   void SeekPercentage(float fPercent = 0.0f) override;
-  float GetPercentage() override;
   void SetVolume(float volume) override;
   void SetDynamicRangeCompression(long drc) override;
   void SetSpeed(float speed = 0) override;
   int GetCacheLevel() const override;
-  int64_t GetTotalTime() override;
   void SetTotalTime(int64_t time) override;
   void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info) override;
-  int64_t GetTime() override;
   void SetTime(int64_t time) override;
   void SeekTime(int64_t iTime = 0) override;
   void GetAudioCapabilities(std::vector<int> &audioCaps) override {}
@@ -91,6 +88,7 @@ protected:
   void OnStartup() override {}
   void Process() override;
   void OnExit() override;
+  float GetPercentage();
 
 private:
   typedef struct

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -379,6 +379,8 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   if(dialog)
     dialog->Close();
 
+  m_updateTimer.Set(0);
+
   return true;
 failed:
   CLog::Log(LOGERROR, "UPNP: CUPnPPlayer::OpenFile - unable to open file %s", file.GetPath().c_str());
@@ -612,5 +614,13 @@ void CUPnPPlayer::SetSpeed(float speed)
 
 }
 
+void CUPnPPlayer::FrameMove()
+{
+  if (m_updateTimer.IsTimePast())
+  {
+    CDataCacheCore::GetInstance().SetPlayTimes(0, GetTime(), 0, GetTotalTime());
+    m_updateTimer.Set(500);
+  }
+}
 
 } /* namespace UPNP */

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -49,7 +49,6 @@ public:
   bool HasAudio() const override { return false; }
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   void SeekPercentage(float fPercent = 0) override;
-  float GetPercentage() override;
   void SetVolume(float volume) override;
   bool CanRecord() override { return false; }
   bool IsRecording() override { return false; }
@@ -61,8 +60,6 @@ public:
   int SeekChapter(int iChapter) override { return -1; }
 
   void SeekTime(int64_t iTime = 0) override;
-  int64_t GetTime() override;
-  int64_t GetTotalTime() override;
   void SetSpeed(float speed = 0) override;
 
   bool IsCaching() const override { return false; }
@@ -76,6 +73,9 @@ public:
 
 private:
   bool IsPaused() const;
+  int64_t GetTime();
+  int64_t GetTotalTime();
+  float GetPercentage();
 
   PLT_MediaController* m_control;
   CUPnPPlayerController* m_delegate;

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -20,6 +20,7 @@
  */
 
 #include "cores/IPlayer.h"
+#include "threads/SystemClock.h"
 #include <string>
 
 class PLT_MediaController;
@@ -68,6 +69,7 @@ public:
   bool OnAction(const CAction &action) override;
 
   std::string GetPlayingTitle() override;
+  void FrameMove() override;
 
   int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);
 
@@ -83,6 +85,7 @@ private:
   std::string m_current_meta;
   bool m_started;
   bool m_stopremote;
+  XbmcThreads::EndTime m_updateTimer;
 };
 
 } /* namespace UPNP */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1228,6 +1228,19 @@ time_t CPVRClients::GetBufferTimeEnd() const
   return time;
 }
 
+bool CPVRClients::GetStreamTimes(PVR_STREAM_TIMES *times) const
+{
+  PVR_CLIENT client;
+  bool ret = 0;
+
+  if (GetPlayingClient(client))
+  {
+    ret = client->GetStreamTimes(times);
+  }
+
+  return ret;
+}
+
 bool CPVRClients::IsRealTimeStream(void) const
 {
   PVR_CLIENT client;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -639,6 +639,8 @@ namespace PVR
     time_t GetBufferTimeStart() const;
     time_t GetBufferTimeEnd() const;
 
+    bool GetStreamTimes(PVR_STREAM_TIMES *times) const;
+
     int GetClientId(const std::string& strId) const;
 
     bool IsRealTimeStream() const;


### PR DESCRIPTION
This cleans up the current mess regarding player times and generalises timeshift. Those times are available now:

1) startTime
For a typical video this will be zero. For live TV, this is a reference time in units of time_t (UTC) from which time elapsed starts. Ideally this would be the start of the tv show but can be any other time as well.

2) current time of playback
advanced time in ms since startTime

3) maxTime
maximun time in ms player can skip forward. for a typical video this will be totalLength. For live tv without timeshift this is zero, and fot live tv with timeshift this will be buffer ahead

3) minTime
zero for typical video. with timeshift this is the time in ms player can go back. this can be before startTime