### PR TITLE
[utils] add file extension provider to enclose extension handling (AS + binary addons)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -93,6 +93,7 @@
 #include "settings/SkinSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/CPUInfo.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/SeekHandler.h"
 #include "ServiceBroker.h"
@@ -2545,7 +2546,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
       else
         pathToUrl = URIUtils::CreateArchivePath("rar", CURL(pMsg->strParam), "");
 
-      CUtil::GetRecursiveListing(pathToUrl.Get(), items, g_advancedSettings.GetPictureExtensions(), XFILE::DIR_FLAG_NO_FILE_DIRS);
+      CUtil::GetRecursiveListing(pathToUrl.Get(), items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), XFILE::DIR_FLAG_NO_FILE_DIRS);
       if (items.Size() > 0)
       {
         pSlideShow->Reset();
@@ -2580,7 +2581,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
 
     CFileItemList items;
     std::string strPath = pMsg->strParam;
-    std::string extensions = g_advancedSettings.GetPictureExtensions();
+    std::string extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
     if (pMsg->param1)
       extensions += "|.tbn";
     CUtil::GetRecursiveListing(strPath, items, extensions);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -59,6 +59,7 @@
 #include "URL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/RegExp.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -822,7 +823,7 @@ bool CFileItem::IsVideo() const
   //! @todo If the file is a zip file, ask the game clients if any support this
   // file before assuming it is video.
 
-  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_videoExtensions);
+  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
 }
 
 bool CFileItem::IsEPG() const
@@ -873,7 +874,7 @@ bool CFileItem::IsDiscStub() const
     return dbItem.IsDiscStub();
   }
 
-  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_discStubExtensions);
+  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetDiscStubExtensions());
 }
 
 bool CFileItem::IsAudio() const
@@ -909,7 +910,7 @@ bool CFileItem::IsAudio() const
   //! @todo If the file is a zip file, ask the game clients if any support this
   // file before assuming it is audio
 
-  return URIUtils::HasExtension(m_strPath, g_advancedSettings.GetMusicExtensions());
+  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions());
 }
 
 bool CFileItem::IsDeleted() const
@@ -975,7 +976,7 @@ bool CFileItem::IsLyrics() const
 
 bool CFileItem::IsSubtitle() const
 {
-  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_subtitlesExtensions);
+  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions());
 }
 
 bool CFileItem::IsCUESheet() const
@@ -2493,7 +2494,7 @@ void CFileItemList::FilterCueItems()
                 }
                 else
                 { // try replacing the extension with one of our allowed ones.
-                  std::vector<std::string> extensions = StringUtils::Split(g_advancedSettings.GetMusicExtensions(), "|");
+                  std::vector<std::string> extensions = StringUtils::Split(CServiceBroker::GetFileExtensionProvider().GetMusicExtensions(), "|");
                   for (std::vector<std::string>::const_iterator i = extensions.begin(); i != extensions.end(); ++i)
                   {
                     strMediaFile = URIUtils::ReplaceExtension(pItem->GetPath(), *i);
@@ -2623,7 +2624,7 @@ void CFileItemList::StackFolders()
           if (bMatch)
           {
             CFileItemList items;
-            CDirectory::GetDirectory(item->GetPath(),items,g_advancedSettings.m_videoExtensions);
+            CDirectory::GetDirectory(item->GetPath(), items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
             // optimized to only traverse listing once by checking for filecount
             // and recording last file item for later use
             int nFiles = 0;
@@ -3247,11 +3248,11 @@ std::string CFileItem::GetLocalFanart() const
     return "";
 
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_advancedSettings.GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+  CDirectory::GetDirectory(strDir, items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
   if (IsOpticalMediaFile())
   { // grab from the optical media parent folder as well
     CFileItemList moreItems;
-    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_advancedSettings.GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
     items.Append(moreItems);
   }
 
@@ -3514,7 +3515,7 @@ std::string CFileItem::FindTrailer() const
 
   std::string strDir = URIUtils::GetDirectory(strFile);
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_advancedSettings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO | DIR_FLAG_NO_FILE_DIRS);
+  CDirectory::GetDirectory(strDir, items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO | DIR_FLAG_NO_FILE_DIRS);
   URIUtils::RemoveExtension(strFile);
   strFile += "-trailer";
   std::string strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -125,6 +125,11 @@ CInputManager& CServiceBroker::GetInputManager()
   return g_application.m_ServiceManager->GetInputManager();
 }
 
+CFileExtensionProvider& CServiceBroker::GetFileExtensionProvider()
+{
+  return g_application.m_ServiceManager->GetFileExtensionProvider();
+}
+
 bool CServiceBroker::IsBinaryAddonCacheUp()
 {
   return g_application.m_ServiceManager->init_level > 1;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -55,6 +55,7 @@ class CSettings;
 class IAE;
 class CFavouritesService;
 class CInputManager;
+class CFileExtensionProvider;
 
 namespace KODI
 {
@@ -98,5 +99,6 @@ public:
   static ADDON::CServiceAddonManager& GetServiceAddons();
   static ADDON::CRepositoryUpdater& GetRepositoryUpdater();
   static CInputManager& GetInputManager();
+  static CFileExtensionProvider &GetFileExtensionProvider();
   static bool IsBinaryAddonCacheUp();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -39,6 +39,7 @@
 #include "interfaces/python/XBPython.h"
 #include "pvr/PVRManager.h"
 #include "settings/Settings.h"
+#include "utils/FileExtensionProvider.h"
 
 using namespace KODI;
 
@@ -111,6 +112,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
 
+  m_fileExtensionProvider.reset(new CFileExtensionProvider());
+
   init_level = 2;
   return true;
 }
@@ -173,6 +176,7 @@ void CServiceManager::DeinitStageThree()
 
 void CServiceManager::DeinitStageTwo()
 {
+  m_fileExtensionProvider.reset();
   m_gameRenderManager.reset();
   m_peripherals.reset();
   m_inputManager.reset();
@@ -311,6 +315,11 @@ CFavouritesService& CServiceManager::GetFavouritesService()
 CInputManager& CServiceManager::GetInputManager()
 {
   return *m_inputManager;
+}
+
+CFileExtensionProvider& CServiceManager::GetFileExtensionProvider()
+{
+  return *m_fileExtensionProvider;
 }
 
 // deleters for unique_ptr

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -82,6 +82,7 @@ namespace PERIPHERALS
 }
 
 class CInputManager;
+class CFileExtensionProvider;
 
 class CServiceManager
 {
@@ -126,6 +127,7 @@ public:
   CSettings& GetSettings();
   CFavouritesService& GetFavouritesService();
   CInputManager &GetInputManager();
+  CFileExtensionProvider &GetFileExtensionProvider();
 
 protected:
   struct delete_dataCacheCore
@@ -171,4 +173,5 @@ protected:
   std::unique_ptr<PERIPHERALS::CPeripherals> m_peripherals;
   std::unique_ptr<CFavouritesService, delete_favouritesService> m_favouritesService;
   std::unique_ptr<CInputManager> m_inputManager;
+  std::unique_ptr<CFileExtensionProvider> m_fileExtensionProvider;
 };

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -80,6 +80,7 @@
 #ifdef HAS_IRSERVERSUITE
 #endif
 #include "guilib/LocalizeStrings.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/md5.h"
 #include "utils/TimeUtils.h"
 #include "utils/URIUtils.h"
@@ -539,7 +540,7 @@ bool CUtil::IsTVRecording(const std::string& strFile)
 bool CUtil::IsPicture(const std::string& strFile)
 {
   return URIUtils::HasExtension(strFile,
-                  g_advancedSettings.GetPictureExtensions()+ "|.tbn|.dds");
+                  CServiceBroker::GetFileExtensionProvider().GetPictureExtensions()+ "|.tbn|.dds");
 }
 
 bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::vector<std::string>& regexps)
@@ -1875,7 +1876,7 @@ void CUtil::GetItemsToScan(const std::string& videoPath,
   for (std::vector<std::string>::const_iterator it = additionalPaths.begin(); it != additionalPaths.end(); ++it)
   {
     CFileItemList moreItems;
-    CDirectory::GetDirectory(*it, moreItems, g_advancedSettings.m_subtitlesExtensions, flags);
+    CDirectory::GetDirectory(*it, moreItems, CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions(), flags);
     items.Append(moreItems);
   }
 }
@@ -1987,7 +1988,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
 
   CFileItemList items;
   const std::vector<std::string> common_sub_dirs = { "subs", "subtitles", "vobsubs", "sub", "vobsub", "subtitle" };
-  GetItemsToScan(strBasePath, g_advancedSettings.m_subtitlesExtensions, common_sub_dirs, items);
+  GetItemsToScan(strBasePath, CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions(), common_sub_dirs, items);
 
   if (!CMediaSettings::GetInstance().GetAdditionalSubtitleDirectoryChecked() && !CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH).empty()) // to avoid checking non-existent directories (network) every time..
   {
@@ -2018,11 +2019,11 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   for (std::vector<std::string>::const_iterator it = strLookInPaths.begin(); it != strLookInPaths.end(); ++it)
   {
     CFileItemList moreItems;
-    CDirectory::GetDirectory(*it, moreItems, g_advancedSettings.m_subtitlesExtensions, flags);
+    CDirectory::GetDirectory(*it, moreItems, CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions(), flags);
     items.Append(moreItems);
   }
 
-  std::vector<std::string> exts = StringUtils::Split(g_advancedSettings.m_subtitlesExtensions, '|');
+  std::vector<std::string> exts = StringUtils::Split(CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions(), '|');
   exts.erase(std::remove(exts.begin(), exts.end(), ".zip"), exts.end());
   exts.erase(std::remove(exts.begin(), exts.end(), ".rar"), exts.end());
 
@@ -2294,9 +2295,9 @@ void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::
   
   CFileItemList items;
   const std::vector<std::string> common_sub_dirs = { "audio", "tracks"};
-  GetItemsToScan(strBasePath, g_advancedSettings.GetMusicExtensions(), common_sub_dirs, items);
+  GetItemsToScan(strBasePath, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions(), common_sub_dirs, items);
 
-  std::vector<std::string> exts = StringUtils::Split(g_advancedSettings.GetMusicExtensions(), "|");
+  std::vector<std::string> exts = StringUtils::Split(CServiceBroker::GetFileExtensionProvider().GetMusicExtensions(), "|");
   ScanPathsForAssociatedItems(strAudio, items, exts, vecAudio);
 }
 

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -24,6 +24,7 @@
 #include "AddonSettings.h"
 #include "FileItem.h"
 #include "GUIInfoManager.h"
+#include "ServiceBroker.h"
 #include "addons/Addon.h"
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "addons/settings/SettingUrlEncodedString.h"
@@ -42,6 +43,7 @@
 #include "settings/lib/SettingsManager.h"
 #include "storage/MediaManager.h"
 #include "threads/SingleLock.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -844,9 +846,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingPath(const std::string& setti
     setting->SetSources({ source });
 
   // setup masking
-  const auto audioMask = g_advancedSettings.GetMusicExtensions();
-  const auto videoMask = g_advancedSettings.m_videoExtensions;
-  const auto imageMask = g_advancedSettings.GetPictureExtensions();
+  const auto audioMask = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
+  const auto videoMask = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
+  const auto imageMask = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
   auto execMask = "";
 #if defined(TARGET_WINDOWS)
   execMask = ".exe|.bat|.cmd|.py";

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIDialogFileBrowser.h"
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
@@ -45,6 +46,7 @@
 #include "utils/log.h"
 #include "URL.h"
 #include "utils/Variant.h"
+#include "utils/FileExtensionProvider.h"
 #include "settings/AdvancedSettings.h"
 #include "messaging/helpers/DialogOKHelper.h"
 
@@ -654,12 +656,12 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList &items, const VE
 
 bool CGUIDialogFileBrowser::ShowAndGetImage(const VECSOURCES &shares, const std::string &heading, std::string &path)
 {
-  return ShowAndGetFile(shares, g_advancedSettings.GetPictureExtensions(), heading, path, true); // true for use thumbs
+  return ShowAndGetFile(shares, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), heading, path, true); // true for use thumbs
 }
 
 bool CGUIDialogFileBrowser::ShowAndGetImageList(const VECSOURCES &shares, const std::string &heading, std::vector<std::string> &path)
 {
-  return ShowAndGetFileList(shares, g_advancedSettings.GetPictureExtensions(), heading, path, true); // true for use thumbs
+  return ShowAndGetFileList(shares, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), heading, path, true); // true for use thumbs
 }
 
 bool CGUIDialogFileBrowser::ShowAndGetDirectory(const VECSOURCES &shares, const std::string &heading, std::string &path, bool bWriteOnly)

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -30,6 +30,7 @@
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "URL.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/HTMLUtil.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -87,9 +88,9 @@ bool CRSSDirectory::ContainsFiles(const CURL& url)
 static bool IsPathToMedia(const std::string& strPath )
 {
   return URIUtils::HasExtension(strPath,
-                              g_advancedSettings.m_videoExtensions + '|' +
-                              g_advancedSettings.GetMusicExtensions() + '|' +
-                              g_advancedSettings.GetPictureExtensions());
+                                CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + '|' +
+                                CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() + '|' +
+                                CServiceBroker::GetFileExtensionProvider().GetPictureExtensions());
 }
 
 static bool IsPathToThumbnail(const std::string& strPath )
@@ -97,7 +98,7 @@ static bool IsPathToThumbnail(const std::string& strPath )
   // Currently just check if this is an image, maybe we will add some
   // other checks later
   return URIUtils::HasExtension(strPath,
-                                    g_advancedSettings.GetPictureExtensions());
+                                CServiceBroker::GetFileExtensionProvider().GetPictureExtensions());
 }
 
 static time_t ParseDate(const std::string & strDate)

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "GUIMultiImage.h"
+#include "ServiceBroker.h"
 #include "TextureManager.h"
 #include "filesystem/Directory.h"
 #include "utils/URIUtils.h"
@@ -28,6 +29,7 @@
 #include "input/Key.h"
 #include "TextureCache.h"
 #include "WindowIDs.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/Random.h"
 #include "utils/StringUtils.h"
 
@@ -315,7 +317,7 @@ bool CGUIMultiImage::CMultiImageJob::DoWork()
 
     URIUtils::AddSlashAtEnd(realPath);
     CFileItemList items;
-    CDirectory::GetDirectory(realPath, items, g_advancedSettings.GetPictureExtensions()+ "|.tbn|.dds", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
+    CDirectory::GetDirectory(realPath, items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions()+ "|.tbn|.dds", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
     for (int i=0; i < items.Size(); i++)
     {
       CFileItem* pItem = items[i].get();

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -33,6 +33,7 @@
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
 #include "system.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/SeekHandler.h"
 #include "utils/StringUtils.h"
@@ -448,8 +449,8 @@ static int PlayMedia(const std::vector<std::string>& params)
   if (item.m_bIsFolder)
   {
     CFileItemList items;
-    std::string extensions = g_advancedSettings.m_videoExtensions + "|" + g_advancedSettings.GetMusicExtensions();
-    XFILE::CDirectory::GetDirectory(item.GetPath(),items,extensions);
+    std::string extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + "|" + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
+    XFILE::CDirectory::GetDirectory(item.GetPath(), items, extensions);
 
     bool containsMusic = false, containsVideo = false;
     for (int i = 0; i < items.Size(); i++)

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -22,6 +22,7 @@
 #include "VideoLibrary.h"
 #include "AudioLibrary.h"
 #include "MediaSource.h"
+#include "ServiceBroker.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "FileItem.h"
@@ -29,6 +30,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "Util.h"
 #include "URL.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/URIUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/Variant.h"
@@ -90,17 +92,17 @@ JSONRPC_STATUS CFileOperations::GetDirectory(const std::string &method, ITranspo
   if (media == "video")
   {
     regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
-    extensions = g_advancedSettings.m_videoExtensions;
+    extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
   }
   else if (media == "music")
   {
     regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
-    extensions = g_advancedSettings.GetMusicExtensions();
+    extensions = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
   }
   else if (media == "pictures")
   {
     regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
-    extensions = g_advancedSettings.GetPictureExtensions();
+    extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
   }
 
   if (CDirectory::GetDirectory(strPath, items, extensions))
@@ -352,17 +354,17 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
       if (media == "video")
       {
         regexps = g_advancedSettings.m_videoExcludeFromListingRegExps;
-        extensions = g_advancedSettings.m_videoExtensions;
+        extensions = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
       }
       else if (media == "music")
       {
         regexps = g_advancedSettings.m_audioExcludeFromListingRegExps;
-        extensions = g_advancedSettings.GetMusicExtensions();
+        extensions = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
       }
       else if (media == "pictures")
       {
         regexps = g_advancedSettings.m_pictureExcludeFromListingRegExps;
-        extensions = g_advancedSettings.GetPictureExtensions();
+        extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
       }
 
       CDirectory directory;

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -48,6 +48,7 @@
 #include "Util.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "storage/MediaManager.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
@@ -457,11 +458,11 @@ namespace XBMCAddon
       XBMC_TRACE;
       String result;
       if (strcmpi(mediaType, "video") == 0)
-        result = g_advancedSettings.m_videoExtensions;
+        result = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
       else if (strcmpi(mediaType, "music") == 0)
-        result = g_advancedSettings.GetMusicExtensions();
+        result = CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
       else if (strcmpi(mediaType, "picture") == 0)
-        result = g_advancedSettings.GetPictureExtensions();
+        result = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
 
       //! @todo implement
       //    else

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -27,6 +27,7 @@
 #include "FileItem.h"
 #include "guilib/WindowIDs.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/SortUtils.h"
 #include "view/ViewStateSettings.h"
@@ -57,7 +58,7 @@ std::string CGUIViewStateWindowMusic::GetLockType()
 
 std::string CGUIViewStateWindowMusic::GetExtensions()
 {
-  return g_advancedSettings.GetMusicExtensions();
+  return CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
 }
 
 VECSOURCES& CGUIViewStateWindowMusic::GetSources()

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -55,6 +55,7 @@
 #include "TextureCache.h"
 #include "threads/SystemClock.h"
 #include "Util.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/md5.h"
 #include "utils/StringUtils.h"
@@ -501,7 +502,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 
   // load subfolder
   CFileItemList items;
-  CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.GetMusicExtensions() + "|.jpg|.tbn|.lrc|.cdg");
+  CDirectory::GetDirectory(strDirectory, items, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() + "|.jpg|.tbn|.lrc|.cdg");
 
   // sort and get the path hash.  Note that we don't filter .cue sheet items here as we want
   // to detect changes in the .cue sheet as well.  The .cue sheet items only need filtering
@@ -1682,7 +1683,7 @@ int CMusicInfoScanner::CountFilesRecursively(const std::string& strPath)
 {
   // load subfolder
   CFileItemList items;
-  CDirectory::GetDirectory(strPath, items, g_advancedSettings.GetMusicExtensions(), DIR_FLAG_NO_FILE_DIRS);
+  CDirectory::GetDirectory(strPath, items, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions(), DIR_FLAG_NO_FILE_DIRS);
 
   if (m_bStop)
     return 0;

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -37,6 +37,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/md5.h"
 #include "utils/SortUtils.h"
@@ -678,10 +679,10 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             // this is the only way to hide unplayable items in the 'files'
             // view as we cannot tell what context (eg music vs video) the
             // request came from
-            std::string supported = g_advancedSettings.GetPictureExtensions() + "|"
-                                  + g_advancedSettings.m_videoExtensions + "|"
-                                  + g_advancedSettings.GetMusicExtensions() + "|"
-                                  + g_advancedSettings.m_discStubExtensions;
+            std::string supported = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions() + "|"
+                                  + CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + "|"
+                                  + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() + "|"
+                                  + CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
             CDirectory::GetDirectory((const char*)parent_id, items, supported);
             DefaultSortItems(items);
         }

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -29,6 +29,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "view/ViewStateSettings.h"
+#include "utils/FileExtensionProvider.h"
 
 using namespace XFILE;
 using namespace ADDON;
@@ -73,9 +74,9 @@ std::string CGUIViewStateWindowPictures::GetLockType()
 
 std::string CGUIViewStateWindowPictures::GetExtensions()
 {
-  std::string extensions = g_advancedSettings.GetPictureExtensions();
+  std::string extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
   if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PICTURES_SHOWVIDEOS))
-    extensions += "|" + g_advancedSettings.m_videoExtensions;
+    extensions += "|" + CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
 
   return extensions;
 }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -28,6 +28,7 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/URIUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -183,7 +184,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       CFileItemList items;
 
-      CDirectory::GetDirectory(pathToUrl, items, g_advancedSettings.GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS);
+      CDirectory::GetDirectory(pathToUrl, items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS);
       
       // create the folder thumb by choosing 4 random thumbs within the folder and putting
       // them into one thumb.
@@ -202,7 +203,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       {
         if (pItem->IsCBZ() || pItem->IsCBR())
         {
-          CDirectory::GetDirectory(pathToUrl, items, g_advancedSettings.GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS);
+          CDirectory::GetDirectory(pathToUrl, items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS);
           for (int i=0;i<items.Size();++i)
           {
             CFileItemPtr item = items[i];

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -25,11 +25,6 @@
 #include <string>
 #include <vector>
 
-#include "addons/AudioDecoder.h"
-#include "addons/BinaryAddonCache.h"
-#include "addons/IAddon.h"
-#include "addons/ImageDecoder.h"
-#include "addons/binary-addons/BinaryAddonBase.h"
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
@@ -1422,34 +1417,4 @@ void CAdvancedSettings::setExtraLogLevel(const std::vector<CVariant> &components
 
     m_extraLogLevels |= static_cast<int>(it->asInteger());
   }
-}
-
-std::string CAdvancedSettings::GetMusicExtensions() const
-{
-  std::string result(m_musicExtensions);
-
-  BinaryAddonBaseList addonInfos;
-  CServiceBroker::GetBinaryAddonManager().GetAddonInfos(addonInfos, true, ADDON_AUDIODECODER);
-  for (const auto& addonInfo : addonInfos)
-  {
-    result += '|';
-    result += CAudioDecoder::GetExtensions(addonInfo);
-  }
-
-  return result;
-}
-
-std::string CAdvancedSettings::GetPictureExtensions() const
-{
-  std::string result(m_pictureExtensions);
-
-  BinaryAddonBaseList addonInfos;
-  CServiceBroker::GetBinaryAddonManager().GetAddonInfos(addonInfos, true, ADDON_IMAGEDECODER);
-  for (auto addonInfo : addonInfos)
-  {
-    result += '|';
-    result += addonInfo->Type(ADDON_IMAGEDECODER)->GetValue("@extension").asString();
-  }
-
-  return result;
 }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -358,12 +358,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float GetLatencyTweak(float refreshrate);
     bool m_initialized;
 
-    //! \brief Returns a list of picture extension for filtering in the GUI
-    std::string GetPictureExtensions() const;
-
-    //! \brief Returns a list of music extension for filtering in the GUI
-    std::string GetMusicExtensions() const;
-
     void SetDebugMode(bool debug);
 
     //! \brief Toggles dirty-region visualization
@@ -373,6 +367,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_videoExtensions;
     std::string m_discStubExtensions;
     std::string m_subtitlesExtensions;
+    std::string m_musicExtensions;
+    std::string m_pictureExtensions;
 
     std::string m_stereoscopicregex_3d;
     std::string m_stereoscopicregex_sbs;
@@ -388,8 +384,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_userAgent;
 
   private:
-    std::string m_musicExtensions;
-    std::string m_pictureExtensions;
     void setExtraLogLevel(const std::vector<CVariant> &components);
 };
 

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES ActorProtocol.cpp
             DatabaseUtils.cpp
             EndianSwap.cpp
             Environment.cpp
+            FileExtensionProvider.cpp
             Fanart.cpp
             FileOperationJob.cpp
             FileUtils.cpp
@@ -96,6 +97,7 @@ set(HEADERS ActorProtocol.h
             Environment.h
             EventStream.h
             EventStreamDetail.h
+            FileExtensionProvider.h
             Fanart.h
             FileOperationJob.h
             FileUtils.h

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -1,0 +1,145 @@
+/*
+ *      Copyright (C) 2012-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileExtensionProvider.h"
+
+#include <string>
+#include <vector>
+
+#include "addons/AddonManager.h"
+#include "addons/binary-addons/BinaryAddonBase.h"
+#include "ServiceBroker.h"
+
+using namespace ADDON;
+
+const std::vector<TYPE> ADDON_TYPES = {
+  ADDON_VFS,
+  ADDON_IMAGEDECODER,
+  ADDON_AUDIODECODER
+};
+
+CFileExtensionProvider::CFileExtensionProvider()
+{
+  m_advancedSettings = g_advancedSettingsRef;
+
+  SetAddonExtensions();
+
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CFileExtensionProvider::OnAddonEvent);
+}
+
+CFileExtensionProvider::~CFileExtensionProvider()
+{
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
+
+  m_advancedSettings.reset();
+  m_addonExtensions.clear();
+}
+
+std::string CFileExtensionProvider::GetDiscStubExtensions() const
+{
+  return m_advancedSettings->m_discStubExtensions;
+}
+
+std::string CFileExtensionProvider::GetMusicExtensions() const
+{
+  std::string extensions(m_advancedSettings->m_musicExtensions);
+  extensions += '|' + GetAddonExtensions(ADDON_VFS);
+  extensions += '|' + GetAddonExtensions(ADDON_AUDIODECODER);
+
+  return extensions;
+}
+
+std::string CFileExtensionProvider::GetPictureExtensions() const
+{
+  std::string extensions(m_advancedSettings->m_pictureExtensions);
+  extensions += '|' + GetAddonExtensions(ADDON_VFS);
+  extensions += '|' + GetAddonExtensions(ADDON_IMAGEDECODER);
+
+  return extensions;
+}
+
+std::string CFileExtensionProvider::GetSubtitleExtensions() const
+{
+  std::string extensions(m_advancedSettings->m_subtitlesExtensions);
+  extensions += '|' + GetAddonExtensions(ADDON_VFS);
+
+  return extensions;
+}
+
+std::string CFileExtensionProvider::GetVideoExtensions() const
+{
+  std::string extensions(m_advancedSettings->m_videoExtensions);
+  extensions += '|' + GetAddonExtensions(ADDON_VFS);
+
+  return extensions;
+}
+
+std::string CFileExtensionProvider::GetAddonExtensions(const TYPE &type) const
+{
+  auto it = m_addonExtensions.find(type);
+  if (it != m_addonExtensions.end())
+    return it->second;
+
+  return "";
+}
+
+void CFileExtensionProvider::SetAddonExtensions()
+{
+  for (auto const type : ADDON_TYPES)
+  {
+    SetAddonExtensions(type);
+  }
+}
+
+void CFileExtensionProvider::SetAddonExtensions(const TYPE& type)
+{
+  std::vector<std::string> extensions;
+  BinaryAddonBaseList addonInfos;
+  CServiceBroker::GetBinaryAddonManager().GetAddonInfos(addonInfos, true, type);
+  for (const auto& addonInfo : addonInfos)
+  {
+    std::string ext = addonInfo->Type(type)->GetValue(ADDON_VFS == type ? "@extensions" : "@extension").asString();
+    if (!ext.empty())
+      extensions.push_back(ext);
+  }
+
+  m_addonExtensions.insert(make_pair(type, StringUtils::Join(extensions, "|")));
+}
+
+void CFileExtensionProvider::OnAddonEvent(const AddonEvent& event)
+{
+  if (typeid(event) == typeid(AddonEvents::Enabled) ||
+      typeid(event) == typeid(AddonEvents::Disabled) ||
+      typeid(event) == typeid(AddonEvents::ReInstalled))
+  {
+    for (auto &type : ADDON_TYPES)
+    {
+      if (CServiceBroker::GetAddonMgr().HasType(event.id, type))
+      {
+        SetAddonExtensions(type);
+        break;
+      }
+    }
+  }
+  else if (typeid(event) == typeid(AddonEvents::UnInstalled))
+  {
+    SetAddonExtensions();
+  }
+}

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -1,0 +1,67 @@
+#pragma once
+/*
+ *      Copyright (C) 2012-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "addons/AddonInfo.h"
+#include "addons/AddonEvents.h"
+#include "settings/AdvancedSettings.h"
+
+class CFileExtensionProvider
+{
+public:
+  CFileExtensionProvider();
+  ~CFileExtensionProvider();
+
+  /*!
+   * @brief Returns a list of picture extensions
+   */
+  std::string GetPictureExtensions() const;
+
+  /*!
+   * @brief Returns a list of music extensions
+   */
+  std::string GetMusicExtensions() const;
+
+  /*!
+   * @brief Returns a list of video extensions
+   */
+  std::string GetVideoExtensions() const;
+
+  /*!
+   * @brief Returns a list of subtitle extensions
+   */
+  std::string GetSubtitleExtensions() const;
+
+  /*!
+   * @brief Returns a list of disc stub extensions
+   */
+  std::string GetDiscStubExtensions() const;
+
+private:
+  std::string GetAddonExtensions(const ADDON::TYPE &type) const;
+  void SetAddonExtensions();
+  void SetAddonExtensions(const ADDON::TYPE &type);
+
+  void OnAddonEvent(const ADDON::AddonEvent& event);
+
+  std::map<ADDON::TYPE, std::string> m_addonExtensions;
+  std::shared_ptr<CAdvancedSettings> m_advancedSettings;
+
+};

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -28,6 +28,8 @@
 #include "network/DNSNameCache.h"
 #include "settings/AdvancedSettings.h"
 #include "URL.h"
+#include "utils/FileExtensionProvider.h"
+#include "ServiceBroker.h"
 #include "StringUtils.h"
 
 #if defined(TARGET_WINDOWS)
@@ -131,10 +133,10 @@ void URIUtils::RemoveExtension(std::string& strFileName)
     strExtension += "|";
 
     std::string strFileMask;
-    strFileMask = g_advancedSettings.GetPictureExtensions();
-    strFileMask += "|" + g_advancedSettings.GetMusicExtensions();
-    strFileMask += "|" + g_advancedSettings.m_videoExtensions;
-    strFileMask += "|" + g_advancedSettings.m_subtitlesExtensions;
+    strFileMask = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
+    strFileMask += "|" + CServiceBroker::GetFileExtensionProvider().GetMusicExtensions();
+    strFileMask += "|" + CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
+    strFileMask += "|" + CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions();
 #if defined(TARGET_DARWIN)
     strFileMask += "|.py|.xml|.milk|.xbt|.cdg|.app|.applescript|.workflow";
 #else

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -31,6 +31,7 @@
 #include "FileItem.h"
 #include "guilib/WindowIDs.h"
 #include "view/ViewStateSettings.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/SortUtils.h"
 
 using namespace XFILE;
@@ -43,7 +44,7 @@ std::string CGUIViewStateWindowVideo::GetLockType()
 
 std::string CGUIViewStateWindowVideo::GetExtensions()
 {
-  return g_advancedSettings.m_videoExtensions;
+  return CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
 }
 
 int CGUIViewStateWindowVideo::GetPlaylist()

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -47,6 +47,7 @@
 #include "threads/SystemClock.h"
 #include "URL.h"
 #include "Util.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
 #include "utils/md5.h"
 #include "utils/RegExp.h"
@@ -295,7 +296,7 @@ namespace VIDEO
       }
       else
       { // need to fetch the folder
-        CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
+        CDirectory::GetDirectory(strDirectory, items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
         items.Stack();
 
         // check whether to re-use previously computed fast hash
@@ -333,7 +334,7 @@ namespace VIDEO
 
       if (foundDirectly && !settings.parent_name_root)
       {
-        CDirectory::GetDirectory(strDirectory, items, g_advancedSettings.m_videoExtensions);
+        CDirectory::GetDirectory(strDirectory, items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
         items.SetPath(strDirectory);
         GetPathHash(items, hash);
         bSkip = true;
@@ -779,7 +780,7 @@ namespace VIDEO
         if (!hash.empty())
           flags |= DIR_FLAG_NO_FILE_INFO;
 
-        CUtil::GetRecursiveListing(item->GetPath(), items, g_advancedSettings.m_videoExtensions, flags);
+        CUtil::GetRecursiveListing(item->GetPath(), items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), flags);
 
         // fast hash failed - compute slow one
         if (hash.empty())

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -53,6 +53,7 @@
 #include "settings/dialogs/GUIDialogContentSettings.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/FileUtils.h"
@@ -221,7 +222,7 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
     if (item.m_bIsFolder && scraper && scraper->Content() != CONTENT_TVSHOWS)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(), items, g_advancedSettings.m_videoExtensions);
+      CDirectory::GetDirectory(item.GetPath(), items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
       items.Stack();
 
       // check for media files


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
This PR adds a new `FileExtensionProvider` to enclose extension providing from `AdvancedSettings` and binary addons like `vfs`, `encoder`.

@notspiff mind taking a look too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
If vfs.rar is not installed or disabled Kodi should not support `.rar` files. They should not to be scanned by our info scanners, because it results in various issues if we only add `file.rar` to the library instead of `rar://path-to-rar/file.mkv` (dupe entries, not able to playback etc.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested on MacOS.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)