### PR TITLE
[music] SortByTrackNumber as default sort for "songs"

### DIFF
--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -47,7 +47,7 @@ CViewStateSettings::CViewStateSettings()
 {
   AddViewState("musicnavartists");
   AddViewState("musicnavalbums");
-  AddViewState("musicnavsongs");
+  AddViewState("musicnavsongs", DEFAULT_VIEW_LIST, SortByTrackNumber);
   AddViewState("musiclastfm");
   AddViewState("videonavactors");
   AddViewState("videonavyears");


### PR DESCRIPTION
The most natural default sort order for viewing songs is track number. But on a clean installation "songs" nodes are currently sorted by file name, and this catches a number of users out. Many get very confused because the name my include a track number, so the odd sorting only shows up when they come to a multiple disc album e.g. have two track 01s next to each other.

A trivial change @jjd-uk  requested, and makes sense to me.