### PR TITLE
ActiveAE: Fix crashing on 48khtz content in PAPlayer

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2158,7 +2158,7 @@ bool CActiveAE::RunStages()
             {
               // copy the samples into the viz input buffer
               CSampleBuffer *viz = m_vizBuffersInput->GetFreeBuffer();
-              int samples = out->pkt->nb_samples;
+              int samples = std::min(512, out->pkt->nb_samples);
               int bytes = samples * out->pkt->config.channels / out->pkt->planes * out->pkt->bytes_per_sample;
               for(int i= 0; i < out->pkt->planes; i++)
               {
@@ -2181,7 +2181,7 @@ bool CActiveAE::RunStages()
                 break;
               else
               {
-                int samples = buf->pkt->nb_samples;
+                int samples = std::min(512, buf->pkt->nb_samples);
                 for (auto& it : m_audioCallback)
                   it->OnAudioData((float*)(buf->pkt->data[0]), samples);
                 buf->Return();


### PR DESCRIPTION
## Description

* Bugfix: This has been present since the first alpha of v14.

  if playing a mix of 44.1khtz and 48khtz music files when a
  44.1kthz song ends and a 48khtz song begins AND while music
  visualizations  are active, KODI will crash with a segfault
  in the "Stages()" sections of AE. Revert the declaration of
  the sample rate variables to values from last known revision
  that does not suffer from this bug (Gotham 13.2)

<!--- Provide a general summary of your change in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
   When playing music with different sample rates when one song finishes and another beghins that is 48htz AND Visualizations are enabled (important! doesnt crash with em off. ANY ONE not just projectm) It also wont happen if you manually press skip + or - you have to let PAPlayer do it. it also does not happen with VideoPlayer
<!--- If it fixes an open issue, please link to the issue here -->
NA

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Put my collection of the Band soundgarden on shuffle because it is a easy way for me to test with 48khtz since a whole album is in 48khtz. Let it play until it comes up on a 48kthz song. without my fix it would crash EVERY TIME. I tried different Linux flavors. different hardware... different PC.. doesnt happen on a raspbery Pi 3. only thing i didnt change was my AVR since i cant.

<!--- Include details of your testing environment, and the tests you ran to -->
Ubuntu 14.04 LTS Minimal 3.13 Kernel Nvidia GT 550 , Drivers version 304.122 and 375.166 (currently 375)
<!--- see how your change affects other areas of the code, etc -->

Tested for a few weeks. thrown all different sample rates etc at it. all seems fine. visuals still work and seem timed up

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [* ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
