### PR TITLE
AESinkALSA: Return false if we don't know about our output channels

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -618,6 +618,11 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
   }
   // adjust format to the configuration we got
   format.m_channelLayout = GetChannelLayout(format, outconfig.channels);
+  // we might end up with an unusable channel layout that contains only UNKNOWN
+  // channels, let's do a sanity check.
+  if (!format.m_channelLayout.IsLayoutValid())
+    return false;
+
   format.m_sampleRate = outconfig.sampleRate;
   format.m_frames = outconfig.periodSize;
   format.m_frameSize = outconfig.frameSize;

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -257,6 +257,30 @@ CAEChannelInfo::operator std::string() const
   return s;
 }
 
+bool CAEChannelInfo::IsChannelValid(const unsigned int pos)
+{
+  assert(pos < m_channelCount);
+  bool isValid = false;
+  if (m_channels[pos] > AE_CH_NULL && m_channels[pos] < AE_CH_UNKNOWN1)
+    isValid = true;
+
+  return isValid;
+}
+
+bool CAEChannelInfo::IsLayoutValid()
+{
+  if (m_channelCount == 0)
+    return false;
+
+  for (unsigned int i = 0; i < m_channelCount; ++i)
+  {
+    // we need at least one valid channel
+    if (IsChannelValid(i))
+      return true;
+  }
+  return false;
+}
+
 const char* CAEChannelInfo::GetChName(const enum AEChannel ch)
 {
   assert(ch >= 0 && ch < AE_CH_MAX);

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.h
@@ -51,6 +51,8 @@ public:
   inline unsigned int Count() const { return m_channelCount; }
   static const char* GetChName(const enum AEChannel ch);
   bool HasChannel(const enum AEChannel ch) const;
+  bool IsChannelValid(const unsigned int pos);
+  bool IsLayoutValid();
   bool ContainsChannels(const CAEChannelInfo& rhs) const;
   void ReplaceChannel(const enum AEChannel from, const enum AEChannel to);
   int BestMatch(const std::vector<CAEChannelInfo>& dsts, int* score = NULL) const;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
A sink is not allowed to return an unusable channel map. Therefore a check was introduced to find at least one channel that is not AE_CH_UNKNOWN1. Else we return false on Initialization.

## Motivation and Context
Lrusak gets issues with ffmpeg's resampler cannot init, cause of an empty destination layout, caused by ALSA sink returning UNKNOWN1, UNKNOWN1 map when it is queried while the display is off on refreshrate switching

## How Has This Been Tested?
Was not runtime tested. Let's wait on @lrusak for testing. Kodi should not crash anymore as we will fallback on the NULL sink first.


## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
