### PR TITLE
[videoplayer] CVideoPlayer::OpenFile: Increase the time player waits for open event

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -701,7 +701,7 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
     params.m_item.SetMimeTypeForInternetFile();
     m_messenger.Put(new CDVDMsgOpenFile(params), 1);
 
-    if (m_openEvent.WaitMSec(2000))
+    if (m_openEvent.WaitMSec(5000))
     {
       if (!m_bStop && !m_bAbortRequest)
         return true;


### PR DESCRIPTION
… from 2 secs to 5 secs. Should be sufficient for tuning channels on slow PVR backends.

This should fix trac17557: https://trac.kodi.tv/ticket/17557

@FernetMenta for review (we discussed this change on Slack already).
@MilhouseVH could you please include this PR in your next build? I will ping the bug reporters.

