### PR TITLE
Fix HTTPS SHOUTcast Streams

### DIFF
--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -57,7 +57,8 @@ bool CShoutcastFile::Open(const CURL& url)
 {
   CURL url2(url);
   url2.SetProtocolOptions(url2.GetProtocolOptions()+"&noshout=true&Icy-MetaData=1");
-  url2.SetProtocol("http");
+  if (url2.IsProtocol("shout"))
+    url2.SetProtocol("http");
 
   bool result = m_file.Open(url2);
   if (result)


### PR DESCRIPTION
This one line fix will remove a forced selection of HTTP for Shoutcast streams which causes a failure for streams that actually use HTTPS.

## Description
When a Shoutcast stream is discovered, this file renegotiates the connection. For some reason, which doesn't appear in any documentation, the connection is forced to be "http" perhaps to support buggy older Shoutcast servers from many years ago.

## Motivation and Context
I was trying to listen to WOSU in Columbus, Ohio using the URLs found at http://wosu.org/listen-live/ ... These point to HTTPS versions of the streams which would not load. Through debugging logs I found that upon renegotiation the https:// of the stream was being rewritten to http:// and then the stream would not play.

## How Has This Been Tested?
I have tested these and several other streams on Ubuntu Linux 16.04 LTS. 

## Screenshots (if appropriate):
N/A

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
