### PR TITLE
RapidJSON can now be compiled internally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(ENABLE_INTERNAL_FFMPEG "Enable internal ffmpeg?" OFF)
 if(UNIX)
   option(FFMPEG_PATH        "Path to external ffmpeg?" "")
   option(ENABLE_INTERNAL_CROSSGUID "Enable internal crossguid?" ON)
+  option(ENABLE_INTERNAL_RapidJSON "Enable internal rapidjson?" OFF)
   option(ENABLE_OPENSSL     "Enable OpenSSL?" ON)
 endif()
 # System options

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -8,6 +8,47 @@
 # RapidJSON_FOUND - system has RapidJSON parser
 # RapidJSON_INCLUDE_DIRS - the RapidJSON parser include directory
 #
+if(ENABLE_INTERNAL_RapidJSON)
+  include(ExternalProject)
+  file(STRINGS ${CMAKE_SOURCE_DIR}/tools/depends/target/rapidjson/Makefile VER REGEX MATCH "^[ ]*VERSION[ ]*=.+$")
+  string(REGEX REPLACE "^[ ]*VERSION[ ]*=[ ]*" "" RJSON_VER "${VER}")
+
+  # allow user to override the download URL with a local tarball
+  # needed for offline build envs
+  if(RapidJSON_URL)
+    get_filename_component(RapidJSON_URL "${RapidJSON_URL}" ABSOLUTE)
+  else()
+    set(RapidJSON_URL http://mirrors.kodi.tv/build-deps/sources/rapidjson-${RJSON_VER}.tar.gz)
+  endif()
+  if(VERBOSE)
+    message(STATUS "RapidJSON_URL: ${RapidJSON_URL}")
+  endif()
+
+  if(APPLE)
+    set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
+  endif()
+
+  set(RapidJSON_LIBRARY ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/librapidjson.a)
+  set(RapidJSON_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/include)
+  externalproject_add(rapidjson
+                      URL ${RapidJSON_URL}
+                      DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/download
+                      PREFIX ${CORE_BUILD_DIR}/rapidjson
+                      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
+                                 -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                                 "${EXTRA_ARGS}"
+                      PATCH_COMMAND patch -p1 < ${CORE_SOURCE_DIR}/tools/depends/target/rapidjson/0001-remove_custom_cxx_flags.patch
+                      BUILD_BYPRODUCTS ${RapidJSON_LIBRARY})
+  set_target_properties(rapidjson PROPERTIES FOLDER "External Projects")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(rapidjson
+                                    REQUIRED_VARS RapidJSON_LIBRARY RapidJSON_INCLUDE_DIR
+                                    VERSION_VAR RJSON_VER)
+
+  set(RapidJSON_LIBRARIES ${RapidJSON_LIBRARY})
+  set(RapidJSON_INCLUDE_DIRS ${RapidJSON_INCLUDE_DIR})
+else()
 
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_RapidJSON RapidJSON>=1.0.2 QUIET)
@@ -38,3 +79,4 @@ endif()
 
 mark_as_advanced(RapidJSON_INCLUDE_DIR)
 
+endif()


### PR DESCRIPTION
## Description
librapidjson doesn't seem to be available on raspbian, this PR provides support for it to be compiled internally, similarly to what we have available for crossguid.

## Motivation and Context
Make it compile in raspbian

## How Has This Been Tested?
Compiling the code

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
