### PR TITLE
[Fix]Add .m4v to music tag loader factory as a valid extension

### DIFF
--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -77,7 +77,7 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& i
       strExtension == "mp3" || 
       strExtension == "wma" || 
       strExtension == "flac" || 
-      strExtension == "m4a" || strExtension == "mp4" ||
+      strExtension == "m4a" || strExtension == "mp4" || strExtension == "m4v" ||
       strExtension == "mpc" || strExtension == "mpp" || strExtension == "mp+" ||
       strExtension == "ogg" || strExtension == "oga" || strExtension == "oggstream" ||
       strExtension == "opus" ||

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1089,7 +1089,7 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
       file = new IT::File(stream);
     else if (strExtension == "mod" || strExtension == "module" || strExtension == "nst" || strExtension == "wow")
       file = new Mod::File(stream);
-    else if (strExtension == "mp4" || strExtension == "m4a" ||
+    else if (strExtension == "mp4" || strExtension == "m4a" || strExtension == "m4v" ||
              strExtension == "m4r" || strExtension == "m4b" ||
              strExtension == "m4p" || strExtension == "3g2")
       file = mp4File = new MP4::File(stream);


### PR DESCRIPTION
Add ".m4v" to tag loader factory as a valid extension so that .m4v files can be added to the music library. Taglib can handle that format of tag already, but it was omitted from the list of valid formats.

Discussed on forum https://forum.kodi.tv/showthread.php?tid=319796

Backport of #12682