### PR TITLE
[video] Fix CVideoInfoTag::SetYear not to except years <= 0.

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1388,6 +1388,9 @@ void CVideoInfoTag::SetPremieredFromDBDate(std::string premieredString)
 
 void CVideoInfoTag::SetYear(int year)
 {
+  if (year <= 0)
+    return;
+
   if (m_bHasPremiered)
     m_premiered.SetDate(year, m_premiered.GetMonth(), m_premiered.GetDay());
   else

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1375,14 +1375,14 @@ void CVideoInfoTag::SetVotes(int votes, const std::string& type /* = "" */)
 
 void CVideoInfoTag::SetPremiered(CDateTime premiered)
 {
-  m_premiered = premiered;
+  m_premiered = std::move(premiered);
   m_bHasPremiered = premiered.IsValid();
 }
 
 void CVideoInfoTag::SetPremieredFromDBDate(std::string premieredString)
 {
   CDateTime premiered;
-  premiered.SetFromDBDate(premieredString);
+  premiered.SetFromDBDate(std::move(premieredString));
   SetPremiered(premiered);
 }
 


### PR DESCRIPTION
Spotted by luck, that some videos showed nonsense years in fullscreen OSD. In my case this was due to python addons setting 'zero' year at video info tags.

<pre>
(lldb) thread backtrace
* thread #41, stop reason = breakpoint 1.1
  * frame #0: 0x000000010218e2c1 kodi.bin`CVideoInfoTag::SetYear(this=0x000000010f4afa00, year=0) at VideoInfoTag.cpp:1392
    frame #1: 0x000000010125a92f kodi.bin`XBMCAddon::xbmcgui::ListItem::setInfo(this=0x0000000130a371b0, type="Video", infoLabels=0x000070000b6f4758) at ListItem.cpp:359
    frame #2: 0x00000001001467e8 kodi.bin`PythonBindings::xbmcgui_XBMCAddon_xbmcgui_ListItem_setInfo(self=0x0000000129264af0, args=0x000000011b6dafd0, kwds=0x000000011bf5dae0) at AddonModuleXbmcgui.i.cpp:1726
    frame #3: 0x000000010365dba1 kodi.bin`PyCFunction_Call(func=0x0000000130265230, arg=0x000000011b6dafd0, kw=0x000000011bf5dae0) at methodobject.c:85
    frame #4: 0x00000001036ffcc3 kodi.bin`do_call(func=0x0000000130265230, pp_stack=0x000070000b6f4d50, na=0, nk=2) at ceval.c:4566
    frame #5: 0x00000001036fde56 kodi.bin`call_function(pp_stack=0x000070000b6f4d50, oparg=512) at ceval.c:4374
    frame #6: 0x00000001036f9e4e kodi.bin`PyEval_EvalFrameEx(f=0x0000000130a38180, throwflag=0) at ceval.c:2989
    frame #7: 0x00000001036f3f35 kodi.bin`PyEval_EvalCodeEx(co=0x000000012b8e6a70, globals=0x0000000127e72a20, locals=0x0000000000000000, args=0x000000010ab73b28, argcount=4, kws=0x000000010ab73b48, kwcount=0, defs=0x000000010ab2ae08, defcount=8, closure=0x0000000000000000) at ceval.c:3584
    frame #8: 0x00000001036ffab5 kodi.bin`fast_function(func=0x000000010ab0f670, pp_stack=0x000070000b6f53f0, n=4, na=4, nk=0) at ceval.c:4447
    frame #9: 0x00000001036fde3a kodi.bin`call_function(pp_stack=0x000070000b6f53f0, oparg=4) at ceval.c:4372
    frame #10: 0x00000001036f9e4e kodi.bin`PyEval_EvalFrameEx(f=0x000000010ab73960, throwflag=0) at ceval.c:2989
    frame #11: 0x00000001036ff9b1 kodi.bin`fast_function(func=0x000000010ab563a0, pp_stack=0x000070000b6f5840, n=0, na=0, nk=0) at ceval.c:4437
    frame #12: 0x00000001036fde3a kodi.bin`call_function(pp_stack=0x000070000b6f5840, oparg=0) at ceval.c:4372
    frame #13: 0x00000001036f9e4e kodi.bin`PyEval_EvalFrameEx(f=0x0000000126a927e0, throwflag=0) at ceval.c:2989
    frame #14: 0x00000001036f3f35 kodi.bin`PyEval_EvalCodeEx(co=0x0000000126a26e50, globals=0x0000000127e72a20, locals=0x0000000127e72a20, args=0x0000000000000000, argcount=0, kws=0x0000000000000000, kwcount=0, defs=0x0000000000000000, defcount=0, closure=0x0000000000000000) at ceval.c:3584
    frame #15: 0x00000001036f2e45 kodi.bin`PyEval_EvalCode(co=0x0000000126a26e50, globals=0x0000000127e72a20, locals=0x0000000127e72a20) at ceval.c:669
    frame #16: 0x000000010372fab2 kodi.bin`run_mod(mod=0x000000010a410b60, filename="/Users/kai/Library/Application Support/Kodi/addons/plugin.video.nasa/addon.py", globals=0x0000000127e72a20, locals=0x0000000127e72a20, flags=0x0000000000000000, arena=0x0000000127e5a610) at pythonrun.c:1376
    frame #17: 0x000000010372fe8f kodi.bin`PyRun_FileExFlags(fp=0x0000000109c878b0, filename="/Users/kai/Library/Application Support/Kodi/addons/plugin.video.nasa/addon.py", start=257, globals=0x0000000127e72a20, locals=0x0000000127e72a20, closeit=1, flags=0x0000000000000000) at pythonrun.c:1362
    frame #18: 0x00000001012b1a39 kodi.bin`CPythonInvoker::executeScript(this=0x00000001289116c0, fp=0x0000000109c878b0, script="/Users/kai/Library/Application Support/Kodi/addons/plugin.video.nasa/addon.py", module=0x0000000126bebd80, moduleDict=0x0000000127e72a20) at PythonInvoker.cpp:443
    frame #19: 0x00000001012ad027 kodi.bin`CPythonInvoker::execute(this=0x00000001289116c0, script="/Users/kai/Library/Application Support/Kodi/addons/plugin.video.nasa/addon.py", arguments=size=4) at PythonInvoker.cpp:301
    frame #20: 0x00000001010d5233 kodi.bin`ILanguageInvoker::Execute(this=0x00000001289116c0, script="/Users/kai/Library/Application Support/Kodi/addons/plugin.video.nasa/addon.py", arguments=size=4) at ILanguageInvoker.cpp:40
    frame #21: 0x00000001012aa57d kodi.bin`CPythonInvoker::Execute(this=0x00000001289116c0, script="/Users/kai/Library/Application Support/Kodi/addons/plugin.video.nasa/addon.py", arguments=size=4) at PythonInvoker.cpp:155
    frame #22: 0x00000001010d5efc kodi.bin`CLanguageInvokerThread::Process(this=0x000000011bc71760) at LanguageInvokerThread.cpp:91
    frame #23: 0x00000001010d5f29 kodi.bin`non-virtual thunk to CLanguageInvokerThread::Process(this=0x000000011bc71760) at LanguageInvokerThread.cpp:0
    frame #24: 0x0000000101cc7390 kodi.bin`CThread::Action(this=0x000000011bc71760) at Thread.cpp:221
    frame #25: 0x0000000101cc59d9 kodi.bin`CThread::staticThread(data=0x000000011bc71760) at Thread.cpp:131
    frame #26: 0x0000000107d6ab90 libsystem_pthread.dylib`_pthread_body + 180
    frame #27: 0x0000000107d6aadc libsystem_pthread.dylib`_pthread_start + 286
    frame #28: 0x0000000107d6a2c5 libsystem_pthread.dylib`thread_start + 13
(lldb) 
</pre> 

With this PR, setting years <= 0 at video info tags will be prevented.

Before:

![screenshot001](https://user-images.githubusercontent.com/3226626/30668685-cdbb6ea2-9e5b-11e7-8bb9-2891a266517f.png)

After:

![screenshot000](https://user-images.githubusercontent.com/3226626/30668695-d50b882c-9e5b-11e7-8ba0-459fd3a4e06e.png)

The second commit is just a small (unrelated) optimization.
