### PR TITLE
[addons][fix] darwin & freebsd have to use struct stat

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -27,7 +27,11 @@
 #if !defined(_WIN32)
   #include <sys/stat.h>
   #if !defined(__stat64)
-    #define __stat64 stat64
+    #if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
+      #define __stat64 stat
+    #else
+      #define __stat64 stat64
+    #endif
   #endif
 #endif
 #ifdef _WIN32                   // windows


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
using struct stat64 is deprecated on those platforms and it's done the same at the following kodi core code  
https://github.com/xbmc/xbmc/blob/53319045389e4f4bc261db4e918c0b1b56d26794/xbmc/linux/PlatformDefs.h#L333-L343
<!--- Describe your change in detail -->

## Motivation and Context
Fix compiling some binary addons for ios.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
With this change audiodecoder.timidity, inputstream.adaptive, peripheral.joystick and vfs.rar are now successfully building for ios.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
