### PR TITLE
[PVR] Fix channel OSD dialog channel preselection.

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -59,14 +59,13 @@ namespace PVR
     void ShowInfo(int item);
     void Clear();
     void Update();
-    CPVRChannelGroupPtr GetPlayingGroup();
+    void SaveSelectedItemPath(int iGroupID);
+    std::string GetLastSelectedItemPath(int iGroupID) const;
 
     CFileItemList *m_vecItems;
     CGUIViewControl m_viewControl;
     CPVRChannelGroupPtr m_group;
     std::map<int, std::string> m_groupSelectedItemPaths;
-    void SaveSelectedItemPath(int iGroupID);
-    std::string GetLastSelectedItemPath(int iGroupID) const;
     XbmcThreads::EndTime m_refreshTimeout;
   };
 }


### PR DESCRIPTION
This fixes a problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=298462&pid=2649281#pid2649281 ff

As channel switching is asynchronous, the currently playing channel group cannot be obtained safely directly after triggering the channel switch. If channel switching takes some time, there will be not yet a new playing channel  group. Furthermore, resetting `m_group` in `CGUIDialogPVRChannelsOSD::GotoChannel` is not needed at all, as the new channel will always be from the same group as the old channel. 

OTOH, `m_group` must be set when an actual channel group switch occurs in `CGUIDialogPVRChannelsOSD::OnAction`. This was missing.

@xhaggi for review?

@MilhouseVH this needs to be runtime tested by the bug reporters. Can you please include this PR in your next build?