### PR TITLE
Fix PDB path for Windows debug build in cmake install

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -255,8 +255,7 @@ macro (build_addon target prefix libs)
 
         if(CMAKE_BUILD_TYPE MATCHES Debug)
           # for debug builds also install the PDB file
-          get_filename_component(LIBRARY_DIR ${LIBRARY_LOCATION} DIRECTORY)
-          install(FILES ${LIBRARY_DIR}/${target}.pdb DESTINATION ${target}
+          install(FILES $<TARGET_PDB_FILE:${target}> DESTINATION ${target}
                   COMPONENT ${target}-${${prefix}_VERSION})
         endif()
       endif()


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
get_filename_component(LIBRARY_DIR ${LIBRARY_LOCATION} DIRECTORY) returns an empty path, causing the INSTALL step to fail when copying the debug PDB file

## Motivation and Context
Fixing binary addon debug build for Windows

## How Has This Been Tested?
Building addons for Win32 and Win64 using "Visual Studio 14"

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
