### PR TITLE
bool return value in Inputstream::OpenStream() to allow reset of demuxstreams

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -173,7 +173,7 @@ extern "C" {
     struct INPUTSTREAM_IDS (__cdecl* get_stream_ids)(const AddonInstance_InputStream* instance);
     struct INPUTSTREAM_INFO (__cdecl* get_stream)(const AddonInstance_InputStream* instance, int streamid);
     void (__cdecl* enable_stream)(const AddonInstance_InputStream* instance, int streamid, bool enable);
-    void(__cdecl* open_stream)(const AddonInstance_InputStream* instance, int streamid);
+    bool(__cdecl* open_stream)(const AddonInstance_InputStream* instance, int streamid);
     void (__cdecl* demux_reset)(const AddonInstance_InputStream* instance);
     void (__cdecl* demux_abort)(const AddonInstance_InputStream* instance);
     void (__cdecl* demux_flush)(const AddonInstance_InputStream* instance);
@@ -278,7 +278,7 @@ namespace addon
     * @param streamid unique id of stream
     * @remarks
     */
-    virtual void OpenStream(int streamid) = 0;
+    virtual bool OpenStream(int streamid) = 0;
 
     /*!
      * Reset the demultiplexer in the add-on.
@@ -513,9 +513,9 @@ namespace addon
       instance->toAddon.addonInstance->EnableStream(streamid, enable);
     }
 
-    inline static void ADDON_OpenStream(const AddonInstance_InputStream* instance, int streamid)
+    inline static bool ADDON_OpenStream(const AddonInstance_InputStream* instance, int streamid)
     {
-      instance->toAddon.addonInstance->OpenStream(streamid);
+      return instance->toAddon.addonInstance->OpenStream(streamid);
     }
 
     inline static void ADDON_DemuxReset(const AddonInstance_InputStream* instance)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -102,8 +102,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.2"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.2"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.3"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.3"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -406,8 +406,7 @@ bool CInputStreamAddon::OpenStream(int streamId)
   if (!m_struct.toAddon.open_stream)
     return false;
 
-  m_struct.toAddon.open_stream(&m_struct, streamId);
-  return true;
+  return m_struct.toAddon.open_stream(&m_struct, streamId);
 }
 
 int CInputStreamAddon::GetNrOfStreams() const


### PR DESCRIPTION
## Description
change void return to bool to allow inputstream addons telling demuxer if streams need to be resetted or not.

## Motivation and Context
several "flicker" tickets, wich are originated by inputstream videos where Inputstream reports the wrongstream parameter (e.g. chanelCount) 

## How Has This Been Tested?
windows10 / force wrong channelcount in DemuxClient.cpp::SetStreamProps().

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
