### PR TITLE
[droid] network fixes

### DIFF
--- a/xbmc/network/android/NetworkAndroid.cpp
+++ b/xbmc/network/android/NetworkAndroid.cpp
@@ -270,6 +270,26 @@ void CNetworkInterfaceAndroid::SetSettings(NetworkAssignment& assignment, std::s
   // Not implemented
 }
 
+std::string CNetworkInterfaceAndroid::GetHostName()
+{
+  CJNIList<CJNILinkAddress> lla = m_lp.getLinkAddresses();
+  if (lla.size() == 0)
+    return "";
+
+  int i = 0;
+  for (;i < lla.size(); ++i)
+  {
+    if (lla.get(i).getAddress().getAddress().size() > 4)  // IPV4 only
+      continue;
+    break;
+  }
+  if (i == lla.size())
+    return "";
+
+  CJNILinkAddress la = lla.get(i);
+  return la.getAddress().getHostName();
+}
+
 
 /*************************/
 
@@ -288,8 +308,13 @@ CNetworkAndroid::~CNetworkAndroid()
 
 bool CNetworkAndroid::GetHostName(std::string& hostname)
 {
-  hostname = CJNIInetAddress::getLocalHost().getHostName();
-  return true;
+  CNetworkInterfaceAndroid* intf = dynamic_cast<CNetworkInterfaceAndroid*>(GetFirstConnectedInterface());
+  if (intf)
+  {
+    hostname = intf->GetHostName();
+    return true;
+  }
+  return false;
 }
 
 std::vector<CNetworkInterface*>& CNetworkAndroid::GetInterfaceList()

--- a/xbmc/network/android/NetworkAndroid.h
+++ b/xbmc/network/android/NetworkAndroid.h
@@ -53,6 +53,8 @@ public:
   virtual void GetSettings(NetworkAssignment& assignment, std::string& ipAddress, std::string& networkMask, std::string& defaultGateway, std::string& essId, std::string& key, EncMode& encryptionMode) override;
   virtual void SetSettings(NetworkAssignment& assignment, std::string& ipAddress, std::string& networkMask, std::string& defaultGateway, std::string& essId, std::string& key, EncMode& encryptionMode) override;
 
+  std::string GetHostName();
+
 protected:
   std::string m_name;
   CJNINetwork m_network;

--- a/xbmc/network/android/ZeroconfBrowserAndroid.cpp
+++ b/xbmc/network/android/ZeroconfBrowserAndroid.cpp
@@ -80,7 +80,8 @@ bool CZeroconfBrowserAndroid::doRemoveServiceType(const std::string& fcr_service
       return false;
     }
     discover = it->second;
-    m_manager.stopServiceDiscovery(*discover);
+    if (discover->IsActive())
+      m_manager.stopServiceDiscovery(*discover);
     // Be extra careful: Discover listener is gone as of now
     m_service_browsers.erase(it);
   }
@@ -213,17 +214,20 @@ void CZeroconfBrowserAndroid::removeDiscoveredService(CZeroconfBrowserAndroidDis
 CZeroconfBrowserAndroidDiscover::CZeroconfBrowserAndroidDiscover(CZeroconfBrowserAndroid* browser)
   : CJNIXBMCNsdManagerDiscoveryListener()
   , m_browser(browser)
+  , m_isActive(false)
 {
 }
 
 void CZeroconfBrowserAndroidDiscover::onDiscoveryStarted(const std::string& serviceType)
 {
   CLog::Log(LOGDEBUG, "CZeroconfBrowserAndroidDiscover::onDiscoveryStarted type: %s", serviceType.c_str());
+  m_isActive = true;
 }
 
 void CZeroconfBrowserAndroidDiscover::onDiscoveryStopped(const std::string& serviceType)
 {
   CLog::Log(LOGDEBUG, "CZeroconfBrowserAndroidDiscover::onDiscoveryStopped type: %s", serviceType.c_str());
+  m_isActive = false;
 }
 
 void CZeroconfBrowserAndroidDiscover::onServiceFound(const jni::CJNINsdServiceInfo& serviceInfo)
@@ -261,11 +265,13 @@ void CZeroconfBrowserAndroidDiscover::onServiceLost(const jni::CJNINsdServiceInf
 void CZeroconfBrowserAndroidDiscover::onStartDiscoveryFailed(const std::string& serviceType, int errorCode)
 {
   CLog::Log(LOGDEBUG, "CZeroconfBrowserAndroidDiscover::onStartDiscoveryFailed type: %s, error: %d", serviceType.c_str(), errorCode);
+  m_isActive = false;
 }
 
 void CZeroconfBrowserAndroidDiscover::onStopDiscoveryFailed(const std::string& serviceType, int errorCode)
 {
   CLog::Log(LOGDEBUG, "CZeroconfBrowserAndroidDiscover::onStopDiscoveryFailed type: %s, error: %d", serviceType.c_str(), errorCode);
+  m_isActive = false;
 }
 
 /***************************************/

--- a/xbmc/network/android/ZeroconfBrowserAndroid.h
+++ b/xbmc/network/android/ZeroconfBrowserAndroid.h
@@ -34,6 +34,7 @@ class CZeroconfBrowserAndroidDiscover : public jni::CJNIXBMCNsdManagerDiscoveryL
 {
 public:
   explicit CZeroconfBrowserAndroidDiscover(CZeroconfBrowserAndroid* browser);
+  bool IsActive() { return m_isActive; }
   
   // CJNINsdManagerDiscoveryListener interface
 public:
@@ -46,6 +47,7 @@ public:
   
 protected:
   CZeroconfBrowserAndroid* m_browser;
+  bool m_isActive;
 };
 
 class CZeroconfBrowserAndroidResolve : public jni::CJNIXBMCNsdManagerResolveListener


### PR DESCRIPTION
Fixes:
1) Crash when disconnecting from airplay
It's due to the limitation on the number of zeroconf discoverers, that still needs to be workarounded somehow

2) Hostname is always "localhost"
Now uses the revert DNS of the IP of the the default interface
Hostname appears at the start of the log

Ref: https://forum.kodi.tv/showthread.php?tid=319539