### PR TITLE
[pvr] PVR Addon API 5.7.1: Support for passing MimeType for PVR streams

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -825,7 +825,11 @@ bool CPVRClient::FillEpgTagStreamFileItem(CFileItem &fileItem)
   {
     if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_STREAMURL, strlen(PVR_STREAM_PROPERTY_STREAMURL)) == 0)
       fileItem.SetDynPath(properties[i].strValue);
-
+    else if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_MIMETYPE, strlen(PVR_STREAM_PROPERTY_MIMETYPE)) == 0)
+    {
+      fileItem.SetMimeType(properties[i].strValue);
+      fileItem.SetContentLookup(false);
+    }
     fileItem.SetProperty(properties[i].strName, properties[i].strValue);
   }
 
@@ -1299,7 +1303,11 @@ bool CPVRClient::FillChannelStreamFileItem(CFileItem &fileItem)
   {
     if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_STREAMURL, strlen(PVR_STREAM_PROPERTY_STREAMURL)) == 0)
       fileItem.SetDynPath(properties[i].strValue);
-
+    else if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_MIMETYPE, strlen(PVR_STREAM_PROPERTY_MIMETYPE)) == 0)
+    {
+      fileItem.SetMimeType(properties[i].strValue);
+      fileItem.SetContentLookup(false);
+    }
     fileItem.SetProperty(properties[i].strName, properties[i].strValue);
   }
   return true;
@@ -1328,7 +1336,11 @@ bool CPVRClient::FillRecordingStreamFileItem(CFileItem &fileItem)
   {
     if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_STREAMURL, strlen(PVR_STREAM_PROPERTY_STREAMURL)) == 0)
       fileItem.SetDynPath(properties[i].strValue);
-
+    else if (strncmp(properties[i].strName, PVR_STREAM_PROPERTY_MIMETYPE, strlen(PVR_STREAM_PROPERTY_MIMETYPE)) == 0)
+    {
+      fileItem.SetMimeType(properties[i].strValue);
+      fileItem.SetContentLookup(false);
+    }
     fileItem.SetProperty(properties[i].strName, properties[i].strValue);
   }
   return true;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -114,7 +114,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "5.7.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.7.1"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "5.7.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "xbmc_pvr_dll.h" \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -81,6 +81,7 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_PROPERTIES     20
 #define PVR_STREAM_PROPERTY_STREAMURL "streamurl" /*!< @brief the URL of the stream that should be played. */
 #define PVR_STREAM_PROPERTY_INPUTSTREAMADDON  "inputstreamaddon" /*!< @brief the name of the inputstream add-on that should be used by Kodi to play the stream denoted by PVR_STREAM_PROPERTY_STREAMURL. Leave blank to use Kodi's built-in playing capabilities. */
+#define PVR_STREAM_PROPERTY_MIMETYPE "mimetype" /*!< @brief the Mime-Type of the stream that should be played. */
 
 /* using the default avformat's MAX_STREAMS value to be safe */
 #define PVR_STREAM_MAX_STREAMS 20


### PR DESCRIPTION
## Description
Allow setting Mime-Type for PVR streams + Disable Content-Lokup for known streams.

Todos for addon maintainers: none, as minimum pvr api version number did not change.

## Motivation and Context
Mime-Type content lookup takes some time (HEAD Request) and can be supressed if PVR addon knows the mime type. Speeds up channel switching.

Should not lead to version issues because PVR_VERSION_MIN is unchanged.

## How Has This Been Tested?
pvr.zattoo + mpeg DASH streams

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
