### PR TITLE
[PVR] CPVRClient::CloseStream must reset playing flags and playing recording/channel.

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1597,10 +1597,12 @@ void CPVRClient::CloseStream(void)
   if (IsPlayingLiveStream())
   {
     m_struct.toAddon.CloseLiveStream();
+    ClearPlayingChannel();
   }
   else if (IsPlayingRecording())
   {
     m_struct.toAddon.CloseRecordedStream();
+    ClearPlayingRecording();
   }
 }
 


### PR DESCRIPTION
Fixes a problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=298462&pid=2643722#pid2643722

This change has been runtime-tested on macOS, latest Kodi master.

@FernetMenta for review?