### PR TITLE
[Linux] Atomic DRM support

### DIFF
--- a/xbmc/windowing/gbm/CMakeLists.txt
+++ b/xbmc/windowing/gbm/CMakeLists.txt
@@ -3,15 +3,16 @@ set(SOURCES OptionalsReg.cpp
             WinSystemGbm.cpp
             GBMUtils.cpp
             DRMUtils.cpp
-            DRMLegacy.cpp)
-
+            DRMLegacy.cpp
+            DRMAtomic.cpp)
 
 set(HEADERS OptionalsReg.h
             GLContextEGL.h
             WinSystemGbm.h
             GBMUtils.h
             DRMUtils.h
-            DRMLegacy.h)
+            DRMLegacy.h
+            DRMAtomic.h)
 
 if(OPENGLES_FOUND)
   list(APPEND SOURCES WinSystemGbmGLESContext.cpp)

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -1,0 +1,231 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <errno.h>
+#include <drm_mode.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "settings/Settings.h"
+#include "utils/log.h"
+
+#include "DRMAtomic.h"
+#include "WinSystemGbmGLESContext.h"
+
+bool CDRMAtomic::AddConnectorProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value)
+{
+  struct connector *obj = m_connector;
+  int prop_id = 0;
+
+  for (unsigned int i = 0 ; i < obj->props->count_props ; i++)
+  {
+    if (strcmp(obj->props_info[i]->name, name) == 0)
+    {
+      prop_id = obj->props_info[i]->prop_id;
+      break;
+    }
+  }
+
+  if (prop_id < 0)
+  {
+    CLog::Log(LOGERROR, "CDRMAtomic::%s - no connector property: %s", __FUNCTION__, name);
+    return false;
+  }
+
+  auto ret = drmModeAtomicAddProperty(req, obj_id, prop_id, value);
+  if (ret < 0)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool CDRMAtomic::AddCrtcProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value)
+{
+  struct crtc *obj = m_crtc;
+  int prop_id = -1;
+
+  for (unsigned int i = 0 ; i < obj->props->count_props ; i++)
+  {
+    if (strcmp(obj->props_info[i]->name, name) == 0)
+    {
+      prop_id = obj->props_info[i]->prop_id;
+      break;
+    }
+  }
+
+  if (prop_id < 0)
+  {
+    CLog::Log(LOGERROR, "CDRMAtomic::%s - no crtc property: %s", __FUNCTION__, name);
+    return false;
+  }
+
+  auto ret = drmModeAtomicAddProperty(req, obj_id, prop_id, value);
+  if (ret < 0)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool CDRMAtomic::AddPlaneProperty(drmModeAtomicReq *req, struct plane *obj, const char *name, int value)
+{
+  int prop_id = -1;
+
+  for (unsigned int i = 0 ; i < obj->props->count_props ; i++)
+  {
+    if (strcmp(obj->props_info[i]->name, name) == 0)
+    {
+      prop_id = obj->props_info[i]->prop_id;
+      break;
+    }
+  }
+
+  if (prop_id < 0)
+  {
+    CLog::Log(LOGERROR, "CDRMAtomic::%s - no plane property: %s", __FUNCTION__, name);
+    return false;
+  }
+
+  auto ret = drmModeAtomicAddProperty(req, obj->plane->plane_id, prop_id, value);
+  if (ret < 0)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool CDRMAtomic::DrmAtomicCommit(int fb_id, int flags)
+{
+  uint32_t blob_id;
+
+  if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
+  {
+    if (!AddConnectorProperty(m_req, m_connector->connector->connector_id, "CRTC_ID", m_crtc->crtc->crtc_id))
+    {
+      return false;
+    }
+
+    if (drmModeCreatePropertyBlob(m_fd, m_mode, sizeof(*m_mode), &blob_id) != 0)
+    {
+      return false;
+    }
+
+    if (!AddCrtcProperty(m_req, m_crtc->crtc->crtc_id, "MODE_ID", blob_id))
+    {
+      return false;
+    }
+
+    if (!AddCrtcProperty(m_req, m_crtc->crtc->crtc_id, "ACTIVE", 1))
+    {
+      return false;
+    }
+  }
+
+  AddPlaneProperty(m_req, m_primary_plane, "FB_ID", fb_id);
+  AddPlaneProperty(m_req, m_primary_plane, "CRTC_ID", m_crtc->crtc->crtc_id);
+  AddPlaneProperty(m_req, m_primary_plane, "SRC_X", 0);
+  AddPlaneProperty(m_req, m_primary_plane, "SRC_Y", 0);
+  AddPlaneProperty(m_req, m_primary_plane, "SRC_W", m_mode->hdisplay << 16);
+  AddPlaneProperty(m_req, m_primary_plane, "SRC_H", m_mode->vdisplay << 16);
+  AddPlaneProperty(m_req, m_primary_plane, "CRTC_X", 0);
+  AddPlaneProperty(m_req, m_primary_plane, "CRTC_Y", 0);
+  AddPlaneProperty(m_req, m_primary_plane, "CRTC_W", m_mode->hdisplay);
+  AddPlaneProperty(m_req, m_primary_plane, "CRTC_H", m_mode->vdisplay);
+
+  auto ret = drmModeAtomicCommit(m_fd, m_req, flags, nullptr);
+  if (ret)
+  {
+    return false;
+  }
+
+  drmModeAtomicFree(m_req);
+
+  m_req = drmModeAtomicAlloc();
+
+  return true;
+}
+
+void CDRMAtomic::FlipPage(struct gbm_bo *bo)
+{
+  uint32_t flags = 0;
+
+  if(m_need_modeset)
+  {
+    flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+    m_need_modeset = false;
+  }
+
+  struct drm_fb *drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
+  if (!drm_fb)
+  {
+    CLog::Log(LOGERROR, "CDRMAtomic::%s - Failed to get a new FBO", __FUNCTION__);
+    return;
+  }
+
+  auto ret = DrmAtomicCommit(drm_fb->fb_id, flags);
+  if (!ret) {
+    CLog::Log(LOGERROR, "CDRMAtomic::%s - failed to commit: %s", __FUNCTION__, strerror(errno));
+    return;
+  }
+}
+
+bool CDRMAtomic::InitDrm()
+{
+  if (!CDRMUtils::OpenDrm())
+  {
+    return false;
+  }
+
+  auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ATOMIC, 1);
+  if (ret)
+  {
+    CLog::Log(LOGERROR, "CDRMAtomic::%s - no atomic modesetting support: %s", __FUNCTION__, strerror(errno));
+    return false;
+  }
+
+  m_req = drmModeAtomicAlloc();
+
+  if (!CDRMUtils::InitDrm())
+  {
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "CDRMAtomic::%s - initialized atomic DRM", __FUNCTION__);
+  return true;
+}
+
+void CDRMAtomic::DestroyDrm()
+{
+  CDRMUtils::DestroyDrm();
+
+  drmModeAtomicFree(m_req);
+  m_req = nullptr;
+}
+
+bool CDRMAtomic::SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo)
+{
+  m_need_modeset = true;
+
+  return true;
+}

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "DRMUtils.h"
+
+class CDRMAtomic : public CDRMUtils
+{
+public:
+  CDRMAtomic() = default;
+  ~CDRMAtomic() { DestroyDrm(); };
+  virtual void FlipPage(struct gbm_bo *bo) override;
+  virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
+  virtual bool InitDrm() override;
+  virtual void DestroyDrm() override;
+
+private:
+  bool AddConnectorProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
+  bool AddCrtcProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
+  bool AddPlaneProperty(drmModeAtomicReq *req, struct plane *obj, const char *name, int value);
+  bool DrmAtomicCommit(int fb_id, int flags);
+
+  bool m_need_modeset;
+};

--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -155,6 +155,11 @@ void CDRMLegacy::FlipPage(struct gbm_bo *bo)
 
 bool CDRMLegacy::InitDrm()
 {
+  if (!CDRMUtils::OpenDrm())
+  {
+    return false;
+  }
+
   if (!CDRMUtils::InitDrm())
   {
     return false;

--- a/xbmc/windowing/gbm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/DRMLegacy.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include "DRMUtils.h"
-#include "GLContextEGL.h"
 
 class CDRMLegacy : public CDRMUtils
 {

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -560,21 +560,30 @@ void CDRMUtils::DestroyDrm()
 {
   RestoreOriginalMode();
 
-  if (m_drm_resources)
-  {
-    drmModeFreeResources(m_drm_resources);
-    m_drm_resources = nullptr;
-  }
-
   drmDropMaster(m_fd);
   close(m_fd);
 
-  m_connector = nullptr;
-  m_encoder = nullptr;
-  m_crtc = nullptr;
-  m_primary_plane = nullptr;
-  m_overlay_plane = nullptr;
   m_fd = -1;
+
+  drmModeFreeResources(m_drm_resources);
+  m_drm_resources = nullptr;
+
+  delete m_connector;
+  m_connector = nullptr;
+
+  delete m_encoder;
+  m_encoder = nullptr;
+
+  delete m_crtc;
+  m_crtc = nullptr;
+
+  delete m_primary_plane;
+  m_primary_plane = nullptr;
+
+  delete m_overlay_plane;
+  m_overlay_plane = nullptr;
+
+  drmModeFreeModeInfo(m_mode);
   m_mode = nullptr;
 }
 

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -423,10 +423,8 @@ bool CDRMUtils::GetPlanes()
   return true;
 }
 
-int CDRMUtils::Open(const char* device)
+bool CDRMUtils::OpenDrm()
 {
-  int fd = -1;
-
   std::vector<const char*>modules =
   {
     "i915",
@@ -442,67 +440,85 @@ int CDRMUtils::Open(const char* device)
     "sun4i-drm",
   };
 
-  for (auto module : modules)
+  for(int i = 0; i < 10; ++i)
   {
-    fd = drmOpen(module, device);
-    if (fd >= 0)
+    std::string device = "/dev/dri/card";
+    device.append(std::to_string(i));
+
+    for (auto module : modules)
     {
-      CLog::Log(LOGDEBUG, "CDRMUtils::%s - opened device: %s using module: %s", __FUNCTION__, device, module);
-      break;
+      m_fd = drmOpen(module, device.c_str());
+      if (m_fd >= 0)
+      {
+        if(!GetResources())
+        {
+          continue;
+        }
+
+        if(!GetConnector())
+        {
+          continue;
+        }
+
+        drmModeFreeResources(m_drm_resources);
+        m_drm_resources = nullptr;
+
+        drmModeFreeConnector(m_connector->connector);
+        m_connector->connector = nullptr;
+
+        drmModeFreeObjectProperties(m_connector->props);
+        m_connector->props = nullptr;
+
+        drmModeFreeProperty(*m_connector->props_info);
+        *m_connector->props_info = nullptr;
+
+        CLog::Log(LOGDEBUG, "CDRMUtils::%s - opened device: %s using module: %s", __FUNCTION__, device.c_str(), module);
+        return true;
+      }
+
+      drmClose(m_fd);
+      m_fd = -1;
     }
   }
 
-  return fd;
+  return false;
 }
 
 bool CDRMUtils::InitDrm()
 {
-  for(int i = 0; i < 10; ++i)
+  if(m_fd >= 0)
   {
-    if (m_fd >= 0)
+    /* caps need to be set before allocating connectors, encoders, crtcs, and planes */
+    auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+    if (ret)
     {
-      drmClose(m_fd);
+      CLog::Log(LOGERROR, "CDRMUtils::%s - failed to set Universal planes capability: %s", __FUNCTION__, strerror(errno));
+      return false;
     }
 
-    std::string device = "/dev/dri/card";
-    device.append(std::to_string(i));
-    m_fd = CDRMUtils::Open(device.c_str());
-
-    if(m_fd >= 0)
+    if(!GetResources())
     {
-      if(!GetResources())
-      {
-        continue;
-      }
+      return false;
+    }
 
-      if(!GetConnector())
-      {
-        continue;
-      }
+    if(!GetConnector())
+    {
+      return false;
+    }
 
-      if(!GetEncoder())
-      {
-        continue;
-      }
+    if(!GetEncoder())
+    {
+      return false;
+    }
 
-      if(!GetCrtc())
-      {
-        continue;
-      }
+    if(!GetCrtc())
+    {
+      return false;
+    }
 
-      auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
-      if (ret)
-      {
-        CLog::Log(LOGERROR, "CDRMUtils::%s - failed to set Universal planes capability: %s", __FUNCTION__, strerror(errno));
-        return false;
-      }
-
-      if(!GetPlanes())
-      {
-        continue;
-      }
-
-      break;
+    if(!GetPlanes())
+    {
+      return false;
     }
   }
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -69,8 +69,8 @@ public:
   virtual void FlipPage(struct gbm_bo *bo) {};
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) { return false; };
   virtual bool InitDrm();
+  virtual void DestroyDrm();
 
-  void DestroyDrm();
   bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
   bool SetMode(RESOLUTION_INFO res);
   void WaitVBlank();
@@ -83,6 +83,7 @@ public:
   struct plane *m_primary_plane = nullptr;
   struct plane *m_overlay_plane = nullptr;
   drmModeModeInfo *m_mode = nullptr;
+  drmModeAtomicReq *m_req = nullptr;
 
 protected:
   bool OpenDrm();
@@ -99,6 +100,7 @@ private:
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
 
   int m_crtc_index;
+
   drmModeResPtr m_drm_resources = nullptr;
   drmModeCrtcPtr m_orig_crtc = nullptr;
 };

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -85,6 +85,7 @@ public:
   drmModeModeInfo *m_mode = nullptr;
 
 protected:
+  bool OpenDrm();
   drm_fb * DrmFbGetFromBo(struct gbm_bo *bo);
 
 private:
@@ -94,7 +95,6 @@ private:
   bool GetCrtc();
   bool GetPlanes();
   bool GetPreferredMode();
-  int Open(const char* device);
   bool RestoreOriginalMode();
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
 


### PR DESCRIPTION
The future is here!

This PR does a few things
1. ~splits out gbm into it's own file~
2. ~splits out drm legacy api into it's own file~
3. implements atomic drm
4. ~adds an abstraction layer for selection of atomic drm or legacy drm~
5. ~removes some of the pointer games that I was playing.~
6. ~implements register/unregister functions for the winsystem~

I'm PR'ing this now so people can have a look at it. I'm going on vacation for a week so it would be nice to have some comments for when I get back.

Something I need to do is the license headers. I have also re-used lot's of code from the kmscube project and would like to give proper credit back to them. https://cgit.freedesktop.org/mesa/kmscube/tree/COPYING

~After this I would like to add support for gbm modifiers and the usage of DrmModeSetFb2~

It might be worth getting @longchair and @Kwiboo to test this out with rockchip

Current working platforms:
- [x] Raspberry Pi (vc4)
- [x] Cubox-i4 (etnaviv)
- [x] Intel
- [x] Dragonboard (msm) (needs kernel 4.10 or later for gpu fencing)
- [x] Orange Pi PC