### PR TITLE
[Krypton] VideoPlayer: fixes for audio delay

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -212,7 +212,12 @@ float CEngineStats::GetCacheTime(CActiveAEStream *stream)
   return delay;
 }
 
-float CEngineStats::GetCacheTotal(CActiveAEStream *stream)
+float CEngineStats::GetCacheTotal()
+{
+  return MAX_CACHE_LEVEL;
+}
+
+float CEngineStats::GetMaxDelay()
 {
   return MAX_CACHE_LEVEL + m_sinkCacheTotal;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -190,7 +190,8 @@ public:
   void GetDelay(AEDelayStatus& status, CActiveAEStream *stream);
   void GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream);
   float GetCacheTime(CActiveAEStream *stream);
-  float GetCacheTotal(CActiveAEStream *stream);
+  float GetCacheTotal();
+  float GetMaxDelay();
   float GetWaterLevel();
   void SetSuspended(bool state);
   void SetDSP(bool state);
@@ -285,7 +286,8 @@ protected:
   void GetDelay(AEDelayStatus& status, CActiveAEStream *stream) { m_stats.GetDelay(status, stream); }
   void GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream) { m_stats.GetSyncInfo(info, stream); }
   float GetCacheTime(CActiveAEStream *stream) { return m_stats.GetCacheTime(stream); }
-  float GetCacheTotal(CActiveAEStream *stream) { return m_stats.GetCacheTotal(stream); }
+  float GetCacheTotal() { return m_stats.GetCacheTotal(); }
+  float GetMaxDelay() { return m_stats.GetMaxDelay(); }
   void FlushStream(CActiveAEStream *stream);
   void PauseStream(CActiveAEStream *stream, bool pause);
   void StopSound(CActiveAESound *sound);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -368,7 +368,12 @@ double CActiveAEStream::GetCacheTime()
 
 double CActiveAEStream::GetCacheTotal()
 {
-  return AE.GetCacheTotal(this);
+  return AE.GetCacheTotal();
+}
+
+double CActiveAEStream::GetMaxDelay()
+{
+  return AE.GetMaxDelay();
 }
 
 void CActiveAEStream::Pause()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -145,6 +145,7 @@ public:
   virtual bool IsBuffering();
   virtual double GetCacheTime();
   virtual double GetCacheTotal();
+  virtual double GetMaxDelay();
 
   virtual void Pause();
   virtual void Resume();

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -116,6 +116,12 @@ public:
   virtual double GetCacheTotal() = 0;
 
   /**
+   * Returns the total time in seconds of maximum delay
+   * @return seconds
+   */
+  virtual double GetMaxDelay() = 0;
+
+  /**
    * Pauses the stream playback
    */
   virtual void Pause() = 0;

--- a/xbmc/cores/VideoPlayer/DVDAudio.cpp
+++ b/xbmc/cores/VideoPlayer/DVDAudio.cpp
@@ -278,6 +278,14 @@ double CDVDAudio::GetCacheTotal()
   return m_pAudioStream->GetCacheTotal();
 }
 
+double CDVDAudio::GetMaxDelay()
+{
+  CSingleLock lock (m_critSection);
+  if (!m_pAudioStream)
+    return 0.0;
+  return m_pAudioStream->GetMaxDelay();
+}
+
 double CDVDAudio::GetPlayingPts()
 {
   if (m_playingPts == DVD_NOPTS_VALUE)

--- a/xbmc/cores/VideoPlayer/DVDAudio.h
+++ b/xbmc/cores/VideoPlayer/DVDAudio.h
@@ -56,7 +56,8 @@ public:
   unsigned int AddPackets(const DVDAudioFrame &audioframe);
   double GetPlayingPts();
   double GetCacheTime();
-  double GetCacheTotal(); // returns total amount the audio device can buffer
+  double GetCacheTotal(); // returns total time a stream can buffer
+  double GetMaxDelay(); // returns total time of audio in AE for the stream
   double GetDelay(); // returns the time it takes to play a packet if we add one at this time
   double GetSyncError();
   void SetSyncErrorCorrection(double correction);


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/12814

Run-time tested on Linux x86_64, kernel 4.12.14, Haswell i3-4330T using an audio sink provided by Pulseaudio 11.1. This fixes audio muted for approx. 10s after skipping in streams.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
