### PR TITLE
Add contextmenu option to remove resume points

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20656,7 +20656,13 @@ msgctxt "#38208"
 msgid "If EXIF information exists (date, time, camera used, etc.), it will be displayed."
 msgstr ""
 
-#empty strings from id 38209 to 38999
+#. Contextmenu entry to remove the resume point of the currently selected item
+#: xbmc/video/ContextMenus.h
+msgctxt "#38209"
+msgid "Reset resume position"
+msgstr ""
+
+#empty strings from id 38210 to 38999
 
 #: system/settings/settings.xml
 msgctxt "#39000"

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -82,6 +82,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CSongInfo>(),
       std::make_shared<CONTEXTMENU::CMarkWatched>(),
       std::make_shared<CONTEXTMENU::CMarkUnWatched>(),
+      std::make_shared<CONTEXTMENU::CRemoveResumePoint>(),
       std::make_shared<CONTEXTMENU::CEjectDisk>(),
       std::make_shared<CONTEXTMENU::CEjectDrive>(),
       std::make_shared<CONTEXTMENU::CRemoveFavourite>(),

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -523,7 +523,7 @@ bool CPVRRecordings::ChangeRecordingsPlayCount(const CFileItemPtr &item, int cou
       items.Add(item);
 
     CLog::Log(LOGDEBUG, "CPVRRecordings - %s - will set watched for %d items", __FUNCTION__, items.Size());
-    for (int i=0;i<items.Size();++i)
+    for (int i = 0; i < items.Size(); ++i)
     {
       CLog::Log(LOGDEBUG, "CPVRRecordings - %s - setting watched for item %d", __FUNCTION__, i);
 
@@ -575,4 +575,22 @@ bool CPVRRecordings::MarkWatched(const CFileItemPtr &item, bool bWatched)
     return IncrementRecordingsPlayCount(item);
   else
     return SetRecordingsPlayCount(item, 0);
+}
+
+bool CPVRRecordings::ResetResumePoint(const CFileItemPtr item)
+{
+  bool bResult = false;
+
+  const CPVRRecordingPtr recording = item->GetPVRRecordingInfoTag();
+  if (recording && m_database.IsOpen())
+  {
+    bResult = true;
+
+    m_database.ClearBookMarksOfFile(item->GetPath(), CBookmark::RESUME);
+    recording->SetResumePoint(CBookmark());
+
+    CServiceBroker::GetPVRManager().PublishEvent(RecordingsInvalidated);
+  }
+
+  return bResult;
 }

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -52,17 +52,25 @@ namespace PVR
     bool HasDeletedRadioRecordings() const;
 
     /**
-     * Deletes the item in question, be it a directory or a file
+     * @brief Deletes the item in question, be it a directory or a file
      * @param item the item to delete
      * @return whether the item was deleted successfully
      */
     bool Delete(const CFileItem &item);
+
     bool Undelete(const CFileItem &item);
     bool DeleteAllRecordingsFromTrash();
     bool RenameRecording(CFileItem &item, std::string &strNewName);
     bool SetRecordingsPlayCount(const CFileItemPtr &item, int count);
     bool IncrementRecordingsPlayCount(const CFileItemPtr &item);
     bool MarkWatched(const CFileItemPtr &item, bool bWatched);
+
+    /**
+     * @brief Resets a recording's resume point, if any
+     * @param item The item to process
+     * @return True, if the item's resume point was reset successfully, false otherwise
+     */
+    bool ResetResumePoint(const CFileItemPtr item);
 
     bool GetDirectory(const std::string& strPath, CFileItemList &items);
     CFileItemPtr GetByPath(const std::string &path);

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -49,6 +49,26 @@ bool CVideoInfo::Execute(const CFileItemPtr& item) const
   return true;
 }
 
+bool CRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
+{
+  CFileItem item(itemIn.GetItemToPlay());
+  if (item.IsDeleted()) // e.g. trashed pvr recording
+    return false;
+
+  return CGUIWindowVideoBase::HasResumeItemOffset(&item);
+}
+
+bool CRemoveResumePoint::Execute(const CFileItemPtr& item) const
+{
+  CVideoDatabase videoDatabase;
+  if (videoDatabase.Open())
+  {
+    videoDatabase.DeleteResumeBookMark(*item);
+  }
+
+  return true;
+}
+
 bool CMarkWatched::IsVisible(const CFileItem& item) const
 {
   if (item.IsDeleted()) // e.g. trashed pvr recording

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -60,12 +60,7 @@ bool CRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
 
 bool CRemoveResumePoint::Execute(const CFileItemPtr& item) const
 {
-  CVideoDatabase videoDatabase;
-  if (videoDatabase.Open())
-  {
-    videoDatabase.DeleteResumeBookMark(*item);
-  }
-
+  CVideoLibraryQueue::GetInstance().ResetResumePoint(item);
   return true;
 }
 

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -56,6 +56,13 @@ struct CMovieInfo : CVideoInfo
   CMovieInfo() : CVideoInfo(MediaTypeMovie) {}
 };
 
+struct CRemoveResumePoint : CStaticContextMenuAction
+{
+  CRemoveResumePoint() : CStaticContextMenuAction(38209) {}
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+};
+
 struct CMarkWatched : CStaticContextMenuAction
 {
   CMarkWatched() : CStaticContextMenuAction(16103) {}

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -603,7 +603,7 @@ public:
   void GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, bool bAppend=false, long partNumber=0);
   void AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD);
   bool GetResumeBookMark(const std::string& strFilenameAndPath, CBookmark &bookmark);
-  void DeleteResumeBookMark(const std::string &strFilenameAndPath);
+  void DeleteResumeBookMark(const CFileItem& item);
   void ClearBookMarkOfFile(const std::string& strFilenameAndPath, CBookmark& bookmark, CBookmark::EType type = CBookmark::STANDARD);
   void ClearBookMarksOfFile(const std::string& strFilenameAndPath, CBookmark::EType type = CBookmark::STANDARD);
   void ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD);

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -30,6 +30,7 @@
 #include "video/jobs/VideoLibraryJob.h"
 #include "video/jobs/VideoLibraryMarkWatchedJob.h"
 #include "video/jobs/VideoLibraryRefreshingJob.h"
+#include "video/jobs/VideoLibraryResetResumePointJob.h"
 #include "video/jobs/VideoLibraryScanningJob.h"
 
 CVideoLibraryQueue::CVideoLibraryQueue()
@@ -151,6 +152,14 @@ void CVideoLibraryQueue::MarkAsWatched(const CFileItemPtr &item, bool watched)
     return;
 
   AddJob(new CVideoLibraryMarkWatchedJob(item, watched));
+}
+
+void CVideoLibraryQueue::ResetResumePoint(const CFileItemPtr item)
+{
+  if (item == nullptr)
+    return;
+
+  AddJob(new CVideoLibraryResetResumePointJob(item));
 }
 
 void CVideoLibraryQueue::AddJob(CVideoLibraryJob *job)

--- a/xbmc/video/VideoLibraryQueue.h
+++ b/xbmc/video/VideoLibraryQueue.h
@@ -112,6 +112,13 @@ public:
   void MarkAsWatched(const CFileItemPtr &item, bool watched);
 
   /*!
+   \brief Queue a reset resume point job.
+
+   \param[in] item Item to reset the resume point for
+   */
+  void ResetResumePoint(const CFileItemPtr item);
+
+  /*!
    \brief Adds the given job to the queue.
 
    \param[in] job Video library job to be queued.

--- a/xbmc/video/jobs/CMakeLists.txt
+++ b/xbmc/video/jobs/CMakeLists.txt
@@ -3,13 +3,15 @@ set(SOURCES VideoLibraryCleaningJob.cpp
             VideoLibraryMarkWatchedJob.cpp
             VideoLibraryProgressJob.cpp
             VideoLibraryRefreshingJob.cpp
-            VideoLibraryScanningJob.cpp)
+            VideoLibraryScanningJob.cpp
+            VideoLibraryResetResumePointJob.cpp)
 
 set(HEADERS VideoLibraryCleaningJob.h
             VideoLibraryJob.h
             VideoLibraryMarkWatchedJob.h
             VideoLibraryProgressJob.h
             VideoLibraryRefreshingJob.h
-            VideoLibraryScanningJob.h)
+            VideoLibraryScanningJob.h
+            VideoLibraryResetResumePointJob.h)
 
 core_add_library(video_jobs)

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -1,0 +1,94 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "VideoLibraryResetResumePointJob.h"
+
+#include <vector>
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "Util.h"
+#include "filesystem/IDirectory.h"
+#ifdef HAS_UPNP
+#include "network/upnp/UPnP.h"
+#endif
+#include "profiles/ProfilesManager.h"
+#include "pvr/PVRManager.h"
+#include "pvr/recordings/PVRRecordings.h"
+#include "utils/URIUtils.h"
+#include "video/VideoDatabase.h"
+
+CVideoLibraryResetResumePointJob::CVideoLibraryResetResumePointJob(const CFileItemPtr item)
+  : m_item(item)
+{
+}
+
+bool CVideoLibraryResetResumePointJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  const CVideoLibraryResetResumePointJob* resetJob = dynamic_cast<const CVideoLibraryResetResumePointJob*>(job);
+  if (!resetJob)
+    return false;
+
+  return m_item->IsSamePath(resetJob->m_item.get());
+}
+
+bool CVideoLibraryResetResumePointJob::Work(CVideoDatabase &db)
+{
+  if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases())
+    return false;
+
+  CFileItemList items;
+  items.Add(std::make_shared<CFileItem>(*m_item));
+
+  if (m_item->m_bIsFolder)
+    CUtil::GetRecursiveListing(m_item->GetPath(), items, "", XFILE::DIR_FLAG_NO_FILE_INFO);
+
+  std::vector<CFileItemPtr> resetItems;
+  for (const auto& item : items)
+  {
+#ifdef HAS_UPNP
+    if (URIUtils::IsUPnP(item->GetPath()) && UPNP::CUPnP::SaveFileState(*item, CBookmark(), false /* updatePlayCount */))
+      continue;
+#endif
+
+    if (item->HasPVRRecordingInfoTag() && CServiceBroker::GetPVRManager().Recordings()->ResetResumePoint(item))
+      continue;
+
+    resetItems.emplace_back(item);
+  }
+
+  if (resetItems.empty())
+    return true;
+
+  db.BeginTransaction();
+
+  for (const auto& resetItem : resetItems)
+  {
+    db.DeleteResumeBookMark(*resetItem);
+  }
+
+  db.CommitTransaction();
+  db.Close();
+
+  return true;
+}

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.h
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.h
@@ -1,0 +1,47 @@
+#pragma once
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileItem.h"
+#include "video/jobs/VideoLibraryJob.h"
+
+/*!
+ \brief Video library job implementation for resetting a resume point.
+ */
+class CVideoLibraryResetResumePointJob : public CVideoLibraryJob
+{
+public:
+  /*!
+   \brief Creates a new job for resetting a given item's resume point.
+
+   \param[in] item Item for that the resume point shall be reset.
+  */
+  CVideoLibraryResetResumePointJob(const CFileItemPtr item);
+  ~CVideoLibraryResetResumePointJob() override = default;
+
+  const char *GetType() const override { return "CVideoLibraryResetResumePointJob"; }
+  bool operator==(const CJob* job) const override;
+
+protected:
+  bool Work(CVideoDatabase &db) override;
+
+private:
+  CFileItemPtr m_item;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Adds a new contextmenu item for videos which enables users to remove a resume point.
Not 100% sure about the wording, so if anybody has an better idea, let me know.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I basically got a forum PM asking for this inside script.trakt. As you can't remove a resume point without loosing all your watched data. Before this PR you needed to "Mark as unwatched", which gets rid of all view counts and the view date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Locally on windows 64

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
