### PR TITLE
Partial revert of imdb crashfix due to a introduced bug

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -398,10 +398,6 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     CGUIDialogOK::ShowAndGetInput(CVariant{13346}, CVariant{14057});
     return false;
   }
-  
-  // If the scraper failed above and no videoinfotag was created, return
-  if (!item->HasVideoInfoTag())
-    return false;
 
   bool listNeedsUpdating = false;
   // 3. Run a loop so that if we Refresh we re-run this block


### PR DESCRIPTION
As discussed with @DaVukovic and @koying in slack this reverts part of my previous imdb crash fix as it was causing a bug in that content can no longer be added manually to the videolibrary.

I would appreciate if also somebody else can also try this PR, so that we are really sure it fixes the issue :-)