### PR TITLE
[PVR][addons] PVR API 5.5.0: Add support for series link based series recordings, ...

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -345,6 +345,7 @@ void CPVRClient::WriteClientTimerInfo(const CPVRTimerInfoTag &xbmcTimer, PVR_TIM
   addonTimer.iMarginEnd                = xbmcTimer.m_iMarginEnd;
   addonTimer.iGenreType                = epgTag ? epgTag->GenreType() : 0;
   addonTimer.iGenreSubType             = epgTag ? epgTag->GenreSubType() : 0;
+  strncpy(addonTimer.strSeriesLink, xbmcTimer.SeriesLink().c_str(), sizeof(addonTimer.strSeriesLink) - 1);
 }
 
 /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -113,8 +113,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.4.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "5.4.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.5.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "5.5.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \
                                                       "xbmc_pvr_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
@@ -116,6 +116,7 @@ extern "C" {
     int           iEpisodePartNumber;  /*!< @brief (optional) episode part number */
     const char *  strEpisodeName;      /*!< @brief (optional) episode name */
     unsigned int  iFlags;              /*!< @brief (optional) bit field of independent flags associated with the EPG entry */
+    const char *  strSeriesLink;       /*!< @brief (optional) series link for this event */
   } ATTRIBUTE_PACKED EPG_TAG;
 
 #ifdef __cplusplus

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -529,14 +529,6 @@ extern "C"
   //@}
 
   /*!
-   * Delay to use when using switching channels for add-ons not providing an input stream.
-   * If the add-on does provide an input stream, then this method will not be called.
-   * Those add-ons can do that in OpenLiveStream() if needed.
-   * @return The delay in milliseconds.
-   */
-  unsigned int GetChannelSwitchDelay(void);
-
-  /*!
    * Check if the backend support pausing the currently playing stream
    * This will enable/disable the pause button in XBMC based on the return value
    * @return false if the PVR addon/backend does not support pausing, true if possible
@@ -690,7 +682,6 @@ extern "C"
     pClient->toAddon.SignalStatus                   = SignalStatus;
     pClient->toAddon.GetDescrambleInfo              = GetDescrambleInfo;
     pClient->toAddon.GetLiveStreamURL               = GetLiveStreamURL;
-    pClient->toAddon.GetChannelSwitchDelay          = GetChannelSwitchDelay;
     pClient->toAddon.CanPauseStream                 = CanPauseStream;
     pClient->toAddon.PauseStream                    = PauseStream;
     pClient->toAddon.CanSeekStream                  = CanSeekStream;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -665,7 +665,6 @@ extern "C" {
     void (__cdecl* DemuxAbort)(void);
     void (__cdecl* DemuxFlush)(void);
     DemuxPacket* (__cdecl* DemuxRead)(void);
-    unsigned int (__cdecl* GetChannelSwitchDelay)(void);
     bool (__cdecl* CanPauseStream)(void);
     void (__cdecl* PauseStream)(bool);
     bool (__cdecl* CanSeekStream)(void);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -155,10 +155,11 @@ extern "C" {
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME            = 0x00040000; /*!< @brief enables an 'Any Time' over-ride option for startTime (using PVR_TIMER.bStartAnyTime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME              = 0x00080000; /*!< @brief enables a separate 'Any Time' over-ride for endTime (using PVR_TIMER.bEndAnyTime) */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_MAX_RECORDINGS           = 0x00100000; /*!< @brief this type supports specifying a maximum recordings setting' (PVR_TIMER.iMaxRecordings) */
-  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE        = 0x00200000; /*!< @brief this type shold not appear on any create menus which don't provide an associated EPG tag */
+  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE        = 0x00200000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag */
   const unsigned int PVR_TIMER_TYPE_FORBIDS_EPG_TAG_ON_CREATE         = 0x00400000; /*!< @brief this type should not appear on any create menus which provide an associated EPG tag */
   const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE     = 0x00800000; /*!< @brief this type should not appear on any create menus unless associated with an EPG tag with 'series' attributes (EPG_TAG.iFlags & EPG_TAG_FLAG_IS_SERIES || EPG_TAG.iSeriesNumber > 0 || EPG_TAG.iEpisodeNumber > 0 || EPG_TAG.iEpisodePartNumber > 0). Implies PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE */
   const unsigned int PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL              = 0x01000000; /*!< @brief this type supports 'any channel', for example when defining a timer rule that should match any channel instaed of a particular channel */
+  const unsigned int PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE = 0x02000000; /*!< @brief this type should not appear on any create menus which don't provide an associated EPG tag with a series link */
 
   /*!
    * @brief PVR timer weekdays (PVR_TIMER.iWeekdays values)
@@ -505,6 +506,8 @@ extern "C" {
     unsigned int    iMarginEnd;                                /*!< @brief (optional) if set, the backend ends the recording iMarginEnd minutes after endTime. */
     int             iGenreType;                                /*!< @brief (optional) genre type */
     int             iGenreSubType;                             /*!< @brief (optional) genre sub type */
+    char            strSeriesLink[PVR_ADDON_URL_STRING_LENGTH]; /*!< @brief (optional) series link for this timer. If set for an epg-based timer rule, matching events will be found by checking strSeriesLink instead of strTitle (and bFullTextEpgSearch) */
+
   } ATTRIBUTE_PACKED PVR_TIMER;
 
   /*!

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -763,6 +763,14 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
         continue;
     }
 
+    // Drop TimerTypes which need series link if none is set
+    if (type->RequiresEpgSeriesLinkOnCreate())
+    {
+      const CPVREpgInfoTagPtr epgTag(m_timerInfoTag->GetEpgInfoTag());
+      if (!epgTag || epgTag->SeriesLink().empty())
+        continue;
+    }
+
     // Drop TimerTypes that forbid EPGInfo, if it is populated
     if (type->ForbidsEpgTagOnCreate() && m_timerInfoTag->GetEpgInfoTag())
       continue;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -128,11 +128,11 @@ CPVREpgInfoTag::CPVREpgInfoTag(const EPG_TAG &data) :
     m_strEpisodeName = data.strEpisodeName;
   if (data.strIconPath)
     m_strIconPath = data.strIconPath;
+  if (data.strSeriesLink)
+    m_strSeriesLink = data.strSeriesLink;
 
   UpdatePath();
 }
-
-CPVREpgInfoTag::~CPVREpgInfoTag() = default;
 
 bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
 {
@@ -170,7 +170,8 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
           m_strFileNameAndPath == right.m_strFileNameAndPath &&
           m_startTime          == right.m_startTime &&
           m_endTime            == right.m_endTime &&
-          m_iFlags             == right.m_iFlags);
+          m_iFlags             == right.m_iFlags &&
+          m_strSeriesLink      == right.m_strSeriesLink);
 }
 
 bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
@@ -213,6 +214,7 @@ void CPVREpgInfoTag::Serialize(CVariant &value) const
   value["isactive"] = IsActive();
   value["wasactive"] = WasActive();
   value["isseries"] = IsSeries();
+  value["serieslink"] = m_strSeriesLink;
 }
 
 CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
@@ -485,6 +487,11 @@ int CPVREpgInfoTag::SeriesNumber(void) const
   return m_iSeriesNumber;
 }
 
+std::string CPVREpgInfoTag::SeriesLink() const
+{
+  return m_strSeriesLink;
+}
+
 int CPVREpgInfoTag::EpisodeNumber(void) const
 {
   return m_iEpisodeNumber;
@@ -598,7 +605,8 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /
         EpgID()              != tag.EpgID() ||
         m_genre              != tag.m_genre ||
         m_strIconPath        != tag.m_strIconPath ||
-        m_iFlags             != tag.m_iFlags
+        m_iFlags             != tag.m_iFlags ||
+        m_strSeriesLink      != tag.m_strSeriesLink
     );
     if (bUpdateBroadcastId)
       bChanged |= (m_iBroadcastId != tag.m_iBroadcastId);
@@ -623,6 +631,7 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /
       m_iGenreSubType      = tag.m_iGenreSubType;
       m_epg                = tag.m_epg;
       m_iFlags             = tag.m_iFlags;
+      m_strSeriesLink      = tag.m_strSeriesLink;
 
       {
         CSingleLock lock(m_critSection);

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -70,7 +70,7 @@ namespace PVR
     CPVREpgInfoTag &operator =(const CPVREpgInfoTag &other) = delete;
 
   public:
-    ~CPVREpgInfoTag() override;
+    ~CPVREpgInfoTag() override = default;
 
     bool operator ==(const CPVREpgInfoTag& right) const;
     bool operator !=(const CPVREpgInfoTag& right) const;
@@ -280,6 +280,12 @@ namespace PVR
     int SeriesNumber(void) const;
 
     /*!
+     * @brief The series link for this event.
+     * @return The series link or empty string, if not available.
+     */
+    std::string SeriesLink() const;
+
+    /*!
      * @brief The episode number of this event.
      * @return The episode number.
      */
@@ -459,6 +465,7 @@ namespace PVR
     CPVREpg *                m_epg;                /*!< the schedule that this event belongs to */
 
     unsigned int             m_iFlags;             /*!< the flags applicable to this EPG entry */
+    std::string              m_strSeriesLink;      /*!< series link */
 
     CCriticalSection         m_critSection;
     PVR::CPVRChannelPtr      m_channel;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -209,6 +209,12 @@ namespace PVR
     const std::string& Path(void) const;
 
     /*!
+     * @brief The series link for this timer.
+     * @return The series link or empty string, if not available.
+     */
+    const std::string& SeriesLink() const;
+
+    /*!
      * @brief Get the UID of the epg event associated with this timer tag, if any.
      * @return the UID or EPG_TAG_INVALID_UID.
      */
@@ -295,6 +301,8 @@ namespace PVR
     bool                  m_bHasChildConflictNOK; /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_CONFLICT_NOK */
     bool                  m_bHasChildRecording;   /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_RECORDING */
     bool                  m_bHasChildErrors;      /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_ERROR */
+
+    std::string m_strSeriesLink; /*!< series link */
 
     mutable unsigned int  m_iEpgUid;   /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
     mutable CPVREpgInfoTagPtr m_epgTag; /*!< epg info tag matching m_iEpgUid. */

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -166,13 +166,20 @@ namespace PVR
      * @return True if new instances require EPG info, false otherwise.
      */
     bool RequiresEpgTagOnCreate() const { return (m_iAttributes & (PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-                                                                   PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE)) > 0; }
+                                                                   PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE |
+                                                                   PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE)) > 0; }
 
     /*!
      * @brief Check whether this timer type requires epg tag info including series attributes to be present.
      * @return True if new instances require an EPG tag with series attributes, false otherwise.
      */
     bool RequiresEpgSeriesOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE) > 0; }
+
+    /*!
+     * @brief Check whether this timer type requires epg tag info including a series link to be present.
+     * @return True if new instances require an EPG tag with a series link, false otherwise.
+     */
+    bool RequiresEpgSeriesLinkOnCreate() const { return (m_iAttributes & PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE) > 0; }
 
     /*!
      * @brief Check whether this type supports the "enabling/disabling" of timers of its type.


### PR DESCRIPTION
This is another PR for a PVR Addon API change for Leia. It contains both the API changes and the related Kodi core changes.

1. New timer type attribute PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE
================================================================
Todo for addon maintainers: none

2. New field PVR_TIMER::strSeriesLink
===========================================================
Todo for addon maintainers: none

3. New field EPG_TAG::strSeriesLink
===========================================================
Todo for addon maintainers: none

4. Removed unused API function GetChannelSwitchDelay
===========================================================
Todo for addon maintainers: Cleanup your code by removing this function.

5. New API function GetStreamTimes
===========================================================
Refer to #12598 for details.  This PR will be merged the same time as this one here.
Todo for addon maintainers: Add minimalistic support for this function (return PVR_ERROR_NOT_IMPLEMENTED;)

Functional changes in Kodi: If a timer rule shall be created from an epg tag and this tag contains a serieslink, this serieslink will be placed into the new timer and transferred to the client addon; so, the addon can create a series recording based on that serieslink. Additionally, the addon can define timer types requiring a series link in an epg. Using this, it is possible for the addon to provide for example a "Series link" timer type which appears in the timer settings dialog:

![28745069-2f5aa378-7470-11e7-8817-24a483a6f949](https://user-images.githubusercontent.com/3226626/28879171-c1f35ade-77a1-11e7-9aa9-83f295d6c1ab.png)
![28745070-2f7d87f8-7470-11e7-96a4-ef9693be2ad5](https://user-images.githubusercontent.com/3226626/28879179-c5ecc3aa-77a1-11e7-8fd1-1254d6bb9b9b.png)

This change has been runtime tested on macOS, latest kodi master.

No addon code changes required, a simple recompile is sufficient.

Reference implementation for pvr.hts: https://github.com/kodi-pvr/pvr.hts/pull/321