### PR TITLE
[PVR] Always check whether a timer has an associated channel. It might be null.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -139,7 +139,7 @@ CFileItem::CFileItem(const CPVREpgInfoTagPtr& tag)
 
   if (!tag->Icon().empty())
     SetIconImage(tag->Icon());
-  else if (tag->HasPVRChannel() && !tag->Channel()->IconPath().empty())
+  else if (tag->HasChannel() && !tag->Channel()->IconPath().empty())
     SetIconImage(tag->Channel()->IconPath());
 
   FillInMimeType(false);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -139,8 +139,8 @@ CFileItem::CFileItem(const CPVREpgInfoTagPtr& tag)
 
   if (!tag->Icon().empty())
     SetIconImage(tag->Icon());
-  else if (tag->HasPVRChannel() && !tag->ChannelTag()->IconPath().empty())
-    SetIconImage(tag->ChannelTag()->IconPath());
+  else if (tag->HasPVRChannel() && !tag->Channel()->IconPath().empty())
+    SetIconImage(tag->Channel()->IconPath());
 
   FillInMimeType(false);
 }
@@ -3589,7 +3589,7 @@ CFileItem CFileItem::GetItemToPlay() const
 {
   if (HasEPGInfoTag())
   {
-    const CPVRChannelPtr channel(GetEPGInfoTag()->ChannelTag());
+    const CPVRChannelPtr channel(GetEPGInfoTag()->Channel());
     if (channel)
       return CFileItem(channel);
   }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10328,8 +10328,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       std::string number;
       if (item->HasPVRChannelInfoTag())
         number = StringUtils::Format("%i", item->GetPVRChannelInfoTag()->ChannelNumber());
-      if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
-        number = StringUtils::Format("%i", item->GetEPGInfoTag()->PVRChannelNumber());
+      if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasChannel())
+        number = StringUtils::Format("%i", item->GetEPGInfoTag()->ChannelNumber());
       if (item->HasPVRTimerInfoTag())
         number = StringUtils::Format("%i", item->GetPVRTimerInfoTag()->ChannelNumber());
 
@@ -10341,7 +10341,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       std::string number;
       if (item->HasPVRChannelInfoTag())
         number = StringUtils::Format("%i", item->GetPVRChannelInfoTag()->SubChannelNumber());
-      if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
+      if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasChannel())
         number = StringUtils::Format("%i", item->GetEPGInfoTag()->Channel()->SubChannelNumber());
       if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->HasChannel())
         number = StringUtils::Format("%i", item->GetPVRTimerInfoTag()->Channel()->SubChannelNumber());
@@ -10354,7 +10354,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       CPVRChannelPtr channel;
       if (item->HasPVRChannelInfoTag())
         channel = item->GetPVRChannelInfoTag();
-      else if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
+      else if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasChannel())
         channel = item->GetEPGInfoTag()->Channel();
       else if (item->HasPVRTimerInfoTag())
         channel = item->GetPVRTimerInfoTag()->Channel();
@@ -10367,8 +10367,8 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
   case LISTITEM_CHANNEL_NAME:
     if (item->HasPVRChannelInfoTag())
       return item->GetPVRChannelInfoTag()->ChannelName();
-    if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
-      return item->GetEPGInfoTag()->PVRChannelName();
+    if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasChannel())
+      return item->GetEPGInfoTag()->ChannelName();
     if (item->HasPVRRecordingInfoTag())
       return item->GetPVRRecordingInfoTag()->m_strChannelName;
     if (item->HasPVRTimerInfoTag())
@@ -10768,7 +10768,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       {
         return pItem->GetPVRChannelInfoTag()->IsEncrypted();
       }
-      else if (pItem->HasEPGInfoTag() && pItem->GetEPGInfoTag()->HasPVRChannel())
+      else if (pItem->HasEPGInfoTag() && pItem->GetEPGInfoTag()->HasChannel())
       {
         return pItem->GetEPGInfoTag()->Channel()->IsEncrypted();
       }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10343,7 +10343,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
         number = StringUtils::Format("%i", item->GetPVRChannelInfoTag()->SubChannelNumber());
       if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
         number = StringUtils::Format("%i", item->GetEPGInfoTag()->ChannelTag()->SubChannelNumber());
-      if (item->HasPVRTimerInfoTag())
+      if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->HasChannel())
         number = StringUtils::Format("%i", item->GetPVRTimerInfoTag()->ChannelTag()->SubChannelNumber());
 
       return number;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7360,7 +7360,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       if (m_currentFile->HasPVRRecordingInfoTag())
       {
         CPVREpgInfoTagPtr epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(m_currentFile->GetPVRRecordingInfoTag()->Channel(), m_currentFile->GetPVRRecordingInfoTag()->BroadcastUid());
-        bReturn = (epgTag && epgTag->IsActive() && epgTag->ChannelTag());
+        bReturn = (epgTag && epgTag->IsActive() && epgTag->Channel());
       }
       break;
     case VISUALISATION_HAS_PRESETS:
@@ -10342,9 +10342,9 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (item->HasPVRChannelInfoTag())
         number = StringUtils::Format("%i", item->GetPVRChannelInfoTag()->SubChannelNumber());
       if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
-        number = StringUtils::Format("%i", item->GetEPGInfoTag()->ChannelTag()->SubChannelNumber());
+        number = StringUtils::Format("%i", item->GetEPGInfoTag()->Channel()->SubChannelNumber());
       if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->HasChannel())
-        number = StringUtils::Format("%i", item->GetPVRTimerInfoTag()->ChannelTag()->SubChannelNumber());
+        number = StringUtils::Format("%i", item->GetPVRTimerInfoTag()->Channel()->SubChannelNumber());
 
       return number;
     }
@@ -10355,9 +10355,9 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (item->HasPVRChannelInfoTag())
         channel = item->GetPVRChannelInfoTag();
       else if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->HasPVRChannel())
-        channel = item->GetEPGInfoTag()->ChannelTag();
+        channel = item->GetEPGInfoTag()->Channel();
       else if (item->HasPVRTimerInfoTag())
-        channel = item->GetPVRTimerInfoTag()->ChannelTag();
+        channel = item->GetPVRTimerInfoTag()->Channel();
 
       return channel ?
           channel->FormattedChannelNumber() :
@@ -10770,7 +10770,7 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
       }
       else if (pItem->HasEPGInfoTag() && pItem->GetEPGInfoTag()->HasPVRChannel())
       {
-        return pItem->GetEPGInfoTag()->ChannelTag()->IsEncrypted();
+        return pItem->GetEPGInfoTag()->Channel()->IsEncrypted();
       }
     }
     else if (condition == LISTITEM_IS_STEREOSCOPIC)

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -202,8 +202,8 @@ namespace PVR
       if (epg)
         return !epg->Timer() &&
                epg->EndAsLocalTime() > CDateTime::GetCurrentDateTime() &&
-               epg->ChannelTag() &&
-               CServiceBroker::GetPVRManager().Clients()->GetClientCapabilities(epg->ChannelTag()->ClientID()).SupportsTimers();
+               epg->Channel() &&
+               CServiceBroker::GetPVRManager().Clients()->GetClientCapabilities(epg->Channel()->ClientID()).SupportsTimers();
 
       return false;
     }
@@ -505,7 +505,7 @@ namespace PVR
       const CPVREpgInfoTagPtr epg(item.GetEPGInfoTag());
       if (epg)
       {
-        const CPVRChannelPtr channel(epg->ChannelTag());
+        const CPVRChannelPtr channel(epg->Channel());
         return (channel && CServiceBroker::GetPVRManager().Clients()->HasMenuHooks(channel->ClientID(), PVR_MENUHOOK_EPG));
       }
 

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1353,7 +1353,7 @@ namespace PVR
     {
       if (item->IsEPG())
       {
-        if (item->GetEPGInfoTag()->HasPVRChannel())
+        if (item->GetEPGInfoTag()->HasChannel())
         {
           iClientID = item->GetEPGInfoTag()->Channel()->ClientID();
           menuCategory = PVR_MENUHOOK_EPG;

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -336,7 +336,7 @@ namespace PVR
 
   bool CPVRGUIActions::AddTimer(const CPVRTimerInfoTagPtr &item) const
   {
-    if (!item->ChannelTag() && item->GetTimerType() && !item->GetTimerType()->IsEpgBasedTimerRule())
+    if (!item->Channel() && item->GetTimerType() && !item->GetTimerType()->IsEpgBasedTimerRule())
     {
       CLog::Log(LOGERROR, "CPVRGUIActions - %s - no channel given", __FUNCTION__);
       CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19109}); // "Information", "Couldn't save timer. Check the log for more information about this message."
@@ -349,7 +349,7 @@ namespace PVR
       return false;
     }
 
-    if (!CheckParentalLock(item->ChannelTag()))
+    if (!CheckParentalLock(item->Channel()))
       return false;
 
     return CServiceBroker::GetPVRManager().Timers()->AddTimer(item);
@@ -1355,7 +1355,7 @@ namespace PVR
       {
         if (item->GetEPGInfoTag()->HasPVRChannel())
         {
-          iClientID = item->GetEPGInfoTag()->ChannelTag()->ClientID();
+          iClientID = item->GetEPGInfoTag()->Channel()->ClientID();
           menuCategory = PVR_MENUHOOK_EPG;
         }
         else

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -885,7 +885,7 @@ void CPVRGUIInfo::UpdatePlayingTag(void)
     CPVREpgInfoTagPtr epgTag(GetPlayingTag());
     CPVRChannelPtr channel;
     if (epgTag)
-      channel = epgTag->ChannelTag();
+      channel = epgTag->Channel();
 
     if (!epgTag || !epgTag->IsActive() ||
         !channel || *channel != *currentChannel)

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -61,13 +61,13 @@ namespace PVR
     }
     else if (m_item->IsEPG())
     {
-      return m_item->GetEPGInfoTag()->ChannelTag();
+      return m_item->GetEPGInfoTag()->Channel();
     }
     else if (m_item->IsPVRTimer())
     {
       const CPVREpgInfoTagPtr epgTag(m_item->GetPVRTimerInfoTag()->GetEpgInfoTag());
       if (epgTag)
-        return epgTag->ChannelTag();
+        return epgTag->Channel();
     }
     else
     {
@@ -130,7 +130,7 @@ namespace PVR
     }
     else if (m_item->IsEPG())
     {
-      const CPVRChannelPtr channel(m_item->GetEPGInfoTag()->ChannelTag());
+      const CPVRChannelPtr channel(m_item->GetEPGInfoTag()->Channel());
       return (channel && channel->IsRadio());
     }
     else if (m_item->IsPVRRecording())

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -1048,7 +1048,7 @@ int CPVRChannelGroup::GetEPGAll(CFileItemList &results, bool bIncludeChannelsWit
       {
         // Add dummy EPG tag associated with this channel
         epgTag = CPVREpgInfoTag::CreateDefaultTag();
-        epgTag->SetPVRChannel(channel);
+        epgTag->SetChannel(channel);
         results.Add(CFileItemPtr(new CFileItem(epgTag)));
       }
     }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -78,7 +78,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(CGUIMessage &message)
   {
     bReturn = true;
 
-    if (!m_progItem || !m_progItem->HasPVRChannel())
+    if (!m_progItem || !m_progItem->HasChannel())
     {
       /* invalid channel */
       CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19067});

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -310,7 +310,7 @@ void CPVREpg::AddEntry(const CPVREpgInfoTag &tag)
   if (newTag)
   {
     newTag->Update(tag);
-    newTag->SetPVRChannel(channel);
+    newTag->SetChannel(channel);
     newTag->SetEpg(this);
     newTag->SetTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(newTag));
     newTag->SetRecording(CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(newTag));
@@ -438,7 +438,7 @@ bool CPVREpg::UpdateEntry(const CPVREpgInfoTagPtr &tag, bool bUpdateDatabase /* 
 
     infoTag->Update(*tag, bNewTag);
     infoTag->SetEpg(this);
-    infoTag->SetPVRChannel(m_pvrChannel);
+    infoTag->SetChannel(m_pvrChannel);
 
     if (bUpdateDatabase)
       m_changedTags.insert(std::make_pair(infoTag->UniqueBroadcastID(), infoTag));
@@ -856,7 +856,7 @@ void CPVREpg::SetChannel(const PVR::CPVRChannelPtr &channel)
     }
     m_pvrChannel = channel;
     for (std::map<CDateTime, CPVREpgInfoTagPtr>::iterator it = m_tags.begin(); it != m_tags.end(); ++it)
-      it->second->SetPVRChannel(m_pvrChannel);
+      it->second->SetChannel(m_pvrChannel);
   }
 }
 

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -419,7 +419,7 @@ CPVREpgInfoTagPtr CPVREpgContainer::GetTagById(const CPVRChannelPtr &channel, un
 
 std::vector<CPVREpgInfoTagPtr> CPVREpgContainer::GetEpgTagsForTimer(const CPVRTimerInfoTagPtr &timer) const
 {
-  CPVRChannelPtr channel(timer->ChannelTag());
+  CPVRChannelPtr channel(timer->Channel());
 
   if (!channel)
     channel = timer->UpdateChannel();

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -220,7 +220,7 @@ CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
   CDateTime now = CDateTime::GetUTCDateTime();
 
   CPVRChannelPtr channel(CServiceBroker::GetPVRManager().Clients()->GetPlayingChannel());
-  if (channel == ChannelTag())
+  if (channel == Channel())
   {
     // Timeshifting active?
     time_t time = CServiceBroker::GetPVRManager().Clients()->GetPlayingTime();
@@ -557,7 +557,7 @@ std::string CPVREpgInfoTag::PVRChannelName(void) const
   return strReturn;
 }
 
-const PVR::CPVRChannelPtr CPVREpgInfoTag::ChannelTag(void) const
+const PVR::CPVRChannelPtr CPVREpgInfoTag::Channel() const
 {
   CSingleLock lock(m_critSection);
   return m_pvrChannel;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -59,7 +59,7 @@ CPVREpgInfoTag::CPVREpgInfoTag(void) :
 {
 }
 
-CPVREpgInfoTag::CPVREpgInfoTag(CPVREpg *epg, const PVR::CPVRChannelPtr &pvrChannel, const std::string &strTableName /* = "" */, const std::string &strIconPath /* = "" */) :
+CPVREpgInfoTag::CPVREpgInfoTag(CPVREpg *epg, const PVR::CPVRChannelPtr &channel, const std::string &strTableName /* = "" */, const std::string &strIconPath /* = "" */) :
     m_bNotify(false),
     m_iBroadcastId(-1),
     m_iGenreType(0),
@@ -74,7 +74,7 @@ CPVREpgInfoTag::CPVREpgInfoTag(CPVREpg *epg, const PVR::CPVRChannelPtr &pvrChann
     m_strIconPath(strIconPath),
     m_epg(epg),
     m_iFlags(EPG_TAG_FLAG_UNDEFINED),
-    m_pvrChannel(pvrChannel)
+    m_channel(channel)
 {
   UpdatePath();
 }
@@ -141,7 +141,7 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
   bool bChannelMatch(false);
   {
     CSingleLock lock(m_critSection);
-    bChannelMatch = (m_pvrChannel == right.m_pvrChannel);
+    bChannelMatch = (m_channel == right.m_channel);
   }
   return (bChannelMatch &&
           m_bNotify            == right.m_bNotify &&
@@ -343,7 +343,7 @@ bool CPVREpgInfoTag::IsParentalLocked() const
   CPVRChannelPtr channel;
   {
     CSingleLock lock(m_critSection);
-    channel = m_pvrChannel;
+    channel = m_channel;
   }
 
   return channel && CServiceBroker::GetPVRManager().IsParentalLocked(channel);
@@ -526,32 +526,32 @@ CPVRTimerInfoTagPtr CPVREpgInfoTag::Timer(void) const
   return m_timer;
 }
 
-void CPVREpgInfoTag::SetPVRChannel(const PVR::CPVRChannelPtr &channel)
+void CPVREpgInfoTag::SetChannel(const PVR::CPVRChannelPtr &channel)
 {
   CSingleLock lock(m_critSection);
-  m_pvrChannel = channel;
+  m_channel = channel;
 }
 
-bool CPVREpgInfoTag::HasPVRChannel(void) const
+bool CPVREpgInfoTag::HasChannel(void) const
 {
   CSingleLock lock(m_critSection);
-  return m_pvrChannel.get() != NULL;
+  return m_channel.get() != NULL;
 }
 
-int CPVREpgInfoTag::PVRChannelNumber(void) const
+int CPVREpgInfoTag::ChannelNumber(void) const
 {
   CSingleLock lock(m_critSection);
-  return m_pvrChannel ? m_pvrChannel->ChannelNumber() : -1;
+  return m_channel ? m_channel->ChannelNumber() : -1;
 }
 
-std::string CPVREpgInfoTag::PVRChannelName(void) const
+std::string CPVREpgInfoTag::ChannelName(void) const
 {
   std::string strReturn;
 
   {
     CSingleLock lock(m_critSection);
-    if (m_pvrChannel)
-      strReturn = m_pvrChannel->ChannelName();
+    if (m_channel)
+      strReturn = m_channel->ChannelName();
   }
 
   return strReturn;
@@ -560,7 +560,7 @@ std::string CPVREpgInfoTag::PVRChannelName(void) const
 const PVR::CPVRChannelPtr CPVREpgInfoTag::Channel() const
 {
   CSingleLock lock(m_critSection);
-  return m_pvrChannel;
+  return m_channel;
 }
 
 bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /* = true */)
@@ -568,7 +568,7 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /
   bool bChanged(false);
   {
     CSingleLock lock(m_critSection);
-    bChanged = (m_pvrChannel != tag.m_pvrChannel);
+    bChanged = (m_channel != tag.m_channel);
   }
 
   {
@@ -626,7 +626,7 @@ bool CPVREpgInfoTag::Update(const CPVREpgInfoTag &tag, bool bUpdateBroadcastId /
 
       {
         CSingleLock lock(m_critSection);
-        m_pvrChannel       = tag.m_pvrChannel;
+        m_channel          = tag.m_channel;
       }
 
       if (m_iGenreType == EPG_GENRE_USE_STRING)

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -380,7 +380,7 @@ namespace PVR
      * @brief Get the channel that plays this event.
      * @return a pointer to the channel.
      */
-    const PVR::CPVRChannelPtr ChannelTag(void) const;
+    const PVR::CPVRChannelPtr Channel(void) const;
 
     /*!
      * @brief Persist this tag in the database.

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -64,7 +64,7 @@ namespace PVR
     /*!
      * @brief Create a new empty event without a unique ID.
      */
-    CPVREpgInfoTag(CPVREpg *epg, const PVR::CPVRChannelPtr &pvrChannel, const std::string &strTableName = "", const std::string &strIconPath = "");
+    CPVREpgInfoTag(CPVREpg *epg, const PVR::CPVRChannelPtr &channel, const std::string &strTableName = "", const std::string &strIconPath = "");
 
     CPVREpgInfoTag(const CPVREpgInfoTag &tag) = delete;
     CPVREpgInfoTag &operator =(const CPVREpgInfoTag &other) = delete;
@@ -365,16 +365,16 @@ namespace PVR
      * @brief Change the channel tag of this epg tag
      * @param channel The new channel
      */
-    void SetPVRChannel(const PVR::CPVRChannelPtr &channel);
+    void SetChannel(const PVR::CPVRChannelPtr &channel);
 
     /*!
      * @return True if this tag has a PVR channel set.
      */
-    bool HasPVRChannel(void) const;
+    bool HasChannel(void) const;
 
-    int PVRChannelNumber(void) const;
+    int ChannelNumber(void) const;
 
-    std::string PVRChannelName(void) const;
+    std::string ChannelName(void) const;
 
     /*!
      * @brief Get the channel that plays this event.
@@ -461,7 +461,7 @@ namespace PVR
     unsigned int             m_iFlags;             /*!< the flags applicable to this EPG entry */
 
     CCriticalSection         m_critSection;
-    PVR::CPVRChannelPtr      m_pvrChannel;
+    PVR::CPVRChannelPtr      m_channel;
     PVR::CPVRRecordingPtr    m_recording;
   };
 }

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -185,7 +185,7 @@ int CPVREpgSearchFilter::RemoveDuplicates(CFileItemList &results)
 
 bool CPVREpgSearchFilter::MatchChannelType(const CPVREpgInfoTagPtr &tag) const
 {
-  return (CServiceBroker::GetPVRManager().IsStarted() && tag->ChannelTag()->IsRadio() == m_bIsRadio);
+  return (CServiceBroker::GetPVRManager().IsStarted() && tag->Channel()->IsRadio() == m_bIsRadio);
 }
 
 bool CPVREpgSearchFilter::MatchChannelNumber(const CPVREpgInfoTagPtr &tag) const
@@ -198,7 +198,7 @@ bool CPVREpgSearchFilter::MatchChannelNumber(const CPVREpgInfoTagPtr &tag) const
     if (!group)
       group = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAllTV();
 
-    bReturn = (m_iChannelNumber == (int) group->GetChannelNumber(tag->ChannelTag()));
+    bReturn = (m_iChannelNumber == (int) group->GetChannelNumber(tag->Channel()));
   }
 
   return bReturn;
@@ -211,7 +211,7 @@ bool CPVREpgSearchFilter::MatchChannelGroup(const CPVREpgInfoTagPtr &tag) const
   if (m_iChannelGroup != EPG_SEARCH_UNSET && CServiceBroker::GetPVRManager().IsStarted())
   {
     CPVRChannelGroupPtr group = CServiceBroker::GetPVRManager().ChannelGroups()->GetByIdFromAll(m_iChannelGroup);
-    bReturn = (group && group->IsGroupMember(tag->ChannelTag()));
+    bReturn = (group && group->IsGroupMember(tag->Channel()));
   }
 
   return bReturn;
@@ -219,7 +219,7 @@ bool CPVREpgSearchFilter::MatchChannelGroup(const CPVREpgInfoTagPtr &tag) const
 
 bool CPVREpgSearchFilter::MatchFreeToAir(const CPVREpgInfoTagPtr &tag) const
 {
-  return (!m_bFreeToAirOnly || !tag->ChannelTag()->IsEncrypted());
+  return (!m_bFreeToAirOnly || !tag->Channel()->IsEncrypted());
 }
 
 bool CPVREpgSearchFilter::MatchTimers(const CPVREpgInfoTagPtr &tag) const

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -142,7 +142,7 @@ bool CPVREpgSearchFilter::FilterEntry(const CPVREpgInfoTagPtr &tag) const
       MatchSearchTerm(tag) &&
       MatchTimers(tag) &&
       MatchRecordings(tag)) &&
-      (!tag->HasPVRChannel() ||
+      (!tag->HasChannel() ||
        (MatchChannelType(tag) &&
         MatchChannelNumber(tag) &&
         MatchChannelGroup(tag) &&

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -493,9 +493,9 @@ CPVRRecordingPtr CPVRRecordings::GetRecordingForEpgTag(const CPVREpgInfoTagPtr &
 
       // note: don't use recording.second->Channel() for comparing channels here as this can lead
       //       to deadlocks. compare client ids and channel ids instead, this has the same effect.
-      if (epgTag->ChannelTag() &&
-          recording.second->ClientID() == epgTag->ChannelTag()->ClientID() &&
-          recording.second->ChannelUid() == epgTag->ChannelTag()->UniqueID() &&
+      if (epgTag->Channel() &&
+          recording.second->ClientID() == epgTag->Channel()->ClientID() &&
+          recording.second->ChannelUid() == epgTag->Channel()->UniqueID() &&
           recording.second->RecordingTimeAsUTC() <= epgTag->StartAsUTC() &&
           recording.second->EndTimeAsUTC() >= epgTag->EndAsUTC())
         return recording.second;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -680,14 +680,14 @@ void CPVRTimerInfoTag::DisplayError(PVR_ERROR err) const
 
 int CPVRTimerInfoTag::ChannelNumber() const
 {
-  CPVRChannelPtr channeltag = ChannelTag();
+  CPVRChannelPtr channeltag = Channel();
   return channeltag ? channeltag->ChannelNumber() : 0;
 }
 
 std::string CPVRTimerInfoTag::ChannelName() const
 {
   std::string strReturn;
-  CPVRChannelPtr channeltag = ChannelTag();
+  CPVRChannelPtr channeltag = Channel();
   if (channeltag)
     strReturn = channeltag->ChannelName();
   else if (m_timerType && m_timerType->IsEpgBasedTimerRule())
@@ -699,7 +699,7 @@ std::string CPVRTimerInfoTag::ChannelName() const
 std::string CPVRTimerInfoTag::ChannelIcon() const
 {
   std::string strReturn;
-  CPVRChannelPtr channeltag = ChannelTag();
+  CPVRChannelPtr channeltag = Channel();
   if (channeltag)
     strReturn = channeltag->IconPath();
   return strReturn;
@@ -781,7 +781,7 @@ CPVRTimerInfoTagPtr CPVRTimerInfoTag::CreateFromEpg(const CPVREpgInfoTagPtr &tag
   CPVRTimerInfoTagPtr newTag(new CPVRTimerInfoTag());
 
   /* check if a valid channel is set */
-  CPVRChannelPtr channel = tag->ChannelTag();
+  CPVRChannelPtr channel = tag->Channel();
   if (!channel)
   {
     CLog::Log(LOGERROR, "%s - no channel set", __FUNCTION__);
@@ -1050,7 +1050,7 @@ bool CPVRTimerInfoTag::HasChannel() const
   return m_channel.get() != nullptr;
 }
 
-CPVRChannelPtr CPVRTimerInfoTag::ChannelTag(void) const
+CPVRChannelPtr CPVRTimerInfoTag::Channel() const
 {
   return m_channel;
 }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -1045,6 +1045,11 @@ void CPVRTimerInfoTag::ClearEpgTag(void)
   SetEpgTag(CPVREpgInfoTagPtr());
 }
 
+bool CPVRTimerInfoTag::HasChannel() const
+{
+  return m_channel.get() != nullptr;
+}
+
 CPVRChannelPtr CPVRTimerInfoTag::ChannelTag(void) const
 {
   return m_channel;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -103,7 +103,7 @@ namespace PVR
      * @brief Get the channel associated with this timer, if any.
      * @return the channel or null if non is associated with this timer.
      */
-    CPVRChannelPtr ChannelTag(void) const;
+    CPVRChannelPtr Channel() const;
 
     /*!
      * @brief updates this timer excluding the state of any children. See UpdateChildState/ResetChildState.

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -92,6 +92,17 @@ namespace PVR
     int ChannelNumber(void) const;
     std::string ChannelName(void) const;
     std::string ChannelIcon(void) const;
+
+    /*!
+     * @brief Check whether this timer has an associated channel.
+     * @return True if this timer has a channel set, false otherwise.
+     */
+    bool HasChannel() const;
+
+    /*!
+     * @brief Get the channel associated with this timer, if any.
+     * @return the channel or null if non is associated with this timer.
+     */
     CPVRChannelPtr ChannelTag(void) const;
 
     /*!

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -656,7 +656,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
       {
         bool bDeleteActiveItem = !bCurrentlyActiveOnly || (*timerIt)->IsRecording();
         bool bDeleteTimerRuleItem = bDeleteTimerRules || !(*timerIt)->IsTimerRule();
-        bool bChannelsMatch = (*timerIt)->HasChannel() && (*timerIt)->ChannelTag() == channel;
+        bool bChannelsMatch = (*timerIt)->HasChannel() && (*timerIt)->Channel() == channel;
 
         if (bDeleteActiveItem && bDeleteTimerRuleItem && bChannelsMatch)
         {
@@ -769,7 +769,7 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CPVREpgInfoTagPtr &epgTa
       return timer;
 
     // try to find a matching timer for the tag.
-    const CPVRChannelPtr channel(epgTag->ChannelTag());
+    const CPVRChannelPtr channel(epgTag->Channel());
     if (channel)
     {
       CSingleLock lock(m_critSection);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -656,7 +656,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
       {
         bool bDeleteActiveItem = !bCurrentlyActiveOnly || (*timerIt)->IsRecording();
         bool bDeleteTimerRuleItem = bDeleteTimerRules || !(*timerIt)->IsTimerRule();
-        bool bChannelsMatch = (*timerIt)->ChannelTag() == channel;
+        bool bChannelsMatch = (*timerIt)->HasChannel() && (*timerIt)->ChannelTag() == channel;
 
         if (bDeleteActiveItem && bDeleteTimerRuleItem && bChannelsMatch)
         {
@@ -815,7 +815,7 @@ bool CPVRTimers::HasRecordingTimerForRecording(const CPVRRecording &recording) c
       if (timersEntry->IsRecording() &&
           !timersEntry->IsTimerRule() &&
           timersEntry->m_iClientId == recording.ClientID() &&
-          timersEntry->ChannelTag()->UniqueID() == recording.ChannelUid() &&
+          timersEntry->m_iClientChannelUid == recording.ChannelUid() &&
           timersEntry->StartAsUTC() <= recording.RecordingTimeAsUTC() &&
           timersEntry->EndAsUTC() >= recording.EndTimeAsUTC())
       {

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -692,7 +692,7 @@ void CGUIEPGGridContainer::UpdateItems()
       else
         newBlockIndex = (eventStart - gridStart).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
 
-      const CPVRChannelPtr channel(prevSelectedEpgTag->ChannelTag());
+      const CPVRChannelPtr channel(prevSelectedEpgTag->Channel());
       if (channel)
         channelUid = channel->UniqueID();
 
@@ -702,7 +702,7 @@ void CGUIEPGGridContainer::UpdateItems()
     {
       const GridItem *currItem(GetItem(m_channelCursor));
       if (currItem)
-        channelUid = currItem->item->GetEPGInfoTag()->ChannelTag()->UniqueID();
+        channelUid = currItem->item->GetEPGInfoTag()->Channel()->UniqueID();
 
       const GridItem *prevItem(GetPrevItem(m_channelCursor));
       if (prevItem)
@@ -772,7 +772,7 @@ void CGUIEPGGridContainer::UpdateItems()
         newChannelIndex = iChannelIndex;
       }
       else if (newChannelIndex >= m_gridModel->ChannelItemsSize() ||
-               m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->ChannelTag() != prevSelectedEpgTag->ChannelTag())
+               m_gridModel->GetGridItem(newChannelIndex, newBlockIndex)->GetEPGInfoTag()->Channel() != prevSelectedEpgTag->Channel())
       {
         // default to first channel
         newChannelIndex = 0;

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
@@ -79,7 +79,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
   for (int i = 0; i < items->Size(); ++i)
   {
     fileItem = items->Get(i);
-    if (!fileItem->HasEPGInfoTag() || !fileItem->GetEPGInfoTag()->HasPVRChannel())
+    if (!fileItem->HasEPGInfoTag() || !fileItem->GetEPGInfoTag()->HasChannel())
       continue;
 
     m_programmeItems.emplace_back(fileItem);
@@ -224,7 +224,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
         else
         {
           CPVREpgInfoTagPtr gapTag(CPVREpgInfoTag::CreateDefaultTag());
-          gapTag->SetPVRChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
+          gapTag->SetChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
           CFileItemPtr gapItem(new CFileItem(gapTag));
           for (int i = block + blockDelta; i >= block - itemSize + sizeDelta; --i)
           {
@@ -249,7 +249,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
           else
           {
             CPVREpgInfoTagPtr gapTag(CPVREpgInfoTag::CreateDefaultTag());
-            gapTag->SetPVRChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
+            gapTag->SetChannel(m_channelItems[channel]->GetPVRChannelInfoTag());
             CFileItemPtr gapItem(new CFileItem(gapTag));
             m_gridIndex[channel][block].item = gapItem;
           }

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
@@ -84,7 +84,7 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
 
     m_programmeItems.emplace_back(fileItem);
 
-    channel = fileItem->GetEPGInfoTag()->ChannelTag();
+    channel = fileItem->GetEPGInfoTag()->Channel();
     if (!channel)
       continue;
 
@@ -291,7 +291,7 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
 
         if (!bFoundPrevChannel && channelUid > -1)
         {
-          chan = tag->ChannelTag();
+          chan = tag->Channel();
           if (chan && chan->UniqueID() == channelUid)
           {
             newChannelIndex = channel;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -563,7 +563,7 @@ void CGUIWindowPVRGuideBase::OnInputDone()
     for (const CFileItemPtr event : m_vecItems->GetList())
     {
       const CPVREpgInfoTagPtr tag(event->GetEPGInfoTag());
-      if (tag->HasPVRChannel() && tag->PVRChannelNumber() == iChannelNumber)
+      if (tag->HasChannel() && tag->ChannelNumber() == iChannelNumber)
       {
         CGUIEPGGridContainer* epgGridContainer = GetGridControl();
         if (epgGridContainer)

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -568,7 +568,7 @@ void CGUIWindowPVRGuideBase::OnInputDone()
         CGUIEPGGridContainer* epgGridContainer = GetGridControl();
         if (epgGridContainer)
         {
-          epgGridContainer->SetChannel(tag->ChannelTag());
+          epgGridContainer->SetChannel(tag->Channel());
           return;
         }
       }


### PR DESCRIPTION
The first commit fixes a crash described here: https://github.com/janbar/pvr.mythtv/issues/77

The second and third commit are just some code cosmetics.

This change has been runtime-tested on macOS, latest Kodi master.

@janbar fyi