### PR TITLE
[VideoPlayer] Never skip the same commercial twice in a row

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -47,7 +47,7 @@ void CEdl::Clear()
   m_vecCuts.clear();
   m_vecSceneMarkers.clear();
   m_iTotalCutTime = 0;
-  m_lastCheckASSTime = 0;
+  m_lastCutTime = 0;
 }
 
 bool CEdl::ReadEditDecisionLists(const std::string& strMovie, const float fFrameRate, const int iHeight)
@@ -842,14 +842,14 @@ bool CEdl::InCut(const int iSeek, Cut *pCut)
   return false;
 }
 
-int CEdl::GetLastCheckASSTime() const
+int CEdl::GetLastCutTime() const
 {
-  return m_lastCheckASSTime;
+  return m_lastCutTime;
 }
 
-void CEdl::SetLastCheckASSTime(const int iCheckASSTime)
+void CEdl::SetLastCutTime(const int iCutTime)
 {
-  m_lastCheckASSTime = iCheckASSTime;
+  m_lastCutTime = iCutTime;
 }
 
 bool CEdl::GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -56,8 +56,8 @@ public:
   bool InCut(int iSeek, Cut *pCut = NULL);
   bool GetNearestCut(bool bPlus, const int iSeek, Cut *pCut) const;
 
-  int GetLastCheckASSTime() const;
-  void SetLastCheckASSTime(const int iCheckASSTime);
+  int GetLastCutTime() const;
+  void SetLastCutTime(const int iCutTime);
 
   bool GetNextSceneMarker(bool bPlus, const int iClock, int *iSceneMarker);
 
@@ -67,7 +67,7 @@ private:
   int m_iTotalCutTime; // ms
   std::vector<Cut> m_vecCuts;
   std::vector<int> m_vecSceneMarkers;
-  int m_lastCheckASSTime;
+  int m_lastCutTime;
 
   bool ReadEdl(const std::string& strMovie, const float fFramesPerSecond);
   bool ReadComskip(const std::string& strMovie, const float fFramesPerSecond);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2341,8 +2341,6 @@ void CVideoPlayer::CheckAutoSceneSkip()
     return;
 
   const int64_t clock = GetTime();
-  int lastPos = m_Edl.GetLastCheckASSTime();
-  m_Edl.SetLastCheckASSTime(clock);
 
   CEdl::Cut cut;
   if (!m_Edl.InCut(clock, &cut))
@@ -2373,10 +2371,12 @@ void CVideoPlayer::CheckAutoSceneSkip()
   else if (cut.action == CEdl::COMM_BREAK)
   {
     // marker for commbrak may be inaccurate. allow user to skip into break from the back
-    if (m_playSpeed >= 0 && lastPos <= cut.start && clock < cut.end - 1000)
+    if (m_playSpeed >= 0 && m_Edl.GetLastCutTime() != cut.start && clock < cut.end - 1000)
     {
       std::string strTimeString = StringUtils::SecondsToTimeString((cut.end - cut.start) / 1000, TIME_FORMAT_MM_SS);
       CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), strTimeString);
+
+      m_Edl.SetLastCutTime(cut.start);
 
       if (m_SkipCommercials)
       {


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Kodi should never skip the same commercial twice in a row.  Both when seeking backwards into a commercial and also when seeking backwards right before the commercial (or to the exact frame where the commercial starts).

To do this, we keep track of the last commercial skipped and we refuse to skip it again.  This allows us to seek back into the middle of the commercial and also to seek back slightly before the commercial.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Commercial skipping is mostly only useful when watching a program linearly.  Once the user starts skipping around, it is usually because there is a problem with the commercial boundaries.  If the user skips back to the start of a commercial break, Kodi needs to *not* try to skip the commercial again.  This causes the user to fight with Kodi, skipping back to the beginning of the commercial and having kodi skip to the end. 

This code already tries to avoid skipping the same commercial twice in a row.  It does this by only skipping if we are playing forwards from a point before the commercial to a point inside the commercial.  That is good, but what if we skip back to the beginning of the commercial (such as with `SeekScene()` and the Next/Prev Scene buttons)?  In that case, Kodi will skip the commercial again, but this is almost surely not what we want.

The old DVDPlayer code in Jarvis and early Krypton builds accomplished this by keeping track of the last skipped commercial break  and basically refusing to skip breaks earlier in the show entirely (it keeps track in m_EdlAutoSkipMarkers, [see here](https://github.com/xbmc/xbmc/blob/Jarvis/xbmc/cores/dvdplayer/DVDPlayer.cpp#L2236)).  This pull is trying to do a similar thing to get closer to that old behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested this with a commercial flagged recording in a variety of skip scenarios (normal watching, skipping backwards into the break, and skipping back to the start of the break).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
