### PR TITLE
[videoplayer] Fix CDVDFactoryInputStream::CreateInputStream fileitem …

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -48,7 +48,7 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
 {
   using namespace ADDON;
 
-  std::string file = fileitem.GetPath();
+  std::string file = fileitem.GetDynPath();
   if (scanforextaudio)
   {
     // find any available external audio tracks


### PR DESCRIPTION
… dynpath fallout.

Stumbled over this while working on https://github.com/kodi-pvr/pvr.demo/pull/50. Fixes tv/radio channel playback using `GetLiveStreamURL`

This has been runtime-tested on macOS, latest Kodi master.