### PR TITLE
mark constructors explicit

### DIFF
--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -35,7 +35,7 @@ public:
   static const CContextMenuItem MAIN;
   static const CContextMenuItem MANAGE;
 
-  CContextMenuManager(ADDON::CAddonMgr& addonMgr);
+  explicit CContextMenuManager(ADDON::CAddonMgr& addonMgr);
   ~CContextMenuManager();
   static CContextMenuManager& GetInstance();
 

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -83,7 +83,7 @@ class FileReader
   : public CueReader
 {
 public:
-  FileReader(const std::string &strFile)
+  explicit FileReader(const std::string &strFile) : m_szBuffer{}
   {
     m_opened = m_file.Open(strFile);
   }
@@ -121,7 +121,7 @@ class BufferReader
   : public CueReader
 {
 public:
-  BufferReader(const std::string &strContent)
+  explicit BufferReader(const std::string &strContent)
     : m_data(strContent)
     , m_pos(0)
   {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -126,7 +126,7 @@ class CSetCurrentItemJob : public CJob
 {
   CFileItemPtr m_itemCurrentFile;
 public:
-  CSetCurrentItemJob(const CFileItemPtr item) : m_itemCurrentFile(item) { }
+  explicit CSetCurrentItemJob(const CFileItemPtr& item) : m_itemCurrentFile(item) { }
   ~CSetCurrentItemJob(void) override = default;
 
   bool DoWork(void) override

--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -119,7 +119,7 @@ private:
   class CLargeTexture
   {
   public:
-    CLargeTexture(const std::string &path);
+    explicit CLargeTexture(const std::string &path);
     virtual ~CLargeTexture();
 
     void AddRef();

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -132,7 +132,7 @@ private:
 class CTextureUseCountJob : public CJob
 {
 public:
-  CTextureUseCountJob(const std::vector<CTextureDetails> &textures);
+  explicit CTextureUseCountJob(const std::vector<CTextureDetails> &textures);
 
   const char* GetType() const override { return "usecount"; };
   bool operator==(const CJob *job) const override;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -402,7 +402,7 @@ void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr &pAddon)
 
 struct AddonIdFinder
 {
-    AddonIdFinder(const std::string& id)
+    explicit AddonIdFinder(const std::string& id)
       : m_id(id)
     {}
 

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -40,7 +40,7 @@ namespace ADDON
                         public XFILE::CMusicFileDirectory
   {
   public:
-    CAudioDecoder(const BinaryAddonBasePtr& addonInfo);
+    explicit CAudioDecoder(const BinaryAddonBasePtr& addonInfo);
     ~CAudioDecoder() override;
 
     // Things that MUST be supplied by the child classes

--- a/xbmc/addons/AudioEncoder.h
+++ b/xbmc/addons/AudioEncoder.h
@@ -27,7 +27,7 @@ namespace ADDON
   class CAudioEncoder : public IEncoder, public IAddonInstanceHandler
   {
   public:
-    CAudioEncoder(BinaryAddonBasePtr addonBase);
+    explicit CAudioEncoder(BinaryAddonBasePtr addonBase);
 
     // Child functions related to IEncoder
     bool Init(AddonToKodiFuncTable_AudioEncoder& callbacks) override;

--- a/xbmc/addons/GUIViewStateAddonBrowser.h
+++ b/xbmc/addons/GUIViewStateAddonBrowser.h
@@ -25,7 +25,7 @@
 class CGUIViewStateAddonBrowser : public CGUIViewState
 {
 public:
-  CGUIViewStateAddonBrowser(const CFileItemList& items);
+  explicit CGUIViewStateAddonBrowser(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;

--- a/xbmc/addons/GameResource.h
+++ b/xbmc/addons/GameResource.h
@@ -29,7 +29,7 @@ namespace ADDON
 class CGameResource : public CResource
 {
 public:
-  CGameResource(CAddonInfo addonInfo);
+  explicit CGameResource(CAddonInfo addonInfo);
   ~CGameResource() override = default;
 
   static std::unique_ptr<CGameResource> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);

--- a/xbmc/addons/ImageDecoder.h
+++ b/xbmc/addons/ImageDecoder.h
@@ -28,7 +28,7 @@ namespace ADDON
                         public IImage
   {
   public:
-    CImageDecoder(ADDON::BinaryAddonBasePtr addonBase);
+    explicit CImageDecoder(ADDON::BinaryAddonBasePtr addonBase);
     ~CImageDecoder() override;
 
     bool Create(const std::string& mimetype);

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -28,7 +28,7 @@ namespace ADDON
 class CScreenSaver : public IAddonInstanceHandler
 {
 public:
-  CScreenSaver(BinaryAddonBasePtr addonBase);
+  explicit CScreenSaver(BinaryAddonBasePtr addonBase);
   ~CScreenSaver() override;
 
   bool Start();

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -200,7 +200,7 @@ CSkinInfo::CSkinInfo(
 
 struct closestRes
 {
-  closestRes(const RESOLUTION_INFO &target) : m_target(target) { };
+  explicit closestRes(const RESOLUTION_INFO &target) : m_target(target) { };
   bool operator()(const RESOLUTION_INFO &i, const RESOLUTION_INFO &j)
   {
     float diff = fabs(i.DisplayRatio() - m_target.DisplayRatio()) - fabs(j.DisplayRatio() - m_target.DisplayRatio());

--- a/xbmc/addons/UISoundsResource.h
+++ b/xbmc/addons/UISoundsResource.h
@@ -27,7 +27,7 @@ namespace ADDON
 class CUISoundsResource : public CResource
 {
 public:
-  CUISoundsResource(CAddonInfo addonInfo) : CResource(std::move(addonInfo)) {};
+  explicit CUISoundsResource(CAddonInfo addonInfo) : CResource(std::move(addonInfo)) {}
   bool IsAllowed(const std::string &file) const override;
   bool IsInUse() const override;
   void OnPostInstall(bool update, bool modal) override;

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -95,7 +95,7 @@ void CVFSAddonCache::Update()
 class CVFSURLWrapper
 {
   public:
-    CVFSURLWrapper(const CURL& url2)
+    explicit CVFSURLWrapper(const CURL& url2)
     {
       m_strings.push_back(url2.Get());
       m_strings.push_back(url2.GetDomain());

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -54,7 +54,7 @@ namespace ADDON
   public:
     //! \brief Construct from add-on properties.
     //! \param addonInfo General addon properties
-    CVFSEntry(BinaryAddonBasePtr addonInfo);
+    explicit CVFSEntry(BinaryAddonBasePtr addonInfo);
     ~CVFSEntry() override;
 
     // Things that MUST be supplied by the child classes
@@ -105,7 +105,7 @@ namespace ADDON
   public:
     //! \brief The constructor initializes the reference to the wrapped CVFSEntry.
     //! \param ptr The CVFSEntry to wrap.
-    CVFSEntryIFileWrapper(VFSEntryPtr ptr);
+    explicit CVFSEntryIFileWrapper(VFSEntryPtr ptr);
 
     //! \brief Empty destructor.
     ~CVFSEntryIFileWrapper() override;
@@ -189,7 +189,7 @@ namespace ADDON
   public:
     //! \brief The constructor initializes the reference to the wrapped CVFSEntry.
     //! \param ptr The CVFSEntry to wrap.
-    CVFSEntryIDirectoryWrapper(VFSEntryPtr ptr);
+    explicit CVFSEntryIDirectoryWrapper(VFSEntryPtr ptr);
 
     //! \brief Empty destructor.
     ~CVFSEntryIDirectoryWrapper() override = default;
@@ -246,7 +246,7 @@ namespace ADDON
   public:
     //! \brief The constructor initializes the reference to the wrapped CVFSEntry.
     //! \param ptr The CVFSEntry to wrap.
-    CVFSEntryIFileDirectoryWrapper(VFSEntryPtr ptr) : CVFSEntryIDirectoryWrapper(ptr) {}
+    explicit CVFSEntryIFileDirectoryWrapper(VFSEntryPtr ptr) : CVFSEntryIDirectoryWrapper(ptr) {}
 
     //! \brief Empty destructor.
     ~CVFSEntryIFileDirectoryWrapper() override = default;

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.h
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.h
@@ -45,7 +45,7 @@ namespace AddOn
 class CAddonCallbacksAddon
 {
 public:
-  CAddonCallbacksAddon(ADDON::CAddon* addon);
+  explicit CAddonCallbacksAddon(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksAddon();
 
   /*!

--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.h
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.h
@@ -36,7 +36,7 @@ namespace GUI
 class CAddonCallbacksGUI
 {
 public:
-  CAddonCallbacksGUI(ADDON::CAddon* addon);
+  explicit CAddonCallbacksGUI(ADDON::CAddon* addon);
   virtual ~CAddonCallbacksGUI();
 
   /**! \name General Functions */

--- a/xbmc/addons/interfaces/GUI/AddonGUIRenderingControl.h
+++ b/xbmc/addons/interfaces/GUI/AddonGUIRenderingControl.h
@@ -33,7 +33,7 @@ class CGUIAddonRenderingControl : public IRenderingCallback
 {
 friend class CAddonCallbacksGUI;
 public:
-  CGUIAddonRenderingControl(CGUIRenderingControl *pControl);
+  explicit CGUIAddonRenderingControl(CGUIRenderingControl *pControl);
   virtual ~CGUIAddonRenderingControl() = default;
   bool Create(int x, int y, int w, int h, void *device) override;
   void Render() override;

--- a/xbmc/addons/interfaces/GUI/controls/Rendering.h
+++ b/xbmc/addons/interfaces/GUI/controls/Rendering.h
@@ -72,7 +72,7 @@ namespace ADDON
   {
   friend struct Interface_GUIControlAddonRendering;
   public:
-    CGUIAddonRenderingControl(CGUIRenderingControl *pControl);
+    explicit CGUIAddonRenderingControl(CGUIRenderingControl *pControl);
     virtual ~CGUIAddonRenderingControl() = default;
 
     bool Create(int x, int y, int w, int h, void *device) override;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -310,7 +310,7 @@ namespace vfs
     //
     // @param[in] dirEntry pointer to own class type
     //
-    CDirEntry(const VFSDirEntry& dirEntry) :
+    explicit CDirEntry(const VFSDirEntry& dirEntry) :
       m_label(dirEntry.label ? dirEntry.label : ""),
       m_path(dirEntry.path ? dirEntry.path : ""),
       m_folder(dirEntry.folder),

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioDecoder.h
@@ -83,7 +83,7 @@ namespace addon
     /// @param[in] instance             The from Kodi given instance given be
     ///                                 add-on CreateInstance call with instance
     ///                                 id ADDON_INSTANCE_AUDIODECODER.
-    CInstanceAudioDecoder(KODI_HANDLE instance)
+    explicit CInstanceAudioDecoder(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_AUDIODECODER)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioEncoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/AudioEncoder.h
@@ -75,7 +75,7 @@ namespace addon
     /// @param[in] instance             The from Kodi given instance given be
     ///                                 add-on CreateInstance call with instance
     ///                                 id ADDON_INSTANCE_AUDIOENCODER.
-    CInstanceAudioEncoder(KODI_HANDLE instance)
+    explicit CInstanceAudioEncoder(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_AUDIOENCODER)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ImageDecoder.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/ImageDecoder.h
@@ -81,7 +81,7 @@ namespace addon
     /// @param[in] instance             The from Kodi given instance given be
     ///                                 add-on CreateInstance call with instance
     ///                                 id ADDON_INSTANCE_IMAGEDECODER.
-    CInstanceImageDecoder(KODI_HANDLE instance)
+    explicit CInstanceImageDecoder(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_IMAGEDECODER)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -218,7 +218,7 @@ namespace addon
   class CInstanceInputStream : public IAddonInstance
   {
   public:
-    CInstanceInputStream(KODI_HANDLE instance)
+    explicit CInstanceInputStream(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_INPUTSTREAM)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Peripheral.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Peripheral.h
@@ -319,7 +319,7 @@ namespace addon
       CAddonBase::m_interface->globalSingleInstance = this;
     }
 
-    CInstancePeripheral(KODI_HANDLE instance)
+    explicit CInstancePeripheral(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_PERIPHERAL)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/PeripheralUtils.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/PeripheralUtils.h
@@ -104,7 +104,7 @@ namespace addon
     {
     }
 
-    Peripheral(const PERIPHERAL_INFO& info) :
+    explicit Peripheral(const PERIPHERAL_INFO& info) :
       m_type(info.type),
       m_strName(info.name ? info.name : ""),
       m_vendorId(info.vendor_id),
@@ -196,7 +196,7 @@ namespace addon
       SetAxisState(state);
     }
 
-    PeripheralEvent(const PERIPHERAL_EVENT& event) :
+    explicit PeripheralEvent(const PERIPHERAL_EVENT& event) :
       m_event(event)
     {
     }
@@ -259,7 +259,7 @@ namespace addon
       *this = other;
     }
 
-    Joystick(const JOYSTICK_INFO& info) :
+    explicit Joystick(const JOYSTICK_INFO& info) :
       Peripheral(info.peripheral),
       m_provider(info.provider ? info.provider : ""),
       m_requestedPort(info.requested_port),
@@ -445,7 +445,7 @@ namespace addon
       return DriverPrimitive(JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOTOR, motorIndex);
     }
 
-    DriverPrimitive(const JOYSTICK_DRIVER_PRIMITIVE& primitive) :
+    explicit DriverPrimitive(const JOYSTICK_DRIVER_PRIMITIVE& primitive) :
       m_type(primitive.type),
       m_driverIndex(0),
       m_hatDirection(JOYSTICK_DRIVER_HAT_UNKNOWN),
@@ -604,12 +604,12 @@ namespace addon
       *this = other;
     }
 
-    JoystickFeature(const JOYSTICK_FEATURE& feature) :
+    explicit JoystickFeature(const JOYSTICK_FEATURE& feature) :
       m_name(feature.name ? feature.name : ""),
       m_type(feature.type)
     {
       for (unsigned int i = 0; i < JOYSTICK_PRIMITIVE_MAX; i++)
-        m_primitives[i] = feature.primitives[i];
+        m_primitives[i] = DriverPrimitive(feature.primitives[i]);
     }
 
     JoystickFeature& operator=(const JoystickFeature& rhs)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Screensaver.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Screensaver.h
@@ -261,7 +261,7 @@ namespace addon
     ///
     /// @warning Only use `instance` from the CreateInstance call
     ///
-    CInstanceScreensaver(KODI_HANDLE instance)
+    explicit CInstanceScreensaver(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_SCREENSAVER)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VFS.h
@@ -119,7 +119,7 @@ namespace addon
   class CInstanceVFS : public IAddonInstance
   {
   public:
-    CInstanceVFS(KODI_HANDLE instance)
+    explicit CInstanceVFS(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_VFS)
     {
       if (CAddonBase::m_interface->globalSingleInstance != nullptr)
@@ -350,7 +350,7 @@ namespace addon
         m_cb->require_authentication(m_cb->ctx, url.c_str());
       }
 
-      CVFSCallbacks(const VFSGetDirectoryCallbacks* cb) : m_cb(cb) { }
+      explicit CVFSCallbacks(const VFSGetDirectoryCallbacks* cb) : m_cb(cb) { }
 
     private:
       const VFSGetDirectoryCallbacks* m_cb;
@@ -519,7 +519,7 @@ namespace addon
                                           VFSGetDirectoryCallbacks* callbacks)
     {
       std::vector<kodi::vfs::CDirEntry> addonEntries;
-      bool ret = instance->toAddon.addonInstance->GetDirectory(*url, addonEntries, callbacks);
+      bool ret = instance->toAddon.addonInstance->GetDirectory(*url, addonEntries, CVFSCallbacks(callbacks));
       if (ret)
       {
         VFSDirEntry* entries = static_cast<VFSDirEntry*>(malloc(sizeof(VFSDirEntry) * addonEntries.size()));

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -158,7 +158,7 @@ namespace kodi
     class CInstanceVideoCodec : public IAddonInstance
     {
     public:
-      CInstanceVideoCodec(KODI_HANDLE instance)
+      explicit CInstanceVideoCodec(KODI_HANDLE instance)
         : IAddonInstance(ADDON_INSTANCE_VIDEOCODEC)
       {
         if (CAddonBase::m_interface->globalSingleInstance != nullptr)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Visualization.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Visualization.h
@@ -340,7 +340,7 @@ namespace addon
     ///
     /// @warning Only use `instance` from the CreateInstance call
     ///
-    CInstanceVisualization(KODI_HANDLE instance)
+    explicit CInstanceVisualization(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_VISUALIZATION),
         m_presetLockedByUser(false)
     {

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/ListItem.h
@@ -37,7 +37,7 @@ namespace gui
     GUIHANDLE GetControlHandle() const { return m_controlHandle; }
 
   protected:
-    CAddonGUIControlBase(CAddonGUIControlBase* window)
+    explicit CAddonGUIControlBase(CAddonGUIControlBase* window)
     : m_controlHandle(nullptr),
       m_interface(::kodi::addon::CAddonBase::m_interface->toKodi),
       m_Window(window) {}
@@ -111,7 +111,7 @@ namespace gui
      * Related to call of "ListItemPtr kodi::gui::CWindow::GetListItem(int listPos)"
      * Not needed for addon development itself
      */
-    CListItem(GUIHANDLE listItemHandle)
+    explicit CListItem(GUIHANDLE listItemHandle)
       : CAddonGUIControlBase(nullptr)
     {
       m_controlHandle = listItemHandle;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/ExtendedProgress.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/ExtendedProgress.h
@@ -75,7 +75,7 @@ namespace dialogs
     ///
     /// @param[in] title  Title string
     ///
-    CExtendedProgress(const std::string& title = "")
+    explicit CExtendedProgress(const std::string& title = "")
     {
       using namespace ::kodi::addon;
       m_DialogHandle = CAddonBase::m_interface->toKodi->kodi_gui->dialogExtendedProgress->new_dialog(CAddonBase::m_interface->toKodi->kodiBase, title.c_str());

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -40,7 +40,7 @@ namespace ADDON
   class CAddonSettings : public CSettingsBase, public CSettingCreator, public CSettingControlCreator, public ISettingCallback
   {
   public:
-    CAddonSettings(std::shared_ptr<const IAddon> addon);
+    explicit CAddonSettings(std::shared_ptr<const IAddon> addon);
     ~CAddonSettings() override = default;
 
     // specialization of CSettingsBase

--- a/xbmc/cdrip/Encoder.h
+++ b/xbmc/cdrip/Encoder.h
@@ -33,7 +33,7 @@ namespace XFILE { class CFile; }
 class CEncoder
 {
 public:
-  CEncoder(std::shared_ptr<IEncoder> encoder);
+  explicit CEncoder(std::shared_ptr<IEncoder> encoder);
   virtual ~CEncoder();
   virtual bool Init(const char* strFile, int iInChannels, int iInRate, int iInBits);
   virtual int Encode(int nNumBytesRead, uint8_t* pbtStream);

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -29,7 +29,7 @@ namespace XbmcCommons
     std::string message;
 
   public:
-    BufferException(const char* message_) : message(message_) {}
+    explicit BufferException(const char* message_) : message(message_) {}
   };
 
   /**
@@ -129,7 +129,7 @@ namespace XbmcCommons
      * other Buffer instances. It will be freed upon destruction of
      * the last Buffer that references it.
      */
-    inline Buffer(size_t bufferSize) : buffer(bufferSize ? new unsigned char[bufferSize] : NULL), mcapacity(bufferSize)
+    inline explicit Buffer(size_t bufferSize) : buffer(bufferSize ? new unsigned char[bufferSize] : NULL), mcapacity(bufferSize)
     { 
       clear(); 
       bufferRef.reset(buffer, std::default_delete<unsigned char[]>());

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -32,7 +32,7 @@ class CExternalPlayer : public IPlayer, public CThread
 public:
   enum WARP_CURSOR { WARP_NONE = 0, WARP_TOP_LEFT, WARP_TOP_RIGHT, WARP_BOTTOM_RIGHT, WARP_BOTTOM_LEFT, WARP_CENTER };
 
-  CExternalPlayer(IPlayerCallback& callback);
+  explicit CExternalPlayer(IPlayerCallback& callback);
   ~CExternalPlayer() override;
   bool Initialize(TiXmlElement* pConfig) override;
   bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -42,7 +42,7 @@ namespace RETRO
                        public IRenderMsg
   {
   public:
-    CRetroPlayer(IPlayerCallback& callback);
+    explicit CRetroPlayer(IPlayerCallback& callback);
     ~CRetroPlayer() override;
 
     // implementation of IPlayer

--- a/xbmc/cores/RetroPlayer/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAudio.h
@@ -34,7 +34,7 @@ namespace RETRO
   class CRetroPlayerAudio : public GAME::IGameAudioCallback
   {
   public:
-    CRetroPlayerAudio(CProcessInfo& processInfo);
+    explicit CRetroPlayerAudio(CProcessInfo& processInfo);
     ~CRetroPlayerAudio() override;
 
     // implementation of IGameAudioCallback

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.h
@@ -29,7 +29,7 @@ namespace RETRO
   class CRetroPlayerAutoSave : protected CThread
   {
   public:
-    CRetroPlayerAutoSave(GAME::CGameClient &gameClient);
+    explicit CRetroPlayerAutoSave(GAME::CGameClient &gameClient);
 
     ~CRetroPlayerAutoSave() override;
 

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -39,7 +39,7 @@ class CDVDClock;
 class CAudioSinkAE : IAEClockCallback
 {
 public:
-  CAudioSinkAE(CDVDClock *clock);
+  explicit CAudioSinkAE(CDVDClock *clock);
   ~CAudioSinkAE();
 
   void SetVolume(float fVolume);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodec.h
@@ -63,7 +63,7 @@ class CDVDAudioCodec
 {
 public:
 
-  CDVDAudioCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
+  explicit CDVDAudioCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
   virtual ~CDVDAudioCodec() = default;
 
   /*

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -35,7 +35,7 @@ class CProcessInfo;
 class CDVDAudioCodecFFmpeg : public CDVDAudioCodec
 {
 public:
-  CDVDAudioCodecFFmpeg(CProcessInfo &processInfo);
+  explicit CDVDAudioCodecFFmpeg(CProcessInfo &processInfo);
   ~CDVDAudioCodecFFmpeg() override;
   bool Open(CDVDStreamInfo &hints,
                     CDVDCodecOptions &options) override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -37,7 +37,7 @@ enum DVDOverlayType
 class CDVDOverlay
 {
 public:
-  CDVDOverlay(DVDOverlayType type)
+  explicit CDVDOverlay(DVDOverlayType type)
   {
     m_type = type;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -39,7 +39,7 @@ class CDVDOverlayCodec
 {
 public:
 
-  CDVDOverlayCodec(const char* name) : m_codecName(name) {}
+  explicit CDVDOverlayCodec(const char* name) : m_codecName(name) {}
 
   virtual ~CDVDOverlayCodec() = default;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
@@ -30,7 +30,7 @@ public:
 
   CDVDSubtitlesLibass* m_libass;
 
-  CDVDOverlaySSA(CDVDSubtitlesLibass* libass) : CDVDOverlay(DVDOVERLAY_TYPE_SSA)
+  explicit CDVDOverlaySSA(CDVDSubtitlesLibass* libass) : CDVDOverlay(DVDOVERLAY_TYPE_SSA)
   {
     replace = true;
     m_libass = libass;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayText.h
@@ -38,7 +38,7 @@ public:
   class CElement
   {
   public:
-    CElement(ElementType type)
+    explicit CElement(ElementType type)
     {
       pNext = NULL;
       m_type = type;
@@ -72,7 +72,7 @@ public:
       else
         m_text.assign(strText, size);
     }
-    CElementText(const std::string& text) : CElement(ELEMENT_TYPE_TEXT),
+    explicit CElementText(const std::string& text) : CElement(ELEMENT_TYPE_TEXT),
       m_text(text)
     {
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -122,7 +122,7 @@ public:
     VC_EOF              //< EOF
   };
 
-  CDVDVideoCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
+  explicit CDVDVideoCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
   virtual ~CDVDVideoCodec() = default;
 
   /**

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -42,7 +42,7 @@ class CVideoBufferPoolFFmpeg;
 class CDVDVideoCodecFFmpeg : public CDVDVideoCodec, public ICallbackHWAccel
 {
 public:
-  CDVDVideoCodecFFmpeg(CProcessInfo &processInfo);
+  explicit CDVDVideoCodecFFmpeg(CProcessInfo &processInfo);
   ~CDVDVideoCodecFFmpeg() override;
   bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
   bool AddData(const DemuxPacket &packet) override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h
@@ -426,7 +426,7 @@ private:
 class CDVDVideoCodecIMX : public CDVDVideoCodec
 {
 public:
-  CDVDVideoCodecIMX(CProcessInfo &processInfo) : CDVDVideoCodec(processInfo), m_pFormatName("iMX-xxx") {}
+  explicit CDVDVideoCodecIMX(CProcessInfo &processInfo) : CDVDVideoCodec(processInfo), m_pFormatName("iMX-xxx") {}
   virtual ~CDVDVideoCodecIMX();
 
   // Methods from CDVDVideoCodec which require overrides

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoPPFFmpeg.h
@@ -30,7 +30,7 @@ class CDVDVideoPPFFmpeg
 {
 public:
 
-  CDVDVideoPPFFmpeg(CProcessInfo &processInfo);
+  explicit CDVDVideoPPFFmpeg(CProcessInfo &processInfo);
   ~CDVDVideoPPFFmpeg();
 
   void SetType(const std::string& mType, bool deinterlace);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1213,7 +1213,7 @@ void CDecoder::Register(bool hevc)
 class VAAPI::CVaapiBufferPool : public IVideoBufferPool
 {
 public:
-  CVaapiBufferPool(CDecoder &decoder);
+  explicit CVaapiBufferPool(CDecoder &decoder);
   ~CVaapiBufferPool() override;
   CVideoBuffer* Get() override;
   void Return(int id) override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -180,7 +180,7 @@ struct CVaapiProcessedPicture
 class CVaapiRenderPicture : public CVideoBuffer
 {
 public:
-  CVaapiRenderPicture(int id) : CVideoBuffer(id) { }
+  explicit CVaapiRenderPicture(int id) : CVideoBuffer(id) { }
   VideoPicture DVDPic;
   CVaapiProcessedPicture procPic;
   AVFrame *avFrame = nullptr;
@@ -364,7 +364,7 @@ class CDecoder
 
 public:
 
-  CDecoder(CProcessInfo& processInfo);
+  explicit CDecoder(CProcessInfo& processInfo);
   ~CDecoder() override;
 
   bool Open (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat) override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -1305,7 +1305,7 @@ void CDecoder::Register()
 class VDPAU::CVdpauBufferPool : public IVideoBufferPool
 {
 public:
-  CVdpauBufferPool(CDecoder &decoder);
+  explicit CVdpauBufferPool(CDecoder &decoder);
   ~CVdpauBufferPool() override;
   CVideoBuffer* Get() override;
   void Return(int id) override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -231,7 +231,7 @@ struct CVdpauProcessedPicture
 class CVdpauRenderPicture : public CVideoBuffer
 {
 public:
-  CVdpauRenderPicture(int id) : CVideoBuffer(id) { }
+  explicit CVdpauRenderPicture(int id) : CVideoBuffer(id) { }
   VideoPicture DVDPic;
   CVdpauProcessedPicture procPic;
   int width;
@@ -286,7 +286,7 @@ public:
 class CMixer : private CThread
 {
 public:
-  CMixer(CEvent *inMsgEvent);
+  explicit CMixer(CEvent *inMsgEvent);
   ~CMixer() override;
   void Start();
   void Dispose();
@@ -511,7 +511,7 @@ public:
     uint32_t aux; /* optional extra parameter... */
   };
 
-  CDecoder(CProcessInfo& processInfo);
+  explicit CDecoder(CProcessInfo& processInfo);
   ~CDecoder() override;
 
   bool Open (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat) override;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -75,7 +75,7 @@ private:
 class CCaptionBlock
 {
 public:
-  CCaptionBlock(int size)
+  explicit CCaptionBlock(int size)
   {
     m_data = (uint8_t*)malloc(size);
     m_size = size;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -28,7 +28,7 @@ class CDecoderCC708;
 class CDVDDemuxCC : public CDVDDemux
 {
 public:
-  CDVDDemuxCC(AVCodecID codec);
+  explicit CDVDDemuxCC(AVCodecID codec);
   ~CDVDDemuxCC() override;
 
   void Reset() override {};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -37,7 +37,7 @@ class CURL;
 class CDemuxStreamVideoFFmpeg : public CDemuxStreamVideo
 {
 public:
-  CDemuxStreamVideoFFmpeg(AVStream* stream) : m_stream(stream) {}
+  explicit CDemuxStreamVideoFFmpeg(AVStream* stream) : m_stream(stream) {}
   std::string GetStreamName() override;
 
   std::string m_description;
@@ -48,7 +48,7 @@ protected:
 class CDemuxStreamAudioFFmpeg : public CDemuxStreamAudio
 {
 public:
-  CDemuxStreamAudioFFmpeg(AVStream* stream) : m_stream(stream) {}
+  explicit CDemuxStreamAudioFFmpeg(AVStream* stream) : m_stream(stream) {}
   std::string GetStreamName() override;
 
   std::string m_description;
@@ -61,7 +61,7 @@ class CDemuxStreamSubtitleFFmpeg
   : public CDemuxStreamSubtitle
 {
 public:
-  CDemuxStreamSubtitleFFmpeg(AVStream* stream) : m_stream(stream) {}
+  explicit CDemuxStreamSubtitleFFmpeg(AVStream* stream) : m_stream(stream) {}
   std::string GetStreamName() override;
 
   std::string m_description;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -53,7 +53,7 @@ private:
     : public CDemuxStreamSubtitle
   {
   public:
-    CStream(CDVDDemuxVobsub* parent)
+    explicit CStream(CDVDDemuxVobsub* parent)
       : m_discard(false), m_parent(parent)
     {}
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxCrypto.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxCrypto.h
@@ -61,7 +61,7 @@ struct DemuxCryptoSession
 
 struct DemuxCryptoInfo
 {
-  DemuxCryptoInfo(const unsigned int numSubs)
+  explicit DemuxCryptoInfo(const unsigned int numSubs)
     : numSubSamples(numSubs)
     , flags(0)
     , clearBytes(new uint16_t[numSubs])

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -26,7 +26,7 @@ class CDVDInputStreamFFmpeg
   : public CDVDInputStream
 {
 public:
-  CDVDInputStreamFFmpeg(const CFileItem& fileitem);
+  explicit CDVDInputStreamFFmpeg(const CFileItem& fileitem);
   ~CDVDInputStreamFFmpeg() override;
   bool Open() override;
   void Close() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -25,7 +25,7 @@
 class CDVDInputStreamFile : public CDVDInputStream
 {
 public:
-  CDVDInputStreamFile(const CFileItem& fileitem);
+  explicit CDVDInputStreamFile(const CFileItem& fileitem);
   ~CDVDInputStreamFile() override;
   bool Open() override;
   void Close() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamMemory.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamMemory.h
@@ -25,7 +25,7 @@
 class CDVDInputStreamMemory : public CDVDInputStream
 {
 public:
-  CDVDInputStreamMemory(CFileItem &fileitem);
+  explicit CDVDInputStreamMemory(CFileItem &fileitem);
   ~CDVDInputStreamMemory() override;
   bool Open() override;
   void Close() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
@@ -27,7 +27,7 @@
 class CDVDInputStreamStack : public CDVDInputStream
 {
 public:
-  CDVDInputStreamStack(const CFileItem& fileitem);
+  explicit CDVDInputStreamStack(const CFileItem& fileitem);
   ~CDVDInputStreamStack() override;
 
   bool Open() override;

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -77,7 +77,7 @@ public:
     SUBTITLE_ADDFILE
   };
 
-  CDVDMsg(Message msg)
+  explicit CDVDMsg(Message msg)
   {
     m_message = msg;
   }
@@ -159,7 +159,7 @@ typedef CDVDMsgType<double> CDVDMsgDouble;
 class CDVDMsgPlayerSetAudioStream : public CDVDMsg
 {
 public:
-  CDVDMsgPlayerSetAudioStream(int streamId) : CDVDMsg(PLAYER_SET_AUDIOSTREAM) { m_streamId = streamId; }
+  explicit CDVDMsgPlayerSetAudioStream(int streamId) : CDVDMsg(PLAYER_SET_AUDIOSTREAM) { m_streamId = streamId; }
   int GetStreamId() { return m_streamId; }
 private:
   int m_streamId;
@@ -168,7 +168,7 @@ private:
 class CDVDMsgPlayerSetVideoStream : public CDVDMsg
 {
 public:
-  CDVDMsgPlayerSetVideoStream(int streamId) : CDVDMsg(PLAYER_SET_VIDEOSTREAM) { m_streamId = streamId; }
+  explicit CDVDMsgPlayerSetVideoStream(int streamId) : CDVDMsg(PLAYER_SET_VIDEOSTREAM) { m_streamId = streamId; }
   int GetStreamId() const { return m_streamId; }
 private:
   int m_streamId;
@@ -177,7 +177,7 @@ private:
 class CDVDMsgPlayerSetSubtitleStream : public CDVDMsg
 {
 public:
-  CDVDMsgPlayerSetSubtitleStream(int streamId) : CDVDMsg(PLAYER_SET_SUBTITLESTREAM) { m_streamId = streamId; }
+  explicit CDVDMsgPlayerSetSubtitleStream(int streamId) : CDVDMsg(PLAYER_SET_SUBTITLESTREAM) { m_streamId = streamId; }
   int GetStreamId() { return m_streamId; }
 private:
   int m_streamId;
@@ -186,7 +186,7 @@ private:
 class CDVDMsgPlayerSetState : public CDVDMsg
 {
 public:
-  CDVDMsgPlayerSetState(const std::string& state) : CDVDMsg(PLAYER_SET_STATE), m_state(state) {}
+  explicit CDVDMsgPlayerSetState(const std::string& state) : CDVDMsg(PLAYER_SET_STATE), m_state(state) {}
   std::string GetState() { return m_state; }
 private:
   std::string m_state;
@@ -206,7 +206,7 @@ public:
     bool trickplay = false;
   };
 
-  CDVDMsgPlayerSeek(CDVDMsgPlayerSeek::CMode mode) : CDVDMsg(PLAYER_SEEK),
+  explicit CDVDMsgPlayerSeek(CDVDMsgPlayerSeek::CMode mode) : CDVDMsg(PLAYER_SEEK),
     m_mode(mode)
   {}
   double GetTime() { return m_mode.time; }
@@ -224,7 +224,7 @@ private:
 class CDVDMsgPlayerSeekChapter : public CDVDMsg
 {
   public:
-    CDVDMsgPlayerSeekChapter(int iChapter)
+    explicit CDVDMsgPlayerSeekChapter(int iChapter)
       : CDVDMsg(PLAYER_SEEK_CHAPTER)
       , m_iChapter(iChapter)
     {}
@@ -245,7 +245,7 @@ public:
     bool m_isTempo;
   };
 
-  CDVDMsgPlayerSetSpeed(SpeedParams params)
+  explicit CDVDMsgPlayerSetSpeed(SpeedParams params)
   : CDVDMsg(PLAYER_SETSPEED)
   , m_params(params)
   {}
@@ -268,7 +268,7 @@ public:
     CPlayerOptions m_options;
   };
 
-  CDVDMsgOpenFile(const FileParams &params)
+  explicit CDVDMsgOpenFile(const FileParams &params)
   : CDVDMsg(PLAYER_OPENFILE)
   , m_params(params)
   {}
@@ -323,7 +323,7 @@ public:
 class CDVDMsgSubtitleClutChange : public CDVDMsg
 {
 public:
-  CDVDMsgSubtitleClutChange(uint8_t* data) : CDVDMsg(SUBTITLE_CLUTCHANGE) { memcpy(m_data, data, 16*4); }
+  explicit CDVDMsgSubtitleClutChange(uint8_t* data) : CDVDMsg(SUBTITLE_CLUTCHANGE) { memcpy(m_data, data, 16*4); }
   uint8_t m_data[16][4];
 private:
 };

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -68,7 +68,7 @@ enum MsgQueueReturnCode
 class CDVDMessageQueue
 {
 public:
-  CDVDMessageQueue(const std::string &owner);
+  explicit CDVDMessageQueue(const std::string &owner);
   virtual ~CDVDMessageQueue();
 
   void Init();

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -44,7 +44,7 @@ class CDVDSubtitleParserCollection
   : public CDVDSubtitleParser
 {
 public:
-  CDVDSubtitleParserCollection(const std::string& strFile) : m_filename(strFile) {}
+  explicit CDVDSubtitleParserCollection(const std::string& strFile) : m_filename(strFile) {}
   ~CDVDSubtitleParserCollection() override = default;
   CDVDOverlay* Parse(double iPts) override
   {

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -51,7 +51,7 @@ public:
 class IDVDStreamPlayer
 {
 public:
-  IDVDStreamPlayer(CProcessInfo &processInfo) : m_processInfo(processInfo) {};
+  explicit IDVDStreamPlayer(CProcessInfo &processInfo) : m_processInfo(processInfo) {};
   virtual ~IDVDStreamPlayer() = default;
   virtual bool OpenStream(CDVDStreamInfo hint) = 0;
   virtual void CloseStream(bool bWaitForBuffers) = 0;
@@ -90,7 +90,7 @@ class CDVDVideoCodec;
 class IDVDStreamPlayerVideo : public IDVDStreamPlayer
 {
 public:
-  IDVDStreamPlayerVideo(CProcessInfo &processInfo) : IDVDStreamPlayer(processInfo) {};
+  explicit IDVDStreamPlayerVideo(CProcessInfo &processInfo) : IDVDStreamPlayer(processInfo) {};
   ~IDVDStreamPlayerVideo() override = default;
   bool OpenStream(CDVDStreamInfo hint) override = 0;
   void CloseStream(bool bWaitForBuffers) override = 0;
@@ -119,7 +119,7 @@ class CDVDAudioCodec;
 class IDVDStreamPlayerAudio : public IDVDStreamPlayer
 {
 public:
-  IDVDStreamPlayerAudio(CProcessInfo &processInfo) : IDVDStreamPlayer(processInfo) {};
+  explicit IDVDStreamPlayerAudio(CProcessInfo &processInfo) : IDVDStreamPlayer(processInfo) {};
   ~IDVDStreamPlayerAudio() override = default;
   bool OpenStream(CDVDStreamInfo hints) override = 0;
   void CloseStream(bool bWaitForBuffers) override = 0;

--- a/xbmc/cores/VideoPlayer/Process/VideoBuffer.h
+++ b/xbmc/cores/VideoPlayer/Process/VideoBuffer.h
@@ -107,7 +107,7 @@ public:
   static bool CopyYUV422PackedPicture(YuvImage* pDst, YuvImage *pSrc);
 
 protected:
-  CVideoBuffer(int id);
+  explicit CVideoBuffer(int id);
   AVPixelFormat m_pixFormat = AV_PIX_FMT_NONE;
   std::atomic_int m_refCount;
   int m_id;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -155,7 +155,7 @@ public:
   *          - it's a default and a forced sub (could lead to users seeing forced subs in a foreign language!), or
   *          - its language matches the preferred subtitle's language (unequal to "original stream's language")
   */
-  PredicateSubtitleFilter(std::string& lang)
+  explicit PredicateSubtitleFilter(const std::string& lang)
     : audiolang(lang),
       original(StringUtils::EqualsNoCase(CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE), "original")),
       nosub(StringUtils::EqualsNoCase(CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE), "none")),
@@ -261,7 +261,7 @@ private:
   bool subson;
   PredicateSubtitleFilter filter;
 public:
-  PredicateSubtitlePriority(std::string& lang)
+  explicit PredicateSubtitlePriority(const std::string& lang)
     : audiolang(lang),
       original(StringUtils::EqualsNoCase(CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE), "original")),
       subson(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleOn),

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -296,7 +296,7 @@ class CProcessInfo;
 class CVideoPlayer : public IPlayer, public CThread, public IVideoPlayer, public IDispResource, public IRenderMsg
 {
 public:
-  CVideoPlayer(IPlayerCallback& callback);
+  explicit CVideoPlayer(IPlayerCallback& callback);
   ~CVideoPlayer() override;
   bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;
   bool CloseFile(bool reopen = false) override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
@@ -43,7 +43,7 @@ class CDVDStreamInfo;
 class CDVDRadioRDSData : public CThread, public IDVDStreamPlayer
 {
 public:
-  CDVDRadioRDSData(CProcessInfo &processInfo);
+  explicit CDVDRadioRDSData(CProcessInfo &processInfo);
   ~CDVDRadioRDSData() override;
 
   bool CheckStream(CDVDStreamInfo &hints);

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.h
@@ -30,7 +30,7 @@ class CDVDStreamInfo;
 class CDVDTeletextData : public CThread, public IDVDStreamPlayer
 {
 public:
-  CDVDTeletextData(CProcessInfo &processInfo);
+  explicit CDVDTeletextData(CProcessInfo &processInfo);
   ~CDVDTeletextData() override;
 
   bool CheckStream(CDVDStreamInfo &hints);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -50,8 +50,8 @@ namespace OVERLAY {
     : public COverlay
   {
   public:
-    COverlayImageDX(CDVDOverlayImage* o);
-    COverlayImageDX(CDVDOverlaySpu*   o);
+    explicit COverlayImageDX(CDVDOverlayImage* o);
+    explicit COverlayImageDX(CDVDOverlaySpu*   o);
     virtual ~COverlayImageDX();
 
     void Load(uint32_t* rgba, int width, int height, int stride);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -36,8 +36,8 @@ namespace OVERLAY {
   class COverlayTextureGL : public COverlay
   {
   public:
-     COverlayTextureGL(CDVDOverlayImage* o);
-     COverlayTextureGL(CDVDOverlaySpu* o);
+     explicit COverlayTextureGL(CDVDOverlayImage* o);
+     explicit COverlayTextureGL(CDVDOverlaySpu* o);
     ~COverlayTextureGL() override;
 
     void Render(SRenderState& state) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h
@@ -41,7 +41,7 @@ class COverlayText : public COverlay
 {
 public:
   COverlayText() = default;
-  COverlayText(CDVDOverlayText* src);
+  explicit COverlayText(CDVDOverlayText* src);
   ~COverlayText() override;
   void Render(SRenderState& state) override;
   using COverlay::PrepareRender;

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.h
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.h
@@ -36,7 +36,7 @@ extern "C" {
 class COMXAudioCodecOMX
 {
 public:
-  COMXAudioCodecOMX(CProcessInfo &processInfo);
+  explicit COMXAudioCodecOMX(CProcessInfo &processInfo);
   virtual ~COMXAudioCodecOMX();
   bool Open(CDVDStreamInfo &hints);
   void Dispose();

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -41,7 +41,7 @@ class PAPlayer : public IPlayer, public CThread, public IJobCallback
 {
 friend class CQueueNextFileJob;
 public:
-  PAPlayer(IPlayerCallback& callback);
+  explicit PAPlayer(IPlayerCallback& callback);
   ~PAPlayer() override;
 
   bool OpenFile(const CFileItem& file, const CPlayerOptions &options) override;

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -31,7 +31,7 @@ class TiXmlElement;
 class CPlayerSelectionRule
 {
 public:
-  CPlayerSelectionRule(TiXmlElement* rule);
+  explicit CPlayerSelectionRule(TiXmlElement* rule);
   virtual ~CPlayerSelectionRule();
 
   void GetPlayers(const CFileItem& item, std::vector<std::string>&validPlayers, std::vector<std::string>&players);

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -131,7 +131,7 @@ protected:
 public:
 /* constructor */
   MysqlDataset();
-  MysqlDataset(MysqlDatabase *newDb);
+  explicit MysqlDataset(MysqlDatabase *newDb);
 
 /* destructor */
   ~MysqlDataset() override;

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -130,7 +130,7 @@ protected:
 public:
 /* constructor */
   SqliteDataset();
-  SqliteDataset(SqliteDatabase *newDb);
+  explicit SqliteDataset(SqliteDatabase *newDb);
 
 /* destructor */
   ~SqliteDataset() override;

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -29,7 +29,7 @@ class CBusyWaiter : public CThread
 {
   std::shared_ptr<CEvent>  m_done;
 public:
-  CBusyWaiter(IRunnable *runnable) : CThread(runnable, "waiting"), m_done(new CEvent()) {  }
+  explicit CBusyWaiter(IRunnable *runnable) : CThread(runnable, "waiting"), m_done(new CEvent()) {  }
   
   bool Wait(unsigned int displaytime, bool allowCancel)
   {

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.h
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.h
@@ -27,7 +27,7 @@
 class CGUIDialogProgressBarHandle
 {
 public:
-  CGUIDialogProgressBarHandle(const std::string &strTitle) :
+  explicit CGUIDialogProgressBarHandle(const std::string &strTitle) :
     m_fPercentage(0),
     m_strTitle(strTitle),
     m_bFinished(false) {}

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -38,7 +38,7 @@ class CGUIDialogYesNo :
       public CGUIDialogBoxBase
 {
 public:
-  CGUIDialogYesNo(int overrideId = -1);
+  explicit CGUIDialogYesNo(int overrideId = -1);
   ~CGUIDialogYesNo(void) override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnBack(int actionID) override;

--- a/xbmc/events/windows/GUIViewStateEventLog.h
+++ b/xbmc/events/windows/GUIViewStateEventLog.h
@@ -24,7 +24,7 @@
 class CGUIViewStateEventLog : public CGUIViewState
 {
 public:
-  CGUIViewStateEventLog(const CFileItemList& items);
+  explicit CGUIViewStateEventLog(const CFileItemList& items);
   ~CGUIViewStateEventLog() override = default;
 
   // specializations of CGUIViewState

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -113,7 +113,7 @@ protected:
 
 class CDoubleCache : public CCacheStrategy{
 public:
-  CDoubleCache(CCacheStrategy *impl);
+  explicit CDoubleCache(CCacheStrategy *impl);
   ~CDoubleCache() override;
 
   int Open() override;

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -35,7 +35,7 @@ namespace XFILE
     class CDir
     {
     public:
-      CDir(DIR_CACHE_TYPE cacheType);
+      explicit CDir(DIR_CACHE_TYPE cacheType);
       virtual ~CDir();
 
       void SetLastAccess(unsigned int &accessCounter);

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -32,7 +32,7 @@ namespace XFILE
   class CFileCache : public IFile, public CThread
   {
   public:
-    CFileCache(const unsigned int flags);
+    explicit CFileCache(const unsigned int flags);
     CFileCache(CCacheStrategy *pCache, bool bDeleteCache = true);
     ~CFileCache() override;
 

--- a/xbmc/filesystem/NptXbmcFile.cpp
+++ b/xbmc/filesystem/NptXbmcFile.cpp
@@ -60,7 +60,7 @@ class NPT_XbmcFileStream
 {
 public:
     // constructors and destructor
-    NPT_XbmcFileStream(NPT_XbmcFileReference file) :
+    explicit NPT_XbmcFileStream(NPT_XbmcFileReference file) :
       m_FileReference(file) {}
 
     // NPT_FileInterface methods
@@ -126,7 +126,7 @@ class NPT_XbmcFileInputStream : public NPT_InputStream,
 {
 public:
     // constructors and destructor
-    NPT_XbmcFileInputStream(NPT_XbmcFileReference& file) :
+    explicit NPT_XbmcFileInputStream(NPT_XbmcFileReference& file) :
         NPT_XbmcFileStream(file) {}
 
     // NPT_InputStream methods
@@ -208,7 +208,7 @@ class NPT_XbmcFileOutputStream : public NPT_OutputStream,
 {
 public:
     // constructors and destructor
-    NPT_XbmcFileOutputStream(NPT_XbmcFileReference& file) :
+    explicit NPT_XbmcFileOutputStream(NPT_XbmcFileReference& file) :
         NPT_XbmcFileStream(file) {}
 
     // NPT_OutputStream methods
@@ -253,7 +253,7 @@ class NPT_XbmcFile: public NPT_FileInterface
 {
 public:
     // constructors and destructor
-    NPT_XbmcFile(NPT_File& delegator);
+    explicit NPT_XbmcFile(NPT_File& delegator);
    ~NPT_XbmcFile() override;
 
     // NPT_FileInterface methods

--- a/xbmc/filesystem/OverrideFile.h
+++ b/xbmc/filesystem/OverrideFile.h
@@ -27,7 +27,7 @@ namespace XFILE
 class COverrideFile : public IFile
 {
 public:
-  COverrideFile(bool writable);
+  explicit COverrideFile(bool writable);
   ~COverrideFile() override;
 
   bool Open(const CURL& url) override;

--- a/xbmc/filesystem/win32/Win32File.h
+++ b/xbmc/filesystem/win32/Win32File.h
@@ -52,7 +52,7 @@ namespace XFILE
     virtual int Stat(struct __stat64* statData);
 
   protected:
-    CWin32File(bool asSmbFile);
+    explicit CWin32File(bool asSmbFile);
     HANDLE  m_hFile;
     int64_t m_filePos;
     bool    m_allowWrite;

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -61,7 +61,7 @@ class CGameClient : public ADDON::CAddonDll
 public:
   static std::unique_ptr<CGameClient> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
 
-  CGameClient(ADDON::CAddonInfo addonInfo);
+  explicit CGameClient(ADDON::CAddonInfo addonInfo);
 
   virtual ~CGameClient(void);
 

--- a/xbmc/games/addons/GameClientHardware.h
+++ b/xbmc/games/addons/GameClientHardware.h
@@ -39,7 +39,7 @@ namespace GAME
      *
      * \param gameClient The game client implementation
      */
-    CGameClientHardware(CGameClient* gameClient);
+    explicit CGameClientHardware(CGameClient* gameClient);
 
     virtual ~CGameClientHardware() = default;
 

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -42,7 +42,7 @@ class CController : public ADDON::CAddon
 public:
   static std::unique_ptr<CController> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
 
-  CController(ADDON::CAddonInfo addonInfo);
+  explicit CController(ADDON::CAddonInfo addonInfo);
 
   virtual ~CController();
 

--- a/xbmc/games/ports/InputSink.h
+++ b/xbmc/games/ports/InputSink.h
@@ -31,7 +31,7 @@ namespace GAME
   class CInputSink : public JOYSTICK::IInputHandler
   {
   public:
-    CInputSink(CGameClient &m_gameClient);
+    explicit CInputSink(CGameClient &m_gameClient);
 
     virtual ~CInputSink() = default;
 

--- a/xbmc/games/ports/PortManager.h
+++ b/xbmc/games/ports/PortManager.h
@@ -55,7 +55,7 @@ namespace GAME
   class CPortManager : public Observable
   {
   public:
-    CPortManager(PERIPHERALS::CPeripherals& peripheralManager);
+    explicit CPortManager(PERIPHERALS::CPeripherals& peripheralManager);
     virtual ~CPortManager();
 
     /*!

--- a/xbmc/games/windows/GUIViewStateWindowGames.h
+++ b/xbmc/games/windows/GUIViewStateWindowGames.h
@@ -28,7 +28,7 @@ namespace GAME
   class CGUIViewStateWindowGames : public CGUIViewState
   {
   public:
-    CGUIViewStateWindowGames(const CFileItemList& items);
+    explicit CGUIViewStateWindowGames(const CFileItemList& items);
 
     virtual ~CGUIViewStateWindowGames() = default;
 

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -59,7 +59,7 @@ public:
   CGUIEditControl(int parentID, int controlID, float posX, float posY,
                   float width, float height, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus,
                   const CLabelInfo& labelInfo, const std::string &text);
-  CGUIEditControl(const CGUIButtonControl &button);
+  explicit CGUIEditControl(const CGUIButtonControl &button);
   ~CGUIEditControl(void) override;
   CGUIEditControl *Clone() const override { return new CGUIEditControl(*this); };
 

--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -88,7 +88,7 @@ class CGUIFontCacheImpl
   
 public:
 
-  CGUIFontCacheImpl(CGUIFontCache<Position, Value>* parent) : m_parent(parent) {}
+  explicit CGUIFontCacheImpl(CGUIFontCache<Position, Value>* parent) : m_parent(parent) {}
   Value &Lookup(Position &pos,
                 const vecColors &colors, const vecText &text,
                 uint32_t alignment, float maxPixelWidth,

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -143,7 +143,7 @@ class CGUIFontCache
 public:
   const CGUIFontTTFBase &m_font;
 
-  CGUIFontCache(CGUIFontTTFBase &font);
+  explicit CGUIFontCache(CGUIFontTTFBase &font);
 
   ~CGUIFontCache();
  

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -89,7 +89,7 @@ class CGUIFontTTFBase
 
 public:
 
-  CGUIFontTTFBase(const std::string& strFileName);
+  explicit CGUIFontTTFBase(const std::string& strFileName);
   virtual ~CGUIFontTTFBase(void);
 
   void Clear();

--- a/xbmc/guilib/GUIFontTTFDX.h
+++ b/xbmc/guilib/GUIFontTTFDX.h
@@ -41,7 +41,7 @@
 class CGUIFontTTFDX : public CGUIFontTTFBase, public ID3DResource
 {
 public:
-  CGUIFontTTFDX(const std::string& strFileName);
+  explicit CGUIFontTTFDX(const std::string& strFileName);
   virtual ~CGUIFontTTFDX(void);
 
   bool FirstBegin() override;

--- a/xbmc/guilib/GUIFontTTFGL.h
+++ b/xbmc/guilib/GUIFontTTFGL.h
@@ -43,7 +43,7 @@
 class CGUIFontTTFGL : public CGUIFontTTFBase
 {
 public:
-  CGUIFontTTFGL(const std::string& strFileName);
+  explicit CGUIFontTTFGL(const std::string& strFileName);
   ~CGUIFontTTFGL(void) override;
 
   bool FirstBegin() override;

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -594,7 +594,7 @@ class ParamReplacer
   int m_numTotalParams;
   int m_numUndefinedParams;
 public:
-  ParamReplacer(const std::map<std::string, std::string>& params)
+  explicit ParamReplacer(const std::map<std::string, std::string>& params)
     : m_params(params), m_numTotalParams(0), m_numUndefinedParams(0) {}
   int GetNumTotalParams() const { return m_numTotalParams; }
   int GetNumDefinedParams() const { return m_numTotalParams - m_numUndefinedParams; }

--- a/xbmc/guilib/GUIMultiImage.h
+++ b/xbmc/guilib/GUIMultiImage.h
@@ -75,7 +75,7 @@ protected:
   class CMultiImageJob : public CJob
   {
   public:
-    CMultiImageJob(const std::string &path);
+    explicit CMultiImageJob(const std::string &path);
     bool DoWork() override;
     const char *GetType() const override { return "multiimage"; };
 

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -62,7 +62,7 @@ public:
    \param contextWindow window context to use for any info labels
    */
   CGUIStaticItem(const TiXmlElement *element, int contextWindow);
-  CGUIStaticItem(const CFileItem &item); // for python
+  explicit CGUIStaticItem(const CFileItem &item); // for python
   ~CGUIStaticItem() override = default;
   CGUIListItem *Clone() const override { return new CGUIStaticItem(*this); };
   

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -72,7 +72,7 @@ class CTextureInfo
 {
 public:
   CTextureInfo();
-  CTextureInfo(const std::string &file);
+  explicit CTextureInfo(const std::string &file);
   CTextureInfo& operator=(const CTextureInfo &right);
   bool       useLarge;
   CRect      border;          // scaled  - unneeded if we get rid of scale on load

--- a/xbmc/guilib/GUIVisualisationControl.h
+++ b/xbmc/guilib/GUIVisualisationControl.h
@@ -30,7 +30,7 @@
 class CAudioBuffer
 {
 public:
-  CAudioBuffer(int iSize);
+  explicit CAudioBuffer(int iSize);
   virtual ~CAudioBuffer();
   const float* Get() const;
   int Size() const;

--- a/xbmc/guilib/MatrixGLES.h
+++ b/xbmc/guilib/MatrixGLES.h
@@ -29,7 +29,7 @@ class CMatrixGL
 public:
 
   CMatrixGL()                                  { memset(&m_pMatrix, 0, sizeof(m_pMatrix)); };
-  CMatrixGL(const float matrix[16])            { memcpy(m_pMatrix, matrix, sizeof(m_pMatrix)); }
+  explicit CMatrixGL(const float matrix[16])   { memcpy(m_pMatrix, matrix, sizeof(m_pMatrix)); }
   CMatrixGL(const CMatrixGL &rhs )             { memcpy(m_pMatrix, rhs.m_pMatrix, sizeof(m_pMatrix)); }
   CMatrixGL &operator=( const CMatrixGL &rhs ) { memcpy(m_pMatrix, rhs.m_pMatrix, sizeof(m_pMatrix)); return *this;}
   operator float*()                            { return m_pMatrix; }
@@ -55,7 +55,7 @@ public:
 class CMatrixGLStack
 {
 public:
-  CMatrixGLStack(GLenum type)
+  explicit CMatrixGLStack(GLenum type)
 #ifdef HAS_GL
   : m_type(type)
 #endif

--- a/xbmc/guilib/Tween.h
+++ b/xbmc/guilib/Tween.h
@@ -60,7 +60,7 @@ enum TweenerType
 class Tweener
 {
 public:
-  Tweener(TweenerType tweenerType = EASE_OUT) { m_tweenerType = tweenerType; }
+  explicit Tweener(TweenerType tweenerType = EASE_OUT) { m_tweenerType = tweenerType; }
   virtual ~Tweener() = default;
 
   void SetEasing(TweenerType type) { m_tweenerType = type; }
@@ -85,7 +85,7 @@ public:
 class QuadTweener : public Tweener
 {
 public:
-  QuadTweener(float a = 1.0f) { _a=a; }
+  explicit QuadTweener(float a = 1.0f) { _a=a; }
   float Tween(float time, float start, float change, float duration) override
   {
     switch (m_tweenerType)
@@ -178,7 +178,7 @@ public:
 class BackTweener : public Tweener
 {
 public:
-  BackTweener(float s=1.70158) { _s=s; }
+  explicit BackTweener(float s=1.70158) { _s=s; }
 
   float Tween(float time, float start, float change, float duration) override
   {

--- a/xbmc/input/InputCodingTableBaiduPY.h
+++ b/xbmc/input/InputCodingTableBaiduPY.h
@@ -31,7 +31,7 @@
 class CInputCodingTableBaiduPY : public IInputCodingTable, public CThread
 {
 public:
-  CInputCodingTableBaiduPY(const std::string& strUrl);
+  explicit CInputCodingTableBaiduPY(const std::string& strUrl);
   ~CInputCodingTableBaiduPY() override = default;
 
   void Initialize() override;

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -87,7 +87,7 @@ class CInputManager : public ISettingCallback,
                       public Observable
 {
 public:
-  CInputManager(const CAppParamParser &params);
+  explicit CInputManager(const CAppParamParser &params);
   CInputManager(const CInputManager&) = delete;
   CInputManager const& operator=(CInputManager const&) = delete;
   ~CInputManager() override;

--- a/xbmc/input/WindowKeymap.h
+++ b/xbmc/input/WindowKeymap.h
@@ -28,7 +28,7 @@
 class CWindowKeymap : public IWindowKeymap
 {
 public:
-  CWindowKeymap(const std::string &controllerId);
+  explicit CWindowKeymap(const std::string &controllerId);
 
   // implementation of IWindowKeymap
   virtual std::string ControllerID() const override { return m_controllerId; }

--- a/xbmc/input/joysticks/JoystickEasterEgg.h
+++ b/xbmc/input/joysticks/JoystickEasterEgg.h
@@ -35,7 +35,7 @@ namespace JOYSTICK
   class CJoystickEasterEgg : public IButtonSequence
   {
   public:
-    CJoystickEasterEgg(const std::string& controllerId);
+    explicit CJoystickEasterEgg(const std::string& controllerId);
     virtual ~CJoystickEasterEgg() = default;
 
     // implementation of IButtonSequence

--- a/xbmc/input/keyboard/generic/JoystickEmulation.h
+++ b/xbmc/input/keyboard/generic/JoystickEmulation.h
@@ -40,7 +40,7 @@ namespace KEYBOARD
   class CJoystickEmulation : public IKeyboardHandler
   {
   public:
-    CJoystickEmulation(JOYSTICK::IDriverHandler* handler);
+    explicit CJoystickEmulation(JOYSTICK::IDriverHandler* handler);
 
     ~CJoystickEmulation(void) override = default;
 

--- a/xbmc/interfaces/generic/ILanguageInvoker.h
+++ b/xbmc/interfaces/generic/ILanguageInvoker.h
@@ -40,7 +40,7 @@ typedef enum {
 class ILanguageInvoker
 {
 public:
-  ILanguageInvoker(ILanguageInvocationHandler *invocationHandler);
+  explicit ILanguageInvoker(ILanguageInvocationHandler *invocationHandler);
   virtual ~ILanguageInvoker();
 
   virtual bool Execute(const std::string &script, const std::vector<std::string> &arguments = std::vector<std::string>());

--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -79,7 +79,7 @@ namespace XBMCAddon
       bool UpdateSettingInActiveDialog(const char* id, const String& value);
 
     public:
-      Addon(const char* id = NULL);
+      explicit Addon(const char* id = NULL);
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
       virtual ~Addon();
 

--- a/xbmc/interfaces/legacy/AddonUtils.h
+++ b/xbmc/interfaces/legacy/AddonUtils.h
@@ -65,7 +65,7 @@ namespace XBMCAddonUtils
   {
     CSingleLock& lock;
   public:
-    InvertSingleLockGuard(CSingleLock& _lock) : lock(_lock) { lock.Leave(); }
+    explicit InvertSingleLockGuard(CSingleLock& _lock) : lock(_lock) { lock.Leave(); }
     ~InvertSingleLockGuard() { lock.Enter(); }
   };
 
@@ -86,7 +86,7 @@ namespace XBMCAddonUtils
 
     const char* getSpaces();
 
-    TraceGuard(const char* _function);
+    explicit TraceGuard(const char* _function);
     TraceGuard();
     ~TraceGuard();
   };

--- a/xbmc/interfaces/legacy/CallbackFunction.h
+++ b/xbmc/interfaces/legacy/CallbackFunction.h
@@ -38,7 +38,7 @@ namespace XBMCAddon
   { 
   protected:
     AddonClass* addonClassObject;
-    Callback(AddonClass* _object) : addonClassObject(_object) { XBMC_TRACE; }
+    explicit Callback(AddonClass* _object) : addonClassObject(_object) { XBMC_TRACE; }
 
   public:
     virtual void executeCallback() = 0;

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -59,7 +59,7 @@ namespace XBMCAddon
 
     public:
 #ifndef SWIG
-      InfoTagMusic(const MUSIC_INFO::CMusicInfoTag& tag);
+      explicit InfoTagMusic(const MUSIC_INFO::CMusicInfoTag& tag);
 #endif
       InfoTagMusic();
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11

--- a/xbmc/interfaces/legacy/InfoTagRadioRDS.h
+++ b/xbmc/interfaces/legacy/InfoTagRadioRDS.h
@@ -61,7 +61,7 @@ namespace XBMCAddon
 
     public:
 #ifndef SWIG
-      InfoTagRadioRDS(const PVR::CPVRRadioRDSInfoTagPtr tag);
+      explicit InfoTagRadioRDS(const PVR::CPVRRadioRDSInfoTagPtr tag);
 #endif
       InfoTagRadioRDS();
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -60,7 +60,7 @@ namespace XBMCAddon
 
     public:
 #ifndef SWIG
-      InfoTagVideo(const CVideoInfoTag& tag);
+      explicit InfoTagVideo(const CVideoInfoTag& tag);
 #endif
       InfoTagVideo();
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11

--- a/xbmc/interfaces/legacy/LanguageHook.h
+++ b/xbmc/interfaces/legacy/LanguageHook.h
@@ -138,7 +138,7 @@ namespace XBMCAddon
     bool clearOnExit;
 
   public:
-    inline DelayedCallGuard(LanguageHook* languageHook_) : languageHook(languageHook_), clearOnExit(false)
+    inline explicit DelayedCallGuard(LanguageHook* languageHook_) : languageHook(languageHook_), clearOnExit(false)
     { if (languageHook) languageHook->DelayedCallOpen(); }
 
     inline DelayedCallGuard() : languageHook(LanguageHook::GetLanguageHook()), clearOnExit(false) 
@@ -156,7 +156,7 @@ namespace XBMCAddon
   class SetLanguageHookGuard
   {
   public:
-    inline SetLanguageHookGuard(LanguageHook* languageHook) { LanguageHook::SetLanguageHook(languageHook); }
+    inline explicit SetLanguageHookGuard(LanguageHook* languageHook) { LanguageHook::SetLanguageHook(languageHook); }
     inline ~SetLanguageHookGuard() { LanguageHook::ClearLanguageHook(); }
   };
   

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -702,7 +702,7 @@ namespace XBMCAddon
           else if (key == "role")
             info.strRole = value;
           else if (key == "thumbnail")
-            info.thumbUrl = value;
+            info.thumbUrl = CScraperUrl(value);
           else if (key == "order")
             info.order = strtol(value.c_str(), nullptr, 10);
         }

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -94,7 +94,9 @@ namespace XBMCAddon
                bool offscreen = false);
 
 #ifndef SWIG
-      inline ListItem(CFileItemPtr pitem) : item(pitem) {}
+      inline explicit ListItem(CFileItemPtr pitem) :
+        item(pitem), m_offscreen(false)
+      {}
 
       static inline AddonClass::Ref<ListItem> fromString(const String& str)
       {

--- a/xbmc/interfaces/legacy/PlayList.h
+++ b/xbmc/interfaces/legacy/PlayList.h
@@ -65,7 +65,7 @@ namespace XBMCAddon
       PLAYLIST::CPlayList *pPlayList;
 
     public:
-      PlayList(int playList);
+      explicit PlayList(int playList);
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
       virtual ~PlayList();
 

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -89,7 +89,7 @@ namespace XBMCAddon
       // Construct a Player proxying the given generated binding. The 
       //  construction of a Player needs to identify whether or not any 
       //  callbacks will be executed asynchronously or not.
-      Player(int playerCore = 0);
+      explicit Player(int playerCore = 0);
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
       virtual ~Player(void);
 #endif

--- a/xbmc/interfaces/legacy/Tuple.h
+++ b/xbmc/interfaces/legacy/Tuple.h
@@ -32,7 +32,7 @@ namespace XBMCAddon
   {
   protected:
     int numValuesSet;
-    inline TupleBase(int pnumValuesSet) : numValuesSet(pnumValuesSet) {}
+    explicit inline TupleBase(int pnumValuesSet) : numValuesSet(pnumValuesSet) {}
     inline TupleBase(const TupleBase& o) : numValuesSet(o.numValuesSet) {}
     inline void nvs(int newSize) { if(numValuesSet < newSize) numValuesSet = newSize; }
   public:
@@ -50,7 +50,7 @@ namespace XBMCAddon
   private:
     T1 v1;
   public:
-    inline Tuple(T1 p1) : TupleBase(1), v1(p1) {}
+    explicit inline Tuple(T1 p1) : TupleBase(1), v1(p1) {}
     inline Tuple() : TupleBase(0) {}
     inline Tuple(const Tuple<T1>& o) : TupleBase(o), v1(o.v1) {}
 
@@ -66,7 +66,7 @@ namespace XBMCAddon
 
   public:
     inline Tuple(T1 p1, T2 p2) : Tuple<T1>(p1), v2(p2) { TupleBase::nvs(2); }
-    inline Tuple(T1 p1) : Tuple<T1>(p1) {}
+    explicit inline Tuple(T1 p1) : Tuple<T1>(p1) {}
     inline Tuple() = default;
     inline Tuple(const Tuple<T1,T2>& o) : Tuple<T1>(o), v2(o.v2) {}
 
@@ -82,7 +82,7 @@ namespace XBMCAddon
   public:
     inline Tuple(T1 p1, T2 p2, T3 p3) : Tuple<T1,T2>(p1,p2), v3(p3) { TupleBase::nvs(3); }
     inline Tuple(T1 p1, T2 p2) : Tuple<T1,T2>(p1,p2) {}
-    inline Tuple(T1 p1) : Tuple<T1,T2>(p1) {}
+    explicit inline Tuple(T1 p1) : Tuple<T1,T2>(p1) {}
     inline Tuple() = default;
     inline Tuple(const Tuple<T1,T2,T3>& o) : Tuple<T1,T2>(o), v3(o.v3) {}
 
@@ -99,7 +99,7 @@ namespace XBMCAddon
     inline Tuple(T1 p1, T2 p2, T3 p3, T4 p4) : Tuple<T1,T2,T3>(p1,p2,p3), v4(p4) { TupleBase::nvs(4); }
     inline Tuple(T1 p1, T2 p2, T3 p3) : Tuple<T1,T2,T3>(p1,p2,p3) {}
     inline Tuple(T1 p1, T2 p2) : Tuple<T1,T2,T3>(p1,p2) {}
-    inline Tuple(T1 p1) : Tuple<T1,T2,T3>(p1) {}
+    explicit inline Tuple(T1 p1) : Tuple<T1,T2,T3>(p1) {}
     inline Tuple() = default;
     inline Tuple(const Tuple<T1,T2,T3,T4>& o) : Tuple<T1,T2,T3>(o), v4(o.v4) {}
 

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -49,7 +49,7 @@ namespace XBMCAddon
     {
       CCriticalSection* lock;
     public:
-      inline MaybeLock(CCriticalSection* p_lock) : lock(p_lock) { if (lock) lock->lock(); }
+      inline explicit MaybeLock(CCriticalSection* p_lock) : lock(p_lock) { if (lock) lock->lock(); }
       inline ~MaybeLock() { if (lock) lock->unlock(); }
     };
 

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -59,7 +59,7 @@ namespace XBMCAddon
       { }
 
 #ifndef SWIG
-      Action(const CAction& caction) { setFromCAction(caction); }
+      explicit Action(const CAction& caction) { setFromCAction(caction); }
 
       void setFromCAction(const CAction& caction);
 
@@ -231,7 +231,7 @@ namespace XBMCAddon
        * the difference.
        * subclasses should use this constructor and not the other.
        */
-      Window(bool discrim);
+      explicit Window(bool discrim);
 
       void deallocating() override;
 
@@ -265,7 +265,7 @@ namespace XBMCAddon
 #endif
 
     public:
-      Window(int existingWindowId = -1);
+      explicit Window(int existingWindowId = -1);
 
       //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
       virtual ~Window();

--- a/xbmc/interfaces/legacy/WindowDialogMixin.h
+++ b/xbmc/interfaces/legacy/WindowDialogMixin.h
@@ -38,7 +38,7 @@ namespace XBMCAddon
       Window* w;
 
     protected:
-      inline WindowDialogMixin(Window* window) : w(window) {}
+      inline explicit WindowDialogMixin(Window* window) : w(window) {}
 
     public:
       virtual ~WindowDialogMixin() = default;

--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -89,7 +89,7 @@ namespace XBMCAddon
     {
       InterceptorBase* w;
     public:
-      inline ref(InterceptorBase* b) : w(b) { w->upcallTls.set(this); }
+      inline explicit ref(InterceptorBase* b) : w(b) { w->upcallTls.set(this); }
       inline ~ref() { w->upcallTls.set(NULL); }
       inline CGUIWindow* operator->() { return w->get(); }
       inline CGUIWindow* get() { return w->get(); }

--- a/xbmc/interfaces/python/LanguageHook.h
+++ b/xbmc/interfaces/python/LanguageHook.h
@@ -50,7 +50,7 @@ namespace XBMCAddon
 
     public:
 
-      inline PythonLanguageHook(PyInterpreterState* interp) : m_interp(interp)  {  }
+      inline explicit PythonLanguageHook(PyInterpreterState* interp) : m_interp(interp)  {  }
       ~PythonLanguageHook() override;
 
       void DelayedCallOpen() override;

--- a/xbmc/interfaces/python/PyContext.cpp
+++ b/xbmc/interfaces/python/PyContext.cpp
@@ -30,7 +30,7 @@ namespace XBMCAddon
   {
     struct PyContextState
     {
-      inline PyContextState(bool pcreatedByGilRelease = false) : 
+      inline explicit PyContextState(bool pcreatedByGilRelease = false) :
         value(0), state(NULL), gilReleasedDepth(0), createdByGilRelease(pcreatedByGilRelease) {}
 
       int value;

--- a/xbmc/interfaces/python/pythreadstate.h
+++ b/xbmc/interfaces/python/pythreadstate.h
@@ -29,7 +29,7 @@
 class CPyThreadState
 {
   public:
-    CPyThreadState(bool save = true)
+    explicit CPyThreadState(bool save = true)
     {
       m_threadState = NULL;
 
@@ -68,6 +68,6 @@ class CPyThreadState
 class GilSafeSingleLock : public CPyThreadState, public CSingleLock
 {
 public:
-  GilSafeSingleLock(const CCriticalSection& critSec) : CPyThreadState(true), CSingleLock(critSec) { CPyThreadState::Restore(); }
+  explicit GilSafeSingleLock(const CCriticalSection& critSec) : CPyThreadState(true), CSingleLock(critSec) { CPyThreadState::Restore(); }
 };
 

--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -38,7 +38,7 @@ namespace PythonBindings
   {
     PyObject* obj;
   public:
-    inline PyObjectDecrementor(PyObject* pyobj) : obj(pyobj) {}
+    inline explicit PyObjectDecrementor(PyObject* pyobj) : obj(pyobj) {}
     inline ~PyObjectDecrementor() { Py_XDECREF(obj); }
 
     inline PyObject* get() { return obj; }

--- a/xbmc/interfaces/python/swig.h
+++ b/xbmc/interfaces/python/swig.h
@@ -52,7 +52,7 @@ namespace PythonBindings
     PyTypeObject pythonType;
     const std::type_index typeIndex;
 
-    TypeInfo(const std::type_info& ti);
+    explicit TypeInfo(const std::type_info& ti);
   };
 
   // This will hold the pointer to the api type, whether known or unknown

--- a/xbmc/linux/XHandle.h
+++ b/xbmc/linux/XHandle.h
@@ -37,7 +37,7 @@ public:
   typedef enum { HND_NULL = 0, HND_FILE, HND_EVENT, HND_MUTEX, HND_FIND_FILE } HandleType;
 
   CXHandle();
-  CXHandle(HandleType nType);
+  explicit CXHandle(HandleType nType);
   CXHandle(const CXHandle &src);
 
   virtual ~CXHandle();

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -34,7 +34,7 @@ typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
 class IListProvider
 {
 public:
-  IListProvider(int parentID) : m_parentID(parentID) {}
+  explicit IListProvider(int parentID) : m_parentID(parentID) {}
   virtual ~IListProvider() = default;
 
   /*! \brief Factory to create list providers.

--- a/xbmc/listproviders/StaticProvider.h
+++ b/xbmc/listproviders/StaticProvider.h
@@ -29,7 +29,7 @@ class CStaticListProvider : public IListProvider
 {
 public:
   CStaticListProvider(const TiXmlElement *element, int parentID);
-  CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items); // for python
+  explicit CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items); // for python
   ~CStaticListProvider() override;
 
   bool Update(bool forceRefresh) override;

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -36,7 +36,7 @@ class CFileItem;
 class CAlbum
 {
 public:
-  CAlbum(const CFileItem& item);
+  explicit CAlbum(const CFileItem& item);
   CAlbum()
     : idAlbum(-1)
     , fRating(-1)

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -116,7 +116,7 @@ class CArtistCredit
 
 public:
   CArtistCredit() : idArtist(-1), m_bScrapedMBID(false) { }
-  CArtistCredit(std::string strArtist) : m_strArtist(strArtist) { }
+  explicit CArtistCredit(std::string strArtist) : m_strArtist(strArtist) { }
   CArtistCredit(std::string strArtist, std::string strMusicBrainzArtistID)
     : m_strArtist(strArtist), m_strMusicBrainzArtistID(strMusicBrainzArtistID) {  }
   CArtistCredit(std::string strArtist, std::string strSortName, std::string strMusicBrainzArtistID)

--- a/xbmc/music/GUIViewStateMusic.h
+++ b/xbmc/music/GUIViewStateMusic.h
@@ -25,7 +25,7 @@
 class CGUIViewStateWindowMusic : public CGUIViewState
 {
 public:
-  CGUIViewStateWindowMusic(const CFileItemList& items) : CGUIViewState(items) {}
+  explicit CGUIViewStateWindowMusic(const CFileItemList& items) : CGUIViewState(items) {}
 protected:
   VECSOURCES& GetSources() override;
   int GetPlaylist() override;
@@ -37,7 +37,7 @@ protected:
 class CGUIViewStateMusicSearch : public CGUIViewStateWindowMusic
 {
 public:
-  CGUIViewStateMusicSearch(const CFileItemList& items);
+  explicit CGUIViewStateMusicSearch(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -46,7 +46,7 @@ protected:
 class CGUIViewStateMusicDatabase : public CGUIViewStateWindowMusic
 {
 public:
-  CGUIViewStateMusicDatabase(const CFileItemList& items);
+  explicit CGUIViewStateMusicDatabase(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -55,7 +55,7 @@ protected:
 class CGUIViewStateMusicSmartPlaylist : public CGUIViewStateWindowMusic
 {
 public:
-  CGUIViewStateMusicSmartPlaylist(const CFileItemList& items);
+  explicit CGUIViewStateMusicSmartPlaylist(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -64,7 +64,7 @@ protected:
 class CGUIViewStateMusicPlaylist : public CGUIViewStateWindowMusic
 {
 public:
-  CGUIViewStateMusicPlaylist(const CFileItemList& items);
+  explicit CGUIViewStateMusicPlaylist(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -73,7 +73,7 @@ protected:
 class CGUIViewStateWindowMusicNav : public CGUIViewStateWindowMusic
 {
 public:
-  CGUIViewStateWindowMusicNav(const CFileItemList& items);
+  explicit CGUIViewStateWindowMusicNav(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -86,7 +86,7 @@ private:
 class CGUIViewStateWindowMusicPlaylist : public CGUIViewStateWindowMusic
 {
 public:
-  CGUIViewStateWindowMusicPlaylist(const CFileItemList& items);
+  explicit CGUIViewStateWindowMusicPlaylist(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -58,7 +58,7 @@ class CSong: public ISerializable
 {
 public:
   CSong() ;
-  CSong(CFileItem& item);
+  explicit CSong(CFileItem& item);
   ~CSong() override = default;
   void Clear() ;
   void MergeScrapedSong(const CSong& source, bool override);

--- a/xbmc/music/infoscanner/MusicInfoScraper.h
+++ b/xbmc/music/infoscanner/MusicInfoScraper.h
@@ -37,7 +37,7 @@ namespace MUSIC_GRABBER
 class CMusicInfoScraper : public CThread
 {
 public:
-  CMusicInfoScraper(const ADDON::ScraperPtr &scraper);
+  explicit CMusicInfoScraper(const ADDON::ScraperPtr &scraper);
   ~CMusicInfoScraper(void) override;
   void FindAlbumInfo(const std::string& strAlbum, const std::string& strArtist = "");
   void LoadAlbumInfo(int iAlbum);

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -47,7 +47,7 @@ using namespace EVENTPACKET;
 
 struct ButtonStateFinder
 {
-  ButtonStateFinder(const CEventButtonState& state)
+  explicit ButtonStateFinder(const CEventButtonState& state)
     : m_keycode(state.m_iKeyCode)
     , m_map(state.m_mapName)
     , m_button(state.m_buttonName)

--- a/xbmc/network/EventClient.h
+++ b/xbmc/network/EventClient.h
@@ -130,7 +130,7 @@ namespace EVENTCLIENT
       Initialize();
     }
 
-    CEventClient(SOCKETS::CAddress& addr):
+    explicit CEventClient(SOCKETS::CAddress& addr):
       m_remoteAddr(addr)
     {
       Initialize();

--- a/xbmc/network/Socket.h
+++ b/xbmc/network/Socket.h
@@ -68,7 +68,7 @@ namespace SOCKETS
       size = sizeof(saddr.saddr4);
     }
 
-    CAddress(const char *address)
+    explicit CAddress(const char *address)
     {
       SetAddress(address);
     }

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -94,7 +94,7 @@ namespace JSONRPC
     class CWebSocketClient : public CTCPClient
     {
     public:
-      CWebSocketClient(CWebSocket *websocket);
+      explicit CWebSocketClient(CWebSocket *websocket);
       CWebSocketClient(const CWebSocketClient& client);
       CWebSocketClient(CWebSocket *websocket, const CTCPClient& client);
       CWebSocketClient& operator=(const CWebSocketClient& client);

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -88,7 +88,7 @@ CWakeOnAccess::WakeUpEntry::WakeUpEntry (bool isAwake)
 class CMACDiscoveryJob : public CJob
 {
 public:
-  CMACDiscoveryJob(const std::string& host) : m_host(host) {}
+  explicit CMACDiscoveryJob(const std::string& host) : m_host(host) {}
 
   bool DoWork() override;
 
@@ -164,7 +164,7 @@ int NestDetect::m_nest = 0;
 class ProgressDialogHelper
 {
 public:
-  ProgressDialogHelper (const std::string& heading) : m_dialog(0)
+  explicit ProgressDialogHelper (const std::string& heading) : m_dialog(0)
   {
     if (g_application.IsCurrentThread())
       m_dialog = g_windowManager.GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
@@ -290,7 +290,7 @@ private:
   class CHostProberJob : public CJob
   {
     public:
-      CHostProberJob(const CWakeOnAccess::WakeUpEntry& server) : m_server (server) {}
+      explicit CHostProberJob(const CWakeOnAccess::WakeUpEntry& server) : m_server (server) {}
 
       bool DoWork() override
       {

--- a/xbmc/network/WakeOnAccess.h
+++ b/xbmc/network/WakeOnAccess.h
@@ -43,7 +43,7 @@ public:
   // struct to keep per host settings
   struct WakeUpEntry
   {
-    WakeUpEntry (bool isAwake = false);
+    explicit WakeUpEntry (bool isAwake = false);
 
     std::string host;
     std::string mac;

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -58,7 +58,7 @@ protected:
     struct MHD_PostProcessor *postprocessor;
     int errorStatus;
 
-    ConnectionHandler(const std::string& uri)
+    explicit ConnectionHandler(const std::string& uri)
       : fullUri(uri)
       , isNew(true)
       , requestHandler(nullptr)

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -143,7 +143,7 @@ private:
   {
   public:
     CPublish(const std::string& fcr_identifier, const PublishInfo& pubinfo);
-    CPublish(const tServiceMap& servmap);
+    explicit CPublish(const tServiceMap& servmap);
 
     bool DoWork() override;
 

--- a/xbmc/network/android/ZeroconfBrowserAndroid.h
+++ b/xbmc/network/android/ZeroconfBrowserAndroid.h
@@ -33,7 +33,7 @@ class CZeroconfBrowserAndroid;
 class CZeroconfBrowserAndroidDiscover : public jni::CJNIXBMCNsdManagerDiscoveryListener
 {
 public:
-  CZeroconfBrowserAndroidDiscover(CZeroconfBrowserAndroid* browser);
+  explicit CZeroconfBrowserAndroidDiscover(CZeroconfBrowserAndroid* browser);
   
   // CJNINsdManagerDiscoveryListener interface
 public:

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -73,7 +73,7 @@ private:
   class CHTTPClient : public JSONRPC::IClient
   {
   public:
-    CHTTPClient(HTTPMethod method);
+    explicit CHTTPClient(HTTPMethod method);
     ~CHTTPClient() override = default;
 
     int GetPermissionFlags() override { return m_permissionFlags; }

--- a/xbmc/network/linux/ZeroconfAvahi.cpp
+++ b/xbmc/network/linux/ZeroconfAvahi.cpp
@@ -38,7 +38,7 @@
 ///helper RAII-struct to block event loop for modifications
 struct ScopedEventLoopBlock
 {
-  ScopedEventLoopBlock(AvahiThreadedPoll* fp_poll):mp_poll(fp_poll)
+  explicit ScopedEventLoopBlock(AvahiThreadedPoll* fp_poll):mp_poll(fp_poll)
   {
     avahi_threaded_poll_lock(mp_poll);
   }

--- a/xbmc/network/linux/ZeroconfBrowserAvahi.cpp
+++ b/xbmc/network/linux/ZeroconfBrowserAvahi.cpp
@@ -31,7 +31,7 @@ namespace
 ///helper RAII-struct to block event loop for modifications
 struct ScopedEventLoopBlock
 {
-  ScopedEventLoopBlock ( AvahiThreadedPoll* fp_poll ) : mp_poll ( fp_poll )
+  explicit ScopedEventLoopBlock ( AvahiThreadedPoll* fp_poll ) : mp_poll ( fp_poll )
   {
     avahi_threaded_poll_lock ( mp_poll );
   }

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -160,7 +160,7 @@ public:
 class CUPnPCleaner : public NPT_Thread
 {
 public:
-    CUPnPCleaner(CUPnP* upnp) : NPT_Thread(true), m_UPnP(upnp) {}
+    explicit CUPnPCleaner(CUPnP* upnp) : NPT_Thread(true), m_UPnP(upnp) {}
     void Run() override {
         delete m_UPnP;
     }
@@ -175,7 +175,7 @@ class CMediaBrowser : public PLT_SyncMediaBrowser,
                       public PLT_MediaContainerChangesListener
 {
 public:
-    CMediaBrowser(PLT_CtrlPointReference& ctrlPoint)
+    explicit CMediaBrowser(PLT_CtrlPointReference& ctrlPoint)
         : PLT_SyncMediaBrowser(ctrlPoint, true)
     {
         SetContainerListener(this);
@@ -310,7 +310,7 @@ class CMediaController
   , public PLT_MediaController
 {
 public:
-  CMediaController(PLT_CtrlPointReference& ctrl_point)
+  explicit CMediaController(PLT_CtrlPointReference& ctrl_point)
     : PLT_MediaController(ctrl_point)
   {
     PLT_MediaController::SetDelegate(this);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1001,7 +1001,7 @@ CFileItemPtr BuildObject(PLT_MediaObject* entry,
 
 struct ResourcePrioritySort
 {
-  ResourcePrioritySort(const PLT_MediaObject* entry)
+  explicit ResourcePrioritySort(const PLT_MediaObject* entry)
   {
     if (entry->m_ObjectClass.type.StartsWith("object.item.audioItem"))
         m_content = "audio";

--- a/xbmc/peripherals/EventScanner.h
+++ b/xbmc/peripherals/EventScanner.h
@@ -50,7 +50,7 @@ namespace PERIPHERALS
                         protected CThread
   {
   public:
-    CEventScanner(IEventScannerCallback* callback);
+    explicit CEventScanner(IEventScannerCallback* callback);
 
     ~CEventScanner(void) override = default;
 

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -61,7 +61,7 @@ namespace PERIPHERALS
                         public ANNOUNCEMENT::IAnnouncer
   {
   public:
-    CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements);
+    explicit CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements);
 
     ~CPeripherals() override;
 

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -52,7 +52,7 @@ namespace PERIPHERALS
   class CPeripheralAddon : public ADDON::IAddonInstanceHandler
   {
   public:
-    CPeripheralAddon(const ADDON::BinaryAddonBasePtr& addonInfo);
+    explicit CPeripheralAddon(const ADDON::BinaryAddonBasePtr& addonInfo);
     ~CPeripheralAddon(void) override;
 
     /*!

--- a/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
+++ b/xbmc/peripherals/bus/android/PeripheralBusAndroid.h
@@ -38,7 +38,7 @@ namespace PERIPHERALS
                                 public IInputDeviceEventHandler
   {
   public:
-    CPeripheralBusAndroid(CPeripherals& manager);
+    explicit CPeripheralBusAndroid(CPeripherals& manager);
     ~CPeripheralBusAndroid() override;
 
     // specialisation of CPeripheralBus

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.h
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUSB.h
@@ -31,7 +31,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals& manager);
+    explicit CPeripheralBusUSB(CPeripherals& manager);
 
     /*!
      * @see PeripheralBus::PerformDeviceScan()

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.h
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.h
@@ -32,7 +32,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals& manager);
+    explicit CPeripheralBusUSB(CPeripherals& manager);
     ~CPeripheralBusUSB(void) override;
 
     void Clear(void) override;

--- a/xbmc/peripherals/bus/osx/PeripheralBusUSB.h
+++ b/xbmc/peripherals/bus/osx/PeripheralBusUSB.h
@@ -34,7 +34,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals& manager);
+    explicit CPeripheralBusUSB(CPeripherals& manager);
     virtual ~CPeripheralBusUSB();
 
     /*!

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -37,7 +37,7 @@ namespace PERIPHERALS
   class CPeripheralBusAddon : public CPeripheralBus
   {
   public:
-    CPeripheralBusAddon(CPeripherals& manager);
+    explicit CPeripheralBusAddon(CPeripherals& manager);
     ~CPeripheralBusAddon(void) override;
 
     void UpdateAddons(void);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.h
@@ -32,7 +32,7 @@ namespace PERIPHERALS
   class CPeripheralBusApplication : public CPeripheralBus
   {
   public:
-    CPeripheralBusApplication(CPeripherals& manager);
+    explicit CPeripheralBusApplication(CPeripherals& manager);
     ~CPeripheralBusApplication(void) override = default;
 
     // implementation of CPeripheralBus

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.h
@@ -40,7 +40,7 @@ namespace PERIPHERALS
   class CPeripheralBusCEC : public CPeripheralBus
   {
   public:
-    CPeripheralBusCEC(CPeripherals& manager);
+    explicit CPeripheralBusCEC(CPeripherals& manager);
     ~CPeripheralBusCEC(void) override;
 
     /*!

--- a/xbmc/peripherals/bus/win32/PeripheralBusUSB.h
+++ b/xbmc/peripherals/bus/win32/PeripheralBusUSB.h
@@ -29,7 +29,7 @@ namespace PERIPHERALS
   class CPeripheralBusUSB : public CPeripheralBus
   {
   public:
-    CPeripheralBusUSB(CPeripherals& manager);
+    explicit CPeripheralBusUSB(CPeripherals& manager);
 
     /*!
      * @see PeripheralBus::PerformDeviceScan()

--- a/xbmc/pictures/GUIViewStatePictures.h
+++ b/xbmc/pictures/GUIViewStatePictures.h
@@ -25,7 +25,7 @@
 class CGUIViewStateWindowPictures : public CGUIViewState
 {
 public:
-  CGUIViewStateWindowPictures(const CFileItemList& items);
+  explicit CGUIViewStateWindowPictures(const CFileItemList& items);
 
   std::string GetLockType() override;
   std::string GetExtensions() override;

--- a/xbmc/platform/android/activity/JNIMainActivity.h
+++ b/xbmc/platform/android/activity/JNIMainActivity.h
@@ -26,7 +26,7 @@
 class CJNIMainActivity : public CJNIActivity, public CJNIInputManagerInputDeviceListener
 {
 public:
-  CJNIMainActivity(const ANativeActivity *nativeActivity);
+  explicit CJNIMainActivity(const ANativeActivity *nativeActivity);
   ~CJNIMainActivity();
 
   static CJNIMainActivity* GetAppInstance() { return m_appInstance; }

--- a/xbmc/platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.h
+++ b/xbmc/platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.h
@@ -28,7 +28,7 @@ class CJNIXBMCAudioManagerOnAudioFocusChangeListener : public CJNIAudioManagerAu
 public:
   CJNIXBMCAudioManagerOnAudioFocusChangeListener();
   CJNIXBMCAudioManagerOnAudioFocusChangeListener(const CJNIXBMCAudioManagerOnAudioFocusChangeListener& other); 
-  CJNIXBMCAudioManagerOnAudioFocusChangeListener(const jni::jhobject &object) : CJNIBase(object) {}
+  explicit CJNIXBMCAudioManagerOnAudioFocusChangeListener(const jni::jhobject &object) : CJNIBase(object) {}
   virtual ~CJNIXBMCAudioManagerOnAudioFocusChangeListener();
   
   static void RegisterNatives(JNIEnv* env);

--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.h
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.h
@@ -31,7 +31,7 @@ class CJNIXBMCNsdManagerDiscoveryListener : public CJNINsdManagerDiscoveryListen
 public:
   CJNIXBMCNsdManagerDiscoveryListener();
   CJNIXBMCNsdManagerDiscoveryListener(const CJNIXBMCNsdManagerDiscoveryListener& other); 
-  CJNIXBMCNsdManagerDiscoveryListener(const jni::jhobject &object) : CJNIBase(object) {}
+  explicit CJNIXBMCNsdManagerDiscoveryListener(const jni::jhobject &object) : CJNIBase(object) {}
   virtual ~CJNIXBMCNsdManagerDiscoveryListener();
   
   static void RegisterNatives(JNIEnv* env);

--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerRegistrationListener.h
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerRegistrationListener.h
@@ -31,7 +31,7 @@ class CJNIXBMCNsdManagerRegistrationListener : public CJNINsdManagerRegistration
 public:
   CJNIXBMCNsdManagerRegistrationListener();
   CJNIXBMCNsdManagerRegistrationListener(const CJNIXBMCNsdManagerRegistrationListener& other); 
-  CJNIXBMCNsdManagerRegistrationListener(const jni::jhobject &object) : CJNIBase(object) {}
+  explicit CJNIXBMCNsdManagerRegistrationListener(const jni::jhobject &object) : CJNIBase(object) {}
   virtual ~CJNIXBMCNsdManagerRegistrationListener();
 
   static void RegisterNatives(JNIEnv* env);

--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerResolveListener.h
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerResolveListener.h
@@ -32,7 +32,7 @@ public:
 public:
   CJNIXBMCNsdManagerResolveListener();  
   CJNIXBMCNsdManagerResolveListener(const CJNIXBMCNsdManagerResolveListener& other); 
-  CJNIXBMCNsdManagerResolveListener(const jni::jhobject &object) : CJNIBase(object) {}
+  explicit CJNIXBMCNsdManagerResolveListener(const jni::jhobject &object) : CJNIBase(object) {}
   virtual ~CJNIXBMCNsdManagerResolveListener();
 
   static void RegisterNatives(JNIEnv* env);

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -70,8 +70,8 @@ struct androidPackage
 class CActivityResultEvent : public CEvent
 {
 public:
-  CActivityResultEvent(int requestcode)
-    : m_requestcode(requestcode)
+  explicit CActivityResultEvent(int requestcode)
+    : m_requestcode(requestcode), m_resultcode(0)
   {}
   int GetRequestCode() const { return m_requestcode; }
   int GetResultCode() const { return m_resultcode; }
@@ -92,7 +92,7 @@ class CXBMCApp
     , public ANNOUNCEMENT::IAnnouncer
 {
 public:
-  CXBMCApp(ANativeActivity *nativeActivity);
+  explicit CXBMCApp(ANativeActivity *nativeActivity);
   virtual ~CXBMCApp();
   static CXBMCApp* get() { return m_xbmcappinstance; }
 

--- a/xbmc/playlists/PlayList.h
+++ b/xbmc/playlists/PlayList.h
@@ -29,7 +29,7 @@ namespace PLAYLIST
 class CPlayList
 {
 public:
-  CPlayList(int id = -1);
+  explicit CPlayList(int id = -1);
   virtual ~CPlayList(void) = default;
   virtual bool Load(const std::string& strFileName);
   virtual bool LoadData(std::istream &stream);

--- a/xbmc/programs/GUIViewStatePrograms.h
+++ b/xbmc/programs/GUIViewStatePrograms.h
@@ -25,7 +25,7 @@
 class CGUIViewStateWindowPrograms : public CGUIViewState
 {
 public:
-  CGUIViewStateWindowPrograms(const CFileItemList& items);
+  explicit CGUIViewStateWindowPrograms(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -41,7 +41,7 @@ namespace PVR
     class clazz : public CStaticContextMenuAction \
     { \
     public: \
-      clazz(uint32_t label) : CStaticContextMenuAction(label) {} \
+      explicit clazz(uint32_t label) : CStaticContextMenuAction(label) {} \
       bool IsVisible(const CFileItem &item) const override; \
       bool Execute(const CFileItemPtr &item) const override; \
     };

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -102,7 +102,7 @@ namespace PVR
   class AsyncRenameRecording : public AsyncRecordingAction
   {
   public:
-    AsyncRenameRecording(const std::string &strNewName) : m_strNewName(strNewName) {}
+    explicit AsyncRenameRecording(const std::string &strNewName) : m_strNewName(strNewName) {}
 
   private:
     bool DoRun(const CFileItemPtr &item) override { return CServiceBroker::GetPVRManager().Recordings()->RenameRecording(*item, m_strNewName); }
@@ -371,7 +371,7 @@ namespace PVR
     class InstantRecordingActionSelector
     {
     public:
-      InstantRecordingActionSelector(int iInstantRecordTime);
+      explicit InstantRecordingActionSelector(int iInstantRecordTime);
       virtual ~InstantRecordingActionSelector() = default;
 
       void AddAction(PVRRECORD_INSTANTRECORDACTION eAction, const std::string &title);

--- a/xbmc/pvr/PVRItem.h
+++ b/xbmc/pvr/PVRItem.h
@@ -29,7 +29,7 @@ namespace PVR
   class CPVRItem
   {
   public:
-    CPVRItem(const CFileItemPtr &item) : m_item(item) {}
+    explicit CPVRItem(const CFileItemPtr &item) : m_item(item) {}
 
     CPVREpgInfoTagPtr GetEpgInfoTag() const;
     CPVRChannelPtr GetChannel() const;

--- a/xbmc/pvr/PVRJobs.h
+++ b/xbmc/pvr/PVRJobs.h
@@ -56,7 +56,7 @@ namespace PVR
   class CPVRChannelEntryTimeoutJob : public CJob, public IJobCallback
   {
   public:
-    CPVRChannelEntryTimeoutJob(int iTimeout);
+    explicit CPVRChannelEntryTimeoutJob(int timeout);
     ~CPVRChannelEntryTimeoutJob() override = default;
     const char *GetType() const override { return "pvr-channel-entry-timeout-job"; }
     void OnJobComplete(unsigned int iJobID, bool bSuccess, CJob *job) override {}

--- a/xbmc/pvr/PVRSettings.h
+++ b/xbmc/pvr/PVRSettings.h
@@ -31,7 +31,7 @@ namespace PVR
   class CPVRSettings : private ISettingCallback
   {
   public:
-    CPVRSettings(const std::set<std::string> & settingNames);
+    explicit CPVRSettings(const std::set<std::string> & settingNames);
     ~CPVRSettings() override;
 
     // ISettingCallback implementation

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -54,7 +54,7 @@ namespace PVR
 
   public:
     /*! @brief Create a new channel */
-    CPVRChannel(bool bRadio = false);
+    explicit CPVRChannel(bool bRadio = false);
     CPVRChannel(const PVR_CHANNEL &channel, unsigned int iClientId);
 
   private:

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -76,7 +76,7 @@ namespace PVR
      * @brief Create a new channel group instance from a channel group provided by an add-on.
      * @param group The channel group provided by the add-on.
      */
-    CPVRChannelGroup(const PVR_CHANNEL_GROUP &group);
+    explicit CPVRChannelGroup(const PVR_CHANNEL_GROUP &group);
 
     /*!
      * @brief Copy constructor

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -34,9 +34,9 @@ namespace PVR
      * @brief Create a new internal channel group.
      * @param bRadio True if this group holds radio channels.
      */
-    CPVRChannelGroupInternal(bool bRadio);
+    explicit CPVRChannelGroupInternal(bool bRadio);
 
-    CPVRChannelGroupInternal(const CPVRChannelGroup &group);
+    explicit CPVRChannelGroupInternal(const CPVRChannelGroup &group);
 
     ~CPVRChannelGroupInternal(void) override;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -41,7 +41,7 @@ namespace PVR
      * @brief Create a new group container.
      * @param bRadio True if this is a container for radio channels, false if it is for tv channels.
      */
-    CPVRChannelGroups(bool bRadio);
+    explicit CPVRChannelGroups(bool bRadio);
     virtual ~CPVRChannelGroups(void);
 
     /*!

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -53,7 +53,7 @@ namespace PVR
      * @brief Create a new EPG infotag with 'data' as content.
      * @param data The tag's content.
      */
-    CPVREpgInfoTag(const EPG_TAG &data);
+    explicit CPVREpgInfoTag(const EPG_TAG &data);
 
   private:
     /*!

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -34,7 +34,7 @@ namespace PVR
     static const std::string PATH_DELETED_TV_RECORDINGS;
     static const std::string PATH_DELETED_RADIO_RECORDINGS;
 
-    CPVRRecordingsPath(const std::string &strPath);
+    explicit CPVRRecordingsPath(const std::string &strPath);
     CPVRRecordingsPath(bool bDeleted, bool bRadio);
     CPVRRecordingsPath(bool bDeleted, bool bRadio,
                        const std::string &strDirectory, const std::string &strTitle,

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -47,7 +47,7 @@ namespace PVR
   class CPVRTimerInfoTag : public ISerializable
   {
   public:
-    CPVRTimerInfoTag(bool bRadio = false);
+    explicit CPVRTimerInfoTag(bool bRadio = false);
     CPVRTimerInfoTag(const PVR_TIMER &timer, const CPVRChannelPtr &channel, unsigned int iClientId);
 
     ~CPVRTimerInfoTag(void) override;

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -309,7 +309,7 @@ namespace PVR
     static const std::string PATH_ADDTIMER;
     static const std::string PATH_NEW;
 
-    CPVRTimersPath(const std::string &strPath);
+    explicit CPVRTimersPath(const std::string &strPath);
     CPVRTimersPath(const std::string &strPath, int iClientId, unsigned int iParentId);
     CPVRTimersPath(bool bRadio, bool bTimerRules);
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -98,7 +98,7 @@ namespace PVR
   class CPVRRefreshTimelineItemsThread : public CThread
   {
   public:
-    CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase *pGuideWindow);
+    explicit CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase *pGuideWindow);
     ~CPVRRefreshTimelineItemsThread() override;
 
     void Process() override;

--- a/xbmc/settings/lib/SettingCategoryAccess.h
+++ b/xbmc/settings/lib/SettingCategoryAccess.h
@@ -27,7 +27,7 @@
 class CSettingCategoryAccessCondition : public CSettingConditionItem
 {
 public:
-  CSettingCategoryAccessCondition(CSettingsManager *settingsManager = nullptr)
+  explicit CSettingCategoryAccessCondition(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionItem(settingsManager)
   { }
   ~CSettingCategoryAccessCondition() override = default;
@@ -38,7 +38,7 @@ public:
 class CSettingCategoryAccessConditionCombination : public CSettingConditionCombination
 {
 public:
-  CSettingCategoryAccessConditionCombination(CSettingsManager *settingsManager = nullptr)
+  explicit CSettingCategoryAccessConditionCombination(CSettingsManager *settingsManager = nullptr)
     : CSettingConditionCombination(settingsManager)
   { }
   ~CSettingCategoryAccessConditionCombination() override = default;
@@ -53,6 +53,6 @@ private:
 class CSettingCategoryAccess : public CSettingCondition
 {
 public:
-  CSettingCategoryAccess(CSettingsManager *settingsManager = nullptr);
+  explicit CSettingCategoryAccess(CSettingsManager *settingsManager = nullptr);
   ~CSettingCategoryAccess() override = default;
 };

--- a/xbmc/threads/Atomics.h
+++ b/xbmc/threads/Atomics.h
@@ -25,7 +25,7 @@
 class CAtomicSpinLock
 {
 public:
-  CAtomicSpinLock(std::atomic_flag& lock);
+  explicit CAtomicSpinLock(std::atomic_flag& lock);
   ~CAtomicSpinLock();
 private:
   std::atomic_flag& m_Lock;

--- a/xbmc/utils/BitstreamStats.h
+++ b/xbmc/utils/BitstreamStats.h
@@ -34,7 +34,7 @@ public:
   // in order not to cause a performance hit, we should only check the clock when
   // we reach m_nEstimatedBitrate bits.
   // if this value is 1, we will calculate bitrate on every sample.
-  BitstreamStats(unsigned int nEstimatedBitrate=(10240*8) /*10Kbit*/);
+  explicit BitstreamStats(unsigned int nEstimatedBitrate=(10240*8) /*10Kbit*/);
   virtual ~BitstreamStats();
 
   void AddSampleBytes(unsigned int nBytes);

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -366,7 +366,7 @@ bool CCharsetConverter::CInnerConverter::customConvert(const std::string& source
 struct charPtrPtrAdapter
 {
   const char** pointer;
-  charPtrPtrAdapter(const char** p) :
+  explicit charPtrPtrAdapter(const char** p) :
     pointer(p) { }
   operator char**()
   { return const_cast<char**>(pointer); }

--- a/xbmc/utils/HttpRangeUtils.h
+++ b/xbmc/utils/HttpRangeUtils.h
@@ -83,7 +83,7 @@ class CHttpRanges
 {
 public:
   CHttpRanges();
-  CHttpRanges(const HttpRanges& httpRanges);
+  explicit CHttpRanges(const HttpRanges& httpRanges);
   virtual ~CHttpRanges() = default;
 
   const HttpRanges& Get() const { return m_ranges; }

--- a/xbmc/utils/JSONVariantParser.cpp
+++ b/xbmc/utils/JSONVariantParser.cpp
@@ -25,7 +25,7 @@
 class CJSONVariantParserHandler
 {
 public:
-  CJSONVariantParserHandler(CVariant& parsedObject);
+  explicit CJSONVariantParserHandler(CVariant& parsedObject);
 
   bool Null();
   bool Bool(bool b);

--- a/xbmc/utils/RecentlyAddedJob.h
+++ b/xbmc/utils/RecentlyAddedJob.h
@@ -31,7 +31,7 @@ enum ERecentlyAddedFlag
 class CRecentlyAddedJob : public CJob
 {
 public:
-  CRecentlyAddedJob(int flag);
+  explicit CRecentlyAddedJob(int flag);
   static bool UpdateVideo();
   static bool UpdateMusic();
   static bool UpdateTotal();

--- a/xbmc/utils/ScraperUrl.h
+++ b/xbmc/utils/ScraperUrl.h
@@ -31,8 +31,8 @@ namespace XFILE { class CCurlFile; }
 class CScraperUrl
 {
 public:
-  CScraperUrl(const std::string&);
-  CScraperUrl(const TiXmlElement*);
+  explicit CScraperUrl(const std::string&);
+  explicit CScraperUrl(const TiXmlElement*);
   CScraperUrl();
   ~CScraperUrl();
 

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -36,7 +36,7 @@ public:
     SUBTITLE
   };
 
-  CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {};
+  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {};
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   virtual bool IsWorseThan(CStreamDetail *that) { return true; };

--- a/xbmc/utils/Weather.h
+++ b/xbmc/utils/Weather.h
@@ -94,7 +94,7 @@ public:
 class CWeatherJob : public CJob
 {
 public:
-  CWeatherJob(int location);
+  explicit CWeatherJob(int location);
 
   bool DoWork() override;
 

--- a/xbmc/video/GUIViewStateVideo.h
+++ b/xbmc/video/GUIViewStateVideo.h
@@ -25,7 +25,7 @@
 class CGUIViewStateWindowVideo : public CGUIViewState
 {
 public:
-  CGUIViewStateWindowVideo(const CFileItemList& items) : CGUIViewState(items) {}
+  explicit CGUIViewStateWindowVideo(const CFileItemList& items) : CGUIViewState(items) {}
 
 protected:
   VECSOURCES& GetSources() override;
@@ -37,7 +37,7 @@ protected:
 class CGUIViewStateWindowVideoNav : public CGUIViewStateWindowVideo
 {
 public:
-  CGUIViewStateWindowVideoNav(const CFileItemList& items);
+  explicit CGUIViewStateWindowVideoNav(const CFileItemList& items);
   bool AutoPlayNextItem() override;
 
 protected:
@@ -48,7 +48,7 @@ protected:
 class CGUIViewStateWindowVideoPlaylist : public CGUIViewStateWindowVideo
 {
 public:
-  CGUIViewStateWindowVideoPlaylist(const CFileItemList& items);
+  explicit CGUIViewStateWindowVideoPlaylist(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -60,7 +60,7 @@ protected:
 class CGUIViewStateVideoMovies : public CGUIViewStateWindowVideo
 {
 public:
-  CGUIViewStateVideoMovies(const CFileItemList& items);
+  explicit CGUIViewStateVideoMovies(const CFileItemList& items);
 protected:
   void SaveViewState() override;
 };
@@ -68,7 +68,7 @@ protected:
 class CGUIViewStateVideoMusicVideos : public CGUIViewStateWindowVideo
 {
 public:
-  CGUIViewStateVideoMusicVideos(const CFileItemList& items);
+  explicit CGUIViewStateVideoMusicVideos(const CFileItemList& items);
 protected:
   void SaveViewState() override;
 };
@@ -76,7 +76,7 @@ protected:
 class CGUIViewStateVideoTVShows : public CGUIViewStateWindowVideo
 {
 public:
-  CGUIViewStateVideoTVShows(const CFileItemList& items);
+  explicit CGUIViewStateVideoTVShows(const CFileItemList& items);
 protected:
   void SaveViewState() override;
 };
@@ -84,7 +84,7 @@ protected:
 class CGUIViewStateVideoEpisodes : public CGUIViewStateWindowVideo
 {
 public:
-  CGUIViewStateVideoEpisodes(const CFileItemList& items);
+  explicit CGUIViewStateVideoEpisodes(const CFileItemList& items);
 protected:
   void SaveViewState() override;
 };

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -42,7 +42,7 @@ typedef std::vector<CScraperUrl> MOVIELIST;
 class CVideoInfoDownloader : public CThread
 {
 public:
-  CVideoInfoDownloader(const ADDON::ScraperPtr &scraper);
+  explicit CVideoInfoDownloader(const ADDON::ScraperPtr &scraper);
   ~CVideoInfoDownloader() override;
 
   // threaded lookup functions

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -51,7 +51,7 @@ class CRating
 {
 public:
   CRating(): rating(0.0f), votes(0) {}
-  CRating(float r): rating(r), votes(0) {}
+  explicit CRating(float r): rating(r), votes(0) {}
   CRating(float r, int v): rating(r), votes(v) {}
   float rating;
   int votes;

--- a/xbmc/video/jobs/VideoLibraryProgressJob.h
+++ b/xbmc/video/jobs/VideoLibraryProgressJob.h
@@ -36,5 +36,5 @@ public:
   bool operator==(const CJob* job) const override { return false; }
 
 protected:
-  CVideoLibraryProgressJob(CGUIDialogProgressBarHandle* progressBar);
+  explicit CVideoLibraryProgressJob(CGUIDialogProgressBarHandle* progressBar);
 };

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -66,7 +66,7 @@ public:
   virtual VECSOURCES& GetSources();
 
 protected:
-  CGUIViewState(const CFileItemList& items);  // no direct object creation, use GetViewState()
+  explicit CGUIViewState(const CFileItemList& items);  // no direct object creation, use GetViewState()
 
   virtual void SaveViewState() = 0;
   virtual void SaveViewToDb(const std::string &path, int windowID, CViewState *viewState = NULL);
@@ -109,7 +109,7 @@ protected:
 class CGUIViewStateGeneral : public CGUIViewState
 {
 public:
-  CGUIViewStateGeneral(const CFileItemList& items);
+  explicit CGUIViewStateGeneral(const CFileItemList& items);
 
 protected:
   void SaveViewState() override { }
@@ -118,7 +118,7 @@ protected:
 class CGUIViewStateFromItems : public CGUIViewState
 {
 public:
-  CGUIViewStateFromItems(const CFileItemList& items);
+  explicit CGUIViewStateFromItems(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;
@@ -127,7 +127,7 @@ protected:
 class CGUIViewStateLibrary : public CGUIViewState
 {
 public:
-  CGUIViewStateLibrary(const CFileItemList& items);
+  explicit CGUIViewStateLibrary(const CFileItemList& items);
 
 protected:
   void SaveViewState() override;

--- a/xbmc/windowing/OSScreenSaver.h
+++ b/xbmc/windowing/OSScreenSaver.h
@@ -52,7 +52,7 @@ public:
 
 private:
   friend class COSScreenSaverManager;
-  COSScreenSaverInhibitor(COSScreenSaverManager* manager);
+  explicit COSScreenSaverInhibitor(COSScreenSaverManager* manager);
   bool m_active;
   COSScreenSaverManager* m_manager;
 

--- a/xbmc/windowing/VideoSync.h
+++ b/xbmc/windowing/VideoSync.h
@@ -27,7 +27,7 @@ typedef void (*PUPDATECLOCK)(int NrVBlanks, uint64_t time, void *clock);
 class CVideoSync
 {
 public:
-  CVideoSync(void *clock) { m_refClock = clock; };
+  explicit CVideoSync(void *clock) { m_refClock = clock; };
   virtual ~CVideoSync() = default;
   virtual bool Setup(PUPDATECLOCK func) = 0;
   virtual void Run(CEvent& stop) = 0;

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -26,7 +26,7 @@
 class CGLContext
 {
 public:
-  CGLContext(Display *dpy)
+  explicit CGLContext(Display *dpy)
   {
     m_dpy = dpy;
   }

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -27,7 +27,7 @@
 class CGLContextEGL : public CGLContext
 {
 public:
-  CGLContextEGL(Display *dpy);
+  explicit CGLContextEGL(Display *dpy);
   ~CGLContextEGL() override;
   bool Refresh(bool force, int screen, Window glWindow, bool &newContext) override;
   void Destroy() override;

--- a/xbmc/windowing/X11/GLContextGLX.h
+++ b/xbmc/windowing/X11/GLContextGLX.h
@@ -26,7 +26,7 @@
 class CGLContextGLX : public CGLContext
 {
 public:
-  CGLContextGLX(Display *dpy);
+  explicit CGLContextGLX(Display *dpy);
   bool Refresh(bool force, int screen, Window glWindow, bool &newContext) override;
   void Destroy() override;
   void Detach() override;

--- a/xbmc/windowing/X11/OSScreenSaverX11.h
+++ b/xbmc/windowing/X11/OSScreenSaverX11.h
@@ -27,7 +27,7 @@
 class COSScreenSaverX11 : public KODI::WINDOWING::IOSScreenSaver
 {
 public:
-  COSScreenSaverX11(Display* dpy);
+  explicit COSScreenSaverX11(Display* dpy);
   void Inhibit() override;
   void Uninhibit() override;
 

--- a/xbmc/windowing/X11/VideoSyncDRM.h
+++ b/xbmc/windowing/X11/VideoSyncDRM.h
@@ -25,7 +25,7 @@
 class CVideoSyncDRM : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncDRM(void *clock) : CVideoSync(clock) {};
+  explicit CVideoSyncDRM(void *clock) : CVideoSync(clock) {};
   bool Setup(PUPDATECLOCK func) override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;

--- a/xbmc/windowing/X11/VideoSyncGLX.h
+++ b/xbmc/windowing/X11/VideoSyncGLX.h
@@ -30,7 +30,7 @@
 class CVideoSyncGLX : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncGLX(void *clock) : CVideoSync(clock) {};
+  explicit CVideoSyncGLX(void *clock) : CVideoSync(clock) {};
   bool Setup(PUPDATECLOCK func) override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;

--- a/xbmc/windowing/X11/XRandR.h
+++ b/xbmc/windowing/X11/XRandR.h
@@ -95,7 +95,7 @@ public:
 class CXRandR
 {
 public:
-  CXRandR(bool query=false);
+  explicit CXRandR(bool query=false);
   bool Query(bool force=false, bool ignoreoff=true);
   bool Query(bool force, int screennum, bool ignoreoff=true);
   std::vector<XOutput> GetModes(void);


### PR DESCRIPTION
to avoid unexpected implicit casts, and to shut cppcheck up.