### PR TITLE
[AML/MediaCodec] release Outputbuffers in case no RenderBuffer is ava…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -63,6 +63,11 @@ CVideoBuffer* CAMLVideoBufferPool::Get()
 void CAMLVideoBufferPool::Return(int id)
 {
   CSingleLock lock(m_criticalSection);
+  if (m_videoBuffers[id]->m_amlCodec)
+  {
+    m_videoBuffers[id]->m_amlCodec->ReleaseFrame(m_videoBuffers[id]->m_bufferIndex, true);
+    m_videoBuffers[id]->m_amlCodec = nullptr;
+  }
   m_freeBuffers.push_back(id);
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -184,9 +184,9 @@ bool CMediaCodecVideoBuffer::WaitForFrame(int millis)
   return m_frameready->WaitMSec(millis);
 }
 
-void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTime)
+void CMediaCodecVideoBuffer::ReleaseOutputBuffer(bool render, int64_t displayTime, CMediaCodecVideoBufferPool* pool)
 {
-  std::shared_ptr<CMediaCodec> codec(static_cast<CMediaCodecVideoBufferPool*>(m_pool.get())->GetMediaCodec());
+  std::shared_ptr<CMediaCodec> codec(static_cast<CMediaCodecVideoBufferPool*>(pool ? pool : m_pool.get())->GetMediaCodec());
 
   if (m_bufferId < 0 || !codec)
     return;
@@ -316,6 +316,7 @@ CVideoBuffer* CMediaCodecVideoBufferPool::Get()
 void CMediaCodecVideoBufferPool::Return(int id)
 {
   CSingleLock lock(m_criticalSection);
+  m_videoBuffers[id]->ReleaseOutputBuffer(false, 0, this);
   m_freeBuffers.push_back(id);
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -71,6 +71,8 @@ private:
   AMediaCodec *m_codec;
 };
 
+class CMediaCodecVideoBufferPool;
+
 class CMediaCodecVideoBuffer : public CVideoBuffer
 {
 public:
@@ -85,7 +87,7 @@ public:
   // meat and potatoes
   bool                WaitForFrame(int millis);
   // MediaCodec related
-  void                ReleaseOutputBuffer(bool render, int64_t displayTime);
+  void                ReleaseOutputBuffer(bool render, int64_t displayTime, CMediaCodecVideoBufferPool* pool = nullptr);
   // SurfaceTexture released
   int                 GetBufferId() const;
   int                 GetTextureId() const;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -115,7 +115,10 @@ void CRendererAML::ReleaseBuffer(int idx)
     if (amli)
     {
       if (amli->m_amlCodec)
+      {
         amli->m_amlCodec->ReleaseFrame(amli->m_bufferIndex, true);
+        amli->m_amlCodec = nullptr; // Released
+      }
       amli->Release();
     }
     buf.videoBuffer = nullptr;


### PR DESCRIPTION
…ilable
## Description
Decoded pictures wich cannot be processed from VideoPlayer because no RenderBuffers are available are currently not proper released. This PR fixes this issue for both AML and MediaCodec.

## Motivation and Context
Stream stall after Pause on Android devices

## How Has This Been Tested?
Play a stream. pause 10 seconds, resume.
- Amlogic Test device (Android 6)
- odroid-C2 / linux ubuntu

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Note:
If you press Pause on Android devices, currently every 500ms a frame is generated and displayed.
This issue is under investigation in Player Core.