### PR TITLE
[pvr] fix database migration and drop bWasPlayingOnQuit from create table

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -64,8 +64,7 @@ void CPVRDatabase::CreateTables()
         "sEPGScraper          varchar(32), "
         "iLastWatched         integer, "
         "iClientId            integer, " //! @todo use mapping table
-        "idEpg                integer, "
-        "bWasPlayingOnQuit    bool"
+        "idEpg                integer"
       ")"
   );
 
@@ -140,12 +139,6 @@ void CPVRDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 29)
     m_pDS->exec("ALTER TABLE channelgroups ADD iPosition integer");
-
-  if (iVersion < 30)
-    m_pDS->exec("ALTER TABLE channels ADD bWasPlayingOnQuit bool");
-
-  if (iVersion < 31)
-    m_pDS->exec("ALTER TABLE channels DROP bWasPlayingOnQuit");
 }
 
 /********** Channel methods **********/


### PR DESCRIPTION
1. Remove column `bWasPlayingOnQuit` from create table after #12548 (leftover)
2. Remove add column `bWasPlayingOnQuit` migration for version 30
3. Remove drop column `bWasPlayingOnQuit` migration for version 31 because SQLlite does not support dropping of columns.

We leave the column in because in SQLlite you need to rename the old table, create a new table without the column, copy the data over to the new table and drop the old table. The syntax to rename a table in SQLlite and MySQL also differ. Really annoying.

Take a look at this paste and you know what I mean.
https://pastebin.com/tbHXx4M3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested on MacOS

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)