### PR TITLE
VideoPlayer: send cb notifications on exit via a job

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2455,12 +2455,17 @@ void CVideoPlayer::OnExit()
   CFFmpegLog::ClearLogLevel();
   m_bStop = true;
 
-  if (m_error)
-    m_callback.OnPlayBackError();
-  else if (m_bAbortRequest)
-    m_callback.OnPlayBackStopped();
-  else
-    m_callback.OnPlayBackEnded();
+  IPlayerCallback *cb = &m_callback;
+  bool error = m_error;
+  bool abort = m_bAbortRequest;
+  CJobManager::GetInstance().Submit([=]() {
+    if (error)
+      cb->OnPlayBackError();
+    else if (abort)
+      cb->OnPlayBackStopped();
+    else
+      cb->OnPlayBackEnded();
+  }, CJob::PRIORITY_NORMAL);
 }
 
 void CVideoPlayer::HandleMessages()


### PR DESCRIPTION
Works around a deadlock situation caused by one of Kodi's biggest design flaws. The issue has been around forever but changes like #10893 made it even worse. GUI interactions or usage of AppMessenger require the main thread. When the mainthread originates a synchronous call of actions and one of those actions use AppMessenger, we deadlock:

Example:
- user presses stop playback
- mainthread deletes player object
- delete is synchronous, it has to wait for threads to exit

If one of those threads sends a synchronous message to AppMessenger (SendMsg), the app is dead. 