### PR TITLE
RetroPlayer: Nearest neighbor scaling support for Windows

### DIFF
--- a/cmake/treedata/common/retroplayer.txt
+++ b/cmake/treedata/common/retroplayer.txt
@@ -3,4 +3,5 @@ xbmc/cores/RetroPlayer/guicontrols                              cores/RetroPlaye
 xbmc/cores/RetroPlayer/process                                  cores/RetroPlayer/process
 xbmc/cores/RetroPlayer/rendering                                cores/RetroPlayer/rendering
 xbmc/cores/RetroPlayer/rendering/VideoRenderers                 cores/RetroPlayer/rendering/VideoRenderers
+xbmc/cores/RetroPlayer/rendering/VideoShaders                   cores/RetroPlayer/rendering/VideoShaders
 xbmc/cores/RetroPlayer/windows                                  cores/RetroPlayer/windows

--- a/cmake/treedata/windows/subdirs.txt
+++ b/cmake/treedata/windows/subdirs.txt
@@ -13,4 +13,5 @@ xbmc/rendering/dx            rendering_dx
 xbmc/threads/platform/win    threads_win
 xbmc/windowing/windows       windowing/windows
 xbmc/cores/RetroPlayer/process/windows cores/RetroPlayer/process/windows
+xbmc/cores/RetroPlayer/rendering/VideoShaders/windows cores/RetroPlayer/rendering/VideoShaders/windows
 xbmc/cores/VideoPlayer/Process/windows cores/VideoPlayer/Process/windows

--- a/system/shaders/rp_output_d3d.fx
+++ b/system/shaders/rp_output_d3d.fx
@@ -1,0 +1,81 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+texture2D g_Texture;
+float2    g_viewPort;
+float     m_params[1]; // 0 - range (0 - full, 1 - limited)
+
+SamplerState TextureSampler : IMMUTABLE
+{
+  AddressU = CLAMP;
+  AddressV = CLAMP;
+#ifdef SAMP_NEAREST
+  Filter   = MIN_MAG_MIP_POINT;
+#else
+  Filter   = MIN_MAG_MIP_LINEAR;
+#endif
+};
+
+struct VS_INPUT
+{
+  float4 Position   : POSITION;
+  float2 TextureUV  : TEXCOORD0;
+};
+
+struct VS_OUTPUT
+{
+  float2 TextureUV  : TEXCOORD0;
+  float4 Position   : SV_POSITION;
+};
+
+//
+// VS for rendering in screen space
+//
+VS_OUTPUT OUTPUT_VS(VS_INPUT In)
+{
+  VS_OUTPUT output  = (VS_OUTPUT)0;
+  output.Position.x =  (In.Position.x / (g_viewPort.x  / 2.0)) - 1;
+  output.Position.y = -(In.Position.y / (g_viewPort.y / 2.0)) + 1;
+  output.Position.z = output.Position.z;
+  output.Position.w = 1.0;
+  output.TextureUV  = In.TextureUV;
+
+  return output;
+}
+
+float4 OUTPUT_PS(VS_OUTPUT In) : SV_TARGET
+{
+  float4 color = g_Texture.Sample(TextureSampler, In.TextureUV);
+  [flatten] if (m_params[0])
+    color = saturate(0.0625 + color * 219.0 / 255.0);
+    
+  color.a = 1.0;
+
+  return color;
+}
+
+technique11 OUTPUT_T
+{
+  pass P0
+  {
+    SetVertexShader( CompileShader( vs_4_0_level_9_1, OUTPUT_VS()) );
+    SetPixelShader( CompileShader( ps_4_0_level_9_1, OUTPUT_PS() ) );
+  }
+};

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -29,7 +29,6 @@
 #include <vector>
 
 class CD3DTexture;
-class COutputShader;
 struct SwsContext;
 
 namespace KODI
@@ -37,6 +36,7 @@ namespace KODI
 namespace RETRO
 {
   class CRenderContext;
+  class CRPWinOutputShader;
 
   class CWinRendererFactory : public IRendererFactory
   {
@@ -115,17 +115,20 @@ namespace RETRO
     /*!
      * \brief The default scaling method of the renderer
      */
-    static const ESCALINGMETHOD DEFAULT_SCALING_METHOD = VS_SCALINGMETHOD_LINEAR;
+    static const ESCALINGMETHOD DEFAULT_SCALING_METHOD = VS_SCALINGMETHOD_NEAREST;
 
-protected:
+  protected:
     // implementation of CRPBaseRenderer
     bool ConfigureInternal() override;
     void RenderInternal(bool clear, uint8_t alpha) override;
 
   private:
+    void CompileOutputShader(ESCALINGMETHOD scalingMethod);
+    void HandleScalingChange();
     void Render(CD3DTexture *target);
 
-    std::unique_ptr<COutputShader> m_outputShader;
+    std::unique_ptr<CRPWinOutputShader> m_outputShader;
+    ESCALINGMETHOD m_prevScalingMethod = VS_SCALINGMETHOD_AUTO;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaders/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaders/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(NOT ENABLE_STATIC_LIBS)
+  core_add_library(rp-videoshaders)
+endif()

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES RPWinOutputShader.cpp)
+
+set(HEADERS RPWinOutputShader.h)
+
+core_add_library(rp-videoshaders-windows)

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.cpp
@@ -1,0 +1,125 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "RPWinOutputShader.h"
+#include "utils/log.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+bool CRPWinOutputShader::Create(ESCALINGMETHOD scalingMethod)
+{
+  CWinShader::CreateVertexBuffer(4, sizeof(CUSTOMVERTEX));
+
+  DefinesMap defines;
+  switch (scalingMethod)
+  {
+  case VS_SCALINGMETHOD_NEAREST:
+    defines["SAMP_NEAREST"] = "";
+    break;
+  case VS_SCALINGMETHOD_LINEAR:
+  default:
+    break;
+  }
+
+  std::string effectPath("special://xbmc/system/shaders/rp_output_d3d.fx");
+
+  if (!LoadEffect(effectPath, &defines))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": Failed to load shader %s.", effectPath.c_str());
+    return false;
+  }
+
+  // Create input layout
+  D3D11_INPUT_ELEMENT_DESC layout[] =
+  {
+    { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+  };
+  return CWinShader::CreateInputLayout(layout, ARRAYSIZE(layout));
+}
+
+void CRPWinOutputShader::Render(CD3DTexture& sourceTexture, unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4]
+  , CRect &viewPort, CD3DTexture *target, unsigned range)
+{
+  PrepareParameters(sourceWidth, sourceHeight, sourceRect, points);
+  SetShaderParameters(sourceTexture, range, viewPort);
+  Execute({ target }, 4);
+}
+
+void CRPWinOutputShader::PrepareParameters(unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4])
+{
+  bool changed = false;
+  for (int i = 0; i < 4 && !changed; ++i)
+    changed = points[i] != m_destPoints[i];
+
+  if (m_sourceWidth != sourceWidth ||
+    m_sourceHeight != sourceHeight ||
+    m_sourceRect != sourceRect ||
+    changed)
+  {
+    m_sourceWidth = sourceWidth;
+    m_sourceHeight = sourceHeight;
+    m_sourceRect = sourceRect;
+
+    for (int i = 0; i < 4; ++i)
+      m_destPoints[i] = points[i];
+
+    CUSTOMVERTEX* v = nullptr;
+    CWinShader::LockVertexBuffer(static_cast<void**>(static_cast<void*>(&v)));
+
+    v[0].x = m_destPoints[0].x;
+    v[0].y = m_destPoints[0].y;
+    v[0].z = 0.0f;
+    v[0].tu = m_sourceRect.x1 / m_sourceWidth;
+    v[0].tv = m_sourceRect.y1 / m_sourceHeight;
+
+    v[1].x = m_destPoints[1].x;
+    v[1].y = m_destPoints[1].y;
+    v[1].z = 0.0f;
+    v[1].tu = m_sourceRect.x2 / m_sourceWidth;
+    v[1].tv = m_sourceRect.y1 / m_sourceHeight;
+
+    v[2].x = m_destPoints[2].x;
+    v[2].y = m_destPoints[2].y;
+    v[2].z = 0.0f;
+    v[2].tu = m_sourceRect.x2 / m_sourceWidth;
+    v[2].tv = m_sourceRect.y2 / m_sourceHeight;
+
+    v[3].x = m_destPoints[3].x;
+    v[3].y = m_destPoints[3].y;
+    v[3].z = 0.0f;
+    v[3].tu = m_sourceRect.x1 / m_sourceWidth;
+    v[3].tv = m_sourceRect.y2 / m_sourceHeight;
+
+    CWinShader::UnlockVertexBuffer();
+  }
+}
+
+void CRPWinOutputShader::SetShaderParameters(CD3DTexture& sourceTexture, unsigned range, CRect &viewPort)
+{
+  m_effect.SetTechnique("OUTPUT_T");
+  m_effect.SetResources("g_Texture", sourceTexture.GetAddressOfSRV(), 1);
+
+  float viewPortArray[2] = { viewPort.Width(), viewPort.Height() };
+  m_effect.SetFloatArray("g_viewPort", viewPortArray, 2);
+
+  float params[3] = { static_cast<float>(range) };
+  m_effect.SetFloatArray("m_params", params, 1);
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoShaders/windows/RPWinOutputShader.h
@@ -1,0 +1,64 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+
+class CRPWinOutputShader : public CWinShader
+{
+public:
+  ~CRPWinOutputShader() = default;
+
+  bool Create(ESCALINGMETHOD scalingMethod);
+  void Render(CD3DTexture &sourceTexture, unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4]
+    , CRect &viewPort, CD3DTexture *target, unsigned range = 0);
+
+private:
+  void PrepareParameters(unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4]);
+  void SetShaderParameters(CD3DTexture& sourceTexture, unsigned range, CRect &viewPort);
+
+  unsigned m_sourceWidth{ 0 };
+  unsigned m_sourceHeight{ 0 };
+  CRect m_sourceRect{ 0.f, 0.f, 0.f, 0.f };
+  CPoint m_destPoints[4] =
+  {
+    { 0.f, 0.f },
+    { 0.f, 0.f },
+    { 0.f, 0.f },
+    { 0.f, 0.f },
+  };
+
+  struct CUSTOMVERTEX {
+    FLOAT x;
+    FLOAT y;
+    FLOAT z;
+
+    FLOAT tu;
+    FLOAT tv;
+  };
+};
+
+} // namespace RETRO
+} // namespace KODI


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
With this PR, RetroPlayer gets its own lighter version of VP's `COutputShader` (plus the shader itself).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
As a result, we get nearest neighbor support for Windows and our own simple output shader system without the need to change VP code or its shaders.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
It has been tested on Windows 7 and Windows 10.

## Screenshots (if appropriate):
Linear:
![image](https://user-images.githubusercontent.com/6632271/31058835-6670d38a-a703-11e7-8413-5e4a9091372a.png)
Nearest neighbor:
![image](https://user-images.githubusercontent.com/6632271/31058842-7c4345d0-a703-11e7-834b-fa6bb2181129.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
