### PR TITLE
Fix crash on exit

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2715,6 +2715,8 @@ bool CApplication::Cleanup()
 {
   try
   {
+    StopPlaying();
+
     if (m_ServiceManager)
       m_ServiceManager->DeinitStageThree();
 


### PR DESCRIPTION
This fixes a crash that occurs when a game is playing on exit. Games depend on services brought up by service manager, so make sure gameplay has ended before tearing down the services.

## How Has This Been Tested?
Tested on windows. Kodi now exits cleanly when the application is quit during gameplay.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
