### PR TITLE
Use our api to set info on python scrapers

### DIFF
--- a/addons/metadata.demo.movies/demo.py
+++ b/addons/metadata.demo.movies/demo.py
@@ -112,5 +112,10 @@ elif action == 'getartwork':
         liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
         liz.setProperty('video.fanart2.dim', '1080')
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+elif action == 'nfourl':
+    nfo=urllib.unquote_plus(params["nfo"])
+    print 'Find url from nfo file'
+    liz=xbmcgui.ListItem('Demo movie 1', offscreen=True)
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/movie1", listitem=liz, isFolder=True)
 
 xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/addons/metadata.demo.movies/demo.py
+++ b/addons/metadata.demo.movies/demo.py
@@ -46,71 +46,48 @@ elif action == 'getdetails':
     url=urllib.unquote_plus(params["url"])
     if url == '/path/to/movie':
         liz=xbmcgui.ListItem('Demo movie 1', offscreen=True)
-        liz.setProperty('video.original_title', 'Demo måvie 1')
-        liz.setProperty('video.sort_title', '2')
-        liz.setProperty('video.ratings', '1')
-        liz.setProperty('video.rating1.value', '5')
-        liz.setProperty('video.rating1.votes', '100')
-        liz.setProperty('video.user_rating', '5')
-        liz.setProperty('video.top250', '3')
-        liz.setProperty('video.unique_id', '123')
-        liz.setProperty('video.imdb_id', '456')
-        liz.setProperty('video.plot_outline', 'Outline yo')
-        liz.setProperty('video.plot', 'Plot yo')
-        liz.setProperty('video.tag_line', 'Tag yo')
-        liz.setProperty('video.duration_minutes', '110')
-        liz.setProperty('video.mpaa', 'T')
-        liz.setProperty('video.trailer', '/home/akva/Videos/porn/bukkake.mkv')
-        liz.setProperty('video.thumbs', '2')
-        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.thumb1.aspect', 'poster')
-        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.thumb2.aspect', 'banner')
-        liz.setProperty('video.genre','Action / Comedy')
-        liz.setProperty('video.country', 'Norway / Sweden / China')
-        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
-        liz.setProperty('video.director', 'spiff / spiff2')
-        liz.setProperty('video.tvshow_links' ,'Demo show 1')
-        liz.setProperty('video.actors', '2')
-        liz.setProperty('video.actor1.name', 'spiff')
-        liz.setProperty('video.actor1.role', 'himself')
-        liz.setProperty('video.actor1.sort_order', '2')
-        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
-        liz.setProperty('video.actor1.thumb_aspect', 'banner')
-        liz.setProperty('video.actor2.name', 'monkey')
-        liz.setProperty('video.actor2.role', 'orange')
-        liz.setProperty('video.actor2.sort_order', '1')
-        liz.setProperty('video.actor1.thumb_aspect', 'poster')
-        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
-        liz.setProperty('video.set_name', 'Spiffy creations')
-        liz.setProperty('video.set_overview', 'Horrors created by spiff')
-        liz.setProperty('video.tags', 'Very / Bad')
-        liz.setProperty('video.studio', 'Studio1 / Studio2')
-        liz.setProperty('video.fanarts', '2')
-        liz.setProperty('video.fanart1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.fanart1.preview', 'DefaultBackFanart.png')
-        liz.setProperty('video.fanart1.dim', '720')
-        liz.setProperty('video.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.fanart2.dim', '1080')
-        liz.setProperty('video.date_added', '2016-01-01')
+        liz.setInfo('video',
+                    {'title': 'Demo movie 1',
+                     'originaltitle': 'Demo måvie 1',
+                     'sorttitle': '2',
+                     'userrating': 5,
+                     'top250': 3,
+                     'plotoutline': 'Outline yo',
+                     'plot': 'Plot yo',
+                     'tagline': 'Tag yo',
+                     'duration': 110,
+                     'mpaa': 'T',
+                     'trailer': '/home/akva//porn/bukkake.mkv',
+                     'genre': ['Action', 'Comedy'],
+                     'country': ['Norway', 'Sweden', 'China'],
+                     'credits': ['None', 'Want', 'To Admit It'],
+                     'director': ['spiff', 'spiff2'],
+                     'set': 'Spiffy creations',
+                     'setoverview': 'Horrors created by spiff',
+                     'studio': ['Studio1', 'Studio2'],
+                     'dateadded': '2016-01-01',
+                     'premiered': '2015-01-01',
+                     'showlink': ['Demo show 1']
+                    })
+                    #todo: missing actor thumb aspect
+        liz.setRating("imdb", 9, 100000, True )
+        liz.setRating("themoviedb", 8.9, 1000)
+        liz.setUniqueIDs({ 'imdb': 'tt8938399', 'tmdb' : '9837493' }, 'imdb')
+        liz.setCast([{'name': 'spiff', 'role': 'himself', 'thumbnail': '/home/akva/Pictures/fish.jpg', 'order': 2},
+                    {'name': 'monkey', 'role': 'orange', 'thumbnail': '/home/akva/Pictures/coffee.jpg', 'order': 1}])
+        liz.addAvailableArtwork('DefaultBackFanart.png', 'banner')
+        liz.addAvailableArtwork('/home/akva/Pictures/hawaii-shirt.png', 'poster')
+        liz.setAvailableFanart([{'image': 'DefaultBackFanart.png', 'preview': 'DefaultBackFanart.png'}, 
+                                {'image': '/home/akva/Pictures/hawaii-shirt.png', 'preview': '/home/akva/Pictures/hawaii-shirt.png'}])
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
 elif action == 'getartwork':
     url=urllib.unquote_plus(params["id"])
     if url == '456':
         liz=xbmcgui.ListItem('Demo movie 1', offscreen=True)
-        liz.setProperty('video.thumbs', '2')
-        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.thumb1.aspect', 'poster')
-        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.thumb2.aspect', 'banner')
-        liz.setProperty('video.fanarts', '2')
-        liz.setProperty('video.fanart1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.fanart1.preview', 'DefaultBackFanart.png')
-        liz.setProperty('video.fanart1.dim', '720')
-        liz.setProperty('video.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.fanart2.dim', '1080')
+        liz.addAvailableArtwork('DefaultBackFanart.png', 'banner')
+        liz.addAvailableArtwork('/home/akva/Pictures/hawaii-shirt.png', 'poster')
+        liz.setAvailableFanart([{'image': 'DefaultBackFanart.png', 'preview': 'DefaultBackFanart.png'}, 
+                                {'image': '/home/akva/Pictures/hawaii-shirt.png', 'preview': '/home/akva/Pictures/hawaii-shirt.png'}])
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
 elif action == 'nfourl':
     nfo=urllib.unquote_plus(params["nfo"])

--- a/addons/metadata.demo.tv/demo.py
+++ b/addons/metadata.demo.tv/demo.py
@@ -196,6 +196,12 @@ elif action == 'getepisodedetails':
         liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
         liz.setProperty('video.date_added', '2016-01-01')
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
+elif action == 'nfourl': 
+    nfo=urllib.unquote_plus(params["nfo"]) 
+    print 'Find url from nfo file' 
+    liz=xbmcgui.ListItem('Demo show 1', offscreen=True) 
+    xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/show", listitem=liz, isFolder=True) 
+ 
 
 
 

--- a/addons/metadata.demo.tv/demo.py
+++ b/addons/metadata.demo.tv/demo.py
@@ -46,155 +46,139 @@ elif action == 'getdetails':
     url=urllib.unquote_plus(params["url"])
     if url == '/path/to/show':
         liz=xbmcgui.ListItem('Demo show 1', offscreen=True)
-        liz.setProperty('video.original_title', 'Demo shåvv 1')
-        liz.setProperty('video.sort_title', '2')
-        liz.setProperty('video.ratings', '1')
-        liz.setProperty('video.rating1.value', '5')
-        liz.setProperty('video.rating1.votes', '100')
-        liz.setProperty('video.user_rating', '5')
-        liz.setProperty('video.unique_id', '123')
-        liz.setProperty('video.plot_outline', 'Outline yo')
-        liz.setProperty('video.plot', 'Plot yo')
-        liz.setProperty('video.tag_line', 'Tag yo')
-        liz.setProperty('video.duration_minutes', '110')
-        liz.setProperty('video.mpaa', 'T')
-        liz.setProperty('video.premiere_year', '2007')
-        liz.setProperty('video.status', 'Cancelled')
-        liz.setProperty('video.first_aired', '2007-01-01')
-        liz.setProperty('video.trailer', '/home/akva/Videos/porn/bukkake.mkv')
-        liz.setProperty('video.thumbs', '2')
-        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.thumb1.aspect', '1.78')
-        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.thumb2.aspect', '2.35')
-        liz.setProperty('video.genre','Action / Comedy')
-        liz.setProperty('video.country', 'Norway / Sweden / China')
-        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
-        liz.setProperty('video.director', 'spiff / spiff2')
-        liz.setProperty('video.seasons', '2')
-        liz.setProperty('video.season1.name', 'Horrible')
-        liz.setProperty('video.season2.name', 'Crap')
-        liz.setProperty('video.actors', '2')
-        liz.setProperty('video.actor1.name', 'spiff')
-        liz.setProperty('video.actor1.role', 'himself')
-        liz.setProperty('video.actor1.sort_order', '2')
-        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
-        liz.setProperty('video.actor1.thumb_aspect', '1.33')
-        liz.setProperty('video.actor2.name', 'monkey')
-        liz.setProperty('video.actor2.role', 'orange')
-        liz.setProperty('video.actor2.sort_order', '1')
-        liz.setProperty('video.actor1.thumb_aspect', '1.78')
-        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
-        liz.setProperty('video.tag', 'Porn / Umomz')
-        liz.setProperty('video.studio', 'Studio1 / Studio2')
-        liz.setProperty('video.episode_guide_url', '/path/to/show/guide')
-        liz.setProperty('video.fanarts', '2')
-        liz.setProperty('video.fanart1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.fanart1.preview', 'DefaultBackFanart.png')
-        liz.setProperty('video.fanart1.dim', '720')
-        liz.setProperty('video.fanart2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.fanart2.preview', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.fanart2.dim', '1080')
-        liz.setProperty('video.date_added', '2016-01-01')
+        liz.setInfo('video',
+                    {'title': 'Demo show 1',
+                     'originaltitle': 'Demo shåvv 1',
+                     'sorttitle': '2',
+                     'userrating': 5,
+                     'plotoutline': 'Outline yo',
+                     'plot': 'Plot yo',
+                     'tagline': 'Tag yo',
+                     'duration': 110,
+                     'mpaa': 'T',
+                     'trailer': '/home/akva//porn/bukkake.mkv',
+                     'genre': ['Action', 'Comedy'],
+                     'country': ['Norway', 'Sweden', 'China'],
+                     'credits': ['None', 'Want', 'To Admit It'],
+                     'director': ['spiff', 'spiff2'],
+                     'studio': ['Studio1', 'Studio2'],
+                     'dateadded': '2016-01-01',
+                     'premiered': '2015-01-01',
+                     'aired': '2007-01-01',
+                     'status': 'Cancelled',
+                     'episodeguide': '/path/to/show/guide',
+                     'tag': ['Porn', 'Umomz']
+                    })
+        liz.setRating("imdb", 9, 100000, True )
+        liz.setRating("tvdb", 8.9, 1000)
+        liz.setUniqueIDs({ 'imdb': 'tt8938399', 'tvdb' : '9837493' }, 'tvdb')
+        liz.addSeason(1, 'Horrible')
+        liz.addSeason(2, 'Crap')
+        liz.setCast([{'name': 'spiff', 'role': 'himself', 'thumbnail': '/home/akva/Pictures/fish.jpg', 'order': 2},
+                    {'name': 'monkey', 'role': 'orange', 'thumbnail': '/home/akva/Pictures/coffee.jpg', 'order': 1}])
+        liz.addAvailableArtwork('DefaultBackFanart.png', 'banner')
+        liz.addAvailableArtwork('/home/akva/Pictures/hawaii-shirt.png', 'poster')
+        liz.setAvailableFanart([{'image': 'DefaultBackFanart.png', 'preview': 'DefaultBackFanart.png'}, 
+                                {'image': '/home/akva/Pictures/hawaii-shirt.png', 'preview': '/home/akva/Pictures/hawaii-shirt.png'}])
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
 elif action == 'getepisodelist':
     url=urllib.unquote_plus(params["url"])
     print('in here yo ' + url)
     if url == '/path/to/show/guide':
         liz=xbmcgui.ListItem('Demo Episode 1x1', offscreen=True)
-        liz.setProperty('video.episode', '1')
-        liz.setProperty('video.season', '1')
-        liz.setProperty('video.aired', '2015-01-01')
-        liz.setProperty('video.id', '1')
-        liz.setProperty('video.url', '/path/to/episode1')
+        liz.setInfo('video',
+                    {'title': 'Demo Episode 1',
+                     'season': 1,
+                     'episode': 1,
+                     'aired': '2015-01-01'
+                     })
+        liz.addAvailableArtwork('/path/to/episode1','banner')
         xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/episode1", listitem=liz, isFolder=False)
         liz=xbmcgui.ListItem('Demo Episode 2x2', offscreen=True)
-        liz.setProperty('video.episode', '2')
+        liz.setInfo('video',
+                    {'title': 'Demo Episode 2',
+                     'season': 2,
+                     'episode': 2,
+                     'aired': '2014-01-01'
+                     })
+        liz.addAvailableArtwork('/path/to/episode2','banner')
         #liz.setProperty('video.sub_episode', '1')
-        liz.setProperty('video.season', '2')
-        liz.setProperty('video.aired', '2014-01-01')
-        liz.setProperty('video.id', '2')
-        liz.setProperty('video.url', '/path/to/episode2')
         xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url="/path/to/episode2", listitem=liz, isFolder=False)
 elif action == 'getepisodedetails':
     url=urllib.unquote_plus(params["url"])
     if url == '/path/to/episode1':
         liz=xbmcgui.ListItem('Demo Episode 1', offscreen=True)
-        liz.setProperty('video.original_title', 'Demo æpisod 1x1')
-        liz.setProperty('video.sort_title', '2')
-        liz.setProperty('video.episode', '1')
-        liz.setProperty('video.season', '1')
-        liz.setProperty('video.ratings', '1')
-        liz.setProperty('video.rating1.value', '5')
-        liz.setProperty('video.rating1.votes', '100')
-        liz.setProperty('video.user_rating', '5')
-        liz.setProperty('video.unique_id', '123')
-        liz.setProperty('video.plot_outline', 'Outline yo')
-        liz.setProperty('video.plot', 'Plot yo')
-        liz.setProperty('video.tag_line', 'Tag yo')
-        liz.setProperty('video.duration_minutes', '110')
-        liz.setProperty('video.mpaa', 'T')
-        liz.setProperty('video.first_aired', '2007-01-01')
-        liz.setProperty('video.thumbs', '2')
-        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.thumb1.aspect', '1.78')
-        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.thumb2.aspect', '2.35')
-        liz.setProperty('video.genre','Action / Comedy')
-        liz.setProperty('video.country', 'Norway / Sweden / China')
-        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
-        liz.setProperty('video.director', 'spiff / spiff2')
-        liz.setProperty('video.actors', '2')
-        liz.setProperty('video.actor1.name', 'spiff')
-        liz.setProperty('video.actor1.role', 'himself')
-        liz.setProperty('video.actor1.sort_order', '2')
-        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
-        liz.setProperty('video.actor1.thumb_aspect', 'poster')
-        liz.setProperty('video.actor2.name', 'monkey')
-        liz.setProperty('video.actor2.role', 'orange')
-        liz.setProperty('video.actor2.sort_order', '1')
-        liz.setProperty('video.actor1.thumb_aspect', '1.78')
-        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
-        liz.setProperty('video.date_added', '2016-01-01')
+        liz.setInfo('video',
+                    {'title': 'Demo Episode 1',
+                     'originaltitle': 'Demo æpisod 1x1',
+                     'sorttitle': '2',
+                     'episode': 1,
+                     'season': 1,
+                     'userrating': 5,
+                     'plotoutline': 'Outline yo',
+                     'plot': 'Plot yo',
+                     'tagline': 'Tag yo',
+                     'duration': 110,
+                     'mpaa': 'T',
+                     'trailer': '/home/akva//porn/bukkake.mkv',
+                     'genre': ['Action', 'Comedy'],
+                     'country': ['Norway', 'Sweden', 'China'],
+                     'credits': ['None', 'Want', 'To Admit It'],
+                     'director': ['spiff', 'spiff2'],
+                     'studio': ['Studio1', 'Studio2'],
+                     'dateadded': '2016-01-01',
+                     'premiered': '2015-01-01',
+                     'aired': '2007-01-01',
+                     'tag': ['Porn', 'Umomz']
+                    })
+        liz.setRating("imdb", 9, 100000, True )
+        liz.setRating("tvdb", 8.9, 1000)
+        liz.setUniqueIDs({ 'tvdb': '3894', 'imdb' : 'tt384940' }, 'tvdb')
+        liz.addSeason(1, 'Horrible')
+        liz.addSeason(2, 'Crap')
+        liz.setCast([{'name': 'spiff', 'role': 'himself', 'thumbnail': '/home/akva/Pictures/fish.jpg', 'order': 2},
+                    {'name': 'monkey', 'role': 'orange', 'thumbnail': '/home/akva/Pictures/coffee.jpg', 'order': 1}])
+        liz.addAvailableArtwork('DefaultBackFanart.png', 'banner')
+        liz.addAvailableArtwork('/home/akva/Pictures/hawaii-shirt.png', 'poster')
+        liz.setAvailableFanart([{'image': 'DefaultBackFanart.png', 'preview': 'DefaultBackFanart.png'}, 
+                                {'image': '/home/akva/Pictures/hawaii-shirt.png', 'preview': '/home/akva/Pictures/hawaii-shirt.png'}])
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
     elif url == '/path/to/episode2':
         liz=xbmcgui.ListItem('Demo Episode 2', offscreen=True)
-        liz.setProperty('video.original_title', 'Demo æpisod 2x2')
-        liz.setProperty('video.sort_title', '1')
-        liz.setProperty('video.episode', '2')
-        liz.setProperty('video.season', '2')
-        liz.setProperty('video.ratings', '1')
-        liz.setProperty('video.rating1.value', '5')
-        liz.setProperty('video.rating1.votes', '100')
-        liz.setProperty('video.user_rating', '5')
-        liz.setProperty('video.unique_id', '123')
-        liz.setProperty('video.plot_outline', 'Outline yo')
-        liz.setProperty('video.plot', 'Plot yo')
-        liz.setProperty('video.tag_line', 'Tag yo')
-        liz.setProperty('video.duration_minutes', '110')
-        liz.setProperty('video.mpaa', 'T')
-        liz.setProperty('video.first_aired', '2007-01-01')
-        liz.setProperty('video.thumbs', '2')
-        liz.setProperty('video.thumb1.url', 'DefaultBackFanart.png')
-        liz.setProperty('video.thumb1.aspect', '1.78')
-        liz.setProperty('video.thumb2.url', '/home/akva/Pictures/hawaii-shirt.png')
-        liz.setProperty('video.thumb2.aspect', '2.35')
-        liz.setProperty('video.genre','Action / Comedy')
-        liz.setProperty('video.country', 'Norway / Sweden / China')
-        liz.setProperty('video.writing_credits', 'None / Want / To Admit It')
-        liz.setProperty('video.director', 'spiff / spiff2')
-        liz.setProperty('video.actors', '2')
-        liz.setProperty('video.actor1.name', 'spiff')
-        liz.setProperty('video.actor1.role', 'himself')
-        liz.setProperty('video.actor1.sort_order', '2')
-        liz.setProperty('video.actor1.thumb', '/home/akva/Pictures/fish.jpg')
-        liz.setProperty('video.actor1.thumb_aspect', 'poster')
-        liz.setProperty('video.actor2.name', 'monkey')
-        liz.setProperty('video.actor2.role', 'orange')
-        liz.setProperty('video.actor2.sort_order', '1')
-        liz.setProperty('video.actor1.thumb_aspect', '1.78')
-        liz.setProperty('video.actor2.thumb', '/home/akva/Pictures/coffee.jpg')
-        liz.setProperty('video.date_added', '2016-01-01')
+        liz.setInfo('video',
+                    {'title': 'Demo Episode 2',
+                     'originaltitle': 'Demo æpisod 2x2',
+                     'sorttitle': '1',
+                     'episode': 2,
+                     'season': 2,
+                     'userrating': 8,
+                     'plotoutline': 'Outline yo',
+                     'plot': 'Plot yo',
+                     'tagline': 'Tag yo',
+                     'duration': 110,
+                     'mpaa': 'T',
+                     'trailer': '/home/akva//porn/bukkake.mkv',
+                     'genre': ['Action', 'Comedy'],
+                     'country': ['Norway', 'Sweden', 'China'],
+                     'credits': ['None', 'Want', 'To Admit It'],
+                     'director': ['spiff', 'spiff2'],
+                     'studio': ['Studio1', 'Studio2'],
+                     'dateadded': '2016-01-01',
+                     'premiered': '2015-01-01',
+                     'aired': '2007-01-01',
+                     'tag': ['Porn', 'Umomz']
+                    })
+        liz.setRating("imdb", 7, 25457, True )
+        liz.setRating("tvdb", 8.1, 5478)
+        liz.setUniqueIDs({ 'tvdb': '3894', 'imdb' : 'tt384940' })
+        liz.addSeason(1, 'Horrible')
+        liz.addSeason(2, 'Crap')
+        liz.setCast([{'name': 'spiff', 'role': 'himself', 'thumbnail': '/home/akva/Pictures/fish.jpg', 'order': 2},
+                    {'name': 'monkey', 'role': 'orange', 'thumbnail': '/home/akva/Pictures/coffee.jpg', 'order': 1}])
+        liz.addAvailableArtwork('DefaultBackFanart.png','banner')
+        liz.addAvailableArtwork('/home/akva/Pictures/hawaii-shirt.png','poster')
+        liz.setAvailableFanart([{'image': 'DefaultBackFanart.png', 'preview': 'DefaultBackFanart.png'}, 
+                                {'image': '/home/akva/Pictures/hawaii-shirt.png', 'preview': '/home/akva/Pictures/hawaii-shirt.png'}])
         xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=True, listitem=liz)
 elif action == 'nfourl': 
     nfo=urllib.unquote_plus(params["nfo"]) 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -440,6 +440,27 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
   if (IsNoop())
     return scurlRet;
 
+  if (m_isPython)
+  {
+    std::stringstream str;
+    str << "plugin://" << ID() << "?action=NfoUrl&nfo="
+      << CURL::Encode(sNfoContent);
+    CFileItemList items;
+    if (!XFILE::CDirectory::GetDirectory(str.str(), items))
+      return scurlRet;
+
+    if (items.Size() == 0)
+      return scurlRet;
+    if (items.Size() > 1)
+      CLog::Log(LOGWARNING, "%s: scraper returned multiple results; using first", __FUNCTION__);
+
+    CScraperUrl::SUrlEntry surl;
+    surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
+    surl.m_url = items[0]->GetPath();
+    scurlRet.m_url.emplace_back(surl);
+    return scurlRet;
+  }
+    
   // scraper function takes contents of .nfo file, returns XML (see below)
   std::vector<std::string> vcsIn;
   vcsIn.push_back(sNfoContent);

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -812,85 +812,8 @@ void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
 template<>
 void DetailsFromFileItem<CVideoInfoTag>(const CFileItem &item, CVideoInfoTag &tag)
 {
-  tag.SetTitle(item.GetLabel());
-  tag.SetOriginalTitle(FromString(item, "video.original_title"));
-  tag.SetShowTitle(FromString(item, "video.show_title"));
-  tag.SetSortTitle(FromString(item, "video.sort_title"));
-  int nRatings = item.GetProperty("video.ratings").asInteger32();
-  for (int i = 0; i < nRatings; ++i)
-  {
-    std::stringstream str;
-    str << "video.rating" << i + 1;
-    int votes = item.GetProperty(str.str() + ".votes").asInteger32();
-    float rating = item.GetProperty(str.str() + ".value").asFloat();
-    tag.SetRating(rating, votes, "default");
-  }
-  tag.m_iUserRating = item.GetProperty("video.user_rating").asInteger32();
-  tag.m_iTop250 = item.GetProperty("video.top250").asInteger32();
-  tag.m_iSeason = item.GetProperty("video.season").asInteger32();
-  tag.m_iEpisode = item.GetProperty("video.episode").asInteger32();
-  tag.m_iTrack = item.GetProperty("video.track").asInteger32();
-  tag.SetUniqueIDs({{"IMDB", FromString(item, "video.imdb_id")}});
-  tag.m_iSpecialSortSeason = item.GetProperty("video.display_season").asInteger32();
-  tag.m_iSpecialSortEpisode = item.GetProperty("video.display_episode").asInteger32();
-  tag.SetPlotOutline(FromString(item, "video.plot_outline"));
-  tag.SetPlot(FromString(item, "video.plot"));
-  tag.SetTagLine(FromString(item, "video.tag_line"));
-  tag.m_duration = item.GetProperty("video.duration_minutes").asInteger32();
-  tag.SetMPAARating(FromString(item, "video.mpaa"));
-  tag.SetYear(item.GetProperty("video.premiere_year").asInteger32());
-  tag.SetStatus(FromString(item, "video.status"));
-  tag.SetProductionCode(FromString(item, "video.production_code"));
-  tag.m_firstAired.SetFromDBDate(FromString(item, "video.first_aired"));
-  tag.SetAlbum(FromString(item, "video.album"));
-  tag.SetTrailer(FromString(item, "video.trailer"));
-  int nThumbs = item.GetProperty("video.thumbs").asInteger32();
-  ParseThumbs(tag.m_strPictureURL, item, nThumbs, "video.thumb");
-  tag.SetGenre(FromArray(item, "video.genre", 1));
-  tag.SetCountry(FromArray(item, "video.country", 1));
-  tag.SetWritingCredits(FromArray(item, "video.writing_credits", 1));
-  tag.SetDirector(FromArray(item, "video.director", 1));
-  tag.SetShowLink(FromArray(item, "video.tvshow_links", 1));
-  int nSeasons = item.GetProperty("video.seasons").asInteger32();
-  for (int i = 0; i < nSeasons; ++i)
-  {
-    std::stringstream str;
-    str << "video.season" << i + 1;
-    tag.m_namedSeasons.insert(std::make_pair(i + 1, FromString(item, str.str() + ".name")));
-  }
-  int nActors = item.GetProperty("video.actors").asInteger32();
-  for (int i = 0; i < nActors; ++i)
-  {
-    std::stringstream str;
-    str << "video.actor" << i + 1;
-    SActorInfo actor;
-    actor.strName = FromString(item, str.str() + ".name");
-    actor.strRole = FromString(item, str.str() + ".role");
-    actor.order = item.GetProperty(str.str() + ".sort_order").asInteger32();
-    std::string url = FromString(item, str.str() + ".thumb");
-    if (!url.empty())
-    {
-      auto aspect = item.GetProperty(str.str() + ".thumb_aspect").asInteger32();
-      TiXmlElement thumb("thumb");
-      thumb.SetAttribute("aspect", aspect);
-      TiXmlText text(url);
-      thumb.InsertEndChild(text);
-      actor.thumbUrl.ParseElement(&thumb);
-    }
-    tag.m_cast.push_back(actor);
-  }
-
-  tag.SetSet(FromString(item, "video.set_name"));
-  tag.SetSetOverview(FromString(item, "video.set_overview"));
-  tag.SetTags(FromArray(item, "video.tags", 1));
-  tag.SetStudio(FromArray(item, "video.studio", 1));
-  tag.SetArtist(FromArray(item, "video.artist", 1));
-  tag.m_strEpisodeGuide =
-      "<episodeguide>" + FromString(item, "video.episode_guide_url") + "</episodeguide>";
-  int nFanart = item.GetProperty("video.fanarts").asInteger32();
-  tag.m_fanart.m_xml = ParseFanart(item, nFanart, "video.fanart");
-  tag.m_fanart.Unpack();
-  tag.m_firstAired.SetFromDBDate(FromString(item, "video.date_added"));
+  if (item.HasVideoInfoTag())
+    tag = std::move(*item.GetVideoInfoTag());
 }
 
 template<class T>
@@ -1265,15 +1188,16 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
     for (int i = 0; i < items.Size(); ++i)
     {
       EPISODE ep;
-      ep.strTitle = items[i]->GetLabel();
-      ep.iSeason = items[i]->GetProperty("video.season").asInteger32();
-      ep.iEpisode = items[i]->GetProperty("video.episode").asInteger32();
-      ep.iSubepisode = items[i]->GetProperty("video.sub_episode").asInteger32();
+      const auto& tag = *items[i]->GetVideoInfoTag();
+      ep.strTitle = tag.m_strTitle;
+      ep.iSeason = tag.m_iSeason;
+      ep.iEpisode = tag.m_iEpisode;
+      ep.cDate = tag.m_firstAired;
+      ep.iSubepisode = items[i]->GetProperty("video.sub_episode").asInteger();
       CScraperUrl::SUrlEntry surl;
       surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
-      surl.m_url = FromString(*items[i], "video.url");
+      surl.m_url = items[i]->GetURL().Get();
       ep.cScraperUrl.m_url.push_back(surl);
-      ep.cScraperUrl.strId = FromString(*items[i], "video.unique_id");
       vcep.push_back(ep);
     }
 
@@ -1469,7 +1393,7 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
             ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   if (m_isPython)
-    return PythonDetails(ID(), "id", details.GetUniqueID("IMDB"), "getartwork", details);
+    return PythonDetails(ID(), "id", details.GetUniqueID(), "getartwork", details);
 
   std::vector<std::string> vcsIn;
   CScraperUrl scurl;

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -746,10 +746,10 @@ namespace XBMCAddon
       GetVideoInfoTag()->m_fanart.Pack();
     }
 
-    void ListItem::addAvailableThumb(std::string url, std::string aspect, std::string referrer, std::string cache, bool post, bool isgz, int season)
+    void ListItem::addAvailableArtwork(std::string url, std::string art_type, std::string referrer, std::string cache, bool post, bool isgz, int season)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      GetVideoInfoTag()->m_strPictureURL.AddElement(url, aspect, referrer, cache, post, isgz, season);
+      GetVideoInfoTag()->m_strPictureURL.AddElement(url, art_type, referrer, cache, post, isgz, season);
     }
 
     void ListItem::addStreamInfo(const char* cType, const Properties& dictionary)

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -804,13 +804,13 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
-      /// @brief \python_func{ addAvailableThumb(images) }
+      /// @brief \python_func{ addAvailableArtwork(images) }
       ///-----------------------------------------------------------------------
-      /// @brief Add a thumb to available thumbs (needed for scrapers)
+      /// @brief Add an image to available artworks (needed for scrapers)
       ///
       /// @param url            string (image path url)
-      /// @param aspect         [opt] string (image type)
-      /// @param referrer       [opt] string (referr url)
+      /// @param art_type       string (image type)
+      /// @param referrer       [opt] string (referrer url)
       /// @param cache          [opt] string (filename in cache)
       /// @param post           [opt] bool (use post to retrieve the image, default false)
       /// @param isgz           [opt] bool (use gzip to retrieve the image, default false)
@@ -822,13 +822,13 @@ namespace XBMCAddon
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
       /// ...
-      /// listitem.addAvailableThumb(path_to_image_1, "1.77")
+      /// listitem.addAvailableArtwork(path_to_image_1, "thumb")
       /// ...
       /// ~~~~~~~~~~~~~
       ///
-      addAvailableThumb(...);
+      addAvailableArtwork(...);
 #else
-      void addAvailableThumb(std::string url, std::string aspect = "", std::string referrer = "", std::string cache = "", bool post = false, bool isgz = false, int season = -1);
+      void addAvailableArtwork(std::string url, std::string art_type = "", std::string referrer = "", std::string cache = "", bool post = false, bool isgz = false, int season = -1);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS


### PR DESCRIPTION
This is a splitup from https://github.com/xbmc/xbmc/pull/12661
I replaced the use of properties with our functions we already use to set info in plugins.
I also added nfo url support that @notspiff original implementation was missing.
I'm not sure if it's worth it in music part since there are only few functions available.
@ronie @DaveTBlake any opinion?

## Motivation and Context
We can use functions we are more familiar with.

## How Has This Been Tested?
Tested with my themoviedb python scraper

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
