### PR TITLE
Fix international keyboard input for Linux input layer

### DIFF
--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -368,7 +368,7 @@ int CLinuxInputDevice::KeyboardGetSymbol(unsigned short value)
     case 0x7f:
       return XBMCK_BACKSPACE;
     case 0xa4:
-      return XBMCK_EURO; /* euro currency sign */
+      return 0x20ac; /* euro currency sign */
     default:
       return index;
     }
@@ -442,6 +442,7 @@ XBMCMod CLinuxInputDevice::UpdateModifiers(XBMC_Event& devt)
     case XBMCK_RALT: modifier = XBMCKMOD_RALT; break;
     case XBMCK_LMETA: modifier = XBMCKMOD_LMETA; break;
     case XBMCK_RMETA: modifier = XBMCKMOD_RMETA; break;
+    case XBMCK_MODE: modifier = XBMCKMOD_RALT; break;
     default: break;
   }
 
@@ -563,10 +564,7 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
       if (keyMapValue != XBMCK_UNKNOWN)
       {
         devt.key.keysym.sym = (XBMCKey) keyMapValue;
-        if (keyMapValue > 0 && keyMapValue < 127)
-        {
-          devt.key.keysym.unicode = devt.key.keysym.sym;
-        }
+        devt.key.keysym.unicode = devt.key.keysym.sym;
       }
     }
   }


### PR DESCRIPTION
Fix keyboard input for international keyboard layouts/keymaps when using plain Linux input layer.

## Description
On platforms using the plain Linux input layer (e.g. OpenELEC/LibreELEC on Raspberry Pi), it is currently not possible to input characters other than ASCII on international keyboards.

This shortcoming has been present for a long time, probably from the very beginning, affecting lots of users. Unfortunately, the issue was never addressed correctly most likely due to a general misunderstanding of the concepts involved - from the bug reports below it is obvious that layouts, keymaps, input layers, virtual keyboard and physical keyboard are mixed up to the point where it is unclear which is what.

From reviewing debug logs on both a LibreELEC/Raspberry and a desktop Linux installation of Kodi, I discovered that unicode input was already working as far as the kernel providing the correct translated unicode character for a given keypress, but somehow this information got lost along the way. After a whole day of digging through the code, I managed to pinpoint the origin of the issue and found the fix to be **very** simple.

While at it, I also fixed two other issues (just for the sake of completeness):

- map mode key ('Alt Gr') to right Alt key like most OS do
- fix Euro currency sign

Related bug reports (probably many more):
https://github.com/OpenELEC/OpenELEC.tv/issues/108
https://github.com/OpenELEC/OpenELEC.tv/issues/739
https://github.com/OpenELEC/OpenELEC.tv/issues/1126
https://github.com/OpenELEC/OpenELEC.tv/issues/1661
https://github.com/OpenELEC/OpenELEC.tv/issues/1965
https://github.com/OpenELEC/OpenELEC.tv/issues/1986
https://github.com/OpenELEC/OpenELEC.tv/issues/2017
https://github.com/OpenELEC/OpenELEC.tv/issues/2094
https://github.com/OpenELEC/OpenELEC.tv/issues/3943
https://github.com/OpenELEC/OpenELEC.tv/issues/4282
http://openelec.tv/forum/124-raspberry-pi/75575-umlaute-not-working-logitec-k400-openelec-5-0-3
http://openelec.tv/forum/105-keyboards/24435-german-keyboard-layout
https://forum.libreelec.tv/thread/5757-raspberry-pi2-le-special-characters-not-work-from-keyboard/
https://forum.libreelec.tv/thread/3384-problems-with-ü-ö-ä-and-ß/
https://forum.libreelec.tv/thread/2107-norwegian-keyboard-layout-norwegian-letters/
https://forum.libreelec.tv/thread/1521-special-characters-in-spanish-keyboard-raspberry-pi-3/

## Motivation and Context
Enable users with keyboard layouts other than _en-US_ to input all possible characters (or, more precisely, all characters supported by Kodi) on platforms using the plain Linux input layer.

## How Has This Been Tested?
Tested successfully with **LibreELEC** (compiled from Git snapshot of 'master' branch as of 09/02/17) on **Raspberry Pi 3**, German keyboard attached via USB and keymap set to 'de-latin1-nodeadkeys'. With the patch applied, I was able to input the characters **üöäÜÖÄß€**, without the patch pressing those keys does nothing.

Please note that the fix is universal, i.e. it should work with all keymaps/layouts.

As far as I can tell, the fix has no side-effects (needs to be verified by others!).

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
