### PR TITLE
[fix][cmake] allow building without smbclient

### DIFF
--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -153,7 +153,7 @@ if(CORE_SYSTEM_NAME STREQUAL android)
                       AndroidAppFile.h)
 endif()
 
-if(NOT CORE_SYSTEM_NAME STREQUAL windows AND ENABLE_SMBCLIENT)
+if(NOT CORE_SYSTEM_NAME STREQUAL windows AND SMBCLIENT_FOUND)
   list(APPEND SOURCES SMBDirectory.cpp
                       SMBFile.cpp)
   list(APPEND HEADERS SMBDirectory.h


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

<!--## Description-->
<!--- Describe your change in detail -->

## Motivation and Context
allow building without smbclient (and without explicitly disabling the feature)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
build for linux without and with libsmclient-dev package installed
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
