### PR TITLE
Linux: add missing wrapper functions to fix playing DVD folders over network

### DIFF
--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -406,6 +406,11 @@ int __wrap_stat(const char *path, struct _stat *buffer)
   return dll_stat(path, buffer);
 }
 
+int __wrap___xstat(int __ver, const char *__filename, struct stat *__stat_buf)
+{
+  return dll_stat(__filename, __stat_buf);
+}
+
 int __wrap___xstat64(int __ver, const char *__filename, struct stat64 *__stat_buf)
 {
   return dll_stat64(__filename, __stat_buf);
@@ -434,6 +439,11 @@ void __wrap_funlockfile(FILE *file)
 int __wrap___fxstat64(int ver, int fd, struct stat64 *buf)
 {
   return dll_fstat64(fd, buf);
+}
+
+int __wrap___fxstat(int ver, int fd, struct stat *buf)
+{
+  return dll_fstat(fd, buf);
 }
 
 int __wrap_fstat(int fd, struct _stat *buf)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
__xstat() and __fxstat() are referenced from built libdvdnav-x86_64-linux.so bypassing the VFS. Adding __wrap___xstat() and _wrap___fxstat() to wrapper.c

## Description / Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Latest bug report is [https://forum.kodi.tv/showthread.php?tid=321465](https://forum.kodi.tv/showthread.php?tid=321465)

The bug can be reproduced with [Kodi 18 Ubuntu 16.04 nightly](http://sprunge.us/iNef) showing
```
01:27:06.438 T:140357732099840    INFO:   msg: libdvdnav: Using dvdnav version 5.0.4
01:27:06.438 T:140357732099840    INFO:   msg: libdvdread: Could not open smb://HTPC/Videos/dvd_menu_test with libdvdcss.
01:27:06.438 T:140357732099840    INFO:   msg: libdvdread: Can't open smb://HTPC/Videos/dvd_menu_test for reading
01:27:06.438 T:140357732099840   DEBUG: libdvdnav: vm: failed to open/read the DVD
01:27:06.438 T:140357732099840   ERROR: Error on dvdnav_open
01:27:06.438 T:140357732099840   ERROR: CVideoPlayer::OpenInputStream - error opening [smb://HTPC/Videos/dvd_menu_test/VIDEO_TS/VIDEO_TS.IFO]
```

Strace shows `stat("smb://HTPC/Videos/dvd_menu_test", 0x7fc5bd7f9270) = -1 ENOENT`, VFS is not used to access the DVD folder.

`objdump -R libdvdnav-x86_64-linux.so` lists the missing stat references:
```
0000000000039098 R_X86_64_JUMP_SLOT  __xstat@GLIBC_2.2.5
0000000000039130 R_X86_64_JUMP_SLOT  __fxstat@GLIBC_2.2.5
```

interestingly Milhouse Generic LE Testbuilds are not affected by the bug, maybe because of using glibc 2.26/gcc 7.2.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

DVD folders over network can be played after adding the wrapper functions to my LE 8.2/Kodi 17.4 build.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
