### PR TITLE
Fix crash if a button in joystick.xml has no action

### DIFF
--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -21,7 +21,6 @@
 #include "JoystickMapper.h"
 #include "ActionIDs.h"
 #include "ActionTranslator.h"
-#include "input/joysticks/JoystickIDs.h"
 #include "input/joysticks/JoystickTranslator.h"
 #include "input/joysticks/JoystickUtils.h"
 #include "input/WindowKeymap.h"
@@ -47,6 +46,8 @@ void CJoystickMapper::MapActions(int windowID, const TiXmlNode *pDevice)
 {
   std::string controllerId;
   DeserializeJoystickNode(pDevice, controllerId);
+  if (controllerId.empty())
+    return;
 
   const TiXmlElement *pButton = pDevice->FirstChildElement();
   while (pButton != nullptr)
@@ -106,8 +107,6 @@ std::vector<std::shared_ptr<const IWindowKeymap>> CJoystickMapper::GetJoystickKe
 
 void CJoystickMapper::DeserializeJoystickNode(const TiXmlNode* pDevice, std::string &controllerId)
 {
-  controllerId = DEFAULT_CONTROLLER_ID;
-
   const TiXmlElement* deviceElem = pDevice->ToElement();
   if (deviceElem != nullptr)
     deviceElem->QueryValueAttribute(JOYSTICK_XML_NODE_PROFILE, &controllerId);

--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -118,7 +118,12 @@ bool CJoystickMapper::DeserializeButton(const TiXmlElement *pButton, std::string
   const char *szButton = pButton->Value();
   if (szButton != nullptr)
   {
-    const char *szAction = pButton->FirstChild()->Value();
+    const char *szAction = nullptr;
+
+    const TiXmlNode *actionNode = pButton->FirstChild();
+    if (actionNode != nullptr)
+      szAction = actionNode->Value();
+
     if (szAction != nullptr)
     {
       feature = szButton;


### PR DESCRIPTION
Reported here: https://github.com/xbmc/xbmc/pull/12366#issuecomment-319995896

## How Has This Been Tested?
Confirmed that an empty action (e.g. `<a></a>`) causes Kodi to crash on startup, and this PR fixes the crash.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
