### PR TITLE
VideoPlayer: bring up busy dialog if opening stream blocks too long

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -167,7 +167,6 @@ public:
   virtual ENextStream NextStream() { return NEXTSTREAM_NONE; }
   virtual void Abort() {}
   virtual int GetBlockSize() { return 0; }
-  virtual void ResetScanTimeout(unsigned int iTimeoutMs) { }
   virtual bool CanSeek() { return true; }
   virtual bool CanPause() { return true; }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -66,11 +66,6 @@ CDVDInputStreamPVRManager::~CDVDInputStreamPVRManager()
   delete m_StreamProps;
 }
 
-void CDVDInputStreamPVRManager::ResetScanTimeout(unsigned int iTimeoutMs)
-{
-  m_ScanTimeout.Set(iTimeoutMs);
-}
-
 bool CDVDInputStreamPVRManager::IsEOF()
 {
   // don't mark as eof while within the scan timeout
@@ -145,7 +140,6 @@ bool CDVDInputStreamPVRManager::Open()
       m_demuxActive = true;
   }
 
-  ResetScanTimeout((unsigned int) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
   CLog::Log(LOGDEBUG, "CDVDInputStreamPVRManager::Open - stream opened: %s", CURL::GetRedacted(m_item.GetDynPath()).c_str());
 
   m_StreamProps->iStreamCount = 0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -86,8 +86,6 @@ public:
    */
   std::string GetInputFormat();
 
-  void ResetScanTimeout(unsigned int iTimeoutMs) override;
-
   // Demux interface
   CDVDInputStream::IDemux* GetIDemux() override;
   bool OpenDemux() override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2954,8 +2954,6 @@ void CVideoPlayer::SetCaching(ECacheState state)
     m_VideoPlayerVideo->SetSpeed(DVD_PLAYSPEED_PAUSE);
     m_streamPlayerSpeed = DVD_PLAYSPEED_PAUSE;
 
-    m_pInputStream->ResetScanTimeout((unsigned int) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
-
     m_cachingTimer.Set(5000);
   }
 
@@ -2966,7 +2964,6 @@ void CVideoPlayer::SetCaching(ECacheState state)
     m_VideoPlayerAudio->SetSpeed(m_playSpeed);
     m_VideoPlayerVideo->SetSpeed(m_playSpeed);
     m_streamPlayerSpeed = m_playSpeed;
-    m_pInputStream->ResetScanTimeout(0);
   }
   m_caching = state;
 


### PR DESCRIPTION
Opening a stream is not supposed to block. The busy dialog keeps the UI alive but finallly addons like dvblogic should fix their issues.