### PR TITLE
[depends][android] fix NDK split (#12662)

### DIFF
--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -57,7 +57,7 @@ endif()
 
 # add Android directories and tools
 if(CORE_SYSTEM_NAME STREQUAL android)
-  set(NDKROOT @use_ndk@)
+  set(NDKROOT @use_ndk_path@)
   set(SDKROOT @use_sdk_path@)
   set(SDK_PLATFORM @use_sdk@)
   string(REPLACE ":" ";" SDK_BUILDTOOLS_PATH "@build_tools_path@")


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
`use_ndk` was renamed to `use_ndk_path` in configure.ac at #12662
@koying FYI
<!--- Describe your change in detail -->

## Motivation and Context
Fix building binary addon `game.libretro.2048` for android.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Build `game.libretro.2048` successfully for android.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
