### PR TITLE
[PVR] Fix CPVRManager::OnPlaybackStarted to always clear playing flag…

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -786,16 +786,17 @@ void CPVRManager::CloseStream(void)
 
 void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
 {
+  m_addons->ClearPlayingChannel();
+  m_addons->ClearPlayingRecording();
+  m_addons->ClearPlayingEpgTag();
+
   if (item->HasPVRChannelInfoTag())
   {
     const CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
 
-    m_addons->ClearPlayingRecording();
-    m_addons->ClearPlayingEpgTag();
     m_addons->SetPlayingChannel(channel);
 
     m_guiActions->GetChannelNavigator().SetPlayingChannel(channel);
-
     SetPlayingGroup(channel);
     UpdateLastWatched(channel);
 
@@ -804,14 +805,10 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
   }
   else if (item->HasPVRRecordingInfoTag())
   {
-    m_addons->ClearPlayingEpgTag();
-    m_addons->ClearPlayingChannel();
     m_addons->SetPlayingRecording(item->GetPVRRecordingInfoTag());
   }
   else if (item->HasEPGInfoTag())
   {
-    m_addons->ClearPlayingRecording();
-    m_addons->ClearPlayingChannel();
     m_addons->SetPlayingEpgTag(item->GetEPGInfoTag());
   }
 }


### PR DESCRIPTION
…s for pvr components.

Fixes a problem described in the forum (=> https://forum.kodi.tv/showthread.php?tid=298462&pid=2642933#pid2642933), where PVR Manager was not aware that it was not playing anymore.

This change has been runtime-tested on macOS, latest Kodi master.

@Jalle19 mind taking a look at the code.