### PR TITLE
FIX: [addons] clarify repo creation

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -793,10 +793,9 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository, cons
 
     DeleteRepository(repository);
 
-    if (!SetLastChecked(repository, version, CDateTime::GetCurrentDateTime().GetAsDBDateTime()))
+    int idRepo = SetLastChecked(repository, version, CDateTime::GetCurrentDateTime().GetAsDBDateTime());
+    if (idRepo < 0)
       return false;
-
-    int idRepo = static_cast<int>(m_pDS->lastinsertid());
     assert(idRepo > 0);
 
     m_pDB->start_transaction();
@@ -883,7 +882,7 @@ std::pair<CDateTime, ADDON::AddonVersion> CAddonDatabase::LastChecked(const std:
   return std::make_pair(date, version);
 }
 
-bool CAddonDatabase::SetLastChecked(const std::string& id,
+int CAddonDatabase::SetLastChecked(const std::string& id,
     const ADDON::AddonVersion& version, const std::string& time)
 {
   try
@@ -891,24 +890,32 @@ bool CAddonDatabase::SetLastChecked(const std::string& id,
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
+    int retId = -1;
     std::string sql = PrepareSQL("SELECT * FROM repo WHERE addonID='%s'", id.c_str());
     m_pDS->query(sql);
 
     if (m_pDS->eof())
+    {
       sql = PrepareSQL("INSERT INTO repo (id, addonID, lastcheck, version) "
           "VALUES (NULL, '%s', '%s', '%s')", id.c_str(), time.c_str(), version.asString().c_str());
+      m_pDS->exec(sql);
+      retId = static_cast<int>(m_pDS->lastinsertid());
+    }
     else
+    {
+      retId = m_pDS->fv(0).get_asInt();
       sql = PrepareSQL("UPDATE repo SET lastcheck='%s', version='%s' WHERE addonID='%s'",
           time.c_str(), version.asString().c_str(), id.c_str());
+      m_pDS->exec(sql);
+    }
 
-    m_pDS->exec(sql);
-    return true;
+    return retId;
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "%s failed on repo '%s'", __FUNCTION__, id.c_str());
   }
-  return false;
+  return -1;
 }
 
 bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -813,7 +813,7 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository, cons
           addon->Description().c_str(),
           addon->ChangeLog().c_str()));
 
-      auto idAddon = m_pDS->lastinsertid();
+      int idAddon = static_cast<int>(m_pDS->lastinsertid());
       if (idAddon <= 0)
       {
         CLog::Log(LOGERROR, "%s insert failed on addon '%s'", __FUNCTION__, addon->ID().c_str());

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -68,7 +68,12 @@ public:
   /*! Get addons across all repositories */
   bool GetRepositoryContent(ADDON::VECADDONS& addons);
 
-  bool SetLastChecked(const std::string& id, const ADDON::AddonVersion& version, const std::string& timestamp);
+  /*!
+   \brief Set repo last checked date, and create the repo if needed
+   \param id id of the repository
+   \returns id of the repository, or -1 on error.
+   */
+  int SetLastChecked(const std::string& id, const ADDON::AddonVersion& version, const std::string& timestamp);
 
   /*!
    \brief Retrieve the time a repository was last checked and the version it was for


### PR DESCRIPTION
This fixes the issue @MartijnKaijser had with his phone.
It's quite empiric, as it's not clear why it failed only in that situation, and not for the vast majority of others

1) Make it clear `SetLastChecked` creates the repo entry, and make it return the id.
The only reason I can see why this works and not the preveious code is some kind of race in `lastinsertid`. Placing it immediately after the `INSERT` seems to fix it

2) We were passing an int64 as idAddon to `PrepareSQL...%i`. That failed while debugging on win32 as well, so not sure how it works currently