### PR TITLE
Controller models and other improvements

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -35,7 +35,6 @@
 #include "games/addons/playback/GameClientRealtimePlayback.h"
 #include "games/addons/playback/GameClientReversiblePlayback.h"
 #include "games/controllers/Controller.h"
-#include "games/controllers/ControllerLayout.h"
 #include "games/ports/PortManager.h"
 #include "games/GameServices.h"
 #include "guilib/GUIWindowManager.h"
@@ -804,14 +803,14 @@ void CGameClient::UpdatePort(unsigned int port, const ControllerPtr& controller)
       game_controller controllerStruct;
 
       controllerStruct.controller_id        = strId.c_str();
-      controllerStruct.digital_button_count = controller->Layout().FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::DIGITAL);
-      controllerStruct.analog_button_count  = controller->Layout().FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::ANALOG);
-      controllerStruct.analog_stick_count   = controller->Layout().FeatureCount(FEATURE_TYPE::ANALOG_STICK);
-      controllerStruct.accelerometer_count  = controller->Layout().FeatureCount(FEATURE_TYPE::ACCELEROMETER);
+      controllerStruct.digital_button_count = controller->FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::DIGITAL);
+      controllerStruct.analog_button_count  = controller->FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::ANALOG);
+      controllerStruct.analog_stick_count   = controller->FeatureCount(FEATURE_TYPE::ANALOG_STICK);
+      controllerStruct.accelerometer_count  = controller->FeatureCount(FEATURE_TYPE::ACCELEROMETER);
       controllerStruct.key_count            = 0; //! @todo
-      controllerStruct.rel_pointer_count    = controller->Layout().FeatureCount(FEATURE_TYPE::RELPOINTER);
-      controllerStruct.abs_pointer_count    = controller->Layout().FeatureCount(FEATURE_TYPE::ABSPOINTER);
-      controllerStruct.motor_count          = controller->Layout().FeatureCount(FEATURE_TYPE::MOTOR);
+      controllerStruct.rel_pointer_count    = controller->FeatureCount(FEATURE_TYPE::RELPOINTER);
+      controllerStruct.abs_pointer_count    = controller->FeatureCount(FEATURE_TYPE::ABSPOINTER);
+      controllerStruct.motor_count          = controller->FeatureCount(FEATURE_TYPE::MOTOR);
 
       try { m_struct.toAddon.UpdatePort(port, true, &controllerStruct); }
       catch (...) { LogException("UpdatePort()"); }

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -21,7 +21,6 @@
 #include "Controller.h"
 #include "ControllerDefinitions.h"
 #include "ControllerLayout.h"
-#include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -79,20 +78,6 @@ CController::CController(ADDON::CAddonInfo addonInfo) :
 }
 
 CController::~CController() = default;
-
-std::string CController::Label(void)
-{
-  if (m_layout->LabelID() >= 0)
-    return g_localizeStrings.GetAddonString(ID(), m_layout->LabelID());
-  return "";
-}
-
-std::string CController::ImagePath(void) const
-{
-  if (!m_layout->Image().empty())
-    return URIUtils::AddFileToFolder(URIUtils::GetDirectory(LibPath()), m_layout->Image());
-  return "";
-}
 
 unsigned int CController::FeatureCount(FEATURE_TYPE type /* = FEATURE_TYPE::UNKNOWN */,
                                        JOYSTICK::INPUT_TYPE inputType /* = JOYSTICK::INPUT_TYPE::UNKNOWN */) const

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -80,8 +80,8 @@ CController::~CController() = default;
 
 std::string CController::Label(void)
 {
-  if (m_layout->Label() > 0)
-    return g_localizeStrings.GetAddonString(ID(), m_layout->Label());
+  if (m_layout->LabelID() >= 0)
+    return g_localizeStrings.GetAddonString(ID(), m_layout->LabelID());
   return "";
 }
 

--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
+#include "URL.h"
 
 #include <algorithm>
 
@@ -134,21 +135,21 @@ bool CController::LoadLayout(void)
   {
     std::string strLayoutXmlPath = LibPath();
 
+    CLog::Log(LOGINFO, "Loading controller layout: %s", CURL::GetRedacted(strLayoutXmlPath).c_str());
+
     CXBMCTinyXML xmlDoc;
     if (!xmlDoc.LoadFile(strLayoutXmlPath))
     {
-      CLog::Log(LOGDEBUG, "Unable to load %s: %s at line %d", strLayoutXmlPath.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+      CLog::Log(LOGDEBUG, "Unable to load file: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
       return false;
     }
 
     TiXmlElement* pRootElement = xmlDoc.RootElement();
     if (!pRootElement || pRootElement->NoChildren() || pRootElement->ValueStr() != LAYOUT_XML_ROOT)
     {
-      CLog::Log(LOGERROR, "%s: Can't find root <%s> tag", strLayoutXmlPath.c_str(), LAYOUT_XML_ROOT);
+      CLog::Log(LOGERROR, "Can't find root <%s> tag", LAYOUT_XML_ROOT);
       return false;
     }
-
-    CLog::Log(LOGINFO, "Loading controller layout %s", strLayoutXmlPath.c_str());
 
     if (m_layout->Deserialize(pRootElement, this, m_features))
       m_bLoaded = true;

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include "ControllerFeature.h"
 #include "ControllerTypes.h"
 #include "addons/Addon.h"
 #include "input/joysticks/JoystickTypes.h"
@@ -46,18 +47,80 @@ public:
 
   static const ControllerPtr EmptyPtr;
 
+  /*!
+   * \brief Get the label of the primary layout used when mapping the controller
+   *
+   * \return The label, or empty if unknown
+   */
   std::string Label(void);
+
+  /*!
+   * \brief Get the image path of the primary layout used when mapping the controller
+   *
+   * \return The image path, or empty if unknown
+   */
   std::string ImagePath(void) const;
+
+  /*!
+   * \brief Get all controller features
+   *
+   * \return The features
+   */
+  const std::vector<CControllerFeature>& Features(void) const { return m_features; }
+
+  /*!
+   * \brief Get the count of controller features matching the specified types
+   *
+   * \param type The feature type, or FEATURE_TYPE::UNKNOWN to match all feature types
+   * \param inputType The input type, or INPUT_TYPE::UNKNOWN to match all input types
+   *
+   * \return The feature count
+   */
+  unsigned int FeatureCount(FEATURE_TYPE type = FEATURE_TYPE::UNKNOWN,
+                            JOYSTICK::INPUT_TYPE inputType = JOYSTICK::INPUT_TYPE::UNKNOWN) const;
+
+  /*!
+   * \brief Get the features matching the specified type
+   *
+   * \param type The feature type, or FEATURE_TYPE::UNKNOWN to get all features
+   */
   void GetFeatures(std::vector<std::string>& features, FEATURE_TYPE type = FEATURE_TYPE::UNKNOWN) const;
-  JOYSTICK::FEATURE_TYPE GetFeatureType(const std::string &feature) const;
+
+  /*!
+   * \brief Get the type of the specified feature
+   *
+   * \param feature The feature name to look up
+   *
+   * \return The feature type, or FEATURE_TYPE::UNKNOWN if an invalid feature was specified
+   */
+  FEATURE_TYPE FeatureType(const std::string &feature) const;
+
+  /*!
+   * \brief Get the input type of the specified feature
+   *
+   * \param feature The feature name to look up
+   *
+   * \return The input type of the feature, or INPUT_TYPE::UNKNOWN if unknown
+   */
   JOYSTICK::INPUT_TYPE GetInputType(const std::string& feature) const;
 
+  /*!
+   * \brief Load the controller layout
+   *
+   * \return true if the layout is loaded or was already loaded, false otherwise
+   */
   bool LoadLayout(void);
 
+  /*!
+   * \brief Get the primary layout
+   *
+   * \return The layout of the primary controller model
+   */
   const CControllerLayout& Layout(void) const { return *m_layout; }
 
 private:
   std::unique_ptr<CControllerLayout> m_layout;
+  std::vector<CControllerFeature> m_features;
   bool m_bLoaded = false;
 };
 

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -49,20 +49,6 @@ public:
   static const ControllerPtr EmptyPtr;
 
   /*!
-   * \brief Get the label of the primary layout used when mapping the controller
-   *
-   * \return The label, or empty if unknown
-   */
-  std::string Label(void);
-
-  /*!
-   * \brief Get the image path of the primary layout used when mapping the controller
-   *
-   * \return The image path, or empty if unknown
-   */
-  std::string ImagePath(void) const;
-
-  /*!
    * \brief Get all controller features
    *
    * \return The features

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -24,6 +24,7 @@
 #include "addons/Addon.h"
 #include "input/joysticks/JoystickTypes.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -118,8 +119,27 @@ public:
    */
   const CControllerLayout& Layout(void) const { return *m_layout; }
 
+  /*!
+   * \brief Get the models defined by this controller
+   *
+   * \return The models, or empty if no models are defined
+   */
+  std::vector<std::string> Models() const;
+
+  /*!
+   * \brief Get the layout for the specified model
+   *
+   * \param model The model name
+   *
+   * \return The model layout, or the primary layout if the model name is invalid
+   */
+  const CControllerLayout& GetModel(const std::string& model) const;
+
 private:
+  void LoadModels(const std::string &modelXmlPath);
+
   std::unique_ptr<CControllerLayout> m_layout;
+  std::map<std::string, std::unique_ptr<CControllerLayout>> m_models;
   std::vector<CControllerFeature> m_features;
   bool m_bLoaded = false;
 };

--- a/xbmc/games/controllers/ControllerDefinitions.h
+++ b/xbmc/games/controllers/ControllerDefinitions.h
@@ -29,7 +29,6 @@
 #define LAYOUT_XML_ELM_ABSPOINTER          "abspointer"
 #define LAYOUT_XML_ATTR_LAYOUT_LABEL       "label"
 #define LAYOUT_XML_ATTR_LAYOUT_IMAGE       "image"
-#define LAYOUT_XML_ATTR_LAYOUT_OVERLAY     "overlay"
 #define LAYOUT_XML_ATTR_CATEGORY_NAME      "name"
 #define LAYOUT_XML_ATTR_CATEGORY_LABEL     "label"
 #define LAYOUT_XML_ATTR_FEATURE_NAME       "name"

--- a/xbmc/games/controllers/ControllerDefinitions.h
+++ b/xbmc/games/controllers/ControllerDefinitions.h
@@ -28,12 +28,18 @@
 #define LAYOUT_XML_ELM_RELPOINTER          "relpointer"
 #define LAYOUT_XML_ELM_ABSPOINTER          "abspointer"
 #define LAYOUT_XML_ATTR_LAYOUT_LABEL       "label"
+#define LAYOUT_XML_ATTR_LAYOUT_ICON        "icon"
 #define LAYOUT_XML_ATTR_LAYOUT_IMAGE       "image"
+#define LAYOUT_XML_ATTR_LAYOUT_MODELS      "models"
 #define LAYOUT_XML_ATTR_CATEGORY_NAME      "name"
 #define LAYOUT_XML_ATTR_CATEGORY_LABEL     "label"
 #define LAYOUT_XML_ATTR_FEATURE_NAME       "name"
 #define LAYOUT_XML_ATTR_FEATURE_LABEL      "label"
 #define LAYOUT_XML_ATTR_INPUT_TYPE         "type"
+
+#define MODELS_XML_ROOT                    "models"
+#define MODELS_XML_ELM_MODEL               "model"
+#define MODELS_XML_ATTR_MODEL_NAME         "name"
 
 #define FEATURE_CATEGORY_FACE              "face"
 #define FEATURE_CATEGORY_SHOULDER          "shoulder"

--- a/xbmc/games/controllers/ControllerFeature.cpp
+++ b/xbmc/games/controllers/ControllerFeature.cpp
@@ -34,11 +34,11 @@ using namespace JOYSTICK;
 
 void CControllerFeature::Reset(void)
 {
+  m_controller = nullptr;
   m_type = FEATURE_TYPE::UNKNOWN;
   m_category = FEATURE_CATEGORY::UNKNOWN;
-  m_strCategory.clear();
+  m_categoryLabelId = -1;
   m_strName.clear();
-  m_strLabel.clear();
   m_labelId = -1;
   m_inputType = INPUT_TYPE::UNKNOWN;
 }
@@ -47,21 +47,44 @@ CControllerFeature& CControllerFeature::operator=(const CControllerFeature& rhs)
 {
   if (this != &rhs)
   {
+    m_controller = rhs.m_controller;
     m_type       = rhs.m_type;
     m_category   = rhs.m_category;
-    m_strCategory = rhs.m_strCategory;
+    m_categoryLabelId = rhs.m_categoryLabelId;
     m_strName    = rhs.m_strName;
-    m_strLabel   = rhs.m_strLabel;
     m_labelId    = rhs.m_labelId;
     m_inputType  = rhs.m_inputType;
   }
   return *this;
 }
 
+std::string CControllerFeature::CategoryLabel() const
+{
+  std::string categoryLabel;
+
+  if (m_categoryLabelId >= 0 && m_controller != nullptr)
+    categoryLabel = g_localizeStrings.GetAddonString(m_controller->ID(), m_categoryLabelId);
+
+  if (categoryLabel.empty())
+    categoryLabel = g_localizeStrings.Get(m_categoryLabelId);
+
+  return categoryLabel;
+}
+
+std::string CControllerFeature::Label() const
+{
+  std::string label;
+
+  if (m_labelId >= 0 && m_controller != nullptr)
+    label = g_localizeStrings.GetAddonString(m_controller->ID(), m_labelId);
+
+  return label;
+}
+
 bool CControllerFeature::Deserialize(const TiXmlElement* pElement,
                                      const CController* controller,
                                      FEATURE_CATEGORY category,
-                                     const std::string& strCategory)
+                                     int categoryLabelId)
 {
   Reset();
 
@@ -80,7 +103,7 @@ bool CControllerFeature::Deserialize(const TiXmlElement* pElement,
 
   // Cagegory was obtained from parent XML node
   m_category = category;
-  m_strCategory = strCategory;
+  m_categoryLabelId = categoryLabelId;
 
   // Name
   m_strName = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_FEATURE_NAME);
@@ -96,10 +119,6 @@ bool CControllerFeature::Deserialize(const TiXmlElement* pElement,
     CLog::Log(LOGDEBUG, "<%s> tag has no \"%s\" attribute", strType.c_str(), LAYOUT_XML_ATTR_FEATURE_LABEL);
   else
     std::istringstream(strLabel) >> m_labelId;
-
-  // Label (string)
-  if (m_labelId >= 0)
-    m_strLabel = g_localizeStrings.GetAddonString(controller->ID(), m_labelId);
 
   // Input type
   if (m_type == FEATURE_TYPE::SCALAR)
@@ -121,6 +140,9 @@ bool CControllerFeature::Deserialize(const TiXmlElement* pElement,
       }
     }
   }
+
+  // Save controller for string translation
+  m_controller = controller;
 
   return true;
 }

--- a/xbmc/games/controllers/ControllerFeature.h
+++ b/xbmc/games/controllers/ControllerFeature.h
@@ -43,23 +43,23 @@ public:
 
   JOYSTICK::FEATURE_TYPE Type(void) const { return m_type; }
   JOYSTICK::FEATURE_CATEGORY Category(void) const { return m_category; }
-  const std::string&     CategoryLabel(void) const { return m_strCategory; }
+  std::string            CategoryLabel(void) const;
   const std::string&     Name(void) const       { return m_strName; }
-  const std::string&     Label(void) const      { return m_strLabel; }
+  std::string            Label(void) const;
   int                    LabelID(void) const    { return m_labelId; }
   JOYSTICK::INPUT_TYPE InputType(void) const { return m_inputType; }
 
   bool Deserialize(const TiXmlElement* pElement,
                    const CController* controller,
                    JOYSTICK::FEATURE_CATEGORY category,
-                   const std::string& strCategory);
+                   int categoryLabelId);
 
 private:
+  const CController *m_controller; // To get the controller ID for translating labels
   JOYSTICK::FEATURE_TYPE m_type;
   JOYSTICK::FEATURE_CATEGORY m_category;
-  std::string            m_strCategory;
+  int m_categoryLabelId;
   std::string            m_strName;
-  std::string            m_strLabel;
   int                    m_labelId;
   JOYSTICK::INPUT_TYPE m_inputType;
 };

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -22,7 +22,6 @@
 #include "Controller.h"
 #include "ControllerDefinitions.h"
 #include "ControllerTranslator.h"
-#include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/XMLUtils.h"
 
@@ -128,23 +127,17 @@ bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CControl
     FEATURE_CATEGORY category = CControllerTranslator::TranslateFeatureCategory(strCategory);
 
     // Category label
-    std::string strCategoryLabel;
+    int categoryLabelId = -1;
 
     std::string strCategoryLabelId = XMLUtils::GetAttribute(pCategory, LAYOUT_XML_ATTR_CATEGORY_LABEL);
     if (!strCategoryLabelId.empty())
-    {
-      unsigned int categoryLabelId;
       std::istringstream(strCategoryLabelId) >> categoryLabelId;
-      strCategoryLabel = g_localizeStrings.GetAddonString(controller->ID(), categoryLabelId);
-      if (strCategoryLabel.empty())
-        strCategoryLabel = g_localizeStrings.Get(categoryLabelId);
-    }
 
     for (const TiXmlElement* pFeature = pCategory->FirstChildElement(); pFeature != nullptr; pFeature = pFeature->NextSiblingElement())
     {
       CControllerFeature feature;
 
-      if (feature.Deserialize(pFeature, controller, category, strCategoryLabel))
+      if (feature.Deserialize(pFeature, controller, category, categoryLabelId))
         m_features.push_back(feature);
     }
   }

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -22,7 +22,9 @@
 #include "Controller.h"
 #include "ControllerDefinitions.h"
 #include "ControllerTranslator.h"
+#include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
+#include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 
 #include <sstream>
@@ -32,6 +34,7 @@ using namespace GAME;
 
 void CControllerLayout::Reset(void)
 {
+  m_controller = nullptr;
   m_labelId = -1;
   m_icon.clear();
   m_strImage.clear();
@@ -57,10 +60,33 @@ bool CControllerLayout::IsValid(bool bLog) const
   return true;
 }
 
+std::string CControllerLayout::Label(void) const
+{
+  std::string label;
+
+  if (m_labelId >= 0 && m_controller != nullptr)
+    label = g_localizeStrings.GetAddonString(m_controller->ID(), m_labelId);
+
+  return label;
+}
+
+std::string CControllerLayout::ImagePath(void) const
+{
+  std::string path;
+
+  if (!m_strImage.empty() && m_controller != nullptr)
+    return URIUtils::AddFileToFolder(URIUtils::GetDirectory(m_controller->LibPath()), m_strImage);
+
+  return path;
+}
+
 void CControllerLayout::Deserialize(const TiXmlElement* pElement, const CController* controller, std::vector<CControllerFeature> &features)
 {
   if (pElement == nullptr || controller == nullptr)
     return;
+
+  // Controller (used for string lookup and path translation)
+  m_controller = controller;
 
   // Label
   std::string strLabel = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_LABEL);

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -32,7 +32,7 @@ using namespace GAME;
 
 void CControllerLayout::Reset(void)
 {
-  m_label = 0;
+  m_labelId = -1;
   m_strImage.clear();
 }
 
@@ -50,7 +50,7 @@ bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CControl
     CLog::Log(LOGERROR, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_LABEL);
     return false;
   }
-  std::istringstream(strLabel) >> m_label;
+  std::istringstream(strLabel) >> m_labelId;
 
   // Image
   m_strImage = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_IMAGE);

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -34,9 +34,6 @@ void CControllerLayout::Reset(void)
 {
   m_label = 0;
   m_strImage.clear();
-  m_strOverlay.clear();
-  m_width = 0;
-  m_height = 0;
 }
 
 bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CController* controller, std::vector<CControllerFeature> &features)

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -33,29 +33,58 @@ using namespace GAME;
 void CControllerLayout::Reset(void)
 {
   m_labelId = -1;
+  m_icon.clear();
   m_strImage.clear();
+  m_models.clear();
 }
 
-bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CController* controller, std::vector<CControllerFeature> &features)
+bool CControllerLayout::IsValid(bool bLog) const
 {
-  Reset();
-
-  if (!pElement)
+  if (m_labelId < 0)
+  {
+    if (bLog)
+      CLog::Log(LOGERROR, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_LABEL);
     return false;
+  }
+
+  if (m_strImage.empty())
+  {
+    if (bLog)
+      CLog::Log(LOGDEBUG, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_IMAGE);
+    return false;
+  }
+
+  return true;
+}
+
+void CControllerLayout::Deserialize(const TiXmlElement* pElement, const CController* controller, std::vector<CControllerFeature> &features)
+{
+  if (pElement == nullptr || controller == nullptr)
+    return;
 
   // Label
   std::string strLabel = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_LABEL);
-  if (strLabel.empty())
-  {
-    CLog::Log(LOGERROR, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_LABEL);
-    return false;
-  }
-  std::istringstream(strLabel) >> m_labelId;
+  if (!strLabel.empty())
+    std::istringstream(strLabel) >> m_labelId;
+
+  // Icon
+  std::string icon = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_ICON);
+  if (!icon.empty())
+    m_icon = icon;
+
+  // Fallback icon, use add-on icon
+  if (m_icon.empty())
+    m_icon = controller->Icon();
 
   // Image
-  m_strImage = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_IMAGE);
-  if (m_strImage.empty())
-    CLog::Log(LOGDEBUG, "<%s> tag has no \"%s\" attribute", LAYOUT_XML_ROOT, LAYOUT_XML_ATTR_LAYOUT_IMAGE);
+  std::string image = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_IMAGE);
+  if (!image.empty())
+    m_strImage = image;
+
+  // Models
+  std::string models = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_LAYOUT_MODELS);
+  if (!models.empty())
+    m_models = models;
 
   // Features
   for (const TiXmlElement* pChild = pElement->FirstChildElement(); pChild != nullptr; pChild = pChild->NextSiblingElement())
@@ -86,6 +115,4 @@ bool CControllerLayout::Deserialize(const TiXmlElement* pElement, const CControl
       CLog::Log(LOGDEBUG, "Ignoring <%s> tag", pChild->ValueStr().c_str());
     }
   }
-
-  return true;
 }

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -40,17 +40,12 @@ public:
 
   unsigned int       Label(void) const   { return m_label; }
   const std::string& Image(void) const   { return m_strImage; }
-  unsigned int       Width(void) const   { return m_width; }
-  unsigned int       Height(void) const  { return m_height; }
 
   bool Deserialize(const TiXmlElement* pLayoutElement, const CController* controller, std::vector<CControllerFeature> &features);
 
 private:
   unsigned int m_label;
   std::string  m_strImage;
-  std::string  m_strOverlay;
-  unsigned int m_width;
-  unsigned int m_height;
 };
 
 }

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -19,8 +19,6 @@
  */
 #pragma once
 
-#include "ControllerFeature.h"
-
 #include <string>
 #include <vector>
 
@@ -30,6 +28,8 @@ namespace KODI
 {
 namespace GAME
 {
+class CController;
+class CControllerFeature;
 
 class CControllerLayout
 {
@@ -43,14 +43,7 @@ public:
   unsigned int       Width(void) const   { return m_width; }
   unsigned int       Height(void) const  { return m_height; }
 
-  const std::vector<CControllerFeature>& Features(void) const { return m_features; }
-
-  unsigned int FeatureCount(KODI::JOYSTICK::FEATURE_TYPE type = KODI::JOYSTICK::FEATURE_TYPE::UNKNOWN,
-                            KODI::JOYSTICK::INPUT_TYPE buttonType = KODI::JOYSTICK::INPUT_TYPE::UNKNOWN) const;
-
-  KODI::JOYSTICK::FEATURE_TYPE FeatureType(const std::string &featureName) const;
-
-  bool Deserialize(const TiXmlElement* pLayoutElement, const CController* controller);
+  bool Deserialize(const TiXmlElement* pLayoutElement, const CController* controller, std::vector<CControllerFeature> &features);
 
 private:
   unsigned int m_label;
@@ -58,8 +51,6 @@ private:
   std::string  m_strOverlay;
   unsigned int m_width;
   unsigned int m_height;
-
-  std::vector<CControllerFeature> m_features;
 };
 
 }

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -34,18 +34,38 @@ class CControllerFeature;
 class CControllerLayout
 {
 public:
-  CControllerLayout(void) { Reset(); }
+  CControllerLayout() = default;
 
   void Reset(void);
 
   int LabelID(void) const { return m_labelId; }
+  const std::string& Icon(void) const { return m_icon; }
   const std::string& Image(void) const   { return m_strImage; }
+  const std::string Models() const { return m_models; }
 
-  bool Deserialize(const TiXmlElement* pLayoutElement, const CController* controller, std::vector<CControllerFeature> &features);
+  /*!
+   * \brief Ensures the layout was deserialized correctly, and optionally logs if not
+   *
+   * \param bLog If true, output the cause of invalidness to the log
+   *
+   * \return True if the layout is valid and can be used in the GUI, false otherwise
+   */
+  bool IsValid(bool bLog) const;
+
+  /*!
+   * \brief Deserialize the specified XML element
+   *
+   * \param pLayoutElement The XML element
+   * \param controller The controller, used to obtain read-only properties
+   * \param features The deserialized features, if any
+   */
+  void Deserialize(const TiXmlElement* pLayoutElement, const CController* controller, std::vector<CControllerFeature> &features);
 
 private:
   int m_labelId = -1;
+  std::string m_icon;
   std::string  m_strImage;
+  std::string m_models;
 };
 
 }

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -53,6 +53,20 @@ public:
   bool IsValid(bool bLog) const;
 
   /*!
+   * \brief Get the label of the primary layout used when mapping the controller
+   *
+   * \return The label, or empty if unknown
+   */
+  std::string Label(void) const;
+
+  /*!
+   * \brief Get the image path of the primary layout used when mapping the controller
+   *
+   * \return The image path, or empty if unknown
+   */
+  std::string ImagePath(void) const;
+
+  /*!
    * \brief Deserialize the specified XML element
    *
    * \param pLayoutElement The XML element
@@ -62,6 +76,7 @@ public:
   void Deserialize(const TiXmlElement* pLayoutElement, const CController* controller, std::vector<CControllerFeature> &features);
 
 private:
+  const CController *m_controller = nullptr;
   int m_labelId = -1;
   std::string m_icon;
   std::string  m_strImage;

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -38,13 +38,13 @@ public:
 
   void Reset(void);
 
-  unsigned int       Label(void) const   { return m_label; }
+  int LabelID(void) const { return m_labelId; }
   const std::string& Image(void) const   { return m_strImage; }
 
   bool Deserialize(const TiXmlElement* pLayoutElement, const CController* controller, std::vector<CControllerFeature> &features);
 
 private:
-  unsigned int m_label;
+  int m_labelId = -1;
   std::string  m_strImage;
 };
 

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIGameController.h"
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerLayout.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 
@@ -68,6 +69,6 @@ void CGUIGameController::ActivateController(const ControllerPtr& controller)
     lock.Leave();
 
     //! @todo Sometimes this fails on window init
-    SetFileName(m_currentController->ImagePath());
+    SetFileName(m_currentController->Layout().ImagePath());
   }
 }

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -42,6 +42,7 @@
 #include "input/joysticks/JoystickIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "peripherals/Peripherals.h"
+#include "utils/StringUtils.h"
 #include "ServiceBroker.h"
 
 using namespace KODI;
@@ -202,7 +203,7 @@ bool CGUIControllerList::RefreshControllers(void)
         if (i->ID() == DEFAULT_CONTROLLER_ID && j->ID() != DEFAULT_CONTROLLER_ID) return true;
         if (i->ID() != DEFAULT_CONTROLLER_ID && j->ID() == DEFAULT_CONTROLLER_ID) return false;
 
-        return i->Name() < j->Name();
+        return StringUtils::CompareNoCase(i->Layout().Label(), j->Layout().Label()) < 0;
       });
   }
 

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -31,6 +31,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
+#include "games/controllers/ControllerLayout.h"
 #include "games/controllers/guicontrols/GUIControllerButton.h"
 #include "games/controllers/guicontrols/GUIGameController.h"
 #include "games/GameServices.h"
@@ -96,7 +97,7 @@ bool CGUIControllerList::Refresh(void)
     {
       const ControllerPtr& controller = *it;
 
-      CGUIButtonControl* pButton = new CGUIControllerButton(*m_controllerButton, controller->Label(), buttonId++);
+      CGUIButtonControl* pButton = new CGUIControllerButton(*m_controllerButton, controller->Layout().Label(), buttonId++);
       m_controllerList->AddControl(pButton);
 
       // Just in case

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -31,7 +31,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
-#include "games/controllers/ControllerLayout.h"
 #include "games/controllers/guicontrols/GUIControllerButton.h"
 #include "games/controllers/guicontrols/GUIGameController.h"
 #include "games/GameServices.h"
@@ -171,7 +170,7 @@ bool CGUIControllerList::RefreshControllers(void)
 
   auto HasButtonForController = [&](const ControllerPtr &controller)
     {
-      const auto &features = controller->Layout().Features();
+      const auto &features = controller->Features();
       auto it = std::find_if(features.begin(), features.end(), HasButtonForFeature);
       return it == features.end();
     };

--- a/xbmc/games/controllers/windows/GUIFeatureList.cpp
+++ b/xbmc/games/controllers/windows/GUIFeatureList.cpp
@@ -26,7 +26,7 @@
 #include "games/controllers/guicontrols/GUIFeatureFactory.h"
 #include "games/controllers/guicontrols/GUIFeatureTranslator.h"
 #include "games/controllers/Controller.h"
-#include "games/controllers/ControllerLayout.h"
+#include "games/controllers/ControllerFeature.h"
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIImage.h"
@@ -107,7 +107,7 @@ void CGUIFeatureList::Load(const ControllerPtr& controller)
   m_controller = controller;
 
   // Get features
-  const std::vector<CControllerFeature>& features = controller->Layout().Features();
+  const std::vector<CControllerFeature>& features = controller->Features();
 
   // Split into groups
   auto featureGroups = GetFeatureGroups(features);
@@ -151,7 +151,7 @@ void CGUIFeatureList::Load(const ControllerPtr& controller)
 
 void CGUIFeatureList::OnSelect(unsigned int index)
 {
-  const unsigned int featureCount = m_controller->Layout().FeatureCount();
+  const unsigned int featureCount = m_controller->FeatureCount();
 
   // Generate list of buttons for the wizard
   std::vector<IFeatureButton*> buttons;

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -21,7 +21,6 @@
 #include "ButtonMapping.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
-#include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
@@ -265,7 +264,7 @@ CButtonMapping::CButtonMapping(IButtonMapper* buttonMapper, IButtonMap* buttonMa
     CControllerManager& controllerManager = CServiceBroker::GetGameControllerManager();
     ControllerPtr controller = controllerManager.GetController(m_keymap->ControllerID());
 
-    const auto& features = controller->Layout().Features();
+    const auto& features = controller->Features();
     for (const auto& feature : features)
     {
       bool bIsSelectAction = false;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -27,7 +27,6 @@
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "games/controllers/Controller.h"
-#include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMap.h"
@@ -876,7 +875,7 @@ unsigned int CPeripheralAddon::cb_feature_count(void* kodiInstance, const char* 
   CControllerManager& controllerManager = CServiceBroker::GetGameControllerManager();
   ControllerPtr controller = controllerManager.GetController(controllerId);
   if (controller)
-    count = controller->Layout().FeatureCount(CPeripheralAddonTranslator::TranslateFeatureType(type));
+    count = controller->FeatureCount(CPeripheralAddonTranslator::TranslateFeatureType(type));
 
   return count;
 }
@@ -890,7 +889,7 @@ JOYSTICK_FEATURE_TYPE CPeripheralAddon::cb_feature_type(void* kodiInstance, cons
   CControllerManager& controllerManager = CServiceBroker::GetGameControllerManager();
   ControllerPtr controller = controllerManager.GetController(controllerId);
   if (controller)
-    type = CPeripheralAddonTranslator::TranslateFeatureType(controller->Layout().FeatureType(featureName));
+    type = CPeripheralAddonTranslator::TranslateFeatureType(controller->FeatureType(featureName));
 
   return type;
 }


### PR DESCRIPTION
This adds the ability to define multiple controller models in a single controller add-on.

## Description
In the upcoming player manager, it is possible to choose which device is plugged into each port. This expands on that idea by allowing the user to choose specific models.

A new parameter, "models", is added to the controller layout:

```xml
<layout label="30000" image="layout_proline.png" mask="mask_proline.png" models="models.xml">
```

This links to a models XML that can override layout parameters:

```xml
<models>
  <model name="proline">
    <layout label="30009"/>
  </model>
  <model name="gamepad">
    <layout label="30010" icon="icon_gamepad.png" image="layout_gamepad.png"/>
  </model>
</models>
```

In this example, the default Atari 7800 model is the Atari Proline Joystick:

![layout_proline](https://user-images.githubusercontent.com/531482/28846884-f91ac3a2-76c1-11e7-8756-a799e372224f.png)

The models.xml file above overrides the name shown in the Controller Dialog, "Atari 7800", with the model name "Atari Proline Joystick". It then adds a second model, with label "Atari 7800 Gamepad" and an alternative image:

![layout_gamepad](https://user-images.githubusercontent.com/531482/28846933-28f22660-76c2-11e7-9585-1e1ed55ed6b8.png)

## Motivation and Context
Some controllers identify themselves to the game console, so that the game console is aware of which controller is plugged into the port. This gives the user control over that.

An alternative was to add separate controller add-ons for each model, but then the Controller Dialog would show multiple controllers with the same button layout. With this solution, the Controller Dialog degrades to using a single layout, while in the upcoming Player Manager the multiple models are exposed.

## How Has This Been Tested?
Multiple models aren't available in the GUI yet, but I've set a breakpoint and verified that the models are loaded correctly.

Because the models degrade to the single layout in the controller dialog, this change is fully backwards compatible with Krypton.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
