### PR TITLE
[PVR] Make PVR database threadsafe.

### DIFF
--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -76,7 +76,7 @@ public:
   CDatabase(void);
   virtual ~CDatabase(void);
   bool IsOpen();
-  void Close();
+  virtual void Close();
   bool Compress(bool bForce=true);
   void Interrupt();
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -37,8 +37,6 @@ using namespace dbiplus;
 using namespace PVR;
 using namespace ADDON;
 
-#define PVRDB_DEBUGGING 0
-
 bool CPVRDatabase::Open()
 {
   CSingleLock lock(m_critSection);
@@ -220,9 +218,6 @@ int CPVRDatabase::Get(CPVRChannelGroupInternal &results, bool bCompressDB)
           channel->m_iEpgId                = m_pDS->fv("idEpg").get_asInt();
         channel->UpdateEncryptionName();
 
-#if PVRDB_DEBUGGING
-        CLog::Log(LOGDEBUG, "PVR - %s - channel '%s' loaded from the database", __FUNCTION__, channel->m_strChannelName.c_str());
-#endif
         PVRChannelGroupMember newMember = { channel, (unsigned int)m_pDS->fv("iChannelNumber").get_asInt() };
         results.m_sortedMembers.push_back(newMember);
         results.m_members.insert(std::make_pair(channel->StorageId(), newMember));
@@ -481,9 +476,6 @@ int CPVRDatabase::Get(CPVRChannelGroup &group, const std::map<int, CPVRChannelPt
 
         if (channel != allChannels.end())
         {
-#if PVRDB_DEBUGGING
-          CLog::Log(LOGDEBUG, "PVR - %s - channel '%s' loaded from the database", __FUNCTION__, channel->m_strChannelName.c_str());
-#endif
           PVRChannelGroupMember newMember = { channel->second, static_cast<unsigned int>(iChannelNumber) };
           group.m_sortedMembers.emplace_back(newMember);
           group.m_members.insert(std::make_pair(channel->second->StorageId(), newMember));

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -19,12 +19,16 @@
  *
  */
 
+#include <map>
 #include <vector>
 
 #include "dbwrappers/Database.h"
+#include "threads/CriticalSection.h"
 #include "utils/log.h"
 
 #include "pvr/PVRManager.h"
+
+#include "pvr/PVRTypes.h"
 
 namespace PVR
 {
@@ -51,6 +55,11 @@ namespace PVR
     bool Open() override;
 
     /*!
+     * @brief Close the database.
+     */
+    void Close() override;
+
+    /*!
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
@@ -74,9 +83,10 @@ namespace PVR
     /*!
      * @brief Add or update a channel entry in the database
      * @param channel The channel to persist.
+     * @param bCommit queue only or queue and commit
      * @return True when persisted or queued, false otherwise.
      */
-    bool Persist(CPVRChannel &channel);
+    bool Persist(CPVRChannel &channel, bool bCommit);
 
     /*!
      * @brief Remove a channel entry from the database
@@ -88,9 +98,10 @@ namespace PVR
     /*!
      * @brief Get the list of channels from the database
      * @param results The channel group to store the results in.
+     * @param bCompressDB Compress the DB after getting the list
      * @return The amount of channels that were added.
      */
-    int Get(CPVRChannelGroupInternal &results);
+    int Get(CPVRChannelGroupInternal &results, bool bCompressDB);
 
     //@}
 
@@ -120,9 +131,10 @@ namespace PVR
     /*!
      * @brief Add the group members to a group.
      * @param group The group to get the channels for.
+     * @param allChannels All channels contained in the "all channels group" matching param group's 'IsRadio' property.
      * @return The amount of channels that were added.
      */
-    int Get(CPVRChannelGroup &group);
+    int Get(CPVRChannelGroup &group, const std::map<int, CPVRChannelPtr> &allChannels);
 
     /*!
      * @brief Add or update a channel group entry in the database.
@@ -180,5 +192,7 @@ namespace PVR
     bool PersistChannels(CPVRChannelGroup &group);
 
     bool RemoveChannelsFromGroup(const CPVRChannelGroup &group);
+
+    CCriticalSection m_critSection;
   };
 }

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -24,16 +24,12 @@
 
 #include "dbwrappers/Database.h"
 #include "threads/CriticalSection.h"
-#include "utils/log.h"
-
-#include "pvr/PVRManager.h"
 
 #include "pvr/PVRTypes.h"
 
 namespace PVR
 {
   class CPVRChannelGroup;
-  class CPVRChannelGroupInternal;
   class CPVRChannel;
   class CPVRChannelGroups;
 
@@ -101,7 +97,7 @@ namespace PVR
      * @param bCompressDB Compress the DB after getting the list
      * @return The amount of channels that were added.
      */
-    int Get(CPVRChannelGroupInternal &results, bool bCompressDB);
+    int Get(CPVRChannelGroup &results, bool bCompressDB);
 
     //@}
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -343,7 +343,7 @@ void CPVRManager::Stop(void)
 
   /* close database */
   const CPVRDatabasePtr database(GetTVDatabase());
-  if (database && database->IsOpen())
+  if (database)
     database->Close();
 
   SetState(ManagerStateStopped);

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -29,6 +29,7 @@
 #include "utils/log.h"
 
 #include "pvr/PVRDatabase.h"
+#include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/epg/EpgContainer.h"

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -235,7 +235,7 @@ bool CPVRChannel::Persist()
   const CPVRDatabasePtr database(CServiceBroker::GetPVRManager().GetTVDatabase());
   if (database)
   {
-    bool bReturn = database->Persist(*this) && database->CommitInsertQueries();
+    bool bReturn = database->Persist(*this, true);
     CSingleLock lock(m_critSection);
     m_bChanged = !bReturn;
     return bReturn;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -224,15 +224,9 @@ int CPVRChannelGroupInternal::LoadFromDb(bool bCompress /* = false */)
 
   int iChannelCount = Size();
 
-  if (database->Get(*this) > 0)
+  if (database->Get(*this, bCompress) == 0)
   {
-    if (bCompress)
-      database->Compress(true);
-  }
-  else
-  {
-    CLog::Log(LOGINFO, "PVRChannelGroupInternal - %s - no channels in the database",
-        __FUNCTION__);
+    CLog::Log(LOGINFO, "PVRChannelGroupInternal - %s - no channels in the database", __FUNCTION__);
   }
 
   SortByChannelNumber();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -125,7 +125,7 @@ void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
   {
     CGUIWindowPVRBase::SetSelectedItemPath(m_group->IsRadio(), m_viewControl.GetSelectedItemPath());
 
-    // next OnInitWindow will set the group which is then selceted
+    // next OnInitWindow will set the group which is then selected
     m_group.reset();
   }
 


### PR DESCRIPTION
class `CPVRDatabase` had no concurrency protection features but is accessed simultaneously from multiple threads. :-/ This PR introduces basic concurrency support for `CPVRDatabase`.

Example:
<pre>
Thread 43 (Thread 0x59d65390 (LWP 736)):
#0  0x007480f8 in dbiplus::field_prop* std::__uninitialized_default_n_1<false>::__uninit_default_n<dbiplus::field_prop*, unsigned int>(dbiplus::field_prop*, unsigned int) ()
#1  0x00748164 in std::vector<dbiplus::field_prop, std::allocator<dbiplus::field_prop> >::_M_default_append(unsigned int) ()
#2  0x00747774 in dbiplus::SqliteDataset::query(std::string const&) ()
#3  0x0073ddd4 in CDatabase::GetSingleValue(std::string const&, std::unique_ptr<dbiplus::Dataset, std::default_delete<dbiplus::Dataset> >&) ()
#4  0x0073ee90 in CDatabase::GetSingleValue(std::string const&, std::string const&, std::string const&, std::string const&) ()
#5  0x008c507c in PVR::CPVRDatabase::PersistChannels(PVR::CPVRChannelGroup&) ()
#6  0x008c696c in PVR::CPVRDatabase::Persist(PVR::CPVRChannelGroup&) ()
#7  0x008aa28c in PVR::CPVRChannelGroup::Persist() ()
#8  0x008ac814 in PVR::CPVRChannelGroup::UpdateGroupEntries(PVR::CPVRChannelGroup const&) ()
#9  0x008af3bc in PVR::CPVRChannelGroupInternal::UpdateGroupEntries(PVR::CPVRChannelGroup const&) ()
#10 0x008aef20 in PVR::CPVRChannelGroupInternal::Update() ()
#11 0x008b1874 in PVR::CPVRChannelGroups::Update(bool) ()
#12 0x008b24e4 in PVR::CPVRChannelGroupsContainer::Update(bool) ()
#13 0x008d184c in PVR::CPVRChannelGroupsUpdateJob::DoWork() ()
#14 0x008c1370 in PVR::CPVRManagerJobQueue::ExecutePendingJobs() ()
#15 0x008c200c in PVR::CPVRManager::Process() ()
#16 0x0066c9a4 in CThread::Action() ()
#17 0x0066d0a0 in CThread::staticThread(void*) ()
#18 0x76efdd34 in start_thread (arg=0x59d65390) at pthread_create.c:465
#19 0x74fd0ab8 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)


Thread 1 (Thread 0x6e8ff390 (LWP 685)):
#0  0x7519ea60 in std::string::assign(std::string const&) () from /usr/lib/libstdc++.so.6
#1  0x00746978 in dbiplus::SqliteDataset::make_query(std::list<std::string, std::allocator<std::string> >&) ()
#2  0x00745a88 in dbiplus::SqliteDataset::make_insert() ()
#3  0x0073e058 in CDatabase::CommitInsertQueries() ()
#4  0x008a7a78 in PVR::CPVRChannel::Persist() ()
#5  0x008ad160 in PVR::CPVRChannelGroup::SearchAndSetChannelIcons(bool) ()
#6  0x008b264c in PVR::CPVRChannelGroupsContainer::SearchMissingChannelIcons() const ()
#7  0x008d1474 in PVR::CPVRSearchMissingChannelIconsJob::DoWork() ()
#8  0x00627984 in CJobWorker::Process() ()
#9  0x0066c9a4 in CThread::Action() ()
#10 0x0066d0a0 in CThread::staticThread(void*) ()
#11 0x76efdd34 in start_thread (arg=0x6e8ff390) at pthread_create.c:465
#12 0x74fd0ab8 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
</pre>

This should fix several occasional crashes reported in the forum and elsewhere.

Example: https://forum.kodi.tv/showthread.php?tid=298461&pid=2651405#pid2651405 (second crashlog in that posting)

I runtime-tested this change on macOS, latest Kodi master.

@Jalle19 for review?