### PR TITLE
[guilib] multiimage don't fade out current image while new directory …

### DIFF
--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -139,7 +139,7 @@ void CGUIMultiImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyre
       }
     }
   }
-  else
+  else if (m_directoryStatus != LOADING)
     m_image.SetFileName("");
 
   if (g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height))


### PR DESCRIPTION
…is loading

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
The `multiimage` control loads some directories (from the filesystem when the directory isn't in an XBT, from plugins, maybe some other situations) in the background as it can take a bit of time, don't fade out the current image during that time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
A slight delay in the artwork switch is much more pleasant than fading to transparent letting the background show through then fading the new image in after the directory has loaded. Jarvis also behaved this way, the fadeout was an unexpected side effect of #9715 introduced early in Krypton.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
By hand, checked that the existing images doesn't fade out when changed to a slow loading directory and that changing to a single artwork is just as speedy as always.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
