### PR TITLE
Open EPG instead of channel window

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -196,7 +196,7 @@
       <select>OSD</select>
       <title>PlayerProcessInfo</title>
       <info>Info</info>
-      <guide>ActivateWindow(PVRChannelGuide)</guide>
+      <guide>ActivateWindow(TVGuide)</guide>
       <teletext>ActivateWindow(Teletext)</teletext>
       <subtitle>NextSubtitle</subtitle>
       <star>NextSubtitle</star>
@@ -259,7 +259,7 @@
       <rootmenu>OSD</rootmenu>
       <start>OSD</start>
       <info>Info</info>
-      <guide>ActivateWindow(PVRChannelGuide)</guide>
+      <guide>ActivateWindow(TVGuide)</guide>
       <playlist>ActivateWindow(PVROSDChannels)</playlist>
       <zero>Number0</zero>
       <one>Number1</one>


### PR DESCRIPTION
This PR harmonizes the behaviour of the "Guide" button.
Currently, if I push the button while
- I am on the home screen, the EPG is opened
- I am watching a channel, the Channel View is opened
- I am watching a video, nothing happens

I would prefer if always the EPG is shown, even if I am already watching TV.