### PR TITLE
[addons] binary cache update is not triggered on enable/disable of addons

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -122,14 +122,15 @@ void CContextMenuManager::ReloadAddonItems()
 
 void CContextMenuManager::OnEvent(const ADDON::AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::InstalledChanged))
+  if (typeid(event) == typeid(AddonEvents::ReInstalled) ||
+      typeid(event) == typeid(AddonEvents::UnInstalled))
   {
     ReloadAddonItems();
   }
-  else if (auto enableEvent = dynamic_cast<const AddonEvents::Enabled*>(&event))
+  else if (typeid(event) == typeid(AddonEvents::Enabled))
   {
     AddonPtr addon;
-    if (m_addonMgr.GetAddon(enableEvent->id, addon, ADDON_CONTEXT_ITEM))
+    if (m_addonMgr.GetAddon(event.id, addon, ADDON_CONTEXT_ITEM))
     {
       CSingleLock lock(m_criticalSection);
       auto items = std::static_pointer_cast<CContextMenuAddon>(addon)->GetItems();
@@ -139,13 +140,12 @@ void CContextMenuManager::OnEvent(const ADDON::AddonEvent& event)
         if (it == m_addonItems.end())
           m_addonItems.push_back(item);
       }
-      CLog::Log(LOGDEBUG, "ContextMenuManager: loaded %s.", enableEvent->id.c_str());
+      CLog::Log(LOGDEBUG, "ContextMenuManager: loaded %s.", event.id.c_str());
     }
   }
-  else if (auto disableEvent = dynamic_cast<const AddonEvents::Disabled*>(&event))
+  else if (typeid(event) == typeid(AddonEvents::Disabled))
   {
-    AddonPtr addon;
-    if (m_addonMgr.GetAddon(disableEvent->id, addon, ADDON_CONTEXT_ITEM, false))
+    if (m_addonMgr.HasType(event.id, ADDON_CONTEXT_ITEM))
     {
       ReloadAddonItems();
     }

--- a/xbmc/addons/AddonEvents.h
+++ b/xbmc/addons/AddonEvents.h
@@ -25,27 +25,35 @@ namespace ADDON
 {
   struct AddonEvent
   {
+    std::string id;
+    explicit AddonEvent(std::string id) : id(std::move(id)) {};
     virtual ~AddonEvent() = default;
   };
 
   namespace AddonEvents
   {
+    /**
+     * Emitted after the add-on has been enabled.
+     */
     struct Enabled : AddonEvent
     {
-      std::string id;
-      explicit Enabled(std::string id) : id(std::move(id)) {}
+      explicit Enabled(std::string id) : AddonEvent(std::move(id)) {}
     };
 
+    /**
+     * Emitted after the add-on has been disabled.
+     */
     struct Disabled : AddonEvent
     {
-      std::string id;
-      explicit Disabled(std::string id) : id(std::move(id)) {}
+      explicit Disabled(std::string id) : AddonEvent(std::move(id)) {}
     };
 
+    /**
+     * Emitted after the add-on's metadata has been changed.
+     */
     struct MetadataChanged : AddonEvent
     {
-      std::string id;
-      explicit MetadataChanged(std::string id) : id(std::move(id)) {}
+      explicit MetadataChanged(std::string id) : AddonEvent(std::move(id)) {}
     };
 
     /**
@@ -54,8 +62,7 @@ namespace ADDON
      */
     struct ReInstalled: AddonEvent
     {
-      std::string id;
-      explicit ReInstalled(std::string id) : id(std::move(id)) {}
+      explicit ReInstalled(std::string id) : AddonEvent(std::move(id)) {}
     };
 
     /**
@@ -63,25 +70,23 @@ namespace ADDON
      */
     struct UnInstalled : AddonEvent
     {
-      std::string id;
-      explicit UnInstalled(std::string id) : id(std::move(id)) {}
+      explicit UnInstalled(std::string id) : AddonEvent(std::move(id)) {}
     };
 
     /**
-     * @deprecated Use Enabled, ReInstalled and UnInstalled instead.
+     * Emitted after the add-on has been loaded.
      */
-    struct InstalledChanged : AddonEvent {};
-
     struct Load : AddonEvent
     {
-      std::string id;
-      explicit Load(std::string id) : id(std::move(id)) {}
+      explicit Load(std::string id) : AddonEvent(std::move(id)) {}
     };
 
+    /**
+     * Emitted after the add-on has been unloaded.
+     */
     struct Unload : AddonEvent
     {
-      std::string id;
-      explicit Unload(std::string id) : id(std::move(id)) {}
+      explicit Unload(std::string id) : AddonEvent(std::move(id)) {}
     };
-  };
-};
+  }
+}

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -654,6 +654,12 @@ bool CAddonMgr::GetAddon(const std::string &str, AddonPtr &addon, const TYPE &ty
   return false;
 }
 
+bool CAddonMgr::HasType(const std::string &id, const TYPE &type)
+{
+  AddonPtr addon;
+  return GetAddon(id, addon, type, false);
+}
+
 bool CAddonMgr::FindAddons()
 {
   bool result = false;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -692,8 +692,6 @@ bool CAddonMgr::FindAddons()
     tmp.clear();
     m_database.GetBlacklisted(tmp);
     m_updateBlacklist = std::move(tmp);
-
-    m_events.Publish(AddonEvents::InstalledChanged());
   }
 
   return result;
@@ -758,7 +756,6 @@ bool CAddonMgr::LoadAddon(const std::string& addonId)
   }
 
   m_events.Publish(AddonEvents::ReInstalled(addon->ID()));
-  m_events.Publish(AddonEvents::InstalledChanged());
   CLog::Log(LOGDEBUG, "CAddonMgr: %s successfully loaded", addon->ID().c_str());
   return true;
 }
@@ -768,7 +765,6 @@ void CAddonMgr::OnPostUnInstall(const std::string& id)
   CSingleLock lock(m_critSection);
   m_disabled.erase(id);
   m_updateBlacklist.erase(id);
-  m_events.Publish(AddonEvents::InstalledChanged());
   m_events.Publish(AddonEvents::UnInstalled(id));
 }
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -96,6 +96,8 @@ namespace ADDON
      */
     bool GetAddon(const std::string &id, AddonPtr &addon, const TYPE &type = ADDON_UNKNOWN, bool enabledOnly = true);
 
+    bool HasType(const std::string &id, const TYPE &type);
+
     bool HasAddons(const TYPE &type);
 
     bool HasInstalledAddons(const TYPE &type);

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -26,6 +26,8 @@
 namespace ADDON
 {
 
+const std::vector<TYPE> ADDONS_TO_CACHE = { ADDON_PVRDLL, ADDON_GAMEDLL };
+
 CBinaryAddonCache::~CBinaryAddonCache()
 {
   Deinit();
@@ -33,10 +35,6 @@ CBinaryAddonCache::~CBinaryAddonCache()
 
 void CBinaryAddonCache::Init()
 {
-  m_addonsToCache = {
-    ADDON_PVRDLL,
-    ADDON_GAMEDLL,
-  };
   CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CBinaryAddonCache::OnEvent);
   Update();
 }
@@ -108,6 +106,19 @@ void CBinaryAddonCache::OnEvent(const AddonEvent& event)
   {
     Update();
   }
+  else if (typeid(event) == typeid(AddonEvents::Enabled) ||
+           typeid(event) == typeid(AddonEvents::Disabled) ||
+           typeid(event) == typeid(AddonEvents::ReInstalled))
+  {
+    for (auto &type : ADDONS_TO_CACHE)
+    {
+      if (CServiceBroker::GetAddonMgr().HasType(event.id, type))
+      {
+        Update();
+        break;
+      }
+    }
+  }
 }
 
 void CBinaryAddonCache::Update()
@@ -115,7 +126,7 @@ void CBinaryAddonCache::Update()
   using AddonMap = std::multimap<TYPE, VECADDONS>;
   AddonMap addonmap;
 
-  for (auto &addonType : m_addonsToCache)
+  for (auto &addonType : ADDONS_TO_CACHE)
   {
     VECADDONS addons;
     CServiceBroker::GetAddonMgr().GetInstalledAddons(addons, addonType);

--- a/xbmc/addons/BinaryAddonCache.cpp
+++ b/xbmc/addons/BinaryAddonCache.cpp
@@ -103,8 +103,11 @@ AddonPtr CBinaryAddonCache::GetAddonInstance(const std::string& strId, TYPE type
 
 void CBinaryAddonCache::OnEvent(const AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::InstalledChanged))
+  if (typeid(event) == typeid(AddonEvents::ReInstalled) ||
+      typeid(event) == typeid(AddonEvents::UnInstalled))
+  {
     Update();
+  }
 }
 
 void CBinaryAddonCache::Update()

--- a/xbmc/addons/BinaryAddonCache.h
+++ b/xbmc/addons/BinaryAddonCache.h
@@ -46,7 +46,6 @@ protected:
   
   CCriticalSection m_critSection;
   std::multimap<TYPE, VECADDONS> m_addons;
-  std::vector<TYPE> m_addonsToCache;
 };
 
 }

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -68,10 +68,9 @@ CRepositoryUpdater::~CRepositoryUpdater()
 
 void CRepositoryUpdater::OnEvent(const ADDON::AddonEvent& event)
 {
-  if (auto enableEvent = dynamic_cast<const AddonEvents::Enabled*>(&event))
+  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled))
   {
-    AddonPtr addon;
-    if (m_addonMgr.GetAddon(enableEvent->id, addon, ADDON_REPOSITORY))
+    if (m_addonMgr.HasType(event.id, ADDON_REPOSITORY))
       ScheduleUpdate();
   }
 }

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -55,22 +55,19 @@ CServiceAddonManager::~CServiceAddonManager()
 
 void CServiceAddonManager::OnEvent(const ADDON::AddonEvent& event)
 {
-  if (auto enableEvent = dynamic_cast<const AddonEvents::Enabled*>(&event))
+  if (typeid(event) == typeid(ADDON::AddonEvents::Enabled))
   {
-    Start(enableEvent->id);
+    Start(event.id);
   }
-  else if (auto disableEvent = dynamic_cast<const AddonEvents::Disabled*>(&event))
+  else if (typeid(event) == typeid(ADDON::AddonEvents::ReInstalled))
   {
-    Stop(disableEvent->id);
+    Stop(event.id);
+    Start(event.id);
   }
-  else if (auto uninstallEvent = dynamic_cast<const AddonEvents::UnInstalled*>(&event))
+  else if (typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+           typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
-    Stop(uninstallEvent->id);
-  }
-  else if (auto reinstallEvent = dynamic_cast<const AddonEvents::ReInstalled*>(&event))
-  {
-    Stop(reinstallEvent->id);
-    Start(reinstallEvent->id);
+    Stop(event.id);
   }
 }
 

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -36,11 +36,13 @@ CVFSAddonCache::~CVFSAddonCache()
 void CVFSAddonCache::Init()
 {
   CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CVFSAddonCache::OnEvent);
+  CServiceBroker::GetAddonMgr().UnloadEvents().Subscribe(this, &CVFSAddonCache::OnEvent);
   Update();
 }
 
 void CVFSAddonCache::Deinit()
 {
+  CServiceBroker::GetAddonMgr().UnloadEvents().Unsubscribe(this);
   CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 }
 
@@ -50,7 +52,7 @@ const std::vector<VFSEntryPtr> CVFSAddonCache::GetAddonInstances()
   return m_addonsInstances;
 }
 
-VFSEntryPtr CVFSAddonCache::GetAddonInstance(const std::string& strId, TYPE type)
+VFSEntryPtr CVFSAddonCache::GetAddonInstance(const std::string& strId)
 {
   VFSEntryPtr addon;
 
@@ -70,10 +72,15 @@ VFSEntryPtr CVFSAddonCache::GetAddonInstance(const std::string& strId, TYPE type
 
 void CVFSAddonCache::OnEvent(const AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::ReInstalled) ||
-      typeid(event) == typeid(AddonEvents::UnInstalled))
+  if (typeid(event) == typeid(AddonEvents::Disabled) ||
+      typeid(event) == typeid(AddonEvents::Unload) ||
+      typeid(event) == typeid(AddonEvents::Enabled) ||
+      typeid(event) == typeid(AddonEvents::Load))
   {
-    Update();
+    if (CServiceBroker::GetAddonMgr().HasType(event.id, ADDON_VFS))
+    {
+      Update();
+    }
   }
 }
 

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -70,8 +70,11 @@ VFSEntryPtr CVFSAddonCache::GetAddonInstance(const std::string& strId, TYPE type
 
 void CVFSAddonCache::OnEvent(const AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::InstalledChanged))
+  if (typeid(event) == typeid(AddonEvents::ReInstalled) ||
+      typeid(event) == typeid(AddonEvents::UnInstalled))
+  {
     Update();
+  }
 }
 
 void CVFSAddonCache::Update()

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -38,7 +38,7 @@ namespace ADDON
     void Init();
     void Deinit();
     const std::vector<VFSEntryPtr> GetAddonInstances();
-    VFSEntryPtr GetAddonInstance(const std::string& strId, TYPE type);
+    VFSEntryPtr GetAddonInstance(const std::string& strId);
 
   protected:
     void Update();

--- a/xbmc/addons/binary-addons/BinaryAddonManager.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonManager.cpp
@@ -175,15 +175,16 @@ bool CBinaryAddonManager::AddAddonBaseEntry(BINARY_ADDON_LIST_ENTRY& entry)
 
 void CBinaryAddonManager::OnEvent(const AddonEvent& event)
 {
-  if (auto enableEvent = dynamic_cast<const AddonEvents::Enabled*>(&event))
+  if (typeid(event) == typeid(AddonEvents::Enabled))
   {
-    EnableEvent(enableEvent->id);
+    EnableEvent(event.id);
   }
-  else if (auto disableEvent = dynamic_cast<const AddonEvents::Disabled*>(&event))
+  else if (typeid(event) == typeid(AddonEvents::Disabled))
   {
-    DisableEvent(disableEvent->id);
+    DisableEvent(event.id);
   }
-  else if (typeid(event) == typeid(AddonEvents::InstalledChanged))
+  else if (typeid(event) == typeid(AddonEvents::ReInstalled) ||
+           typeid(event) == typeid(AddonEvents::UnInstalled))
   {
     InstalledChangeEvent();
   }

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -150,7 +150,8 @@ void CGUIControllerList::ResetController(void)
 
 void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
 {
-  if (typeid(event) == typeid(ADDON::AddonEvents::InstalledChanged))
+  if (typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+      typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
     using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -289,7 +289,8 @@ void CDirectoryProvider::OnAddonEvent(const ADDON::AddonEvent& event)
   {
     if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
         typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-        typeid(event) == typeid(ADDON::AddonEvents::InstalledChanged) ||
+        typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+        typeid(event) == typeid(ADDON::AddonEvents::UnInstalled) ||
         typeid(event) == typeid(ADDON::AddonEvents::MetadataChanged))
       m_updateState = INVALIDATED;
   }

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -42,6 +42,7 @@ CPeripheralBusAddon::CPeripheralBusAddon(CPeripherals& manager) :
   using namespace ADDON;
 
   CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CPeripheralBusAddon::OnEvent);
+  CServiceBroker::GetAddonMgr().UnloadEvents().Subscribe(this, &CPeripheralBusAddon::OnEvent);
 
   UpdateAddons();
 }
@@ -50,6 +51,7 @@ CPeripheralBusAddon::~CPeripheralBusAddon()
 {
   using namespace ADDON;
 
+  CServiceBroker::GetAddonMgr().UnloadEvents().Unsubscribe(this);
   CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 
   // stop everything before destroying any (loaded) addons
@@ -333,10 +335,17 @@ void CPeripheralBusAddon::GetDirectory(const std::string &strPath, CFileItemList
 void CPeripheralBusAddon::OnEvent(const ADDON::AddonEvent& event)
 {
   if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
-    UpdateAddons();
+      typeid(event) == typeid(ADDON::AddonEvents::Load))
+  {
+    if (CServiceBroker::GetAddonMgr().HasType(event.id, ADDON::ADDON_PERIPHERALDLL))
+      UpdateAddons();
+  }
+  else if (typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
+           typeid(event) == typeid(ADDON::AddonEvents::Unload))
+  {
+    if (CServiceBroker::GetAddonMgr().HasType(event.id, ADDON::ADDON_PERIPHERALDLL))
+      UnRegisterAddon(event.id);
+  }
 }
 
 bool CPeripheralBusAddon::SplitLocation(const std::string& strLocation, PeripheralAddonPtr& addon, unsigned int& peripheralIndex) const
@@ -429,28 +438,33 @@ void CPeripheralBusAddon::UpdateAddons(void)
   // Destroy removed add-ons
   for (const std::string& addonId : removed)
   {
-    CLog::Log(LOGDEBUG, "Add-on bus: Unregistering add-on %s", addonId.c_str());
+    UnRegisterAddon(addonId);
+  }
+}
 
-    PeripheralAddonPtr erased;
-    auto ErasePeripheralAddon = [&addonId, &erased](const PeripheralAddonPtr& addon)
-      {
-        if (addon->ID() == addonId)
-        {
-          erased = addon;
-          return true;
-        }
-        return false;
-      };
+void CPeripheralBusAddon::UnRegisterAddon(const std::string& addonId)
+{
+  CLog::Log(LOGDEBUG, "Add-on bus: Unregistering add-on %s", addonId.c_str());
 
-    m_addons.erase(std::remove_if(m_addons.begin(), m_addons.end(), ErasePeripheralAddon), m_addons.end());
-    if (!erased)
-      m_failedAddons.erase(std::remove_if(m_failedAddons.begin(), m_failedAddons.end(), ErasePeripheralAddon), m_failedAddons.end());
-
-    if (erased)
+  PeripheralAddonPtr erased;
+  auto ErasePeripheralAddon = [&addonId, &erased](const PeripheralAddonPtr& addon)
     {
-      CSingleExit exit(m_critSection);
-      erased->DestroyAddon();
-    }
+      if (addon->ID() == addonId)
+      {
+        erased = addon;
+        return true;
+      }
+      return false;
+    };
+
+  m_addons.erase(std::remove_if(m_addons.begin(), m_addons.end(), ErasePeripheralAddon), m_addons.end());
+  if (!erased)
+    m_failedAddons.erase(std::remove_if(m_failedAddons.begin(), m_failedAddons.end(), ErasePeripheralAddon), m_failedAddons.end());
+
+  if (erased)
+  {
+    CSingleExit exit(m_critSection);
+    erased->DestroyAddon();
   }
 }
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -334,7 +334,8 @@ void CPeripheralBusAddon::OnEvent(const ADDON::AddonEvent& event)
 {
   if (typeid(event) == typeid(ADDON::AddonEvents::Enabled) ||
       typeid(event) == typeid(ADDON::AddonEvents::Disabled) ||
-      typeid(event) == typeid(ADDON::AddonEvents::InstalledChanged))
+      typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
+      typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
     UpdateAddons();
 }
 

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -90,6 +90,7 @@ namespace PERIPHERALS
 
   private:
     void OnEvent(const ADDON::AddonEvent& event);
+    void UnRegisterAddon(const std::string& addonId);
 
     void PromptEnableAddons(const ADDON::BinaryAddonBaseList& disabledAddons);
 


### PR DESCRIPTION
Enabling/disabling of VFS addons does not trigger update of binary addon caches. This PR will fix the issue.

@mkortstiege mind taking a look.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Runtime tested on MacOS

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
