### PR TITLE
Add EFlags to inputstream API interface

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -109,11 +109,26 @@ extern "C" {
       TYPE_TELETEXT
     } m_streamType;
 
-    enum Codec_FEATURES
+    enum Codec_FEATURES : uint32_t
     {
       FEATURE_DECODE = 1
     };
-    unsigned int m_features;
+    uint32_t m_features;
+
+    enum STREAM_FLAGS : uint32_t
+    {
+      FLAG_NONE = 0x0000,
+      FLAG_DEFAULT = 0x0001,
+      FLAG_DUB = 0x0002,
+      FLAG_ORIGINAL = 0x0004,
+      FLAG_COMMENT = 0x0008,
+      FLAG_LYRICS = 0x0010,
+      FLAG_KARAOKE = 0x0020,
+      FLAG_FORCED = 0x0040,
+      FLAG_HEARING_IMPAIRED = 0x0080,
+      FLAG_VISUAL_IMPAIRED = 0x0100
+    };
+    uint32_t m_flags;
 
     char m_codecName[32];                /*!< @brief (required) name of codec according to ffmpeg */
     char m_codecInternalName[32];        /*!< @brief (optional) internal name of codec (selectionstream info) */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -102,8 +102,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.3"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.3"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.4"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.4"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -371,6 +371,7 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   {
     demuxStream->ExtraData = new uint8_t[stream.m_ExtraSize];
     demuxStream->ExtraSize = stream.m_ExtraSize;
+    demuxStream->flags = static_cast<CDemuxStream::EFlags>(stream.m_flags);
     for (unsigned int j = 0; j < stream.m_ExtraSize; ++j)
       demuxStream->ExtraData[j] = stream.m_ExtraData[j];
   }


### PR DESCRIPTION
## Description
Support EFlags in inputstream API interface t allow tagging streams with information loke impaired streams

## Motivation and Context
Netflix supports e.g. audio_visible streams wich are taken from kodi as default because they are not tagged.

## How Has This Been Tested?
Windows 10 / "A Series of Unfortunate Events" S01E01

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
