### PR TITLE
ActiveAE: Avoid resetting error interval

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2460,7 +2460,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
   {
     stream->m_processingBuffers->SetRR(1.0, m_settings.atempoThreshold);
   }
-  stream->m_syncError.Flush(stream->GetErrorInterval());
+  stream->m_syncError.SetErrorInterval(stream->GetErrorInterval());
 
   return ret;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -49,6 +49,13 @@ public:
     m_timer.Set(interval);
   }
 
+  void SetErrorInterval(int interval = 100)
+  {
+    m_buffer = 0.0f;
+    m_count = 0;
+    m_timer.Set(interval);
+  }
+
   bool Get(double& error, int interval = 100)
   {
     if(m_timer.IsTimePast())


### PR DESCRIPTION

<!--- Provide a general summary of your change in the Title above -->

## Description
PR12002 resulted in audio sync error term always being zero.

## Motivation and Context
Reported here: https://forum.kodi.tv/showthread.php?tid=298461&pid=2639400#pid2639400
(Bug report 2)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
