### PR TITLE
Implement File::GetProperty to allow (binary) addons access to e.g. reponse headers

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -156,7 +156,7 @@ bool CRepository::FetchIndex(const DirInfo& repo, VECADDONS& addons) noexcept
   }
 
   if (URIUtils::HasExtension(repo.info, ".gz")
-      || CMime::GetFileTypeFromMime(http.GetMimeType()) == CMime::EFileType::FileTypeGZip)
+      || CMime::GetFileTypeFromMime(http.GetProperty(XFILE::FILE_PROPERTY_MIME_TYPE)) == CMime::EFileType::FileTypeGZip)
   {
     CLog::Log(LOGDEBUG, "CRepository '%s' is gzip. decompressing", repo.info.c_str());
     std::string buffer;

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -507,7 +507,7 @@ int Interface_Filesystem::get_file_chunk_size(void* kodiBase, void* file)
 const char* Interface_Filesystem::get_property(void* kodiBase, void* file, int type, const char *name)
 {
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
-  if (addon == nullptr || file == nullptr)
+  if (addon == nullptr || file == nullptr || name == nullptr)
   {
     CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
     return "";

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -504,13 +504,13 @@ int Interface_Filesystem::get_file_chunk_size(void* kodiBase, void* file)
   return static_cast<CFile*>(file)->GetChunkSize();
 }
 
-const char* Interface_Filesystem::get_property(void* kodiBase, void* file, int type, const char *name)
+char* Interface_Filesystem::get_property(void* kodiBase, void* file, int type, const char *name)
 {
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || name == nullptr)
   {
     CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
-    return "";
+    return nullptr;
   }
 
   XFILE::FileProperty internalType;
@@ -533,9 +533,9 @@ const char* Interface_Filesystem::get_property(void* kodiBase, void* file, int t
     break;
   default:
     CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
-    return "";
+    return nullptr;
   };
-  return static_cast<CFile*>(file)->GetProperty(internalType, name).c_str();
+  return strdup(static_cast<CFile*>(file)->GetProperty(internalType, name).c_str());
 }
 
 void* Interface_Filesystem::curl_create(void* kodiBase, const char* url)

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -73,6 +73,7 @@ void Interface_Filesystem::Init(AddonGlobalInterface* addonInterface)
   addonInterface->toKodi->kodi_filesystem->get_file_download_speed = get_file_download_speed;
   addonInterface->toKodi->kodi_filesystem->close_file = close_file;
   addonInterface->toKodi->kodi_filesystem->get_file_chunk_size = get_file_chunk_size;
+  addonInterface->toKodi->kodi_filesystem->get_property = get_property;
 
   addonInterface->toKodi->kodi_filesystem->curl_create = curl_create;
   addonInterface->toKodi->kodi_filesystem->curl_add_option = curl_add_option;
@@ -501,6 +502,40 @@ int Interface_Filesystem::get_file_chunk_size(void* kodiBase, void* file)
   }
 
   return static_cast<CFile*>(file)->GetChunkSize();
+}
+
+const char* Interface_Filesystem::get_property(void* kodiBase, void* file, int type, const char *name)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (addon == nullptr || file == nullptr)
+  {
+    CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
+    return "";
+  }
+
+  XFILE::FileProperty internalType;
+  switch (type)
+  {
+  case ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL:
+    internalType = XFILE::FILE_PROPERTY_RESPONSE_PROTOCOL;
+    break;
+  case ADDON_FILE_PROPERTY_RESPONSE_HEADER:
+    internalType = XFILE::FILE_PROPERTY_RESPONSE_HEADER;
+    break;
+  case ADDON_FILE_PROPERTY_CONTENT_TYPE:
+    internalType = XFILE::FILE_PROPERTY_CONTENT_TYPE;
+    break;
+  case ADDON_FILE_PROPERTY_CONTENT_CHARSET:
+    internalType = XFILE::FILE_PROPERTY_CONTENT_CHARSET;
+    break;
+  case ADDON_FILE_PROPERTY_MIME_TYPE:
+    internalType = XFILE::FILE_PROPERTY_MIME_TYPE;
+    break;
+  default:
+    CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
+    return "";
+  };
+  return static_cast<CFile*>(file)->GetProperty(internalType, name).c_str();
 }
 
 void* Interface_Filesystem::curl_create(void* kodiBase, const char* url)

--- a/xbmc/addons/interfaces/Filesystem.h
+++ b/xbmc/addons/interfaces/Filesystem.h
@@ -77,7 +77,7 @@ namespace ADDON
     static double get_file_download_speed(void* kodiBase, void* file);
     static void close_file(void* kodiBase, void* file);
     static int get_file_chunk_size(void* kodiBase, void* file);
-    static const char* get_property(void* kodiBase, void* file, int type, const char *name);
+    static char* get_property(void* kodiBase, void* file, int type, const char *name);
 
     static void* curl_create(void* kodiBase, const char* url);
     static bool curl_add_option(void* kodiBase, void* file, int type, const char* name, const char* value);

--- a/xbmc/addons/interfaces/Filesystem.h
+++ b/xbmc/addons/interfaces/Filesystem.h
@@ -77,6 +77,7 @@ namespace ADDON
     static double get_file_download_speed(void* kodiBase, void* file);
     static void close_file(void* kodiBase, void* file);
     static int get_file_chunk_size(void* kodiBase, void* file);
+    static const char* get_property(void* kodiBase, void* file, int type, const char *name);
 
     static void* curl_create(void* kodiBase, const char* url);
     static bool curl_add_option(void* kodiBase, void* file, int type, const char* name, const char* value);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -110,7 +110,7 @@ extern "C"
     double (*get_file_download_speed)(void* kodiBase, void* file);
     void (*close_file)(void* kodiBase, void* file);
     int (*get_file_chunk_size)(void* kodiBase, void* file);
-    const char* (*get_property)(void* kodiBase, void* file, int type, const char *name);
+    char* (*get_property)(void* kodiBase, void* file, int type, const char *name);
 
     void* (*curl_create)(void* kodiBase, const char* url);
     bool (*curl_add_option)(void* kodiBase, void* file, int type, const char* name, const char* value);
@@ -1547,7 +1547,15 @@ namespace vfs
         kodi::Log(ADDON_LOG_ERROR, "kodi::vfs::CURLCreate(...) needed to call before GetProperty!");
         return "";
       }
-      return ::kodi::addon::CAddonBase::m_interface->toKodi->kodi_filesystem->get_property(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, m_file, type, name.c_str());
+      char *res(::kodi::addon::CAddonBase::m_interface->toKodi->kodi_filesystem->get_property(
+        ::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, m_file, type, name.c_str()));
+      if (res)
+      {
+        std::string strReturn(res);
+        ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, res);
+        return strReturn;
+      }
+      return "";
     }
     //--------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -110,6 +110,7 @@ extern "C"
     double (*get_file_download_speed)(void* kodiBase, void* file);
     void (*close_file)(void* kodiBase, void* file);
     int (*get_file_chunk_size)(void* kodiBase, void* file);
+    const char* (*get_property)(void* kodiBase, void* file, int type, const char *name);
 
     void* (*curl_create)(void* kodiBase, const char* url);
     bool (*curl_add_option)(void* kodiBase, void* file, int type, const char* name, const char* value);
@@ -192,6 +193,25 @@ typedef enum CURLOptiontype
   /// Add a Header
   ADDON_CURL_OPTION_HEADER
 } CURLOptiontype;
+//------------------------------------------------------------------------------
+
+//==============================================================================
+/// \ingroup cpp_kodi_vfs_Defs
+/// @brief Used CURL message types
+///
+typedef enum FilePropertyTypes
+{
+  /// Get protocol response line
+  ADDON_FILE_PROPERTY_RESPONSE_PROTOCOL,
+  /// Get a response header
+  ADDON_FILE_PROPERTY_RESPONSE_HEADER,
+  /// Get file content type
+  ADDON_FILE_PROPERTY_CONTENT_TYPE,
+  /// Get file content charset
+  ADDON_FILE_PROPERTY_CONTENT_CHARSET,
+  /// Get file mime type
+  ADDON_FILE_PROPERTY_MIME_TYPE
+} FilePropertyTypes;
 //------------------------------------------------------------------------------
 
 //============================================================================
@@ -1508,6 +1528,26 @@ namespace vfs
       if (!m_file)
         return -1;
       return ::kodi::addon::CAddonBase::m_interface->toKodi->kodi_filesystem->get_file_chunk_size(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, m_file);
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// @ingroup cpp_kodi_vfs_CFile
+    /// @brief retrieve a file property
+    ///
+    /// @param[in] type         The type of the file property to retrieve the value for
+    /// @param[in] name         The name of a named property value (e.g. Header)
+    /// @return                 value of requested property, empty on failure / non-existance
+    ///
+    const std::string GetProperty(FilePropertyTypes type, const std::string &name) const
+    {
+      if (!m_file)
+      {
+        kodi::Log(ADDON_LOG_ERROR, "kodi::vfs::CURLCreate(...) needed to call before GetProperty!");
+        return "";
+      }
+      return ::kodi::addon::CAddonBase::m_interface->toKodi->kodi_filesystem->get_property(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, m_file, type, name.c_str());
     }
     //--------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -67,7 +67,7 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h"
 
 #define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.0.1"
-#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.0.0"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.0.1"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h"
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -98,7 +98,7 @@ bool CDVDInputStreamFile::Open()
   }
 
   if (m_pFile->GetImplementation() && (content.empty() || content == "application/octet-stream"))
-    m_content = m_pFile->GetImplementation()->GetContent();
+    m_content = m_pFile->GetImplementation()->GetProperty(XFILE::FILE_PROPERTY_CONTENT_TYPE);
 
   m_eof = false;
   return true;

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1925,7 +1925,7 @@ const std::string CCurlFile::GetProperty(XFILE::FileProperty type, const std::st
   case FILE_PROPERTY_MIME_TYPE:
     return m_state->m_httpheader.GetMimeType();
   default:
-    return StringUtils::Empty;
+    return "";
   }
 }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1766,14 +1766,6 @@ void CCurlFile::SetRequestHeader(const std::string& header, long value)
   m_requestheaders[header] = StringUtils::Format("%ld", value);
 }
 
-std::string CCurlFile::GetServerReportedCharset(void)
-{
-  if (!m_state)
-    return "";
-
-  return m_state->m_httpheader.GetCharset();
-}
-
 std::string CCurlFile::GetURL(void)
 {
   return m_url;
@@ -1812,7 +1804,7 @@ bool CCurlFile::GetMimeType(const CURL &url, std::string &content, const std::st
     if (buffer.st_mode == _S_IFDIR)
       content = "x-directory/normal";
     else
-      content = file.GetMimeType();
+      content = file.GetProperty(XFILE::FILE_PROPERTY_MIME_TYPE);
     CLog::Log(LOGDEBUG, "CCurlFile::GetMimeType - %s -> %s", redactUrl.c_str(), content.c_str());
     return true;
   }
@@ -1834,7 +1826,7 @@ bool CCurlFile::GetContentType(const CURL &url, std::string &content, const std:
     if (buffer.st_mode == _S_IFDIR)
       content = "x-directory/normal";
     else
-      content = file.GetContent();
+      content = file.GetProperty(XFILE::FILE_PROPERTY_CONTENT_TYPE, "");
     CLog::Log(LOGDEBUG, "CCurlFile::GetContentType - %s -> %s", redactUrl.c_str(), content.c_str());
     return true;
   }
@@ -1916,6 +1908,25 @@ int CCurlFile::IoControl(EIoControl request, void* param)
   }
 
   return -1;
+}
+
+const std::string CCurlFile::GetProperty(XFILE::FileProperty type, const std::string &name) const
+{
+  switch (type)
+  {
+  case FILE_PROPERTY_RESPONSE_PROTOCOL:
+    return m_state->m_httpheader.GetProtoLine();
+  case FILE_PROPERTY_RESPONSE_HEADER:
+    return m_state->m_httpheader.GetValue(name);
+  case FILE_PROPERTY_CONTENT_TYPE:
+    return m_state->m_httpheader.GetValue("content-type");
+  case FILE_PROPERTY_CONTENT_CHARSET:
+    return m_state->m_httpheader.GetCharset();
+  case FILE_PROPERTY_MIME_TYPE:
+    return m_state->m_httpheader.GetMimeType();
+  default:
+    return StringUtils::Empty;
+  }
 }
 
 double CCurlFile::GetDownloadSpeed()

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -61,10 +61,8 @@ namespace XFILE
       bool ReadString(char *szLine, int iLineLength) override { return m_state->ReadString(szLine, iLineLength); }
       ssize_t Read(void* lpBuf, size_t uiBufSize) override { return m_state->Read(lpBuf, uiBufSize); }
       ssize_t Write(const void* lpBuf, size_t uiBufSize) override;
-      virtual std::string GetMimeType() { return m_state->m_httpheader.GetMimeType(); }
-      std::string GetContent() override { return m_state->m_httpheader.GetValue("content-type"); }
+      virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const override;
       int IoControl(EIoControl request, void* param) override;
-      std::string GetContentCharset(void) override { return GetServerReportedCharset(); }
       double GetDownloadSpeed() override;
 
       bool Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML);
@@ -94,7 +92,6 @@ namespace XFILE
       void SetBufferSize(unsigned int size);
 
       const CHttpHeader& GetHttpHeader() const { return m_state->m_httpheader; }
-      std::string GetServerReportedCharset(void);
       std::string GetURL(void);
 
       /* static function that will get content type of a file */

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -61,7 +61,7 @@ namespace XFILE
       bool ReadString(char *szLine, int iLineLength) override { return m_state->ReadString(szLine, iLineLength); }
       ssize_t Read(void* lpBuf, size_t uiBufSize) override { return m_state->Read(lpBuf, uiBufSize); }
       ssize_t Write(const void* lpBuf, size_t uiBufSize) override;
-      virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const override;
+      const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const override;
       int IoControl(EIoControl request, void* param) override;
       double GetDownloadSpeed() override;
 

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -137,7 +137,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   std::string strResponse;
   dav.ReadData(strResponse);
 
-  std::string fileCharset(dav.GetServerReportedCharset());
+  std::string fileCharset(dav.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET));
   CXBMCTinyXML davResponse;
   davResponse.Parse(strResponse, fileCharset);
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -953,7 +953,7 @@ int CFile::GetChunkSize()
 const std::string CFile::GetProperty(XFILE::FileProperty type, const std::string &name) const
 {
   if (!m_pFile)
-    return StringUtils::Empty;
+    return "";
   return m_pFile->GetProperty(type, name);
 }
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -950,18 +950,11 @@ int CFile::GetChunkSize()
   return 0;
 }
 
-std::string CFile::GetContentMimeType(void)
+const std::string CFile::GetProperty(XFILE::FileProperty type, const std::string &name) const
 {
   if (!m_pFile)
-    return "";
-  return m_pFile->GetContent();
-}
-
-std::string CFile::GetContentCharset(void)
-{
-  if (!m_pFile)
-    return "";
-  return m_pFile->GetContentCharset();
+    return StringUtils::Empty;
+  return m_pFile->GetProperty(type, name);
 }
 
 ssize_t CFile::LoadFile(const std::string &filename, auto_buffer& outputBuffer)

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <string>
 #include "utils/auto_buffer.h"
-#include "utils/StringUtils.h"
 #include "IFileTypes.h"
 #include "PlatformDefs.h"
 #include "URL.h"
@@ -110,7 +109,7 @@ public:
   int64_t GetLength();
   void Close();
   int GetChunkSize();
-  const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const;
+  const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const;
   ssize_t LoadFile(const std::string &filename, auto_buffer& outputBuffer);
 
 

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <string>
 #include "utils/auto_buffer.h"
+#include "utils/StringUtils.h"
 #include "IFileTypes.h"
 #include "PlatformDefs.h"
 #include "URL.h"
@@ -109,8 +110,7 @@ public:
   int64_t GetLength();
   void Close();
   int GetChunkSize();
-  std::string GetContentMimeType(void);
-  std::string GetContentCharset(void);
+  const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const;
   ssize_t LoadFile(const std::string &filename, auto_buffer& outputBuffer);
 
 
@@ -128,7 +128,7 @@ public:
 
   int IoControl(EIoControl request, void* param);
 
-  IFile *GetImplementation() { return m_pFile; }
+  IFile *GetImplementation() const { return m_pFile; }
 
   // CURL interface
   static bool Exists(const CURL& file, bool bUseCache = true);

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -566,21 +566,12 @@ void CFileCache::StopThread(bool bWait /*= true*/)
   CThread::StopThread(bWait);
 }
 
-std::string CFileCache::GetContent()
+const std::string CFileCache::GetProperty(XFILE::FileProperty type, const std::string &name) const
 {
   if (!m_source.GetImplementation())
-    return IFile::GetContent();
+    return IFile::GetProperty(type, name);
 
-  return m_source.GetImplementation()->GetContent();
-}
-
-std::string CFileCache::GetContentCharset(void)
-{
-  IFile* impl = m_source.GetImplementation();
-  if (!impl)
-    return IFile::GetContentCharset();
-
-  return impl->GetContentCharset();
+  return m_source.GetImplementation()->GetProperty(type, name);
 }
 
 int CFileCache::IoControl(EIoControl request, void* param)

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -59,7 +59,7 @@ namespace XFILE
 
     IFile *GetFileImp();
 
-    virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const override;
+    const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const override;
 
   private:
     CCacheStrategy *m_pCache;

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -59,8 +59,7 @@ namespace XFILE
 
     IFile *GetFileImp();
 
-    std::string GetContent() override;
-    std::string GetContentCharset(void) override;
+    virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const override;
 
   private:
     CCacheStrategy *m_pCache;

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -75,7 +75,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   while(http.ReadString(buffer, sizeof(buffer)-1))
   {
     std::string strBuffer = buffer;
-    std::string fileCharset(http.GetServerReportedCharset());
+    std::string fileCharset(http.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET));
     if (!fileCharset.empty() && fileCharset != "UTF-8")
     {
       std::string converted;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "PlatformDefs.h" // for __stat64, ssize_t
-#include "utils/StringUtils.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -130,9 +129,9 @@ public:
 
   virtual int IoControl(EIoControl request, void* param) { return -1; }
 
-  virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const
+  virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const
   {
-    return type == XFILE::FILE_PROPERTY_CONTENT_TYPE ? XFILE::DefaultContentType : StringUtils::Empty;
+    return type == XFILE::FILE_PROPERTY_CONTENT_TYPE ? "application/octet-stream" : "";
   };
 };
 

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "PlatformDefs.h" // for __stat64, ssize_t
+#include "utils/StringUtils.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -129,8 +130,10 @@ public:
 
   virtual int IoControl(EIoControl request, void* param) { return -1; }
 
-  virtual std::string GetContent()                           { return "application/octet-stream"; }
-  virtual std::string GetContentCharset(void)                { return ""; }
+  virtual const std::string GetProperty(XFILE::FileProperty type, const std::string &name = StringUtils::Empty) const
+  {
+    return type == XFILE::FILE_PROPERTY_CONTENT_TYPE ? XFILE::DefaultContentType : StringUtils::Empty;
+  };
 };
 
 class CRedirectException

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 
 namespace XFILE
 {
@@ -83,4 +84,15 @@ enum CURLOPTIONTYPE
   CURL_OPTION_HEADER      /**< Add a Header           */
 };
 
+enum FileProperty
+{
+  FILE_PROPERTY_RESPONSE_PROTOCOL,          /**< Get response protocol line  */
+  FILE_PROPERTY_RESPONSE_HEADER,            /**< Get response Header value  */
+  FILE_PROPERTY_CONTENT_TYPE,               /**< Get file content-type  */
+  FILE_PROPERTY_CONTENT_CHARSET,            /**< Get file content charset  */
+  FILE_PROPERTY_MIME_TYPE                   /**< Get file mime type  */
+};
+
+/* default content-type for use in returns by ref */
+const std::string DefaultContentType = "application/octet-stream";
 }

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <string>
 
 namespace XFILE
 {
@@ -93,6 +92,4 @@ enum FileProperty
   FILE_PROPERTY_MIME_TYPE                   /**< Get file mime type  */
 };
 
-/* default content-type for use in returns by ref */
-const std::string DefaultContentType = "application/octet-stream";
 }

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -83,7 +83,7 @@ bool CShoutcastFile::Open(const CURL& url)
       m_tag.SetGenre(m_file.GetHttpHeader().GetValue("ice-genre")); // icecast
     m_tag.SetLoaded(true);
   }
-  m_fileCharset = m_file.GetServerReportedCharset();
+  m_fileCharset = m_file.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET);
   m_metaint = atoi(m_file.GetHttpHeader().GetValue("icy-metaint").c_str());
   if (!m_metaint)
     m_metaint = -1;

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -177,7 +177,7 @@ void CRssReader::Process()
         {
           if (http.Get(strUrl, strXML))
           {
-            fileCharset = http.GetServerReportedCharset();
+            fileCharset = http.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET);
             CLog::Log(LOGDEBUG, "Got rss feed: %s", strUrl.c_str());
             break;
           }

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -230,7 +230,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
 
   strHTML = strHTML1;
 
-  std::string mimeType(http.GetMimeType());
+  std::string mimeType(http.GetProperty(XFILE::FILE_PROPERTY_MIME_TYPE));
   CMime::EFileType ftype = CMime::GetFileTypeFromMime(mimeType);
   if (ftype == CMime::FileTypeUnknown)
     ftype = CMime::GetFileTypeFromContent(strHTML);
@@ -249,7 +249,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
       CLog::Log(LOGWARNING, "%s: \"%s\" looks like archive, but cannot be unpacked", __FUNCTION__, scrURL.m_url.c_str());
   }
 
-  std::string reportedCharset(http.GetServerReportedCharset());
+  std::string reportedCharset(http.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET));
   if (ftype == CMime::FileTypeHtml)
   {
     std::string realHtmlCharset, converted;

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -83,7 +83,7 @@ bool CXBMCTinyXML::LoadFile(const std::string& _filename, TiXmlEncoding encoding
   buffer.clear(); // free memory early
 
   if (encoding == TIXML_ENCODING_UNKNOWN)
-    Parse(data, file.GetContentCharset());
+    Parse(data, file.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET));
   else
     Parse(data, encoding);
 


### PR DESCRIPTION
## Description
Provide Interface to get CURL Response Headers / CURL return code

## Motivation and Context
For manifest updates (Live content) I need the ETag Header field for requesting only new manifest data if content is changed.  If content is not changed (regarding ETag) I have to evaluate the return code.

Beside this Cookie header values are needed by zattoo pve addon.

## How Has This Been Tested?
Regression test using Win10 and several internet / local streams

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
