### PR TITLE
[ADDON] Transfer ContentLookup properly

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -188,6 +188,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
       resultItem.SetProperty("original_listitem_url", resultItem.GetPath());
     resultItem.SetPath(newDir.m_fileResult->GetPath());
     resultItem.SetMimeType(newDir.m_fileResult->GetMimeType());
+    resultItem.SetContentLookup(newDir.m_fileResult->ContentLookup());
     resultItem.UpdateInfo(*newDir.m_fileResult);
     if (newDir.m_fileResult->HasVideoInfoTag() && newDir.m_fileResult->GetVideoInfoTag()->GetResumePoint().IsSet())
       resultItem.m_lStartOffset = STARTOFFSET_RESUME; // resume point set in the resume item, so force resume


### PR DESCRIPTION
## Description
Currently calling listItem.setContentLookup from python addon does nothing, because it's value is not copied from Addon ListItem -> kodi ListItem in PluginDirectory. This PR does the copy step.

## Motivation and Context
Some Addons fail if Mime-Type is checked (HEAD request)

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
