### PR TITLE
GBM: Fixup after Retroplayer texture changes

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -25,7 +25,7 @@
 #endif
 
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"


### PR DESCRIPTION
Fixes:
```
 /home/fritsch/Desktop/xbmc-fritsch/kodi-agile/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp: In member function 'virtual bool CWinSystemGbmGLESContext::InitWindowSystem()':
/home/fritsch/Desktop/xbmc-fritsch/kodi-agile/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp:41:61: error: 'CRendererFactoryGuiTexture' in namespace 'KODI::RETRO' does not name a type
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
build/windowing/gbm/CMakeFiles/windowing_Gbm.dir/build.make:134: recipe for target 'build/windowing/gbm/CMakeFiles/windowing_Gbm.dir/WinSystemGbmGLESContext.cpp.o' failed
make[2]: *** [build/windowing/gbm/CMakeFiles/windowing_Gbm.dir/WinSystemGbmGLESContext.cpp.o] Error 1
CMakeFiles/Makefile2:9935: recipe for target 'build/windowing/gbm/CMakeFiles/windowing_Gbm.dir/all' failed
make[1]: *** [build/windowing/gbm/CMakeFiles/windowing_Gbm.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs.... 
```