### PR TITLE
Allow setting custom http request from binary addon

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -186,7 +186,7 @@ typedef enum CURLOptiontype
 {
   /// Set a general option
   ADDON_CURL_OPTION_OPTION,
-  /// Set a protocol option
+  /// Set a protocol option (see below)
   ADDON_CURL_OPTION_PROTOCOL,
   /// Set User and password
   ADDON_CURL_OPTION_CREDENTIALS,
@@ -194,6 +194,25 @@ typedef enum CURLOptiontype
   ADDON_CURL_OPTION_HEADER
 } CURLOptiontype;
 //------------------------------------------------------------------------------
+
+///
+// The following names for ADDON_CURL_OPTION_PROTOCOL are possible:
+//
+// accept-charset: Set the "accept-charset" header
+// acceptencoding or encoding: Set the "accept-encoding" header
+// active-remote: Set the "active-remote" header
+// auth: Set the authentication method. Possible values: any, anysafe, digest, ntlm
+// connection-timeout: Set the connection timeout in seconds
+// cookie: Set the "cookie" header
+// customrequest: Set a custom HTTP request like DELETE
+// noshout: Set to true if kodi detects a stream as shoutcast by mistake.
+// postdata: Set the post body (value needs to be base64 encoded). (Implicitly sets the request to POST)
+// referer: Set the "referer" header
+// user-agent: Set the "user-agent" header
+// seekable: Set the stream seekable. 1: enable, 0: disable
+// sslcipherlist: Set list of accepted SSL ciphers.
+//
+///
 
 //==============================================================================
 /// \ingroup cpp_kodi_vfs_Defs

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -830,6 +830,10 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         {
           SetRequestHeader(it->first, value);
         }
+        else if (name == "customrequest")
+        {
+          SetCustomRequest(value);
+        }
         else
         {
           if (name.length() > 0 && name[0] == '!')

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -78,10 +78,28 @@ typedef enum {
 enum CURLOPTIONTYPE
 {
   CURL_OPTION_OPTION,     /**< Set a general option   */
-  CURL_OPTION_PROTOCOL,   /**< Set a protocol option  */
+  CURL_OPTION_PROTOCOL,   /**< Set a protocol option (see below)  */
   CURL_OPTION_CREDENTIALS,/**< Set User and password  */
   CURL_OPTION_HEADER      /**< Add a Header           */
 };
+
+/**
+ * The following names for CURL_OPTION_PROTOCOL are possible:
+ *
+ * accept-charset: Set the "accept-charset" header
+ * acceptencoding or encoding: Set the "accept-encoding" header
+ * active-remote: Set the "active-remote" header
+ * auth: Set the authentication method. Possible values: any, anysafe, digest, ntlm
+ * connection-timeout: Set the connection timeout in seconds
+ * cookie: Set the "cookie" header
+ * customrequest: Set a custom HTTP request like DELETE
+ * noshout: Set to true if kodi detects a stream as shoutcast by mistake.
+ * postdata: Set the post body (value needs to be base64 encoded). (Implicitly sets the request to POST)
+ * referer: Set the "referer" header
+ * user-agent: Set the "user-agent" header
+ * seekable: Set the stream seekable. 1: enable, 0: disable
+ * sslcipherlist: Set list of accepted SSL ciphers.
+ */
 
 enum FileProperty
 {


### PR DESCRIPTION
With this PR, it is possible to set a custom request for a CURL HTTP call.

In my case (pvr.teleboy) this is required to do DELETE calls against the REST-API of Teleboy to delete timer and recordings.