### PR TITLE
[XBMCHelper] - fixed up and down buttons on ir remotes with macOS High Sierra

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/HIDRemote/HIDRemote.m
+++ b/tools/EventClients/Clients/OSXRemote/HIDRemote/HIDRemote.m
@@ -1017,6 +1017,14 @@ static HIDRemote *sHIDRemote = nil;
 				case kHIDUsage_Csmr_Menu:
 					buttonCode = kHIDRemoteButtonCodeMenuHold;
 				break;
+
+				case kHIDUsage_Csmr_VolumeIncrement:
+					buttonCode = kHIDRemoteButtonCodeUp;
+				break;
+
+				case kHIDUsage_Csmr_VolumeDecrement:
+					buttonCode = kHIDRemoteButtonCodeDown;
+				break;
 			}
 		break;
 		


### PR DESCRIPTION
In High Sierra the up and down buttons of apple ir remotes stopped working.

This is a backport of the upstream (HIDRemote) fix for this problem. 

## Motivation and Context
Regression introduced in macOS High Sierra

## How Has This Been Tested?
User tested it and confirmed the fix.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
