### PR TITLE
Disable top bar: FullscreenGame version

### DIFF
--- a/addons/skin.estuary/xml/DialogBusy.xml
+++ b/addons/skin.estuary/xml/DialogBusy.xml
@@ -11,7 +11,7 @@
 				<texture>colors/black.png</texture>
 				<include>FullScreenDimensions</include>
 				<animation effect="fade" start="100" end="70" time="0" condition="true">Conditional</animation>
-				<animation effect="fade" start="100" end="0" time="240" condition="Window.IsVisible(fullscreenvideo)">Conditional</animation>
+				<animation effect="fade" start="100" end="0" time="240" condition="Window.IsVisible(fullscreenvideo) | Window.IsVisible(FullscreenGame)">Conditional</animation>
 			</control>
 			<control type="group">
 				<depth>DepthMax</depth>

--- a/addons/skin.estuary/xml/DialogExtendedProgressBar.xml
+++ b/addons/skin.estuary/xml/DialogExtendedProgressBar.xml
@@ -10,7 +10,7 @@
 			<width>80</width>
 			<top>0</top>
 			<animation effect="slide" end="0,-90" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>
-			<animation effect="slide" end="0,-80" time="150" condition="Window.IsVisible(FullscreenVideo)">conditional</animation>
+			<animation effect="slide" end="0,-80" time="150" condition="Window.IsVisible(FullscreenVideo) | Window.IsVisible(FullscreenGame)">conditional</animation>
 			<control type="image">
 				<left>20</left>
 				<top>10</top>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<visible>Player.Seeking | Player.DisplayAfterSeek | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | Player.ShowInfo | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(GameOSD) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(Player.SeekNumeric) | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
+	<visible>Player.Seeking | Player.DisplayAfterSeek | [Player.Paused + !Player.Caching] | Player.Forwarding | Player.Rewinding | Player.ShowInfo | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | !String.IsEmpty(Player.SeekNumeric) | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
 	<visible>![Window.IsActive(sliderdialog) | Window.IsActive(pvrosdchannels)]</visible>
 	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
 	<include>Animation_BottomSlide</include>

--- a/addons/skin.estuary/xml/DialogVolumeBar.xml
+++ b/addons/skin.estuary/xml/DialogVolumeBar.xml
@@ -20,7 +20,7 @@
 				<width>88</width>
 				<height>88</height>
 				<texture>osd/buffer-bg.png</texture>
-				<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(slideshow)</visible>
+				<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(FullscreenGame) | Window.IsActive(slideshow)</visible>
 			</control>
 			<control type="image">
 				<left>22</left>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1120,7 +1120,7 @@
 				<animation effect="zoom" center="auto" end="102,102" time="0" condition="Integer.IsGreater(System.StereoscopicMode,0)">conditional</animation>
 				<control type="group">
 					<animation effect="fade" start="100" end="bg_alpha" time="0" condition="!Control.IsVisible(31111)">Conditional</animation>
-					<animation effect="fade" start="0" end="100" time="300" condition="Window.Previous(fullscreenvideo) | Window.Previous(startup)">WindowOpen</animation>
+					<animation effect="fade" start="0" end="100" time="300" condition="Window.Previous(fullscreenvideo) | Window.Previous(FullscreenGame) | Window.Previous(startup)">WindowOpen</animation>
 					<include>ColoredBackgroundImages</include>
 				</control>
 				<control type="group" id="31111">

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -35,7 +35,7 @@
 		<control type="group">
 			<animation effect="zoom" center="auto" end="102,102" time="0" condition="Integer.IsGreater(System.StereoscopicMode,0)">conditional</animation>
 			<animation effect="fade" start="100" end="bg_alpha" time="0" condition="Player.HasMedia">Conditional</animation>
-			<animation effect="fade" start="0" end="100" time="300" condition="Window.Previous(fullscreenvideo) | Window.Previous(startup)">WindowOpen</animation>
+			<animation effect="fade" start="0" end="100" time="300" condition="Window.Previous(fullscreenvideo) | Window.Previous(FullscreenGame) | Window.Previous(startup)">WindowOpen</animation>
 			<include>ColoredBackgroundImages</include>
 		</control>
 		<control type="multiimage">

--- a/addons/skin.estuary/xml/PlayerControls.xml
+++ b/addons/skin.estuary/xml/PlayerControls.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">201</defaultcontrol>
-	<visible>Player.HasMedia + Window.IsActive(PlayerControls) + !Window.IsActive(FullscreenVideo) + !Window.IsActive(Visualisation)</visible>
+	<visible>Player.HasMedia + Window.IsActive(PlayerControls) + !Window.IsActive(FullscreenVideo) + !Window.IsActive(FullscreenGame) + !Window.IsActive(Visualisation)</visible>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">

--- a/cmake/treedata/common/retroplayer.txt
+++ b/cmake/treedata/common/retroplayer.txt
@@ -1,3 +1,4 @@
 xbmc/cores/RetroPlayer                                          cores/RetroPlayer
 xbmc/cores/RetroPlayer/guicontrols                              cores/RetroPlayer/guicontrols
 xbmc/cores/RetroPlayer/rendering                                cores/RetroPlayer/rendering
+xbmc/cores/RetroPlayer/windows                                  cores/RetroPlayer/windows

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7314,7 +7314,8 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       bReturn = (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_RENDERMETHOD) == RENDER_OVERLAYS);
     break;
     case VIDEOPLAYER_ISFULLSCREEN:
-      bReturn = g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO;
+      bReturn = g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
+                g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME;
     break;
     case VIDEOPLAYER_HASMENU:
       bReturn = g_application.m_pPlayer->HasMenu();

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -850,6 +850,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
     // restore to previous window if needed
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW ||
       g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
+      g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
       g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION)
       g_windowManager.PreviousWindow();
 
@@ -929,6 +930,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
 
     if ((stopSlideshow && g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) ||
       (stopVideo && g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO) ||
+      (stopVideo && g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME) ||
       (stopMusic && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION))
       g_windowManager.PreviousWindow();
 

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -169,6 +169,7 @@ void CRepositoryUpdater::OnTimeout()
 {
   //workaround
   if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
+      g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
       g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW)
   {
     CLog::Log(LOGDEBUG,"CRepositoryUpdater: busy playing. postponing scheduled update");

--- a/xbmc/cores/RetroPlayer/windows/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/windows/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES GameWindowFullScreen.cpp
+)
+
+set(HEADERS GameWindowFullScreen.h
+)
+
+core_add_library(retroplayer_windows)

--- a/xbmc/cores/RetroPlayer/windows/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/windows/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(SOURCES GameWindowFullScreen.cpp
+            GameWindowFullScreenText.cpp
 )
 
 set(HEADERS GameWindowFullScreen.h
+            GameWindowFullScreenText.h
 )
 
 core_add_library(retroplayer_windows)

--- a/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.cpp
@@ -19,12 +19,200 @@
  */
 
 #include "GameWindowFullScreen.h"
+#include "GameWindowFullScreenText.h"
+#include "guilib/GraphicContext.h" //! @todo Remove me
+#include "guilib/GUIDialog.h"
+#include "guilib/GUIControl.h"
+#include "guilib/GUIWindowManager.h" //! @todo Remove me
 #include "guilib/WindowIDs.h"
+#include "input/Action.h"
+#include "input/ActionIDs.h"
+#include "Application.h" //! @todo Remove me
+#include "ApplicationPlayer.h" //! @todo Remove me
+#include "GUIInfoManager.h" //! @todo Remove me
 
 using namespace KODI;
 using namespace RETRO;
 
 CGameWindowFullScreen::CGameWindowFullScreen(void) :
-  CGUIWindowFullScreen(WINDOW_FULLSCREEN_GAME)
+  CGUIWindow(WINDOW_FULLSCREEN_GAME, "VideoFullScreen.xml"),
+  m_fullscreenText(new CGameWindowFullScreenText(*this))
 {
+  // initialize CGUIControl
+  m_controlStats = new GUICONTROLSTATS;
+
+  // initialize CGUIWindow
+  m_loadType = KEEP_IN_MEMORY;
+}
+
+CGameWindowFullScreen::~CGameWindowFullScreen()
+{
+  delete m_controlStats;
+}
+
+void CGameWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &dirtyregion)
+{
+  MarkDirtyRegion();
+
+  m_controlStats->Reset();
+
+  CGUIWindow::Process(currentTime, dirtyregion);
+
+  //! @todo This isn't quite optimal - ideally we'd only be dirtying up the actual video render rect
+  //!       which is probably the job of the renderer as it can more easily track resizing etc.
+  m_renderRegion.SetRect(0, 0, static_cast<float>(g_graphicsContext.GetWidth()), static_cast<float>(g_graphicsContext.GetHeight()));
+}
+
+void CGameWindowFullScreen::Render()
+{
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetVideoResolution(), false);
+  g_application.m_pPlayer->Render(true, 255);
+  g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
+  CGUIWindow::Render();
+}
+
+void CGameWindowFullScreen::RenderEx()
+{
+  CGUIWindow::RenderEx();
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetVideoResolution(), false);
+  g_application.m_pPlayer->Render(false, 255, false);
+  g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
+}
+
+bool CGameWindowFullScreen::OnAction(const CAction &action)
+{
+  switch (action.GetID())
+  {
+  case ACTION_SHOW_OSD:
+  {
+    ToggleOSD();
+    return true;
+  }
+  case ACTION_TRIGGER_OSD:
+  {
+    TriggerOSD();
+    return true;
+  }
+  case ACTION_SHOW_GUI:
+  {
+    // Switch back to the menu
+    g_windowManager.PreviousWindow();
+    return true;
+  }
+  case ACTION_ASPECT_RATIO:
+  {
+    // Toggle the aspect ratio mode (only if the info is onscreen)
+    //g_application.m_pPlayer->SetRenderViewMode(CViewModeSettings::GetNextQuickCycleViewMode(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode));
+    return true;
+  }
+  default:
+    break;
+  }
+
+  return CGUIWindow::OnAction(action);
+}
+
+bool CGameWindowFullScreen::OnMessage(CGUIMessage& message)
+{
+  switch (message.GetMessage())
+  {
+  case GUI_MSG_SETFOCUS:
+  case GUI_MSG_LOSTFOCUS:
+  {
+    if (message.GetSenderId() != WINDOW_FULLSCREEN_GAME)
+      return true;
+    break;
+  }
+  default:
+    break;
+  }
+
+  return CGUIWindow::OnMessage(message);
+}
+
+void CGameWindowFullScreen::FrameMove()
+{
+  if (!g_application.m_pPlayer->HasPlayer())
+    return;
+
+  m_fullscreenText->FrameMove();
+
+  CGUIWindow::FrameMove();
+}
+
+void CGameWindowFullScreen::ClearBackground()
+{
+  if (g_application.m_pPlayer->IsRenderingVideoLayer())
+#ifdef HAS_IMXVPU
+    g_graphicsContext.Clear((16 << 16) | (8 << 8) | 16);
+#else
+    g_graphicsContext.Clear(0);
+#endif
+}
+
+bool CGameWindowFullScreen::HasVisibleControls()
+{
+  return m_controlStats->nCountVisible > 0;
+}
+
+void CGameWindowFullScreen::OnWindowLoaded()
+{
+  CGUIWindow::OnWindowLoaded();
+
+  // Override the clear colour - we must never clear fullscreen
+  m_clearBackground = 0;
+
+  m_fullscreenText->OnWindowLoaded();
+}
+
+void CGameWindowFullScreen::OnInitWindow()
+{
+  g_infoManager.SetShowInfo(false);
+  g_infoManager.SetDisplayAfterSeek(0); // Make sure display after seek is off
+
+  // Switch resolution
+  g_graphicsContext.SetFullScreenVideo(true); //! @todo
+
+  CGUIWindow::OnInitWindow();
+}
+
+void CGameWindowFullScreen::OnDeinitWindow(int nextWindowID)
+{
+  // Close all active modal dialogs
+  g_windowManager.CloseInternalModalDialogs(true);
+
+  CGUIWindow::OnDeinitWindow(nextWindowID);
+
+  CSingleLock lock(g_graphicsContext);
+
+  g_graphicsContext.SetFullScreenVideo(false); //! @todo
+}
+
+void CGameWindowFullScreen::ToggleOSD()
+{
+  CGUIDialog *pOSD = GetOSD();
+  if (pOSD != nullptr)
+  {
+    if (pOSD->IsDialogRunning())
+      pOSD->Close();
+    else
+      pOSD->Open();
+  }
+
+  MarkDirtyRegion();
+}
+
+void CGameWindowFullScreen::TriggerOSD()
+{
+  CGUIDialog *pOSD = GetOSD();
+  if (pOSD != nullptr)
+  {
+    if (!pOSD->IsDialogRunning())
+      pOSD->Open();
+  }
+}
+
+CGUIDialog *CGameWindowFullScreen::GetOSD()
+{
+  return g_windowManager.GetDialog(WINDOW_DIALOG_GAME_OSD);
 }

--- a/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.cpp
@@ -1,0 +1,30 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameWindowFullScreen.h"
+#include "guilib/WindowIDs.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CGameWindowFullScreen::CGameWindowFullScreen(void) :
+  CGUIWindowFullScreen(WINDOW_FULLSCREEN_GAME)
+{
+}

--- a/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.h
+++ b/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.h
@@ -19,17 +19,47 @@
  */
 #pragma once
 
-#include "video/windows/GUIWindowFullScreen.h" //! @todo
+#include "guilib/GUIWindow.h"
+
+class CGUIDialog;
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CGameWindowFullScreen : public CGUIWindowFullScreen
+  class CGameWindowFullScreenText;
+
+  class CGameWindowFullScreen : public CGUIWindow
   {
   public:
     CGameWindowFullScreen();
-    ~CGameWindowFullScreen() override = default;
+    ~CGameWindowFullScreen() override;
+
+    // implementation of CGUIControl via CGUIWindow
+    void Process(unsigned int currentTime, CDirtyRegionList &dirtyregion) override;
+    void Render() override;
+    void RenderEx() override;
+    bool OnAction(const CAction &action) override;
+    bool OnMessage(CGUIMessage& message) override;
+
+    // implementation of CGUIWindow
+    void FrameMove() override;
+    void ClearBackground() override;
+    bool HasVisibleControls() override;
+    void OnWindowLoaded() override;
+    void OnDeinitWindow(int nextWindowID) override;
+
+  protected:
+    // implementation of CGUIWindow
+    void OnInitWindow() override;
+
+  private:
+    void ToggleOSD();
+    void TriggerOSD();
+    CGUIDialog *GetOSD();
+
+    // GUI parameters
+    std::unique_ptr<CGameWindowFullScreenText> m_fullscreenText;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.h
+++ b/xbmc/cores/RetroPlayer/windows/GameWindowFullScreen.h
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "video/windows/GUIWindowFullScreen.h" //! @todo
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CGameWindowFullScreen : public CGUIWindowFullScreen
+  {
+  public:
+    CGameWindowFullScreen();
+    ~CGameWindowFullScreen() override = default;
+  };
+}
+}

--- a/xbmc/cores/RetroPlayer/windows/GameWindowFullScreenText.cpp
+++ b/xbmc/cores/RetroPlayer/windows/GameWindowFullScreenText.cpp
@@ -1,0 +1,137 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameWindowFullScreenText.h"
+#include "video/windows/GUIWindowFullScreenDefines.h"
+#include "guilib/GUIDialog.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIWindow.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CGameWindowFullScreenText::CGameWindowFullScreenText(CGUIWindow &fullscreenWindow) :
+  m_fullscreenWindow(fullscreenWindow)
+{
+}
+
+void CGameWindowFullScreenText::OnWindowLoaded()
+{
+  m_bShowText = false;
+  m_bTextChanged = true;
+  m_bTextVisibilityChanged = true;
+  m_lines.clear();
+}
+
+void CGameWindowFullScreenText::FrameMove()
+{
+  if (m_bTextChanged)
+  {
+    m_bTextChanged = false;
+    UploadText();
+  }
+
+  if (m_bTextVisibilityChanged)
+  {
+    m_bTextVisibilityChanged = false;
+
+    if (m_bShowText)
+      Show();
+    else
+      Hide();
+  }
+}
+
+const std::string &CGameWindowFullScreenText::GetText(unsigned int lineIndex) const
+{
+  if (lineIndex < m_lines.size())
+    return m_lines[lineIndex];
+
+  static const std::string empty;
+  return empty;
+}
+
+void CGameWindowFullScreenText::SetText(unsigned int lineIndex, std::string line)
+{
+  if (lineIndex >= m_lines.size())
+    m_lines.resize(lineIndex + 1);
+
+  m_lines[lineIndex] = std::move(line);
+}
+
+const std::vector<std::string> &CGameWindowFullScreenText::GetText() const
+{
+  return m_lines;
+}
+
+void CGameWindowFullScreenText::SetText(std::vector<std::string> text)
+{
+  m_lines = std::move(text);
+}
+
+void CGameWindowFullScreenText::UploadText()
+{
+  for (unsigned int i = 0; i < m_lines.size(); i++)
+  {
+    int rowControl = GetControlID(i);
+    if (rowControl > 0)
+      SET_CONTROL_LABEL(rowControl, m_lines[i]);
+  }
+}
+
+void CGameWindowFullScreenText::Show()
+{
+  SET_CONTROL_VISIBLE(LABEL_ROW1);
+  SET_CONTROL_VISIBLE(LABEL_ROW2);
+  SET_CONTROL_VISIBLE(LABEL_ROW3);
+  SET_CONTROL_VISIBLE(BLUE_BAR);
+}
+
+void CGameWindowFullScreenText::Hide()
+{
+  SET_CONTROL_HIDDEN(LABEL_ROW1);
+  SET_CONTROL_HIDDEN(LABEL_ROW2);
+  SET_CONTROL_HIDDEN(LABEL_ROW3);
+  SET_CONTROL_HIDDEN(BLUE_BAR);
+}
+
+int CGameWindowFullScreenText::GetID() const
+{
+  return m_fullscreenWindow.GetID();
+}
+
+bool CGameWindowFullScreenText::OnMessage(CGUIMessage &message)
+{
+  return m_fullscreenWindow.OnMessage(message);
+}
+
+int CGameWindowFullScreenText::GetControlID(unsigned int lineIndex)
+{
+  switch (lineIndex)
+  {
+  case 0: return LABEL_ROW1;
+  case 1: return LABEL_ROW2;
+  case 2: return LABEL_ROW3;
+  default:
+    break;
+  }
+
+  return -1;
+}

--- a/xbmc/cores/RetroPlayer/windows/GameWindowFullScreenText.h
+++ b/xbmc/cores/RetroPlayer/windows/GameWindowFullScreenText.h
@@ -1,0 +1,95 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+class CGUIDialog;
+class CGUIMessage;
+class CGUIWindow;
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CGameWindowFullScreenText
+  {
+  public:
+    CGameWindowFullScreenText(CGUIWindow &fullscreenWindow);
+    ~CGameWindowFullScreenText() = default;
+
+    // Window functions
+    void OnWindowLoaded();
+    void FrameMove();
+
+    /*!
+     * \brief Get a line of text
+     */
+    const std::string &GetText(unsigned int lineIndex) const;
+
+    /*!
+     * \brief Set a line of text
+     */
+    void SetText(unsigned int lineIndex, std::string line);
+
+    /*!
+     * \brief Get entire text
+     */
+    const std::vector<std::string> &GetText() const;
+
+    /*!
+    * \brief Set entire text
+    */
+    void SetText(std::vector<std::string> text);
+
+  private:
+    // Window functions
+    void UploadText();
+    void Show();
+    void Hide();
+
+    /*!
+     * \brief Translate line index to the control ID in the skin
+     *
+     * \param lineIndex The line in the string vector
+     *
+     * \return The ID of the line's label control in the skin
+     */
+    static int GetControlID(unsigned int lineIndex);
+
+    // Window functions required by GUIMessage macros
+    //! @todo Change macros into functions
+    int GetID() const;
+    bool OnMessage(CGUIMessage &message);
+
+    // Construction parameters
+    CGUIWindow &m_fullscreenWindow;
+
+    // Window state
+    bool m_bShowText = false;
+    bool m_bTextChanged = true;
+    bool m_bTextVisibilityChanged = true;
+
+    // Text
+    std::vector<std::string> m_lines;
+  };
+}
+}

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -118,6 +118,8 @@ void CDialogGameVideoSelect::FrameMove()
   CGUIBaseContainer *thumbs = dynamic_cast<CGUIBaseContainer*>(GetControl(CONTROL_THUMBS));
   if (thumbs != nullptr)
     OnItemFocus(thumbs->GetSelectedItem());
+
+  CGUIDialog::FrameMove();
 }
 
 void CDialogGameVideoSelect::OnWindowLoaded()

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -392,7 +392,9 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
   if (!m_active)
     return;
 
-  forceClose |= (nextWindowID == WINDOW_FULLSCREEN_VIDEO);
+  forceClose |= (nextWindowID == WINDOW_FULLSCREEN_VIDEO ||
+                 nextWindowID == WINDOW_FULLSCREEN_GAME);
+
   if (!forceClose && HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
   {
     if (!m_closing)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -147,6 +147,7 @@
 #include "addons/interfaces/AddonInterfaces.h"
 
 /* Game related include files */
+#include "cores/RetroPlayer/windows/GameWindowFullScreen.h"
 #include "games/controllers/windows/GUIControllerWindow.h"
 #include "games/windows/GUIWindowGames.h"
 #include "games/dialogs/osd/DialogGameOSD.h"
@@ -305,6 +306,7 @@ void CGUIWindowManager::CreateWindows()
   Add(new GAME::CDialogGameOSD);
   Add(new GAME::CDialogGameVideoFilter);
   Add(new GAME::CDialogGameViewMode);
+  Add(new RETRO::CGameWindowFullScreen);
 }
 
 bool CGUIWindowManager::DestroyWindows()
@@ -410,6 +412,7 @@ bool CGUIWindowManager::DestroyWindows()
     DestroyWindow(WINDOW_DIALOG_GAME_OSD);
     DestroyWindow(WINDOW_DIALOG_GAME_VIDEO_FILTER);
     DestroyWindow(WINDOW_DIALOG_GAME_VIEW_MODE);
+    DestroyWindow(WINDOW_FULLSCREEN_GAME);
 
     Remove(WINDOW_SETTINGS_SERVICE);
     Remove(WINDOW_SETTINGS_MYPVR);
@@ -808,9 +811,9 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   // pause game when leaving fullscreen or resume game when entering fullscreen
   if (g_application.m_pPlayer->IsPlayingGame())
   {
-    if (GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO && !g_application.m_pPlayer->IsPaused())
+    if (GetActiveWindow() == WINDOW_FULLSCREEN_GAME && !g_application.m_pPlayer->IsPaused())
       g_application.OnAction(ACTION_PAUSE);
-    else if (iWindowID == WINDOW_FULLSCREEN_VIDEO && g_application.m_pPlayer->IsPaused())
+    else if (iWindowID == WINDOW_FULLSCREEN_GAME && g_application.m_pPlayer->IsPaused())
       g_application.OnAction(ACTION_PAUSE);
   }
 
@@ -1474,9 +1477,6 @@ int CGUIWindowManager::GetActiveWindowID() const
     // special casing for numeric seek
     else if (CSeekHandler::GetInstance().HasTimeCode())
       iWin = WINDOW_VIDEO_TIME_SEEK;
-    // check if a game is playing
-    else if (g_application.m_pPlayer->IsPlayingGame())
-      iWin = WINDOW_FULLSCREEN_GAME;
   }
   if (iWin == WINDOW_VISUALISATION)
   {

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -566,7 +566,8 @@ bool CInputManager::OnKey(const CKey& key)
     return true;
   }
 
-  if (iWin != WINDOW_FULLSCREEN_VIDEO)
+  if (iWin != WINDOW_FULLSCREEN_VIDEO ||
+      iWin != WINDOW_FULLSCREEN_GAME)
   {
     // current active window isnt the fullscreen window
     // just use corresponding section from keymap.xml

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -127,7 +127,7 @@ const CWindowTranslator::WindowMapByName CWindowTranslator::WindowMappingByName 
     { "fullscreenvideo"          , WINDOW_FULLSCREEN_VIDEO },
     { "fullscreenlivetv"         , WINDOW_FULLSCREEN_LIVETV },         // virtual window/keymap section for PVR specific bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
     { "fullscreenradio"          , WINDOW_FULLSCREEN_RADIO },          // virtual window for fullscreen radio, uses WINDOW_VISUALISATION as fallback
-    { "fullscreengame"           , WINDOW_FULLSCREEN_GAME },           // virtual window for fullscreen games, uses WINDOW_FULLSCREEN_VIDEO as fallback
+    { "fullscreengame"           , WINDOW_FULLSCREEN_GAME },
     { "visualisation"            , WINDOW_VISUALISATION },
     { "slideshow"                , WINDOW_SLIDESHOW },
     { "weather"                  , WINDOW_WEATHER },

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -389,6 +389,7 @@ static int PlayMedia(const std::vector<std::string>& params)
   // restore to previous window if needed
   if( g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW ||
       g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
+      g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
       g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION )
     g_windowManager.PreviousWindow();
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -246,7 +246,8 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
     //g_graphicsContext.SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution(), TRUE);
   }
 
-  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO)
+  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO ||
+      nextWindowID != WINDOW_FULLSCREEN_GAME)
   {
     // wait for any outstanding picture loads
     if (m_pBackgroundLoader)

--- a/xbmc/video/windows/CMakeLists.txt
+++ b/xbmc/video/windows/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES GUIWindowFullScreen.cpp
             VideoFileItemListModifier.cpp)
 
 set(HEADERS GUIWindowFullScreen.h
+            GUIWindowFullScreenDefines.h
             GUIWindowVideoBase.h
             GUIWindowVideoNav.h
             GUIWindowVideoPlaylist.h

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -21,6 +21,7 @@
 #include "threads/SystemClock.h"
 #include "system.h"
 #include "GUIWindowFullScreen.h"
+#include "GUIWindowFullScreenDefines.h"
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
@@ -57,28 +58,12 @@
 
 using namespace KODI::MESSAGING;
 
-#define BLUE_BAR                          0
-#define LABEL_ROW1                       10
-#define LABEL_ROW2                       11
-#define LABEL_ROW3                       12
-
-//Displays current position, visible after seek or when forced
-//Alt, use conditional visibility Player.DisplayAfterSeek
-#define LABEL_CURRENT_TIME               22
-
-//Displays when video is rebuffering
-//Alt, use conditional visibility Player.IsCaching
-#define LABEL_BUFFERING                  24
-
-//Progressbar used for buffering status and after seeking
-#define CONTROL_PROGRESS                 23
-
 #if defined(TARGET_DARWIN)
 static CLinuxResourceCounter m_resourceCounter;
 #endif
 
-CGUIWindowFullScreen::CGUIWindowFullScreen(int windowId)
-    : CGUIWindow(windowId, "VideoFullScreen.xml")
+CGUIWindowFullScreen::CGUIWindowFullScreen()
+    : CGUIWindow(WINDOW_FULLSCREEN_VIDEO, "VideoFullScreen.xml")
 {
   m_viewModeChanged = true;
   m_dwShowViewModeTimeout = 0;
@@ -480,8 +465,5 @@ bool CGUIWindowFullScreen::HasVisibleControls()
 
 CGUIDialog *CGUIWindowFullScreen::GetOSD()
 {
-  if (g_application.m_pPlayer->IsPlayingGame())
-    return g_windowManager.GetDialog(WINDOW_DIALOG_GAME_OSD);
-  else
-    return g_windowManager.GetDialog(WINDOW_DIALOG_VIDEO_OSD);
+  return g_windowManager.GetDialog(WINDOW_DIALOG_VIDEO_OSD);
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -77,8 +77,8 @@ using namespace KODI::MESSAGING;
 static CLinuxResourceCounter m_resourceCounter;
 #endif
 
-CGUIWindowFullScreen::CGUIWindowFullScreen(void)
-    : CGUIWindow(WINDOW_FULLSCREEN_VIDEO, "VideoFullScreen.xml")
+CGUIWindowFullScreen::CGUIWindowFullScreen(int windowId)
+    : CGUIWindow(windowId, "VideoFullScreen.xml")
 {
   m_viewModeChanged = true;
   m_dwShowViewModeTimeout = 0;

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -21,14 +21,13 @@
  */
 
 #include "guilib/GUIWindow.h"
-#include "guilib/WindowIDs.h" //! @todo
 
 class CGUIDialog;
 
 class CGUIWindowFullScreen : public CGUIWindow
 {
 public:
-  CGUIWindowFullScreen(int windowId = WINDOW_FULLSCREEN_VIDEO); //! @todo
+  CGUIWindowFullScreen();
   ~CGUIWindowFullScreen(void) override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -21,13 +21,14 @@
  */
 
 #include "guilib/GUIWindow.h"
+#include "guilib/WindowIDs.h" //! @todo
 
 class CGUIDialog;
 
 class CGUIWindowFullScreen : public CGUIWindow
 {
 public:
-  CGUIWindowFullScreen(void);
+  CGUIWindowFullScreen(int windowId = WINDOW_FULLSCREEN_VIDEO); //! @todo
   ~CGUIWindowFullScreen(void) override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;

--- a/xbmc/video/windows/GUIWindowFullScreenDefines.h
+++ b/xbmc/video/windows/GUIWindowFullScreenDefines.h
@@ -1,0 +1,36 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define BLUE_BAR                          0
+#define LABEL_ROW1                       10
+#define LABEL_ROW2                       11
+#define LABEL_ROW3                       12
+
+ // Displays current position, visible after seek or when forced
+ // Alt, use conditional visibility Player.DisplayAfterSeek
+#define LABEL_CURRENT_TIME               22
+
+ // Displays when video is rebuffering
+ // Alt, use conditional visibility Player.IsCaching
+#define LABEL_BUFFERING                  24
+
+ // Progressbar used for buffering status and after seeking
+#define CONTROL_PROGRESS                 23


### PR DESCRIPTION
As a follow-up to #12742, this change separates the FullscreenVideo window name from the FullscreenGame window name. As a result, the top bar no longer shows up during gameplay.

## Motivation and Context
This creates a new fullscreen game class where future rendering stuff can be put.

## How Has This Been Tested?
Tested on Windows, no top bar appears inside game.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
