### PR TITLE
Navigationfix when closing addons

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -897,6 +897,12 @@ void CGUIWindowManager::OnApplicationMessage(ThreadMessage* pMsg)
   }
   break;
 
+  case TMSG_GUI_PREVIOUS_WINDOW:
+  {
+    PreviousWindow();
+  }
+  break;
+
   case TMSG_GUI_ADDON_DIALOG:
   {
     if (pMsg->lpVoid)

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -671,7 +671,7 @@ namespace XBMCAddon
 
       {
         DelayedCallGuard dcguard(languageHook);
-        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTIVATE_WINDOW, iOldWindowId, 0);
+        CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_PREVIOUS_WINDOW, iOldWindowId, 0);
       }
 
       iOldWindowId = 0;

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -133,6 +133,15 @@
 */
 #define TMSG_GUI_DIALOG_YESNO             TMSG_MASK_WINDOWMANAGER + 8
 
+/*!
+  \def TMSG_GUI_PREVIOUS_WINDOW
+  \brief Message sent through CApplicationMessenger to go back to the previous window
+
+  This is an alternative to TMSG_GUI_ACTIVATE_WINDOW, but it keeps
+  all configured parameters, like startup directory.
+*/
+#define TMSG_GUI_PREVIOUS_WINDOW          TMSG_MASK_WINDOWMANAGER + 9
+
 
 #define TMSG_CALLBACK                     800
 


### PR DESCRIPTION
This adds a new message to trigger PREVIOUS_WINDOW from a python addon.
When calling "close" from an addon we now trigger the new message instead of ACTIVATE_WINDOW.

## Motivation and Context
Scenario:
* You started up kodi and went into the tvshow section.
* You have access to an addon there and open it.
* The addon is not a dialog window but a normal window.
* When you hit back to close the addon, you are in the tvshow section again.
* When you hit back again, you assume to be taken to the home screen again, instead
  you are in the folder view of the MyVideoNav.xml

This happens because the ACTIVATE_WINDOW initializes the window without a start directory.
I can not think about any case where you want to not go "back" when closing an addon.

Maybe anyone can judge if this change is correct!?

## How Has This Been Tested?
Tested with kodi master and a windowed addon.

## Types of change
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@Paxxi Do I need any more documentation when I add new Appmessenger messages?
@xhaggi You've been in the reviewer suggestions ;)