### PR TITLE
FIX: [droid] update avail stream during state update

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -660,6 +660,14 @@ void CXBMCApp::UpdateSessionState()
   float speed = 0.0;
   if (m_playback_state != PLAYBACK_STATE_STOPPED)
   {
+    if (g_application.m_pPlayer->HasVideo())
+      m_playback_state |= PLAYBACK_STATE_VIDEO;
+    else
+      m_playback_state &= ~PLAYBACK_STATE_VIDEO;
+    if (g_application.m_pPlayer->HasAudio())
+      m_playback_state |= PLAYBACK_STATE_AUDIO;
+    else
+      m_playback_state &= ~PLAYBACK_STATE_AUDIO;
     pos = g_application.m_pPlayer->GetTime();
     speed = g_application.m_pPlayer->GetPlaySpeed();
     if (m_playback_state & PLAYBACK_STATE_PLAYING)


### PR DESCRIPTION
In the PVR case, the streams might not be available when the "onPlay" annouce is triggered.
Refresh the status periodically.

Cf. https://forum.kodi.tv/showthread.php?tid=320007&pid=2636866#pid2636866