### PR TITLE
FFmpeg: Bump to 3.1.11-Krypton-17.5 (Krypton)

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg/archive
-VERSION=3.1.9-Krypton-17.4
+VERSION=3.1.11-Krypton-17.5
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
Incorporate latest security changes of the stable ffmpeg 3.1 branch. This needs runtime testing on all platforms.