### PR TITLE
[PVR] CPVRClient(s)::OpenStream: Remove unused parameter bIsSwitchingChannels

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1555,7 +1555,7 @@ void CPVRClient::ClearPlayingEpgTag()
   m_bIsPlayingEpgTag = false;
 }
 
-bool CPVRClient::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel)
+bool CPVRClient::OpenStream(const CPVRChannelPtr &channel)
 {
   bool bReturn(false);
   CloseStream();

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -607,10 +607,9 @@ namespace PVR
     /*!
      * @brief Open a live stream on the server.
      * @param channel The channel to stream.
-     * @param bIsSwitchingChannel True when switching channels, false otherwise.
      * @return True if the stream opened successfully, false otherwise.
      */
-    bool OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel);
+    bool OpenStream(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Close an open live stream.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -769,7 +769,7 @@ bool CPVRManager::OpenLiveStream(const CFileItem &fileItem)
   // check if we're allowed to play this file
   const CPVRChannelPtr channel = fileItem.GetPVRChannelInfoTag();
   if (!IsParentalLocked(channel))
-    bReturn = m_addons->OpenStream(channel, false);
+    bReturn = m_addons->OpenStream(channel);
 
   return bReturn;
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1142,7 +1142,7 @@ bool CPVRClients::FillRecordingStreamFileItem(CFileItem &fileItem)
   return false;
 }
 
-bool CPVRClients::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel)
+bool CPVRClients::OpenStream(const CPVRChannelPtr &channel)
 {
   bool bReturn(false);
   CloseStream();
@@ -1150,7 +1150,7 @@ bool CPVRClients::OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingCha
   /* try to open the stream on the client */
   PVR_CLIENT client;
   if (GetCreatedClient(channel->ClientID(), client))
-    bReturn = client->OpenStream(channel, bIsSwitchingChannel);
+    bReturn = client->OpenStream(channel);
 
   if (bReturn)
     SetPlayingChannel(channel);

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -297,10 +297,9 @@ namespace PVR
     /*!
      * @brief Open a stream on the given channel.
      * @param channel The channel to start playing.
-     * @param bIsSwitchingChannel True when switching channels, false otherwise.
      * @return True if the stream was opened successfully, false otherwise.
      */
-    bool OpenStream(const CPVRChannelPtr &channel, bool bIsSwitchingChannel);
+    bool OpenStream(const CPVRChannelPtr &channel);
 
     /*!
      * @brief Set the channel that is currently playing.


### PR DESCRIPTION
Just a tiny method signature cleanup - leftover from videoplayer channels witch rework.

@Jalle19 mind doing the review?