### PR TITLE
Disable top bar overlay in Game OSD

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window type="dialog" id="1109">
-	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
+	<visible>[Window.IsActive(fullscreenvideo) + !Player.HasGame] | Window.IsActive(visualisation)</visible>
 	<visible>Window.IsActive(seekbar) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)</visible>
 	<depth>DepthOSD</depth>
 	<include>Animation_TopSlide</include>


### PR DESCRIPTION
This disables the filename and time that show up at the top in throughout the game OSD.

## Motivation and Context
Cleaner UI

## Screenshots (if appropriate):
![mfrlf2z](https://user-images.githubusercontent.com/531482/29828024-82290af8-8c90-11e7-99e7-e30ff69491a4.png)
![5bvypen](https://user-images.githubusercontent.com/531482/29828034-8811d774-8c90-11e7-8afa-461f99141933.png)
![8ir9b3r](https://user-images.githubusercontent.com/531482/29828047-8dd0f94c-8c90-11e7-9364-7ee441ea822d.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
