### PR TITLE
[videoinfo] get video aspect ration from CDataCacheCore

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6207,7 +6207,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case VIDEOPLAYER_VIDEO_ASPECT:
     if (g_application.m_pPlayer->IsPlaying())
     {
-      strLabel = CStreamDetails::VideoAspectToAspectDescription(m_videoInfo.videoAspectRatio);
+      strLabel = CStreamDetails::VideoAspectToAspectDescription(CServiceBroker::GetDataCacheCore().GetVideoDAR());
     }
     break;
   case VIDEOPLAYER_AUDIO_CHANNELS:


### PR DESCRIPTION
…ect by dividing videowidth by videoheight

I noticed that in recent builds ```VideoPlayer.VideoAspect``` returns empty. While I couldn't find the root cause of this, I did find we return empty in case the stream details don't return the videoaspect ratio. This adds a fallback in that case by calculating the aspect ratio from the width and height.


EDIT:
Instead of adding a fallback I changed to PR to pull the aspect from CDataCacheCore instead of m_videoInfo as that is deprecated.