### PR TITLE
[PVR] Fix and refactor PVR internal 'playing' states after removal of…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3501,6 +3501,8 @@ void CApplication::OnPlayBackEnded()
   CDarwinUtils::EnableOSScreenSaver(true);
 #endif
 
+  CServiceBroker::GetPVRManager().OnPlaybackEnded(m_itemCurrentFile);
+
   CVariant data(CVariant::VariantTypeObject);
   data["end"] = true;
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnStop", m_itemCurrentFile, data);
@@ -3528,6 +3530,8 @@ void CApplication::OnPlayBackStarted()
   if (m_pPlayer->IsPlayingVideo())
     CDarwinUtils::EnableOSScreenSaver(false);
 #endif
+
+  CServiceBroker::GetPVRManager().OnPlaybackStarted(m_itemCurrentFile);
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_STARTED, 0, 0);
   g_windowManager.SendThreadMessage(msg);
@@ -3567,6 +3571,8 @@ void CApplication::OnPlayBackStopped()
 #elif defined(TARGET_DARWIN_IOS)
   CDarwinUtils::EnableOSScreenSaver(true);
 #endif
+
+  CServiceBroker::GetPVRManager().OnPlaybackStopped(m_itemCurrentFile);
 
   CVariant data(CVariant::VariantTypeObject);
   data["end"] = false;

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1311,6 +1311,13 @@ bool CPVRClient::IsPlaying(void) const
          IsPlayingRecording();
 }
 
+void CPVRClient::SetPlayingChannel(const CPVRChannelPtr channel)
+{
+  CSingleLock lock(m_critSection);
+  m_playingChannel = channel;
+  m_bIsPlayingTV = true;
+}
+
 CPVRChannelPtr CPVRClient::GetPlayingChannel() const
 {
   CSingleLock lock(m_critSection);
@@ -1320,6 +1327,20 @@ CPVRChannelPtr CPVRClient::GetPlayingChannel() const
   return CPVRChannelPtr();
 }
 
+void CPVRClient::ClearPlayingChannel()
+{
+  CSingleLock lock(m_critSection);
+  m_playingChannel.reset();
+  m_bIsPlayingTV = false;
+}
+
+void CPVRClient::SetPlayingRecording(const CPVRRecordingPtr recording)
+{
+  CSingleLock lock(m_critSection);
+  m_playingRecording = recording;
+  m_bIsPlayingRecording = true;
+}
+
 CPVRRecordingPtr CPVRClient::GetPlayingRecording(void) const
 {
   CSingleLock lock(m_critSection);
@@ -1327,6 +1348,13 @@ CPVRRecordingPtr CPVRClient::GetPlayingRecording(void) const
     return m_playingRecording;
 
   return CPVRRecordingPtr();
+}
+
+void CPVRClient::ClearPlayingRecording()
+{
+  CSingleLock lock(m_critSection);
+  m_playingRecording.reset();
+  m_bIsPlayingRecording = false;
 }
 
 bool CPVRClient::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel)
@@ -1347,15 +1375,6 @@ bool CPVRClient::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChan
     bReturn = m_struct.toAddon.OpenLiveStream(tag);
   }
 
-  if (bReturn)
-  {
-    CPVRChannelPtr currentChannel(CServiceBroker::GetPVRManager().ChannelGroups()->GetByUniqueID(channel->UniqueID(), channel->ClientID()));
-    CSingleLock lock(m_critSection);
-    m_playingChannel      = currentChannel;
-    m_bIsPlayingTV        = true;
-    m_bIsPlayingRecording = false;
-  }
-
   return bReturn;
 }
 
@@ -1372,14 +1391,6 @@ bool CPVRClient::OpenStream(const CPVRRecordingPtr &recording)
     bReturn = m_struct.toAddon.OpenRecordedStream(tag);
   }
 
-  if (bReturn)
-  {
-    CSingleLock lock(m_critSection);
-    m_playingRecording    = recording;
-    m_bIsPlayingTV        = false;
-    m_bIsPlayingRecording = true;
-  }
-
   return bReturn;
 }
 
@@ -1388,16 +1399,10 @@ void CPVRClient::CloseStream(void)
   if (IsPlayingLiveStream())
   {
     m_struct.toAddon.CloseLiveStream();
-
-    CSingleLock lock(m_critSection);
-    m_bIsPlayingTV = false;
   }
   else if (IsPlayingRecording())
   {
     m_struct.toAddon.CloseRecordedStream();
-
-    CSingleLock lock(m_critSection);
-    m_bIsPlayingRecording = false;
   }
 }
 

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -723,8 +723,40 @@ namespace PVR
     bool IsPlayingEncryptedChannel(void) const;
     bool IsPlayingRecording(void) const;
     bool IsPlaying(void) const;
-    CPVRRecordingPtr GetPlayingRecording(void) const;
+
+    /*!
+     * @brief Set the channel that is currently playing.
+     * @param channel The channel that is currently playing.
+     */
+    void SetPlayingChannel(const CPVRChannelPtr channel);
+
+    /*!
+     * @brief Clear the channel that is currently playing, if any.
+     */
+    void ClearPlayingChannel();
+
+    /*!
+     * @brief Get the channel that is currently playing.
+     * @return the channel that is currently playing, NULL otherwise.
+     */
     CPVRChannelPtr GetPlayingChannel() const;
+
+    /*!
+     * @brief Set the recording that is currently playing.
+     * @param recording The recording that is currently playing.
+     */
+    void SetPlayingRecording(const CPVRRecordingPtr recording);
+
+    /*!
+     * @brief Get the recording that is currently playing.
+     * @return The recording that is currently playing, NULL otherwise.
+     */
+    CPVRRecordingPtr GetPlayingRecording() const;
+
+    /*!
+     * @brief Clear the recording that is currently playing, if any.
+     */
+    void ClearPlayingRecording();
 
     static const char *ToString(const PVR_ERROR error);
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -285,6 +285,24 @@ namespace PVR
     void ResetPlayingTag(void);
 
     /*!
+     * @brief Inform PVR manager that playback of an item just started.
+     * @param item The item that started to play.
+     */
+    void OnPlaybackStarted(const CFileItemPtr item);
+
+    /*!
+     * @brief Inform PVR manager that playback of an item was stopped due to user interaction.
+     * @param item The item that stopped to play.
+     */
+    void OnPlaybackStopped(const CFileItemPtr item);
+
+    /*!
+     * @brief Inform PVR manager that playback of an item has stopped without user interaction.
+     * @param item The item that ended to play.
+     */
+    void OnPlaybackEnded(const CFileItemPtr item);
+
+    /*!
      * @brief Close an open PVR stream.
      */
     void CloseStream(void);

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -297,6 +297,17 @@ namespace PVR
     bool OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel);
 
     /*!
+     * @brief Set the channel that is currently playing.
+     * @param channel The channel that is currently playing.
+     */
+    void SetPlayingChannel(const CPVRChannelPtr channel);
+
+    /*!
+     * @brief Clear the channel that is currently playing, if any.
+     */
+    void ClearPlayingChannel();
+
+    /*!
      * @brief Get the channel that is currently playing.
      * @return the channel that is currently playing, NULL otherwise.
      */
@@ -309,13 +320,24 @@ namespace PVR
 
     /*!
      * @brief Open a stream from the given recording.
-     * @param tag The recording to start playing.
+     * @param recording The recording to start playing.
      * @return True if the stream was opened successfully, false otherwise.
      */
-    bool OpenStream(const CPVRRecordingPtr &tag);
+    bool OpenStream(const CPVRRecordingPtr &recording);
 
     /*!
-     * @brief Get the recordings that is currently playing.
+     * @brief Set the recording that is currently playing.
+     * @param recording The recording that is currently playing.
+     */
+    void SetPlayingRecording(const CPVRRecordingPtr recording);
+
+    /*!
+     * @brief Clear the recording that is currently playing, if any.
+     */
+    void ClearPlayingRecording();
+
+    /*!
+     * @brief Get the recording that is currently playing.
      * @return The recording that is currently playing, NULL otherwise.
      */
     CPVRRecordingPtr GetPlayingRecording(void) const;


### PR DESCRIPTION
… VideoPlayer's 'other stream hack'."

Hopefully the last fallout from #12550. Fixes Live TV OSD for playing "dynpath" channels and other glitches.

This has been runtime tested on macOS, latest Kodi master.

@FernetMenta as discussed on Slack...