### PR TITLE
Allow video scrapers/NFO files/library import to add any artwork type…

### DIFF
--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -108,7 +108,7 @@ namespace VIDEO
      \param useLocal whether to use local thumbs, defaults to true
      */
     static void GetSeasonThumbs(const CVideoInfoTag &show, std::map<int, std::map<std::string, std::string> > &art, const std::vector<std::string> &artTypes, bool useLocal = true);
-    static std::string GetImage(CFileItem *pItem, bool useLocal, bool bApplyToDir, const std::string &type = "");
+    static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
     static std::string GetFanart(CFileItem *pItem, bool useLocal);
 
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);


### PR DESCRIPTION
… for items

<!--- Provide a general summary of your change in the Title above -->

## Description
Scrapers (along with friends NFO files and library importing from single file XML export) can set any type of artwork (clearlogo, landscape, etc) for items in the video library.

This is such a simple loop change that doesn't disturb the beast that is scrapers, I so very much wish I had found it a couple of years ago when I first went looking for it.

## Motivation and Context
The video library has long supported freely named artwork for items in most other places, now scrapers can set this artwork from the beginning.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
By hand, I modified the new demo Python scrapers and a classic scraper to set some extra artwork, and modified a couple of NFO files to match, then ensuring the results are what I expect. I also refreshed a few items with a regular scraper and ensured they still set their expected artwork.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
