### PR TITLE
FindFmt can now be compiled internally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if(UNIX)
   option(FFMPEG_PATH        "Path to external ffmpeg?" "")
   option(ENABLE_INTERNAL_CROSSGUID "Enable internal crossguid?" ON)
   option(ENABLE_INTERNAL_RapidJSON "Enable internal rapidjson?" OFF)
+  option(ENABLE_INTERNAL_FMT "Enable internal fmt?" OFF)
   option(ENABLE_OPENSSL     "Enable OpenSSL?" ON)
 endif()
 # System options

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -12,6 +12,48 @@
 #
 #   Fmt::Fmt   - The Fmt library
 
+if(ENABLE_INTERNAL_FMT)
+  include(ExternalProject)
+  file(STRINGS ${CMAKE_SOURCE_DIR}/tools/depends/target/libfmt/Makefile VER REGEX "^[ ]*VERSION[ ]*=.+$")
+  string(REGEX REPLACE "^[ ]*VERSION[ ]*=[ ]*" "" FMT_VERSION "${VER}")
+
+  # allow user to override the download URL with a local tarball
+  # needed for offline build envs
+  if(FMT_URL)
+      get_filename_component(FMT_URL "${FMT_URL}" ABSOLUTE)
+  else()
+      set(FMT_URL http://mirrors.kodi.tv/build-deps/sources/fmt-${FMT_VERSION}.tar.gz)
+  endif()
+  if(VERBOSE)
+      message(STATUS "FMT_URL: ${FMT_URL}")
+  endif()
+
+  if(APPLE)
+    set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
+  endif()  
+
+  set(FMT_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/libfmt.a)
+  set(FMT_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+  externalproject_add(fmt
+                      URL ${FMT_URL}
+                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      PREFIX ${CORE_BUILD_DIR}/fmt
+                      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+                                 -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                                 "${EXTRA_ARGS}"
+                      BUILD_BYPRODUCTS ${FMT_LIBRARY})
+  set_target_properties(fmt PROPERTIES FOLDER "External Projects")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Fmt
+                                    REQUIRED_VARS FMT_LIBRARY FMT_INCLUDE_DIR
+                                    VERSION_VAR FMT_VERSION)
+
+  set(FMT_LIBRARIES ${FMT_LIBRARY})
+  set(FMT_INCLUDE_DIRS ${FMT_INCLUDE_DIR})
+
+else()
+
 if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
   # TODO: fix windows fmt package to include fmt-config.cmake and fmt-config-version.cmake
   set(FMT_VERSION 3.0.1)
@@ -55,3 +97,5 @@ if(FMT_FOUND)
 endif()
 
 mark_as_advanced(FMT_INCLUDE_DIR FMT_LIBRARY)
+
+endif()


### PR DESCRIPTION
## Description
libfmt doesn't seem to be available on raspbian, this PR provides support for it to be compiled internally, similarly to what we have available for crossguid.

## Motivation and Context
Make it compile in raspbian

## How Has This Been Tested?
Compiling the code

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
