### PR TITLE
FFMPEG: Fixes rbpi compilation

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -250,6 +250,7 @@ if(NOT FFMPEG_FOUND)
                                  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                                  -DFFMPEG_VER=${FFMPEG_VER}
                                  -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
+                                 -DCORE_PLATFORM_NAME=${CORE_PLATFORM_NAME_LC}
                                  -DCPU=${CPU}
                                  -DENABLE_NEON=${ENABLE_NEON}
                                  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -35,7 +35,11 @@ if(CMAKE_BUILD_TYPE STREQUAL Release)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd)
-  list(APPEND ffmpeg_conf --enable-vdpau --enable-vaapi --enable-pic)
+  if(CORE_PLATFORM_NAME STREQUAL rbpi)
+    list(APPEND ffmpeg_conf --cpu=${CPU} --disable-vaapi --disable-vdpau)
+  else()
+    list(APPEND ffmpeg_conf --enable-vdpau --enable-vaapi --enable-pic)
+  endif()
 elseif(CORE_SYSTEM_NAME STREQUAL android)
   if(CPU MATCHES arm64)
     list(APPEND ffmpeg_conf --cpu=cortex-a53 --arch=aarch64)
@@ -58,8 +62,6 @@ elseif(CORE_SYSTEM_NAME STREQUAL osx)
                           --disable-decoder=mpeg_xvmc --disable-vda --disable-crystalhd --enable-videotoolbox
                           --target-os=darwin
                           --disable-securetransport)
-elseif(CORE_PLATFORM_NAME STREQUAL rbpi)
-  list(APPEND ffmpeg_conf --cpu=${CPU} --disable-vaapi --disable-vdpau)
 endif()
 
 if(CPU MATCHES arm OR CORE_PLATFORM_NAME STREQUAL rbpi)


### PR DESCRIPTION
## Description
With the latest refactoring of platforms and systems, raspberry pi compilation was not getting the correct flags. This PR attempts to fix it.

## Motivation and Context
Fixing compiler flags for raspberry pi builds.
 
## How Has This Been Tested?
Compiling code.

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
