### PR TITLE
Game OSD: Video filter dialog updates

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8712,7 +8712,31 @@ msgctxt "#16206"
 msgid "Failed to delete at least one file. Check the log for more information about this message."
 msgstr ""
 
-#empty strings from id 16207 to 16299
+#empty strings from id 16207 to 16295
+
+#. Name of the video filter that uses jagged pixels without smoothing
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16296"
+msgid "Pixelate"
+msgstr ""
+
+#. Name of the video filter that smooths pixels to remove jagged edges
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16297"
+msgid "Smooth"
+msgstr ""
+
+#. Description of the video filter that uses jagged pixels without smoothing
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16298"
+msgid "Shows the game's pixels without any modifications."
+msgstr ""
+
+#. Description of the video filter that smooths pixels to remove jagged edges
+#: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+msgctxt "#16299"
+msgid "Removes the jagged edges of pixels by evenly fading between adjacent pixels."
+msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16300"

--- a/addons/skin.estuary/xml/DialogSelect.xml
+++ b/addons/skin.estuary/xml/DialogSelect.xml
@@ -4,7 +4,8 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<depth>DepthOSD</depth>
 	<controls>
-		<include condition="Window.IsActive(gameviewmode) | Window.IsActive(gamevideofilter)">GameDialogSelectLayout</include>
 		<include condition="![Window.IsActive(gameviewmode) | Window.IsActive(gamevideofilter)]">DefaultDialogSelectLayout</include>
+		<include condition="Window.IsActive(gamevideofilter)">GameDialogSelectFilterLayout</include>
+		<include condition="Window.IsActive(gameviewmode)">GameDialogSelectViewLayout</include>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -148,7 +148,111 @@
 			</control>
 		</control>
 	</include>
-	<include name="GameDialogSelectLayout">
+	<include name="GameDialogSelectFilterLayout">
+		<control type="button">
+			<description>background close area</description>
+			<left>0</left>
+			<top>0</top>
+			<width>100%</width>
+			<bottom>540</bottom>
+			<texturefocus />
+			<texturenofocus />
+			<onclick>Action(close)</onclick>
+		</control>
+		<control type="group">
+			<bottom>0</bottom>
+			<height>540</height>
+			<width>100%</width>
+			<control type="image">
+				<animation effect="fade" start="0" end="100" time="300">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
+			</control>
+			<control type="panel" id="11">
+				<top>30</top>
+				<scrolltime tween="sine">200</scrolltime>
+				<orientation>horizontal</orientation>
+				<itemlayout width="480" height="340">
+					<control type="group">
+						<left>18</left>
+						<right>18</right>
+						<top>5</top>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>scale</aspectratio>
+							<texture border="4">DefaultVideo.png</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>4</bordersize>
+						</control>
+						<control type="gamewindow">
+							<width>444</width>
+							<height>250</height>
+							<scalingmethod>$INFO[ListItem.Property(game.scalingmethod)]</scalingmethod>
+							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
+						</control>
+						<control type="label">
+							<top>250</top>
+							<width>444</width>
+							<height>80</height>
+							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
+							<font>font37</font>
+							<shadowcolor>text_shadow</shadowcolor>
+							<align>center</align>
+						</control>
+					</control>
+				</itemlayout>
+				<focusedlayout width="480" height="340">
+					<control type="group">
+						<left>18</left>
+						<right>18</right>
+						<top>5</top>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>scale</aspectratio>
+							<texture border="4">DefaultVideo.png</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>4</bordersize>
+						</control>
+						<control type="gamewindow">
+							<width>444</width>
+							<height>250</height>
+							<scalingmethod>$INFO[ListItem.Property(game.scalingmethod)]</scalingmethod>
+							<viewmode>$INFO[ListItem.Property(game.viewmode)]</viewmode>
+						</control>
+						<control type="label">
+							<top>250</top>
+							<width>444</width>
+							<height>80</height>
+							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
+							<font>font37</font>
+							<shadowcolor>text_shadow</shadowcolor>
+							<align>center</align>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
+							<visible>Control.HasFocus(11)</visible>
+						</control>
+					</control>
+				</focusedlayout>
+			</control>
+			<control type="textbox" id="12">
+				<description>Description Area</description>
+				<top>410</top>
+				<left>100</left>
+				<right>100</right>
+				<height>200</height>
+				<font>font37</font>
+				<align>justify</align>
+				<shadowcolor>text_shadow</shadowcolor>
+				<autoscroll time="3000" delay="5000" repeat="5000">true</autoscroll>
+			</control>
+		</control>
+	</include>
+	<include name="GameDialogSelectViewLayout">
 		<control type="button">
 			<description>background close area</description>
 			<left>0</left>
@@ -169,7 +273,7 @@
 				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 			</control>
 			<control type="panel" id="11">
-				<top>50</top>
+				<top>30</top>
 				<scrolltime tween="sine">200</scrolltime>
 				<orientation>horizontal</orientation>
 				<itemlayout width="480" height="340">
@@ -196,7 +300,7 @@
 							<width>444</width>
 							<height>40</height>
 							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
-							<font>font12</font>
+							<font>font37</font>
 							<shadowcolor>text_shadow</shadowcolor>
 							<align>center</align>
 						</control>
@@ -226,7 +330,7 @@
 							<width>444</width>
 							<height>40</height>
 							<label>$INFO[ListItem.Label][CR][COLOR grey]$INFO[ListItem.Label2][/COLOR]</label>
-							<font>font12</font>
+							<font>font37</font>
 							<shadowcolor>text_shadow</shadowcolor>
 							<align>center</align>
 						</control>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -404,6 +404,12 @@
       <escape>Fullscreen</escape>
     </keyboard>
   </FullscreenGame>
+  <GameOSD>
+    <keyboard>
+      <m>OSD</m>
+      <menu>OSD</menu>
+    </keyboard>
+  </GameOSD>
   <VideoTimeSeek>
     <keyboard>
       <return>Select</return>

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -40,7 +40,6 @@
 #include "games/tags/GameInfoTag.h"
 #include "games/GameServices.h"
 #include "games/GameUtils.h"
-#include "guilib/GUIDialog.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
@@ -544,28 +543,13 @@ void CRetroPlayer::CloseOSD()
 
 void CRetroPlayer::RegisterWindowCallbacks()
 {
-  m_gameServices.GameRenderManager().RegisterFactory(m_renderManager->GetGUIRenderTargetFactory());
-
-  CDialogGameVideoSelect *dialogVideoFilter = dynamic_cast<CDialogGameVideoSelect*>(g_windowManager.GetWindow(WINDOW_DIALOG_GAME_VIDEO_FILTER));
-  if (dialogVideoFilter != nullptr)
-    dialogVideoFilter->RegisterCallback(m_renderManager.get());
-
-  CDialogGameVideoSelect *dialogViewMode = dynamic_cast<CDialogGameVideoSelect*>(g_windowManager.GetWindow(WINDOW_DIALOG_GAME_VIEW_MODE));
-  if (dialogViewMode != nullptr)
-    dialogViewMode->RegisterCallback(m_renderManager.get());
+  m_gameServices.GameRenderManager().RegisterPlayer(m_renderManager->GetGUIRenderTargetFactory(),
+                                                    m_renderManager.get());
 }
 
 void CRetroPlayer::UnregisterWindowCallbacks()
 {
-  CDialogGameVideoSelect *dialogVideoFilter = dynamic_cast<CDialogGameVideoSelect*>(g_windowManager.GetWindow(WINDOW_DIALOG_GAME_VIDEO_FILTER));
-  if (dialogVideoFilter != nullptr)
-    dialogVideoFilter->UnregisterCallback();
-
-  CDialogGameVideoSelect *dialogViewMode = dynamic_cast<CDialogGameVideoSelect*>(g_windowManager.GetWindow(WINDOW_DIALOG_GAME_VIEW_MODE));
-  if (dialogViewMode != nullptr)
-    dialogViewMode->UnregisterCallback();
-
-  m_gameServices.GameRenderManager().UnregisterFactory();
+  m_gameServices.GameRenderManager().UnregisterPlayer();
 }
 
 void CRetroPlayer::PrintGameInfo(const CFileItem &file) const

--- a/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES GUIGameRenderManager.cpp
             GUIGameSettings.cpp
+            GUIGameVideoHandle.cpp
             GUIRenderHandle.cpp
             GUIRenderTarget.cpp
             GUIRenderTargetFactory.cpp
@@ -12,6 +13,7 @@ set(SOURCES GUIGameRenderManager.cpp
 
 set(HEADERS GUIGameRenderManager.h
             GUIGameSettings.h
+            GUIGameVideoHandle.h
             GUIRenderHandle.h
             GUIRenderTarget.h
             GUIRenderTargetFactory.h

--- a/xbmc/cores/RetroPlayer/rendering/GUIGameVideoHandle.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/GUIGameVideoHandle.cpp
@@ -1,0 +1,50 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GUIGameVideoHandle.h"
+#include "GUIGameRenderManager.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CGUIGameVideoHandle::CGUIGameVideoHandle(CGUIGameRenderManager &renderManager) :
+  m_renderManager(renderManager)
+{
+}
+
+CGUIGameVideoHandle::~CGUIGameVideoHandle()
+{
+  m_renderManager.UnregisterHandle(this);
+}
+
+bool CGUIGameVideoHandle::IsPlayingGame()
+{
+  return m_renderManager.IsPlayingGame();
+}
+
+bool CGUIGameVideoHandle::SupportsRenderFeature(ERENDERFEATURE feature)
+{
+  return m_renderManager.SupportsRenderFeature(feature);
+}
+
+bool CGUIGameVideoHandle::SupportsScalingMethod(ESCALINGMETHOD method)
+{
+  return m_renderManager.SupportsScalingMethod(method);
+}

--- a/xbmc/cores/RetroPlayer/rendering/GUIGameVideoHandle.h
+++ b/xbmc/cores/RetroPlayer/rendering/GUIGameVideoHandle.h
@@ -1,0 +1,45 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "cores/IPlayer.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CGUIGameRenderManager;
+
+  class CGUIGameVideoHandle
+  {
+  public:
+    CGUIGameVideoHandle(CGUIGameRenderManager &renderManager);
+    virtual ~CGUIGameVideoHandle();
+
+    bool IsPlayingGame();
+    bool SupportsRenderFeature(ERENDERFEATURE feature);
+    bool SupportsScalingMethod(ESCALINGMETHOD method);
+
+  private:
+    // Construction parameters
+    CGUIGameRenderManager &m_renderManager;
+  };
+}
+}

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "DialogGameVideoFilter.h"
-#include "cores/RetroPlayer/rendering/IRenderCallback.h"
+#include "cores/RetroPlayer/rendering/GUIGameVideoHandle.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "settings/GameSettings.h"
@@ -69,11 +69,11 @@ void CDialogGameVideoFilter::PreInit()
 
 void CDialogGameVideoFilter::InitScalingMethods()
 {
-  if (m_callback != nullptr)
+  if (m_gameVideoHandle)
   {
     for (const auto &scalingMethodProps : scalingMethods)
     {
-      if (m_callback->SupportsScalingMethod(scalingMethodProps.scalingMethod))
+      if (m_gameVideoHandle->SupportsScalingMethod(scalingMethodProps.scalingMethod))
       {
         CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(scalingMethodProps.nameIndex));
         item->SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -26,28 +26,26 @@
 #include "settings/MediaSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-#include "FileItem.h"
 
 using namespace KODI;
 using namespace GAME;
 
-const std::vector<CDialogGameVideoFilter::VideoFilterProperties> CDialogGameVideoFilter::m_allVideoFilters =
+namespace
 {
-  { 16301,  VS_SCALINGMETHOD_NEAREST },
-  { 16302,  VS_SCALINGMETHOD_LINEAR },
-  { 16303,  VS_SCALINGMETHOD_CUBIC },
-  { 16304,  VS_SCALINGMETHOD_LANCZOS2 },
-  { 16323,  VS_SCALINGMETHOD_SPLINE36_FAST },
-  { 16315,  VS_SCALINGMETHOD_LANCZOS3_FAST },
-  { 16322,  VS_SCALINGMETHOD_SPLINE36 },
-  { 16305,  VS_SCALINGMETHOD_LANCZOS3 },
-  { 16306,  VS_SCALINGMETHOD_SINC8 },
-  { 16307,  VS_SCALINGMETHOD_BICUBIC_SOFTWARE },
-  { 16308,  VS_SCALINGMETHOD_LANCZOS_SOFTWARE },
-  { 16309,  VS_SCALINGMETHOD_SINC_SOFTWARE },
-  { 13120,  VS_SCALINGMETHOD_VDPAU_HARDWARE },
-  { 16319,  VS_SCALINGMETHOD_DXVA_HARDWARE },
-};
+  struct ScalingMethodProperties
+  {
+    int nameIndex;
+    int categoryIndex;
+    int descriptionIndex;
+    ESCALINGMETHOD scalingMethod;
+  };
+
+  const std::vector<ScalingMethodProperties> scalingMethods =
+  {
+    { 16301, 16296, 16298, VS_SCALINGMETHOD_NEAREST },
+    { 16302, 16297, 16299, VS_SCALINGMETHOD_LINEAR },
+  };
+}
 
 CDialogGameVideoFilter::CDialogGameVideoFilter() :
   CDialogGameVideoSelect(WINDOW_DIALOG_GAME_VIDEO_FILTER)
@@ -56,45 +54,67 @@ CDialogGameVideoFilter::CDialogGameVideoFilter() :
 
 void CDialogGameVideoFilter::PreInit()
 {
-  m_videoFilters.clear();
+  m_items.Clear();
 
+  InitScalingMethods();
+
+  if (m_items.Size() == 0)
+  {
+    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(231)); // "None"
+    m_items.Add(std::move(item));
+  }
+
+  m_bHasDescription = false;
+}
+
+void CDialogGameVideoFilter::InitScalingMethods()
+{
   if (m_callback != nullptr)
   {
-    for (const auto &videoFilter : m_allVideoFilters)
+    for (const auto &scalingMethodProps : scalingMethods)
     {
-      if (m_callback->SupportsScalingMethod(videoFilter.scalingMethod))
-        m_videoFilters.emplace_back(videoFilter);
+      if (m_callback->SupportsScalingMethod(scalingMethodProps.scalingMethod))
+      {
+        CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(scalingMethodProps.nameIndex));
+        item->SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));
+        item->SetProperty("game.scalingmethod", CVariant{ scalingMethodProps.scalingMethod });
+        item->SetProperty("game.videofilterdescription", CVariant{ g_localizeStrings.Get(scalingMethodProps.descriptionIndex) });
+        m_items.Add(std::move(item));
+      }
     }
   }
 }
 
 void CDialogGameVideoFilter::GetItems(CFileItemList &items)
 {
-  for (const auto &videoFilter : m_videoFilters)
-  {
-    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(videoFilter.stringIndex));
-    item->SetProperty("game.scalingmethod", CVariant{ videoFilter.scalingMethod });
-    items.Add(std::move(item));
-  }
-
-  if (items.Size() == 0)
-  {
-    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(16316)); // "Auto"
-    items.Add(std::move(item));
-  }
+  for (const auto &item : m_items)
+    items.Add(item);
 }
 
 void CDialogGameVideoFilter::OnItemFocus(unsigned int index)
 {
-  if (index < m_videoFilters.size())
+  if (static_cast<int>(index) < m_items.Size())
   {
-    const ESCALINGMETHOD scalingMethod = m_videoFilters[index].scalingMethod;
+    CFileItemPtr item = m_items[index];
+
+    ESCALINGMETHOD scalingMethod;
+    std::string description;
+    GetProperties(*item, scalingMethod, description);
 
     CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
+
     if (gameSettings.ScalingMethod() != scalingMethod)
     {
       gameSettings.SetScalingMethod(scalingMethod);
       gameSettings.NotifyObservers(ObservableMessageSettingsChanged);
+
+      OnDescriptionChange(description);
+      m_bHasDescription = true;
+    }
+    else if (!m_bHasDescription)
+    {
+      OnDescriptionChange(description);
+      m_bHasDescription = true;
     }
   }
 }
@@ -103,11 +123,16 @@ unsigned int CDialogGameVideoFilter::GetFocusedItem() const
 {
   CGameSettings &gameSettings = CMediaSettings::GetInstance().GetCurrentGameSettings();
 
-  for (unsigned int i = 0; i < m_videoFilters.size(); i++)
+  for (int i = 0; i < m_items.Size(); i++)
   {
-    const ESCALINGMETHOD scalingMethod = m_videoFilters[i].scalingMethod;
+    ESCALINGMETHOD scalingMethod;
+    std::string description;
+    GetProperties(*m_items[i], scalingMethod, description);
+
     if (scalingMethod == gameSettings.ScalingMethod())
+    {
       return i;
+    }
   }
 
   return 0;
@@ -115,5 +140,15 @@ unsigned int CDialogGameVideoFilter::GetFocusedItem() const
 
 void CDialogGameVideoFilter::PostExit()
 {
-  m_videoFilters.clear();
+  m_items.Clear();
+}
+
+void CDialogGameVideoFilter::GetProperties(const CFileItem &item, ESCALINGMETHOD &scalingMethod, std::string &description)
+{
+  scalingMethod = VS_SCALINGMETHOD_AUTO;
+  description = item.GetProperty("game.videofilterdescription").asString();
+
+  std::string strScalingMethod = item.GetProperty("game.scalingmethod").asString();
+  if (StringUtils::IsNaturalNumber(strScalingMethod))
+    scalingMethod = static_cast<ESCALINGMETHOD>(item.GetProperty("game.scalingmethod").asUnsignedInteger());
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -52,6 +52,11 @@ CDialogGameVideoFilter::CDialogGameVideoFilter() :
 {
 }
 
+std::string CDialogGameVideoFilter::GetHeading()
+{
+  return g_localizeStrings.Get(35225); // "Video filter"
+}
+
 void CDialogGameVideoFilter::PreInit()
 {
   m_items.Clear();

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -35,6 +35,7 @@ namespace GAME
 
   protected:
     // implementation of CDialogGameVideoSelect
+    std::string GetHeading() override;
     void PreInit() override;
     void GetItems(CFileItemList &items) override;
     void OnItemFocus(unsigned int index) override;

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -21,6 +21,7 @@
 
 #include "DialogGameVideoSelect.h"
 #include "cores/IPlayer.h"
+#include "FileItem.h"
 
 namespace KODI
 {
@@ -41,15 +42,14 @@ namespace GAME
     void PostExit() override;
 
   private:
-    struct VideoFilterProperties
-    {
-      int stringIndex;
-      ESCALINGMETHOD scalingMethod;
-    };
+    void InitScalingMethods();
 
-    std::vector<VideoFilterProperties> m_videoFilters;
+    static void GetProperties(const CFileItem &item, ESCALINGMETHOD &scalingMethod, std::string &description);
 
-    static const std::vector<VideoFilterProperties> m_allVideoFilters;
+    CFileItemList m_items;
+
+    //! \brief Set to true when a description has first been set
+    bool m_bHasDescription = false;
   };
 }
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -21,6 +21,8 @@
 #include "DialogGameVideoSelect.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/GUIBaseContainer.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/WindowIDs.h"
 #include "input/ActionIDs.h"
 #include "settings/GameSettings.h"
@@ -37,6 +39,7 @@ using namespace KODI;
 using namespace GAME;
 
 #define CONTROL_THUMBS                11
+#define CONTROL_DESCRIPTION           12
 
 CDialogGameVideoSelect::CDialogGameVideoSelect(int windowId) :
   CGUIDialog(windowId, "DialogSelect.xml"),
@@ -144,6 +147,8 @@ void CDialogGameVideoSelect::OnInitWindow()
 
   CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), CONTROL_THUMBS);
   OnMessage(msg);
+
+  FrameMove();
 }
 
 void CDialogGameVideoSelect::OnDeinitWindow(int nextWindowID)
@@ -186,7 +191,10 @@ void CDialogGameVideoSelect::OnRefreshList()
   GetItems(*m_vecItems);
 
   m_viewControl->SetItems(*m_vecItems);
-  m_viewControl->SetSelectedItem(GetFocusedItem());
+
+  auto focusedIndex = GetFocusedItem();
+  m_viewControl->SetSelectedItem(focusedIndex);
+  OnItemFocus(focusedIndex);
 }
 
 void CDialogGameVideoSelect::SaveSettings()
@@ -199,4 +207,11 @@ void CDialogGameVideoSelect::SaveSettings()
     defaultSettings = currentSettings;
     CServiceBroker::GetSettings().Save();
   }
+}
+
+void CDialogGameVideoSelect::OnDescriptionChange(const std::string &description)
+{
+  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_DESCRIPTION);
+  msg.SetLabel(description);
+  g_windowManager.SendThreadMessage(msg, GetID());
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -19,6 +19,8 @@
  */
 
 #include "DialogGameVideoSelect.h"
+#include "cores/RetroPlayer/rendering/GUIGameVideoHandle.h"
+#include "cores/RetroPlayer/rendering/GUIGameRenderManager.h"
 #include "guilib/GraphicContext.h"
 #include "guilib/GUIBaseContainer.h"
 #include "guilib/GUIMessage.h"
@@ -52,25 +54,24 @@ CDialogGameVideoSelect::CDialogGameVideoSelect(int windowId) :
 
 CDialogGameVideoSelect::~CDialogGameVideoSelect() = default;
 
-void CDialogGameVideoSelect::RegisterCallback(RETRO::IRenderCallback *callback)
-{
-  m_callback = callback;
-}
-
-void CDialogGameVideoSelect::UnregisterCallback()
-{
-  m_callback = nullptr;
-}
-
 bool CDialogGameVideoSelect::OnMessage(CGUIMessage &message)
 {
   switch (message.GetMessage())
   {
     case GUI_MSG_WINDOW_INIT:
     {
+      RegisterDialog();
+
       // Don't init this dialog if we aren't playing a game
-      if (m_callback == nullptr)
+      if (!m_gameVideoHandle || !m_gameVideoHandle->IsPlayingGame())
         return false;
+
+      break;
+    }
+    case GUI_MSG_WINDOW_DEINIT:
+    {
+      UnregisterDialog();
+
       break;
     }
     case GUI_MSG_SETFOCUS:
@@ -214,4 +215,14 @@ void CDialogGameVideoSelect::OnDescriptionChange(const std::string &description)
   CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_DESCRIPTION);
   msg.SetLabel(description);
   g_windowManager.SendThreadMessage(msg, GetID());
+}
+
+void CDialogGameVideoSelect::RegisterDialog()
+{
+  m_gameVideoHandle = CServiceBroker::GetGameRenderManager().RegisterDialog(*this);
+}
+
+void CDialogGameVideoSelect::UnregisterDialog()
+{
+  m_gameVideoHandle.reset();
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -22,9 +22,7 @@
 #include "guilib/GraphicContext.h"
 #include "guilib/GUIBaseContainer.h"
 #include "guilib/WindowIDs.h"
-#include "input/Action.h"
 #include "input/ActionIDs.h"
-#include "messaging/ApplicationMessenger.h"
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
@@ -92,9 +90,8 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage &message)
         {
           using namespace MESSAGING;
 
-          // Send OSD command to resume gameplay
-          CAction *action = new CAction(ACTION_SHOW_OSD);
-          CApplicationMessenger::GetInstance().PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(action));
+          // Changed from sending ACTION_SHOW_OSD to closing the dialog
+          Close();
 
           return true;
         }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -40,6 +40,7 @@
 using namespace KODI;
 using namespace GAME;
 
+#define CONTROL_HEADING               1
 #define CONTROL_THUMBS                11
 #define CONTROL_DESCRIPTION           12
 
@@ -148,6 +149,9 @@ void CDialogGameVideoSelect::OnInitWindow()
 
   CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), CONTROL_THUMBS);
   OnMessage(msg);
+
+  std::string heading = GetHeading();
+  SET_CONTROL_LABEL(CONTROL_HEADING, heading);
 
   FrameMove();
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -56,6 +56,7 @@ namespace GAME
     void OnInitWindow() override;
 
     // Video select interface
+    virtual std::string GetHeading() = 0;
     virtual void PreInit() = 0;
     virtual void GetItems(CFileItemList &items) = 0;
     virtual void OnItemFocus(unsigned int index) = 0;

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -65,6 +65,8 @@ namespace GAME
     virtual unsigned int GetFocusedItem() const = 0;
     virtual void PostExit() = 0;
 
+    void OnDescriptionChange(const std::string &description);
+
     RETRO::IRenderCallback *m_callback = nullptr;
 
   private:

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -30,7 +30,7 @@ namespace KODI
 {
 namespace RETRO
 {
-  class IRenderCallback;
+  class CGUIGameVideoHandle;
 }
 
 namespace GAME
@@ -39,9 +39,6 @@ namespace GAME
   {
   public:
     ~CDialogGameVideoSelect() override;
-
-    void RegisterCallback(RETRO::IRenderCallback *callback);
-    void UnregisterCallback();
 
     // implementation of CGUIControl via CGUIDialog
     bool OnMessage(CGUIMessage &message) override;
@@ -67,7 +64,7 @@ namespace GAME
 
     void OnDescriptionChange(const std::string &description);
 
-    RETRO::IRenderCallback *m_callback = nullptr;
+    std::shared_ptr<RETRO::CGUIGameVideoHandle> m_gameVideoHandle;
 
   private:
     void Update();
@@ -76,6 +73,9 @@ namespace GAME
     void OnRefreshList();
 
     void SaveSettings();
+
+    void RegisterDialog();
+    void UnregisterDialog();
 
     std::unique_ptr<CGUIViewControl> m_viewControl;
     std::unique_ptr<CFileItemList> m_vecItems;

--- a/xbmc/games/dialogs/osd/DialogGameViewMode.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameViewMode.cpp
@@ -45,6 +45,11 @@ CDialogGameViewMode::CDialogGameViewMode() :
 {
 }
 
+std::string CDialogGameViewMode::GetHeading()
+{
+  return g_localizeStrings.Get(629); // "View mode"
+}
+
 void CDialogGameViewMode::PreInit()
 {
   m_viewModes.clear();

--- a/xbmc/games/dialogs/osd/DialogGameViewMode.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameViewMode.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "DialogGameViewMode.h"
-#include "cores/RetroPlayer/rendering/IRenderCallback.h"
+#include "cores/RetroPlayer/rendering/GUIGameVideoHandle.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "settings/GameSettings.h"
@@ -62,17 +62,17 @@ void CDialogGameViewMode::PreInit()
 
       case ViewModeStretch4x3:
       case ViewModeStretch16x9:
-        if (m_callback != nullptr)
+        if (m_gameVideoHandle)
         {
-          bSupported = m_callback->SupportsRenderFeature(RENDERFEATURE_STRETCH) ||
-                       m_callback->SupportsRenderFeature(RENDERFEATURE_PIXEL_RATIO);
+          bSupported = m_gameVideoHandle->SupportsRenderFeature(RENDERFEATURE_STRETCH) ||
+                       m_gameVideoHandle->SupportsRenderFeature(RENDERFEATURE_PIXEL_RATIO);
         }
         break;
 
       case ViewModeStretch16x9Nonlin:
-        if (m_callback != nullptr)
+        if (m_gameVideoHandle)
         {
-          bSupported = m_callback->SupportsRenderFeature(RENDERFEATURE_NONLINSTRETCH);
+          bSupported = m_gameVideoHandle->SupportsRenderFeature(RENDERFEATURE_NONLINSTRETCH);
         }
         break;
 

--- a/xbmc/games/dialogs/osd/DialogGameViewMode.h
+++ b/xbmc/games/dialogs/osd/DialogGameViewMode.h
@@ -34,6 +34,7 @@ namespace GAME
 
   protected:
     // implementation of CDialogGameVideoSelect
+    std::string GetHeading() override;
     void PreInit() override;
     void GetItems(CFileItemList &items) override;
     void OnItemFocus(unsigned int index) override;


### PR DESCRIPTION
This PR concludes the work I've done to enable the GSoC shader work (https://github.com/garbear/xbmc/pull/86) to be eventually included in master:

* https://github.com/VelocityRa/xbmc/pull/21 - Selecting a filter closes the dialog instead of resuming gameplay
* https://github.com/VelocityRa/xbmc/pull/17 - Adds a description field giving information about the filter
* Refactor to remove RetroPlayer's GUI dependence introduced in #12639

Also included are some features requested on the forum:

* Set ID 1 to dialog names for View Mode and Video Filter dialogs ([request post](https://forum.kodi.tv/showthread.php?tid=315263&pid=2646448#pid2646448))
* Close OSD when "m" is pressed (same post)

## Motivation and Context
Final changes required for shaders.

## How Has This Been Tested?
Tested in Windows, Linux, OSX and RPi

## Screenshots (if appropriate):
<img width="1255" alt="screen shot 2017-09-28 at 12 35 25 pm" src="https://user-images.githubusercontent.com/531482/30986828-ab0b578e-a449-11e7-944f-0fd6285fde55.png">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
