### PR TITLE
[PVR] Cleanup: Remove obsolete and unused setting pvrplayback.scantime.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9990,11 +9990,7 @@ msgctxt "#19169"
 msgid "Hide video information box"
 msgstr ""
 
-#. pvr settings "playback timeout" setting label
-#: system/settings/settings.xml
-msgctxt "#19170"
-msgid "Timeout when starting playback"
-msgstr ""
+#empty string with id 19170
 
 #. pvr settings "start playback full screen" setting label
 #: system/settings/settings.xml
@@ -18158,10 +18154,7 @@ msgctxt "#36229"
 msgid "Display signal quality information in the codec information window (if supported by the add-on and backend)."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36230"
-msgid "Time to wait for a channel to be received after a channel change. Useful for over-the-air channels that occasionally lose signal strength."
-msgstr ""
+#empty string with id 36230
 
 #: system/settings/settings.xml
 msgctxt "#36231"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1393,18 +1393,6 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
-        <setting id="pvrplayback.scantime" type="integer" label="19170" help="36230">
-          <level>3</level>
-          <default>10</default>
-          <constraints>
-            <minimum>1</minimum>
-            <step>1</step>
-            <maximum>60</maximum>
-          </constraints>
-          <control type="spinner" format="string">
-            <formatlabel>14045</formatlabel>
-          </control>
-        </setting>
         <setting id="pvrplayback.confirmchannelswitch" type="boolean" label="19281" help="36231">
           <level>1</level>
           <default>true</default>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -237,7 +237,6 @@ const std::string CSettings::SETTING_EPG_IGNOREDBFORCLIENT = "epg.ignoredbforcli
 const std::string CSettings::SETTING_EPG_RESETEPG = "epg.resetepg";
 const std::string CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN = "pvrplayback.switchtofullscreen";
 const std::string CSettings::SETTING_PVRPLAYBACK_SIGNALQUALITY = "pvrplayback.signalquality";
-const std::string CSettings::SETTING_PVRPLAYBACK_SCANTIME = "pvrplayback.scantime";
 const std::string CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH = "pvrplayback.confirmchannelswitch";
 const std::string CSettings::SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT = "pvrplayback.channelentrytimeout";
 const std::string CSettings::SETTING_PVRPLAYBACK_FPS = "pvrplayback.fps";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -183,7 +183,6 @@ public:
   static const std::string SETTING_EPG_RESETEPG;
   static const std::string SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN;
   static const std::string SETTING_PVRPLAYBACK_SIGNALQUALITY;
-  static const std::string SETTING_PVRPLAYBACK_SCANTIME;
   static const std::string SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH;
   static const std::string SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT;
   static const std::string SETTING_PVRPLAYBACK_FPS;


### PR DESCRIPTION
Cleanup as followup to recent videoplayer changes.

@FernetMenta for review (we discussed this in Slack)?