### PR TITLE
DemuxClient: Force intialization of stream after OpenStream

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3729,11 +3729,6 @@ void CApplication::UpdateFileState()
            streamdetails if total duration > 15m (Should yield more correct info) */
         if (!(m_progressTrackingItem->IsDiscImage() || m_progressTrackingItem->IsDVDFile()) || m_pPlayer->GetTotalTime() > 15*60*1000)
         {
-          CStreamDetails details;
-          // Update with stream details from player, if any
-          if (m_pPlayer->GetStreamDetails(details))
-            m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails = details;
-
           if (m_progressTrackingItem->IsStack())
             m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails.SetVideoDuration(0, (int)GetTotalTime()); // Overwrite with CApp's totaltime as it takes into account total stack time
         }

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -545,12 +545,6 @@ bool CApplicationPlayer::QueueNextFile(const CFileItem &file)
   return (player && player->QueueNextFile(file));
 }
 
-bool CApplicationPlayer::GetStreamDetails(CStreamDetails &details)
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  return (player && player->GetStreamDetails(details));
-}
-
 bool CApplicationPlayer::SetPlayerState(const std::string& state)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -115,7 +115,6 @@ public:
   std::string GetPlayerState();
   std::string GetPlayingTitle();
   int   GetPreferredPlaylist() const;
-  bool  GetStreamDetails(CStreamDetails &details);
   int   GetSubtitle();
   void  GetSubtitleCapabilities(std::vector<int> &subCaps);
   int   GetSubtitleCount();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -314,7 +314,6 @@ public:
    */
   virtual void SetTotalTime(int64_t time) { }
   virtual int GetSourceBitrate(){ return 0;}
-  virtual bool GetStreamDetails(CStreamDetails &details){ return false;}
   virtual void SetSpeed(float speed) = 0;
   virtual void SetTempo(float tempo) { };
   virtual bool SupportsTempo() { return false; }

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -320,12 +320,6 @@ uint64_t CRetroPlayer::GetTotalTime()
   return 0;
 }
 
-bool CRetroPlayer::GetStreamDetails(CStreamDetails &details)
-{
-  //! @todo
-  return false;
-}
-
 void CRetroPlayer::SetSpeed(float speed)
 {
   if (m_gameClient)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -102,7 +102,6 @@ namespace RETRO
     bool SeekTimeRelative(int64_t iTime) override;
     //virtual void SetTotalTime(int64_t time) override { } // Only used by Air Tunes Server
     //virtual int GetSourceBitrate() override { return 0; }
-    bool GetStreamDetails(CStreamDetails &details) override;
     void SetSpeed(float speed) override;
     //virtual bool IsCaching() const override { return false; }
     //virtual int GetCacheLevel() const override { return -1; }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -355,11 +355,11 @@ void CDVDDemuxClient::RequestStreams()
 {
   std::map<int, std::shared_ptr<CDemuxStream>> newStreamMap;
   for (auto stream : m_IDemux->GetStreams())
-    RequestStream(stream, newStreamMap);
+    RequestStream(stream, newStreamMap, false);
   m_streams = newStreamMap;
 }
 
-void CDVDDemuxClient::RequestStream(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map)
+void CDVDDemuxClient::RequestStream(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map, bool forceInit)
 {
   if (!stream)
   {
@@ -383,7 +383,7 @@ void CDVDDemuxClient::RequestStream(CDemuxStream *stream, std::map<int, std::sha
     std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>> streamAudio;
     if (oldStream)
       streamAudio = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>>(oldStream);
-    if (!streamAudio || streamAudio->codec != source->codec)
+    if (forceInit || !streamAudio || streamAudio->codec != source->codec)
     {
       streamAudio.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamAudio>());
       streamAudio->m_parser = av_parser_init(source->codec);
@@ -423,8 +423,7 @@ void CDVDDemuxClient::RequestStream(CDemuxStream *stream, std::map<int, std::sha
     std::shared_ptr<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>> streamVideo;
     if (oldStream)
       streamVideo = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>>(oldStream);
-    if (!streamVideo || streamVideo->codec != source->codec ||
-        streamVideo->iWidth != source->iWidth || streamVideo->iHeight != source->iHeight)
+    if (forceInit || !streamVideo || streamVideo->codec != source->codec)
     {
       streamVideo.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamVideo>());
       streamVideo->m_parser = av_parser_init(source->codec);
@@ -640,7 +639,7 @@ void CDVDDemuxClient::OpenStream(int id)
   if (m_IDemux)
   {
     m_IDemux->OpenStream(id);
-    RequestStream(m_IDemux->GetStream(id), m_streams);
+    RequestStream(m_IDemux->GetStream(id), m_streams, true);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -54,9 +54,8 @@ public:
 
 protected:
   void RequestStreams();
-  void RequestStream(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map);
+  void RequestStream(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map, bool forceInit);
   bool ParsePacket(DemuxPacket* pPacket);
-  void DisposeStream(int iStreamId);
   void DisposeStreams();
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);
   

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -362,7 +362,6 @@ public:
   bool OnAction(const CAction &action) override;
 
   int GetSourceBitrate() override;
-  bool GetStreamDetails(CStreamDetails &details) override;
   void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info) override;
 
   std::string GetPlayerState() override;
@@ -485,7 +484,6 @@ protected:
   void OpenDefaultStreams(bool reset = true);
 
   void UpdatePlayState(double timeout);
-  void UpdateStreamInfos();
   void GetGeneralInfo(std::string& strVideoInfo);
   int64_t GetUpdatedTime();
   int64_t GetTime();
@@ -587,6 +585,4 @@ protected:
   // omxplayer variables
   struct SOmxPlayerState m_OmxPlayerState;
   bool m_omxplayer_mode;            // using omxplayer acceleration
-
-  XbmcThreads::EndTime m_player_status_timer;
 };


### PR DESCRIPTION
## Description
Current Implementation requests a sream from addon after OpenStream is called.
If codec has not changed, values wich are evaluated from DemuxClient during packet analysis are not properly reinitialized.
This PR forces (re)initialization of all stream properties after OpenStream.

Example:
- Demuxclient requests on initialization an audio stream
- Demuxer does have codec, but not samplerate information, samplerate = 0
- DemuxClient calls OpenStream and requests changes (GetStream)
- Demuxer has now all necessary information, and returns correct samlerate
- DemuxClient does not set this new samplerate because codec has not changed.

## Motivation and Context
- solves Segfault in AudioSink at startup
- reduces initial streamchanges on video startup

## How Has This Been Tested?
strm file:
#KODIPROP:inputstreamaddon=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
https://tungsten.aaplimg.com/VOD/bipbop_adv_fmp4_example/master.m3u8

inputstream.adaptive >= 2.0.7 available / activated

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
