### PR TITLE
Integrate Wayland build into buildsteps

### DIFF
--- a/tools/buildsteps/linux64-wayland/configure-depends
+++ b/tools/buildsteps/linux64-wayland/configure-depends
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  cd $WORKSPACE/tools/depends;./configure \
+    --with-toolchain=/usr --prefix=$XBMC_DEPENDS_ROOT --host=x86_64-linux-gnu --with-tarballs=$TARBALLS --enable-wayland $DEBUG_SWITCH
+fi

--- a/tools/buildsteps/linux64-wayland/configure-xbmc
+++ b/tools/buildsteps/linux64-wayland/configure-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+make -C $WORKSPACE/tools/depends/target/cmakebuildsys

--- a/tools/buildsteps/linux64-wayland/make-binary-addons
+++ b/tools/buildsteps/linux64-wayland/make-binary-addons
@@ -1,0 +1,28 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+. $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-native-depends
+
+#clear the build failed file
+rm -f $WORKSPACE/cmake/$FAILED_BUILD_FILENAME
+
+ALL_BINARY_ADDONS_BUILT="1"
+#only build binary addons when requested by env/jenkins
+if [ "$BUILD_BINARY_ADDONS" == "true" ]
+then
+  for addon in $BINARY_ADDONS
+  do
+    echo "building $addon"
+    git clean -xffd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon
+    cd $WORKSPACE/$BINARY_ADDONS_ROOT/$addon;make -j $BUILDTHREADS V=99 VERBOSE=1  || ALL_BINARY_ADDONS_BUILT="0"
+  done
+fi
+
+if [ "$ALL_BINARY_ADDONS_BUILT" == "1" ]
+then
+  tagSuccessFulBuild $WORKSPACE/cmake
+else
+  #mark the build failure in the filesystem but leave jenkins running
+  tagFailedBuild $WORKSPACE/cmake
+fi

--- a/tools/buildsteps/linux64-wayland/make-depends
+++ b/tools/buildsteps/linux64-wayland/make-depends
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  cd $WORKSPACE/tools/depends;make -j $BUILDTHREADS || make && tagSuccessFulBuild $WORKSPACE/tools/depends
+fi
+

--- a/tools/buildsteps/linux64-wayland/make-native-depends
+++ b/tools/buildsteps/linux64-wayland/make-native-depends
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ] && [ "$BINARY_ADDONS_CLEAN_NATIVETOOLS" != "0" ]
+then
+  git clean -xffd $WORKSPACE/tools/depends/native
+  cd $WORKSPACE/tools/depends/native;make -j $BUILDTHREADS && tagSuccessFulBuild $WORKSPACE/tools/depends
+fi

--- a/tools/buildsteps/linux64-wayland/make-xbmc
+++ b/tools/buildsteps/linux64-wayland/make-xbmc
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE/build;make -j$BUILDTHREADS || make

--- a/tools/buildsteps/linux64-wayland/package
+++ b/tools/buildsteps/linux64-wayland/package
@@ -1,0 +1,5 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#nothing for linux atm

--- a/tools/buildsteps/linux64-wayland/prepare-depends
+++ b/tools/buildsteps/linux64-wayland/prepare-depends
@@ -1,0 +1,15 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#clean without depends for skipping depends build if possible
+#also skip binary addons (pvr, audioencoder) as long as they are deployed in tree
+cd $WORKSPACE;git clean -xfd -e "cmake/.last_success_revision" -e "tools/depends" ${DEPLOYED_BINARY_ADDONS}
+
+# if depends path has changed - cleanout everything and do a full rebuild
+if [ "$(pathChanged $WORKSPACE/tools/depends)" == "1" ]
+then
+  #clean up the rest too
+  cd $WORKSPACE;git clean -xffd
+  cd $WORKSPACE/tools/depends/;./bootstrap
+fi

--- a/tools/buildsteps/linux64-wayland/prepare-xbmc
+++ b/tools/buildsteps/linux64-wayland/prepare-xbmc
@@ -1,0 +1,9 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+#build binary addons before building xbmc...
+#make sure that binary_addons don't clean the native tools
+#here (e.x. on release builds where pathChanged always returns 1
+BINARY_ADDONS_CLEAN_NATIVETOOLS="0"
+. $WORKSPACE/tools/buildsteps/$XBMC_PLATFORM_DIR/make-binary-addons

--- a/tools/buildsteps/linux64-wayland/run-tests
+++ b/tools/buildsteps/linux64-wayland/run-tests
@@ -1,0 +1,14 @@
+WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
+XBMC_PLATFORM_DIR=linux64-wayland
+. $WORKSPACE/tools/buildsteps/defaultenv
+
+cd $WORKSPACE/build;make -j$BUILDTHREADS kodi-test
+if [ "$Configuration" != "Coverage" ]; then
+  cd $WORKSPACE;build/kodi-test --gtest_output=xml:gtestresults.xml
+else
+  cd $WORKSPACE/build;GTEST_OUTPUT="xml:$WORKSPACE/gtestresults.xml" make coverage
+fi
+
+awk '{ if ($1 == "<testcase" && match($0, "notrun")) print substr($0,0,length($0)-2) "><skipped/></testcase>"; else print $0;}' gtestresults.xml > gtestresults-skipped.xml
+rm gtestresults.xml
+mv gtestresults-skipped.xml gtestresults.xml


### PR DESCRIPTION

## Description
Add linux64-wayland to buildsteps, copy of linux64 but with `--enable-wayland`

## Motivation and Context
Wayland should be integrated into CI so build doesn't break unexpectedly

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
