### PR TITLE
Special Protocol path calculation migration

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -610,7 +610,7 @@ bool CApplication::Create(const CAppParamParser &params)
   //! @todo - move to CPlatformXXX
 #ifdef TARGET_WINDOWS
   CWIN32Util::SetThreadLocalLocale(true); // enable independent locale for each thread, see https://connect.microsoft.com/VisualStudio/feedback/details/794122
-#endif // TARGET_WINDOWS 
+#endif // TARGET_WINDOWS
 
   // initialize the addon database (must be before the addon manager is init'd)
   CDatabaseManager::GetInstance().Initialize(true);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -610,7 +610,7 @@ bool CApplication::Create(const CAppParamParser &params)
   //! @todo - move to CPlatformXXX
 #ifdef TARGET_WINDOWS
   CWIN32Util::SetThreadLocalLocale(true); // enable independent locale for each thread, see https://connect.microsoft.com/VisualStudio/feedback/details/794122
-#endif // TARGET_WINDOWS
+#endif // TARGET_WINDOWS 
 
   // initialize the addon database (must be before the addon manager is init'd)
   CDatabaseManager::GetInstance().Initialize(true);
@@ -985,6 +985,10 @@ bool CApplication::InitDirectoriesWin32()
 #ifdef TARGET_WINDOWS
   std::string xbmcPath = CUtil::GetHomePath();
   CEnvironment::setenv("KODI_HOME", xbmcPath);
+  
+  /*
+	No need for the setters below (only in Windows right now). Using specific getters now.
+ 
   CSpecialProtocol::SetXBMCBinPath(xbmcPath);
   CSpecialProtocol::SetXBMCPath(xbmcPath);
   CSpecialProtocol::SetXBMCBinAddonPath(xbmcPath + "/addons");
@@ -994,6 +998,7 @@ bool CApplication::InitDirectoriesWin32()
   CSpecialProtocol::SetHomePath(strWin32UserFolder);
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
   CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));
+ */
 
   CEnvironment::setenv("KODI_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -250,7 +250,7 @@ public:
   bool IsMusicScanning() const;
   bool IsVideoScanning() const;
 
-  /*! 
+  /*!
    \brief Starts a video library cleanup.
    \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
    */

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -250,7 +250,7 @@ public:
   bool IsMusicScanning() const;
   bool IsVideoScanning() const;
 
-  /*!
+  /*! 
    \brief Starts a video library cleanup.
    \param userInitiated Whether the action was initiated by the user (either via GUI or any other method) or not.  It is meant to hide or show dialogs.
    */

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -35,260 +35,357 @@
 #include "utils/StringUtils.h"
 #endif
 
+#ifdef TARGET_WINDOWS
+#include "platform/win32/WIN32Util.h"
+#endif
+
+
+#ifdef TARGET_WINDOWS
+ //Getters
+std::string CSpecialProtocol::GetHomePath() 
+{
+	return CWIN32Util::GetProfilePath();
+}
+
+std::string CSpecialProtocol::GetHomePath(const std::string &fileName) 
+{
+	return URIUtils::AddFileToFolder(GetHomePath(), fileName);
+}
+
+std::string CSpecialProtocol::GetTmpPath() 
+{
+	return URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), "cache");
+}
+
+std::string CSpecialProtocol::GetTmpPath(const std::string &fileName) 
+{
+	return URIUtils::AddFileToFolder(GetTmpPath(), fileName);
+}
+
+
+std::string CSpecialProtocol::GetXBMCBinAddonPath() 
+{
+	std::string str = GetXBMCPath("/addons");
+	return str;
+}
+
+std::string CSpecialProtocol::GetProfilePath()
+{
+	return CProfilesManager::GetInstance().GetProfileUserDataFolder();
+}
+
+std::string CSpecialProtocol::GetProfilePath(const std::string &fileName)
+{
+	return URIUtils::AddFileToFolder(GetProfilePath(), fileName);
+}
+
+std::string CSpecialProtocol::GetMasterProfilePath() 
+{
+	return URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), "userdata");
+}
+
+std::string CSpecialProtocol::GetMasterProfilePath(const std::string &fileName)
+{
+	return URIUtils::AddFileToFolder(GetMasterProfilePath(), fileName);
+}
+
+std::string CSpecialProtocol::GetXBMCPath()
+{
+	return CUtil::GetHomePath();
+}
+
+std::string CSpecialProtocol::GetXBMCPath(const std::string &fileName) 
+{
+	return URIUtils::AddFileToFolder(GetXBMCPath(), fileName);
+	//TODO: need to add other platforms
+}
+#endif
+
 void CSpecialProtocol::SetProfilePath(const std::string &dir)
 {
-  SetPath("profile", dir);
-  CLog::Log(LOGNOTICE, "special://profile/ is mapped to: %s", GetPath("profile").c_str());
+	SetPath("profile", dir);
+	CLog::Log(LOGNOTICE, "special://profile/ is mapped to: %s", GetPath("profile").c_str());
 }
 
 void CSpecialProtocol::SetXBMCPath(const std::string &dir)
 {
-  SetPath("xbmc", dir);
+	SetPath("xbmc", dir);
 }
 
 void CSpecialProtocol::SetXBMCBinPath(const std::string &dir)
 {
-  SetPath("xbmcbin", dir);
+	SetPath("xbmcbin", dir);
 }
 
 void CSpecialProtocol::SetXBMCBinAddonPath(const std::string &dir)
 {
-  SetPath("xbmcbinaddons", dir);
+	SetPath("xbmcbinaddons", dir);
 }
 
 void CSpecialProtocol::SetXBMCAltBinAddonPath(const std::string &dir)
 {
-  SetPath("xbmcaltbinaddons", dir);
+	SetPath("xbmcaltbinaddons", dir);
 }
 
 void CSpecialProtocol::SetXBMCFrameworksPath(const std::string &dir)
 {
-  SetPath("frameworks", dir);
+	SetPath("frameworks", dir);
 }
 
 void CSpecialProtocol::SetHomePath(const std::string &dir)
 {
-  SetPath("home", dir);
+	SetPath("home", dir);
 }
 
 void CSpecialProtocol::SetUserHomePath(const std::string &dir)
 {
-  SetPath("userhome", dir);
+	SetPath("userhome", dir);
 }
 
 void CSpecialProtocol::SetEnvHomePath(const std::string &dir)
 {
-  SetPath("envhome", dir);
+	SetPath("envhome", dir);
 }
 
 void CSpecialProtocol::SetMasterProfilePath(const std::string &dir)
 {
-  SetPath("masterprofile", dir);
+	SetPath("masterprofile", dir);
 }
 
 void CSpecialProtocol::SetTempPath(const std::string &dir)
 {
-  SetPath("temp", dir);
+	SetPath("temp", dir);
 }
 
 void CSpecialProtocol::SetLogPath(const std::string &dir)
 {
-  SetPath("logpath", dir);
+	SetPath("logpath", dir);
 }
 
 bool CSpecialProtocol::ComparePath(const std::string &path1, const std::string &path2)
 {
-  return TranslatePath(path1) == TranslatePath(path2);
+	return TranslatePath(path1) == TranslatePath(path2);
 }
 
 std::string CSpecialProtocol::TranslatePath(const std::string &path)
 {
-  CURL url(path);
-  // check for special-protocol, if not, return
-  if (!url.IsProtocol("special"))
-  {
-    return path;
-  }
-  return TranslatePath(url);
+	CURL url(path);
+	// check for special-protocol, if not, return
+	if (!url.IsProtocol("special"))
+	{
+		return path;
+	}
+	return TranslatePath(url);
 }
 
 std::string CSpecialProtocol::TranslatePath(const CURL &url)
 {
-  // check for special-protocol, if not, return
-  if (!url.IsProtocol("special"))
-  {
+	// check for special-protocol, if not, return
+	if (!url.IsProtocol("special"))
+	{
 #if defined(TARGET_POSIX) && defined(_DEBUG)
-    std::string path(url.Get());
-    if (path.length() >= 2 && path[1] == ':')
-    {
-      CLog::Log(LOGWARNING, "Trying to access old style dir: %s\n", path.c_str());
-     // printf("Trying to access old style dir: %s\n", path.c_str());
-    }
+		std::string path(url.Get());
+		if (path.length() >= 2 && path[1] == ':')
+		{
+			CLog::Log(LOGWARNING, "Trying to access old style dir: %s\n", path.c_str());
+			// printf("Trying to access old style dir: %s\n", path.c_str());
+		}
 #endif
 
-    return url.Get();
-  }
+		return url.Get();
+	}
 
-  std::string FullFileName = url.GetFileName();
+	std::string FullFileName = url.GetFileName();
+	std::string translatedPath;
+	std::string FileName;
+	std::string RootDir;
 
-  std::string translatedPath;
-  std::string FileName;
-  std::string RootDir;
+	// Split up into the special://root and the rest of the filename
+	size_t pos = FullFileName.find('/');
+	if (pos != std::string::npos && pos > 1)
+	{
+		RootDir = FullFileName.substr(0, pos);
 
-  // Split up into the special://root and the rest of the filename
-  size_t pos = FullFileName.find('/');
-  if (pos != std::string::npos && pos > 1)
-  {
-    RootDir = FullFileName.substr(0, pos);
+		if (pos < FullFileName.size())
+			FileName = FullFileName.substr(pos + 1);
+	}
+	else
+		RootDir = FullFileName;
 
-    if (pos < FullFileName.size())
-      FileName = FullFileName.substr(pos + 1);
-  }
-  else
-    RootDir = FullFileName;
+	if (RootDir == "subtitles")
+		translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH), FileName);
+	else if (RootDir == "userdata")
+		translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetUserDataFolder(), FileName);
+	else if (RootDir == "database")
+		translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetDatabaseFolder(), FileName);
+	else if (RootDir == "thumbnails")
+		translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetThumbnailsFolder(), FileName);
+	else if (RootDir == "recordings" || RootDir == "cdrips")
+		translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_AUDIOCDS_RECORDINGPATH), FileName);
+	else if (RootDir == "screenshots")
+		translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_DEBUG_SCREENSHOTPATH), FileName);
+	else if (RootDir == "musicplaylists")
+		translatedPath = URIUtils::AddFileToFolder(CUtil::MusicPlaylistsLocation(), FileName);
+	else if (RootDir == "videoplaylists")
+		translatedPath = URIUtils::AddFileToFolder(CUtil::VideoPlaylistsLocation(), FileName);
+	else if (RootDir == "skin")
+		translatedPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName);
 
-  if (RootDir == "subtitles")
-    translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH), FileName);
-  else if (RootDir == "userdata")
-    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetUserDataFolder(), FileName);
-  else if (RootDir == "database")
-    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetDatabaseFolder(), FileName);
-  else if (RootDir == "thumbnails")
-    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetThumbnailsFolder(), FileName);
-  else if (RootDir == "recordings" || RootDir == "cdrips")
-    translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_AUDIOCDS_RECORDINGPATH), FileName);
-  else if (RootDir == "screenshots")
-    translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_DEBUG_SCREENSHOTPATH), FileName);
-  else if (RootDir == "musicplaylists")
-    translatedPath = URIUtils::AddFileToFolder(CUtil::MusicPlaylistsLocation(), FileName);
-  else if (RootDir == "videoplaylists")
-    translatedPath = URIUtils::AddFileToFolder(CUtil::VideoPlaylistsLocation(), FileName);
-  else if (RootDir == "skin")
-    translatedPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName);
+	// from here on, we have our "real" special paths
 
-  // from here on, we have our "real" special paths
-  else if (RootDir == "xbmc" ||
-           RootDir == "xbmcbin" ||
-           RootDir == "xbmcbinaddons" ||
-           RootDir == "xbmcaltbinaddons" ||
-           RootDir == "home" ||
-           RootDir == "envhome" ||
-           RootDir == "userhome" ||
-           RootDir == "temp" ||
-           RootDir == "profile" ||
-           RootDir == "masterprofile" ||
-           RootDir == "frameworks" ||
-           RootDir == "logpath")
-  {
-    std::string basePath = GetPath(RootDir);
-    if (!basePath.empty())
-      translatedPath = URIUtils::AddFileToFolder(basePath, FileName);
-    else
-      translatedPath.clear();
-  }
+/* In Windows platform the static path map isn't used anymore. Instead we use specific getters.
+   (for alleviating the early destruction of the map when exiting Kodi)
+*/
+#ifdef TARGET_WINDOWS
+	else if (RootDir == "profile")
+	{
+		translatedPath = GetProfilePath(FileName);
+	}
+	else if (RootDir == "masterprofile")
+	{
+		translatedPath = GetMasterProfilePath(FileName);
+	}
+	else if (RootDir == "xbmc" || RootDir == "xbmcbin")
+	{
+		translatedPath = GetXBMCPath(FileName);
+	}
+	else if (RootDir == "xbmcbinaddons")
+	{
+		translatedPath = GetXBMCBinAddonPath();
+	}
+	else if (RootDir == "home" || RootDir == "logpath")
+	{
+		translatedPath = GetHomePath(FileName);
+	}
+	else if (RootDir == "temp")
+	{
+		translatedPath = GetTmpPath(FileName);
+	}
+#else
+	else if (
+		RootDir == "xbmc" ||
+		RootDir == "xbmcbin" ||
+		RootDir == "xbmcbinaddons" ||
+		RootDir == "xbmcaltbinaddons" ||
+		RootDir == "home" ||
+		RootDir == "envhome" ||
+		RootDir == "userhome" ||
+		RootDir == "temp" ||
+		RootDir == "profile" ||
+		RootDir == "masterprofile" ||
+		RootDir == "frameworks" ||
+		RootDir == "logpath")
+	{
+		std::string basePath = GetPath(RootDir);
+		if (!basePath.empty())
+			translatedPath = URIUtils::AddFileToFolder(basePath, FileName);
+		else
+			translatedPath.clear();
+	}
+#endif
 
-  // check if we need to recurse in
-  if (URIUtils::IsSpecial(translatedPath))
-  { // we need to recurse in, as there may be multiple translations required
-    return TranslatePath(translatedPath);
-  }
+		// check if we need to recurse in
+		if (URIUtils::IsSpecial(translatedPath))
+		{ // we need to recurse in, as there may be multiple translations required
+			return TranslatePath(translatedPath);
+		}
 
-  // Validate the final path, just in case
-  return CUtil::ValidatePath(translatedPath);
-}
+		// Validate the final path, just in case
+		return CUtil::ValidatePath(translatedPath);
+	}
 
-std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
-{
-  std::string translatedPath = TranslatePath(path);
+	std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
+	{
+		std::string translatedPath = TranslatePath(path);
 
 #ifdef TARGET_POSIX
-  if (translatedPath.find("://") != std::string::npos)
-    return translatedPath;
+		if (translatedPath.find("://") != std::string::npos)
+			return translatedPath;
 
-  // If the file exists with the requested name, simply return it
-  struct stat stat_buf;
-  if (stat(translatedPath.c_str(), &stat_buf) == 0)
-    return translatedPath;
+		// If the file exists with the requested name, simply return it
+		struct stat stat_buf;
+		if (stat(translatedPath.c_str(), &stat_buf) == 0)
+			return translatedPath;
 
-  std::string result;
-  std::vector<std::string> tokens;
-  StringUtils::Tokenize(translatedPath, tokens, "/");
-  std::string file;
-  DIR* dir;
-  struct dirent* de;
+		std::string result;
+		std::vector<std::string> tokens;
+		StringUtils::Tokenize(translatedPath, tokens, "/");
+		std::string file;
+		DIR* dir;
+		struct dirent* de;
 
-  for (unsigned int i = 0; i < tokens.size(); i++)
-  {
-    file = result + "/";
-    file += tokens[i];
-    if (stat(file.c_str(), &stat_buf) == 0)
-    {
-      result += "/" + tokens[i];
-    }
-    else
-    {
-      dir = opendir(result.c_str());
-      if (dir)
-      {
-        while ((de = readdir(dir)) != NULL)
-        {
-          // check if there's a file with same name but different case
-          if (strcasecmp(de->d_name, tokens[i].c_str()) == 0)
-          {
-            result += "/";
-            result += de->d_name;
-            break;
-          }
-        }
+		for (unsigned int i = 0; i < tokens.size(); i++)
+		{
+			file = result + "/";
+			file += tokens[i];
+			if (stat(file.c_str(), &stat_buf) == 0)
+			{
+				result += "/" + tokens[i];
+			}
+			else
+			{
+				dir = opendir(result.c_str());
+				if (dir)
+				{
+					while ((de = readdir(dir)) != NULL)
+					{
+						// check if there's a file with same name but different case
+						if (strcasecmp(de->d_name, tokens[i].c_str()) == 0)
+						{
+							result += "/";
+							result += de->d_name;
+							break;
+						}
+					}
 
-        // if we did not find any file that somewhat matches, just
-        // fallback but we know it's not gonna be a good ending
-        if (de == NULL)
-          result += "/" + tokens[i];
+					// if we did not find any file that somewhat matches, just
+					// fallback but we know it's not gonna be a good ending
+					if (de == NULL)
+						result += "/" + tokens[i];
 
-        closedir(dir);
-      }
-      else
-      { // this is just fallback, we won't succeed anyway...
-        result += "/" + tokens[i];
-      }
-    }
-  }
+					closedir(dir);
+	}
+				else
+				{ // this is just fallback, we won't succeed anyway...
+					result += "/" + tokens[i];
+				}
+}
+		}
 
-  return result;
+		return result;
 #else
-  return translatedPath;
+		return translatedPath;
 #endif
 }
 
-void CSpecialProtocol::LogPaths()
-{
-  CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetPath("xbmc").c_str());
-  CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetPath("xbmcbin").c_str());
-  CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetPath("xbmcbinaddons").c_str());
-  CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetPath("masterprofile").c_str());
+	void CSpecialProtocol::LogPaths()
+	{
+		CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetXBMCPath().c_str());
+		CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetXBMCPath().c_str());
+		CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetXBMCBinAddonPath().c_str());
+		CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetMasterProfilePath().c_str());
 #if defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
+		CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
 #endif
-  CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetPath("home").c_str());
-  CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetPath("temp").c_str());
-  CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetPath("logpath").c_str());
-  //CLog::Log(LOGNOTICE, "special://userhome/ is mapped to: %s", GetPath("userhome").c_str());
-  if (!CUtil::GetFrameworksPath().empty())
-    CLog::Log(LOGNOTICE, "special://frameworks/ is mapped to: %s", GetPath("frameworks").c_str());
-}
+		CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetHomePath().c_str());
+		CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetTmpPath().c_str());
+		CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetHomePath().c_str());
+		//CLog::Log(LOGNOTICE, "special://userhome/ is mapped to: %s", GetPath("userhome").c_str());
+		if (!CUtil::GetFrameworksPath().empty())
+			CLog::Log(LOGNOTICE, "special://frameworks/ is mapped to: %s", GetPath("frameworks").c_str());
+	}
 
-// private routines, to ensure we only set/get an appropriate path
-void CSpecialProtocol::SetPath(const std::string &key, const std::string &path)
-{
-  m_pathMap[key] = path;
-}
+	// private routines, to ensure we only set/get an appropriate path
+	void CSpecialProtocol::SetPath(const std::string &key, const std::string &path)
+	{
+		m_pathMap[key] = path;
+	}
 
-std::string CSpecialProtocol::GetPath(const std::string &key)
-{
-  std::map<std::string, std::string>::iterator it = m_pathMap.find(key);
-  if (it != m_pathMap.end())
-    return it->second;
-  assert(false);
-  return "";
-}
+	std::string CSpecialProtocol::GetPath(const std::string &key)
+	{
+		std::map<std::string, std::string>::iterator it = m_pathMap.find(key);
+		if (it != m_pathMap.end())
+			return it->second;
+		assert(false);
+		return "";
+	}

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -97,7 +97,6 @@ std::string CSpecialProtocol::GetXBMCPath()
 std::string CSpecialProtocol::GetXBMCPath(const std::string &fileName) 
 {
 	return URIUtils::AddFileToFolder(GetXBMCPath(), fileName);
-	//TODO: need to add other platforms
 }
 #endif
 

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -41,7 +41,7 @@
 
 
 #ifdef TARGET_WINDOWS
- //Getters
+//Getters
 std::string CSpecialProtocol::GetHomePath() 
 {
 	return CWIN32Util::GetProfilePath();
@@ -97,7 +97,6 @@ std::string CSpecialProtocol::GetXBMCPath()
 std::string CSpecialProtocol::GetXBMCPath(const std::string &fileName) 
 {
 	return URIUtils::AddFileToFolder(GetXBMCPath(), fileName);
-	//TODO: need to add other platforms
 }
 #endif
 

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -22,62 +22,77 @@
 #include <map>
 #include <string>
 
-// static class for path translation from our special:// URLs.
+ // static class for path translation from our special:// URLs.
 
-/* paths are as follows:
+ /* paths are as follows:
 
- special://xbmc/          - the main XBMC folder (i.e. where the app resides).
- special://home/          - a writeable version of the main XBMC folder
-                             Linux: ~/.kodi/
-                             OS X:  ~/Library/Application Support/Kodi/
-                             Win32: ~/Application Data/XBMC/
- special://envhome/       - on posix systems this will be equal to the $HOME
- special://userhome/      - a writable version of the user home directory
-                             Linux, OS X: ~/.kodi
-                             Win32: home directory of user
- special://masterprofile/ - the master users userdata folder - usually special://home/userdata
-                             Linux: ~/.kodi/userdata/
-                             OS X:  ~/Library/Application Support/Kodi/UserData/
-                             Win32: ~/Application Data/XBMC/UserData/
- special://profile/       - the current users userdata folder - usually special://masterprofile/profiles/<current_profile>
-                             Linux: ~/.kodi/userdata/profiles/<current_profile>
-                             OS X:  ~/Library/Application Support/Kodi/UserData/profiles/<current_profile>
-                             Win32: ~/Application Data/XBMC/UserData/profiles/<current_profile>
+  special://xbmc/          - the main XBMC folder (i.e. where the app resides).
+  special://home/          - a writeable version of the main XBMC folder
+							  Linux: ~/.kodi/
+							  OS X:  ~/Library/Application Support/Kodi/
+							  Win32: ~/Application Data/XBMC/
+  special://envhome/       - on posix systems this will be equal to the $HOME
+  special://userhome/      - a writable version of the user home directory
+							  Linux, OS X: ~/.kodi
+							  Win32: home directory of user
+  special://masterprofile/ - the master users userdata folder - usually special://home/userdata
+							  Linux: ~/.kodi/userdata/
+							  OS X:  ~/Library/Application Support/Kodi/UserData/
+							  Win32: ~/Application Data/XBMC/UserData/
+  special://profile/       - the current users userdata folder - usually special://masterprofile/profiles/<current_profile>
+							  Linux: ~/.kodi/userdata/profiles/<current_profile>
+							  OS X:  ~/Library/Application Support/Kodi/UserData/profiles/<current_profile>
+							  Win32: ~/Application Data/XBMC/UserData/profiles/<current_profile>
 
- special://temp/          - the temporary directory.
-                             Linux: ~/.kodi/temp
-                             OS X:  ~/
-                             Win32: ~/Application Data/XBMC/cache
-*/
+  special://temp/          - the temporary directory.
+							  Linux: ~/.kodi/temp
+							  OS X:  ~/
+							  Win32: ~/Application Data/XBMC/cache
+ */
 class CURL;
 class CSpecialProtocol
 {
 public:
-  static void SetProfilePath(const std::string &path);
-  static void SetXBMCPath(const std::string &path);
-  static void SetXBMCBinPath(const std::string &path);
-  static void SetXBMCBinAddonPath(const std::string &path);
-  static void SetXBMCAltBinAddonPath(const std::string &path);
-  static void SetXBMCFrameworksPath(const std::string &path);
-  static void SetHomePath(const std::string &path);
-  static void SetUserHomePath(const std::string &path);
-  static void SetEnvHomePath(const std::string &path);
-  static void SetMasterProfilePath(const std::string &path);
-  static void SetTempPath(const std::string &path);
-  static void SetLogPath(const std::string &dir);
+	static void SetProfilePath(const std::string &path);
+	static void SetXBMCPath(const std::string &path);
+	static void SetXBMCBinPath(const std::string &path);
+	static void SetXBMCBinAddonPath(const std::string &path);
+	static void SetXBMCAltBinAddonPath(const std::string &path);
+	static void SetXBMCFrameworksPath(const std::string &path);
+	static void SetHomePath(const std::string &path);
+	static void SetUserHomePath(const std::string &path);
+	static void SetEnvHomePath(const std::string &path);
+	static void SetMasterProfilePath(const std::string &path);
+	static void SetTempPath(const std::string &path);
+	static void SetLogPath(const std::string &dir);
 
-  static bool ComparePath(const std::string &path1, const std::string &path2);
-  static void LogPaths();
+	static bool ComparePath(const std::string &path1, const std::string &path2);
+	static void LogPaths();
 
-  static std::string TranslatePath(const std::string &path);
-  static std::string TranslatePath(const CURL &url);
-  static std::string TranslatePathConvertCase(const std::string& path);
+	static std::string TranslatePath(const std::string &path);
+	static std::string TranslatePath(const CURL &url);
+	static std::string TranslatePathConvertCase(const std::string& path);
 
 private:
-  static void SetPath(const std::string &key, const std::string &path);
-  static std::string GetPath(const std::string &key);
+	// Specific Path Getters (Instead of using GetPath())
+	static std::string GetProfilePath();
+	static std::string GetProfilePath(const std::string &fileName);
+	static std::string GetMasterProfilePath();
+	static std::string GetMasterProfilePath(const std::string &fileName);
+	static std::string GetXBMCPath();
+	static std::string GetXBMCPath(const std::string &fileName);
+	static std::string GetXBMCBinAddonPath();
+	//static std::string GetXBMCBinAddonPath(const std::string &fileName);  // I don't think there is a need to this signature.
+	static std::string GetHomePath();
+	static std::string GetHomePath(const std::string &fileName);
+	static std::string GetTmpPath();
+	static std::string GetTmpPath(const std::string &fileName);
 
-  static std::map<std::string, std::string> m_pathMap;
+
+	static void SetPath(const std::string &key, const std::string &path);
+	static std::string GetPath(const std::string &key);
+
+	static std::map<std::string, std::string> m_pathMap;
 };
 
 #ifdef TARGET_WINDOWS

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -22,7 +22,7 @@
 #include <map>
 #include <string>
 
- // static class for path translation from our special:// URLs.
+// static class for path translation from our special:// URLs.
 
  /* paths are as follows:
 
@@ -82,7 +82,6 @@ private:
 	static std::string GetXBMCPath();
 	static std::string GetXBMCPath(const std::string &fileName);
 	static std::string GetXBMCBinAddonPath();
-	//static std::string GetXBMCBinAddonPath(const std::string &fileName);  // I don't think there is a need to this signature.
 	static std::string GetHomePath();
 	static std::string GetHomePath(const std::string &fileName);
 	static std::string GetTmpPath();

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -82,7 +82,6 @@ private:
 	static std::string GetXBMCPath();
 	static std::string GetXBMCPath(const std::string &fileName);
 	static std::string GetXBMCBinAddonPath();
-	//static std::string GetXBMCBinAddonPath(const std::string &fileName);  // I don't think there is a need to this signature.
 	static std::string GetHomePath();
 	static std::string GetHomePath(const std::string &fileName);
 	static std::string GetTmpPath();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Migrating from using static map to special paths stored in https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/SpecialProtocol.cpp and calculated in 
https://github.com/xbmc/xbmc/blob/master/xbmc/Application.cpp to On-the-fly path calculations in  "SpecialProtocol.cpp" instead. Currently change is implemented only for Windows platform.

## Description
<!--- Describe your change in detail -->
Instead of using GetPath() in "SpecialProtocol.h" (For Windows platform) specific Static getters were implemented, means that the static path map in "SpecialProtocol.cpp" isn't needed for path calculations anymore (Windows only right now)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The aim is to solve the early destruction of the static path map (m_pathMap) while Kodi is exiting when the stored paths still needed by other code.
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Ran the kodi-test project main and passed all tests, Ran Kodi to check for errors. Printed some logs to make sure the path translation (TranslatePath() in SpecialProtocol.h) is the same via GetPath() and new/replacement getters . 
<!--- Include details of your testing environment, and the tests you ran to -->
VS 2017 debugger (Windows 10), kodi-test main (which runs all tests)
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ x] I have updated the documentation accordingly
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ x] All new and existing tests passed
