### PR TITLE
Fix python3 incompatilities in build scripts

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -178,7 +178,7 @@ install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/scripts/${APP_NAME}Config.cm
         COMPONENT kodi-addon-dev)
 
 if(ENABLE_EVENTCLIENTS)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(prefix='')"
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix=''))"
                   OUTPUT_VARIABLE PYTHON_LIB_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
   # Install kodi-eventclients-common BT python files
   install(PROGRAMS ${CMAKE_SOURCE_DIR}/tools/EventClients/lib/python/bt/__init__.py


### PR DESCRIPTION
After #12705 there were a couple of Python2-only code snippets that remained, which caused Linux builds to fail to install the Python scripts correctly. See https://github.com/xbmc/xbmc/pull/12705#issuecomment-326774773

## Description
Ensure code that is run by the Python3 interpreter is Python3 compatible.

## Motivation and Context
Kodi now installs the Python scripts into the correct location.

Not entirely sure about the Samba change, it may not be required but it probably doesn't do any harm as it will work with Python2 and Python3 (although I'm pretty sure Samba will not build with Python 3 without a _lot_ of work).

## How Has This Been Tested?
I've completed a Linux build, and the Python scripts are now installed correctly:

install_manifest.txt before: http://sprunge.us/STUY
install_manifest.txt after: http://sprunge.us/GLCE

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
