### PR TITLE
[PVR] Implement CPVRGUIActions::StopRecording for recording items.

### DIFF
--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -714,7 +714,14 @@ namespace PVR
 
   bool CPVRGUIActions::DeleteTimer(const CFileItemPtr &item, bool bIsRecording, bool bDeleteRule) const
   {
-    CPVRTimerInfoTagPtr timer(CPVRItem(item).GetTimerInfoTag());
+    CPVRTimerInfoTagPtr timer;
+    const CPVRRecordingPtr recording(CPVRItem(item).GetRecording());
+    if (recording)
+      timer = CServiceBroker::GetPVRManager().Timers()->GetRecordingTimerForRecording(*recording);
+
+    if (!timer)
+      timer = CPVRItem(item).GetTimerInfoTag();
+
     if (!timer)
     {
       CLog::Log(LOGERROR, "CPVRGUIActions - %s - no timer!", __FUNCTION__);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -805,6 +805,11 @@ CPVRTimerInfoTagPtr CPVRTimers::GetTimerForEpgTag(const CPVREpgInfoTagPtr &epgTa
 
 bool CPVRTimers::HasRecordingTimerForRecording(const CPVRRecording &recording) const
 {
+  return GetRecordingTimerForRecording(recording) != nullptr;
+}
+
+CPVRTimerInfoTagPtr CPVRTimers::GetRecordingTimerForRecording(const CPVRRecording &recording) const
+{
   CSingleLock lock(m_critSection);
 
   for (const auto &tagsEntry : m_tags)
@@ -818,12 +823,12 @@ bool CPVRTimers::HasRecordingTimerForRecording(const CPVRRecording &recording) c
           timersEntry->StartAsUTC() <= recording.RecordingTimeAsUTC() &&
           timersEntry->EndAsUTC() >= recording.EndTimeAsUTC())
       {
-        return true;
+        return timersEntry;
       }
     }
   }
 
-  return false;
+  return CPVRTimerInfoTagPtr();
 }
 
 CPVRTimerInfoTagPtr CPVRTimers::GetTimerRule(const CPVRTimerInfoTagPtr &timer) const

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -251,6 +251,13 @@ namespace PVR
     bool HasRecordingTimerForRecording(const CPVRRecording &recording) const;
 
     /*!
+     * @brief Get the timer currently recording the given recording, if any.
+     * @param recording The recording to check.
+     * @return The requested timer tag, or an null if none was found.
+     */
+    CPVRTimerInfoTagPtr GetRecordingTimerForRecording(const CPVRRecording &recording) const;
+
+    /*!
      * Get the timer rule for a given timer tag
      * @param timer The timer to query the timer rule for
      * @return The timer rule, or null if none was found.


### PR DESCRIPTION
Ooops. I forgot to push the actual core implementation for the new context menu item "Stop recording" at a in progress recording item, which I introduced with #12763.