### PR TITLE
Make sure we don't overwrite path with an empty value. 

### DIFF
--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -93,7 +93,7 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
     if (m_mark)
     {
       std::string path(item->GetPath());
-      if (item->HasVideoInfoTag())
+      if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->GetPath().empty())
         path = item->GetVideoInfoTag()->GetPath();
 
       db.ClearBookMarksOfFile(path, CBookmark::RESUME);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Fixes out of library bookmark deletion on "Set as watched"

While I'm not 100% happy with this approach, this seems to be what we do in this case, see for e.g. https://github.com/xbmc/xbmc/blob/53038bb8ea815d4f19d35324eb67b1bf0a799c6b/xbmc/interfaces/json-rpc/FileItemHandler.cpp#L277

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://forum.kodi.tv/showthread.php?tid=316509

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on windows and out of library. I didn't test inside library, but I'm pretty sure it will still work.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
