### PR TITLE
 [depends] bump dbus to 1.11.16 (and actually build it)

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -113,6 +113,7 @@ libdvdnav: libdvdread
 libdvdread: $(DVDREAD_DEPS)
 wayland: expat libffi
 waylandpp: wayland $(WAYLANDPP_DEPS)
+dbus: expat
 
 .installed-$(PLATFORM): $(DEPENDS)
 	touch $@

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -64,7 +64,7 @@ endif
 WAYLANDPP_DEPS=
 ALSA_LIB=
 ifeq ($(OS),linux)
-  DEPENDS += libuuid
+  DEPENDS += dbus libuuid
   #not for raspberry pi
   ifneq ($(TARGET_PLATFORM),raspberry-pi)
     DEPENDS += linux-system-libs

--- a/tools/depends/target/dbus/Makefile
+++ b/tools/depends/target/dbus/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=dbus
-VERSION=1.4.6
+VERSION=1.11.16
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
build dbus for linux and bump it to version 1.11.16
<!--- Describe your change in detail -->

## Motivation and Context
Dbus was never compiled by depends although it was added already 4 years ago.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
compiled depends for linux
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
