### PR TITLE
ActiveAE: Fix up Typo

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2382,7 +2382,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
           }
         }
 
-        if (!ret->pkt->nb_samples & !ret->pkt->pause_burst_ms)
+        if ((ret->pkt->nb_samples == 0) && (ret->pkt->pause_burst_ms == 0))
         {
           ret->Return();
           ret = nullptr;


### PR DESCRIPTION
The code sometimes worked by accident. I changed the !int to == 0 to properly speak boolean.