### PR TITLE
[PVR] Fix channel preview OSD (now behaves like in Krypton again).

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -135,11 +135,14 @@ bool CPVRActionListener::OnAction(const CAction &action)
       if (!bIsPlayingPVR)
         return false;
 
-      if ((action.GetID() == ACTION_MOVE_UP && // only up/down shows a preview, all others do switch
-           CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH)) ||
-          CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT) > 0)
+      if (action.GetID() == ACTION_MOVE_UP && // only up/down shows only a preview, all others do switch
+          CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH))
       {
-        CServiceBroker::GetPVRManager().ChannelPreviewUp();
+        CServiceBroker::GetPVRManager().ChannelPreviewUp(ChannelSwitchMode::NO_SWITCH);
+      }
+      else if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT) > 0)
+      {
+        CServiceBroker::GetPVRManager().ChannelPreviewUp(ChannelSwitchMode::DELAYED_SWITCH);
       }
       else
       {
@@ -157,11 +160,14 @@ bool CPVRActionListener::OnAction(const CAction &action)
       if (!bIsPlayingPVR)
         return false;
 
-      if ((action.GetID() == ACTION_MOVE_DOWN && // only up/down shows a preview, all others do switch
-           CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH)) ||
-          CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT) > 0)
+      if (action.GetID() == ACTION_MOVE_DOWN && // only up/down shows only a preview, all others do switch
+          CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH))
       {
-        CServiceBroker::GetPVRManager().ChannelPreviewDown();
+        CServiceBroker::GetPVRManager().ChannelPreviewDown(ChannelSwitchMode::NO_SWITCH);
+      }
+      else if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT) > 0)
+      {
+        CServiceBroker::GetPVRManager().ChannelPreviewDown(ChannelSwitchMode::DELAYED_SWITCH);
       }
       else
       {

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -71,6 +71,12 @@ namespace PVR
     bool m_bStopped;
   };
 
+  enum class ChannelSwitchMode
+  {
+    NO_SWITCH,
+    DELAYED_SWITCH
+  };
+
   class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer
   {
   public:
@@ -465,23 +471,17 @@ namespace PVR
     /*!
      * @brief Activate channel preview for next channel in current channel group.
      */
-    void ChannelPreviewUp();
+    void ChannelPreviewUp(ChannelSwitchMode eSwitchMode);
 
     /*!
      * @brief Activate channel preview for previous channel in current channel group.
      */
-    void ChannelPreviewDown();
+    void ChannelPreviewDown(ChannelSwitchMode eSwitchMode);
 
     /*!
      * @brief Switch to the channel currently previewed.
      */
     void ChannelPreviewSelect();
-
-    /*!
-     * @brief Explicitly set the state of channel preview. This is when channel is displayed on OSD without actually switching
-     * @param bPreview true to activate channel preview, false otherwise.
-     */
-    void SetChannelPreview(bool bPreview);
 
     /*!
      * @brief Query the state of channel preview
@@ -578,7 +578,7 @@ namespace PVR
      * @brief Activate preview for a given channel.
      * @param item the channel the preview is to be activated for.
      */
-    void ChannelPreview(const CFileItemPtr item);
+    void ChannelPreview(const CFileItemPtr item, ChannelSwitchMode eSwitchMode);
 
     /*!
      * @brief Continue playback on the last played channel.


### PR DESCRIPTION
@da-anda you reported a functional change in behavior on Slack. This PR restores the behavior as we had it in Krypton. up/down action now again ignores "channel switch delay" setting if "confirm channel switch with ok" setting is active.

This change has been runtime -tested on macOS, latest kodi master.

@FernetMenta mind taking a look.