### PR TITLE
[Music]Fix missing "* Item Folder" entry when browsing for artist fanart

### DIFF
--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -504,9 +504,10 @@ void CGUIDialogMusicInfo::OnGetFanart()
   }
 
   std::string result;
-  VECSOURCES sources = *CMediaSourceSettings::GetInstance().GetSources("music");
+  bool flip = false;
+  VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
+  AddItemPathToFileBrowserSources(sources, *m_albumItem);
   g_mediaManager.GetLocalDrives(sources);
-  bool flip=false;
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(20437), result, &flip, 20445))
     return;   // user cancelled
 


### PR DESCRIPTION
Fix missing "* Item Folder" entry when browsing for artist fanart from Artist Info Dialog