### PR TITLE
[windowtranslator] windowname is std::string

### DIFF
--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -244,12 +244,12 @@ int CWindowTranslator::GetFallbackWindow(int windowId)
   return -1;
 }
 
-std::map<int, const char*> CWindowTranslator::CreateReverseWindowMapping()
+std::map<int, std::string> CWindowTranslator::CreateReverseWindowMapping()
 {
-  std::map<WindowID, const char*> reverseWindowMapping;
+  std::map<WindowID, WindowName> reverseWindowMapping;
 
   for (auto itMapping : WindowMapping)
-    reverseWindowMapping.insert(std::make_pair(itMapping.second, itMapping.first.c_str()));
+    reverseWindowMapping.insert(std::make_pair(itMapping.second, itMapping.first));
 
   return reverseWindowMapping;
 }

--- a/xbmc/input/WindowTranslator.h
+++ b/xbmc/input/WindowTranslator.h
@@ -52,5 +52,5 @@ public:
   static int GetFallbackWindow(int windowId);
 
 private:
-  static std::map<int, const char*> CreateReverseWindowMapping();
+  static std::map<int, std::string> CreateReverseWindowMapping();
 };


### PR DESCRIPTION
This fixes an issue reported on the forums (https://forum.kodi.tv/showthread.php?tid=319304) where the DebugInfo fails to display the actual translated window name.