### PR TITLE
Fix Coverity CIDs 175368 and 175367

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -566,7 +566,7 @@ bool CInputManager::OnKey(const CKey& key)
     return true;
   }
 
-  if (iWin != WINDOW_FULLSCREEN_VIDEO ||
+  if (iWin != WINDOW_FULLSCREEN_VIDEO &&
       iWin != WINDOW_FULLSCREEN_GAME)
   {
     // current active window isnt the fullscreen window

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -246,7 +246,7 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
     //g_graphicsContext.SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution(), TRUE);
   }
 
-  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO ||
+  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO &&
       nextWindowID != WINDOW_FULLSCREEN_GAME)
   {
     // wait for any outstanding picture loads


### PR DESCRIPTION
This fixes two logic errors in commit acd30c1bf of #12761.

Coverity CID 175368:

** CID 175368:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
GUIWindowSlideShow.cpp: 249 in CGUIWindowSlideShow::OnDeinitWindow(int)()
```
________________________________________________________________________________________________________
*** CID 175368:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
GUIWindowSlideShow.cpp: 249 in CGUIWindowSlideShow::OnDeinitWindow(int)()
243       if (m_Resolution != CDisplaySettings::GetInstance().GetCurrentResolution())
244       {
245         //FIXME: Use GUI resolution for now
246         //g_graphicsContext.SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution(), TRUE);
247       }
248
>>>     CID 175368:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
>>>     The "or" condition "nextWindowID != 12005 || nextWindowID != 12906" will always be true because "nextWindowID" cannot be equal to two different values at the same time, so it must be not equal to at least one of them.
249       if (nextWindowID != WINDOW_FULLSCREEN_VIDEO ||
250           nextWindowID != WINDOW_FULLSCREEN_GAME)
251       {
252         // wait for any outstanding picture loads
253         if (m_pBackgroundLoader)
254         {
```

Coverity CID 175367:

** CID 175367:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
InputManager.cpp: 569 in CInputManager::OnKey(const CKey &)()
```
________________________________________________________________________________________________________
*** CID 175367:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
InputManager.cpp: 569 in CInputManager::OnKey(const CKey &)()
563       if (g_application.WakeUpScreenSaverAndDPMS(processKey) && !processKey)
564       {
565         CLog::LogF(LOGDEBUG, "%s pressed, screen saver/dpms woken up", m_Keyboard.GetKeyName((int)key.GetButtonCode()).c_str());
566         return true;
567       }
568
>>>     CID 175367:  Integer handling issues  (CONSTANT_EXPRESSION_RESULT)
>>>     The "or" condition "iWin != 12005 || iWin != 12906" will always be true because "iWin" cannot be equal to two different values at the same time, so it must be not equal to at least one of them.
569       if (iWin != WINDOW_FULLSCREEN_VIDEO ||
570           iWin != WINDOW_FULLSCREEN_GAME)
571       {
572         // current active window isnt the fullscreen window
573         // just use corresponding section from keymap.xml
574         // to map key->action
```
