### PR TITLE
[addons] add pts on CAddonAEStream::AddData addon function

### DIFF
--- a/xbmc/addons/interfaces/AudioEngine.cpp
+++ b/xbmc/addons/interfaces/AudioEngine.cpp
@@ -155,7 +155,8 @@ unsigned int Interface_AudioEngine::AEStream_GetSpace(void* kodiBase, AEStreamHa
   return static_cast<IAEStream*>(streamHandle)->GetSpace();
 }
 
-unsigned int Interface_AudioEngine::AEStream_AddData(void* kodiBase, AEStreamHandle* streamHandle, uint8_t* const *data, unsigned int offset, unsigned int frames)
+unsigned int Interface_AudioEngine::AEStream_AddData(void* kodiBase, AEStreamHandle* streamHandle, uint8_t* const *data,
+                                                     unsigned int offset, unsigned int frames, double pts)
 {
   if (!kodiBase || !streamHandle)
   {
@@ -163,7 +164,7 @@ unsigned int Interface_AudioEngine::AEStream_AddData(void* kodiBase, AEStreamHan
     return 0;
   }
 
-  return static_cast<IAEStream*>(streamHandle)->AddData(data, offset, frames);
+  return static_cast<IAEStream*>(streamHandle)->AddData(data, offset, frames, pts);
 }
 
 double Interface_AudioEngine::AEStream_GetDelay(void* kodiBase, AEStreamHandle* streamHandle)

--- a/xbmc/addons/interfaces/AudioEngine.h
+++ b/xbmc/addons/interfaces/AudioEngine.h
@@ -65,7 +65,8 @@ namespace ADDON
     * @param[in] frames number of frames
     * @return The number of frames consumed
     */
-    static unsigned int AEStream_AddData(void* kodiBase, AEStreamHandle* streamHandle, uint8_t* const *data, unsigned int offset, unsigned int frames);
+    static unsigned int AEStream_AddData(void* kodiBase, AEStreamHandle* streamHandle, uint8_t* const *data,
+                                         unsigned int offset, unsigned int frames, double pts);
 
     /**
     * Returns the time in seconds that it will take

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AudioEngine.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AudioEngine.h
@@ -160,7 +160,8 @@ extern "C"
 
     // Audio Engine Stream definitions
     unsigned int (*AEStream_GetSpace) (void *kodiBase, AEStreamHandle *handle);
-    unsigned int (*AEStream_AddData) (void *kodiBase, AEStreamHandle *handle, uint8_t* const *Data, unsigned int Offset, unsigned int Frames);
+    unsigned int (*AEStream_AddData) (void *kodiBase, AEStreamHandle *handle, uint8_t* const *data,
+                                      unsigned int offset, unsigned int frames, double pts);
     double (*AEStream_GetDelay)(void *kodiBase, AEStreamHandle *handle);
     bool (*AEStream_IsBuffering)(void *kodiBase, AEStreamHandle *handle);
     double (*AEStream_GetCacheTime)(void *kodiBase, AEStreamHandle *handle);
@@ -305,11 +306,12 @@ namespace audioengine
     /// @param data             array of pointers to the planes
     /// @param offset           to frame in frames
     /// @param frames           number of frames
+    /// @param pts              presentation timestamp
     /// @return                 The number of frames consumed
     ///
-    unsigned int AddData(uint8_t* const *data, unsigned int offset, unsigned int frames)
+    unsigned int AddData(uint8_t* const *data, unsigned int offset, unsigned int frames, double pts = 0.0)
     {
-      return m_cb->AEStream_AddData(m_kodiBase, m_StreamHandle, data, offset, frames);
+      return m_cb->AEStream_AddData(m_kodiBase, m_StreamHandle, data, offset, frames, pts);
     }
     //--------------------------------------------------------------------------
 


### PR DESCRIPTION
The PTS is needed for streams who go not with right time flow.
Was also predefined on Kodi Site and only the pass of value added
to addon.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
