### PR TITLE
Fixed issues with Win64 build failing to build ffmpeg

### DIFF
--- a/tools/buildsteps/windows/buildffmpeg.sh
+++ b/tools/buildsteps/windows/buildffmpeg.sh
@@ -19,7 +19,7 @@ do_getFFmpegConfig() {
     FFMPEG_OPTS_SHARED="$FFMPEG_BASE_OPTS $FFMPEG_DEFAULT_OPTS"
   fi
 
-  if [ "$ARCH" == "x86_x64" ]; then
+  if [ "$ARCH" == "x86_64" ]; then
     FFMPEG_TARGET_OS=mingw64
   elif [ "$ARCH" == "x86" ]; then
     FFMPEG_TARGET_OS=mingw32
@@ -85,7 +85,7 @@ if [ "$TOOLS" = "msvc" ]; then
   do_addOption "--disable-openssl"
   do_addOption "--toolchain=msvc"
 
-  if [ "$ARCH" == "x86_x64" ]; then
+  if [ "$ARCH" == "x86_64" ]; then
     FFMPEG_TARGET_OS=win64
   elif [ "$ARCH" = "x86" ]; then
     FFMPEG_TARGET_OS=win32

--- a/tools/buildsteps/windows/patches/0002-ffmpeg-zlib-config-conflict.patch
+++ b/tools/buildsteps/windows/patches/0002-ffmpeg-zlib-config-conflict.patch
@@ -1,0 +1,12 @@
+--- a/configure
++++ b/configure
+@@ -6835,6 +6836,9 @@
+                                      $CONFIG_EXTRA      \
+                                      $ALL_COMPONENTS    \
+ 
++echo "#if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H == 0" >> $TMPH
++echo "#undef HAVE_UNISTD_H" >> $TMPH
++echo "#endif" >> $TMPH
+ echo "#endif /* FFMPEG_CONFIG_H */" >> $TMPH
+ echo "endif # FFMPEG_CONFIG_MAK" >> config.mak
+ 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
buildmpeg.sh was changed to match the value assigned to ARCH in other scripts/batch files (x86_64). It looks like it was just typoed initially.

The ffmpeg patch fixes an issue where the zlib includes (zconf.h:477) were trying to `#include <unistd.h>` when compiled with Visual Studio. I tracked this down to the ffmpeg configure script creating `#define HAVE_UNISTD_H 0` in config.h. This works fine for ffmpeg, since all its checks use `#if HAVE_UNISTD_H`, but does not work on zlib which uses `#ifdef HAVE_UNISTD_H` (zconf.h:436). The patch simply `#undef HAVE_UNISTD_H` if `HAVE_UNISTD_H` is set to `0`. This will cause `HAVE_UNISTD_H` checks to work with both zlib and ffmpeg.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to check out the latest Kodi Alpha, and my build environment is Win64 using Visual Studio 2015. I followed the build instructions, but ended up running into errors. I tracked down the source of the different errors and came up with my best attempt at fixing them that worked with the existing build system.
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I ran the build from a clean state (git clean -xdf) with only my additional commit and was able to build, run tests, and use Kodi.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
