### PR TITLE
[PVR] Coverity: Fix CID174857 (WRAPPER_ESCAPE).

### DIFF
--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -891,13 +891,6 @@ namespace PVR
     static void WriteClientChannelInfo(const CPVRChannelPtr &xbmcChannel, PVR_CHANNEL &addonChannel);
 
     /*!
-     * @brief Copy over epg info from CPVREpgInfoTag to EPG_TAG.
-     * @param kodiTag The epg tag on Kodi's side.
-     * @param addonTag The epg tag on the addon's side.
-     */
-    static void WriteEpgTag(const CConstPVREpgInfoTagPtr &kodiTag, EPG_TAG &addonTag);
-
-    /*!
      * @brief Whether a channel can be played by this add-on
      * @param channel The channel to check.
      * @return True when it can be played, false otherwise.


### PR DESCRIPTION
Fixes CID17857. Problem was introduced with latest PVR Addon API changes PR.

<pre>
________________________________________________________________________________________________________
*** CID 174857:    (WRAPPER_ESCAPE)
/xbmc/addons/PVRClient.cpp: 391 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
385       addonTag.iSeriesNumber = kodiTag->SeriesNumber();
386       addonTag.iEpisodeNumber = kodiTag->EpisodeNumber();
387       addonTag.iEpisodePartNumber = kodiTag->EpisodePart();
388       addonTag.iStarRating = kodiTag->StarRating();
389       addonTag.iYear = kodiTag->Year();
390       addonTag.iFlags = kodiTag->Flags();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strTitle", but is destroyed when it exits scope.
391       addonTag.strTitle = kodiTag->Title(true).c_str();
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
/xbmc/addons/PVRClient.cpp: 392 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
386       addonTag.iEpisodeNumber = kodiTag->EpisodeNumber();
387       addonTag.iEpisodePartNumber = kodiTag->EpisodePart();
388       addonTag.iStarRating = kodiTag->StarRating();
389       addonTag.iYear = kodiTag->Year();
390       addonTag.iFlags = kodiTag->Flags();
391       addonTag.strTitle = kodiTag->Title(true).c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strPlotOutline", but is destroyed when it exits scope.
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
/xbmc/addons/PVRClient.cpp: 393 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
387       addonTag.iEpisodePartNumber = kodiTag->EpisodePart();
388       addonTag.iStarRating = kodiTag->StarRating();
389       addonTag.iYear = kodiTag->Year();
390       addonTag.iFlags = kodiTag->Flags();
391       addonTag.strTitle = kodiTag->Title(true).c_str();
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strPlot", but is destroyed when it exits scope.
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
/xbmc/addons/PVRClient.cpp: 394 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
388       addonTag.iStarRating = kodiTag->StarRating();
389       addonTag.iYear = kodiTag->Year();
390       addonTag.iFlags = kodiTag->Flags();
391       addonTag.strTitle = kodiTag->Title(true).c_str();
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strOriginalTitle", but is destroyed when it exits scope.
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
/xbmc/addons/PVRClient.cpp: 395 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
389       addonTag.iYear = kodiTag->Year();
390       addonTag.iFlags = kodiTag->Flags();
391       addonTag.strTitle = kodiTag->Title(true).c_str();
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strCast", but is destroyed when it exits scope.
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
400       addonTag.strIconPath = kodiTag->Icon().c_str();
/xbmc/addons/PVRClient.cpp: 396 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
390       addonTag.iFlags = kodiTag->Flags();
391       addonTag.strTitle = kodiTag->Title(true).c_str();
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strDirector", but is destroyed when it exits scope.
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
400       addonTag.strIconPath = kodiTag->Icon().c_str();
401       addonTag.iGenreType = kodiTag->GenreType();
/xbmc/addons/PVRClient.cpp: 397 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
391       addonTag.strTitle = kodiTag->Title(true).c_str();
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strWriter", but is destroyed when it exits scope.
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
400       addonTag.strIconPath = kodiTag->Icon().c_str();
401       addonTag.iGenreType = kodiTag->GenreType();
402       addonTag.iGenreSubType = kodiTag->GenreSubType();
/xbmc/addons/PVRClient.cpp: 398 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
392       addonTag.strPlotOutline = kodiTag->PlotOutline().c_str();
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strIMDBNumber", but is destroyed when it exits scope.
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
400       addonTag.strIconPath = kodiTag->Icon().c_str();
401       addonTag.iGenreType = kodiTag->GenreType();
402       addonTag.iGenreSubType = kodiTag->GenreSubType();
403       addonTag.strSeriesLink = kodiTag->SeriesLink().c_str();
/xbmc/addons/PVRClient.cpp: 399 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
393       addonTag.strPlot = kodiTag->Plot().c_str();
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strEpisodeName", but is destroyed when it exits scope.
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
400       addonTag.strIconPath = kodiTag->Icon().c_str();
401       addonTag.iGenreType = kodiTag->GenreType();
402       addonTag.iGenreSubType = kodiTag->GenreSubType();
403       addonTag.strSeriesLink = kodiTag->SeriesLink().c_str();
404     }
/xbmc/addons/PVRClient.cpp: 400 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
394       addonTag.strOriginalTitle = kodiTag->OriginalTitle(true).c_str();
395       addonTag.strCast = kodiTag->Cast().c_str();
396       addonTag.strDirector = kodiTag->Director().c_str();
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strIconPath", but is destroyed when it exits scope.
400       addonTag.strIconPath = kodiTag->Icon().c_str();
401       addonTag.iGenreType = kodiTag->GenreType();
402       addonTag.iGenreSubType = kodiTag->GenreSubType();
403       addonTag.strSeriesLink = kodiTag->SeriesLink().c_str();
404     }
405     
/xbmc/addons/PVRClient.cpp: 403 in PVR::CPVRClient::WriteEpgTag(const std::shared_ptr<const PVR::CPVREpgInfoTag> &, EPG_TAG &)()
397       addonTag.strWriter = kodiTag->Writer().c_str();
398       addonTag.strIMDBNumber = kodiTag->IMDBNumber().c_str();
399       addonTag.strEpisodeName = kodiTag->EpisodeName().c_str();
400       addonTag.strIconPath = kodiTag->Icon().c_str();
401       addonTag.iGenreType = kodiTag->GenreType();
402       addonTag.iGenreSubType = kodiTag->GenreSubType();
>>>     CID 174857:    (WRAPPER_ESCAPE)
>>>     The internal representation of temporary of type "std::string" escapes into "addonTag.strSeriesLink", but is destroyed when it exits scope.
403       addonTag.strSeriesLink = kodiTag->SeriesLink().c_str();
404     }
405     
406     bool CPVRClient::GetAddonProperties(void)
407     {
408       std::string strBackendName, strConnectionString, strFriendlyName, strBackendVersion, strBackendHostname;
</pre>

@Jalle19 for review?