### PR TITLE
 [PVR] Clean the mess. Refactor channel navigation/selection, incl. channel preview.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10302,11 +10302,7 @@ msgctxt "#19228"
 msgid "Timer deleted"
 msgstr ""
 
-#. label for PVR settings close channel OSD after channel switch control
-#: system/settings/settings.xml
-msgctxt "#19229"
-msgid "Close channel OSD after switching channels"
-msgstr ""
+#empty string with id 19229
 
 #. label for PVR settings no epg updates during playback control
 #: system/settings/settings.xml
@@ -18029,10 +18025,7 @@ msgctxt "#36213"
 msgid "Open the group manager, which allows modification of groups and their respective channels"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36214"
-msgid "Close the on screen display controls after switching channels."
-msgstr ""
+#empty string with id 36214
 
 #. Description of setting with label #14110 "Long date format"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1280,11 +1280,6 @@
             <formatlabel>14045</formatlabel>
           </control>
         </setting>
-        <setting id="pvrmenu.closechannelosdonswitch" type="boolean" label="19229" help="36214">
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
       </group>
       <group id="2" label="14302">
         <setting id="pvrmenu.iconpath" type="path" label="19018" help="36216">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9174,7 +9174,6 @@ void CGUIInfoManager::SetCurrentItemJob(const CFileItemPtr item)
     CPVREpgInfoTagPtr tag(item->GetPVRChannelInfoTag()->GetEPGNow());
     if (tag)
       m_currentFile->SetEPGInfoTag(tag);
-    m_isPvrChannelPreview = CServiceBroker::GetPVRManager().IsChannelPreview();
   }
 
   SetChanged();
@@ -9385,9 +9384,6 @@ bool CGUIInfoManager::GetDisplayAfterSeek()
 void CGUIInfoManager::SetShowInfo(bool showinfo)
 {
   m_playerShowInfo = showinfo;
-
-  if (!showinfo)
-    m_isPvrChannelPreview = false;
 }
 
 bool CGUIInfoManager::ToggleShowInfo()
@@ -9438,7 +9434,7 @@ void CGUIInfoManager::UpdateFPS()
 
 void CGUIInfoManager::UpdateAVInfo()
 {
-  if(g_application.m_pPlayer->IsPlaying())
+  if (g_application.m_pPlayer->IsPlaying())
   {
     if (CServiceBroker::GetDataCacheCore().HasAVInfoChanges())
     {
@@ -9450,8 +9446,6 @@ void CGUIInfoManager::UpdateAVInfo()
 
       m_videoInfo = video;
       m_audioInfo = audio;
-
-      m_isPvrChannelPreview = CServiceBroker::GetPVRManager().IsChannelPreview();
     }
   }
 }
@@ -11128,10 +11122,10 @@ bool CGUIInfoManager::ConditionsChangedValues(const std::map<INFO::InfoPtr, bool
 
 bool CGUIInfoManager::IsPlayerChannelPreviewActive() const
 {
-  bool bReturn(false);
+  bool bReturn = false;
   if (m_playerShowInfo && m_currentFile->HasPVRChannelInfoTag())
   {
-    if (m_isPvrChannelPreview)
+    if (CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreview())
     {
       bReturn = true;
     }

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -192,7 +192,6 @@ public:
   void SetShowInfo(bool showinfo);
   bool GetShowInfo() const { return m_playerShowInfo; }
   bool ToggleShowInfo();
-  bool IsPlayerChannelPreviewActive() const;
 
   std::string GetSystemHeatInfo(int info);
   CTemperature GetGPUTemperature();
@@ -347,12 +346,12 @@ protected:
 
   SPlayerVideoStreamInfo m_videoInfo;
   SPlayerAudioStreamInfo m_audioInfo;
-  bool m_isPvrChannelPreview;
 
   CCriticalSection m_critInfo;
 
 private:
   static std::string FormatRatingAndVotes(float rating, int votes);
+  bool IsPlayerChannelPreviewActive() const;
 };
 
 /*!

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -29,6 +29,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/InputManager.h"
 #include "input/Key.h"
+#include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -50,13 +51,14 @@ CGUIWindowVisualisation::CGUIWindowVisualisation(void)
 bool CGUIWindowVisualisation::OnAction(const CAction &action)
 {
   if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH) &&
-      g_infoManager.IsPlayerChannelPreviewActive() &&
-      (action.GetID() == ACTION_SELECT_ITEM || CServiceBroker::GetInputManager().GetGlobalAction(action.GetButtonCode()).GetID() == ACTION_SELECT_ITEM))
+      CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreview() &&
+      (action.GetID() == ACTION_SELECT_ITEM ||
+       CServiceBroker::GetInputManager().GetGlobalAction(action.GetButtonCode()).GetID() == ACTION_SELECT_ITEM))
   {
     // If confirm channel switch is active, channel preview is currently shown
     // and the button that caused this action matches (global) action "Select" (OK)
     // switch to the channel currently displayed within the preview.
-    CServiceBroker::GetPVRManager().ChannelPreviewSelect();
+    CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().SwitchToCurrentChannel();
     return true;
   }
 

--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -7,7 +7,8 @@ set(SOURCES PVRActionListener.cpp
             PVRGUIActions.cpp
             PVRItem.cpp
             PVRChannelNumberInputHandler.cpp
-            PVRJobs.cpp)
+            PVRJobs.cpp
+            PVRGUIChannelNavigator.cpp)
 
 set(HEADERS PVRActionListener.h
             PVRDatabase.h
@@ -20,6 +21,7 @@ set(HEADERS PVRActionListener.h
             PVRItem.h
             PVRTypes.h
             PVRChannelNumberInputHandler.h
-            PVRJobs.h)
+            PVRJobs.h
+            PVRGUIChannelNavigator.h)
 
 core_add_library(pvr)

--- a/xbmc/pvr/PVRActionListener.h
+++ b/xbmc/pvr/PVRActionListener.h
@@ -26,6 +26,8 @@
 namespace PVR
 {
 
+enum class ChannelSwitchMode;
+
 class CPVRActionListener : public IActionListener, public ISettingCallback
 {
 public:
@@ -42,6 +44,8 @@ public:
 private:
   CPVRActionListener(const CPVRActionListener&) = delete;
   CPVRActionListener& operator=(const CPVRActionListener&) = delete;
+
+  static ChannelSwitchMode GetChannelSwitchMode(int iAction);
 };
 
 } // namespace PVR

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -157,8 +157,7 @@ namespace PVR
       CSettings::SETTING_PVRRECORD_INSTANTRECORDACTION,
       CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN,
       CSettings::SETTING_PVRPARENTAL_PIN,
-      CSettings::SETTING_PVRPARENTAL_ENABLED,
-      CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO
+      CSettings::SETTING_PVRPARENTAL_ENABLED
     })
   {
   }
@@ -1119,11 +1118,6 @@ namespace PVR
       }
 
       StartPlayback(new CFileItem(channel), bFullscreen);
-
-      int iChannelInfoDisplayTime = m_settings.GetIntValue(CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO);
-      if (iChannelInfoDisplayTime > 0)
-        CServiceBroker::GetPVRManager().ShowPlayerInfo(iChannelInfoDisplayTime);
-
       return true;
     }
 
@@ -1618,6 +1612,11 @@ namespace PVR
 
     // default
     return m_channelNumberInputHandler;
+  }
+
+  CPVRGUIChannelNavigator &CPVRGUIActions::GetChannelNavigator()
+  {
+    return m_channelNavigator;
   }
 
   void CPVRChannelSwitchingInputHandler::OnInputDone()

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -19,9 +19,10 @@
  *
  */
 
+#include "pvr/PVRChannelNumberInputHandler.h"
+#include "pvr/PVRGUIChannelNavigator.h"
 #include "pvr/PVRSettings.h"
 #include "pvr/PVRTypes.h"
-#include "pvr/PVRChannelNumberInputHandler.h"
 
 #include <memory>
 #include <string>
@@ -323,6 +324,12 @@ namespace PVR
      */
     CPVRChannelNumberInputHandler &GetChannelNumberInputHandler();
 
+    /*!
+     * @brief Get the channel navigator.
+     * @return the navigator.
+     */
+    CPVRGUIChannelNavigator &GetChannelNavigator();
+
   private:
     CPVRGUIActions(const CPVRGUIActions&) = delete;
     CPVRGUIActions const& operator=(CPVRGUIActions const&) = delete;
@@ -423,7 +430,7 @@ namespace PVR
     CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
     bool m_bChannelScanRunning;
     CPVRSettings m_settings;
-
+    CPVRGUIChannelNavigator m_channelNavigator;
   };
 
 } // namespace PVR

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -1,0 +1,224 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PVRGUIChannelNavigator.h"
+
+#include "GUIInfoManager.h"
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
+#include "settings/lib/SettingsManager.h"
+
+#include "pvr/PVRGUIActions.h"
+#include "pvr/PVRJobs.h"
+#include "pvr/PVRManager.h"
+#include "pvr/channels/PVRChannelGroup.h"
+
+namespace PVR
+{
+  void CPVRGUIChannelNavigator::SelectNextChannel(ChannelSwitchMode eSwitchMode)
+  {
+    if (!g_infoManager.GetShowInfo() && eSwitchMode == ChannelSwitchMode::NO_SWITCH)
+    {
+      // show info for current channel on first next channel selection.
+      ShowInfo(false);
+      return;
+    }
+
+    const CPVRChannelPtr nextChannel = GetNextOrPrevChannel(true);
+    if (nextChannel)
+      SelectChannel(nextChannel, eSwitchMode);
+  }
+
+  void CPVRGUIChannelNavigator::SelectPreviousChannel(ChannelSwitchMode eSwitchMode)
+  {
+    if (!g_infoManager.GetShowInfo() && eSwitchMode == ChannelSwitchMode::NO_SWITCH)
+    {
+      // show info for current channel on first previous channel selection.
+      ShowInfo(false);
+      return;
+    }
+
+    const CPVRChannelPtr prevChannel = GetNextOrPrevChannel(false);
+    if (prevChannel)
+      SelectChannel(prevChannel, eSwitchMode);
+  }
+
+  CPVRChannelPtr CPVRGUIChannelNavigator::GetNextOrPrevChannel(bool bNext)
+  {
+    const bool bPlayingRadio = CServiceBroker::GetPVRManager().IsPlayingRadio();
+    const bool bPlayingTV = CServiceBroker::GetPVRManager().IsPlayingTV();
+
+    if (bPlayingTV || bPlayingRadio)
+    {
+      const CPVRChannelGroupPtr group = CServiceBroker::GetPVRManager().GetPlayingGroup(bPlayingRadio);
+      if (group)
+      {
+        CSingleLock lock(m_critSection);
+        const CFileItemPtr item = bNext
+          ? group->GetByChannelUp(m_currentChannel)
+          : group->GetByChannelDown(m_currentChannel);;
+        if (item)
+          return item->GetPVRChannelInfoTag();
+      }
+    }
+    return CPVRChannelPtr();
+  }
+
+  void CPVRGUIChannelNavigator::SelectChannel(const CPVRChannelPtr channel, ChannelSwitchMode eSwitchMode)
+  {
+    g_infoManager.SetCurrentItem(CFileItemPtr(new CFileItem(channel)));
+
+    CSingleLock lock(m_critSection);
+    m_currentChannel = channel;
+    ShowInfo(false);
+
+    if (IsPreview() && eSwitchMode == ChannelSwitchMode::INSTANT_OR_DELAYED_SWITCH)
+    {
+      int iTimeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT);
+      if (iTimeout > 0)
+      {
+        // delayed switch
+        if (m_iChannelEntryJobId >= 0)
+          CJobManager::GetInstance().CancelJob(m_iChannelEntryJobId);
+
+        CPVRChannelEntryTimeoutJob *job = new CPVRChannelEntryTimeoutJob(iTimeout);
+        m_iChannelEntryJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
+      }
+      else
+      {
+        // instant switch
+        SwitchToCurrentChannel();
+      }
+    }
+  }
+
+  void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
+  {
+    CFileItemPtr item;
+
+    {
+      CSingleLock lock(m_critSection);
+
+      if (m_iChannelEntryJobId >= 0)
+      {
+        CJobManager::GetInstance().CancelJob(m_iChannelEntryJobId);
+        m_iChannelEntryJobId = -1;
+      }
+
+      item.reset(new CFileItem(m_currentChannel));
+    }
+
+    if (item)
+      CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, false);
+  }
+
+  bool CPVRGUIChannelNavigator::IsPreview() const
+  {
+    CSingleLock lock(m_critSection);
+    return m_currentChannel != m_playingChannel;
+  }
+
+  void CPVRGUIChannelNavigator::ShowInfo()
+  {
+    ShowInfo(true);
+  }
+
+  void CPVRGUIChannelNavigator::ShowInfo(bool bForce)
+  {
+    int iTimeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO);
+
+    if (bForce || iTimeout > 0)
+    {
+      g_infoManager.SetShowInfo(true);
+
+      if (iTimeout > 0)
+      {
+        CSingleLock lock(m_critSection);
+
+        if (m_iChannelInfoJobId >= 0)
+          CJobManager::GetInstance().CancelJob(m_iChannelInfoJobId);
+
+        CPVRChannelInfoTimeoutJob *job = new CPVRChannelInfoTimeoutJob(iTimeout * 1000);
+        m_iChannelInfoJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
+      }
+    }
+  }
+
+  void CPVRGUIChannelNavigator::HideInfo()
+  {
+    g_infoManager.SetShowInfo(false);
+
+    CFileItemPtr item;
+
+    {
+      CSingleLock lock(m_critSection);
+
+      if (m_iChannelInfoJobId >= 0)
+      {
+        CJobManager::GetInstance().CancelJob(m_iChannelInfoJobId);
+        m_iChannelInfoJobId = -1;
+      }
+
+      m_currentChannel = m_playingChannel;
+
+      if (m_currentChannel)
+        item.reset(new CFileItem(m_playingChannel));
+    }
+
+    if (item)
+      g_infoManager.SetCurrentItem(item);
+  }
+
+  void CPVRGUIChannelNavigator::ToggleInfo()
+  {
+    if (g_infoManager.GetShowInfo())
+      HideInfo();
+    else
+      ShowInfo();
+  }
+
+  void CPVRGUIChannelNavigator::SetPlayingChannel(const CPVRChannelPtr channel)
+  {
+    CFileItemPtr item;
+
+    if (channel)
+    {
+      CSingleLock lock(m_critSection);
+
+      m_playingChannel = channel;
+      m_currentChannel = m_playingChannel;
+
+      item.reset(new CFileItem(m_playingChannel));
+    }
+
+    if (item)
+      g_infoManager.SetCurrentItem(item);
+
+    ShowInfo(false);
+  }
+
+  void CPVRGUIChannelNavigator::ClearPlayingChannel()
+  {
+    CSingleLock lock(m_critSection);
+    m_playingChannel.reset();
+    HideInfo();
+  }
+
+} // namespace PVR

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -72,8 +72,8 @@ namespace PVR
       {
         CSingleLock lock(m_critSection);
         const CFileItemPtr item = bNext
-          ? group->GetByChannelUp(m_currentChannel)
-          : group->GetByChannelDown(m_currentChannel);;
+          ? group->GetNextChannel(m_currentChannel)
+          : group->GetPreviousChannel(m_currentChannel);;
         if (item)
           return item->GetPVRChannelInfoTag();
       }

--- a/xbmc/pvr/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/PVRGUIChannelNavigator.h
@@ -1,0 +1,116 @@
+#pragma once
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "threads/CriticalSection.h"
+
+#include "pvr/PVRTypes.h"
+
+namespace PVR
+{
+  enum class ChannelSwitchMode
+  {
+    NO_SWITCH, // no channel switch
+    INSTANT_OR_DELAYED_SWITCH // switch according to SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT
+  };
+
+  class CPVRGUIChannelNavigator
+  {
+  public:
+    virtual ~CPVRGUIChannelNavigator() = default;
+
+    /*!
+     * @brief Select the next channel in currently playing channel group, relative to the currently selected channel.
+     * @param eSwitchMode controls whether only the channel info OSD is triggered or whther additionally a (delayed) channel switch will be done.
+     */
+    void SelectNextChannel(ChannelSwitchMode eSwitchMode);
+
+    /*!
+     * @brief Select the previous channel in currently playing channel group, relative to the currently selected channel.
+     * @param eSwitchMode controls whether only the channel info OSD is triggered or whther additionally a (delayed) channel switch will be done.
+     */
+    void SelectPreviousChannel(ChannelSwitchMode eSwitchMode);
+
+    /*!
+     * @brief Switch to the currently selected channel.
+     */
+    void SwitchToCurrentChannel();
+
+    /*!
+     * @brief Query the state of channel preview.
+     * @return True, if the currently selected channel is different from the currently playing channel, False otherwise.
+     */
+    bool IsPreview() const;
+
+    /*!
+     * @brief Show the channel info OSD.
+     */
+    void ShowInfo();
+
+    /*!
+     * @brief Hide the channel info OSD.
+     */
+    void HideInfo();
+
+    /*!
+     * @brief Toggle the channel info OSD visibility.
+     */
+    void ToggleInfo();
+
+    /*!
+     * @brief Set a new playing channel and show the channel info OSD for the new channel.
+     * @param channel The new playing channel
+     */
+    void SetPlayingChannel(const CPVRChannelPtr channel);
+
+    /*!
+     * @brief Clear the currently playing channel and hide the channel info OSD.
+     */
+    void ClearPlayingChannel();
+
+  private:
+    /*!
+     * @brief Get next or previous channel of the playing channel group, relative to the currently selected channel.
+     * @param bNext True to get the next channel, false to get the previous channel.
+     * @param return The channel or nullptr if not found.
+     */
+    CPVRChannelPtr GetNextOrPrevChannel(bool bNext);
+
+    /*!
+     * @brief Select a given channel, display channel info OSD, switch according to given switch mode.
+     * @param item The channel to select.
+     * @param eSwitchMode The channel switch mode.
+     */
+    void SelectChannel(const CPVRChannelPtr channel, ChannelSwitchMode eSwitchMode);
+
+    /*!
+     * @brief Show the channel info OSD.
+     * @param bForce True ignores value of SETTING_PVRMENU_DISPLAYCHANNELINFO and always activates the info, False acts aaccording settings value.
+     */
+    void ShowInfo(bool bForce);
+
+    CCriticalSection m_critSection;
+    CPVRChannelPtr m_playingChannel;
+    CPVRChannelPtr m_currentChannel;
+    int m_iChannelEntryJobId = -1;
+    int m_iChannelInfoJobId = -1;
+  };
+
+} // namespace PVR

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -23,7 +23,6 @@
 #include "pvr/PVRTypes.h"
 #include "pvr/addons/PVRClients.h"
 #include "threads/CriticalSection.h"
-#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 #include "utils/Observer.h"
 
@@ -60,13 +59,6 @@ namespace PVR
      * @return The position in milliseconds or NULL if no channel is playing.
      */
     int GetStartTime(void) const;
-
-    /*!
-     * @brief Show the player info.
-     * @param iTimeout Hide the player info after iTimeout seconds.
-     * @todo not really the right place for this :-)
-     */
-    void ShowPlayerInfo(int iTimeout);
 
     /*!
      * @brief Clear the playing EPG tag.
@@ -191,7 +183,6 @@ namespace PVR
     void UpdateTimeshift(void);
 
     void UpdateTimersToggle(void);
-    void ToggleShowInfo(void);
 
     void CharInfoPlayingDuration(std::string &strValue) const;
     void CharInfoPlayingTime(std::string &strValue) const;
@@ -251,7 +242,6 @@ namespace PVR
 
     PVR_SIGNAL_STATUS               m_qualityInfo;       /*!< stream quality information */
     PVR_DESCRAMBLE_INFO             m_descrambleInfo;    /*!< stream descramble information */
-    XbmcThreads::EndTime            m_ToggleShowInfo;
     CPVREpgInfoTagPtr               m_playingEpgTag;
     std::vector<SBackend>           m_backendProperties;
 

--- a/xbmc/pvr/PVRJobs.cpp
+++ b/xbmc/pvr/PVRJobs.cpp
@@ -20,22 +20,22 @@
 
 #include "PVRJobs.h"
 
+#include "PlayListPlayer.h"
+#include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
 #include "interfaces/AnnouncementManager.h"
+#ifdef TARGET_POSIX
+#include "linux/XTimeUtils.h"
+#endif
 
-#include "PlayListPlayer.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
-#include "ServiceBroker.h"
-#ifdef TARGET_POSIX
-#include "linux/XTimeUtils.h"
-#endif
 
 namespace PVR
 {
@@ -56,7 +56,26 @@ bool CPVRChannelEntryTimeoutJob::DoWork()
   {
     if (m_delayTimer.IsTimePast())
     {
-      CServiceBroker::GetPVRManager().ChannelPreviewSelect();
+      CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().SwitchToCurrentChannel();
+      return true;
+    }
+    Sleep(10);
+  }
+  return false;
+}
+
+CPVRChannelInfoTimeoutJob::CPVRChannelInfoTimeoutJob(int iTimeout)
+{
+  m_delayTimer.Set(iTimeout);
+}
+
+bool CPVRChannelInfoTimeoutJob::DoWork()
+{
+  while (!ShouldCancel(0, 0))
+  {
+    if (m_delayTimer.IsTimePast())
+    {
+      CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().HideInfo();
       return true;
     }
     Sleep(10);

--- a/xbmc/pvr/PVRJobs.h
+++ b/xbmc/pvr/PVRJobs.h
@@ -66,6 +66,19 @@ namespace PVR
     XbmcThreads::EndTime m_delayTimer;
   };
 
+  class CPVRChannelInfoTimeoutJob : public CJob, public IJobCallback
+  {
+  public:
+    CPVRChannelInfoTimeoutJob(int iTimeout);
+    ~CPVRChannelInfoTimeoutJob() override = default;
+    const char *GetType() const override { return "pvr-channel-info-timeout-job"; }
+    void OnJobComplete(unsigned int iJobID, bool bSuccess, CJob *job) override {}
+
+    bool DoWork() override;
+  private:
+    XbmcThreads::EndTime m_delayTimer;
+  };
+
   class CPVREventlogJob : public CJob
   {
   public:

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -676,19 +676,6 @@ CPVRRecordingPtr CPVRManager::GetCurrentRecording(void) const
   return m_addons->GetPlayingRecording();
 }
 
-int CPVRManager::GetCurrentEpg(CFileItemList &results) const
-{
-  int iReturn = -1;
-
-  CPVRChannelPtr channel(m_addons->GetPlayingChannel());
-  if (channel)
-    iReturn = channel->GetEPG(results);
-  else
-    CLog::Log(LOGDEBUG,"PVRManager - %s - no current channel set", __FUNCTION__);
-
-  return iReturn;
-}
-
 void CPVRManager::ResetPlayingTag(void)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -43,7 +43,6 @@
 class CGUIDialogExtendedProgressBar;
 class CGUIDialogProgressBarHandle;
 class CStopWatch;
-class CFileItemList;
 class CVariant;
 
 namespace PVR
@@ -271,13 +270,6 @@ namespace PVR
      * @brief Update the channel displayed in guiinfomanager and application to match the currently playing channel.
      */
     void UpdateCurrentChannel(void);
-
-    /*!
-     * @brief Return the EPG for the channel that is currently playing.
-     * @param channel The EPG or NULL if no channel is playing.
-     * @return The amount of results that was added or -1 if none.
-     */
-    int GetCurrentEpg(CFileItemList &results) const;
 
     /*!
      * @brief Check whether EPG tags for channels have been created.
@@ -526,11 +518,6 @@ namespace PVR
     void SetPlayingGroup(const CPVRChannelPtr &channel);
 
     /*!
-     * @brief Save the currently playing channel as last played channel
-     */
-    void SaveLastPlayedChannel() const;
-
-    /*!
      * @brief Executes "pvrpowermanagement.setwakeupcmd"
      */
     bool SetWakeupCommand(void);
@@ -566,15 +553,6 @@ namespace PVR
     void Clear(void);
 
     /*!
-     * @brief Called by ChannelUp() and ChannelDown() to perform a channel switch.
-     * @param iNewChannelNumber The new channel number after the switch.
-     * @param bPreview Preview window if true.
-     * @param bUp Go one channel up if true, one channel down if false.
-     * @return True if the switch was successful, false otherwise.
-     */
-    bool ChannelUpDown(unsigned int *iNewChannelNumber, bool bPreview, bool bUp);
-
-    /*!
      * @brief Activate preview for a given channel.
      * @param item the channel the preview is to be activated for.
      */
@@ -595,8 +573,16 @@ namespace PVR
       ManagerStateStarted
     };
 
+    /*!
+     * @brief Get the current state of the PVR manager.
+     * @return the state.
+     */
     ManagerState GetState(void) const;
 
+    /*!
+     * @brief Set the current state of the PVR manager.
+     * @param state the new state.
+     */
     void SetState(ManagerState state);
 
     bool AllLocalBackendsIdle(CPVRTimerInfoTagPtr& causingEvent) const;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -70,12 +70,6 @@ namespace PVR
     bool m_bStopped;
   };
 
-  enum class ChannelSwitchMode
-  {
-    NO_SWITCH,
-    DELAYED_SWITCH
-  };
-
   class CPVRManager : private CThread, public Observable, public ANNOUNCEMENT::IAnnouncer
   {
   public:
@@ -195,13 +189,6 @@ namespace PVR
     bool TranslateBoolInfo(DWORD dwInfo) const;
 
     /*!
-     * @brief Show the player info.
-     * @param iTimeout Hide the player info after iTimeout seconds.
-     * @todo not really the right place for this :-)
-     */
-    void ShowPlayerInfo(int iTimeout);
-
-    /*!
      * @brief Check if a TV channel, radio channel or recording is playing.
      * @return True if it's playing, false otherwise.
      */
@@ -265,11 +252,6 @@ namespace PVR
      * @return The recording or NULL if none is playing.
      */
     CPVRRecordingPtr GetCurrentRecording(void) const;
-
-    /*!
-     * @brief Update the channel displayed in guiinfomanager and application to match the currently playing channel.
-     */
-    void UpdateCurrentChannel(void);
 
     /*!
      * @brief Check whether EPG tags for channels have been created.
@@ -399,11 +381,6 @@ namespace PVR
     int GetStartTime(void) const;
 
     /*!
-     * @brief Update the currently playing file in the guiinfomanager.
-     */
-    void UpdateCurrentFile(void);
-
-    /*!
      * @brief Check whether names are still correct after the language settings changed.
      */
     void LocalizationChanged(void);
@@ -459,26 +436,6 @@ namespace PVR
      * @brief Signal a connection change of a client
      */
     void ConnectionStateChange(CPVRClient *client, std::string connectString, PVR_CONNECTION_STATE state, std::string message);
-
-    /*!
-     * @brief Activate channel preview for next channel in current channel group.
-     */
-    void ChannelPreviewUp(ChannelSwitchMode eSwitchMode);
-
-    /*!
-     * @brief Activate channel preview for previous channel in current channel group.
-     */
-    void ChannelPreviewDown(ChannelSwitchMode eSwitchMode);
-
-    /*!
-     * @brief Switch to the channel currently previewed.
-     */
-    void ChannelPreviewSelect();
-
-    /*!
-     * @brief Query the state of channel preview
-     */
-    bool IsChannelPreview() const;
 
     /*!
      * @brief Query the events available for CEventStream
@@ -553,12 +510,6 @@ namespace PVR
     void Clear(void);
 
     /*!
-     * @brief Activate preview for a given channel.
-     * @param item the channel the preview is to be activated for.
-     */
-    void ChannelPreview(const CFileItemPtr item, ChannelSwitchMode eSwitchMode);
-
-    /*!
      * @brief Continue playback on the last played channel.
      */
     void TriggerPlayChannelOnStartup(void);
@@ -602,11 +553,9 @@ namespace PVR
 
     CPVRManagerJobQueue             m_pendingUpdates;              /*!< vector of pending pvr updates */
 
-    CFileItemPtr                    m_currentFile;                 /*!< the PVR file that is currently playing */
     CPVRDatabasePtr                 m_database;                    /*!< the database for all PVR related data */
     CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
     bool                            m_bFirstStart;                 /*!< true when the PVR manager was started first, false otherwise */
-    bool                            m_bIsSwitchingChannels;        /*!< true while switching channels */
     bool                            m_bEpgsCreated;                /*!< true if epg data for channels has been created */
     CGUIDialogExtendedProgressBar * m_progressBar;                 /*!< extended progress dialog instance pointer */
     CGUIDialogProgressBarHandle *   m_progressHandle;              /*!< progress dialog that is displayed while the pvrmanager is loading */
@@ -617,8 +566,6 @@ namespace PVR
 
     CCriticalSection                m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */
 
-    std::atomic_bool m_bIsChannelPreview;
-    int m_iChannelEntryJobId = -1;
     CEventSource<PVREvent> m_events;
 
     CPVRActionListener m_actionListener;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -489,7 +489,7 @@ CFileItemPtr CPVRChannelGroup::GetByChannelNumber(unsigned int iChannelNumber, u
   return retval;
 }
 
-CFileItemPtr CPVRChannelGroup::GetByChannelUp(const CPVRChannelPtr &channel) const
+CFileItemPtr CPVRChannelGroup::GetNextChannel(const CPVRChannelPtr &channel) const
 {
   CFileItemPtr retval;
 
@@ -517,7 +517,7 @@ CFileItemPtr CPVRChannelGroup::GetByChannelUp(const CPVRChannelPtr &channel) con
   return retval;
 }
 
-CFileItemPtr CPVRChannelGroup::GetByChannelDown(const CPVRChannelPtr &channel) const
+CFileItemPtr CPVRChannelGroup::GetPreviousChannel(const CPVRChannelPtr &channel) const
 {
   CFileItemPtr retval;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -308,14 +308,14 @@ namespace PVR
      * @param channel The current channel.
      * @return The channel or NULL if it wasn't found.
      */
-    CFileItemPtr GetByChannelUp(const CPVRChannelPtr &channel) const;
+    CFileItemPtr GetNextChannel(const CPVRChannelPtr &channel) const;
 
     /*!
      * @brief Get the previous channel in this group.
      * @param channel The current channel.
      * @return The channel or NULL if it wasn't found.
      */
-    CFileItemPtr GetByChannelDown(const CPVRChannelPtr &channel) const;
+    CFileItemPtr GetPreviousChannel(const CPVRChannelPtr &channel) const;
 
     /*!
      * @brief Get a channel given it's channel ID.

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -225,7 +225,6 @@ const std::string CSettings::SETTING_PVRMANAGER_GROUPMANAGER = "pvrmanager.group
 const std::string CSettings::SETTING_PVRMANAGER_CHANNELSCAN = "pvrmanager.channelscan";
 const std::string CSettings::SETTING_PVRMANAGER_RESETDB = "pvrmanager.resetdb";
 const std::string CSettings::SETTING_PVRMENU_DISPLAYCHANNELINFO = "pvrmenu.displaychannelinfo";
-const std::string CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH = "pvrmenu.closechannelosdonswitch";
 const std::string CSettings::SETTING_PVRMENU_ICONPATH = "pvrmenu.iconpath";
 const std::string CSettings::SETTING_PVRMENU_SEARCHICONS = "pvrmenu.searchicons";
 const std::string CSettings::SETTING_EPG_DAYSTODISPLAY = "epg.daystodisplay";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -171,7 +171,6 @@ public:
   static const std::string SETTING_PVRMANAGER_CHANNELSCAN;
   static const std::string SETTING_PVRMANAGER_RESETDB;
   static const std::string SETTING_PVRMENU_DISPLAYCHANNELINFO;
-  static const std::string SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH;
   static const std::string SETTING_PVRMENU_ICONPATH;
   static const std::string SETTING_PVRMENU_SEARCHICONS;
   static const std::string SETTING_EPG_DAYSTODISPLAY;

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -31,6 +31,7 @@
 #include "video/dialogs/GUIDialogAudioSubtitleSettings.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
+#include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "video/dialogs/GUIDialogFullScreenInfo.h"
 #include "settings/DisplaySettings.h"
@@ -111,14 +112,14 @@ CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
   if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH) &&
-      g_infoManager.IsPlayerChannelPreviewActive() &&
+      CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreview() &&
       (action.GetID() == ACTION_SELECT_ITEM ||
        CServiceBroker::GetInputManager().GetGlobalAction(action.GetButtonCode()).GetID() == ACTION_SELECT_ITEM))
   {
     // If confirm channel switch is active, channel preview is currently shown
     // and the button that caused this action matches (global) action "Select" (OK)
     // switch to the channel currently displayed within the preview.
-    CServiceBroker::GetPVRManager().ChannelPreviewSelect();
+    CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().SwitchToCurrentChannel();
     return true;
   }
 


### PR DESCRIPTION
Formerly, the channel preview implementation was scattered over a bunch of files, making it a huge mess. This PR tries to clean this up by encapsulating the implementation in its own class. At least I am able to understand now what the feature exactly does and how. ;-)

There are no functional changes for this PR, just a small bug fix fpr toggling the info display.

This has been carefully tested on macOS and Linux, latest Kodi master. 

@FernetMenta @xhaggi for review?