### PR TITLE
Special protocol migration

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -431,10 +431,6 @@ bool CApplication::Create(const CAppParamParser &params)
 
 
   //! @todo - move to CPlatformXXX
-  #if defined(TARGET_POSIX)
-    // set special://envhome
-    CSpecialProtocol::SetEnvHomePath(getenv("HOME"));
-  #endif
 
   // only the InitDirectories* for the current platform should return true
   bool inited = InitDirectoriesLinux();
@@ -808,7 +804,6 @@ bool CApplication::InitDirectoriesLinux()
   StringUtils::ToLower(dotLowerAppName);
   const char* envAppHome = "KODI_HOME";
   const char* envAppBinHome = "KODI_BIN_HOME";
-  const char* envAppTemp = "KODI_TEMP";
 
   auto appBinPath = CUtil::GetHomePath(envAppBinHome);
   // overridden by user
@@ -836,48 +831,10 @@ bool CApplication::InitDirectoriesLinux()
   setenv(envAppBinHome, appBinPath.c_str(), 0);
   setenv(envAppHome, appPath.c_str(), 0);
 
-  if (m_bPlatformDirectories)
-  {
     // map our special drives
-    CSpecialProtocol::SetXBMCBinPath(appBinPath);
-    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
-    CSpecialProtocol::SetXBMCPath(appPath);
-    CSpecialProtocol::SetHomePath(userHome + "/" + dotLowerAppName);
-    CSpecialProtocol::SetMasterProfilePath(userHome + "/" + dotLowerAppName + "/userdata");
-
-    std::string strTempPath = userHome;
-    strTempPath = URIUtils::AddFileToFolder(strTempPath, dotLowerAppName + "/temp");
-    if (getenv(envAppTemp))
-      strTempPath = getenv(envAppTemp);
-    CSpecialProtocol::SetTempPath(strTempPath);
-    CSpecialProtocol::SetLogPath(strTempPath);
 
     CreateUserDirs();
 
-  }
-  else
-  {
-    URIUtils::AddSlashAtEnd(appPath);
-
-    CSpecialProtocol::SetXBMCBinPath(appBinPath);
-    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
-    CSpecialProtocol::SetXBMCPath(appPath);
-    CSpecialProtocol::SetHomePath(URIUtils::AddFileToFolder(appPath, "portable_data"));
-    CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(appPath, "portable_data/userdata"));
-
-    std::string strTempPath = appPath;
-    strTempPath = URIUtils::AddFileToFolder(strTempPath, "portable_data/temp");
-    if (getenv(envAppTemp))
-      strTempPath = getenv(envAppTemp);
-    CSpecialProtocol::SetTempPath(strTempPath);
-    CSpecialProtocol::SetLogPath(strTempPath);
-    CreateUserDirs();
-  }
-  CSpecialProtocol::SetXBMCBinAddonPath(appBinPath + "/addons");
-
-#if defined(TARGET_ANDROID)
-  CXBMCApp::InitDirectories();
-#endif
 
   return true;
 #else
@@ -915,25 +872,12 @@ bool CApplication::InitDirectoriesOSX()
 
   // setup path to our internal dylibs so loader can find them
   std::string frameworksPath = CUtil::GetFrameworksPath();
-  CSpecialProtocol::SetXBMCFrameworksPath(frameworksPath);
 
   // OSX always runs with m_bPlatformDirectories == true
   if (m_bPlatformDirectories)
   {
     // map our special drives
-    CSpecialProtocol::SetXBMCBinPath(appPath);
-    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
-    CSpecialProtocol::SetXBMCPath(appPath);
-    #if defined(TARGET_DARWIN_IOS)
-      std::string appName = CCompileInfo::GetAppName();
-      CSpecialProtocol::SetHomePath(userHome + "/" + CDarwinUtils::GetAppRootFolder() + "/" + appName);
-      CSpecialProtocol::SetMasterProfilePath(userHome + "/" + CDarwinUtils::GetAppRootFolder() + "/" + appName + "/userdata");
-    #else
-      std::string appName = CCompileInfo::GetAppName();
-      CSpecialProtocol::SetHomePath(userHome + "/Library/Application Support/" + appName);
-      CSpecialProtocol::SetMasterProfilePath(userHome + "/Library/Application Support/" + appName + "/userdata");
-    #endif
-
+    std::string appName = CCompileInfo::GetAppName();
     std::string dotLowerAppName = "." + appName;
     StringUtils::ToLower(dotLowerAppName);
     // location for temp files
@@ -944,9 +888,8 @@ bool CApplication::InitDirectoriesOSX()
       CDirectory::Create(strTempPath);
       strTempPath = URIUtils::AddFileToFolder(userHome, dotLowerAppName + "/temp");
     #endif
-    CSpecialProtocol::SetTempPath(strTempPath);
 
-    // xbmc.log file location
+   //  xbmc.log file location
     #if defined(TARGET_DARWIN_IOS)
       strTempPath = userHome + "/" + std::string(CDarwinUtils::GetAppRootFolder());
     #else

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -782,26 +782,9 @@ bool CApplication::InitDirectoriesLinux()
 */
 
 #if defined(TARGET_POSIX) && !defined(TARGET_DARWIN)
-  std::string userName;
-  if (getenv("USER"))
-    userName = getenv("USER");
-  else
-    userName = "root";
-
-  std::string userHome;
-  if (getenv("HOME"))
-    userHome = getenv("HOME");
-  else
-    userHome = "/root";
-
-  std::string binaddonAltDir;
-  if (getenv("KODI_BINADDON_PATH"))
-    binaddonAltDir = getenv("KODI_BINADDON_PATH");
 
   std::string appPath;
   std::string appName = CCompileInfo::GetAppName();
-  std::string dotLowerAppName = "." + appName;
-  StringUtils::ToLower(dotLowerAppName);
   const char* envAppHome = "KODI_HOME";
   const char* envAppBinHome = "KODI_BIN_HOME";
 
@@ -830,12 +813,7 @@ bool CApplication::InitDirectoriesLinux()
   /* Set some environment variables */
   setenv(envAppBinHome, appBinPath.c_str(), 0);
   setenv(envAppHome, appPath.c_str(), 0);
-
-    // map our special drives
-
-    CreateUserDirs();
-
-
+  CreateUserDirs();
   return true;
 #else
   return false;
@@ -845,22 +823,6 @@ bool CApplication::InitDirectoriesLinux()
 bool CApplication::InitDirectoriesOSX()
 {
 #if defined(TARGET_DARWIN)
-  std::string userName;
-  if (getenv("USER"))
-    userName = getenv("USER");
-  else
-    userName = "root";
-
-  std::string userHome;
-  if (getenv("HOME"))
-    userHome = getenv("HOME");
-  else
-    userHome = "/root";
-
-  std::string binaddonAltDir;
-  if (getenv("KODI_BINADDON_PATH"))
-    binaddonAltDir = getenv("KODI_BINADDON_PATH");
-
   std::string appPath = CUtil::GetHomePath();
   setenv("KODI_HOME", appPath.c_str(), 0);
 
@@ -870,9 +832,6 @@ bool CApplication::InitDirectoriesOSX()
   setenv("FONTCONFIG_FILE", fontconfigPath.c_str(), 0);
 #endif
 
-  // setup path to our internal dylibs so loader can find them
-  std::string frameworksPath = CUtil::GetFrameworksPath();
-
   // OSX always runs with m_bPlatformDirectories == true
   if (m_bPlatformDirectories)
   {
@@ -881,38 +840,18 @@ bool CApplication::InitDirectoriesOSX()
     std::string dotLowerAppName = "." + appName;
     StringUtils::ToLower(dotLowerAppName);
     // location for temp files
-    #if defined(TARGET_DARWIN_IOS)
-      std::string strTempPath = URIUtils::AddFileToFolder(userHome,  std::string(CDarwinUtils::GetAppRootFolder()) + "/" + appName + "/temp");
-    #else
-      std::string strTempPath = URIUtils::AddFileToFolder(userHome, dotLowerAppName + "/");
-      CDirectory::Create(strTempPath);
-      strTempPath = URIUtils::AddFileToFolder(userHome, dotLowerAppName + "/temp");
-    #endif
+    #if !defined(TARGET_DARWIN_IOS)
+    std::string userHome;
+    if (getenv("HOME"))
+      userHome = getenv("HOME");
+    else
+      userHome = "/root";
 
-   //  xbmc.log file location
-    #if defined(TARGET_DARWIN_IOS)
-      strTempPath = userHome + "/" + std::string(CDarwinUtils::GetAppRootFolder());
-    #else
-      strTempPath = userHome + "/Library/Logs";
+    std::string strTempPath = URIUtils::AddFileToFolder(userHome, dotLowerAppName + "/");
+    CDirectory::Create(strTempPath);
     #endif
-    CSpecialProtocol::SetLogPath(strTempPath);
     CreateUserDirs();
   }
-  else
-  {
-    URIUtils::AddSlashAtEnd(appPath);
-
-    CSpecialProtocol::SetXBMCBinPath(appPath);
-    CSpecialProtocol::SetXBMCAltBinAddonPath(binaddonAltDir);
-    CSpecialProtocol::SetXBMCPath(appPath);
-    CSpecialProtocol::SetHomePath(URIUtils::AddFileToFolder(appPath, "portable_data"));
-    CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(appPath, "portable_data/userdata"));
-
-    std::string strTempPath = URIUtils::AddFileToFolder(appPath, "portable_data/temp");
-    CSpecialProtocol::SetTempPath(strTempPath);
-    CSpecialProtocol::SetLogPath(strTempPath);
-  }
-  CSpecialProtocol::SetXBMCBinAddonPath(appPath + "/addons");
   return true;
 #else
   return false;
@@ -924,9 +863,7 @@ bool CApplication::InitDirectoriesWin32()
 #ifdef TARGET_WINDOWS
   std::string xbmcPath = CUtil::GetHomePath();
   CEnvironment::setenv("KODI_HOME", xbmcPath);
-  
   CEnvironment::setenv("KODI_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
-
   CreateUserDirs();
 
   return true;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -981,16 +981,7 @@ bool CApplication::InitDirectoriesWin32()
 #ifdef TARGET_WINDOWS
   std::string xbmcPath = CUtil::GetHomePath();
   CEnvironment::setenv("KODI_HOME", xbmcPath);
-  CSpecialProtocol::SetXBMCBinPath(xbmcPath);
-  CSpecialProtocol::SetXBMCPath(xbmcPath);
-  CSpecialProtocol::SetXBMCBinAddonPath(xbmcPath + "/addons");
-
-  std::string strWin32UserFolder = CWIN32Util::GetProfilePath();
-  CSpecialProtocol::SetLogPath(strWin32UserFolder);
-  CSpecialProtocol::SetHomePath(strWin32UserFolder);
-  CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
-  CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));
-
+  
   CEnvironment::setenv("KODI_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
 
   CreateUserDirs();

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -35,6 +35,71 @@
 #include "utils/StringUtils.h"
 #endif
 
+#ifdef TARGET_WINDOWS
+#include "platform/win32/WIN32Util.h"
+#endif
+
+
+#ifdef TARGET_WINDOWS
+//Getters
+std::string CSpecialProtocol::GetHomePath() 
+{
+  return CWIN32Util::GetProfilePath();
+}
+
+std::string CSpecialProtocol::GetHomePath(const std::string &fileName) 
+{
+  return URIUtils::AddFileToFolder(GetHomePath(), fileName);
+}
+
+std::string CSpecialProtocol::GetTmpPath() 
+{
+  return URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), "cache");
+}
+
+std::string CSpecialProtocol::GetTmpPath(const std::string &fileName) 
+{
+  return URIUtils::AddFileToFolder(GetTmpPath(), fileName);
+}
+
+
+std::string CSpecialProtocol::GetXBMCBinAddonPath() 
+{
+  std::string str = GetXBMCPath("/addons");
+  return str;
+}
+
+std::string CSpecialProtocol::GetProfilePath()
+{
+  return CProfilesManager::GetInstance().GetProfileUserDataFolder();
+}
+
+std::string CSpecialProtocol::GetProfilePath(const std::string &fileName)
+{
+  return URIUtils::AddFileToFolder(GetProfilePath(), fileName);
+}
+
+std::string CSpecialProtocol::GetMasterProfilePath() 
+{
+  return URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(), "userdata");
+}
+
+std::string CSpecialProtocol::GetMasterProfilePath(const std::string &fileName)
+{
+  return URIUtils::AddFileToFolder(GetMasterProfilePath(), fileName);
+}
+
+std::string CSpecialProtocol::GetXBMCPath()
+{
+  return CUtil::GetHomePath();
+}
+
+std::string CSpecialProtocol::GetXBMCPath(const std::string &fileName) 
+{
+  return URIUtils::AddFileToFolder(GetXBMCPath(), fileName);
+}
+#endif
+
 void CSpecialProtocol::SetProfilePath(const std::string &dir)
 {
   SetPath("profile", dir);
@@ -130,7 +195,6 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
   }
 
   std::string FullFileName = url.GetFileName();
-
   std::string translatedPath;
   std::string FileName;
   std::string RootDir;
@@ -167,18 +231,49 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
     translatedPath = URIUtils::AddFileToFolder(g_graphicsContext.GetMediaDir(), FileName);
 
   // from here on, we have our "real" special paths
-  else if (RootDir == "xbmc" ||
-           RootDir == "xbmcbin" ||
-           RootDir == "xbmcbinaddons" ||
-           RootDir == "xbmcaltbinaddons" ||
-           RootDir == "home" ||
-           RootDir == "envhome" ||
-           RootDir == "userhome" ||
-           RootDir == "temp" ||
-           RootDir == "profile" ||
-           RootDir == "masterprofile" ||
-           RootDir == "frameworks" ||
-           RootDir == "logpath")
+
+/* In Windows platform the static path map isn't used anymore. Instead we use specific getters.
+   (for alleviating the early destruction of the map when exiting Kodi)
+*/
+#ifdef TARGET_WINDOWS
+  else if (RootDir == "profile")
+  {
+    translatedPath = GetProfilePath(FileName);
+  }
+  else if (RootDir == "masterprofile")
+  {
+    translatedPath = GetMasterProfilePath(FileName);
+  }
+  else if (RootDir == "xbmc" || RootDir == "xbmcbin")
+  {
+    translatedPath = GetXBMCPath(FileName);
+  }
+  else if (RootDir == "xbmcbinaddons")
+  {
+    translatedPath = GetXBMCBinAddonPath();
+  }
+  else if (RootDir == "home" || RootDir == "logpath")
+  {
+    translatedPath = GetHomePath(FileName);
+  }
+  else if (RootDir == "temp")
+  {
+    translatedPath = GetTmpPath(FileName);
+  }
+#else
+  else if (
+    RootDir == "xbmc" ||
+    RootDir == "xbmcbin" ||
+    RootDir == "xbmcbinaddons" ||
+    RootDir == "xbmcaltbinaddons" ||
+    RootDir == "home" ||
+    RootDir == "envhome" ||
+    RootDir == "userhome" ||
+    RootDir == "temp" ||
+    RootDir == "profile" ||
+    RootDir == "masterprofile" ||
+    RootDir == "frameworks" ||
+    RootDir == "logpath")
   {
     std::string basePath = GetPath(RootDir);
     if (!basePath.empty())
@@ -186,6 +281,7 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
     else
       translatedPath.clear();
   }
+#endif
 
   // check if we need to recurse in
   if (URIUtils::IsSpecial(translatedPath))
@@ -253,7 +349,7 @@ std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
         result += "/" + tokens[i];
       }
     }
-  }
+ }
 
   return result;
 #else
@@ -263,16 +359,16 @@ std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
 
 void CSpecialProtocol::LogPaths()
 {
-  CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetPath("xbmc").c_str());
-  CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetPath("xbmcbin").c_str());
-  CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetPath("xbmcbinaddons").c_str());
-  CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetPath("masterprofile").c_str());
+  CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetXBMCPath().c_str());
+  CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetXBMCPath().c_str());
+  CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetXBMCBinAddonPath().c_str());
+  CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetMasterProfilePath().c_str());
 #if defined(TARGET_POSIX)
-  CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
+		CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
 #endif
-  CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetPath("home").c_str());
-  CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetPath("temp").c_str());
-  CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetPath("logpath").c_str());
+  CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetHomePath().c_str());
+  CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetTmpPath().c_str());
+  CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetHomePath().c_str());
   //CLog::Log(LOGNOTICE, "special://userhome/ is mapped to: %s", GetPath("userhome").c_str());
   if (!CUtil::GetFrameworksPath().empty())
     CLog::Log(LOGNOTICE, "special://frameworks/ is mapped to: %s", GetPath("frameworks").c_str());

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -409,6 +409,7 @@ std::string CSpecialProtocol::GetLogPath(const std::string &fileName)
   return URIUtils::AddFileToFolder(GetLogPath(), fileName);
 }
 
+// returns path to our internal dylibs
 std::string CSpecialProtocol::GetXBMCFrameworksPath(const std::string &fileName)
 {
   return URIUtils::AddFileToFolder(GetXBMCFrameworksPath(), fileName);

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -359,19 +359,29 @@ std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)
 
 void CSpecialProtocol::LogPaths()
 {
+#ifdef TARGET_WINDOWS
   CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetXBMCPath().c_str());
   CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetXBMCPath().c_str());
   CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetXBMCBinAddonPath().c_str());
   CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetMasterProfilePath().c_str());
-#if defined(TARGET_POSIX)
-		CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
-#endif
   CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetHomePath().c_str());
   CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetTmpPath().c_str());
   CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetHomePath().c_str());
+#else
+  CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetPath("xbmc").c_str());
+  CLog::Log(LOGNOTICE, "special://xbmcbin/ is mapped to: %s", GetPath("xbmcbin").c_str());
+  CLog::Log(LOGNOTICE, "special://xbmcbinaddons/ is mapped to: %s", GetPath("xbmcbinaddons").c_str());
+  CLog::Log(LOGNOTICE, "special://masterprofile/ is mapped to: %s", GetPath("masterprofile").c_str());
+#if defined(TARGET_POSIX)
+  CLog::Log(LOGNOTICE, "special://envhome/ is mapped to: %s", GetPath("envhome").c_str());
+#endif
+  CLog::Log(LOGNOTICE, "special://home/ is mapped to: %s", GetPath("home").c_str());
+  CLog::Log(LOGNOTICE, "special://temp/ is mapped to: %s", GetPath("temp").c_str());
+  CLog::Log(LOGNOTICE, "special://logpath/ is mapped to: %s", GetPath("logpath").c_str());
   //CLog::Log(LOGNOTICE, "special://userhome/ is mapped to: %s", GetPath("userhome").c_str());
   if (!CUtil::GetFrameworksPath().empty())
     CLog::Log(LOGNOTICE, "special://frameworks/ is mapped to: %s", GetPath("frameworks").c_str());
+#endif
 }
 
 // private routines, to ensure we only set/get an appropriate path

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -75,20 +75,28 @@ public:
 
 private:
   // Specific Path Getters (Instead of using GetPath())
-#ifdef TARGET_WINDOWS 
   static std::string GetProfilePath();
   static std::string GetProfilePath(const std::string &fileName);
   static std::string GetMasterProfilePath();
   static std::string GetMasterProfilePath(const std::string &fileName);
   static std::string GetXBMCPath();
   static std::string GetXBMCPath(const std::string &fileName);
+  static std::string GetXBMCBinPath();
+  static std::string GetXBMCBinPath(const std::string &fileName);
   static std::string GetXBMCBinAddonPath();
+  static std::string GetXBMCBinAddonPath(const std::string &fileName);
+  static std::string GetXBMCAltBinAddonPath();
+  static std::string GetXBMCAltBinAddonPath(const std::string &fileName);
   static std::string GetHomePath();
   static std::string GetHomePath(const std::string &fileName);
   static std::string GetTmpPath();
   static std::string GetTmpPath(const std::string &fileName);
-#endif
-
+  static std::string GetLogPath();
+  static std::string GetLogPath(const std::string &fileName);
+  static std::string GetXBMCFrameworksPath();
+  static std::string GetXBMCFrameworksPath(const std::string &fileName);
+  static std::string GetEnvHomePath();
+  static std::string GetEnvHomePath(const std::string &fileName);
 
   static void SetPath(const std::string &key, const std::string &path);
   static std::string GetPath(const std::string &key);

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -74,6 +74,20 @@ public:
   static std::string TranslatePathConvertCase(const std::string& path);
 
 private:
+  // Specific Path Getters (Instead of using GetPath())
+  static std::string GetProfilePath();
+  static std::string GetProfilePath(const std::string &fileName);
+  static std::string GetMasterProfilePath();
+  static std::string GetMasterProfilePath(const std::string &fileName);
+  static std::string GetXBMCPath();
+  static std::string GetXBMCPath(const std::string &fileName);
+  static std::string GetXBMCBinAddonPath();
+  static std::string GetHomePath();
+  static std::string GetHomePath(const std::string &fileName);
+  static std::string GetTmpPath();
+  static std::string GetTmpPath(const std::string &fileName);
+
+
   static void SetPath(const std::string &key, const std::string &path);
   static std::string GetPath(const std::string &key);
 

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -75,6 +75,7 @@ public:
 
 private:
   // Specific Path Getters (Instead of using GetPath())
+#ifdef TARGET_WINDOWS 
   static std::string GetProfilePath();
   static std::string GetProfilePath(const std::string &fileName);
   static std::string GetMasterProfilePath();
@@ -86,6 +87,7 @@ private:
   static std::string GetHomePath(const std::string &fileName);
   static std::string GetTmpPath();
   static std::string GetTmpPath(const std::string &fileName);
+#endif
 
 
   static void SetPath(const std::string &key, const std::string &path);

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -73,7 +73,7 @@ public:
   static std::string TranslatePath(const CURL &url);
   static std::string TranslatePathConvertCase(const std::string& path);
 
-private:
+//private:
   // Specific Path Getters (Instead of using GetPath())
   static std::string GetProfilePath();
   static std::string GetProfilePath(const std::string &fileName);
@@ -100,7 +100,7 @@ private:
 
   static void SetPath(const std::string &key, const std::string &path);
   static std::string GetPath(const std::string &key);
-
+private: //for tests only!
   static std::map<std::string, std::string> m_pathMap;
 };
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -960,12 +960,6 @@ void CXBMCApp::SetSystemVolume(float percent)
     android_printf("CXBMCApp::SetSystemVolume: Could not get Audio Manager");
 }
 
-// To be removed after SpecialProtocol migration
-void cxbmcapp::initdirectories()
-{
-  cspecialprotocol::setxbmcbinaddonpath(getapplicationinfo().nativelibrarydir.c_str());
-}
-
 void CXBMCApp::onReceive(CJNIIntent intent)
 {
   std::string action = intent.getAction();

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -960,9 +960,10 @@ void CXBMCApp::SetSystemVolume(float percent)
     android_printf("CXBMCApp::SetSystemVolume: Could not get Audio Manager");
 }
 
-void CXBMCApp::InitDirectories()
+// To be removed after SpecialProtocol migration
+void cxbmcapp::initdirectories()
 {
-  CSpecialProtocol::SetXBMCBinAddonPath(getApplicationInfo().nativeLibraryDir.c_str());
+  cspecialprotocol::setxbmcbinaddonpath(getapplicationinfo().nativelibrarydir.c_str());
 }
 
 void CXBMCApp::onReceive(CJNIIntent intent)

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -539,5 +539,4 @@ void CProfilesManager::SetCurrentProfileId(size_t profileId)
 {
   CSingleLock lock(m_critical);
   m_currentProfile = profileId;
-  CSpecialProtocol::SetProfilePath(GetProfileUserDataFolder());
 }

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -48,6 +48,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <climits>
+#include "utils/log.h"
 
 void TestBasicEnvironment::SetUp()
 {
@@ -63,7 +64,11 @@ void TestBasicEnvironment::SetUp()
   g_advancedSettings.Initialize();
 
   if (!CXBMCTestUtils::Instance().SetReferenceFileBasePath())
+  {
+    fprintf(stderr, "!CXBMCTestUtils::Instance().SetReferenceFileBasePath() == true => SetupError()\n");
     SetUpError();
+  }
+    
   CXBMCTestUtils::Instance().setTestFileFactoryWriteInputFile(
     XBMC_REF_FILE_PATH("xbmc/filesystem/test/reffile.txt")
   );
@@ -86,14 +91,29 @@ void TestBasicEnvironment::SetUp()
   using KODI::PLATFORM::WINDOWS::FromW;
   std::wstring xbmcTempPath;
   TCHAR lpTempPathBuffer[MAX_PATH];
+  fprintf(stderr, "Print Test\n");
   if (!GetTempPath(MAX_PATH, lpTempPathBuffer))
+  {
+    //CLog::Log(LOGDEBUG, "!GetTempPath(MAX_PATH, lpTempPathBuffer) == true => SetupError()\n");
+    fprintf(stderr, "!GetTempPath(MAX_PATH, lpTempPathBuffer) == true => SetupError()\n");
     SetUpError();
+  }
   xbmcTempPath = lpTempPathBuffer;
   if (!GetTempFileName(xbmcTempPath.c_str(), L"xbmctempdir", 0, lpTempPathBuffer))
+  { 
+    //CLog::Log(LOGDEBUG, "!GetTempFileName(xbmcTempPath.c_str(), L\"xbmctempdir\", 0, lpTempPathBuffer) == true => SetupError()\n");
+    fprintf(stderr, "!GetTempFileName(xbmcTempPath.c_str(), L\"xbmctempdir\", 0, lpTempPathBuffer) == true => SetupError()\n");
     SetUpError();
+  }
+   
   DeleteFile(lpTempPathBuffer);
   if (!CreateDirectory(lpTempPathBuffer, NULL))
+  {
+    //CLog::Log(LOGDEBUG, "!CreateDirectory(lpTempPathBuffer, NULL) == true => SetupError()\n");
+    fprintf(stderr, "!CreateDirectory(lpTempPathBuffer, NULL) == true => SetupError()\n");
     SetUpError();
+  }
+
   CSpecialProtocol::SetTempPath(FromW(lpTempPathBuffer));
   CSpecialProtocol::SetProfilePath(FromW(lpTempPathBuffer));
 #else
@@ -101,11 +121,18 @@ void TestBasicEnvironment::SetUp()
   char *tmp;
   strcpy(buf, "/tmp/xbmctempdirXXXXXX");
   if ((tmp = mkdtemp(buf)) == NULL)
+  {
+    //CLog::Log(LOGDEBUG, "(tmp = mkdtemp(buf)) == NULL) == true => SetupError()\n");
+    fprintf(stderr, "(tmp = mkdtemp(buf)) == NULL) == true => SetupError()\n");
     SetUpError();
+  }
+    
   CSpecialProtocol::SetTempPath(tmp);
   CSpecialProtocol::SetProfilePath(tmp);
 #endif
-
+  
+  fprintf(stderr, ("Test temp path was set to: " + CSpecialProtocol::GetPath("temp")+ "\n").c_str());
+  fprintf(stderr, ("Actually translated  temp path by CSpecialProtocol::TranslatePath is: " + CSpecialProtocol::GetTmpPath() + "\n").c_str());
   /* Create and delete a tempfile to initialize the VFS (really to initialize
    * CLibcdio). This is done so that the initialization of the VFS does not
    * affect the performance results of the test cases.
@@ -114,9 +141,16 @@ void TestBasicEnvironment::SetUp()
    * testable in a test case.
    */
   f = XBMC_CREATETEMPFILE("");
+  if (!f)
+  {
+    fprintf(stderr,"f == false! <=> XBMC_CREATETEMPFILE("") == false \n");
+  }
+
   if (!f || !XBMC_DELETETEMPFILE(f))
   {
     TearDown();
+    fprintf(stderr, "(!f || !XBMC_DELETETEMPFILE(f)) == true => SetupError()\n");
+    //CLog::Log(LOGDEBUG, "(!f || !XBMC_DELETETEMPFILE(f)) == true => SetupError()\n");
     SetUpError();
   }
   g_powerManager.Initialize();

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -25,6 +25,7 @@
 #include "platform/win32/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 
 #ifdef TARGET_WINDOWS
 #include <windows.h>
@@ -47,6 +48,7 @@ public:
     char tmp[MAX_PATH];
 
     m_ptempFileDirectory = CSpecialProtocol::TranslatePath("special://temp/");
+    fprintf(stderr, ("TestUtils=>CTempFile=>Create=>m_ptempFileDirectory == " + m_ptempFileDirectory + "\n").c_str());
     m_ptempFilePath = m_ptempFileDirectory + "xbmctempfileXXXXXX";
     m_ptempFilePath += suffix;
     if (m_ptempFilePath.length() >= MAX_PATH)
@@ -62,6 +64,7 @@ public:
     if (!GetTempFileName(ToW(CSpecialProtocol::TranslatePath("special://temp/")).c_str(),
                          L"xbmctempfile", 0, tmpW))
     {
+      fprintf(stderr,"CTempFile::Create() returns false\n");
       m_ptempFilePath = "";
       return false;
     }
@@ -71,6 +74,7 @@ public:
     if ((fd = mkstemps(tmp, suffix.length())) < 0)
     {
       m_ptempFilePath = "";
+      fprintf(stderr, "CTempFile::Create() returns false\n");
       return false;
     }
     close(fd);
@@ -78,6 +82,7 @@ public:
 #endif
 
     OpenForWrite(m_ptempFilePath.c_str(), true);
+    fprintf(stderr, "CTempFile::Create() returns true\n");
     return true;
   }
   bool Delete()
@@ -111,15 +116,18 @@ CXBMCTestUtils &CXBMCTestUtils::Instance()
 
 std::string CXBMCTestUtils::ReferenceFilePath(const std::string& path)
 {
-#ifdef TARGET_POSIX
-  return CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("", path));
-#else
-  return CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("special://xbmc", path)); 
-#endif
+  //CLog::Log(LOGDEBUG, "ReferenceFilePath() invoked\n");
+  fprintf(stderr, "ReferenceFilePath() invoked\n");
+  std::string retStr = CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("special://xbmc", path));
+  fprintf(stderr, ("ReferenceFilePath() => "+ retStr+"\n").c_str());
+  return retStr;
+
 }
 
 bool CXBMCTestUtils::SetReferenceFileBasePath()
 {
+  //CLog::Log(LOGDEBUG,"SetReferenceFileBasePath() invoked\n");
+  fprintf(stderr, "SetReferenceFileBasePath() invoked\n");
   std::string xbmcPath = CUtil::GetHomePath();
   if (xbmcPath.empty())
     return false;
@@ -137,6 +145,7 @@ XFILE::CFile *CXBMCTestUtils::CreateTempFile(std::string const& suffix)
   CTempFile *f = new CTempFile();
   if (f->Create(suffix))
     return f;
+  fprintf(stderr, "CXBMCTestUtils::CreateTempFile() failed!\n");
   delete f;
   return NULL;
 }
@@ -147,7 +156,9 @@ bool CXBMCTestUtils::DeleteTempFile(XFILE::CFile *tempfile)
     return true;
   CTempFile *f = static_cast<CTempFile*>(tempfile);
   bool retval = f->Delete();
-  delete f;
+  delete f; 
+  fprintf(stderr, "DeleteTempFile == ");
+  fprintf(stderr, (retval == true) ? "True\n" : "False\n");
   return retval;
 }
 

--- a/xbmc/test/TestUtils.cpp
+++ b/xbmc/test/TestUtils.cpp
@@ -111,7 +111,11 @@ CXBMCTestUtils &CXBMCTestUtils::Instance()
 
 std::string CXBMCTestUtils::ReferenceFilePath(const std::string& path)
 {
-  return CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("special://xbmc", path));
+#ifdef TARGET_POSIX
+  return CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("", path));
+#else
+  return CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder("special://xbmc", path)); 
+#endif
 }
 
 bool CXBMCTestUtils::SetReferenceFileBasePath()


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Migrating from using static map to special paths stored in https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/SpecialProtocol.cpp and calculated in
https://github.com/xbmc/xbmc/blob/master/xbmc/Application.cpp to On-the-fly path calculations in "SpecialProtocol.cpp" instead.
## Description
<!--- Describe your change in detail -->
Instead of using GetPath() in "SpecialProtocol.h" specific Static getters were implemented, means that the static path map in "SpecialProtocol.cpp" isn't needed for path calculations anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The aim is to solve the early destruction of the static path map (m_pathMap) while Kodi is exiting when the stored paths still needed by other code.

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Ran the kodi-test project main and passed all tests, Ran Kodi to check for errors. Printed some logs to make sure the path translation (TranslatePath() in SpecialProtocol.h) is the same via GetPath() and new/replacement getters .

<!--- Include details of your testing environment, and the tests you ran to -->
VS 2017 debugger (Windows 10), kodi-test main (which runs all tests)
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x[ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x ] All new and existing tests passed
