### PR TITLE
[ADDON API] #define __stat64 for DARWIN_IOS

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -26,7 +26,11 @@
 #if !defined(_WIN32)
   #include <sys/stat.h>
   #if !defined(__stat64)
-    #define __stat64 stat64
+    #if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
+      #define __stat64 stat
+    #else
+      #define __stat64 stat64
+    #endif
   #endif
 #endif
 #ifdef _WIN32                   // windows


### PR DESCRIPTION
## Description
inputstream.adaptive does not compile because of unresolved stat64 on IOS
This PR introduces the same platform behaviour be found in linux/Platformdefs.h

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
