### PR TITLE
Add system/lcms2.dll to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,7 @@ lib/cpluff/stamp-h1
 /system/libmysql.dll
 /system/python27.dll
 /system/zlib.dll
+/system/lcms2.dll
 
 # /system/players/VideoPlayer
 /system/players/VideoPlayer/*


### PR DESCRIPTION
After the 3rd time I commited it by mistake I finally asked about it.. Thx Rechi!

## Description
Add system/lcms2.dll to .gitignore

## Motivation and Context
The file it's not in .gitignore and in Win32 it keeps popping up 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
