### PR TITLE
 tvshowmatching: match xx.xx.xxxx as dd.mm.yyyy

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -328,7 +328,7 @@ void CAdvancedSettings::Initialize()
       false, "[\\._ -]?()e(?:p[ ._-]?)?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$");
   // foo.yyyy.mm.dd.* (byDate=true)
   m_tvshowEnumRegExps.emplace_back(true, "([0-9]{4})[\\.-]([0-1][0-9])[\\.-]([0-3][0-9])");
-  // foo.mm.dd.yyyy.* (byDate=true)
+  // foo.dd.mm.yyyy.* or foo.mm-dd-yyyy.* (byDate=true)
   m_tvshowEnumRegExps.emplace_back(true, "([0-3][0-9])[\\.-]([0-3][0-9])[\\.-]([0-9]{4})");
   // foo.1x09* or just /1x09*
   m_tvshowEnumRegExps.emplace_back(

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -327,9 +327,9 @@ void CAdvancedSettings::Initialize()
   m_tvshowEnumRegExps.emplace_back(
       false, "[\\._ -]?()e(?:p[ ._-]?)?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$");
   // foo.yyyy.mm.dd.* (byDate=true)
-  m_tvshowEnumRegExps.emplace_back(true, "([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})");
+  m_tvshowEnumRegExps.emplace_back(true, "([0-9]{4})[\\.-]([0-1][0-9])[\\.-]([0-3][0-9])");
   // foo.mm.dd.yyyy.* (byDate=true)
-  m_tvshowEnumRegExps.emplace_back(true, "([0-9]{2})[\\.-]([0-9]{2})[\\.-]([0-9]{4})");
+  m_tvshowEnumRegExps.emplace_back(true, "([0-3][0-9])[\\.-]([0-3][0-9])[\\.-]([0-9]{4})");
   // foo.1x09* or just /1x09*
   m_tvshowEnumRegExps.emplace_back(
       false, "[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$");

--- a/xbmc/utils/EpisodeUtils.cpp
+++ b/xbmc/utils/EpisodeUtils.cpp
@@ -82,8 +82,12 @@ bool GetAirDateFromRegExp(CRegExp& reg, VIDEO::EPISODE& episodeInfo)
     }
     else if (len1 == 2 && len2 == 2 && len3 == 4)
     {
+      // dd.mm.yyyy
+      if (reg.GetMatch(0)[2] == '.' && reg.GetMatch(0)[5] == '.')
+        episodeInfo.cDate.SetDate(atoi(param3.c_str()), atoi(param2.c_str()), atoi(param1.c_str()));
       // mm dd yyyy format
-      episodeInfo.cDate.SetDate(atoi(param3.c_str()), atoi(param1.c_str()), atoi(param2.c_str()));
+      else
+        episodeInfo.cDate.SetDate(atoi(param3.c_str()), atoi(param1.c_str()), atoi(param2.c_str()));
     }
   }
   return episodeInfo.cDate.IsValid();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
tvshowmatching: match xx.xx.xxxx as dd.mm.yyyy
dot separated date format normally is interpreted as dd.mm.yyyy instead of mm.dd.yyyy
<!--- Describe your change in detail -->

## Motivation and Context
fix https://trac.kodi.tv/ticket/17592
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Scraped dummy files with different date formats
- `The Daily Show/05.09.2017.strm`
- `The Daily Show/2017.09.05.strm`
- `The Daily Show/2017-09-05.strm`
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
