### PR TITLE
[cmake] FindMySqlClient: Compatibility with MariaDB

### DIFF
--- a/cmake/modules/FindMySqlClient.cmake
+++ b/cmake/modules/FindMySqlClient.cmake
@@ -21,7 +21,7 @@ else()
   set(EXTRA_FIND_ARGS)
 endif()
 
-find_path(MYSQLCLIENT_INCLUDE_DIR mysql/mysql_time.h)
+find_path(MYSQLCLIENT_INCLUDE_DIR NAMES mysql/mysql.h mysql/server/mysql.h)
 find_library(MYSQLCLIENT_LIBRARY_RELEASE NAMES mysqlclient libmysql
                                          PATH_SUFFIXES mysql
                                          ${EXTRA_FIND_ARGS})


### PR DESCRIPTION
MariaDB places many of its headers in 'mysql/server' (as opposed to just 'mysql')

## Description
Changing FindMySqlClient to be compatible with mysql and mariadb.

This issue was originally reported at https://bugs.gentoo.org/show_bug.cgi?id=629084

## Motivation and Context
Makes Kodi able to compile against mariadb.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on my Gentoo Linux amd64 system with MariaDB 10.2.8.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
