### PR TITLE
[visualization][fix] last parameter of CVisualization::Start is song title

### DIFF
--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -177,8 +177,11 @@ void CGUIVisualisationControl::Process(unsigned int currentTime, CDirtyRegionLis
         m_alreadyStarted = false;
       }
 
-      std::string strFile = URIUtils::GetFileName(g_application.CurrentFile());
-      m_alreadyStarted = m_instance->Start(m_channels, m_samplesPerSec, m_bitsPerSample, strFile);
+      std::string songTitle = URIUtils::GetFileName(g_application.CurrentFile());
+      const MUSIC_INFO::CMusicInfoTag* tag = g_infoManager.GetCurrentSongTag();
+      if (tag && !tag->GetTitle().empty())
+        songTitle = tag->GetTitle();
+      m_alreadyStarted = m_instance->Start(m_channels, m_samplesPerSec, m_bitsPerSample, songTitle);
       g_graphicsContext.ApplyStateBlock();
       m_callStart = false;
       m_updateTrack = true;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Pass the song title instead of file name to CVisualization::Start
<!--- Describe your change in detail -->

## Motivation and Context
Goom Visualization showed number.mp3 at song start, but it should show the the song title and parameter is everywhere described as song title.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested with Goom on osx.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
