### PR TITLE
Fix path autoconf-pre-depends looks in for m4

### DIFF
--- a/tools/depends/pre-depends/autoconf-pre-depends/Makefile
+++ b/tools/depends/pre-depends/autoconf-pre-depends/Makefile
@@ -10,7 +10,7 @@ VERSION=2.68
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
-export PATH:=$(CURDIR)/../pre-build-deps/bin:$(PATH)
+export PATH:=$(CURDIR)/../../pre-build-deps/bin:$(PATH)
 
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX)

--- a/tools/depends/pre-depends/m4-pre-depends/Makefile
+++ b/tools/depends/pre-depends/m4-pre-depends/Makefile
@@ -1,4 +1,5 @@
 include ../../Makefile.include.in
+DEPS=Makefile
 PREFIX=$(CURDIR)/../../pre-build-deps
 PLATFORM=native
 TARBALLS_LOCATION=$(PREFIX)
@@ -6,14 +7,14 @@ RETRIEVE_TOOL=curl
 ARCHIVE_TOOL=tar
 # lib name, version
 LIBNAME=m4
-VERSION=1.4.9
+VERSION=1.4.17
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX)
 
-LIBDYLIB=$(PLATFORM)/bin/$(LIBNAME)
+LIBDYLIB=$(PLATFORM)/src/$(LIBNAME)
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 


### PR DESCRIPTION
The pre-build-deps folder is under tools/depends so one .. is missing

## Description
<!--- Describe your change in detail -->

## Motivation and Context
pre-depends build fails because autoconf does not find m4

## How Has This Been Tested?
depends build on linux

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
