### PR TITLE
CSetCurrentItemJob: CFileItem instances need to by copied before they…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4171,7 +4171,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         CServiceBroker::GetPlaylistPlayer().SetCurrentSong(m_nextPlaylistItem);
         m_itemCurrentFile.reset(new CFileItem(*item));
       }
-      g_infoManager.SetCurrentItem(m_itemCurrentFile);
+      g_infoManager.SetCurrentItem(*m_itemCurrentFile);
       g_partyModeManager.OnSongChange(true);
 
       CVariant param;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -127,7 +127,8 @@ class CSetCurrentItemJob : public CJob
 {
   CFileItemPtr m_itemCurrentFile;
 public:
-  explicit CSetCurrentItemJob(const CFileItemPtr& item) : m_itemCurrentFile(item) { }
+  explicit CSetCurrentItemJob(const CFileItem& item) : m_itemCurrentFile(std::make_shared<CFileItem>(item)) { }
+
   ~CSetCurrentItemJob(void) override = default;
 
   bool DoWork(void) override
@@ -8990,7 +8991,7 @@ void CGUIInfoManager::ResetCurrentItem()
   m_currentMovieDuration = "";
 }
 
-void CGUIInfoManager::SetCurrentItem(const CFileItemPtr item)
+void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 {
   CSetCurrentItemJob *job = new CSetCurrentItemJob(item);
   CJobManager::GetInstance().AddJob(job, NULL);
@@ -11030,13 +11031,12 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
     if (!item)
       return;
 
-    CFileItemPtr itemptr(item);
     if (pMsg->param1 == 1 && item->HasMusicInfoTag()) // only grab music tag
       SetCurrentSongTag(*item->GetMusicInfoTag());
     else if (pMsg->param1 == 2 && item->HasVideoInfoTag()) // only grab video tag
       SetCurrentVideoTag(*item->GetVideoInfoTag());
     else
-      SetCurrentItem(itemptr);
+      SetCurrentItem(*item);
   }
   break;
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -151,7 +151,7 @@ public:
   /*! \brief Set currently playing file item
    \param blocking whether to run in current thread (true) or background thread (false)
    */
-  void SetCurrentItem(const CFileItemPtr item);
+  void SetCurrentItem(const CFileItem &item);
   void ResetCurrentItem();
   // Current song stuff
   /// \brief Retrieves tag info (if necessary) and fills in our current song path.

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -629,8 +629,7 @@ void CDVDRadioRDSData::ResetRDSCache()
   m_currentInfoTag = CPVRRadioRDSInfoTag::CreateDefaultTag();
   m_currentChannel = g_application.CurrentFileItem().GetPVRChannelInfoTag();
   g_application.CurrentFileItem().SetPVRRadioRDSInfoTag(m_currentInfoTag);
-  CFileItemPtr itemptr(new CFileItem(g_application.CurrentFileItem()));
-  g_infoManager.SetCurrentItem(itemptr);
+  g_infoManager.SetCurrentItem(g_application.CurrentFileItem());
 
   // send a message to all windows to tell them to update the radiotext
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
@@ -857,8 +856,7 @@ void CDVDRadioRDSData::ProcessUECP(const unsigned char *data, unsigned int len)
 
           if (m_currentFileUpdate && !m_bStop)
           {
-            CFileItemPtr itemptr(new CFileItem(g_application.CurrentFileItem()));
-            g_infoManager.SetCurrentItem(itemptr);
+            g_infoManager.SetCurrentItem(g_application.CurrentFileItem());
             m_currentFileUpdate = false;
           }
         }

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -83,7 +83,7 @@ namespace PVR
 
   void CPVRGUIChannelNavigator::SelectChannel(const CPVRChannelPtr channel, ChannelSwitchMode eSwitchMode)
   {
-    g_infoManager.SetCurrentItem(CFileItemPtr(new CFileItem(channel)));
+    g_infoManager.SetCurrentItem(CFileItem(channel));
 
     CSingleLock lock(m_critSection);
     m_currentChannel = channel;
@@ -183,7 +183,7 @@ namespace PVR
     }
 
     if (item)
-      g_infoManager.SetCurrentItem(item);
+      g_infoManager.SetCurrentItem(*item);
   }
 
   void CPVRGUIChannelNavigator::ToggleInfo()
@@ -209,7 +209,7 @@ namespace PVR
     }
 
     if (item)
-      g_infoManager.SetCurrentItem(item);
+      g_infoManager.SetCurrentItem(*item);
 
     ShowInfo(false);
   }


### PR DESCRIPTION
… can be used safely in another thread (here, the job worker thread).

@peak3d @FernetMenta we discussed this on Slack.