### PR TITLE
[settings] Fix missing CEC settings dialog labels.

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -237,6 +237,8 @@ void CSetting::OnSettingPropertyChanged(std::shared_ptr<const CSetting> setting,
 void CSetting::Copy(const CSetting &setting)
 {
   SetVisible(setting.IsVisible());
+  SetLabel(setting.GetLabel());
+  SetHelp(setting.GetHelp());
   SetRequirementsMet(setting.MeetsRequirements());
   m_callback = setting.m_callback;
   m_level = setting.m_level;


### PR DESCRIPTION
@Montellese I think this is fallout from https://github.com/xbmc/xbmc/pull/12276/commits/bee0d5eb56518c60d54e21bf2c593d9cf9cb8d19

Runtime-tested on macOS, latest kodi master, using my P8 CEC adapter.

@da-anda fyi