### PR TITLE
AE: fix pause bursts

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -929,6 +929,7 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
 
   if (m_requestedFormat.m_dataFormat == AE_FMT_RAW)
   {
+    bool skipSwap = false;
     if (m_needIecPack)
     {
       if (frames > 0)
@@ -962,7 +963,8 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
       {
         // construct a pause burst if we have already output valid audio
         bool burst = m_extStreaming && (m_packer->GetBuffer()[0] != 0);
-        m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms, burst);
+        if (!m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms, burst))
+          skipSwap = true;
       }
       else
         m_packer->Reset();
@@ -978,7 +980,8 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
         case SKIP_SWAP:
           break;
         case NEED_BYTESWAP:
-          Endian_Swap16_buf((uint16_t *)buffer[0], (uint16_t *)buffer[0], size / 2);
+          if (!skipSwap)
+            Endian_Swap16_buf((uint16_t *)buffer[0], (uint16_t *)buffer[0], size / 2);
           break;
         case CHECK_SWAP:
           SwapInit(samples);

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -93,11 +93,11 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
   }
 }
 
-void CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts)
+bool CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts)
 {
   // re-use last buffer
   if (m_pauseDuration == millis)
-    return;
+    return false;
 
   switch (info.m_type)
   {
@@ -125,6 +125,8 @@ void CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, boo
   {
     memset(m_packedBuffer, 0, m_dataSize);
   }
+
+  return true;
 }
 
 unsigned int CAEBitstreamPacker::GetSize()

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -33,7 +33,7 @@ public:
   ~CAEBitstreamPacker();
 
   void Pack(CAEStreamInfo &info, uint8_t* data, int size);
-  void PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts);
+  bool PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts);
   void Reset();
   uint8_t* GetBuffer();
   unsigned int GetSize();

--- a/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.cpp
@@ -239,7 +239,8 @@ int CAEPackIEC61937::PackPause(uint8_t *dest, unsigned int millis, unsigned int 
     memcpy(dest+i*periodInBytes, dest, periodInBytes);
   }
 
-  packet->m_data[1] = (gap & 0x00FF) << 8;
-  packet->m_data[0] = (gap & 0xFF00) >> 8;
+  uint16_t *gapPtr = reinterpret_cast<uint16_t*>(packet->m_data);
+  *gapPtr = gap;
+
   return periodsNeeded * periodInBytes;
 }


### PR DESCRIPTION
Done by Fernet months ago. This change fixes pause bursts IEC package creation. Especially my AVR (Denon X1300W) went to "unknown" format on stream start or on seek as the old pause bursts were plain wrong and confused the AVR.