### PR TITLE
[XBMCHelper] - fixed up and down buttons on ir remotes with macOS High Sierra

### DIFF
--- a/tools/EventClients/Clients/OSXRemote/HIDRemote/HIDRemote.m
+++ b/tools/EventClients/Clients/OSXRemote/HIDRemote/HIDRemote.m
@@ -1017,6 +1017,14 @@ static HIDRemote *sHIDRemote = nil;
 				case kHIDUsage_Csmr_Menu:
 					buttonCode = kHIDRemoteButtonCodeMenuHold;
 				break;
+
+				case kHIDUsage_Csmr_VolumeIncrement:
+					buttonCode = kHIDRemoteButtonCodeUp;
+				break;
+
+				case kHIDUsage_Csmr_VolumeDecrement:
+					buttonCode = kHIDRemoteButtonCodeDown;
+				break;
 			}
 		break;
 		


### PR DESCRIPTION
backport of #12848