### PR TITLE
 [PVR][addons] PVR Addon API 5.6.0: Channel and recording URLs & properties

### DIFF
--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -648,11 +648,18 @@ namespace PVR
     bool GetDescrambleInfo(PVR_DESCRAMBLE_INFO &descrambleinfo) const;
 
     /*!
-     * @brief Get the stream URL for a channel from the PVR backend.
-     * @param channel The channel to get the stream URL for.
-     * @return The requested URL or empty string if not available.
+     * @brief Fill the file item for a channel with the properties required for playback. Values are obtained from the PVR backend.
+     * @param fileItem The file item to be filled.
+     * @return True if the stream properties have been set, false otherwiese.
      */
-    std::string GetLiveStreamURL(const CPVRChannelPtr &channel);
+    bool FillChannelStreamFileItem(CFileItem &fileItem);
+
+    /*!
+     * @brief Fill the file item for a recording with the properties required for playback. Values are obtained from the PVR backend.
+     * @param fileItem The file item to be filled.
+     * @return True if the stream properties have been set, false otherwiese.
+     */
+    bool FillRecordingStreamFileItem(CFileItem &fileItem);
 
     /*!
      * @brief Check whether PVR backend supports pausing the currently playing stream

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -113,8 +113,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.5.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "5.5.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.6.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "5.6.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \
                                                       "xbmc_pvr_types.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -426,12 +426,24 @@ extern "C"
   PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO* descrambleInfo);
 
   /*!
-   * Get the stream URL for a channel from the backend. Used by the MediaPortal add-on.
-   * @param channel The channel to get the stream URL for.
-   * @return The requested URL.
-   * @remarks Optional, and only used if bHandlesInputStream is set to true. Return NULL if this add-on won't provide this function.
+   * Get the stream properties for a channel from the backend.
+   * @param[in] channel The channel to get the stream properties for.
+   * @param[inout] properties in: an array for the properties to return, out: the properties required to play the stream.
+   * @param[inout] iPropertiesCount: in the size of the properties array, out: the number of properties returned.
+   * @return PVR_ERROR_NO_ERROR if the stream is available.
+   * @remarks Required if PVR_ADDON_CAPABILITIES::bSupportsTV or PVR_ADDON_CAPABILITIES::bSupportsRadio are set to true and PVR_ADDON_CAPABILITIES::bHandlesInputStream is set to false. In this case the implementation must fill the property PVR_STREAM_PROPERTY_STREAMURL with the URL Kodi should resolve to playback the channel. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  const char* GetLiveStreamURL(const PVR_CHANNEL& channel);
+  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
+
+  /*!
+   * Get the stream properties for a recording from the backend.
+   * @param[in] channel The recording to get the stream properties for.
+   * @param[inout] properties in: an array for the properties to return, out: the properties required to play the stream.
+   * @param[inout] iPropertiesCount: in the size of the properties array, out: the number of properties returned.
+   * @return PVR_ERROR_NO_ERROR if the stream is available.
+   * @remarks Required if PVR_ADDON_CAPABILITIES::bSupportsRecordings is set to true and the add-on does not implement recording stream functions (OpenRecordedStream, ...). In this case your implementation must fill the property PVR_STREAM_PROPERTY_STREAMURL with the URL Kodi should resolve to playback the recording. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
+   */
+  PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
 
   /*!
    * Get the stream properties of the stream that's currently being read.
@@ -686,7 +698,8 @@ extern "C"
     pClient->toAddon.LengthLiveStream               = LengthLiveStream;
     pClient->toAddon.SignalStatus                   = SignalStatus;
     pClient->toAddon.GetDescrambleInfo              = GetDescrambleInfo;
-    pClient->toAddon.GetLiveStreamURL               = GetLiveStreamURL;
+    pClient->toAddon.GetChannelStreamProperties     = GetChannelStreamProperties;
+    pClient->toAddon.GetRecordingStreamProperties   = GetRecordingStreamProperties;
     pClient->toAddon.CanPauseStream                 = CanPauseStream;
     pClient->toAddon.PauseStream                    = PauseStream;
     pClient->toAddon.CanSeekStream                  = CanSeekStream;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -77,6 +77,10 @@ struct DemuxPacket;
 #define XBMC_INVALID_CODEC_ID   0
 #define XBMC_INVALID_CODEC      { XBMC_CODEC_TYPE_UNKNOWN, XBMC_INVALID_CODEC_ID }
 
+/* defines for GetChannelStreamProperties and GetRecordingStreamProperties */
+#define PVR_STREAM_MAX_PROPERTIES     20
+#define PVR_STREAM_PROPERTY_STREAMURL "streamurl"
+
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20
 
@@ -266,6 +270,14 @@ extern "C" {
   } PVR_RECORDING_CHANNEL_TYPE;
 
   /*!
+   * @brief Representation of a named value
+   */
+  typedef struct PVR_NAMED_VALUE {
+    char  strName[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (required) name */
+    char  strValue[PVR_ADDON_NAME_STRING_LENGTH]; /*!< @brief (required) value */
+  } ATTRIBUTE_PACKED PVR_NAMED_VALUE;
+
+  /*!
    * @brief Properties passed to the Create() method of an add-on.
    */
   typedef struct PVR_PROPERTIES
@@ -335,8 +347,8 @@ extern "C" {
       int               iBlockAlign;        /*!< @brief (required) block alignment */
       int               iBitRate;           /*!< @brief (required) bit rate */
       int               iBitsPerSample;     /*!< @brief (required) bits per sample */
-     } stream[PVR_STREAM_MAX_STREAMS];      /*!< @brief (required) the streams */
-   } ATTRIBUTE_PACKED PVR_STREAM_PROPERTIES;
+    } stream[PVR_STREAM_MAX_STREAMS];       /*!< @brief (required) the streams */
+  } ATTRIBUTE_PACKED PVR_STREAM_PROPERTIES;
 
   /*!
    * @brief Signal status information
@@ -520,7 +532,6 @@ extern "C" {
     int    iSeriesNumber;                                 /*!< @brief (optional) series number (usually called season). Set to "0" for specials/pilot. For 'invalid' see iEpisodeNumber or set to -1 */
     int    iEpisodeNumber;                                /*!< @brief (optional) episode number within the "iSeriesNumber" season. For 'invalid' set to -1 or iSeriesNumber=iEpisodeNumber=0 to show both are invalid */
     int    iYear;                                         /*!< @brief (optional) year of first release (use to identify a specific movie re-make) / first airing for TV shows. Set to '0' for invalid. */
-    char   strStreamURL[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (required) stream URL to access this recording */
     char   strDirectory[PVR_ADDON_URL_STRING_LENGTH];     /*!< @brief (optional) directory of this recording on the client */
     char   strPlotOutline[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) plot outline */
     char   strPlot[PVR_ADDON_DESC_STRING_LENGTH];         /*!< @brief (optional) plot */
@@ -665,7 +676,8 @@ extern "C" {
     long long (__cdecl* LengthLiveStream)(void);
     PVR_ERROR (__cdecl* SignalStatus)(PVR_SIGNAL_STATUS&);
     PVR_ERROR (__cdecl* GetDescrambleInfo)(PVR_DESCRAMBLE_INFO*);
-    const char*  (__cdecl* GetLiveStreamURL)(const PVR_CHANNEL&);
+    PVR_ERROR  (__cdecl* GetChannelStreamProperties)(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*);
+    PVR_ERROR  (__cdecl* GetRecordingStreamProperties)(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*);
     bool (__cdecl* OpenRecordedStream)(const PVR_RECORDING&);
     void (__cdecl* CloseRecordedStream)(void);
     int (__cdecl* ReadRecordedStream)(unsigned char*, unsigned int);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -143,7 +143,7 @@ bool CInputStreamAddon::Open()
     props.m_nCountInfoValues++;
   }
 
-  props.m_strURL = m_item.GetPath().c_str();
+  props.m_strURL = m_item.GetDynPath().c_str();
 
   std::string libFolder = URIUtils::GetDirectory(Addon()->Path());
   std::string profileFolder = CSpecialProtocol::TranslatePath(Addon()->Profile());

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -988,9 +988,8 @@ namespace PVR
 
   void CPVRGUIActions::StartPlayback(CFileItem *item, bool bFullscreen) const
   {
-    const CPVRChannelPtr channel = item->GetPVRChannelInfoTag();
-    if (channel)
-      item->SetDynPath(CServiceBroker::GetPVRManager().Clients()->GetLiveStreamURL(channel));
+    // Obtain dynamic playback url and properties from the respecive pvr client
+    CServiceBroker::GetPVRManager().FillStreamFileItem(*item);
 
     CApplicationMessenger::GetInstance().PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
     CheckAndSwitchToFullscreen(bFullscreen);
@@ -1009,7 +1008,8 @@ namespace PVR
       return true;
     }
 
-    std::string stream = recording->m_strStreamURL;
+    CServiceBroker::GetPVRManager().FillStreamFileItem(*item); // fill item's dynpath
+    const std::string stream = item->GetDynPath();
     if (stream.empty())
     {
       if (!bCheckResume || CheckResumeRecording(item))
@@ -1051,13 +1051,13 @@ namespace PVR
           /* If we have a stack change the path of the item to it */
           XFILE::CStackDirectory dir;
           std::string stackPath = dir.ConstructStackPath(items, stack);
-          item->SetPath(stackPath);
+          item->SetDynPath(stackPath);
         }
       }
       else
       {
         /* If no asterisk is present play only the given stream URL */
-        item->SetPath(stream);
+        item->SetDynPath(stream);
       }
     }
     else

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -1039,6 +1039,16 @@ void CPVRManager::SearchMissingChannelIcons(void)
     m_channelGroups->SearchMissingChannelIcons();
 }
 
+bool CPVRManager::FillStreamFileItem(CFileItem &fileItem)
+{
+  if (fileItem.IsPVRChannel())
+    return m_addons->FillChannelStreamFileItem(fileItem);
+  else if (fileItem.IsPVRRecording())
+    return m_addons->FillRecordingStreamFileItem(fileItem);
+  else
+    return false;
+}
+
 void CPVRManager::TriggerEpgsCreate(void)
 {
   m_pendingUpdates.AppendJob(new CPVREpgsCreateJob());

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -339,6 +339,13 @@ namespace PVR
     CPVRChannelGroupPtr GetPlayingGroup(bool bRadio = false);
 
     /*!
+     * @brief Fill the file item for a recording or a channel with the properties required for playback. Values are obtained from the PVR backend.
+     * @param fileItem The file item to be filled. Item must contain either a pvr recording or a pvr channel.
+     * @return True if the stream properties have been set, false otherwiese.
+     */
+    bool FillStreamFileItem(CFileItem &fileItem);
+
+    /*!
      * @brief Let the background thread create epg tags for all channels.
      */
     void TriggerEpgsCreate(void);

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1043,13 +1043,22 @@ bool CPVRClients::GetPlayingClient(PVR_CLIENT &client) const
   return GetCreatedClient(GetPlayingClientID(), client);
 }
 
-std::string CPVRClients::GetLiveStreamURL(const CPVRChannelPtr &channel)
+bool CPVRClients::FillChannelStreamFileItem(CFileItem &fileItem)
 {
   PVR_CLIENT client;
-  if (GetCreatedClient(channel->ClientID(), client))
-    return client->GetLiveStreamURL(channel);
+  if (GetCreatedClient(fileItem.GetPVRChannelInfoTag()->ClientID(), client))
+    return client->FillChannelStreamFileItem(fileItem);
 
-  return std::string();
+  return false;
+}
+
+bool CPVRClients::FillRecordingStreamFileItem(CFileItem &fileItem)
+{
+  PVR_CLIENT client;
+  if (GetCreatedClient(fileItem.GetPVRRecordingInfoTag()->ClientID(), client))
+    return client->FillRecordingStreamFileItem(fileItem);
+
+  return false;
 }
 
 bool CPVRClients::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel)

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -282,11 +282,18 @@ namespace PVR
     bool IsEncrypted(void) const;
 
     /*!
-     * @brief Get the stream URL for a given channel from the respective client.
-     * @param channel The channel to get the stream URL for.
-     * @return The stream URL or empty string if not available.
+     * @brief Fill the file item for a channel with the properties required for playback. Values are obtained from the PVR backend.
+     * @param fileItem The file item to be filled.
+     * @return True if the stream properties have been set, false otherwiese.
      */
-    std::string GetLiveStreamURL(const CPVRChannelPtr &channel);
+    bool FillChannelStreamFileItem(CFileItem &fileItem);
+
+    /*!
+     * @brief Fill the file item for a recording with the properties required for playback. Values are obtained from the PVR backend.
+     * @param fileItem The file item to be filled.
+     * @return True if the stream properties have been set, false otherwiese.
+     */
+    bool FillRecordingStreamFileItem(CFileItem &fileItem);
 
     /*!
      * @brief Open a stream on the given channel.

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -94,7 +94,6 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING &recording, unsigned int iClien
   m_strDirectory                   = recording.bIsDeleted ? "" : recording.strDirectory;
   m_strPlot                        = recording.strPlot;
   m_strPlotOutline                 = recording.strPlotOutline;
-  m_strStreamURL                   = recording.strStreamURL;
   m_strChannelName                 = recording.strChannelName;
   m_strIconPath                    = recording.strIconPath;
   m_strThumbnailPath               = recording.strThumbnailPath;
@@ -147,7 +146,6 @@ bool CPVRRecording::operator ==(const CPVRRecording& right) const
        GetDuration()        == right.GetDuration() &&
        m_strPlotOutline     == right.m_strPlotOutline &&
        m_strPlot            == right.m_strPlot &&
-       m_strStreamURL       == right.m_strStreamURL &&
        m_iPriority          == right.m_iPriority &&
        m_iLifetime          == right.m_iLifetime &&
        m_strDirectory       == right.m_strDirectory &&
@@ -178,7 +176,6 @@ void CPVRRecording::Serialize(CVariant& value) const
 
   value["channel"] = m_strChannelName;
   value["lifetime"] = m_iLifetime;
-  value["streamurl"] = m_strStreamURL;
   value["directory"] = m_strDirectory;
   value["icon"] = m_strIconPath;
   value["starttime"] = m_recordingTime.IsValid() ? m_recordingTime.GetAsDBDateTime() : "";
@@ -203,7 +200,6 @@ void CPVRRecording::Reset(void)
   m_iClientId          = 0;
   m_strChannelName     .clear();
   m_strDirectory       .clear();
-  m_strStreamURL       .clear();
   m_iPriority          = -1;
   m_iLifetime          = -1;
   m_strFileNameAndPath .clear();
@@ -366,7 +362,6 @@ void CPVRRecording::Update(const CPVRRecording &tag)
   m_strDirectory      = tag.m_strDirectory;
   m_strPlot           = tag.m_strPlot;
   m_strPlotOutline    = tag.m_strPlotOutline;
-  m_strStreamURL      = tag.m_strStreamURL;
   m_strChannelName    = tag.m_strChannelName;
   m_genre             = tag.m_genre;
   m_strIconPath       = tag.m_strIconPath;
@@ -406,15 +401,8 @@ void CPVRRecording::Update(const CPVRRecording &tag)
 
 void CPVRRecording::UpdatePath(void)
 {
-  if (!m_strStreamURL.empty())
-  {
-    m_strFileNameAndPath = m_strStreamURL;
-  }
-  else
-  {
-    m_strFileNameAndPath = CPVRRecordingsPath(
-      m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode, GetYear(), m_strShowTitle, m_strChannelName, m_recordingTime, m_strRecordingId);
-  }
+  m_strFileNameAndPath = CPVRRecordingsPath(
+    m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode, GetYear(), m_strShowTitle, m_strChannelName, m_recordingTime, m_strRecordingId);
 }
 
 const CDateTime &CPVRRecording::RecordingTimeAsLocalTime(void) const

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -74,7 +74,6 @@ namespace PVR
     std::string   m_strChannelName;   /*!< name of the channel this was recorded from */
     int           m_iPriority;        /*!< priority of this recording */
     int           m_iLifetime;        /*!< lifetime of this recording */
-    std::string   m_strStreamURL;     /*!< stream URL. if empty use pvr client */
     std::string   m_strDirectory;     /*!< directory of this recording on the client */
     std::string   m_strIconPath;      /*!< icon path */
     std::string   m_strThumbnailPath; /*!< thumbnail path */

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1094,7 +1094,6 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   }
   CLog::Log(LOGDEBUG, "%s %s", __FUNCTION__, CURL::GetRedacted(item.GetPath()).c_str());
 
-
   //! @todo delete entire block in v18
   //! @deprecated m_strStreamURL is deprecated in v17
   if (item.IsPVR())
@@ -1107,54 +1106,58 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
 
       /* For recordings we check here for a available stream URL */
       CFileItemPtr tag = CServiceBroker::GetPVRManager().Recordings()->GetByPath(item.GetPath());
-      if (tag && tag->HasPVRRecordingInfoTag() && !tag->GetPVRRecordingInfoTag()->m_strStreamURL.empty())
+      if (tag && tag->HasPVRRecordingInfoTag())
       {
-        std::string stream = tag->GetPVRRecordingInfoTag()->m_strStreamURL;
+        CServiceBroker::GetPVRManager().FillStreamFileItem(*tag); // fill item's dynpath
+        const std::string stream = tag->GetDynPath();
 
-        /* Isolate the folder from the filename */
-        size_t found = stream.find_last_of("/");
-        if (found == std::string::npos)
-          found = stream.find_last_of("\\");
-
-        if (found != std::string::npos)
+        if (!stream.empty())
         {
-          /* Check here for asterix at the begin of the filename */
-          if (stream[found+1] == '*')
+          /* Isolate the folder from the filename */
+          size_t found = stream.find_last_of("/");
+          if (found == std::string::npos)
+            found = stream.find_last_of("\\");
+
+          if (found != std::string::npos)
           {
-            /* Create a "stack://" url with all files matching the extension */
-            std::string ext = URIUtils::GetExtension(stream);
-            std::string dir = stream.substr(0, found).c_str();
-
-            CFileItemList items;
-            CDirectory::GetDirectory(dir, items);
-            items.Sort(SortByFile, SortOrderAscending);
-
-            std::vector<int> stack;
-            for (int i = 0; i < items.Size(); ++i)
+            /* Check here for asterix at the begin of the filename */
+            if (stream[found+1] == '*')
             {
-              if (URIUtils::HasExtension(items[i]->GetPath(), ext))
-                stack.push_back(i);
+              /* Create a "stack://" url with all files matching the extension */
+              std::string ext = URIUtils::GetExtension(stream);
+              std::string dir = stream.substr(0, found).c_str();
+
+              CFileItemList items;
+              CDirectory::GetDirectory(dir, items);
+              items.Sort(SortByFile, SortOrderAscending);
+
+              std::vector<int> stack;
+              for (int i = 0; i < items.Size(); ++i)
+              {
+                if (URIUtils::HasExtension(items[i]->GetPath(), ext))
+                  stack.push_back(i);
+              }
+
+              if (stack.size() > 0)
+              {
+                /* If we have a stack change the path of the item to it */
+                CStackDirectory dir;
+                std::string stackPath = dir.ConstructStackPath(items, stack);
+                item.SetDynPath(stackPath);
+              }
             }
-
-            if (stack.size() > 0)
+            else
             {
-              /* If we have a stack change the path of the item to it */
-              CStackDirectory dir;
-              std::string stackPath = dir.ConstructStackPath(items, stack);
-              item.SetPath(stackPath);
+              /* If no asterix is present play only the given stream URL */
+              item.SetDynPath(stream);
             }
           }
           else
           {
-            /* If no asterix is present play only the given stream URL */
-            item.SetPath(stream);
+            CLog::Log(LOGERROR, "%s Can't open recording, no valid filename!", __FUNCTION__);
+            CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19036});
+            return false;
           }
-        }
-        else
-        {
-          CLog::Log(LOGERROR, "CGUIWindowTV: Can't open recording, no valid filename!");
-          CGUIDialogOK::ShowAndGetInput(CVariant{19033}, CVariant{19036});
-          return false;
         }
       }
     }


### PR DESCRIPTION
1. Replace API function `GetLiveStreamURL()` by `GetChannelStreamProperties()`
================================================================
Todo  for addon maintainers: Remove `GetLiveStreamURL` from your addon implementation. If your addon supports Live TV and/or Radio and it does implement live stream functions (`OpenLiveStream`, ...) (`bHandlesInputStream` set to false) you must implement the new API function. The new function basically does what `GetLiveStreamURL` did, but besides from the stream URL (as a new `property "streamurl"`) you can now also supply additional properties required to open the stream.

2. Add API function `GetRecordingStreamProperties()`
================================================================
Todo for addon maintainers: If your addon supports recordings and it does not implement recording stream functions (`OpenRecordedStream`, ...) you must implement the new API function. Functionality of the new function is similar to `GetChannelStreamProperties`.

3. Remove struct member `PVR_RECORDING::m_strStreamURL`
================================================================
Todo for addon maintainers: Remove references to `PVR_RECORDING::m_strStreamURL` from your addon implementation. Put the value you filled in there into the `property "streamurl"` in your implementation of the new API function `GetRecordingStreamProperties`.

Superseeds #12654 

Many thanks to @rbuehlma for the initial implementation which I shamelessly used as a base for this PR.