### PR TITLE
SPDIF: Make it possible to use 352 khz and 384 khz

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16383,8 +16383,20 @@ msgctxt "#34128"
 msgid "192.0"
 msgstr ""
 
+#. SPDIF max sampling rate
+#: system/settings/settings.xml
+msgctxt "#34129"
+msgid "352.8"
+msgstr ""
+
+#. SPDIF max sampling rate
+#: system/settings/settings.xml
+msgctxt "#34130"
+msgid "384.0"
+msgstr ""
+
 #empty strings from id 34129 to 34200
-#34129-34200 reserved for future use
+#34131-34200 reserved for future use
 
 #: xbmc/PlayListPlayer.cpp
 msgctxt "#34201"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2580,6 +2580,8 @@
               <option label="34126">88200</option>
               <option label="34127">96000</option>
               <option label="34128">192000</option>
+              <option label="34129">352800</option>
+              <option label="34130">384000</option>
             </options>
           </constraints>
           <control type="list" format="integer" />


### PR DESCRIPTION
I could not believe it first, but there are now SPDIF devices out there that accept 384 khz / 32 bit input. See for example the following device: http://www.ca.marantz.com/ca/Products/Pages/ProductDetails.aspx?CatId=HiFiComponents&SubCatId=0&ProductId=HDAMP1

A user on LibreELEC forum verified with ALSA's speaker-test that it works correctly. In order to support this usecase a minimal change to kodi (only Settings and Language) needs to happen.

Note: ALSA sink currently does not support 352 khz, but pulseaudio does. 384 khz both support.

LE Forum thread: https://forum.libreelec.tv/thread/9823-audio-output-device-sampling-rate/?pageNo=1