### PR TITLE
Don't export CAddonBase for gnu compilers

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -38,10 +38,12 @@
 #undef ATTRIBUTE_PACKED
 #undef PRAGMA_PACK_BEGIN
 #undef PRAGMA_PACK_END
+#undef ATTRIBUTE_NOEXPORT
 
 #if defined(__GNUC__)
   #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
     #define ATTRIBUTE_PACKED __attribute__ ((packed))
+    #define ATTRIBUTE_NOEXPORT __attribute__((visibility("hidden")))
     #define PRAGMA_PACK 0
   #endif
 #endif
@@ -49,6 +51,10 @@
 #if !defined(ATTRIBUTE_PACKED)
   #define ATTRIBUTE_PACKED
   #define PRAGMA_PACK 1
+#endif
+
+#if !defined(ATTRIBUTE_NOEXPORT)
+  #define ATTRIBUTE_NOEXPORT
 #endif
 
 #include "versions.h"
@@ -273,7 +279,7 @@ private:
 namespace kodi {
 namespace addon {
 /// Add-on main instance class.
-class CAddonBase
+class ATTRIBUTE_NOEXPORT CAddonBase
 {
 public:
   CAddonBase()


### PR DESCRIPTION
## Description
Class symbol visibility leads at least on OSX / GNU to wrong behaviour during binary addon initialization.
This PR prevents CAddonBase class to export itself.

## Motivation and Context
Opening inputstream binary addon on OSX mixes method calls with Joystick addon.

## How Has This Been Tested?
@FernetMenta runtime tested on OSX

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
