### PR TITLE
Use applicationmessenger to show CGUIDialogYesNo with an helper

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5065,7 +5065,7 @@ void CApplication::StartMusicScan(const std::string &strDirectory, bool userInit
     // Ask for full rescan of music files
     //! @todo replace with a music library setting in UI
     if (g_advancedSettings.m_bMusicLibraryPromptFullTagScan)
-      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 799 }, CVariant{ 38062 }))
+      if (HELPERS::ShowYesNoDialogText(CVariant{ 799 }, CVariant{ 38062 }) == HELPERS::DialogResponse::YES)
         flags |= CMusicInfoScanner::SCAN_RESCAN;
   }
 

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -23,9 +23,9 @@
 #include "threads/SingleLock.h"
 #include "messaging/ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -99,16 +99,8 @@ void CAddonStatusHandler::Process()
   /* Some required settings are missing/invalid */
   else if (m_status == ADDON_STATUS_NEED_SETTINGS)
   {
-    CGUIDialogYesNo* pDialogYesNo = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-    if (!pDialogYesNo) return;
-
-    pDialogYesNo->SetHeading(CVariant{heading});
-    pDialogYesNo->SetLine(1, CVariant{24070});
-    pDialogYesNo->SetLine(2, CVariant{24072});
-    pDialogYesNo->SetLine(3, CVariant{m_message});
-    pDialogYesNo->Open();
-
-    if (!pDialogYesNo->IsConfirmed()) return;
+    if (HELPERS::ShowYesNoDialogLines(CVariant{ heading }, CVariant{ 24070 }, CVariant{ 24072 }, CVariant{ m_message }) != HELPERS::DialogResponse::YES) 
+      return;
 
     if (!m_addon->HasSettings())
       return;

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -32,7 +32,6 @@
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogTextViewer.h"
 #include "dialogs/GUIDialogSelect.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "games/GameUtils.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIUserMessages.h"
@@ -440,12 +439,12 @@ void CGUIDialogAddonInfo::OnUninstall()
     return;
 
   // prompt user to be sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{24037}, CVariant{750}))
+  if (HELPERS::ShowYesNoDialogText(CVariant{24037}, CVariant{750}) != HELPERS::DialogResponse::YES)
     return;
 
   bool removeData = false;
   if (CDirectory::Exists("special://profile/addon_data/"+m_localAddon->ID()))
-    removeData = CGUIDialogYesNo::ShowAndGetInput(CVariant{24037}, CVariant{39014});
+    removeData = (HELPERS::ShowYesNoDialogText(CVariant{24037}, CVariant{39014}) == HELPERS::DialogResponse::YES);
 
   CJobManager::GetInstance().AddJob(new CAddonUnInstallJob(m_localAddon, removeData),
                                     &CAddonInstaller::GetInstance());

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -25,7 +25,6 @@
 #include "GUIDialogAddonInfo.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "dialogs/GUIDialogBusy.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "GUIUserMessages.h"
@@ -56,6 +55,7 @@
 
 using namespace ADDON;
 using namespace XFILE;
+using namespace KODI::MESSAGING::HELPERS;
 
 CGUIWindowAddonBrowser::CGUIWindowAddonBrowser(void)
 : CGUIMediaWindow(WINDOW_ADDON_BROWSER, "AddonBrowser.xml")
@@ -186,7 +186,6 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
   CFileItemPtr item = m_vecItems->Get(iItem);
   if (item->GetPath() == "addons://install/")
   {
-    using namespace KODI::MESSAGING::HELPERS;
 
     if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_ADDONS_ALLOW_UNKNOWN_SOURCES))
     {
@@ -218,7 +217,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
     // cancel a downloading job
     if (item->HasProperty("Addon.Downloading"))
     {
-      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{24000}, item->GetProperty("Addon.Name"), CVariant{24066}, CVariant{""}))
+      if (ShowYesNoDialogText(CVariant{24000}, item->GetProperty("Addon.Name"), CVariant{24066}, CVariant{""}) == DialogResponse::YES)
       {
         if (CAddonInstaller::GetInstance().Cancel(item->GetProperty("Addon.ID").asString()))
           Refresh();

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -28,7 +28,6 @@
 #include "addons/AddonManager.h"
 #include "addons/RepositoryUpdater.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "events/AddonManagementEvent.h"
 #include "events/EventLog.h"
 #include "FileItem.h"
@@ -36,7 +35,6 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/ZipFile.h"
-#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "TextureDatabase.h"
 #include "URL.h"
@@ -50,9 +48,6 @@
 
 using namespace XFILE;
 using namespace ADDON;
-using namespace KODI::MESSAGING;
-
-using KODI::MESSAGING::HELPERS::DialogResponse;
 
 std::unique_ptr<CRepository> CRepository::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {

--- a/xbmc/addons/interfaces/GUI/dialogs/YesNo.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/YesNo.cpp
@@ -22,7 +22,6 @@
 #include "addons/kodi-addon-dev-kit/include/kodi/gui/dialogs/YesNo.h"
 
 #include "addons/binary-addons/AddonDll.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "utils/log.h"
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -29,7 +29,6 @@
 #include "cores/RetroPlayer/rendering/GUIRenderSettings.h"
 #include "cores/RetroPlayer/rendering/RPRenderManager.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/File.h"
 #include "games/addons/playback/IGameClientPlayback.h"
 #include "games/addons/savestates/Savestate.h"
@@ -44,6 +43,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "input/Action.h"
 #include "input/ActionIDs.h"
 #include "settings/MediaSettings.h"
@@ -56,6 +56,7 @@
 #include "URL.h"
 
 using namespace KODI;
+using namespace KODI::MESSAGING::HELPERS;
 using namespace GAME;
 using namespace RETRO;
 
@@ -155,7 +156,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
           // Warn the user that continuing with a different game client will
           // overwrite the save
           bool dummy;
-          if (!CGUIDialogYesNo::ShowAndGetInput(438, StringUtils::Format(g_localizeStrings.Get(35217), addon->Name()), dummy, 222, 35218, 0))
+          if (ShowYesNoDialogLines(438, StringUtils::Format(g_localizeStrings.Get(35217), addon->Name()), dummy, 222, 35218, 0) != DialogResponse::YES)
             bSuccess = false;
         }
       }

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -36,15 +36,17 @@
 #include "storage/MediaManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "GUIDialogYesNo.h"
 #include "FileItem.h"
 #include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "TextureCache.h"
 #include "URL.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "addons/Scraper.h"
+
+using namespace KODI::MESSAGING::HELPERS;
 
 #define BACKGROUND_IMAGE       999
 #define GROUP_LIST             996
@@ -304,7 +306,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
         return false;
     }
     // prompt user if they want to really delete the source
-    if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{751}, CVariant{750}))
+    if (ShowYesNoDialogText(CVariant{751}, CVariant{750}) != DialogResponse::YES)
       return false;
 
     // check default before we delete, as deletion will kill the share object
@@ -446,7 +448,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
 
-      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12335}, CVariant{750}))
+      if (ShowYesNoDialogText(CVariant{12335}, CVariant{750}) != DialogResponse::YES)
         return false;
 
       share->m_iHasLock = 0;

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -31,7 +31,6 @@
 #include "GUIPassword.h"
 #include "guilib/GUIWindowManager.h"
 #include "Application.h"
-#include "GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "GUIUserMessages.h"
 #include "filesystem/Directory.h"
@@ -42,6 +41,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "utils/log.h"
 #include "URL.h"
 #include "utils/Variant.h"
@@ -897,7 +897,7 @@ void CGUIDialogFileBrowser::OnAddNetworkLocation()
   {
     // verify the path by doing a GetDirectory.
     CFileItemList items;
-    if (CDirectory::GetDirectory(path, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(CVariant{1001}, CVariant{1002}))
+    if (CDirectory::GetDirectory(path, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || HELPERS::ShowYesNoDialogText(CVariant{1001}, CVariant{1002}) == HELPERS::DialogResponse::YES)
     { // add the network location to the shares list
       CMediaSource share;
       share.strPath = path; //setPath(path);

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -33,8 +33,8 @@
 #include "utils/Variant.h"
 #include "filesystem/Directory.h"
 #include "filesystem/PVRDirectory.h"
-#include "GUIDialogYesNo.h"
 #include "FileItem.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
@@ -47,6 +47,7 @@
 #include "filesystem/File.h"
 #endif
 
+using namespace KODI::MESSAGING::HELPERS;
 using namespace XFILE;
 
 #define CONTROL_HEADING          2
@@ -397,7 +398,7 @@ void CGUIDialogMediaSource::OnOK()
   VECSOURCES *shares = CMediaSourceSettings::GetInstance().GetSources(m_type);
   if (shares)
     shares->push_back(share);
-  if (StringUtils::StartsWithNoCase(share.strPath, "plugin://") || CDirectory::GetDirectory(share.strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(CVariant{ 1001 }, CVariant{ 1025 }))
+  if (StringUtils::StartsWithNoCase(share.strPath, "plugin://") || CDirectory::GetDirectory(share.strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || ShowYesNoDialogText(CVariant{ 1001 }, CVariant{ 1025 }) == DialogResponse::YES)
   {
     m_confirmed = true;
     Close();

--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -23,9 +23,9 @@
 #include "addons/IAddon.h"
 #include "addons/AddonManager.h"
 #include "addons/GameResource.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -33,6 +33,7 @@
 #include <cstring>
 
 using namespace KODI;
+using namespace KODI::MESSAGING::HELPERS;
 using namespace ADDON;
 using namespace GAME;
 using namespace XFILE;
@@ -104,7 +105,7 @@ const char** CGameClientProperties::GetProxyDllPaths(void)
         {
           // Failed to play game
           // This game depends on a disabled add-on. Would you like to enable it?
-          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 35210 }, CVariant{ 35215 }))
+          if (ShowYesNoDialogText(CVariant{ 35210 }, CVariant{ 35215 }) == DialogResponse::YES)
             CAddonMgr::GetInstance().EnableAddon(addon->ID());
           else
             addon.reset();

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -28,7 +28,6 @@
 #include "GUIControllerWindow.h"
 #include "GUIFeatureList.h"
 #include "addons/AddonManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerFeature.h"
 #include "games/controllers/ControllerLayout.h"
@@ -41,11 +40,13 @@
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/JoystickIDs.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "peripherals/Peripherals.h"
 #include "utils/StringUtils.h"
 #include "ServiceBroker.h"
 
 using namespace KODI;
+using namespace KODI::MESSAGING::HELPERS;
 using namespace ADDON;
 using namespace GAME;
 
@@ -141,7 +142,7 @@ void CGUIControllerList::ResetController(void)
     // For now, ask the user if they would like to reset all peripherals
     // "Reset controller profile"
     // "Would you like to reset this controller profile for all devices?"
-    if (!CGUIDialogYesNo::ShowAndGetInput(35060, 35061))
+    if (ShowYesNoDialogText(35060, 35061) != DialogResponse::YES)
       return;
 
     CServiceBroker::GetPeripherals().ResetButtonMaps(strControllerId);

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -22,7 +22,6 @@
 
 #include "Application.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -19,7 +19,6 @@
  */
 #include "LanguageHook.h"
 
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogTextViewer.h"
@@ -36,6 +35,7 @@
 #include "utils/Variant.h"
 #include "WindowException.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "Dialog.h"
 #include "ListItem.h"
@@ -61,31 +61,7 @@ namespace XBMCAddon
                        int autoclose)
     {
       DelayedCallGuard dcguard(languageHook);
-      CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-      if (pDialog == NULL)
-        throw WindowException("Error: Window is NULL, this is not possible :-)");
-
-      // get lines, last 4 lines are optional.
-      if (!heading.empty())
-        pDialog->SetHeading(CVariant{heading});
-      if (!line1.empty())
-        pDialog->SetLine(0, CVariant{line1});
-      if (!line2.empty())
-        pDialog->SetLine(1, CVariant{line2});
-      if (!line3.empty())
-        pDialog->SetLine(2, CVariant{line3});
-
-      if (!nolabel.empty())
-        pDialog->SetChoice(0, CVariant{nolabel});
-      if (!yeslabel.empty())
-        pDialog->SetChoice(1, CVariant{yeslabel});
-
-      if (autoclose > 0)
-        pDialog->SetAutoClose(autoclose);
-
-      pDialog->Open();
-
-      return pDialog->IsConfirmed();
+      return (HELPERS::ShowYesNoDialogLines(CVariant{ heading }, CVariant{ line1 }, CVariant{ line2 }, CVariant{ line3 }) == HELPERS::DialogResponse::YES);
     }
 
     bool Dialog::info(const ListItem* item)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -45,7 +45,6 @@
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "FileItem.h"
 #include "filesystem/File.h"
@@ -63,6 +62,7 @@
 #include "utils/Variant.h"
 #include "URL.h"
 #include "music/infoscanner/MusicInfoScanner.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "guiinfo/GUIInfoLabels.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
@@ -1317,13 +1317,13 @@ void CGUIWindowMusicBase::OnInitWindow()
     if (g_infoManager.GetLibraryBool(LIBRARY_HAS_MUSIC) && !g_application.IsMusicScanning())
     {
       // rescan of music library required
-      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{38060}))
+      if (HELPERS::ShowYesNoDialogText(CVariant{799}, CVariant{38060}) == HELPERS::DialogResponse::YES)
       {
         int flags = CMusicInfoScanner::SCAN_RESCAN;
         // When set to fetch information on update enquire about scraping that as well
         // It may take some time, so the user may want to do it later by "Query Info For All"
         if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO))
-          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{799}, CVariant{38061}))
+          if (HELPERS::ShowYesNoDialogText(CVariant{799}, CVariant{38061}) == HELPERS::DialogResponse::YES)
             flags |= CMusicInfoScanner::SCAN_ONLINE;
         if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
           flags |= CMusicInfoScanner::SCAN_BACKGROUND;
@@ -1382,7 +1382,7 @@ void CGUIWindowMusicBase::DoScan(const std::string &strPath)
 void CGUIWindowMusicBase::OnRemoveSource(int iItem)
 {
   bool bCanceled;
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{522}, CVariant{20340}, bCanceled, CVariant{""}, CVariant{""}, CGUIDialogYesNo::NO_TIMEOUT))
+  if (HELPERS::ShowYesNoDialogLines(CVariant{522}, CVariant{20340}, bCanceled, CVariant{""}, CVariant{""}) == HELPERS::DialogResponse::YES)
   {
     MAPSONGS songs;
     CMusicDatabase database;
@@ -1407,7 +1407,7 @@ void CGUIWindowMusicBase::OnAssignContent(const std::string &path)
   // Add content selection logic here, if music is ready for that some day
 
   // This won't ask you to clean/delete your content, when you change the scraper to none (if music gets this), might ne nice in the future
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 20444 }, CVariant{ 20447 }))
+  if (HELPERS::ShowYesNoDialogText(CVariant{ 20444 }, CVariant{ 20447 }) == HELPERS::DialogResponse::YES)
     g_application.StartMusicScan(path, true);
 }
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -41,13 +41,13 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "view/GUIViewState.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIEditControl.h"
 #include "GUIUserMessages.h"
 #include "FileItem.h"
 #include "Application.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/LegacyPathTranslation.h"
@@ -317,7 +317,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr item)
         msgctxt = 38069;
         if (content == CONTENT_ARTISTS)
           msgctxt = 38068;
-        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 20195 }, msgctxt)) // Change information provider, confirm for all shown
+        if (HELPERS::ShowYesNoDialogText(CVariant{ 20195 }, msgctxt) == HELPERS::DialogResponse::YES) // Change information provider, confirm for all shown
         { 
           // Set scraper for all items on curent view. 
           std::string strPath = "musicdb://";
@@ -343,7 +343,7 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr item)
         msgctxt = 38071; 
         if (content == CONTENT_ARTISTS)
           msgctxt = 38070;
-        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20195}, msgctxt)) // Change information provider, confirm default and clear
+        if (HELPERS::ShowYesNoDialogText(CVariant{20195}, msgctxt) == HELPERS::DialogResponse::YES) // Change information provider, confirm default and clear
         {
           // Save scraper addon default setting values
           scraper->SaveSettings();
@@ -370,13 +370,13 @@ bool CGUIWindowMusicNav::ManageInfoProvider(const CFileItemPtr item)
     if (action == CONTEXT_BUTTON_SETTINGS || action == CONTEXT_BUTTON_SET_DEFAULT)
     { 
       // Change information provider, all artists or albums
-      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20195}, CVariant{38072}))
+      if (HELPERS::ShowYesNoDialogText(CVariant{20195}, CVariant{38072}) == HELPERS::DialogResponse::YES)
         OnItemInfoAll(m_vecItems->GetPath(), true);
     }
     else
     {
       // Change information provider, selected artist or album
-      if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20195}, CVariant{38073}))
+      if (HELPERS::ShowYesNoDialogText(CVariant{20195}, CVariant{38073}) == HELPERS::DialogResponse::YES)
       {
         std::string itempath = StringUtils::Format("musicdb://albums/%li/", id);
         if (content == CONTENT_ARTISTS)

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -23,8 +23,8 @@
 #include <utility>
 
 #include "addons/Skin.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "peripherals/Peripherals.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingSection.h"
@@ -32,6 +32,7 @@
 #include "utils/Variant.h"
 #include "ServiceBroker.h"
 
+using namespace KODI::MESSAGING::HELPERS;
 using namespace PERIPHERALS;
 
 CGUIDialogPeripheralSettings::CGUIDialogPeripheralSettings()
@@ -108,7 +109,7 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   if (!peripheral)
     return;
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
+  if (ShowYesNoDialogText(CVariant{10041}, CVariant{10042}) != DialogResponse::YES)
     return;
 
   // reset the settings in the peripheral

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -32,7 +32,6 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "addons/Skin.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/File.h"
@@ -40,6 +39,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
 #include "storage/DetectDVDType.h"
@@ -65,6 +65,7 @@
 #define XML_NEXTID        "nextIdProfile"
 #define XML_PROFILE       "profile"
 
+using namespace KODI::MESSAGING::HELPERS;
 using namespace XFILE;
 
 static CProfile EmptyProfile;
@@ -304,18 +305,8 @@ bool CProfilesManager::DeleteProfile(size_t index)
   if (profile == NULL)
     return false;
 
-  CGUIDialogYesNo* dlgYesNo = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-  if (dlgYesNo == NULL)
-    return false;
-
   std::string str = g_localizeStrings.Get(13201);
-  dlgYesNo->SetHeading(CVariant{13200});
-  dlgYesNo->SetLine(0, CVariant{StringUtils::Format(str.c_str(), profile->getName().c_str())});
-  dlgYesNo->SetLine(1, CVariant{""});
-  dlgYesNo->SetLine(2, CVariant{""});
-  dlgYesNo->Open();
-
-  if (!dlgYesNo->IsConfirmed())
+  if (ShowYesNoDialogText(CVariant{13200}, CVariant{StringUtils::Format(str.c_str(), profile->getName().c_str())}) != DialogResponse::YES)
     return false;
 
   // fall back to master profile if necessary

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -23,7 +23,6 @@
 #include <utility>
 
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
@@ -31,6 +30,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/lib/Setting.h"
@@ -48,6 +48,8 @@
 #define SETTING_PROFILE_LOCKS         "profile.locks"
 #define SETTING_PROFILE_MEDIA         "profile.media"
 #define SETTING_PROFILE_MEDIA_SOURCES "profile.mediasources"
+
+using namespace KODI::MESSAGING::HELPERS;
 
 CGUIDialogProfileSettings::CGUIDialogProfileSettings()
     : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PROFILE_SETTINGS, "DialogSettings.xml"),
@@ -131,7 +133,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
 
       /*std::string strLabel;
       strLabel.Format(g_localizeStrings.Get(20047),dialog->m_strName);
-      if (!CGUIDialogYesNo::ShowAndGetInput(20058, strLabel, dialog->m_strDirectory, ""))
+      if (ShowYesNoDialogLines(20058, strLabel, dialog->m_strDirectory, "") != DialogResponse::YES)
       {
         CDirectory::Remove(URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetUserDataFolder(), dialog->m_strDirectory));
         return false;
@@ -142,7 +144,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       CProfilesManager::GetInstance().AddProfile(profile);
       bool exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory, "guisettings.xml"));
 
-      if (exists && !CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20104}))
+      if (exists && ShowYesNoDialogText(CVariant{20058}, CVariant{20104}) != DialogResponse::YES)
         exists = false;
 
       if (!exists)
@@ -150,7 +152,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         // copy masterprofile guisettings to new profile guisettings
         // If the user selects 'start fresh', do nothing as a fresh
         // guisettings.xml will be created on first profile use.
-        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20048}, CVariant{""}, CVariant{""}, CVariant{20044}, CVariant{20064}))
+        if (ShowYesNoDialogLines(CVariant{20058}, CVariant{20048}, CVariant{""}, CVariant{""}, CVariant{20044}, CVariant{20064}) == DialogResponse::YES)
         {
           XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "guisettings.xml"),
                               URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory, "guisettings.xml"));
@@ -158,7 +160,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       }
 
       exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory, "sources.xml"));
-      if (exists && !CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20106}))
+      if (exists && ShowYesNoDialogText(CVariant{20058}, CVariant{20106}) != DialogResponse::YES)
         exists = false;
 
       if (!exists)
@@ -166,7 +168,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         if ((dialog->m_sourcesMode & 2) == 2)
           // prompt user to copy masterprofile's sources.xml file
           // If 'start fresh' (no) is selected, do nothing.
-          if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20058}, CVariant{20071}, CVariant{""}, CVariant{""}, CVariant{20044}, CVariant{20064}))
+          if (ShowYesNoDialogLines(CVariant{20058}, CVariant{20071}, CVariant{""}, CVariant{""}, CVariant{20044}, CVariant{20064}) == DialogResponse::YES)
           {
             XFILE::CFile::Copy(URIUtils::AddFileToFolder("special://masterprofile/", "sources.xml"),
                                 URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory, "sources.xml"));
@@ -175,7 +177,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     }
 
     /*if (!dialog->m_bIsNewUser)
-      if (!CGUIDialogYesNo::ShowAndGetInput(20067, 20103))
+      if (ShowYesNoDialogText(20067, 20103) != DialogResponse::YES)
         return false;*/
 
     CProfile *profile = CProfilesManager::GetInstance().GetProfile(iProfile);
@@ -272,7 +274,7 @@ void CGUIDialogProfileSettings::OnSettingAction(std::shared_ptr<const CSetting> 
     {
       if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE && !m_isDefault)
       {
-        if (CGUIDialogYesNo::ShowAndGetInput(CVariant{20066}, CVariant{20118}))
+        if (ShowYesNoDialogText(CVariant{20066}, CVariant{20118}) == DialogResponse::YES)
           g_passwordManager.SetMasterLockMode(false);
         if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
           return;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -27,12 +27,12 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
@@ -238,21 +238,8 @@ bool CGUIDialogPVRChannelManager::OnClickButtonCancel(CGUIMessage &message)
 
 bool CGUIDialogPVRChannelManager::OnClickButtonRadioTV(CGUIMessage &message)
 {
-  if (m_bContainsChanges)
-  {
-    CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-    if (!pDialog)
-      return true;
-
-    pDialog->SetHeading(CVariant{20052});
-    pDialog->SetLine(0, CVariant{""});
-    pDialog->SetLine(1, CVariant{19212});
-    pDialog->SetLine(2, CVariant{20103});
-    pDialog->Open();
-
-    if (pDialog->IsConfirmed())
+  if (m_bContainsChanges && HELPERS::ShowYesNoDialogLines(CVariant{20052}, CVariant{""}, CVariant{19212}, CVariant{20103}) == HELPERS::DialogResponse::YES)
       SaveList();
-  }
 
   m_iSelected = 0;
   m_bMovingMode = false;
@@ -612,15 +599,7 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
   }
   else if (button == CONTEXT_BUTTON_DELETE)
   {
-    CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-    if (!pDialog)
-      return true;
-
-    pDialog->SetHeading(CVariant{19211}); // Delete channel
-    pDialog->SetText(CVariant{750});      // Are you sure?
-    pDialog->Open();
-
-    if (pDialog->IsConfirmed())
+    if (HELPERS::ShowYesNoDialogText(CVariant{19211}, CVariant{750}) == HELPERS::DialogResponse::YES)      // Delete Channel. Are you sure?
     {
       CPVRChannelPtr channel = pItem->GetPVRChannelInfoTag();
       PVR_ERROR ret = CServiceBroker::GetPVRManager().Clients()->DeleteChannel(channel);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -22,12 +22,12 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers//DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -142,17 +142,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonDeleteGroup(CGUIMessage &message)
     if (!m_selectedGroup)
       return bReturn;
 
-    CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-    if (!pDialog)
-      return bReturn;
-
-    pDialog->SetHeading(CVariant{117});
-    pDialog->SetLine(0, CVariant{""});
-    pDialog->SetLine(1, CVariant{m_selectedGroup->GroupName()});
-    pDialog->SetLine(2, CVariant{""});
-    pDialog->Open();
-
-    if (pDialog->IsConfirmed())
+    if (HELPERS::ShowYesNoDialogLines(CVariant{117}, CVariant{""}, CVariant{m_selectedGroup->GroupName()}, CVariant{""}) == HELPERS::DialogResponse::YES)
     {
       if (static_cast<CPVRChannelGroups*>(CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio))->DeleteGroup(*m_selectedGroup))
         Update();

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -24,7 +24,6 @@
 
 #include "Application.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -22,7 +22,6 @@
 
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -24,12 +24,12 @@
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -42,6 +42,7 @@
 #include "pvr/dialogs/GUIDialogPVRGroupManager.h"
 #include "pvr/epg/EpgContainer.h"
 
+using namespace KODI::MESSAGING::HELPERS;
 using namespace PVR;
 
 CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string &xmlFile) :
@@ -256,10 +257,10 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr &item)
 {
   const CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{19251}, // "Update guide information"
-                                        CVariant{19252}, // "Schedule guide update for this channel?"
-                                        CVariant{""},
-                                        CVariant{channel->ChannelName()}))
+  if (ShowYesNoDialogLines(CVariant{19251}, // "Update guide information"
+                           CVariant{19252}, // "Schedule guide update for this channel?"
+                           CVariant{""},
+                           CVariant{channel->ChannelName()}) != DialogResponse::YES)
     return;
 
   const CPVREpgPtr epg = channel->GetEPG();

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPManager.cpp
@@ -25,12 +25,12 @@
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "dialogs/GUIDialogTextViewer.h"
 #include "dialogs/GUIDialogBusy.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/GUIListContainer.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "input/Key.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -213,7 +213,7 @@ void CGUIDialogAudioDSPManager::OnDeinitWindow(int nextWindowID)
     }
     else
     {
-      if (CGUIDialogYesNo::ShowAndGetInput(g_localizeStrings.Get(19098), g_localizeStrings.Get(15079)))
+      if (HELPERS::ShowYesNoDialogText(g_localizeStrings.Get(19098), g_localizeStrings.Get(15079)) == HELPERS::DialogResponse::YES)
       {
         SaveList();
       }

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -24,7 +24,6 @@
 
 #include "GUIDialogSettingsBase.h"
 #include "GUIUserMessages.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIImage.h"
@@ -36,6 +35,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/SettingControl.h"
 #include "settings/lib/SettingSection.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -58,6 +58,8 @@
 #define CONTROL_DEFAULT_EDIT            12
 #define CONTROL_DEFAULT_SLIDER          13
 #define CONTROL_DEFAULT_SETTING_LABEL   14
+
+using namespace KODI::MESSAGING::HELPERS;
 
 CGUIDialogSettingsBase::CGUIDialogSettingsBase(int windowId, const std::string &xmlFile)
     : CGUIDialog(windowId, xmlFile),
@@ -798,7 +800,7 @@ void CGUIDialogSettingsBase::SetDescription(const CVariant &label)
 
 void CGUIDialogSettingsBase::OnResetSettings()
 {
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
+  if (ShowYesNoDialogText(CVariant{10041}, CVariant{10042}) == DialogResponse::YES)
   {
     for(std::vector<BaseSettingControlPtr>::iterator it = m_settingControls.begin(); it != m_settingControls.end(); ++it)
     {

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -27,9 +27,9 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -46,6 +46,8 @@
 #define CONTROL_PIXEL_RATIO  11
 #define CONTROL_VIDEO   20
 #define CONTROL_NONE   0
+
+using namespace KODI::MESSAGING::HELPERS;
 
 CGUIWindowSettingsScreenCalibration::CGUIWindowSettingsScreenCalibration(void)
     : CGUIWindow(WINDOW_SCREEN_CALIBRATION, "SettingsScreenCalibration.xml")
@@ -72,15 +74,8 @@ bool CGUIWindowSettingsScreenCalibration::OnAction(const CAction &action)
 
   case ACTION_CALIBRATE_RESET:
     {
-      CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-      pDialog->SetHeading(CVariant{20325});
       std::string strText = StringUtils::Format(g_localizeStrings.Get(20326).c_str(), g_graphicsContext.GetResInfo(m_Res[m_iCurRes]).strMode.c_str());
-      pDialog->SetLine(0, CVariant{std::move(strText)});
-      pDialog->SetLine(1, CVariant{20327});
-      pDialog->SetChoice(0, CVariant{222});
-      pDialog->SetChoice(1, CVariant{186});
-      pDialog->Open();
-      if (pDialog->IsConfirmed())
+      if (ShowYesNoDialogLines(CVariant{20325}, CVariant{std::move(strText)}, CVariant{20327}, CVariant(), CVariant{222}, CVariant{186}) == DialogResponse::YES)
       {
         g_graphicsContext.ResetScreenParameters(m_Res[m_iCurRes]);
         ResetControls();

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -20,7 +20,6 @@
 #include "FileUtils.h"
 #include "ServiceBroker.h"
 #include "guilib/GUIWindowManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "utils/log.h"
 #include "guilib/LocalizeStrings.h"
@@ -29,6 +28,7 @@
 #include "URIUtils.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/MultiPathDirectory.h"
+#include "messaging/helpers/DialogHelper.h"
 #include <vector>
 #include "settings/MediaSourceSettings.h"
 #include "Util.h"
@@ -37,6 +37,7 @@
 #include "settings/Settings.h"
 #include "utils/Variant.h"
 
+using namespace KODI::MESSAGING::HELPERS;
 using namespace XFILE;
 
 bool CFileUtils::DeleteItem(const std::string &strPath, bool force)
@@ -53,16 +54,8 @@ bool CFileUtils::DeleteItem(const CFileItemPtr &item, bool force)
   if (!item || item->IsParentFolder())
     return false;
 
-  CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-  if (!force && pDialog)
-  {
-    pDialog->SetHeading(CVariant{122});
-    pDialog->SetLine(0, CVariant{125});
-    pDialog->SetLine(1, CVariant{CURL(item->GetPath()).GetWithoutUserDetails()});
-    pDialog->SetLine(2, CVariant{""});
-    pDialog->Open();
-    if (!pDialog->IsConfirmed()) return false;
-  }
+  if (ShowYesNoDialogLines(CVariant{122}, CVariant{125}, CVariant{CURL(item->GetPath()).GetWithoutUserDetails()}) != DialogResponse::YES)
+    return false;
 
   // Create a temporary item list containing the file/folder for deletion
   CFileItemPtr pItemTemp(new CFileItem(*item));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -34,7 +34,6 @@
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
@@ -46,6 +45,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfilesManager.h"
@@ -8740,18 +8740,8 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
             del = false;
           else
           {
-            CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-            if (pDialog != NULL)
-            {
-              CURL sourceUrl(sourcePath);
-              pDialog->SetHeading(CVariant{15012});
-              pDialog->SetText(CVariant{StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str())});
-              pDialog->SetChoice(0, CVariant{15015});
-              pDialog->SetChoice(1, CVariant{15014});
-              pDialog->Open();
-
-              del = !pDialog->IsConfirmed();
-            }
+            CURL sourceUrl(sourcePath);
+            del = (HELPERS::ShowYesNoDialogText(CVariant{ 15012 }, CVariant{ StringUtils::Format(g_localizeStrings.Get(15013).c_str(), sourceUrl.GetWithoutUserDetails().c_str()) }, CVariant{ 15015 }, CVariant{ 15014 }) != HELPERS::DialogResponse::YES);
           }
         }
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -29,12 +29,12 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/IPlayer.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
 #include "filesystem/File.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
@@ -64,6 +64,8 @@
 #define SETTING_SUBTITLE_BROWSER               "subtitles.browser"
 
 #define SETTING_AUDIO_MAKE_DEFAULT             "audio.makedefault"
+
+using namespace KODI::MESSAGING::HELPERS;
 
 CGUIDialogAudioSubtitleSettings::CGUIDialogAudioSubtitleSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "DialogSettings.xml"),
@@ -253,7 +255,7 @@ void CGUIDialogAudioSubtitleSettings::Save()
     return;
 
   // prompt user if they are sure
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{12376}, CVariant{12377}))
+  if (ShowYesNoDialogText(CVariant{12376}, CVariant{12377}) != DialogResponse::YES)
     return;
 
   // reset the settings

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -27,7 +27,6 @@
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -24,10 +24,10 @@
 
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "GUIPassword.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
@@ -64,6 +64,8 @@
 #define SETTING_VIDEO_MAKE_DEFAULT        "video.save"
 #define SETTING_VIDEO_CALIBRATION         "video.calibration"
 #define SETTING_VIDEO_STREAM              "video.stream"
+
+using namespace KODI::MESSAGING::HELPERS;
 
 CGUIDialogVideoSettings::CGUIDialogVideoSettings()
     : CGUIDialogSettingsManualBase(WINDOW_DIALOG_VIDEO_OSD_SETTINGS, "DialogSettings.xml"),
@@ -179,7 +181,7 @@ void CGUIDialogVideoSettings::Save()
     return;
 
   // prompt user if they are sure
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant(12376), CVariant(12377)))
+  if (ShowYesNoDialogText(CVariant(12376), CVariant(12377)) == DialogResponse::YES)
   { // reset the settings
     CVideoDatabase db;
     if (!db.Open())

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -25,11 +25,11 @@
 #include "dialogs/GUIDialogExtendedProgressBar.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "media/MediaType.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -114,7 +114,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
           heading = m_item->m_bIsFolder ? 20351 : 20352;
         else if (scraper->Content() == CONTENT_MUSICVIDEOS)
           heading = 20393;
-        if (CGUIDialogYesNo::ShowAndGetInput(heading, 20446))
+        if (HELPERS::ShowYesNoDialogText(heading, 20446) == HELPERS::DialogResponse::YES)
         {
           hasDetails = false;
           ignoreNfo = true;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -29,7 +29,6 @@
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "view/GUIViewState.h"
 #include "playlists/PlayListFactory.h"
 #include "Application.h"
@@ -53,6 +52,7 @@
 #include "settings/dialogs/GUIDialogContentSettings.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/FileUtils.h"
@@ -65,6 +65,7 @@
 #include "utils/GroupUtils.h"
 #include "TextureDatabase.h"
 
+using namespace KODI::MESSAGING::HELPERS;
 using namespace XFILE;
 using namespace PLAYLIST;
 using namespace VIDEODATABASEDIRECTORY;
@@ -1568,10 +1569,10 @@ void CGUIWindowVideoBase::AppendAndClearSearchItems(CFileItemList &searchItems, 
 
 bool CGUIWindowVideoBase::OnUnAssignContent(const std::string &path, int header, int text)
 {
-  bool bCanceled;
   CVideoDatabase db;
   db.Open();
-  if (CGUIDialogYesNo::ShowAndGetInput(CVariant{header}, CVariant{text}, bCanceled, CVariant{ "" }, CVariant{ "" }, CGUIDialogYesNo::NO_TIMEOUT))
+  auto res = ShowYesNoDialogText(CVariant{ header }, CVariant{ text });
+  if (res == DialogResponse::YES)
   {
     CGUIDialogProgress *progress = g_windowManager.GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
     db.RemoveContentForPath(path, progress);
@@ -1581,7 +1582,7 @@ bool CGUIWindowVideoBase::OnUnAssignContent(const std::string &path, int header,
   }
   else
   {
-    if (!bCanceled)
+    if (res != DialogResponse::CANCELLED)
     {
       ADDON::ScraperPtr info;
       SScanSettings settings;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -33,11 +33,11 @@
 #include "music/MusicDatabase.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogMediaSource.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "FileItem.h"
 #include "Application.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/AdvancedSettings.h"
@@ -58,9 +58,9 @@
 
 #include <utility>
 
+using namespace KODI::MESSAGING;
 using namespace XFILE;
 using namespace VIDEODATABASEDIRECTORY;
-using namespace KODI::MESSAGING;
 
 #define CONTROL_BTNVIEWASICONS     2
 #define CONTROL_BTNSORTBY          3
@@ -837,13 +837,8 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
   else if (StringUtils::StartsWithNoCase(pItem->GetPath(), "videodb://movies/sets/") &&
            pItem->GetPath().size() > 22 && pItem->m_bIsFolder)
   {
-    CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-    pDialog->SetHeading(CVariant{432});
     std::string strLabel = StringUtils::Format(g_localizeStrings.Get(433).c_str(),pItem->GetLabel().c_str());
-    pDialog->SetLine(1, CVariant{std::move(strLabel)});
-    pDialog->SetLine(2, CVariant{""});
-    pDialog->Open();
-    if (pDialog->IsConfirmed())
+    if (HELPERS::ShowYesNoDialogText(CVariant{432}, CVariant{std::move(strLabel)}) == HELPERS::DialogResponse::YES)
     {
       CFileItemList items;
       CDirectory::GetDirectory(pItem->GetPath(),items,"",DIR_FLAG_NO_FILE_DIRS);
@@ -858,12 +853,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
   }
   else if (m_vecItems->GetContent() == "tags" && pItem->m_bIsFolder)
   {
-    CGUIDialogYesNo* pDialog = g_windowManager.GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
-    pDialog->SetHeading(CVariant{432});
-    pDialog->SetLine(1, CVariant{ StringUtils::Format(g_localizeStrings.Get(433).c_str(), pItem->GetLabel().c_str()) });
-    pDialog->SetLine(2, CVariant{""});
-    pDialog->Open();
-    if (pDialog->IsConfirmed())
+    if (HELPERS::ShowYesNoDialogText(CVariant{432}, CVariant{ StringUtils::Format(g_localizeStrings.Get(433).c_str(), pItem->GetLabel().c_str()) }) == HELPERS::DialogResponse::YES)
     {
       CVideoDatabaseDirectory dir;
       CQueryParams params;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -37,7 +37,6 @@
 #include "network/Network.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "favourites/FavouritesService.h"
@@ -49,6 +48,7 @@
 #include "settings/Settings.h"
 #include "input/InputManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -708,7 +708,7 @@ void CGUIWindowFileManager::OnMark(int iList, int iItem)
 
 void CGUIWindowFileManager::OnCopy(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{120}, CVariant{123}))
+  if (HELPERS::ShowYesNoDialogText(CVariant{120}, CVariant{123}) !=HELPERS::DialogResponse::YES)
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionCopy,
@@ -719,7 +719,7 @@ void CGUIWindowFileManager::OnCopy(int iList)
 
 void CGUIWindowFileManager::OnMove(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{121}, CVariant{124}))
+  if (HELPERS::ShowYesNoDialogText(CVariant{121}, CVariant{124}) != HELPERS::DialogResponse::YES)
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionMove,
@@ -730,7 +730,7 @@ void CGUIWindowFileManager::OnMove(int iList)
 
 void CGUIWindowFileManager::OnDelete(int iList)
 {
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{122}, CVariant{125}))
+  if (HELPERS::ShowYesNoDialogText(CVariant{122}, CVariant{125}) != HELPERS::DialogResponse::YES)
     return;
 
   AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete,


### PR DESCRIPTION
Same as https://github.com/xbmc/xbmc/pull/10893 only with YeSNo Dialog. 

## Description
Replace direct call to the dialog class with the existing helper class

## Motivation and Context
Helps to untangle guilib dependencies

## How Has This Been Tested?
Tried a yesno dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
