### PR TITLE
[Win] WinRenderer::NeedBuffer: use loaded state instead HasPic()

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -1141,9 +1141,9 @@ bool CWinRenderer::NeedBuffer(int idx)
   // check if processor wants to keep past frames
   if (m_renderMethod == RENDER_DXVA && m_processor)
   {
-    int numPast = m_processor->PastRefs();
-    if (m_renderBuffers[idx].HasPic())
+    if (m_renderBuffers[idx].loaded)
     {
+      int numPast = m_processor->PastRefs();
       if (m_renderBuffers[idx].frameIdx + numPast*2 >= m_renderBuffers[m_iYV12RenderBuffer].frameIdx)
         return true;
     }


### PR DESCRIPTION
## Description
[Win] WinRenderer::NeedBuffer: use loaded state instead HasPic() to increase resume after seek.

## Motivation and Context
WinRendere has to store pastFrames for proper working.
After seek (wich does not flush renderbuffers) those past frames block insertion of new frames.
Using Image::loaded instead Image::HasPic counts past-frames only if they are loaded.

## How Has This Been Tested?
Win10 

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
