### PR TITLE
[Fix] [Music] GetGenresByArtist for album artists

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1782,17 +1782,34 @@ bool CMusicDatabase::GetGenresByArtist(int idArtist, CFileItem* item)
 {
   try
   {
-    std::string strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre FROM "
-      "song_artist JOIN song ON song_artist.idSong = song.idSong JOIN "
-      "song_genre ON song.idSong = song_genre.idSong JOIN "
-      "genre ON song_genre.idGenre = genre.idGenre "
-      "WHERE song_artist.idArtist = %i ORDER BY song_genre.idGenre", idArtist);
+    std::string strSQL;
+    strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre FROM "
+      "album_artist JOIN song ON album_artist.idAlbum = song.idAlbum "
+      "JOIN song_genre ON song.idSong = song_genre.idSong "
+      "JOIN genre ON song_genre.idGenre = genre.idGenre "
+      "WHERE album_artist.idArtist = %i "
+      "ORDER BY song_genre.idGenre", idArtist);
     if (!m_pDS->query(strSQL))
       return false;
     if (m_pDS->num_rows() == 0)
     {
+      // Artist does have any song genres via albums may not be an album artist.
+      // Check via songs artist to fetch song genres from compilations or where they are guest artist
       m_pDS->close();
-      return true;
+      strSQL = PrepareSQL("SELECT DISTINCT song_genre.idGenre, genre.strGenre FROM "
+        "song_artist JOIN song ON song_artist.idSong = song.idSong JOIN "
+        "song_genre ON song.idSong = song_genre.idSong "
+        "JOIN genre ON song_genre.idGenre = genre.idGenre "
+        "WHERE song_artist.idArtist = %i "
+        "ORDER BY song_genre.idGenre", idArtist);
+      if (!m_pDS->query(strSQL))
+        return false;
+      if (m_pDS->num_rows() == 0)
+      {
+        //No song genres, but query sucessfull
+        m_pDS->close();
+        return true;
+      }
     }
 
     CVariant artistSongGenres(CVariant::VariantTypeArray);


### PR DESCRIPTION
GetGenresByArtist is not handling artists that have relationship with song is via album and album artist rather than song artist. Minor query change to return these values and correct the oversight.

Explanation: not all album artists are also song artists for songs on the album. For example Musicbrainz tagging guidelines use the guitarist as the release (album) artist but composer as the track/recording (song) artist on classical guitar music. So collating the song genres for an artist needs to consider the genre(s) of songs on albums by each artist.


