### PR TITLE
GetFileProperty for "old" binary addon interface

### DIFF
--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
@@ -76,6 +76,7 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->GetFileChunkSize   = GetFileChunkSize;
   m_callbacks->FileExists         = FileExists;
   m_callbacks->StatFile           = StatFile;
+  m_callbacks->GetFileProperty    = GetFileProperty;
   m_callbacks->DeleteFile         = DeleteFile;
 
   m_callbacks->CanOpenDirectory   = CanOpenDirectory;
@@ -502,6 +503,18 @@ int CAddonCallbacksAddon::StatFile(const void* addonData, const char *strFileNam
     return -1;
 
   return CFile::Stat(strFileName, buffer);
+}
+
+char *CAddonCallbacksAddon::GetFileProperty(const void* addonData, void* file, XFILE::FileProperty type, const char *name)
+{
+  CAddonInterfaces* helper = (CAddonInterfaces*)addonData;
+  if (!helper)
+    return nullptr;
+
+  CFile* cfile = (CFile*)file;
+  if (cfile)
+    return strdup(cfile->GetProperty(type, name).c_str());
+  return nullptr;
 }
 
 bool CAddonCallbacksAddon::DeleteFile(const void* addonData, const char *strFileName)

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.h
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.h
@@ -79,6 +79,7 @@ public:
   static int GetFileChunkSize(const void* addonData, void* file);
   static bool FileExists(const void* addonData, const char *strFileName, bool bUseCache);
   static int StatFile(const void* addonData, const char *strFileName, struct __stat64* buffer);
+  static char *GetFileProperty(const void* addonData, void* file, XFILE::FileProperty type, const char *name);
   static bool DeleteFile(const void* addonData, const char *strFileName);
   static bool CanOpenDirectory(const void* addonData, const char* strURL);
   static bool CreateDirectory(const void* addonData, const char *strPath);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
@@ -155,6 +155,7 @@ typedef struct CB_AddOn
   int (*GetFileChunkSize)(const void* addonData, void* file);
   bool (*FileExists)(const void* addonData, const char *strFileName, bool bUseCache);
   int (*StatFile)(const void* addonData, const char *strFileName, struct __stat64* buffer);
+  char *(*GetFileProperty)(const void* addonData, void* file, XFILE::FileProperty type, const char *name);
   bool (*DeleteFile)(const void* addonData, const char *strFileName);
   bool (*CanOpenDirectory)(const void* addonData, const char* strURL);
   bool (*CreateDirectory)(const void* addonData, const char *strPath);
@@ -462,6 +463,18 @@ namespace ADDON
     int StatFile(const char *strFileName, struct __stat64* buffer)
     {
       return m_Callbacks->StatFile(m_Handle->addonData, strFileName, buffer);
+    }
+
+    /*!
+    * @brief Get a property from an open file.
+    * @param file The file to get an property for
+    * @param type type of the requested property.
+    * @param name of the requested property / can be null.
+    * @return The value of the requested property, must be FreeString'ed.
+    */
+    char *GetFileProperty(void* file, XFILE::FileProperty type, const char *name)
+    {
+      return m_Callbacks->GetFileProperty(m_Handle->addonData, file, type, name);
     }
 
     /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -41,8 +41,8 @@
  * overview.
  */
 
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.10"
-#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.10"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.11"
+#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.11"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \
                                                       "xbmc_addon_dll.h" \


### PR DESCRIPTION
## Description
Provide Interface to get CURL Response Headers / CURL return code

Addition to https://github.com/xbmc/xbmc/pull/12737

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
