### PR TITLE
VideoPlayer: make OpenFile asynchron

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3618,6 +3618,14 @@ void CApplication::OnPlayBackStopped()
   g_windowManager.SendThreadMessage(msg);
 }
 
+void CApplication::OnPlayBackError()
+{
+  //@todo Playlists can be continued by calling OnPlaybackEnded instead
+  // open error dialog
+  HELPERS::ShowOKDialogText(CVariant{16026}, CVariant{16027});
+  OnPlayBackStopped();
+}
+
 void CApplication::OnPlayBackPaused()
 {
 #ifdef HAS_PYTHON

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -171,6 +171,7 @@ public:
   void OnPlayBackPaused() override;
   void OnPlayBackResumed() override;
   void OnPlayBackStopped() override;
+  void OnPlayBackError() override;
   void OnQueueNextItem() override;
   void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) override;
   void OnPlayBackSeekChapter(int iChapter) override;

--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -29,6 +29,7 @@ public:
   virtual void OnPlayBackPaused() {};
   virtual void OnPlayBackResumed() {};
   virtual void OnPlayBackStopped() = 0;
+  virtual void OnPlayBackError() = 0;
   virtual void OnQueueNextItem() = 0;
   virtual void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) {};
   virtual void OnPlayBackSeekChapter(int iChapter) {};

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2482,6 +2482,7 @@ void CVideoPlayer::HandleMessages()
       SAFE_DELETE(m_pCCDemuxer);
       SAFE_DELETE(m_pInputStream);
 
+      m_callback.OnPlayBackStopped();
       m_item = msg.GetItem();
       m_playerOptions = msg.GetOptions();
       Prepare();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -492,9 +492,9 @@ protected:
   bool m_players_created;
 
   CFileItem m_item;
-  CEvent m_openEvent;
   CPlayerOptions m_playerOptions;
   bool m_bAbortRequest;
+  bool m_error;
 
   ECacheState  m_caching;
   XbmcThreads::EndTime m_cachingTimer;

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -202,6 +202,12 @@ namespace XBMCAddon
       invokeCallback(new CallbackFunction<Player>(this,&Player::onPlayBackStopped));
     }
 
+    void Player::OnPlayBackError()
+    {
+      XBMC_TRACE;
+      invokeCallback(new CallbackFunction<Player>(this,&Player::onPlayBackError));
+    }
+
     void Player::OnPlayBackPaused()
     { 
       XBMC_TRACE;
@@ -249,6 +255,11 @@ namespace XBMCAddon
     }
 
     void Player::onPlayBackStopped()
+    {
+      XBMC_TRACE;
+    }
+
+    void Player::onPlayBackError()
     {
       XBMC_TRACE;
     }

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -257,6 +257,20 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_PlayerCB
+      /// @brief \python_func{ onPlayBackError() }
+      ///-----------------------------------------------------------------------
+      /// onPlayBackError method.
+      ///
+      /// Will be called when playback stops due to an error.
+      ///
+      onPlayBackError();
+#else
+      virtual void onPlayBackError();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_PlayerCB
       /// @brief \python_func{ onPlayBackPaused() }
       ///-----------------------------------------------------------------------
       /// onPlayBackPaused method.
@@ -715,6 +729,7 @@ namespace XBMCAddon
       SWIGHIDDENVIRTUAL void OnPlayBackStarted() override;
       SWIGHIDDENVIRTUAL void OnPlayBackEnded() override;
       SWIGHIDDENVIRTUAL void OnPlayBackStopped() override;
+      SWIGHIDDENVIRTUAL void OnPlayBackError() override;
       SWIGHIDDENVIRTUAL void OnPlayBackPaused() override;
       SWIGHIDDENVIRTUAL void OnPlayBackResumed() override;
       SWIGHIDDENVIRTUAL void OnQueueNextItem() override;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -179,6 +179,18 @@ void XBPython::OnPlayBackStopped()
   }
 }
 
+// message all registered callbacks that playback stopped due to error
+void XBPython::OnPlayBackError()
+{
+  XBMC_TRACE;
+  LOCK_AND_COPY(std::vector<PVOID>,tmp,m_vecPlayerCallbackList);
+  for (PlayerCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
+  {
+    if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList,(*it)))
+      ((IPlayerCallback*)(*it))->OnPlayBackError();
+  }
+}
+
 // message all registered callbacks that playback speed changed (FF/RW)
 void XBPython::OnPlayBackSpeedChanged(int iSpeed)
 {

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -73,6 +73,7 @@ public:
   void OnPlayBackPaused() override;
   void OnPlayBackResumed() override;
   void OnPlayBackStopped() override;
+  void OnPlayBackError() override;
   void OnPlayBackSpeedChanged(int iSpeed) override;
   void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) override;
   void OnPlayBackSeekChapter(int iChapter) override;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -161,7 +161,6 @@ void CAdvancedSettings::Initialize()
   m_DXVAForceProcessorRenderer = true;
   m_DXVAAllowHqScaling = true;
   m_videoFpsDetect = 1;
-  m_videoBusyDialogDelay_ms = 500;
 
   m_mediacodecForceSoftwareRendering = false;
 
@@ -685,10 +684,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "usedisplaycontrolhwstereo", m_useDisplayControlHWStereo);
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
-
-    // controls the delay, in milliseconds, until
-    // the busy dialog is shown when starting video playback.
-    XMLUtils::GetInt(pElement, "busydialogdelayms", m_videoBusyDialogDelay_ms, 0, 1000);
 
     // Store global display latency settings
     TiXmlElement* pVideoLatency = pElement->FirstChildElement("latency");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -190,7 +190,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVAForceProcessorRenderer;
     bool m_DXVAAllowHqScaling;
     int  m_videoFpsDetect;
-    int  m_videoBusyDialogDelay_ms;
     bool m_mediacodecForceSoftwareRendering;
 
     std::string m_videoDefaultPlayer;


### PR DESCRIPTION
Instead of blocking in OpenFile VideoPlayer always returns true and fires OnPlaybackError in case of error.