### PR TITLE
[PVR] Fix jumping timeline while switching channel groups in Guide window

### DIFF
--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -686,16 +686,16 @@ void CGUIEPGGridContainer::UpdateItems()
 
     if (prevSelectedEpgTag->StartAsUTC().IsValid() && prevSelectedEpgTag->EndAsUTC().IsValid()) // "normal" tag selected
     {
-      const CDateTime gridStart(m_gridModel->GetGridStart());
       const CDateTime eventStart(prevSelectedEpgTag->StartAsUTC());
-
-      if (gridStart >= eventStart)
+      if (oldGridStart >= eventStart)
       {
         // start of previously selected event is before grid start
         newBlockIndex = eventOffset;
       }
       else
-        newBlockIndex = (eventStart - gridStart).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
+      {
+        newBlockIndex = m_gridModel->GetFirstEventBlock(eventStart) + eventOffset;
+      }
 
       const CPVRChannelPtr channel(prevSelectedEpgTag->Channel());
       if (channel)
@@ -715,16 +715,21 @@ void CGUIEPGGridContainer::UpdateItems()
         const CPVREpgInfoTagPtr tag(prevItem->item->GetEPGInfoTag());
         if (tag && tag->EndAsUTC().IsValid())
         {
-          const CDateTime gridStart(m_gridModel->GetGridStart());
-          const CDateTime eventEnd(tag->EndAsUTC());
+          const CDateTime eventStart(tag->StartAsUTC());
 
-          if (gridStart >= eventEnd)
+          if (oldGridStart >= eventStart)
           {
-            // start of previously selected gap tag is before grid start
+            // start of previously selected event is before grid start
             newBlockIndex = eventOffset;
           }
           else
-            newBlockIndex = (eventEnd - gridStart).GetSecondsTotal() / 60 / CGUIEPGGridContainerModel::MINSPERBLOCK + eventOffset;
+          {
+            // first block of previously selected gap tag is one block after last block of tag before previously selected gap tag.
+            int gapTagStartIndex = m_gridModel->GetLastEventBlock(tag->EndAsUTC()) + 1;
+
+            newBlockIndex = m_gridModel->GetFirstEventBlock(eventStart); // points to tag before previously selected gap tag
+            eventOffset = gapTagStartIndex - newBlockIndex; // newBlockIndex + eventOffset points to first block of previously selected gap tag
+          }
 
           broadcastUid = tag->UniqueBroadcastID();
         }

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.cpp
@@ -20,6 +20,8 @@
 
 #include "GUIEPGGridContainerModel.h"
 
+#include <cmath>
+
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Variant.h"
@@ -184,6 +186,9 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
         item = m_programmeItems[progIdx];
         tag = item->GetEPGInfoTag();
 
+        // Note: Start block of an event is start-time-based calculated block + 1,
+        //       unless start times matches exactly the begin of a block.
+
         if (tag->EpgID() != iEpgId || gridCursor < tag->StartAsUTC() || m_gridEnd <= tag->StartAsUTC())
           break;
 
@@ -269,35 +274,35 @@ void CGUIEPGGridContainerModel::Refresh(const std::unique_ptr<CFileItemList> &it
 void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int &newChannelIndex, int &newBlockIndex) const
 {
   const CDateTimeSpan blockDuration(0, 0, MINSPERBLOCK, 0);
-  bool bFoundPrevChannel = false;
 
   newChannelIndex = INVALID_INDEX;
   newBlockIndex = INVALID_INDEX;
 
-  for (size_t channel = 0; channel < m_channelItems.size(); ++channel)
+  // find the channel
+  int iCurrentChannel = 0;
+  for (const auto& channel : m_channelItems)
   {
+    if (channel->GetPVRChannelInfoTag()->UniqueID() == channelUid)
+    {
+      newChannelIndex = iCurrentChannel;
+      break;
+    }
+    iCurrentChannel++;
+  }
+
+  if (newChannelIndex != INVALID_INDEX)
+  {
+    // find the block
     CDateTime gridCursor(m_gridStart); //reset cursor for new channel
-    unsigned long progIdx = m_epgItemsPtr[channel].start;
-    unsigned long lastIdx = m_epgItemsPtr[channel].stop;
+    unsigned long progIdx = m_epgItemsPtr[newChannelIndex].start;
+    unsigned long lastIdx = m_epgItemsPtr[newChannelIndex].stop;
     int iEpgId = m_programmeItems[progIdx]->GetEPGInfoTag()->EpgID();
     CPVREpgInfoTagPtr tag;
-    CPVRChannelPtr chan;
-
     for (int block = 0; block < m_blocks; ++block)
     {
       while (progIdx <= lastIdx)
       {
         tag = m_programmeItems[progIdx]->GetEPGInfoTag();
-
-        if (!bFoundPrevChannel && channelUid > -1)
-        {
-          chan = tag->Channel();
-          if (chan && chan->UniqueID() == channelUid)
-          {
-            newChannelIndex = channel;
-            bFoundPrevChannel = true;
-          }
-        }
 
         if (tag->EpgID() != iEpgId || gridCursor < tag->StartAsUTC() || m_gridEnd <= tag->StartAsUTC())
           break; // next block
@@ -306,9 +311,8 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid, unsigne
         {
           if (broadcastUid > 0 && tag->UniqueBroadcastID() == broadcastUid)
           {
-            newChannelIndex = channel;
-            newBlockIndex   = block + eventOffset;
-            return; // both found. done.
+            newBlockIndex = block + eventOffset;
+            return; // done.
           }
           break; // next block
         }
@@ -419,4 +423,28 @@ void CGUIEPGGridContainerModel::FreeItemsMemory()
     channel->FreeMemory();
   for (const auto &ruler : m_rulerItems)
     ruler->FreeMemory();
+}
+
+int CGUIEPGGridContainerModel::GetFirstEventBlock(const CDateTime &eventStart) const
+{
+  int diff = (eventStart - m_gridStart).GetSecondsTotal();
+  if (diff <= 0)
+    return -1;
+
+  // First block of a tag is always the block calculated using event's start time, rounded up.
+  // Refer to CGUIEPGGridContainerModel::Refresh, where the model is created, for details!
+  float fBlockIndex = diff / 60.0f / MINSPERBLOCK;
+  return std::ceil(fBlockIndex);
+}
+
+int CGUIEPGGridContainerModel::GetLastEventBlock(const CDateTime &eventEnd) const
+{
+  int diff = (eventEnd - m_gridStart).GetSecondsTotal();
+  if (diff <= 0)
+    return -1;
+
+  // Last block of a tag is always the block calculated using event's end time, not rounded up.
+  // Refer to CGUIEPGGridContainerModel::Refresh, where the model is created, for details!
+  int iBlockIndex = diff / 60 / MINSPERBLOCK;
+  return iBlockIndex;
 }

--- a/xbmc/pvr/windows/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainerModel.h
@@ -86,6 +86,9 @@ namespace PVR
 
     unsigned int GetGridStartPadding() const;
 
+    int GetFirstEventBlock(const CDateTime &eventStart) const;
+    int GetLastEventBlock(const CDateTime &eventEnd) const;
+
   private:
     void FreeItemsMemory();
     void Reset();


### PR DESCRIPTION
This fixes jumping epg grid timeline while switching channel groups in Guide window. This has been reported for both Krypton and Leia several times. :-/ Finally I was able to reproduce this and thus a fix was possible.

This has been runtime tested on macOS, latest Kodi master (as usual on my end).

@Jalle19 mind taking a look.