### PR TITLE
[addons] remove the CAddonMgr::GetInstance() usage

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1410,13 +1410,13 @@ void CApplication::OnSettingAction(std::shared_ptr<const CSetting> setting)
   else if (settingId == CSettings::SETTING_SCREENSAVER_SETTINGS)
   {
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE), addon, ADDON_SCREENSAVER))
+    if (CServiceBroker::GetAddonMgr().GetAddon(m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE), addon, ADDON_SCREENSAVER))
       CGUIDialogAddonSettings::ShowForAddon(addon);
   }
   else if (settingId == CSettings::SETTING_AUDIOCDS_SETTINGS)
   {
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(m_ServiceManager->GetSettings().GetString(CSettings::SETTING_AUDIOCDS_ENCODER), addon, ADDON_AUDIOENCODER))
+    if (CServiceBroker::GetAddonMgr().GetAddon(m_ServiceManager->GetSettings().GetString(CSettings::SETTING_AUDIOCDS_ENCODER), addon, ADDON_AUDIOENCODER))
       CGUIDialogAddonSettings::ShowForAddon(addon);
   }
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION)
@@ -1561,7 +1561,7 @@ bool CApplication::LoadSkin(const std::string& skinID)
   SkinPtr skin;
   {
     AddonPtr addon;
-    if (!CAddonMgr::GetInstance().GetAddon(skinID, addon, ADDON_SKIN))
+    if (!CServiceBroker::GetAddonMgr().GetAddon(skinID, addon, ADDON_SKIN))
       return false;
     skin = std::static_pointer_cast<ADDON::CSkinInfo>(addon);
   }
@@ -3016,7 +3016,7 @@ bool CApplication::PlayMedia(const CFileItem& item, const std::string &player, i
   if (path.GetProtocol() == "game")
   {
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(path.GetHostName(), addon, ADDON_GAMEDLL))
+    if (CServiceBroker::GetAddonMgr().GetAddon(path.GetHostName(), addon, ADDON_GAMEDLL))
     {
       CFileItem addonItem(addon);
       return PlayFile(addonItem, player, false) == PLAYBACK_OK;
@@ -4047,7 +4047,7 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
   }
   else if (m_screensaverIdInUse.empty())
     return;
-  else if (CAddonMgr::GetInstance().GetAddon(m_screensaverIdInUse, m_pythonScreenSaver, ADDON_SCREENSAVER))
+  else if (CServiceBroker::GetAddonMgr().GetAddon(m_screensaverIdInUse, m_pythonScreenSaver, ADDON_SCREENSAVER))
   {
     std::string libPath = m_pythonScreenSaver->LibPath();
     if (CScriptInvocationManager::GetInstance().HasLanguageInvoker(libPath))

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -58,7 +58,7 @@ bool CContextMenuItem::Execute(const CFileItemPtr& item) const
     return false;
 
   ADDON::AddonPtr addon;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddon(m_addonId, addon))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(m_addonId, addon))
     return false;
 
 #ifdef HAS_PYTHON

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6706,7 +6706,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     {
       AddonPtr addon;
       strLabel = CServiceBroker::GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION);
-      if (CAddonMgr::GetInstance().GetAddon(strLabel,addon) && addon)
+      if (CServiceBroker::GetAddonMgr().GetAddon(strLabel,addon) && addon)
         strLabel = addon->Name();
     }
     break;
@@ -7673,7 +7673,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
       case SYSTEM_HAS_ADDON:
       {
         AddonPtr addon;
-        bReturn = CAddonMgr::GetInstance().GetAddon(m_stringParameters[info.GetData1()],addon) && addon;
+        bReturn = CServiceBroker::GetAddonMgr().GetAddon(m_stringParameters[info.GetData1()],addon) && addon;
         break;
       }
       case CONTAINER_SCROLL_PREVIOUS:
@@ -8137,9 +8137,9 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
     // in the future.
     AddonPtr addon;
     if (info.GetData2() == 0)
-      CAddonMgr::GetInstance().GetAddon(const_cast<CGUIInfoManager*>(this)->GetLabel(info.GetData1(), contextWindow),addon,ADDON_UNKNOWN,false);
+      CServiceBroker::GetAddonMgr().GetAddon(const_cast<CGUIInfoManager*>(this)->GetLabel(info.GetData1(), contextWindow),addon,ADDON_UNKNOWN,false);
     else
-      CAddonMgr::GetInstance().GetAddon(m_stringParameters[info.GetData1()],addon,ADDON_UNKNOWN,false);
+      CServiceBroker::GetAddonMgr().GetAddon(m_stringParameters[info.GetData1()],addon,ADDON_UNKNOWN,false);
     if (addon && info.m_info == SYSTEM_ADDON_TITLE)
       return addon->Name();
     if (addon && info.m_info == SYSTEM_ADDON_ICON)
@@ -10433,7 +10433,7 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (item->GetAddonInfo()->Origin() == ORIGIN_SYSTEM)
         return g_localizeStrings.Get(24992);
       AddonPtr origin;
-      if (CAddonMgr::GetInstance().GetAddon(item->GetAddonInfo()->Origin(), origin, ADDON_UNKNOWN, false))
+      if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->Origin(), origin, ADDON_UNKNOWN, false))
         return origin->Name();
       return g_localizeStrings.Get(13205);
     }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -651,7 +651,7 @@ LanguageResourcePtr CLangInfo::GetLanguageAddon(const std::string& locale /* = "
     addonId = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_LANGUAGE);
 
   ADDON::AddonPtr addon;
-  if (ADDON::CAddonMgr::GetInstance().GetAddon(addonId, addon, ADDON::ADDON_RESOURCE_LANGUAGE, true) && addon != NULL)
+  if (CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON::ADDON_RESOURCE_LANGUAGE, true) && addon != NULL)
     return std::dynamic_pointer_cast<ADDON::CLanguageResource>(addon);
 
   return NULL;
@@ -672,13 +672,13 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
     language = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_LANGUAGE);
 
   ADDON::AddonPtr addon;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
   {
     CLog::Log(LOGWARNING, "CLangInfo: could not find language add-on '%s', loading default..", language.c_str());
     language = std::static_pointer_cast<const CSettingString>(CServiceBroker::GetSettings().GetSetting(
         CSettings::SETTING_LOCALE_LANGUAGE))->GetDefault();
 
-    if (!ADDON::CAddonMgr::GetInstance().GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
+    if (!CServiceBroker::GetAddonMgr().GetAddon(language, addon, ADDON::ADDON_RESOURCE_LANGUAGE, false))
     {
       CLog::Log(LOGFATAL, "CLangInfo: could not find default language add-on '%s'", language.c_str());
       return false;
@@ -700,7 +700,7 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   }
 
   ADDON::VECADDONS addons;
-  if (ADDON::CAddonMgr::GetInstance().GetInstalledAddons(addons))
+  if (CServiceBroker::GetAddonMgr().GetInstalledAddons(addons))
   {
     auto locale = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_LANGUAGE);
     for (const auto& addon : addons)
@@ -1123,7 +1123,7 @@ void CLangInfo::SettingOptionsLanguageNamesFiller(SettingConstPtr setting, std::
 {
   // find languages...
   ADDON::VECADDONS addons;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddons(addons, ADDON::ADDON_RESOURCE_LANGUAGE))
+  if (!CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON::ADDON_RESOURCE_LANGUAGE))
     return;
 
   for (ADDON::VECADDONS::const_iterator addon = addons.begin(); addon != addons.end(); ++addon)

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -22,6 +22,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "NfoFile.h"
+#include "ServiceBroker.h"
 #include "video/VideoInfoDownloader.h"
 #include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
@@ -99,7 +100,7 @@ CNfoFile::NFOResult CNfoFile::Create(const std::string& strPath,
 
   // Add all scrapers except selected and default
   VECADDONS addons;
-  CAddonMgr::GetInstance().GetAddons(addons, m_type);
+  CServiceBroker::GetAddonMgr().GetAddons(addons, m_type);
 
   for (unsigned i = 0; i < addons.size(); ++i)
   {

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -203,7 +203,7 @@ void CAddon::SaveSettings(void)
   m_hasUserSettings = true;
   
   //push the settings changes to the running addon instance
-  CAddonMgr::GetInstance().ReloadSettings(ID());
+  CServiceBroker::GetAddonMgr().ReloadSettings(ID());
 #ifdef HAS_PYTHON
   g_pythonParser.OnSettingsChanged(ID());
 #endif

--- a/xbmc/addons/AddonBuilder.cpp
+++ b/xbmc/addons/AddonBuilder.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "ServiceBroker.h"
 #include "addons/AddonBuilder.h"
 #include "addons/ContextMenuAddon.h"
 #include "addons/GameResource.h"
@@ -67,7 +68,7 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
   {
     // built in screensaver or python screensaver
     if (StringUtils::StartsWithNoCase(m_extPoint->plugin->identifier, "screensaver.xbmc.builtin.") ||
-        URIUtils::HasExtension(CAddonMgr::GetInstance().GetExtValue(m_extPoint->configuration, "@library"), ".py"))
+        URIUtils::HasExtension(CServiceBroker::GetAddonMgr().GetExtValue(m_extPoint->configuration, "@library"), ".py"))
       return std::make_shared<CAddon>(std::move(m_addonInfo));
   }
 
@@ -92,7 +93,7 @@ std::shared_ptr<IAddon> CAddonBuilder::Build()
       type == ADDON_PERIPHERALDLL ||
       type == ADDON_GAMEDLL)
   {
-    std::string value = CAddonMgr::GetInstance().GetPlatformLibraryName(m_extPoint->plugin->extensions->configuration);
+    std::string value = CServiceBroker::GetAddonMgr().GetPlatformLibraryName(m_extPoint->plugin->extensions->configuration);
     if (value.empty())
       return AddonPtr();
   }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -167,7 +167,7 @@ bool CAddonInstaller::InstallModal(const std::string &addonID, ADDON::AddonPtr &
     return false;
 
   // we assume that addons that are enabled don't get to this routine (i.e. that GetAddon() has been called)
-  if (CAddonMgr::GetInstance().GetAddon(addonID, addon, ADDON_UNKNOWN, false))
+  if (CServiceBroker::GetAddonMgr().GetAddon(addonID, addon, ADDON_UNKNOWN, false))
     return false; // addon is installed but disabled, and the user has specifically activated something that needs
                   // the addon - should we enable it?
 
@@ -190,7 +190,7 @@ bool CAddonInstaller::InstallModal(const std::string &addonID, ADDON::AddonPtr &
   if (!InstallOrUpdate(addonID, false, true))
     return false;
 
-  return CAddonMgr::GetInstance().GetAddon(addonID, addon);
+  return CServiceBroker::GetAddonMgr().GetAddon(addonID, addon);
 }
 
 
@@ -217,7 +217,7 @@ void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& ve
     return;
 
   AddonPtr repo;
-  if (!CAddonMgr::GetInstance().GetAddon(repoId, repo, ADDON_REPOSITORY))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(repoId, repo, ADDON_REPOSITORY))
     return;
 
   std::string hash;
@@ -287,7 +287,7 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   }
 
   AddonPtr addon;
-  if (CAddonMgr::GetInstance().LoadAddonDescription(items[0]->GetPath(), addon))
+  if (CServiceBroker::GetAddonMgr().LoadAddonDescription(items[0]->GetPath(), addon))
     return DoInstall(addon, RepositoryPtr());
 
   CEventLog::GetInstance().AddWithNotification(EventPtr(new CNotificationEvent(24045,
@@ -330,7 +330,7 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon,
     const AddonVersion &version = i->second.first;
     bool optional = i->second.second;
     AddonPtr dep;
-    bool haveAddon = CAddonMgr::GetInstance().GetAddon(addonID, dep);
+    bool haveAddon = CServiceBroker::GetAddonMgr().GetAddon(addonID, dep);
     if ((haveAddon && !dep->MeetsVersion(version)) || (!haveAddon && !optional))
     {
       // we have it but our version isn't good enough, or we don't have it and we need it
@@ -427,10 +427,10 @@ void CAddonInstaller::PrunePackageCache()
 
 void CAddonInstaller::InstallUpdates()
 {
-  auto updates = CAddonMgr::GetInstance().GetAvailableUpdates();
+  auto updates = CServiceBroker::GetAddonMgr().GetAvailableUpdates();
   for (const auto& addon : updates)
   {
-    if (!CAddonMgr::GetInstance().IsBlacklisted(addon->ID()))
+    if (!CServiceBroker::GetAddonMgr().IsBlacklisted(addon->ID()))
     {
       AddonPtr toInstall;
       RepositoryPtr repo;
@@ -482,17 +482,17 @@ CAddonInstallJob::CAddonInstallJob(const AddonPtr &addon, const AddonPtr &repo,
     m_isAutoUpdate(isAutoUpdate)
 {
   AddonPtr dummy;
-  m_isUpdate = CAddonMgr::GetInstance().GetAddon(addon->ID(), dummy, ADDON_UNKNOWN, false);
+  m_isUpdate = CServiceBroker::GetAddonMgr().GetAddon(addon->ID(), dummy, ADDON_UNKNOWN, false);
 }
 
 bool CAddonInstallJob::GetAddonWithHash(const std::string& addonID, RepositoryPtr& repo,
     ADDON::AddonPtr& addon, std::string& hash)
 {
-  if (!CAddonMgr::GetInstance().FindInstallableById(addonID, addon))
+  if (!CServiceBroker::GetAddonMgr().FindInstallableById(addonID, addon))
     return false;
 
   AddonPtr tmp;
-  if (!CAddonMgr::GetInstance().GetAddon(addon->Origin(), tmp, ADDON_REPOSITORY))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addon->Origin(), tmp, ADDON_REPOSITORY))
     return false;
 
   repo = std::static_pointer_cast<CRepository>(tmp);
@@ -588,7 +588,7 @@ bool CAddonInstallJob::DoWork()
       AddonPtr temp;
       if (!CDirectory::GetDirectory(archive, archivedFiles) ||
           archivedFiles.Size() != 1 || !archivedFiles[0]->m_bIsFolder ||
-          !CAddonMgr::GetInstance().LoadAddonDescription(archivedFiles[0]->GetPath(), temp))
+          !CServiceBroker::GetAddonMgr().LoadAddonDescription(archivedFiles[0]->GetPath(), temp))
       {
         CLog::Log(LOGERROR, "CAddonInstallJob[%s]: invalid package %s", m_addon->ID().c_str(), package.c_str());
         db.RemovePackage(package);
@@ -615,8 +615,8 @@ bool CAddonInstallJob::DoWork()
     return false;
 
   // Load new installed and if successed replace defined m_addon here with new one
-  if (!CAddonMgr::GetInstance().LoadAddon(m_addon->ID()) ||
-      !CAddonMgr::GetInstance().GetAddon(m_addon->ID(), m_addon))
+  if (!CServiceBroker::GetAddonMgr().LoadAddon(m_addon->ID()) ||
+      !CServiceBroker::GetAddonMgr().GetAddon(m_addon->ID(), m_addon))
   {
     CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to reload addon", m_addon->ID().c_str());
     return false;
@@ -643,7 +643,7 @@ bool CAddonInstallJob::DoWork()
   if (m_isAutoUpdate && !m_addon->Broken().empty())
   {
     CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: auto-disabling due to being marked as broken", m_addon->ID().c_str());
-    CAddonMgr::GetInstance().DisableAddon(m_addon->ID());
+    CServiceBroker::GetAddonMgr().DisableAddon(m_addon->ID());
     CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(m_addon, 24094)), true, false);
   }
 
@@ -720,7 +720,7 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& r
       const AddonVersion &version = it->second.first;
       bool optional = it->second.second;
       AddonPtr dependency;
-      bool haveAddon = CAddonMgr::GetInstance().GetAddon(addonID, dependency, ADDON_UNKNOWN, false);
+      bool haveAddon = CServiceBroker::GetAddonMgr().GetAddon(addonID, dependency, ADDON_UNKNOWN, false);
       if ((haveAddon && !dependency->MeetsVersion(version)) || (!haveAddon && !optional))
       {
         // we have it but our version isn't good enough, or we don't have it and we need it
@@ -733,7 +733,7 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& r
           while (CAddonInstaller::GetInstance().HasJob(addonID))
             Sleep(50);
 
-          if (!CAddonMgr::GetInstance().IsAddonInstalled(addonID))
+          if (!CServiceBroker::GetAddonMgr().IsAddonInstalled(addonID))
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to install dependency %s", m_addon->ID().c_str(), addonID.c_str());
             ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
@@ -811,7 +811,7 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
   if (addon != NULL)
   {
     AddonPtr addon2;
-    CAddonMgr::GetInstance().GetAddon(addonID, addon2);
+    CServiceBroker::GetAddonMgr().GetAddon(addonID, addon2);
     if (msg.empty())
       msg = g_localizeStrings.Get(addon2 != NULL ? 113 : 114);
 
@@ -842,7 +842,7 @@ bool CAddonUnInstallJob::DoWork()
 
   //Unregister addon with the manager to ensure nothing tries
   //to interact with it while we are uninstalling.
-  if (!CAddonMgr::GetInstance().UnloadAddon(m_addon->ID()))
+  if (!CServiceBroker::GetAddonMgr().UnloadAddon(m_addon->ID()))
   {
     CLog::Log(LOGERROR, "CAddonUnInstallJob[%s]: failed to unload addon.", m_addon->ID().c_str());
     return false;
@@ -867,7 +867,7 @@ bool CAddonUnInstallJob::DoWork()
     addon = m_addon;
   CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24144)));
 
-  CAddonMgr::GetInstance().OnPostUnInstall(m_addon->ID());
+  CServiceBroker::GetAddonMgr().OnPostUnInstall(m_addon->ID());
   database.OnPostUnInstall(m_addon->ID());
 
   ADDON::OnPostUnInstall(m_addon);

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -254,11 +254,6 @@ CAddonMgr::~CAddonMgr()
   DeInit();
 }
 
-CAddonMgr &CAddonMgr::GetInstance()
-{
-  return CServiceBroker::GetAddonMgr();
-}
-
 IAddonMgrCallback* CAddonMgr::GetCallbackForType(TYPE type)
 {
   if (m_managers.find(type) == m_managers.end())

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -95,9 +95,9 @@ bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder
       builder.SetType(CAddonInfo::TranslateType(ext->ext_point_id));
       builder.SetExtPoint(ext);
 
-      auto libname = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@library");
+      auto libname = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@library");
       if (libname.empty())
-        libname = CAddonMgr::GetInstance().GetPlatformLibraryName(ext->configuration);
+        libname = CServiceBroker::GetAddonMgr().GetPlatformLibraryName(ext->configuration);
       builder.SetLibName(libname);
     }
   }
@@ -139,15 +139,15 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
     builder.SetDependencies(std::move(dependencies));
   }
 
-  auto metadata = CAddonMgr::GetInstance().GetExtension(plugin, "xbmc.addon.metadata");
+  auto metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "xbmc.addon.metadata");
   if (!metadata)
-    metadata = CAddonMgr::GetInstance().GetExtension(plugin, "kodi.addon.metadata");
+    metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "kodi.addon.metadata");
 
   if (plugin->plugin_path && strcmp(plugin->plugin_path, "") != 0)
   {
     //backwards compatibility
-    std::string icon = metadata && CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "noicon") == "true" ? "" : "icon.png";
-    std::string fanart = metadata && CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "nofanart") == "true" ? "" : "fanart.jpg";
+    std::string icon = metadata && CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "noicon") == "true" ? "" : "icon.png";
+    std::string fanart = metadata && CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "nofanart") == "true" ? "" : "fanart.jpg";
     if (!icon.empty())
       builder.SetIcon(URIUtils::AddFileToFolder(plugin->plugin_path, icon));
     if (!fanart.empty())
@@ -156,14 +156,14 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
 
   if (metadata)
   {
-    builder.SetSummary(CAddonMgr::GetInstance().GetTranslatedString(metadata->configuration, "summary"));
-    builder.SetDescription(CAddonMgr::GetInstance().GetTranslatedString(metadata->configuration, "description"));
-    builder.SetDisclaimer(CAddonMgr::GetInstance().GetTranslatedString(metadata->configuration, "disclaimer"));
-    builder.SetChangelog(CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "news"));
-    builder.SetLicense(CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "license"));
-    builder.SetPackageSize(StringUtils::ToUint64(CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "size"), 0));
+    builder.SetSummary(CServiceBroker::GetAddonMgr().GetTranslatedString(metadata->configuration, "summary"));
+    builder.SetDescription(CServiceBroker::GetAddonMgr().GetTranslatedString(metadata->configuration, "description"));
+    builder.SetDisclaimer(CServiceBroker::GetAddonMgr().GetTranslatedString(metadata->configuration, "disclaimer"));
+    builder.SetChangelog(CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "news"));
+    builder.SetLicense(CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "license"));
+    builder.SetPackageSize(StringUtils::ToUint64(CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "size"), 0));
 
-    std::string language = CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "language");
+    std::string language = CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "language");
     if (!language.empty())
     {
       InfoMap extrainfo;
@@ -171,16 +171,16 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
       builder.SetExtrainfo(std::move(extrainfo));
     }
 
-    builder.SetBroken(CAddonMgr::GetInstance().GetExtValue(metadata->configuration, "broken"));
+    builder.SetBroken(CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "broken"));
 
     if (plugin->plugin_path && strcmp(plugin->plugin_path, "") != 0)
     {
-      auto assets = CAddonMgr::GetInstance().GetExtElement(metadata->configuration, "assets");
+      auto assets = CServiceBroker::GetAddonMgr().GetExtElement(metadata->configuration, "assets");
       if (assets)
       {
         builder.SetIcon("");
         builder.SetArt("fanart", "");
-        std::string icon = CAddonMgr::GetInstance().GetExtValue(assets, "icon");
+        std::string icon = CServiceBroker::GetAddonMgr().GetExtValue(assets, "icon");
         if (!icon.empty())
           icon = URIUtils::AddFileToFolder(plugin->plugin_path, icon);
         builder.SetIcon(icon);
@@ -189,7 +189,7 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
         std::array<std::string, 3> artTypes{{"fanart", "banner", "clearlogo"}};
         for (auto type : artTypes)
         {
-          auto value = CAddonMgr::GetInstance().GetExtValue(assets, type.c_str());
+          auto value = CServiceBroker::GetAddonMgr().GetExtValue(assets, type.c_str());
           if (!value.empty())
           {
             value = URIUtils::AddFileToFolder(plugin->plugin_path, value);
@@ -199,7 +199,7 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
 
         std::vector<std::string> screenshots;
         ELEMENTS elements;
-        if (CAddonMgr::GetInstance().GetExtElements(assets, "screenshot", elements))
+        if (CServiceBroker::GetAddonMgr().GetExtElements(assets, "screenshot", elements))
         {
           for (const auto& elem : elements)
           {
@@ -811,7 +811,7 @@ static void ResolveDependencies(const std::string& addonId, std::vector<std::str
     return;
 
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(addonId, addon, ADDON_UNKNOWN, false))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON_UNKNOWN, false))
     missing.push_back(addonId);
   else
   {
@@ -993,16 +993,16 @@ std::string CAddonMgr::GetTranslatedString(const cp_cfg_element_t *root, const c
 
 bool CAddonMgr::PlatformSupportsAddon(const cp_plugin_info_t *plugin)
 {
-  auto *metadata = CAddonMgr::GetInstance().GetExtension(plugin, "xbmc.addon.metadata");
+  auto *metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "xbmc.addon.metadata");
   if (!metadata)
-    metadata = CAddonMgr::GetInstance().GetExtension(plugin, "kodi.addon.metadata");
+    metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "kodi.addon.metadata");
 
   // if platforms are not specified, assume supported
   if (!metadata)
     return true;
 
   std::vector<std::string> platforms;
-  if (!CAddonMgr::GetInstance().GetExtList(metadata->configuration, "platform", platforms))
+  if (!CServiceBroker::GetAddonMgr().GetExtList(metadata->configuration, "platform", platforms))
     return true;
 
   if (platforms.empty())

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -72,7 +72,6 @@ namespace ADDON
   class CAddonMgr
   {
   public:
-    static CAddonMgr &GetInstance();
     bool ReInit() { DeInit(); return Init(); }
     bool Init();
     void DeInit();

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -77,7 +77,7 @@ namespace ADDON
     void DeInit();
 
     CAddonMgr();
-    CAddonMgr(const CAddonMgr&);
+    CAddonMgr(const CAddonMgr&) = delete;
     virtual ~CAddonMgr();
 
     CEventStream<AddonEvent>& Events() { return m_events; }

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -18,6 +18,7 @@
  *
  */
 #include "AddonStatusHandler.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "threads/SingleLock.h"
@@ -52,7 +53,7 @@ CAddonStatusHandler::CAddonStatusHandler(const std::string &addonID, ADDON_STATU
 {
   //! @todo The status handled CAddonStatusHandler by is related to the class, not the instance
   //! having CAddonMgr construct an instance makes no sense
-  if (!CAddonMgr::GetInstance().GetAddon(addonID, m_addon))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonID, m_addon))
     return;
 
   CLog::Log(LOGINFO, "Called Add-on status handler for '%u' of clientName:%s, clientID:%s (same Thread=%s)", status, m_addon->Name().c_str(), m_addon->ID().c_str(), sameThread ? "yes" : "no");
@@ -94,7 +95,7 @@ void CAddonStatusHandler::Process()
   if (m_status == ADDON_STATUS_NEED_RESTART)
   {
     HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{24074});
-    CAddonMgr::GetInstance().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
+    CServiceBroker::GetAddonMgr().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
   }
   /* Some required settings are missing/invalid */
   else if (m_status == ADDON_STATUS_NEED_SETTINGS)
@@ -117,7 +118,7 @@ void CAddonStatusHandler::Process()
     {
       //! @todo Doesn't dialogaddonsettings save these automatically? It should do this.
       m_addon->SaveSettings();
-      CAddonMgr::GetInstance().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
+      CServiceBroker::GetAddonMgr().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
     }
   }
 }

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -87,7 +87,7 @@ bool CAddonSystemSettings::GetActive(const TYPE& type, AddonPtr& addon)
   if (it != m_activeSettings.end())
   {
     auto settingValue = CServiceBroker::GetSettings().GetString(it->second);
-    return CAddonMgr::GetInstance().GetAddon(settingValue, addon, type);
+    return CServiceBroker::GetAddonMgr().GetAddon(settingValue, addon, type);
   }
   return false;
 }
@@ -131,9 +131,9 @@ std::vector<std::string> CAddonSystemSettings::MigrateAddons(std::function<void(
 {
   auto getIncompatible = [](){
     VECADDONS incompatible;
-    CAddonMgr::GetInstance().GetAddons(incompatible);
+    CServiceBroker::GetAddonMgr().GetAddons(incompatible);
     incompatible.erase(std::remove_if(incompatible.begin(), incompatible.end(),
-        [](const AddonPtr a){ return CAddonMgr::GetInstance().IsCompatible(*a); }), incompatible.end());
+        [](const AddonPtr a){ return CServiceBroker::GetAddonMgr().IsCompatible(*a); }), incompatible.end());
     return incompatible;
   };
 
@@ -163,7 +163,7 @@ std::vector<std::string> CAddonSystemSettings::MigrateAddons(std::function<void(
       CLog::Log(LOGWARNING, "ADDON: failed to unset %s", addon->ID().c_str());
       continue;
     }
-    if (!CAddonMgr::GetInstance().DisableAddon(addon->ID()))
+    if (!CServiceBroker::GetAddonMgr().DisableAddon(addon->ID()))
     {
       CLog::Log(LOGWARNING, "ADDON: failed to disable %s", addon->ID().c_str());
     }

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -20,6 +20,7 @@
 
 #include "BinaryAddonCache.h"
 #include "AddonManager.h"
+#include "ServiceBroker.h"
 #include "threads/SingleLock.h"
 
 namespace ADDON
@@ -36,13 +37,13 @@ void CBinaryAddonCache::Init()
     ADDON_PVRDLL,
     ADDON_GAMEDLL,
   };
-  CAddonMgr::GetInstance().Events().Subscribe(this, &CBinaryAddonCache::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CBinaryAddonCache::OnEvent);
   Update();
 }
 
 void CBinaryAddonCache::Deinit()
 {
-  CAddonMgr::GetInstance().Events().Unsubscribe(this);
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 }
 
 void CBinaryAddonCache::GetAddons(VECADDONS& addons, const TYPE& type)
@@ -52,7 +53,7 @@ void CBinaryAddonCache::GetAddons(VECADDONS& addons, const TYPE& type)
 
   for (auto &addon : myAddons)
   {
-    if (!CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
+    if (!CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID()))
       addons.emplace_back(std::move(addon));
   }
 }
@@ -64,7 +65,7 @@ void CBinaryAddonCache::GetDisabledAddons(VECADDONS& addons, const TYPE& type)
 
   for (auto &addon : myAddons)
   {
-    if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
+    if (CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID()))
       addons.emplace_back(std::move(addon));
   }
 }
@@ -114,7 +115,7 @@ void CBinaryAddonCache::Update()
   for (auto &addonType : m_addonsToCache)
   {
     VECADDONS addons;
-    CAddonMgr::GetInstance().GetInstalledAddons(addons, addonType);
+    CServiceBroker::GetAddonMgr().GetInstalledAddons(addons, addonType);
     addonmap.insert(AddonMap::value_type(addonType, addons));
   }
 

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -19,13 +19,15 @@
  */
 
 #include "ContextMenuAddon.h"
+
 #include "AddonManager.h"
 #include "ContextMenuManager.h"
 #include "ContextMenuItem.h"
+#include "ServiceBroker.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include <sstream>
 
+#include <sstream>
 
 namespace ADDON
 {
@@ -37,8 +39,8 @@ void CContextMenuAddon::ParseMenu(
     int& anonGroupCount,
     std::vector<CContextMenuItem>& items)
 {
-  auto menuId = CAddonMgr::GetInstance().GetExtValue(elem, "@id");
-  auto menuLabel = CAddonMgr::GetInstance().GetExtValue(elem, "label");
+  auto menuId = CServiceBroker::GetAddonMgr().GetExtValue(elem, "@id");
+  auto menuLabel = CServiceBroker::GetAddonMgr().GetExtValue(elem, "label");
   if (StringUtils::IsNaturalNumber(menuLabel))
     menuLabel = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(menuLabel.c_str()));
 
@@ -53,18 +55,18 @@ void CContextMenuAddon::ParseMenu(
   items.push_back(CContextMenuItem::CreateGroup(menuLabel, parent, menuId, addonInfo.ID()));
 
   ELEMENTS subMenus;
-  if (CAddonMgr::GetInstance().GetExtElements(elem, "menu", subMenus))
+  if (CServiceBroker::GetAddonMgr().GetExtElements(elem, "menu", subMenus))
     for (const auto& subMenu : subMenus)
       ParseMenu(addonInfo, subMenu, menuId, anonGroupCount, items);
 
   ELEMENTS elems;
-  if (CAddonMgr::GetInstance().GetExtElements(elem, "item", elems))
+  if (CServiceBroker::GetAddonMgr().GetExtElements(elem, "item", elems))
   {
     for (const auto& elem : elems)
     {
-      auto visCondition = CAddonMgr::GetInstance().GetExtValue(elem, "visible");
-      auto library = CAddonMgr::GetInstance().GetExtValue(elem, "@library");
-      auto label = CAddonMgr::GetInstance().GetExtValue(elem, "label");
+      auto visCondition = CServiceBroker::GetAddonMgr().GetExtValue(elem, "visible");
+      auto library = CServiceBroker::GetAddonMgr().GetExtValue(elem, "@library");
+      auto label = CServiceBroker::GetAddonMgr().GetExtValue(elem, "label");
       if (StringUtils::IsNaturalNumber(label))
         label = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(label.c_str()));
 
@@ -82,7 +84,7 @@ std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(CAddonInfo a
 {
   std::vector<CContextMenuItem> items;
 
-  cp_cfg_element_t* menu = CAddonMgr::GetInstance().GetExtElement(ext->configuration, "menu");
+  cp_cfg_element_t* menu = CServiceBroker::GetAddonMgr().GetExtElement(ext->configuration, "menu");
   if (menu)
   {
     int tmp = 0;
@@ -92,18 +94,18 @@ std::unique_ptr<CContextMenuAddon> CContextMenuAddon::FromExtension(CAddonInfo a
   {
     //backwards compatibility. add first item definition
     ELEMENTS elems;
-    if (CAddonMgr::GetInstance().GetExtElements(ext->configuration, "item", elems))
+    if (CServiceBroker::GetAddonMgr().GetExtElements(ext->configuration, "item", elems))
     {
       cp_cfg_element_t *elem = elems[0];
 
-      std::string visCondition = CAddonMgr::GetInstance().GetExtValue(elem, "visible");
+      std::string visCondition = CServiceBroker::GetAddonMgr().GetExtValue(elem, "visible");
       if (visCondition.empty())
         visCondition = "false";
 
-      std::string parent = CAddonMgr::GetInstance().GetExtValue(elem, "parent") == "kodi.core.manage"
+      std::string parent = CServiceBroker::GetAddonMgr().GetExtValue(elem, "parent") == "kodi.core.manage"
           ? CContextMenuManager::MANAGE.m_groupId : CContextMenuManager::MAIN.m_groupId;
 
-      auto label = CAddonMgr::GetInstance().GetExtValue(elem, "label");
+      auto label = CServiceBroker::GetAddonMgr().GetExtValue(elem, "label");
       if (StringUtils::IsNaturalNumber(label))
         label = g_localizeStrings.GetAddonString(addonInfo.ID(), atoi(label.c_str()));
 

--- a/xbmc/addons/ContextMenus.cpp
+++ b/xbmc/addons/ContextMenus.cpp
@@ -36,14 +36,14 @@ bool CAddonSettings::IsVisible(const CFileItem& item) const
 {
   AddonPtr addon;
   return item.HasAddonInfo()
-         && CAddonMgr::GetInstance().GetAddon(item.GetAddonInfo()->ID(), addon, ADDON_UNKNOWN, false)
+         && CServiceBroker::GetAddonMgr().GetAddon(item.GetAddonInfo()->ID(), addon, ADDON_UNKNOWN, false)
          && addon->HasSettings();
 }
 
 bool CAddonSettings::Execute(const CFileItemPtr& item) const
 {
   AddonPtr addon;
-  return CAddonMgr::GetInstance().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_UNKNOWN, false)
+  return CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_UNKNOWN, false)
          && CGUIDialogAddonSettings::ShowForAddon(addon);
 }
 
@@ -55,7 +55,7 @@ bool CCheckForUpdates::IsVisible(const CFileItem& item) const
 bool CCheckForUpdates::Execute(const CFileItemPtr& item) const
 {
   AddonPtr addon;
-  if (item->HasAddonInfo() && CAddonMgr::GetInstance().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_REPOSITORY))
+  if (item->HasAddonInfo() && CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_REPOSITORY))
   {
     CServiceBroker::GetRepositoryUpdater().CheckForUpdates(std::static_pointer_cast<CRepository>(addon), true);
     return true;
@@ -67,24 +67,24 @@ bool CCheckForUpdates::Execute(const CFileItemPtr& item) const
 bool CEnableAddon::IsVisible(const CFileItem& item) const
 {
   return item.HasAddonInfo() &&
-      CAddonMgr::GetInstance().IsAddonDisabled(item.GetAddonInfo()->ID()) &&
-      CAddonMgr::GetInstance().CanAddonBeEnabled(item.GetAddonInfo()->ID());
+      CServiceBroker::GetAddonMgr().IsAddonDisabled(item.GetAddonInfo()->ID()) &&
+      CServiceBroker::GetAddonMgr().CanAddonBeEnabled(item.GetAddonInfo()->ID());
 }
 
 bool CEnableAddon::Execute(const CFileItemPtr& item) const
 {
-  return CAddonMgr::GetInstance().EnableAddon(item->GetAddonInfo()->ID());
+  return CServiceBroker::GetAddonMgr().EnableAddon(item->GetAddonInfo()->ID());
 }
 
 bool CDisableAddon::IsVisible(const CFileItem& item) const
 {
   return item.HasAddonInfo() &&
-      !CAddonMgr::GetInstance().IsAddonDisabled(item.GetAddonInfo()->ID()) &&
-      CAddonMgr::GetInstance().CanAddonBeDisabled(item.GetAddonInfo()->ID());
+      !CServiceBroker::GetAddonMgr().IsAddonDisabled(item.GetAddonInfo()->ID()) &&
+      CServiceBroker::GetAddonMgr().CanAddonBeDisabled(item.GetAddonInfo()->ID());
 }
 
 bool CDisableAddon::Execute(const CFileItemPtr& item) const
 {
-  return CAddonMgr::GetInstance().DisableAddon(item->GetAddonInfo()->ID());
+  return CServiceBroker::GetAddonMgr().DisableAddon(item->GetAddonInfo()->ID());
 }
 }

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -173,10 +173,10 @@ void CGUIDialogAddonInfo::UpdateControls()
     return;
 
   bool isInstalled = NULL != m_localAddon.get();
-  m_addonEnabled = m_localAddon && !CAddonMgr::GetInstance().IsAddonDisabled(m_localAddon->ID());
-  bool canDisable = isInstalled && CAddonMgr::GetInstance().CanAddonBeDisabled(m_localAddon->ID());
+  m_addonEnabled = m_localAddon && !CServiceBroker::GetAddonMgr().IsAddonDisabled(m_localAddon->ID());
+  bool canDisable = isInstalled && CServiceBroker::GetAddonMgr().CanAddonBeDisabled(m_localAddon->ID());
   bool canInstall = !isInstalled && m_item->GetAddonInfo()->Broken().empty();
-  bool canUninstall = m_localAddon && CAddonMgr::GetInstance().CanUninstall(m_localAddon);
+  bool canUninstall = m_localAddon && CServiceBroker::GetAddonMgr().CanUninstall(m_localAddon);
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canInstall || canUninstall);
   SET_CONTROL_LABEL(CONTROL_BTN_INSTALL, isInstalled ? 24037 : 24038);
@@ -197,7 +197,7 @@ void CGUIDialogAddonInfo::UpdateControls()
   bool autoUpdatesOn = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_ADDONS_AUTOUPDATES) == AUTO_UPDATES_ON;
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_AUTOUPDATE, isInstalled && autoUpdatesOn);
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTN_AUTOUPDATE, isInstalled && autoUpdatesOn &&
-      !CAddonMgr::GetInstance().IsBlacklisted(m_localAddon->ID()));
+      !CServiceBroker::GetAddonMgr().IsBlacklisted(m_localAddon->ID()));
   SET_CONTROL_LABEL(CONTROL_BTN_AUTOUPDATE, 21340);
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_SELECT, m_addonEnabled && (CanOpen() ||
@@ -246,7 +246,7 @@ int CGUIDialogAddonInfo::AskForVersion(std::vector<std::pair<AddonVersion, std::
       item.SetIconImage("DefaultAddonRepository.png");
       dialog->Add(item);
     }
-    else if (CAddonMgr::GetInstance().GetAddon(versionInfo.second, repo, ADDON_REPOSITORY))
+    else if (CServiceBroker::GetAddonMgr().GetAddon(versionInfo.second, repo, ADDON_REPOSITORY))
     {
       item.SetLabel2(repo->Name());
       item.SetIconImage(repo->Icon());
@@ -303,7 +303,7 @@ void CGUIDialogAddonInfo::OnUpdate()
       Close();
       //turn auto updating off if downgrading
       if (m_localAddon->Version() > versions[i].first)
-        CAddonMgr::GetInstance().AddToUpdateBlacklist(m_localAddon->ID());
+        CServiceBroker::GetAddonMgr().AddToUpdateBlacklist(m_localAddon->ID());
 
       if (versions[i].second == LOCAL_CACHE)
         CAddonInstaller::GetInstance().InstallFromZip(StringUtils::Format(
@@ -322,9 +322,9 @@ void CGUIDialogAddonInfo::OnToggleAutoUpdates()
   {
     bool selected = msg.GetParam1() == 1;
     if (selected)
-      CAddonMgr::GetInstance().RemoveFromUpdateBlacklist(m_localAddon->ID());
+      CServiceBroker::GetAddonMgr().RemoveFromUpdateBlacklist(m_localAddon->ID());
     else
-      CAddonMgr::GetInstance().AddToUpdateBlacklist(m_localAddon->ID());
+      CServiceBroker::GetAddonMgr().AddToUpdateBlacklist(m_localAddon->ID());
   }
 }
 
@@ -408,7 +408,7 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2)
 
   VECADDONS addons;
   std::vector<std::string> deps;
-  CAddonMgr::GetInstance().GetAddons(addons);
+  CServiceBroker::GetAddonMgr().GetAddons(addons);
   for (VECADDONS::const_iterator it  = addons.begin();
        it != addons.end();++it)
   {
@@ -465,10 +465,10 @@ void CGUIDialogAddonInfo::OnEnableDisable()
     if (PromptIfDependency(24075, 24091))
       return; //required. can't disable
 
-    CAddonMgr::GetInstance().DisableAddon(m_localAddon->ID());
+    CServiceBroker::GetAddonMgr().DisableAddon(m_localAddon->ID());
   }
   else
-    CAddonMgr::GetInstance().EnableAddon(m_localAddon->ID());
+    CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID());
 
   UpdateControls();
 }
@@ -572,6 +572,6 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 
   m_item = std::make_shared<CFileItem>(*item);
   m_localAddon.reset();
-  CAddonMgr::GetInstance().GetAddon(item->GetAddonInfo()->ID(), m_localAddon, ADDON_UNKNOWN, false);
+  CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon, ADDON_UNKNOWN, false);
   return true;
 }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -71,7 +71,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
     case GUI_MSG_WINDOW_DEINIT:
     {
       CServiceBroker::GetRepositoryUpdater().Events().Unsubscribe(this);
-      CAddonMgr::GetInstance().Events().Unsubscribe(this);
+      CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 
       if (m_thumbLoader.IsLoading())
         m_thumbLoader.StopThread();
@@ -80,7 +80,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CServiceBroker::GetRepositoryUpdater().Events().Subscribe(this, &CGUIWindowAddonBrowser::OnEvent);
-      CAddonMgr::GetInstance().Events().Subscribe(this, &CGUIWindowAddonBrowser::OnEvent);
+      CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CGUIWindowAddonBrowser::OnEvent);
 
       SetProperties();
     }
@@ -164,7 +164,7 @@ class UpdateAddons : public IRunnable
 {
   void Run() override
   {
-    for (const auto& addon : CAddonMgr::GetInstance().GetAvailableUpdates())
+    for (const auto& addon : CServiceBroker::GetAddonMgr().GetAvailableUpdates())
       CAddonInstaller::GetInstance().InstallOrUpdate(addon->ID());
   }
 };
@@ -297,7 +297,7 @@ bool CGUIWindowAddonBrowser::GetDirectory(const std::string& strDirectory, CFile
         {
           //check if it's installed
           AddonPtr addon;
-          if (!CAddonMgr::GetInstance().GetAddon(items[i]->GetProperty("Addon.ID").asString(), addon))
+          if (!CServiceBroker::GetAddonMgr().GetAddon(items[i]->GetProperty("Addon.ID").asString(), addon))
             items.Remove(i);
         }
       }
@@ -405,7 +405,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
       else if (*type == ADDON_GAME)
         CAddonsDirectory::GetScriptsAndPlugins("game", typeAddons);
       else
-        CAddonMgr::GetInstance().GetAddons(typeAddons, *type);
+        CServiceBroker::GetAddonMgr().GetAddons(typeAddons, *type);
 
       addons.insert(addons.end(), typeAddons.begin(), typeAddons.end());
     }
@@ -414,7 +414,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
   if (showInstallable || showMore)
   {
     VECADDONS installableAddons;
-    if (CAddonMgr::GetInstance().GetInstallableAddons(installableAddons))
+    if (CServiceBroker::GetAddonMgr().GetInstallableAddons(installableAddons))
     {
       for (ADDON::IVECADDONS addon = installableAddons.begin(); addon != installableAddons.end();)
       {
@@ -534,7 +534,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
         const AddonPtr& addon = itAddon->second;
 
         // if the addon isn't installed we need to install it
-        if (!CAddonMgr::GetInstance().IsAddonInstalled(addon->ID()))
+        if (!CServiceBroker::GetAddonMgr().IsAddonInstalled(addon->ID()))
         {
           AddonPtr installedAddon;
           if (!CAddonInstaller::GetInstance().InstallModal(addon->ID(), installedAddon, false))
@@ -542,8 +542,8 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<ADDON::TYPE> &types,
         }
 
         // if the addon is disabled we need to enable it
-        if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
-          CAddonMgr::GetInstance().EnableAddon(addon->ID());
+        if (CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID()))
+          CServiceBroker::GetAddonMgr().EnableAddon(addon->ID());
       }
     }
 

--- a/xbmc/addons/ImageResource.cpp
+++ b/xbmc/addons/ImageResource.cpp
@@ -19,6 +19,7 @@
 */
 #include "ImageResource.h"
 #include "URL.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "filesystem/File.h"
 #include "filesystem/XbtManager.h"
@@ -30,7 +31,7 @@ namespace ADDON
 
 std::unique_ptr<CImageResource> CImageResource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {
-  std::string type = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@type");
+  std::string type = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@type");
   return std::unique_ptr<CImageResource>(new CImageResource(std::move(addonInfo), std::move(type)));
 }
 

--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -41,30 +41,30 @@ namespace ADDON
 std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {
   // parse <extension> attributes
-  CLocale locale = CLocale::FromString(CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@locale"));
+  CLocale locale = CLocale::FromString(CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@locale"));
 
   // parse <charsets>
   std::string charsetGui;
   bool forceUnicodeFont(false);
   std::string charsetSubtitle;
-  cp_cfg_element_t *charsetsElement = CAddonMgr::GetInstance().GetExtElement(ext->configuration, "charsets");
+  cp_cfg_element_t *charsetsElement = CServiceBroker::GetAddonMgr().GetExtElement(ext->configuration, "charsets");
   if (charsetsElement != NULL)
   {
-    charsetGui = CAddonMgr::GetInstance().GetExtValue(charsetsElement, "gui");
-    forceUnicodeFont = CAddonMgr::GetInstance().GetExtValue(charsetsElement, "gui@unicodefont") == "true";
-    charsetSubtitle = CAddonMgr::GetInstance().GetExtValue(charsetsElement, "subtitle");
+    charsetGui = CServiceBroker::GetAddonMgr().GetExtValue(charsetsElement, "gui");
+    forceUnicodeFont = CServiceBroker::GetAddonMgr().GetExtValue(charsetsElement, "gui@unicodefont") == "true";
+    charsetSubtitle = CServiceBroker::GetAddonMgr().GetExtValue(charsetsElement, "subtitle");
   }
 
   // parse <dvd>
   std::string dvdLanguageMenu;
   std::string dvdLanguageAudio;
   std::string dvdLanguageSubtitle;
-  cp_cfg_element_t *dvdElement = CAddonMgr::GetInstance().GetExtElement(ext->configuration, "dvd");
+  cp_cfg_element_t *dvdElement = CServiceBroker::GetAddonMgr().GetExtElement(ext->configuration, "dvd");
   if (dvdElement != NULL)
   {
-    dvdLanguageMenu = CAddonMgr::GetInstance().GetExtValue(dvdElement, "menu");
-    dvdLanguageAudio = CAddonMgr::GetInstance().GetExtValue(dvdElement, "audio");
-    dvdLanguageSubtitle = CAddonMgr::GetInstance().GetExtValue(dvdElement, "subtitle");
+    dvdLanguageMenu = CServiceBroker::GetAddonMgr().GetExtValue(dvdElement, "menu");
+    dvdLanguageAudio = CServiceBroker::GetAddonMgr().GetExtValue(dvdElement, "audio");
+    dvdLanguageSubtitle = CServiceBroker::GetAddonMgr().GetExtValue(dvdElement, "subtitle");
   }
   // fall back to the language of the addon if a DVD language is not defined
   if (dvdLanguageMenu.empty())
@@ -76,7 +76,7 @@ std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(CAddonInfo a
 
   // parse <sorttokens>
   std::set<std::string> sortTokens;
-  cp_cfg_element_t *sorttokensElement = CAddonMgr::GetInstance().GetExtElement(ext->configuration, "sorttokens");
+  cp_cfg_element_t *sorttokensElement = CServiceBroker::GetAddonMgr().GetExtElement(ext->configuration, "sorttokens");
   if (sorttokensElement != NULL)
   {
     for (size_t i = 0; i < sorttokensElement->num_children; ++i)
@@ -86,7 +86,7 @@ std::unique_ptr<CLanguageResource> CLanguageResource::FromExtension(CAddonInfo a
           tokenElement.value != NULL)
       {
         std::string token(tokenElement.value);
-        std::string separators = CAddonMgr::GetInstance().GetExtValue(&tokenElement, "@separators");
+        std::string separators = CServiceBroker::GetAddonMgr().GetExtValue(&tokenElement, "@separators");
         if (separators.empty())
           separators = " ._";
 
@@ -178,7 +178,7 @@ bool CLanguageResource::FindLegacyLanguage(const std::string &locale, std::strin
   std::string addonId = GetAddonId(locale);
 
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(addonId, addon, ADDON_RESOURCE_LANGUAGE, true))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON_RESOURCE_LANGUAGE, true))
     return false;
 
   legacyLanguage = addon->Name();

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "AddonManager.h"
+#include "ServiceBroker.h"
 #include "utils/StringUtils.h"
 
 namespace ADDON
@@ -30,7 +31,7 @@ namespace ADDON
 
 std::unique_ptr<CPluginSource> CPluginSource::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {
-  std::string provides = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "provides");
+  std::string provides = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "provides");
   if (!provides.empty())
     addonInfo.AddExtraInfo("provides", provides);
   return std::unique_ptr<CPluginSource>(new CPluginSource(std::move(addonInfo), provides));

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -23,6 +23,7 @@
 #include <iterator>
 #include <utility>
 
+#include "ServiceBroker.h"
 #include "addons/AddonDatabase.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
@@ -59,33 +60,33 @@ std::unique_ptr<CRepository> CRepository::FromExtension(CAddonInfo addonInfo, co
   DirList dirs;
   AddonVersion version("0.0.0");
   AddonPtr addonver;
-  if (CAddonMgr::GetInstance().GetAddon("xbmc.addon", addonver))
+  if (CServiceBroker::GetAddonMgr().GetAddon("xbmc.addon", addonver))
     version = addonver->Version();
   for (size_t i = 0; i < ext->configuration->num_children; ++i)
   {
     if(ext->configuration->children[i].name &&
        strcmp(ext->configuration->children[i].name, "dir") == 0)
     {
-      AddonVersion min_version(CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "@minversion"));
+      AddonVersion min_version(CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "@minversion"));
       if (min_version <= version)
       {
         DirInfo dir;
         dir.version = min_version;
-        dir.checksum = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "checksum");
-        dir.info = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "info");
-        dir.datadir = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "datadir");
-        dir.hashes = CAddonMgr::GetInstance().GetExtValue(&ext->configuration->children[i], "hashes") == "true";
+        dir.checksum = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "checksum");
+        dir.info = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "info");
+        dir.datadir = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "datadir");
+        dir.hashes = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "hashes") == "true";
         dirs.push_back(std::move(dir));
       }
     }
   }
-  if (!CAddonMgr::GetInstance().GetExtValue(ext->configuration, "info").empty())
+  if (!CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "info").empty())
   {
     DirInfo info;
-    info.checksum = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "checksum");
-    info.info = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "info");
-    info.datadir = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "datadir");
-    info.hashes = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "hashes") == "true";
+    info.checksum = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "checksum");
+    info.info = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "info");
+    info.datadir = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "datadir");
+    info.hashes = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "hashes") == "true";
     dirs.push_back(std::move(info));
   }
   return std::unique_ptr<CRepository>(new CRepository(std::move(addonInfo), std::move(dirs)));
@@ -168,7 +169,7 @@ bool CRepository::FetchIndex(const DirInfo& repo, VECADDONS& addons) noexcept
     response = std::move(buffer);
   }
 
-  return CAddonMgr::GetInstance().AddonsFromRepoXML(repo, response, addons);
+  return CServiceBroker::GetAddonMgr().AddonsFromRepoXML(repo, response, addons);
 }
 
 CRepository::FetchStatus CRepository::FetchIfChanged(const std::string& oldChecksum,

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "Scraper.h"
+#include "ServiceBroker.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
@@ -130,10 +131,10 @@ static void CheckScraperError(const TiXmlElement *pxeRoot)
 
 std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {
-  bool requiressettings = CAddonMgr::GetInstance().GetExtValue(ext->configuration,"@requiressettings") == "true";
+  bool requiressettings = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration,"@requiressettings") == "true";
 
   CDateTimeSpan persistence;
-  std::string tmp = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@cachepersistence");
+  std::string tmp = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@cachepersistence");
   if (!tmp.empty())
     persistence.SetFromTimeString(tmp);
 
@@ -376,7 +377,7 @@ bool CScraper::Load()
 
       bool bOptional = itr->second.second;
 
-      if (CAddonMgr::GetInstance().GetAddon((*itr).first, dep))
+      if (CServiceBroker::GetAddonMgr().GetAddon((*itr).first, dep))
       {
         CXBMCTinyXML doc;
         if (dep->Type() == ADDON_SCRAPER_LIBRARY && doc.LoadFile(dep->LibPath()))

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -19,6 +19,7 @@
  */
 #include "Service.h"
 #include "AddonManager.h"
+#include "ServiceBroker.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "system.h"
 #include "utils/log.h"
@@ -31,7 +32,7 @@ namespace ADDON
 std::unique_ptr<CService> CService::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
 {
   START_OPTION startOption(START_OPTION::LOGIN);
-  std::string start = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@start");
+  std::string start = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@start");
   if (start == "startup")
     startOption = START_OPTION::STARTUP;
   return std::unique_ptr<CService>(new CService(std::move(addonInfo), startOption));

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -158,16 +158,16 @@ std::unique_ptr<CSkinInfo> CSkinInfo::FromExtension(CAddonInfo addonInfo, const 
   std::vector<RESOLUTION_INFO> resolutions;
 
   ELEMENTS elements;
-  if (CAddonMgr::GetInstance().GetExtElements(ext->configuration, "res", elements))
+  if (CServiceBroker::GetAddonMgr().GetExtElements(ext->configuration, "res", elements))
   {
     for (ELEMENTS::iterator i = elements.begin(); i != elements.end(); ++i)
     {
-      int width = atoi(CAddonMgr::GetInstance().GetExtValue(*i, "@width").c_str());
-      int height = atoi(CAddonMgr::GetInstance().GetExtValue(*i, "@height").c_str());
-      bool defRes = CAddonMgr::GetInstance().GetExtValue(*i, "@default") == "true";
-      std::string folder = CAddonMgr::GetInstance().GetExtValue(*i, "@folder");
+      int width = atoi(CServiceBroker::GetAddonMgr().GetExtValue(*i, "@width").c_str());
+      int height = atoi(CServiceBroker::GetAddonMgr().GetExtValue(*i, "@height").c_str());
+      bool defRes = CServiceBroker::GetAddonMgr().GetExtValue(*i, "@default") == "true";
+      std::string folder = CServiceBroker::GetAddonMgr().GetExtValue(*i, "@folder");
       float aspect = 0;
-      std::string strAspect = CAddonMgr::GetInstance().GetExtValue(*i, "@aspect");
+      std::string strAspect = CServiceBroker::GetAddonMgr().GetExtValue(*i, "@aspect");
       std::vector<std::string> fracs = StringUtils::Split(strAspect, ':');
       if (fracs.size() == 2)
         aspect = (float)(atof(fracs[0].c_str())/atof(fracs[1].c_str()));
@@ -183,18 +183,18 @@ std::unique_ptr<CSkinInfo> CSkinInfo::FromExtension(CAddonInfo addonInfo, const 
   }
   else
   { // no resolutions specified -> backward compatibility
-    std::string defaultWide = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@defaultwideresolution");
+    std::string defaultWide = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@defaultwideresolution");
     if (defaultWide.empty())
-      defaultWide = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@defaultresolution");
+      defaultWide = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@defaultresolution");
     TranslateResolution(defaultWide, defaultRes);
   }
 
   float effectsSlowDown(1.f);
-  std::string str = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@effectslowdown");
+  std::string str = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@effectslowdown");
   if (!str.empty())
     effectsSlowDown = (float)atof(str.c_str());
 
-  bool debugging = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@debugging") == "true";
+  bool debugging = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@debugging") == "true";
 
   return std::unique_ptr<CSkinInfo>(new CSkinInfo(std::move(addonInfo), defaultRes, resolutions,
       effectsSlowDown, debugging));

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -35,13 +35,13 @@ CVFSAddonCache::~CVFSAddonCache()
 
 void CVFSAddonCache::Init()
 {
-  CAddonMgr::GetInstance().Events().Subscribe(this, &CVFSAddonCache::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CVFSAddonCache::OnEvent);
   Update();
 }
 
 void CVFSAddonCache::Deinit()
 {
-  CAddonMgr::GetInstance().Events().Unsubscribe(this);
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 }
 
 const std::vector<VFSEntryPtr> CVFSAddonCache::GetAddonInstances()

--- a/xbmc/addons/Webinterface.cpp
+++ b/xbmc/addons/Webinterface.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "Webinterface.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -30,7 +31,7 @@ std::unique_ptr<CWebinterface> CWebinterface::FromExtension(CAddonInfo addonInfo
 {
   // determine the type of the webinterface
   WebinterfaceType type(WebinterfaceTypeStatic);
-  std::string webinterfaceType = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@type");
+  std::string webinterfaceType = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@type");
   if (StringUtils::EqualsNoCase(webinterfaceType.c_str(), "wsgi"))
     type = WebinterfaceTypeWsgi;
   else if (!webinterfaceType.empty() && !StringUtils::EqualsNoCase(webinterfaceType.c_str(), "static") && !StringUtils::EqualsNoCase(webinterfaceType.c_str(), "html"))
@@ -38,7 +39,7 @@ std::unique_ptr<CWebinterface> CWebinterface::FromExtension(CAddonInfo addonInfo
 
   // determine the entry point of the webinterface
   std::string entryPoint(WEBINTERFACE_DEFAULT_ENTRY_POINT);
-  std::string entry = CAddonMgr::GetInstance().GetExtValue(ext->configuration, "@entry");
+  std::string entry = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@entry");
   if (!entry.empty())
     entryPoint = entry;
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -21,6 +21,7 @@
 #include "BinaryAddonManager.h"
 #include "BinaryAddonBase.h"
 
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/Directory.h"
@@ -41,10 +42,10 @@ CBinaryAddonManager::~CBinaryAddonManager()
 
 bool CBinaryAddonManager::Init()
 {
-  CAddonMgr::GetInstance().Events().Subscribe(this, &CBinaryAddonManager::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CBinaryAddonManager::OnEvent);
 
   BINARY_ADDON_LIST binaryAddonList;
-  if (!CAddonMgr::GetInstance().GetInstalledBinaryAddons(binaryAddonList))
+  if (!CServiceBroker::GetAddonMgr().GetInstalledBinaryAddons(binaryAddonList))
   {
     CLog::Log(LOGNOTICE, "CBinaryAddonManager::%s: No binary addons present and related manager, init not necessary", __FUNCTION__);
     return true;
@@ -64,7 +65,7 @@ void CBinaryAddonManager::DeInit()
   if (XFILE::CDirectory::Exists(m_tempAddonBasePath))
     XFILE::CDirectory::RemoveRecursive(CSpecialProtocol::TranslatePath(m_tempAddonBasePath));
 
-  CAddonMgr::GetInstance().Events().Unsubscribe(this);
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 }
 
 bool CBinaryAddonManager::HasInstalledAddons(const TYPE &type) const
@@ -233,7 +234,7 @@ void CBinaryAddonManager::DisableEvent(const std::string& addonId)
 void CBinaryAddonManager::InstalledChangeEvent()
 {
   BINARY_ADDON_LIST binaryAddonList;
-  CAddonMgr::GetInstance().GetInstalledBinaryAddons(binaryAddonList);
+  CServiceBroker::GetAddonMgr().GetInstalledBinaryAddons(binaryAddonList);
 
   CSingleLock lock(m_critSection);
 

--- a/xbmc/addons/binary-addons/BinaryAddonManager.h
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.h
@@ -40,6 +40,7 @@ namespace ADDON
   {
   public:
     CBinaryAddonManager();
+    CBinaryAddonManager(const CBinaryAddonManager&) = delete;
     ~CBinaryAddonManager();
 
     bool Init();

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -137,7 +137,7 @@ bool Interface_General::open_settings_dialog(void* kodiBase)
 
   // show settings dialog
   AddonPtr addonInfo;
-  if (CAddonMgr::GetInstance().GetAddon(addon->ID(), addonInfo))
+  if (CServiceBroker::GetAddonMgr().GetAddon(addon->ID(), addonInfo))
   {
     CLog::Log(LOGERROR, "Interface_General::%s - Could not get addon information for '%s'", __FUNCTION__, addon->ID().c_str());
     return false;

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -89,7 +89,7 @@ bool CEncoderFFmpeg::Init(AddonToKodiFuncTable_AudioEncoder& callbacks)
   }
 
   AddonPtr addon;
-  CAddonMgr::GetInstance().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_AUDIOCDS_ENCODER), addon);
+  CServiceBroker::GetAddonMgr().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_AUDIOCDS_ENCODER), addon);
   if (addon)
   {
     m_Format->bit_rate = (128+32*strtol(addon->GetSetting("bitrate").c_str(), NULL, 10))*1000;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.cpp
@@ -269,7 +269,7 @@ bool CActiveAEDSP::IsInUse(const std::string &strAddonId) const
   CSingleLock lock(m_critSection);
 
   for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
-    if (!CAddonMgr::GetInstance().IsAddonDisabled(citr->second->ID()) && citr->second->ID() == strAddonId)
+    if (!CServiceBroker::GetAddonMgr().IsAddonDisabled(citr->second->ID()) && citr->second->ID() == strAddonId)
       return true;
   return false;
 }
@@ -598,7 +598,7 @@ void CActiveAEDSP::UpdateAddons()
 
   for (auto &addonInfo : addonInfos)
   {
-    bool bEnabled = !CAddonMgr::GetInstance().IsAddonDisabled(addonInfo->ID());
+    bool bEnabled = !CServiceBroker::GetAddonMgr().IsAddonDisabled(addonInfo->ID());
     if (bEnabled && (!IsKnownAudioDSPAddon(addonInfo->ID()) || !IsReadyAudioDSPAddon(addonInfo)))
     {
       std::hash<std::string> hasher;
@@ -690,7 +690,7 @@ int CActiveAEDSP::EnabledAudioDSPAddonAmount(void) const
 
   for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (!CAddonMgr::GetInstance().IsAddonDisabled(citr->second->ID()))
+    if (!CServiceBroker::GetAddonMgr().IsAddonDisabled(citr->second->ID()))
       ++iReturn;
   }
 
@@ -709,7 +709,7 @@ int CActiveAEDSP::GetEnabledAudioDSPAddons(AE_DSP_ADDONMAP &addons) const
 
   for (AE_DSP_ADDONMAP_CITR citr = m_addonMap.begin(); citr != m_addonMap.end(); ++citr)
   {
-    if (!CAddonMgr::GetInstance().IsAddonDisabled(citr->second->ID()))
+    if (!CServiceBroker::GetAddonMgr().IsAddonDisabled(citr->second->ID()))
     {
       addons.insert(std::make_pair(citr->second->GetID(), citr->second));
       ++iReturn;
@@ -833,7 +833,7 @@ bool CActiveAEDSP::HaveMenuHooks(AE_DSP_MENUHOOK_CAT cat, int iDSPAddonID)
       else if (cat == AE_DSP_MENUHOOK_SETTING)
       {
         AddonPtr addon;
-        if (CAddonMgr::GetInstance().GetAddon(citr->second->ID(), addon) && addon->HasSettings())
+        if (CServiceBroker::GetAddonMgr().GetAddon(citr->second->ID(), addon) && addon->HasSettings())
           return true;
       }
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPDatabase.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPDatabase.cpp
@@ -91,10 +91,10 @@ void CActiveAEDSPDatabase::CreateTables()
 
   // disable all Audio DSP add-on when started the first time
   ADDON::VECADDONS addons;
-  if (CAddonMgr::GetInstance().GetAddons(addons, ADDON_ADSPDLL))
+  if (CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON_ADSPDLL))
   {
     for (IVECADDONS it = addons.begin(); it != addons.end(); ++it)
-      CAddonMgr::GetInstance().DisableAddon(it->get()->ID());
+      CServiceBroker::GetAddonMgr().DisableAddon(it->get()->ID());
   }
 }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -112,7 +112,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   {
     CLog::Log(LOGERROR, "Can't play game, no game client was passed to RetroPlayer!");
   }
-  else if (!ADDON::CAddonMgr::GetInstance().GetAddon(gameClientId, addon, ADDON::ADDON_GAMEDLL))
+  else if (!CServiceBroker::GetAddonMgr().GetAddon(gameClientId, addon, ADDON::ADDON_GAMEDLL))
   {
     CLog::Log(LOGERROR, "Can't find add-on %s for game file!", gameClientId.c_str());
   }
@@ -150,7 +150,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
       if (save.GameClient() != m_gameClient->ID())
       {
         ADDON::AddonPtr addon;
-        if (ADDON::CAddonMgr::GetInstance().GetAddon(save.GameClient(), addon))
+        if (CServiceBroker::GetAddonMgr().GetAddon(save.GameClient(), addon))
         {
           // Warn the user that continuing with a different game client will
           // overwrite the save

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -117,8 +117,8 @@ bool CPluginDirectory::StartScript(const std::string& strPath, bool retrievingDi
   CURL url(strPath);
 
   // try the plugin type first, and if not found, try an unknown type
-  if (!CAddonMgr::GetInstance().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN) &&
-      !CAddonMgr::GetInstance().GetAddon(url.GetHostName(), m_addon, ADDON_UNKNOWN) &&
+  if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN) &&
+      !CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), m_addon, ADDON_UNKNOWN) &&
       !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), m_addon))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
@@ -450,7 +450,7 @@ bool CPluginDirectory::RunScriptWithParams(const std::string& strPath, bool resu
     return false;
 
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) && !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) && !CAddonInstaller::GetInstance().InstallModal(url.GetHostName(), addon))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;

--- a/xbmc/filesystem/ResourceFile.cpp
+++ b/xbmc/filesystem/ResourceFile.cpp
@@ -21,6 +21,7 @@
 #include "ResourceFile.h"
 #include "URL.h"
 #include "Util.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/Resource.h"
 #include "utils/URIUtils.h"
@@ -57,7 +58,7 @@ bool CResourceFile::TranslatePath(const CURL &url, std::string &translatedPath)
     return false;
 
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(addonId, addon, ADDON_UNKNOWN, true) || addon == NULL)
+  if (!CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON_UNKNOWN, true) || addon == NULL)
     return false;
 
   std::shared_ptr<CResource> resource = std::dynamic_pointer_cast<ADDON::CResource>(addon);

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -103,7 +103,7 @@ void CGameUtils::GetGameClients(const CFileItem& file, GameClientVector& candida
 
   // Get remote candidates
   VECADDONS remoteAddons;
-  if (CAddonMgr::GetInstance().GetInstallableAddons(remoteAddons, ADDON_GAMEDLL))
+  if (CServiceBroker::GetAddonMgr().GetInstallableAddons(remoteAddons, ADDON_GAMEDLL))
   {
     GetGameClients(remoteAddons, translatedUrl, installable, bVfs);
     bHasVfsGameClient |= bVfs;
@@ -185,7 +185,7 @@ bool CGameUtils::HasGameExtension(const std::string &path)
 
   // Check remote add-ons
   gameClients.clear();
-  if (CAddonMgr::GetInstance().GetInstallableAddons(gameClients, ADDON_GAMEDLL))
+  if (CServiceBroker::GetAddonMgr().GetInstallableAddons(gameClients, ADDON_GAMEDLL))
   {
     for (auto& gameClient : gameClients)
     {
@@ -215,7 +215,7 @@ std::set<std::string> CGameUtils::GetGameExtensions()
 
   // Check remote add-ons
   gameClients.clear();
-  if (CAddonMgr::GetInstance().GetInstallableAddons(gameClients, ADDON_GAMEDLL))
+  if (CServiceBroker::GetAddonMgr().GetInstallableAddons(gameClients, ADDON_GAMEDLL))
   {
     for (auto& gameClient : gameClients)
     {

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -111,7 +111,7 @@ std::unique_ptr<CGameClient> CGameClient::FromExtension(ADDON::CAddonInfo addonI
 
   for (const auto& property : properties)
   {
-    std::string strProperty = CAddonMgr::GetInstance().GetExtValue(ext->configuration, property.c_str());
+    std::string strProperty = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, property.c_str());
     if (!strProperty.empty())
       addonInfo.AddExtraInfo(property, strProperty);
   }
@@ -452,7 +452,7 @@ std::string CGameClient::GetMissingResource()
     if (StringUtils::StartsWith(strDependencyId, "resource.games"))
     {
       AddonPtr addon;
-      const bool bInstalled = CAddonMgr::GetInstance().GetAddon(strDependencyId, addon);
+      const bool bInstalled = CServiceBroker::GetAddonMgr().GetAddon(strDependencyId, addon);
       if (!bInstalled)
       {
         strAddonId = strDependencyId;

--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -20,6 +20,7 @@
 
 #include "GameClientProperties.h"
 #include "GameClient.h"
+#include "ServiceBroker.h"
 #include "addons/IAddon.h"
 #include "addons/AddonManager.h"
 #include "addons/GameResource.h"
@@ -97,15 +98,15 @@ const char** CGameClientProperties::GetProxyDllPaths(void)
     {
       const std::string& strAddonId = it->first;
       AddonPtr addon;
-      if (CAddonMgr::GetInstance().GetAddon(strAddonId, addon, ADDON_GAMEDLL, false))
+      if (CServiceBroker::GetAddonMgr().GetAddon(strAddonId, addon, ADDON_GAMEDLL, false))
       {
         // If add-on is disabled, ask the user to enable it
-        if (CAddonMgr::GetInstance().IsAddonDisabled(addon->ID()))
+        if (CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID()))
         {
           // Failed to play game
           // This game depends on a disabled add-on. Would you like to enable it?
           if (CGUIDialogYesNo::ShowAndGetInput(CVariant{ 35210 }, CVariant{ 35215 }))
-            CAddonMgr::GetInstance().EnableAddon(addon->ID());
+            CServiceBroker::GetAddonMgr().EnableAddon(addon->ID());
           else
             addon.reset();
         }
@@ -132,7 +133,7 @@ const char** CGameClientProperties::GetResourceDirectories(void)
     {
       const std::string& strAddonId = it->first;
       AddonPtr addon;
-      if (CAddonMgr::GetInstance().GetAddon(strAddonId, addon, ADDON_RESOURCE_GAMES))
+      if (CServiceBroker::GetAddonMgr().GetAddon(strAddonId, addon, ADDON_RESOURCE_GAMES))
       {
         std::shared_ptr<CGameResource> resource = std::static_pointer_cast<CGameResource>(addon);
 

--- a/xbmc/games/addons/savestates/SavestateDatabase.cpp
+++ b/xbmc/games/addons/savestates/SavestateDatabase.cpp
@@ -22,6 +22,7 @@
 #include "Savestate.h"
 #include "SavestateDefines.h"
 #include "SavestateUtils.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "games/GameTypes.h"
 #include "games/tags/GameInfoTag.h"
@@ -82,7 +83,7 @@ CFileItem* CSavestateDatabase::CreateFileItem(const CVariant& object) const
   else
   {
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(save.GameClient(), addon, ADDON_GAMEDLL))
+    if (CServiceBroker::GetAddonMgr().GetAddon(save.GameClient(), addon, ADDON_GAMEDLL))
       item->SetArt("thumb", addon->Icon());
   }
 

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -20,6 +20,7 @@
 
 #include "ControllerManager.h"
 #include "Controller.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "input/joysticks/JoystickIDs.h"
 
@@ -35,7 +36,7 @@ ControllerPtr CControllerManager::GetController(const std::string& controllerId)
   if (!cachedController && m_failedControllers.find(controllerId) == m_failedControllers.end())
   {
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER, false))
+    if (CServiceBroker::GetAddonMgr().GetAddon(controllerId, addon, ADDON_GAME_CONTROLLER, false))
       cachedController = LoadController(std::move(addon));
   }
 
@@ -54,7 +55,7 @@ ControllerVector CControllerManager::GetControllers()
   ControllerVector controllers;
 
   VECADDONS addons;
-  if (CAddonMgr::GetInstance().GetInstalledAddons(addons, ADDON_GAME_CONTROLLER))
+  if (CServiceBroker::GetAddonMgr().GetInstalledAddons(addons, ADDON_GAME_CONTROLLER))
   {
     for (auto& addon : addons)
     {

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -67,7 +67,7 @@ bool CGUIControllerList::Initialize(void)
   if (m_controllerButton)
     m_controllerButton->SetVisible(false);
 
-  CAddonMgr::GetInstance().Events().Subscribe(this, &CGUIControllerList::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CGUIControllerList::OnEvent);
   Refresh();
 
   return m_controllerList != nullptr &&
@@ -76,7 +76,7 @@ bool CGUIControllerList::Initialize(void)
 
 void CGUIControllerList::Deinitialize(void)
 {
-  CAddonMgr::GetInstance().Events().Unsubscribe(this);
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 
   CleanupButtons();
 

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -286,7 +286,7 @@ void CGUIControllerWindow::UpdateButtons(void)
   using namespace ADDON;
 
   VECADDONS addons;
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_GET_MORE, CAddonMgr::GetInstance().GetInstallableAddons(addons, ADDON::ADDON_GAME_CONTROLLER) && !addons.empty());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_GET_MORE, CServiceBroker::GetAddonMgr().GetInstallableAddons(addons, ADDON::ADDON_GAME_CONTROLLER) && !addons.empty());
 }
 
 void CGUIControllerWindow::GetMoreControllers(void)

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogSelectGameClient.h"
+#include "ServiceBroker.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
 #include "addons/GUIWindowAddonBrowser.h"
@@ -103,7 +104,7 @@ std::string CGUIDialogSelectGameClient::InstallGameClient(const GameClientVector
   {
     CLog::Log(LOGDEBUG, "Select game client dialog: User installed %s", chosenClientId.c_str());
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(chosenClientId, addon, ADDON_GAMEDLL))
+    if (CServiceBroker::GetAddonMgr().GetAddon(chosenClientId, addon, ADDON_GAMEDLL))
       gameClient = addon->ID();
 
     if (gameClient.empty())
@@ -135,8 +136,8 @@ std::string CGUIDialogSelectGameClient::InstallGameClient(const GameClientVector
       CLog::Log(LOGDEBUG, "Select game client dialog: Successfully installed %s", installedAddon->ID().c_str());
 
       // if the addon is disabled we need to enable it
-      if (CAddonMgr::GetInstance().IsAddonDisabled(installedAddon->ID()))
-        CAddonMgr::GetInstance().EnableAddon(installedAddon->ID());
+      if (CServiceBroker::GetAddonMgr().IsAddonDisabled(installedAddon->ID()))
+        CServiceBroker::GetAddonMgr().EnableAddon(installedAddon->ID());
 
       gameClient = installedAddon->ID();
     }

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -229,7 +229,7 @@ std::string GetSoundSkinPath()
     return "";
 
   ADDON::AddonPtr addon;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddon(value, addon, ADDON::ADDON_RESOURCE_UISOUNDS))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(value, addon, ADDON::ADDON_RESOURCE_UISOUNDS))
   {
     CLog::Log(LOGNOTICE, "Unknown sounds addon '%s'. Setting default sounds.", value.c_str());
     setting->Reset();

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -99,7 +99,7 @@ static int RunAddon(const std::vector<std::string>& params)
     const std::string& addonid = params[0];
 
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(addonid, addon, ADDON_PLUGIN))
+    if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_PLUGIN))
     {
       PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
       std::string urlParameters;
@@ -136,16 +136,16 @@ static int RunAddon(const std::vector<std::string>& params)
         cmd = StringUtils::Format("RunPlugin(%s)", StringUtils::Join(params, ",").c_str());
       CBuiltins::GetInstance().Execute(cmd);
     }
-    else if (CAddonMgr::GetInstance().GetAddon(addonid, addon, ADDON_SCRIPT) ||
-        CAddonMgr::GetInstance().GetAddon(addonid, addon, ADDON_SCRIPT_WEATHER) ||
-        CAddonMgr::GetInstance().GetAddon(addonid, addon, ADDON_SCRIPT_LYRICS) ||
-        CAddonMgr::GetInstance().GetAddon(addonid, addon, ADDON_SCRIPT_LIBRARY))
+    else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT) ||
+        CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT_WEATHER) ||
+        CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT_LYRICS) ||
+        CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_SCRIPT_LIBRARY))
     {
       // Pass the script name (addonid) and all the parameters
       // (params[1] ... params[x]) separated by a comma to RunScript
       CBuiltins::GetInstance().Execute(StringUtils::Format("RunScript(%s)", StringUtils::Join(params, ",").c_str()));
     }
-    else if (CAddonMgr::GetInstance().GetAddon(addonid, addon, ADDON_GAMEDLL))
+    else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, ADDON_GAMEDLL))
     {
       CFileItem item;
 
@@ -204,20 +204,20 @@ static int RunScript(const std::vector<std::string>& params)
     AddonPtr addon;
     std::string scriptpath;
     // Test to see if the param is an addon ID
-    if (CAddonMgr::GetInstance().GetAddon(params[0], addon))
+    if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon))
     {
       //Get the correct extension point to run
-      if (CAddonMgr::GetInstance().GetAddon(params[0], addon, ADDON_SCRIPT) ||
-          CAddonMgr::GetInstance().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
-          CAddonMgr::GetInstance().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS) ||
-          CAddonMgr::GetInstance().GetAddon(params[0], addon, ADDON_SCRIPT_LIBRARY))
+      if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT) ||
+          CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT_WEATHER) ||
+          CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT_LYRICS) ||
+          CServiceBroker::GetAddonMgr().GetAddon(params[0], addon, ADDON_SCRIPT_LIBRARY))
       {
         scriptpath = addon->LibPath();
       }
       else
       {
         //Run a random extension point (old behaviour).
-        CAddonMgr::GetInstance().GetAddon(params[0], addon);
+        CServiceBroker::GetAddonMgr().GetAddon(params[0], addon);
         scriptpath = addon->LibPath();
         CLog::Log(LOGWARNING, "RunScript called for a non-script addon '%s'. This behaviour is deprecated.", params[0].c_str());
       }
@@ -285,7 +285,7 @@ static int SetDefaultAddon(const std::vector<std::string>& params)
 static int AddonSettings(const std::vector<std::string>& params)
 {
   AddonPtr addon;
-  if (CAddonMgr::GetInstance().GetAddon(params[0], addon))
+  if (CServiceBroker::GetAddonMgr().GetAddon(params[0], addon))
     CGUIDialogAddonSettings::ShowForAddon(addon);
 
   return 0;
@@ -304,7 +304,7 @@ static int StopScript(const std::vector<std::string>& params)
   std::string scriptpath(params[0]);
   // Test to see if the param is an addon ID
   AddonPtr script;
-  if (CAddonMgr::GetInstance().GetAddon(params[0], script))
+  if (CServiceBroker::GetAddonMgr().GetAddon(params[0], script))
     scriptpath = script->LibPath();
   CScriptInvocationManager::GetInstance().Stop(scriptpath);
 
@@ -326,7 +326,7 @@ static int UpdateRepos(const std::vector<std::string>& params)
  */
 static int UpdateLocals(const std::vector<std::string>& params)
 {
-  CAddonMgr::GetInstance().FindAddons();
+  CServiceBroker::GetAddonMgr().FindAddons();
 
   return 0;
 }

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -20,6 +20,7 @@
 
 #include "AddonsOperations.h"
 #include "JSONUtils.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/AddonDatabase.h"
 #include "addons/PluginSource.h"
@@ -85,28 +86,28 @@ JSONRPC_STATUS CAddonsOperations::GetAddons(const std::string &method, ITranspor
       if (!enabled.isBoolean()) //All
       {
         if (!installed.isBoolean() || installed.asBoolean())
-          CAddonMgr::GetInstance().GetInstalledAddons(typeAddons);
+          CServiceBroker::GetAddonMgr().GetInstalledAddons(typeAddons);
         if (!installed.isBoolean() || (installed.isBoolean() && !installed.asBoolean()))
-          CAddonMgr::GetInstance().GetInstallableAddons(typeAddons);
+          CServiceBroker::GetAddonMgr().GetInstallableAddons(typeAddons);
       }
       else if (enabled.asBoolean() && (!installed.isBoolean() || installed.asBoolean())) //Enabled
-        CAddonMgr::GetInstance().GetAddons(typeAddons);
+        CServiceBroker::GetAddonMgr().GetAddons(typeAddons);
       else if (!installed.isBoolean() || installed.asBoolean())
-        CAddonMgr::GetInstance().GetDisabledAddons(typeAddons);
+        CServiceBroker::GetAddonMgr().GetDisabledAddons(typeAddons);
     }
     else
     {
       if (!enabled.isBoolean()) //All
       {
         if (!installed.isBoolean() || installed.asBoolean())
-          CAddonMgr::GetInstance().GetInstalledAddons(typeAddons, *typeIt);
+          CServiceBroker::GetAddonMgr().GetInstalledAddons(typeAddons, *typeIt);
         if (!installed.isBoolean() || (installed.isBoolean() && !installed.asBoolean()))
-          CAddonMgr::GetInstance().GetInstallableAddons(typeAddons, *typeIt);
+          CServiceBroker::GetAddonMgr().GetInstallableAddons(typeAddons, *typeIt);
       }
       else if (enabled.asBoolean() && (!installed.isBoolean() || installed.asBoolean())) //Enabled
-        CAddonMgr::GetInstance().GetAddons(typeAddons, *typeIt);
+        CServiceBroker::GetAddonMgr().GetAddons(typeAddons, *typeIt);
       else if (!installed.isBoolean() || installed.asBoolean())
-        CAddonMgr::GetInstance().GetDisabledAddons(typeAddons, *typeIt);
+        CServiceBroker::GetAddonMgr().GetDisabledAddons(typeAddons, *typeIt);
     }
 
     addons.insert(addons.end(), typeAddons.begin(), typeAddons.end());
@@ -141,7 +142,7 @@ JSONRPC_STATUS CAddonsOperations::GetAddonDetails(const std::string &method, ITr
 {
   std::string id = parameterObject["addonid"].asString();
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, false) || addon.get() == NULL ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, false) || addon.get() == NULL ||
       addon->Type() <= ADDON_UNKNOWN || addon->Type() >= ADDON_MAX)
     return InvalidParams;
     
@@ -155,7 +156,7 @@ JSONRPC_STATUS CAddonsOperations::SetAddonEnabled(const std::string &method, ITr
 {
   std::string id = parameterObject["addonid"].asString();
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, false) || addon == nullptr ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon, ADDON::ADDON_UNKNOWN, false) || addon == nullptr ||
     addon->Type() <= ADDON_UNKNOWN || addon->Type() >= ADDON_MAX)
     return InvalidParams;
 
@@ -164,11 +165,11 @@ JSONRPC_STATUS CAddonsOperations::SetAddonEnabled(const std::string &method, ITr
     disabled = !parameterObject["enabled"].asBoolean();
   // we need to toggle the current disabled state of the addon
   else if (parameterObject["enabled"].isString())
-    disabled = !CAddonMgr::GetInstance().IsAddonDisabled(id);
+    disabled = !CServiceBroker::GetAddonMgr().IsAddonDisabled(id);
   else
     return InvalidParams;
 
-  bool success = disabled ? CAddonMgr::GetInstance().DisableAddon(id) : CAddonMgr::GetInstance().EnableAddon(id);
+  bool success = disabled ? CServiceBroker::GetAddonMgr().DisableAddon(id) : CServiceBroker::GetAddonMgr().EnableAddon(id);
   return success ? ACK : InvalidParams;
 }
 
@@ -176,7 +177,7 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
 {
   std::string id = parameterObject["addonid"].asString();
   AddonPtr addon;
-  if (!CAddonMgr::GetInstance().GetAddon(id, addon) || addon.get() == NULL ||
+  if (!CServiceBroker::GetAddonMgr().GetAddon(id, addon) || addon.get() == NULL ||
       addon->Type() < ADDON_VIZ || addon->Type() >= ADDON_MAX)
     return InvalidParams;
     
@@ -279,11 +280,11 @@ void CAddonsOperations::FillDetails(AddonPtr addon, const CVariant& fields, CVar
     // from the addon database because it can't be read from addon.xml
     if (field == "enabled")
     {
-      object[field] = !CAddonMgr::GetInstance().IsAddonDisabled(addon->ID());
+      object[field] = !CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
     }
     else if (field == "installed")
     {
-      object[field] = CAddonMgr::GetInstance().IsAddonInstalled(addon->ID());
+      object[field] = CServiceBroker::GetAddonMgr().IsAddonInstalled(addon->ID());
     }
     else if (field == "fanart" || field == "thumbnail")
     {

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -142,7 +142,7 @@ JSONRPC_STATUS CGUIOperations::GetPropertyValue(const std::string &property, CVa
   {
     std::string skinId = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);
     AddonPtr addon;
-    if (!CAddonMgr::GetInstance().GetAddon(skinId, addon, ADDON_SKIN))
+    if (!CServiceBroker::GetAddonMgr().GetAddon(skinId, addon, ADDON_SKIN))
       return InternalError;
 
     result["id"] = skinId;

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -21,6 +21,7 @@
 #include "Addon.h"
 #include "LanguageHook.h"
 
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "guilib/GUIWindowManager.h"
@@ -71,15 +72,15 @@ namespace XBMCAddon
       if (id.empty())
         throw AddonException("No valid addon id could be obtained. None was passed and the script wasn't executed in a normal xbmc manner.");
 
-      if (!ADDON::CAddonMgr::GetInstance().GetAddon(id.c_str(), pAddon))
+      if (!CServiceBroker::GetAddonMgr().GetAddon(id.c_str(), pAddon))
         throw AddonException("Unknown addon id '%s'.", id.c_str());
 
-      CAddonMgr::GetInstance().AddToUpdateableAddons(pAddon);
+      CServiceBroker::GetAddonMgr().AddToUpdateableAddons(pAddon);
     }
 
     Addon::~Addon()
     {
-      CAddonMgr::GetInstance().RemoveFromUpdateableAddons(pAddon);
+      CServiceBroker::GetAddonMgr().RemoveFromUpdateableAddons(pAddon);
     }
 
     String Addon::getLocalizedString(int id)

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -212,7 +212,7 @@ bool CPythonInvoker::execute(const std::string &script, const std::vector<std::s
         "modules installed to python path as fallback. This behaviour will be removed in future "
         "version.", GetId());
     ADDON::VECADDONS addons;
-    ADDON::CAddonMgr::GetInstance().GetAddons(addons, ADDON::ADDON_SCRIPT_MODULE);
+    CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON::ADDON_SCRIPT_MODULE);
     for (unsigned int i = 0; i < addons.size(); ++i)
       addPath(CSpecialProtocol::TranslatePath(addons[i]->LibPath()));
   }
@@ -640,7 +640,7 @@ void CPythonInvoker::getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<s
   {
     //Check if dependency is a module addon
     ADDON::AddonPtr dependency;
-    if (ADDON::CAddonMgr::GetInstance().GetAddon(it->first, dependency, ADDON::ADDON_SCRIPT_MODULE))
+    if (CServiceBroker::GetAddonMgr().GetAddon(it->first, dependency, ADDON::ADDON_SCRIPT_MODULE))
     {
       std::string path = CSpecialProtocol::TranslatePath(dependency->LibPath());
       if (paths.find(path) == paths.end())

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -336,7 +336,7 @@ void CDirectoryProvider::Reset()
     m_isAnnounced = false;
     CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
     CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
-    ADDON::CAddonMgr::GetInstance().Events().Unsubscribe(this);
+    CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
     CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
   }
 }
@@ -448,7 +448,7 @@ bool CDirectoryProvider::UpdateURL()
   {
     m_isAnnounced = true;
     CAnnouncementManager::GetInstance().AddAnnouncer(this);
-    ADDON::CAddonMgr::GetInstance().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
+    CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
     CServiceBroker::GetPVRManager().Events().Subscribe(this, &CDirectoryProvider::OnPVRManagerEvent);
     CServiceBroker::GetFavouritesService().Events().Subscribe(this, &CDirectoryProvider::OnFavouritesEvent);
   }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6134,7 +6134,7 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE &content, ADDON::Scra
 
       // Use pre configured or default scraper
       ADDON::AddonPtr addon;
-      if (!scraperUUID.empty() && ADDON::CAddonMgr::GetInstance().GetAddon(scraperUUID, addon) && addon)
+      if (!scraperUUID.empty() && CServiceBroker::GetAddonMgr().GetAddon(scraperUUID, addon) && addon)
       {
         scraper = std::dynamic_pointer_cast<ADDON::CScraper>(addon);
         if (scraper)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "HTTPWebinterfaceAddonsHandler.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "network/WebServer.h"
 
@@ -33,7 +34,7 @@ int CHTTPWebinterfaceAddonsHandler::HandleRequest()
 {
   m_responseData = ADDON_HEADER;
   ADDON::VECADDONS addons;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddons(addons, ADDON::ADDON_WEB_INTERFACE) || addons.empty())
+  if (!CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON::ADDON_WEB_INTERFACE) || addons.empty())
   {
     m_response.type = HTTPError;
     m_response.status = MHD_HTTP_INTERNAL_SERVER_ERROR;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "HTTPWebinterfaceHandler.h"
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/Webinterface.h"
@@ -96,7 +97,7 @@ bool CHTTPWebinterfaceHandler::ResolveAddon(const std::string &url, ADDON::Addon
     if (components.size() <= 1)
       return false;
 
-    if (!ADDON::CAddonMgr::GetInstance().GetAddon(components.at(1), addon) || addon == NULL)
+    if (!CServiceBroker::GetAddonMgr().GetAddon(components.at(1), addon) || addon == NULL)
       return false;
 
     addonPath = addon->Path();

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -993,7 +993,7 @@ void CPeripherals::OnSettingAction(std::shared_ptr<const CSetting> setting)
     if (CGUIWindowAddonBrowser::SelectAddonID(ADDON::ADDON_PERIPHERALDLL, strAddonId, false, true, true, false, true) == 1 && !strAddonId.empty())
     {
       ADDON::AddonPtr addon;
-      if (ADDON::CAddonMgr::GetInstance().GetAddon(strAddonId, addon))
+      if (CServiceBroker::GetAddonMgr().GetAddon(strAddonId, addon))
         CGUIDialogAddonSettings::ShowForAddon(addon);
     }
   }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -41,7 +41,7 @@ CPeripheralBusAddon::CPeripheralBusAddon(CPeripherals& manager) :
 {
   using namespace ADDON;
 
-  CAddonMgr::GetInstance().Events().Subscribe(this, &CPeripheralBusAddon::OnEvent);
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CPeripheralBusAddon::OnEvent);
 
   UpdateAddons();
 }
@@ -50,7 +50,7 @@ CPeripheralBusAddon::~CPeripheralBusAddon()
 {
   using namespace ADDON;
 
-  CAddonMgr::GetInstance().Events().Unsubscribe(this);
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 
   // stop everything before destroying any (loaded) addons
   Clear();
@@ -479,7 +479,7 @@ void CPeripheralBusAddon::PromptEnableAddons(const ADDON::BinaryAddonBaseList& d
     for (const auto& addonInfo : disabledAddons)
     {
       if (CPeripheralAddon::ProvidesJoysticks(addonInfo))
-        CAddonMgr::GetInstance().EnableAddon(addonInfo->ID());
+        CServiceBroker::GetAddonMgr().EnableAddon(addonInfo->ID());
     }
   }
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -57,13 +57,13 @@ CPVRClients::CPVRClients(void) :
 
 CPVRClients::~CPVRClients(void)
 {
-  CAddonMgr::GetInstance().UnregisterAddonMgrCallback(ADDON_PVRDLL);
+  CServiceBroker::GetAddonMgr().UnregisterAddonMgrCallback(ADDON_PVRDLL);
   Unload();
 }
 
 void CPVRClients::Start(void)
 {
-  CAddonMgr::GetInstance().RegisterAddonMgrCallback(ADDON_PVRDLL, this);
+  CServiceBroker::GetAddonMgr().RegisterAddonMgrCallback(ADDON_PVRDLL, this);
 
   UpdateAddons();
 }
@@ -179,7 +179,7 @@ int CPVRClients::EnabledClientAmount(void) const
   }
 
   for (const auto &client : clientMap)
-    if (!CAddonMgr::GetInstance().IsAddonDisabled(client.second->ID()))
+    if (!CServiceBroker::GetAddonMgr().IsAddonDisabled(client.second->ID()))
       ++iReturn;
 
   return iReturn;
@@ -194,7 +194,7 @@ bool CPVRClients::HasEnabledClients(void) const
   }
 
   for (const auto &client : clientMap)
-    if (!CAddonMgr::GetInstance().IsAddonDisabled(client.second->ID()))
+    if (!CServiceBroker::GetAddonMgr().IsAddonDisabled(client.second->ID()))
       return true;
   return false;
 }
@@ -1032,14 +1032,14 @@ bool CPVRClients::IsKnownClient(const AddonPtr &client) const
 void CPVRClients::UpdateAddons(void)
 {
   VECADDONS addons;
-  CAddonMgr::GetInstance().GetInstalledAddons(addons, ADDON_PVRDLL);
+  CServiceBroker::GetAddonMgr().GetInstalledAddons(addons, ADDON_PVRDLL);
 
   if (addons.empty())
     return;
 
   for (auto &addon : addons)
   {
-    bool bEnabled = !CAddonMgr::GetInstance().IsAddonDisabled(addon->ID());
+    bool bEnabled = !CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
 
     if (bEnabled && (!IsKnownClient(addon) || !IsCreatedClient(addon)))
     {
@@ -1077,7 +1077,7 @@ void CPVRClients::UpdateAddons(void)
         CLog::Log(LOGERROR, "%s - failed to create add-on %s, status = %d", __FUNCTION__, addon->Name().c_str(), status);
         if (status == ADDON_STATUS_PERMANENT_FAILURE)
         {
-          CAddonMgr::GetInstance().DisableAddon(addon->ID());
+          CServiceBroker::GetAddonMgr().DisableAddon(addon->ID());
           CJobManager::GetInstance().AddJob(new CPVREventlogJob(true, true, addon->Name(), g_localizeStrings.Get(24070), addon->Icon()), nullptr);
         }
       }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -253,7 +253,7 @@ void CGUIWindowPVRBase::SetInvalid()
 bool CGUIWindowPVRBase::CanBeActivated() const
 {
   // check if there is at least one enabled PVR add-on
-  if (!ADDON::CAddonMgr::GetInstance().HasAddons(ADDON::ADDON_PVRDLL))
+  if (!CServiceBroker::GetAddonMgr().HasAddons(ADDON::ADDON_PVRDLL))
   {
     HELPERS::ShowOKDialogText(CVariant{19296}, CVariant{19272}); // No PVR add-on enabled, You need a tuner, backend software...
     return false;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -60,7 +60,7 @@ bool AddonHasSettings(const std::string &condition, const std::string &value, Se
     return false;
 
   ADDON::AddonPtr addon;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddon(settingAddon->GetValue(), addon, settingAddon->GetAddonType()) || addon == NULL)
+  if (!CServiceBroker::GetAddonMgr().GetAddon(settingAddon->GetValue(), addon, settingAddon->GetAddonType()) || addon == NULL)
     return false;
 
   if (addon->Type() == ADDON::ADDON_SKIN)

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -27,6 +27,7 @@
 #include <limits.h>
 
 #include "GUIDialogContentSettings.h"
+#include "ServiceBroker.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "addons/GUIWindowAddonBrowser.h"
@@ -104,7 +105,7 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSet
     dialog->SetContent(content != CONTENT_NONE ? content : scraper->Content());
     dialog->SetScraper(scraper);
     // toast selected but disabled scrapers
-    if (CAddonMgr::GetInstance().IsAddonDisabled(scraper->ID()))
+    if (CServiceBroker::GetAddonMgr().IsAddonDisabled(scraper->ID()))
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24024), scraper->Name(), 2000, true);
   }
 
@@ -262,7 +263,7 @@ void CGUIDialogContentSettings::OnSettingAction(std::shared_ptr<const CSetting> 
         && selectedAddonId != currentScraperId)
     {
       AddonPtr scraperAddon;
-      CAddonMgr::GetInstance().GetAddon(selectedAddonId, scraperAddon);
+      CServiceBroker::GetAddonMgr().GetAddon(selectedAddonId, scraperAddon);
       m_scraper = std::dynamic_pointer_cast<CScraper>(scraperAddon);
 
       SetupView();
@@ -297,7 +298,7 @@ void CGUIDialogContentSettings::SetupView()
   else
   {
     ToggleState(SETTING_SCRAPER_LIST, true);
-    if (m_scraper != NULL && !CAddonMgr::GetInstance().IsAddonDisabled(m_scraper->ID()))
+    if (m_scraper != NULL && !CServiceBroker::GetAddonMgr().IsAddonDisabled(m_scraper->ID()))
     {
       SetLabel2(SETTING_SCRAPER_LIST, m_scraper->Name());
       if (m_scraper && m_scraper->Supports(m_content) && m_scraper->HasSettings())
@@ -319,7 +320,7 @@ void CGUIDialogContentSettings::InitializeSettings()
 
   if (m_content == CONTENT_NONE)
     m_showScanSettings = false;
-  else if (m_scraper != NULL && !CAddonMgr::GetInstance().IsAddonDisabled(m_scraper->ID()))
+  else if (m_scraper != NULL && !CServiceBroker::GetAddonMgr().IsAddonDisabled(m_scraper->ID()))
     m_showScanSettings = true;
 
   std::shared_ptr<CSettingCategory> category = AddCategory("contentsettings", -1);

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <utility>
 
+#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/GUIWindowAddonBrowser.h"
 #include "addons/settings/SettingUrlEncodedString.h"
@@ -717,7 +718,7 @@ void CGUIControlButtonSetting::Update(bool updateDisplayOnly /* = false */)
         if (controlFormat == "addon")
         {
           ADDON::AddonPtr addon;
-          if (ADDON::CAddonMgr::GetInstance().GetAddon(strValue, addon))
+          if (CServiceBroker::GetAddonMgr().GetAddon(strValue, addon))
             strText = addon->Name();
           if (strText.empty())
             strText = g_localizeStrings.Get(231); // None

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -24,6 +24,7 @@
 
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
+#include "ServiceBroker.h"
 #include "filesystem/File.h"
 #include "interfaces/builtins/Builtins.h"
 #include "messaging/ApplicationMessenger.h"
@@ -77,7 +78,7 @@ void CRssManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
   if (settingId == CSettings::SETTING_LOOKANDFEEL_RSSEDIT)
   {
     ADDON::AddonPtr addon;
-    if (!ADDON::CAddonMgr::GetInstance().GetAddon("script.rss.editor", addon))
+    if (!CServiceBroker::GetAddonMgr().GetAddon("script.rss.editor", addon))
     {
       if (!CAddonInstaller::GetInstance().InstallModal("script.rss.editor", addon))
         return;

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -79,7 +79,7 @@ bool CWeatherJob::DoWork()
     return false;
 
   AddonPtr addon;
-  if (!ADDON::CAddonMgr::GetInstance().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_WEATHER_ADDON), addon, ADDON_SCRIPT_WEATHER))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_WEATHER_ADDON), addon, ADDON_SCRIPT_WEATHER))
     return false;
 
   // initialize our sys.argv variables
@@ -421,7 +421,7 @@ void CWeather::OnSettingAction(std::shared_ptr<const CSetting> setting)
   if (settingId == CSettings::SETTING_WEATHER_ADDONSETTINGS)
   {
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_WEATHER_ADDON), addon, ADDON_SCRIPT_WEATHER) && addon != NULL)
+    if (CServiceBroker::GetAddonMgr().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_WEATHER_ADDON), addon, ADDON_SCRIPT_WEATHER) && addon != NULL)
     { //! @todo maybe have ShowAndGetInput return a bool if settings changed, then only reset weather if true.
       CGUIDialogAddonSettings::ShowForAddon(addon);
       Refresh();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7274,7 +7274,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
       std::string scraperID = m_pDS->fv("path.strScraper").get_asString();
 
       AddonPtr addon;
-      if (!scraperID.empty() && CAddonMgr::GetInstance().GetAddon(scraperID, addon))
+      if (!scraperID.empty() && CServiceBroker::GetAddonMgr().GetAddon(scraperID, addon))
       {
         scraper = std::dynamic_pointer_cast<CScraper>(addon);
         if (!scraper)
@@ -7317,7 +7317,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
 
           AddonPtr addon;
           if (content != CONTENT_NONE &&
-              CAddonMgr::GetInstance().GetAddon(m_pDS->fv("path.strScraper").get_asString(), addon))
+              CServiceBroker::GetAddonMgr().GetAddon(m_pDS->fv("path.strScraper").get_asString(), addon))
           {
             scraper = std::dynamic_pointer_cast<CScraper>(addon);
             scraper->SetPathSettings(content, m_pDS->fv("path.strSettings").get_asString());
@@ -9417,7 +9417,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         AddonPtr addon;
         std::string id;
         XMLUtils::GetString(path,"scraperpath",id);
-        if (CAddonMgr::GetInstance().GetAddon(id, addon))
+        if (CServiceBroker::GetAddonMgr().GetAddon(id, addon))
         {
           SScanSettings settings;
           ScraperPtr scraper = std::dynamic_pointer_cast<CScraper>(addon);

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -236,7 +236,7 @@ void CGUIDialogSubtitles::FillServices()
   ClearServices();
 
   VECADDONS addons;
-  ADDON::CAddonMgr::GetInstance().GetAddons(addons, ADDON_SUBTITLE_MODULE);
+  CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON_SUBTITLE_MODULE);
 
   if (addons.empty())
   {

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -571,7 +571,7 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
   {
     CURL url(items.GetPath());
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN))
+    if (CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN))
     {
       PluginPtr plugin = std::static_pointer_cast<CPluginSource>(addon);
       if (plugin->Provides(CPluginSource::AUDIO))

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -672,7 +672,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   CLog::Log(LOGDEBUG,"  ParentPath = [%s]", CURL::GetRedacted(strParentPath).c_str());
 
   if (pathToUrl.IsProtocol("plugin"))
-    CAddonMgr::GetInstance().UpdateLastUsed(pathToUrl.GetHostName());
+    CServiceBroker::GetAddonMgr().UpdateLastUsed(pathToUrl.GetHostName());
 
   // see if we can load a previously cached folder
   CFileItemList cachedItems(strDirectory);
@@ -978,11 +978,11 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     // execute the script
     CURL url(pItem->GetPath());
     AddonPtr addon;
-    if (CAddonMgr::GetInstance().GetAddon(url.GetHostName(), addon, ADDON_SCRIPT))
+    if (CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(), addon, ADDON_SCRIPT))
     {
       if (!CScriptInvocationManager::GetInstance().Stop(addon->LibPath()))
       {
-        CAddonMgr::GetInstance().UpdateLastUsed(addon->ID());
+        CServiceBroker::GetAddonMgr().UpdateLastUsed(addon->ID());
         CScriptInvocationManager::GetInstance().ExecuteAsync(addon->LibPath(), addon);
       }
       return true;
@@ -1074,7 +1074,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     {
       CURL url(m_vecItems->GetPath());
       AddonPtr addon;
-      if (CAddonMgr::GetInstance().GetAddon(url.GetHostName(),addon))
+      if (CServiceBroker::GetAddonMgr().GetAddon(url.GetHostName(),addon))
       {
         PluginPtr plugin = std::dynamic_pointer_cast<CPluginSource>(addon);
         if (plugin && plugin->Provides(CPluginSource::AUDIO))

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -305,7 +305,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   }
 
   // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status
-  ADDON::CAddonMgr::GetInstance().ReInit();
+  CServiceBroker::GetAddonMgr().ReInit();
 
   // let CApplication know that we are logging into a new profile
   g_application.SetLoggingIn(true);

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -21,6 +21,7 @@
 #include "GUIWindowScreensaverDim.h"
 
 #include "Application.h"
+#include "ServiceBroker.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/GUITexture.h"
@@ -50,7 +51,7 @@ void CGUIWindowScreensaverDim::UpdateVisibility()
     {
       m_visible = true;
       ADDON::AddonPtr info;
-      ADDON::CAddonMgr::GetInstance().GetAddon(usedId, info, ADDON::ADDON_SCREENSAVER);
+      CServiceBroker::GetAddonMgr().GetAddon(usedId, info, ADDON::ADDON_SCREENSAVER);
       if (info && !info->GetSetting("level").empty())
         m_newDimLevel = 100.0f - (float)atof(info->GetSetting("level").c_str());
       else


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Do this direct with 'CServiceBroker::GetAddonMgr()'.

Also becomes the class copy construction prevent changed to C++11 who generates a compile fault instead of a linker fault.
<!--- Describe your change in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
