### PR TITLE
VAAPI: fix hevc interop test

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -391,9 +391,15 @@ bool CVaapiTexture::TestInteropHevc(VADisplay vaDpy, EGLDisplay eglDisplay)
   VAImage image;
   VABufferInfo bufferInfo;
 
+  VASurfaceAttrib attribs = { };
+  attribs.flags = VA_SURFACE_ATTRIB_SETTABLE;
+  attribs.type = VASurfaceAttribPixelFormat;
+  attribs.value.type = VAGenericValueTypeInteger;
+  attribs.value.value.i = VA_FOURCC_P010;
+
   if (vaCreateSurfaces(vaDpy,  VA_RT_FORMAT_YUV420_10BPP,
                        width, height,
-                       &surface, 1, NULL, 0) != VA_STATUS_SUCCESS)
+                       &surface, 1, &attribs, 1) != VA_STATUS_SUCCESS)
   {
     return ret;
   }


### PR DESCRIPTION
In light of changes present in mesa 17.2.x it seems that they have become more strict or it was just working by chance before.

before:
```
(gdb) print image
 = {image_id = 167772160, format = {fourcc = 842094169, byte_order = 1, bits_per_pixel = 12, depth = 0, red_mask = 0, green_mask = 0, 
    blue_mask = 0, alpha_mask = 0}, buf = 134217728, width = 1920, height = 1080, data_size = 3133440, num_planes = 3, pitches = {1920, 
    960, 960}, offsets = {0, 2088960, 2611200}, num_palette_entries = 0, entry_bytes = 0, component_order = 000000000}
```

after:
```
(gdb) print image
 = {image_id = 167772160, format = {fourcc = 808530000, byte_order = 1, bits_per_pixel = 24, depth = 0, red_mask = 0, green_mask = 0, 
    blue_mask = 0, alpha_mask = 0}, buf = 134217728, width = 1920, height = 1080, data_size = 6266880, num_planes = 2, pitches = {3840, 
    3840, 0}, offsets = {0, 4177920, 0}, num_palette_entries = 0, entry_bytes = 0, component_order = 000000000}
```

Thanks to the guys in #dri-devel for helping out on this one