### PR TITLE
[lang] remove language add-on migration code

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15002,15 +15002,7 @@ msgctxt "#24132"
 msgid "Would you like to switch to this language?"
 msgstr ""
 
-#: xbmc/Application.cpp
-msgctxt "#24133"
-msgid "Failed to load language"
-msgstr ""
-
-#: xbmc/Application.cpp
-msgctxt "#24134"
-msgid "We were unable to load your configured language. Please check your language settings."
-msgstr ""
+#empty strings from id 24133 to 24134
 
 #. Folder name in addon settings window
 #: xbmc/addons/addon.cpp

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -282,7 +282,6 @@ CApplication::CApplication(void)
   , m_volumeLevel(VOLUME_MAXIMUM)
   , m_pInertialScrollingHandler(new CInertialScrollingHandler())
   , m_network(nullptr)
-  , m_fallbackLanguageLoaded(false)
   , m_WaitingExternalCalls(0)
   , m_ProcessedExternalCalls(0)
 {
@@ -4160,9 +4159,6 @@ bool CApplication::OnMessage(CGUIMessage& message)
         if (IsMuted() || GetVolume(false) <= VOLUME_MINIMUM)
           ShowVolumeBar();
 
-        if (m_fallbackLanguageLoaded)
-          CGUIDialogOK::ShowAndGetInput(CVariant{24133}, CVariant{24134});
-
         if (!m_incompatibleAddons.empty())
         {
           auto addonList = StringUtils::Join(m_incompatibleAddons, ", ");
@@ -5164,7 +5160,7 @@ bool CApplication::SetLanguage(const std::string &strLanguage)
 bool CApplication::LoadLanguage(bool reload)
 {
   // load the configured langauge
-  if (!g_langInfo.SetLanguage(m_fallbackLanguageLoaded, "", reload))
+  if (!g_langInfo.SetLanguage("", reload))
     return false;
 
   // set the proper audio and subtitle languages

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -522,8 +522,6 @@ protected:
   
   std::vector<IActionListener *> m_actionListeners;
 
-  bool m_fallbackLanguageLoaded;
-
   std::vector<std::string> m_incompatibleAddons;  /*!< Result of addon migration */
 
 private:

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -666,102 +666,23 @@ std::string CLangInfo::GetEnglishLanguageName(const std::string& locale /* = "" 
   return addon->Name();
 }
 
-bool CLangInfo::SetLanguage(const std::string &strLanguage /* = "" */, bool reloadServices /* = true */)
+bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices /* = true */)
 {
-  bool fallback;
-  return SetLanguage(fallback, strLanguage, reloadServices);
-}
-
-bool CLangInfo::SetLanguage(bool& fallback, const std::string &strLanguage /* = "" */, bool reloadServices /* = true */)
-{
-  fallback = false;
-
-  std::string language = strLanguage;
   if (language.empty())
-  {
     language = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_LANGUAGE);
 
-    if (language.empty())
+  ADDON::AddonPtr addon;
+  if (!ADDON::CAddonMgr::GetInstance().GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
+  {
+    CLog::Log(LOGWARNING, "CLangInfo: could not find language add-on '%s', loading default..", language.c_str());
+    language = std::static_pointer_cast<const CSettingString>(CServiceBroker::GetSettings().GetSetting(
+        CSettings::SETTING_LOCALE_LANGUAGE))->GetDefault();
+
+    if (!ADDON::CAddonMgr::GetInstance().GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
     {
-      CLog::Log(LOGFATAL, "CLangInfo: cannot load empty language.");
+      CLog::Log(LOGFATAL, "CLangInfo: could not find default language add-on '%s'", language.c_str());
       return false;
     }
-  }
-
-  LanguageResourcePtr languageAddon;
-  {
-    std::string addonId = ADDON::CLanguageResource::GetAddonId(language);
-    if (addonId.empty())
-      addonId = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_LANGUAGE);
-
-    ADDON::AddonPtr addon;
-    if (ADDON::CAddonMgr::GetInstance().GetAddon(addonId, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
-    {
-      languageAddon = std::static_pointer_cast<ADDON::CLanguageResource>(addon);
-      ADDON::CAddonMgr::GetInstance().EnableAddon(languageAddon->ID());
-    }
-  }
-
-  if (languageAddon == NULL)
-  {
-    CLog::Log(LOGWARNING, "CLangInfo: unable to load language \"%s\". Trying to determine matching language addon...", language.c_str());
-
-    // we may have to fall back to the default language
-    std::string defaultLanguage = std::static_pointer_cast<CSettingString>(CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_LOCALE_LANGUAGE))->GetDefault();
-    std::string newLanguage = defaultLanguage;
-
-    // try to determine a language addon matching the given language in name
-    if (!ADDON::CLanguageResource::FindLanguageAddonByName(language, newLanguage))
-    {
-      CLog::Log(LOGWARNING, "CLangInfo: unable to find an installed language addon matching \"%s\". Trying to find an installable language...", language.c_str());
-
-      bool foundMatchingAddon = false;
-      CAddonDatabase addondb;
-      if (addondb.Open())
-      {
-        // update the addon repositories to check if there's a matching language addon available for download
-        if (CServiceBroker::GetRepositoryUpdater().CheckForUpdates())
-          CServiceBroker::GetRepositoryUpdater().Await();
-
-        ADDON::VECADDONS languageAddons;
-        if (addondb.GetRepositoryContent(languageAddons) && !languageAddons.empty())
-        {
-          languageAddons.erase(std::remove_if(languageAddons.begin(), languageAddons.end(),
-              [](const ADDON:: AddonPtr& addon){ return !addon->IsType(ADDON::ADDON_RESOURCE_LANGUAGE); }), languageAddons.end());
-          // try to get the proper language addon by its name from all available language addons
-          if (ADDON::CLanguageResource::FindLanguageAddonByName(language, newLanguage, languageAddons))
-          {
-            if (CAddonInstaller::GetInstance().InstallOrUpdate(newLanguage, false, false))
-            {
-              CLog::Log(LOGINFO, "CLangInfo: successfully installed language addon \"%s\" matching current language \"%s\"", newLanguage.c_str(), language.c_str());
-              foundMatchingAddon = true;
-            }
-            else
-              CLog::Log(LOGERROR, "CLangInfo: failed to installed language addon \"%s\" matching current language \"%s\"", newLanguage.c_str(), language.c_str());
-          }
-          else
-            CLog::Log(LOGERROR, "CLangInfo: unable to match old language \"%s\" to any available language addon", language.c_str());
-        }
-        else
-          CLog::Log(LOGERROR, "CLangInfo: no language addons available to match against \"%s\"", language.c_str());
-      }
-      else
-        CLog::Log(LOGERROR, "CLangInfo: unable to open addon database to look for a language addon matching \"%s\"", language.c_str());
-
-      // if the new language matches the default language we are loading the
-      // default language as a fallback
-      if (!foundMatchingAddon && newLanguage == defaultLanguage)
-      {
-        CLog::Log(LOGINFO, "CLangInfo: fall back to the default language \"%s\"", defaultLanguage.c_str());
-        fallback = true;
-      }
-    }
-
-    if (!CServiceBroker::GetSettings().SetString(CSettings::SETTING_LOCALE_LANGUAGE, newLanguage))
-      return false;
-
-    CServiceBroker::GetSettings().Save();
-    return true;
   }
 
   CLog::Log(LOGINFO, "CLangInfo: loading %s language information...", language.c_str());

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -69,8 +69,6 @@ public:
   // implementation of ISettingsHandler
   void OnSettingsLoaded() override;
 
-  bool Load(const std::string& strLanguage);
-
   /*!
    \brief Returns the language addon for the given locale (or the current one).
 
@@ -99,16 +97,7 @@ public:
   \param reloadServices (optional) Whether to reload services relying on localization.
   \return True if the language has been successfully loaded, false otherwise.
   */
-  bool SetLanguage(const std::string &strLanguage = "", bool reloadServices = true);
-  /*!
-   \brief Sets and loads the given (or configured) language, its details and strings.
-
-   \param fallback Whether the fallback language has been loaded instead of the given language.
-   \param strLanguage (optional) Language to be loaded.
-   \param reloadServices (optional) Whether to reload services relying on localization.
-   \return True if the language has been successfully loaded, false otherwise.
-   */
-  bool SetLanguage(bool& fallback, const std::string &strLanguage = "", bool reloadServices = true);
+  bool SetLanguage(std::string strLanguage = "", bool reloadServices = true);
 
   const std::string& GetAudioLanguage() const;
   // language can either be a two char language code as defined in ISO639
@@ -200,6 +189,7 @@ public:
 
 protected:
   void SetDefaults();
+  bool Load(const std::string& strLanguage);
 
   static bool DetermineUse24HourClockFromTimeFormat(const std::string& timeFormat);
   static bool DetermineUseMeridiemFromTimeFormat(const std::string& timeFormat);

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -185,34 +185,4 @@ bool CLanguageResource::FindLegacyLanguage(const std::string &locale, std::strin
   return true;
 }
 
-bool CLanguageResource::FindLanguageAddonByName(const std::string &legacyLanguage, std::string &addonId, const VECADDONS &languageAddons /* = VECADDONS() */)
-{
-  if (legacyLanguage.empty())
-    return false;
-
-  VECADDONS addons;
-  if (!languageAddons.empty())
-    addons = languageAddons;
-  else if (!CAddonMgr::GetInstance().GetInstalledAddons(addons, ADDON_RESOURCE_LANGUAGE) || addons.empty())
-    return false;
-
-  // try to find a language that matches the old language in name or id
-  for (VECADDONS::const_iterator addon = addons.begin(); addon != addons.end(); ++addon)
-  {
-    const CLanguageResource* languageAddon = static_cast<CLanguageResource*>(addon->get());
-
-    // check if the old language matches the language addon id, the language
-    // locale or the language addon name
-    if (legacyLanguage.compare((*addon)->ID()) == 0 ||
-        languageAddon->GetLocale().Equals(legacyLanguage) ||
-        StringUtils::EqualsNoCase(legacyLanguage, languageAddon->Name()))
-    {
-      addonId = (*addon)->ID();
-      return true;
-    }
-  }
-
-  return false;
-}
-
 }

--- a/xbmc/addons/LanguageResource.h
+++ b/xbmc/addons/LanguageResource.h
@@ -64,7 +64,6 @@ public:
   static std::string GetAddonId(const std::string& locale);
 
   static bool FindLegacyLanguage(const std::string &locale, std::string &legacyLanguage);
-  static bool FindLanguageAddonByName(const std::string &legacyLanguage, std::string &addonId, const VECADDONS &languageAddons = VECADDONS());
 
 private:
   CLocale m_locale;


### PR DESCRIPTION
It's been 3 version since we migrated. No need for this anymore