### PR TITLE
Allow binary addon to get multiple values for same property name

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -498,6 +498,7 @@ bool CAddonDll::InitInterface(KODI_HANDLE firstKodiInstance)
   m_interface.toKodi->set_setting_float = set_setting_float;
   m_interface.toKodi->set_setting_string = set_setting_string;
   m_interface.toKodi->free_string = free_string;
+  m_interface.toKodi->free_string_array = free_string_array;
 
   // Create function list from addon to kodi, generated with calloc to have
   // compatible with other versions and everything with "0"
@@ -835,6 +836,19 @@ void CAddonDll::free_string(void* kodiBase, char* str)
   if (str)
     free(str);
 }
+
+void CAddonDll::free_string_array(void* kodiBase, char** arr, int numElements)
+{
+  if (arr)
+  {
+    for (int i = 0; i < numElements; ++i)
+    {
+      free(arr[i]);
+    }
+    free(arr);
+  }
+}
+
 
 //@}
 

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -131,6 +131,7 @@ namespace ADDON
     static bool set_setting_float(void* kodiBase, const char* id, float value);
     static bool set_setting_string(void* kodiBase, const char* id, const char* value);
     static void free_string(void* kodiBase, char* str);
+    static void free_string_array(void* kodiBase, char** arr, int numElements);
     //@}
   };
 

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.h
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.h
@@ -62,6 +62,7 @@ public:
   static char* GetLocalizedString(const void* addonData, long dwCode);
   static char* GetDVDMenuLanguage(const void* addonData);
   static void FreeString(const void* addonData, char* str);
+  static void FreeStringArray(const void* addonData, char** arr, int numElements);
 
   // file operations
   static void* OpenFile(const void* addonData, const char* strFileName, unsigned int flags);
@@ -79,7 +80,8 @@ public:
   static int GetFileChunkSize(const void* addonData, void* file);
   static bool FileExists(const void* addonData, const char *strFileName, bool bUseCache);
   static int StatFile(const void* addonData, const char *strFileName, struct __stat64* buffer);
-  static char *GetFileProperty(const void* addonData, void* file, XFILE::FileProperty type, const char *name);
+  static char *GetFilePropertyValue(const void* addonData, void* file, XFILE::FileProperty type, const char *name);
+  static char **GetFilePropertyValues(const void* addonData, void* file, XFILE::FileProperty type, const char *name, int *numValues);
   static bool DeleteFile(const void* addonData, const char *strFileName);
   static bool CanOpenDirectory(const void* addonData, const char* strURL);
   static bool CreateDirectory(const void* addonData, const char *strPath);

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <vector>
+
 #include "Filesystem.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/Filesystem.h"
 
@@ -73,7 +75,7 @@ void Interface_Filesystem::Init(AddonGlobalInterface* addonInterface)
   addonInterface->toKodi->kodi_filesystem->get_file_download_speed = get_file_download_speed;
   addonInterface->toKodi->kodi_filesystem->close_file = close_file;
   addonInterface->toKodi->kodi_filesystem->get_file_chunk_size = get_file_chunk_size;
-  addonInterface->toKodi->kodi_filesystem->get_property = get_property;
+  addonInterface->toKodi->kodi_filesystem->get_property_values = get_property_values;
 
   addonInterface->toKodi->kodi_filesystem->curl_create = curl_create;
   addonInterface->toKodi->kodi_filesystem->curl_add_option = curl_add_option;
@@ -504,7 +506,7 @@ int Interface_Filesystem::get_file_chunk_size(void* kodiBase, void* file)
   return static_cast<CFile*>(file)->GetChunkSize();
 }
 
-char* Interface_Filesystem::get_property(void* kodiBase, void* file, int type, const char *name)
+char** Interface_Filesystem::get_property_values(void* kodiBase, void* file, int type, const char *name, int *numValues)
 {
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || name == nullptr)
@@ -535,7 +537,14 @@ char* Interface_Filesystem::get_property(void* kodiBase, void* file, int type, c
     CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
     return nullptr;
   };
-  return strdup(static_cast<CFile*>(file)->GetProperty(internalType, name).c_str());
+  std::vector<std::string> values = static_cast<CFile*>(file)->GetPropertyValues(internalType, name);
+  *numValues = values.size();
+  char **ret = static_cast<char**>(malloc(sizeof(char*)*values.size()));
+  for (int i = 0; i < *numValues; ++i)
+  {
+    ret[i] = strdup(values[i].c_str());
+  }
+  return ret;
 }
 
 void* Interface_Filesystem::curl_create(void* kodiBase, const char* url)

--- a/xbmc/addons/interfaces/Filesystem.h
+++ b/xbmc/addons/interfaces/Filesystem.h
@@ -77,7 +77,7 @@ namespace ADDON
     static double get_file_download_speed(void* kodiBase, void* file);
     static void close_file(void* kodiBase, void* file);
     static int get_file_chunk_size(void* kodiBase, void* file);
-    static char* get_property(void* kodiBase, void* file, int type, const char *name);
+    static char** get_property_values(void* kodiBase, void* file, int type, const char *name, int *numValues);
 
     static void* curl_create(void* kodiBase, const char* url);
     static bool curl_add_option(void* kodiBase, void* file, int type, const char* name, const char* value);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -160,6 +160,7 @@ typedef struct AddonToKodiFuncTable_Addon
 
   // Function addresses used for callbacks from addon to Kodi
   void (*free_string)(void* kodiBase, char* str);
+  void (*free_string_array)(void* kodiBase, char** arr, int numElements);
   char* (*get_addon_path)(void* kodiBase);
   char* (*get_base_user_path)(void* kodiBase);
   void (*addon_log_msg)(void* kodiBase, const int loglevel, const char *msg);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -22,6 +22,7 @@
 #include "AddonBase.h"
 
 #include <map>
+#include <vector>
 
 #if !defined(_WIN32)
   #include <sys/stat.h>
@@ -110,7 +111,7 @@ extern "C"
     double (*get_file_download_speed)(void* kodiBase, void* file);
     void (*close_file)(void* kodiBase, void* file);
     int (*get_file_chunk_size)(void* kodiBase, void* file);
-    char* (*get_property)(void* kodiBase, void* file, int type, const char *name);
+    char** (*get_property_values)(void* kodiBase, void* file, int type, const char *name, int *numValues);
 
     void* (*curl_create)(void* kodiBase, const char* url);
     bool (*curl_add_option)(void* kodiBase, void* file, int type, const char* name, const char* value);
@@ -1540,22 +1541,51 @@ namespace vfs
     /// @param[in] name         The name of a named property value (e.g. Header)
     /// @return                 value of requested property, empty on failure / non-existance
     ///
-    const std::string GetProperty(FilePropertyTypes type, const std::string &name) const
+    const std::string GetPropertyValue(FilePropertyTypes type, const std::string &name) const
     {
       if (!m_file)
       {
-        kodi::Log(ADDON_LOG_ERROR, "kodi::vfs::CURLCreate(...) needed to call before GetProperty!");
+        kodi::Log(ADDON_LOG_ERROR, "kodi::vfs::CURLCreate(...) needed to call before GetPropertyValue!");
         return "";
       }
-      char *res(::kodi::addon::CAddonBase::m_interface->toKodi->kodi_filesystem->get_property(
-        ::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, m_file, type, name.c_str()));
+      std::vector<std::string> values = GetPropertyValues(type, name);
+      if (values.empty()) {
+        return "";
+      }
+      return values[0];
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// @ingroup cpp_kodi_vfs_CFile
+    /// @brief retrieve file property values
+    ///
+    /// @param[in] type         The type of the file property values to retrieve the value for
+    /// @param[in] name         The name of the named property (e.g. Header)
+    /// @return                 values of requested property, empty vector on failure / non-existance
+    ///
+    const std::vector<std::string> GetPropertyValues(FilePropertyTypes type, const std::string &name) const
+    {
+      if (!m_file)
+      {
+        kodi::Log(ADDON_LOG_ERROR, "kodi::vfs::CURLCreate(...) needed to call before GetPropertyValues!");
+        return std::vector<std::string>();
+      }
+      int numValues;
+      char **res(::kodi::addon::CAddonBase::m_interface->toKodi->kodi_filesystem->get_property_values(
+        ::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, m_file, type, name.c_str(), &numValues));
       if (res)
       {
-        std::string strReturn(res);
-        ::kodi::addon::CAddonBase::m_interface->toKodi->free_string(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, res);
-        return strReturn;
+        std::vector<std::string> vecReturn;
+        for (int i = 0; i < numValues; ++i)
+        {
+          vecReturn.emplace_back(res[i]);
+        }
+        ::kodi::addon::CAddonBase::m_interface->toKodi->free_string_array(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, res, numValues);
+        return vecReturn;
       }
-      return "";
+      return std::vector<std::string>();
     }
     //--------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_addon.h
@@ -139,6 +139,7 @@ typedef struct CB_AddOn
   char* (*GetLocalizedString)(const void* addonData, long dwCode);
   char* (*GetDVDMenuLanguage)(const void* addonData);
   void (*FreeString)(const void* addonData, char* str);
+  void (*FreeStringArray)(const void* addonData, char** arr, int numElements);
 
   void* (*OpenFile)(const void* addonData, const char* strFileName, unsigned int flags);
   void* (*OpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);
@@ -155,7 +156,8 @@ typedef struct CB_AddOn
   int (*GetFileChunkSize)(const void* addonData, void* file);
   bool (*FileExists)(const void* addonData, const char *strFileName, bool bUseCache);
   int (*StatFile)(const void* addonData, const char *strFileName, struct __stat64* buffer);
-  char *(*GetFileProperty)(const void* addonData, void* file, XFILE::FileProperty type, const char *name);
+  char *(*GetFilePropertyValue)(const void* addonData, void* file, XFILE::FileProperty type, const char *name);
+  char **(*GetFilePropertyValues)(const void* addonData, void* file, XFILE::FileProperty type, const char *name, int *numPorperties);
   bool (*DeleteFile)(const void* addonData, const char *strFileName);
   bool (*CanOpenDirectory)(const void* addonData, const char* strURL);
   bool (*CreateDirectory)(const void* addonData, const char *strPath);
@@ -298,6 +300,16 @@ namespace ADDON
     void FreeString(char* str)
     {
       m_Callbacks->FreeString(m_Handle->addonData, str);
+    }
+    
+    /*!
+     * @brief Free the memory used by arr including its elements
+     * @param arr The string array to free
+     * @param numElements The length of the array
+     */
+    void FreeStringArray(char** arr, int numElements)
+    {
+      m_Callbacks->FreeStringArray(m_Handle->addonData, arr, numElements);
     }
 
     /*!
@@ -468,13 +480,26 @@ namespace ADDON
     /*!
     * @brief Get a property from an open file.
     * @param file The file to get an property for
-    * @param type type of the requested property.
-    * @param name of the requested property / can be null.
+    * @param type Type of the requested property.
+    * @param name Name of the requested property / can be null.
     * @return The value of the requested property, must be FreeString'ed.
     */
-    char *GetFileProperty(void* file, XFILE::FileProperty type, const char *name)
+    char *GetFilePropertyValue(void* file, XFILE::FileProperty type, const char *name)
     {
-      return m_Callbacks->GetFileProperty(m_Handle->addonData, file, type, name);
+      return m_Callbacks->GetFilePropertyValue(m_Handle->addonData, file, type, name);
+    }
+
+    /*!
+    * @brief Get multiple property values from an open file.
+    * @param file The file to get the property values for
+    * @param type Type of the requested property.
+    * @param name Name of the requested property / can be null.
+    * @param numValues Number of property values returned.
+    * @return List of values of the requested property, must be FreeStringArray'ed.
+    */
+    char **GetFilePropertyValues(void* file, XFILE::FileProperty type, const char *name, int *numValues)
+    {
+      return m_Callbacks->GetFilePropertyValues(m_Handle->addonData, file, type, name, numValues);
     }
 
     /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -41,8 +41,8 @@
  * overview.
  */
 
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.11"
-#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.11"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.12"
+#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.12"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \
                                                       "xbmc_addon_dll.h" \
@@ -66,8 +66,8 @@
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_XML_ID       "kodi.binary.global.audioengine"
 #define ADDON_GLOBAL_VERSION_AUDIOENGINE_DEPENDS      "AudioEngine.h"
 
-#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.0.1"
-#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.0.1"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM               "1.0.2"
+#define ADDON_GLOBAL_VERSION_FILESYSTEM_MIN           "1.0.2"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_XML_ID        "kodi.binary.global.filesystem"
 #define ADDON_GLOBAL_VERSION_FILESYSTEM_DEPENDS       "Filesystem.h"
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1929,6 +1929,21 @@ const std::string CCurlFile::GetProperty(XFILE::FileProperty type, const std::st
   }
 }
 
+const std::vector<std::string> CCurlFile::GetPropertyValues(XFILE::FileProperty type, const std::string &name) const
+{
+  if (type == FILE_PROPERTY_RESPONSE_HEADER)
+  {
+    return m_state->m_httpheader.GetValues(name);
+  }
+  std::vector<std::string> values;
+  std::string value = GetProperty(type, name);
+  if (!value.empty())
+  {
+    values.emplace_back(value);
+  }
+  return values;
+}
+
 double CCurlFile::GetDownloadSpeed()
 {
   double res = 0.0f;

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -62,6 +62,7 @@ namespace XFILE
       ssize_t Read(void* lpBuf, size_t uiBufSize) override { return m_state->Read(lpBuf, uiBufSize); }
       ssize_t Write(const void* lpBuf, size_t uiBufSize) override;
       const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const override;
+      const std::vector<std::string> GetPropertyValues(XFILE::FileProperty type, const std::string &name = "") const override;
       int IoControl(EIoControl request, void* param) override;
       double GetDownloadSpeed() override;
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -957,6 +957,15 @@ const std::string CFile::GetProperty(XFILE::FileProperty type, const std::string
   return m_pFile->GetProperty(type, name);
 }
 
+const std::vector<std::string> CFile::GetPropertyValues(XFILE::FileProperty type, const std::string &name) const
+{
+  if (!m_pFile)
+  {
+    return std::vector<std::string>();
+  }
+  return m_pFile->GetPropertyValues(type, name);
+}
+
 ssize_t CFile::LoadFile(const std::string &filename, auto_buffer& outputBuffer)
 {
   const CURL pathToUrl(filename);

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <stdio.h>
 #include <string>
+#include <vector>
 #include "utils/auto_buffer.h"
 #include "IFileTypes.h"
 #include "PlatformDefs.h"
@@ -110,6 +111,7 @@ public:
   void Close();
   int GetChunkSize();
   const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const;
+  const std::vector<std::string> GetPropertyValues(XFILE::FileProperty type, const std::string &name = "") const;
   ssize_t LoadFile(const std::string &filename, auto_buffer& outputBuffer);
 
 

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -61,6 +61,11 @@ namespace XFILE
 
     const std::string GetProperty(XFILE::FileProperty type, const std::string &name = "") const override;
 
+    virtual const std::vector<std::string> GetPropertyValues(XFILE::FileProperty type, const std::string &name = "") const override
+    {
+      return std::vector<std::string>();
+    }
+
   private:
     CCacheStrategy *m_pCache;
     bool m_bDeleteCache;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -35,6 +35,7 @@
 #include <stdint.h>
 #include <sys/stat.h>
 #include <string>
+#include <vector>
 
 #if !defined(SIZE_MAX) || !defined(SSIZE_MAX)
 #include <limits.h>
@@ -133,6 +134,17 @@ public:
   {
     return type == XFILE::FILE_PROPERTY_CONTENT_TYPE ? "application/octet-stream" : "";
   };
+
+  virtual const std::vector<std::string> GetPropertyValues(XFILE::FileProperty type, const std::string &name = "") const
+  {
+    std::vector<std::string> values;
+    std::string value = GetProperty(type, name);
+    if (!value.empty())
+    {
+      values.emplace_back(value);
+    }
+    return values;
+  }
 };
 
 class CRedirectException


### PR DESCRIPTION
This is an extension to https://github.com/xbmc/xbmc/pull/12737

There are some properties (probably only HTTP headers) which can have multiple values for the same key. (e.g. set-cookie can be sent multiple times by the server).
With GetFileProperties, it is possible to get a list of all these values.

@peak3d this function could replace File::GetProperty but as GetProperty is simpler to call and probably sufficient in most cases, I think its better to keep GetProperty. What do you think?

(sorry to bug again with "my cookies". but as far as I can see, this is the last remaining issue :-) )