### PR TITLE
[addons] save skin settings after they get changed

### DIFF
--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -36,6 +36,8 @@ class CSetting;
 namespace ADDON
 {
 
+class CSkinSettingUpdateHandler;
+
 class CSkinSetting
 {
 public:
@@ -109,11 +111,9 @@ public:
   static std::unique_ptr<CSkinInfo> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
 
   //FIXME: CAddonCallbacksGUI/WindowXML hack
-  explicit CSkinInfo(CAddonInfo addonInfo, const RESOLUTION_INFO& resolution = RESOLUTION_INFO())
-      : CAddon(std::move(addonInfo)),
-        m_defaultRes(resolution),
-        m_effectsSlowDown(1.f),
-        m_debugging(false) {}
+  explicit CSkinInfo(
+      CAddonInfo addonInfo,
+      const RESOLUTION_INFO& resolution = RESOLUTION_INFO());
 
   CSkinInfo(
       CAddonInfo addonInfo,
@@ -121,6 +121,8 @@ public:
       const std::vector<RESOLUTION_INFO>& resolutions,
       float effectsSlowDown,
       bool debugging);
+
+  ~CSkinInfo() override;
 
   /*! \brief Load resolution information from directories in Path().
    */
@@ -243,6 +245,7 @@ protected:
 private:
   std::map<int, CSkinSettingStringPtr> m_strings;
   std::map<int, CSkinSettingBoolPtr> m_bools;
+  std::unique_ptr<CSkinSettingUpdateHandler> m_settingsUpdateHandler;
 };
 
 } /*namespace ADDON*/


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Skin settings are not saved immediately after changing them, only on switching skins and a clean shutdown. To not lose the changes if Kodi crashes or something else happens the settings will now be saved after they get changed. This is done by a handler which do a delayed (atm 500ms) call to save the settings. Each update to a skin setting will trigger the handler but results in an unique save call within the delay period of 500ms.

@Montellese and @MartijnKaijser mind taking a look.

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Feature request: https://forum.kodi.tv/showthread.php?tid=319552

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested on MacOS

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)