### PR TITLE
[cmake] FindCdio: also search for libiso9660

### DIFF
--- a/cmake/modules/FindCdio.cmake
+++ b/cmake/modules/FindCdio.cmake
@@ -23,16 +23,25 @@ find_path(CDIO_INCLUDE_DIR NAMES cdio/cdio.h
 find_library(CDIO_LIBRARY NAMES cdio libcdio
                           PATHS ${CDIO_libcdio_LIBDIR} ${CDIO_libiso9660_LIBDIR})
 
+if(NOT WIN32)
+  find_path(ISO9660_INCLUDE_DIR NAMES cdio/iso9660.h
+                                PATHS ${PC_CDIO_libcdio_INCLUDEDIR}
+                                      ${PC_CDIO_libiso9660_INCLUDEDIR})
+  find_library(ISO9660_LIBRARY NAMES iso9660
+                               PATHS ${CDIO_libcdio_LIBDIR} ${CDIO_libiso9660_LIBDIR})
+  list(APPEND ISO9660_VARS ISO9660_INCLUDE_DIR ISO9660_LIBRARY)
+endif()
+
 set(CDIO_VERSION ${PC_CDIO_libcdio_VERSION})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Cdio
-                                  REQUIRED_VARS CDIO_LIBRARY CDIO_INCLUDE_DIR
+                                  REQUIRED_VARS CDIO_LIBRARY CDIO_INCLUDE_DIR ${ISO9660_VARS}
                                   VERSION_VAR CDIO_VERSION)
 
 if(CDIO_FOUND)
-  set(CDIO_LIBRARIES ${CDIO_LIBRARY})
-  set(CDIO_INCLUDE_DIRS ${CDIO_INCLUDE_DIR})
+  set(CDIO_LIBRARIES ${CDIO_LIBRARY} ${ISO9660_LIBRARY})
+  set(CDIO_INCLUDE_DIRS ${CDIO_INCLUDE_DIR} ${ISO9660_INCLUDE_DIR})
 
   if(NOT TARGET CDIO::CDIO)
     add_library(CDIO::CDIO UNKNOWN IMPORTED)
@@ -42,4 +51,4 @@ if(CDIO_FOUND)
   endif()
 endif()
 
-mark_as_advanced(CDIO_INCLUDE_DIR CDIO_LIBRARY)
+mark_as_advanced(CDIO_INCLUDE_DIR CDIO_LIBRARY ISO9660_INCLUDE_DIR ISO9660_LIBRARY)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
also search for libiso9660 which is needed on all platforms expect windows
<!--- Describe your change in detail -->

## Motivation and Context
build on a fresh installed linux package and noticed that cmake finds succeed, but build later failed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
tested cmake for linux, osx and windows platform
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
