### PR TITLE
fixed: fix multitrack support for audio decoders

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1009,13 +1009,17 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
     || IsRAR()
     || IsRSS()
     || IsAudioBook()
-    || IsType(".ogg|.oga|.nsf|.sid|.sap|.xbt|.xsp")
+    || IsType(".ogg|.oga|.xbt")
 #if defined(TARGET_ANDROID)
     || IsType(".apk")
 #endif
     )
     return true;
   }
+
+  if (CServiceBroker::IsBinaryAddonCacheUp() &&
+      IsType(CServiceBroker::GetFileExtensionProvider().GetFileFolderExtensions().c_str()))
+    return true;
 
   if(types & EFILEFOLDER_TYPE_ONBROWSE)
   {

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -31,6 +31,7 @@ CAudioDecoder::CAudioDecoder(const BinaryAddonBasePtr& addonInfo)
 {
   m_CodecName = addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@name").asString();
   m_strExt = m_CodecName + "stream";
+  m_hasTags = addonInfo->Type(ADDON_AUDIODECODER)->GetValue("@tags").asBoolean();
   m_struct = {{ 0 }};
 }
 
@@ -116,10 +117,18 @@ int CAudioDecoder::GetTrackCount(const std::string& strPath)
 
   int result = m_struct.toAddon.track_count(&m_struct, strPath.c_str());
 
-  if (result > 1 && !Load(strPath, XFILE::CMusicFileDirectory::m_tag, nullptr))
-    return 0;
+  if (result > 1)
+  {
+    if (m_hasTags)
+    {
+      if (!Load(strPath, XFILE::CMusicFileDirectory::m_tag, nullptr))
+        return 0;
+    }
+    else
+      XFILE::CMusicFileDirectory::m_tag.SetTitle(CURL(strPath).GetFileNameWithoutPath());
+    XFILE::CMusicFileDirectory::m_tag.SetLoaded(true);
+  }
 
-  XFILE::CMusicFileDirectory::m_tag.SetLoaded(true);
   return result;
 }
 

--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -77,6 +77,7 @@ namespace ADDON
   private:
     const AEChannel* m_channel;
     AddonInstance_AudioDecoder m_struct;
+    bool m_hasTags;
   };
 
 } /*namespace ADDON*/

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -312,9 +312,9 @@ char* Interface_General::get_temp_path(void* kodiBase)
     return nullptr;
   }
 
-  const std::string tempPath = URIUtils::AddFileToFolder(CServiceBroker::GetBinaryAddonManager().GetTempAddonBasePath(), addon->ID());
-  if (!XFILE::CDirectory::Exists(tempPath))
-    XFILE::CDirectory::Create(tempPath);
+  std::string tempPath = URIUtils::AddFileToFolder(CServiceBroker::GetBinaryAddonManager().GetTempAddonBasePath(), addon->ID());
+  tempPath += "-temp";
+  XFILE::CDirectory::Create(tempPath);
 
   return strdup(CSpecialProtocol::TranslatePath(tempPath).c_str());
 }

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -67,7 +67,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     CServiceBroker::GetBinaryAddonManager().GetAddonInfos(addonInfos, true, ADDON_AUDIODECODER);
     for (const auto& addonInfo : addonInfos)
     {
-      if (CAudioDecoder::HasTags(addonInfo) &&
+      if (CAudioDecoder::HasTracks(addonInfo) &&
           CAudioDecoder::GetExtensions(addonInfo).find(strExtension) != std::string::npos)
       {
         CAudioDecoder* result = new CAudioDecoder(addonInfo);

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -54,8 +54,14 @@ public:
    */
   std::string GetDiscStubExtensions() const;
 
+  /*!
+   * @brief Returns a file folder extensions
+   */
+  std::string GetFileFolderExtensions() const;
+
 private:
   std::string GetAddonExtensions(const ADDON::TYPE &type) const;
+  std::string GetAddonFileFolderExtensions(const ADDON::TYPE &type) const;
   void SetAddonExtensions();
   void SetAddonExtensions(const ADDON::TYPE &type);
 
@@ -63,5 +69,5 @@ private:
 
   std::map<ADDON::TYPE, std::string> m_addonExtensions;
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
-
+  std::map<ADDON::TYPE, std::string> m_addonFileFolderExtensions;
 };


### PR DESCRIPTION
Somebody has confused tracks and tags, as well as enforced that tags must be supported for tracks to work. Fix this.