### PR TITLE
[PVR] Fix deadlocks on enable/disable addons.

### DIFF
--- a/xbmc/pvr/CMakeLists.txt
+++ b/xbmc/pvr/CMakeLists.txt
@@ -8,7 +8,8 @@ set(SOURCES PVRActionListener.cpp
             PVRItem.cpp
             PVRChannelNumberInputHandler.cpp
             PVRJobs.cpp
-            PVRGUIChannelNavigator.cpp)
+            PVRGUIChannelNavigator.cpp
+            PVRGUIProgressHandler.cpp)
 
 set(HEADERS PVRActionListener.h
             PVRDatabase.h
@@ -22,6 +23,7 @@ set(HEADERS PVRActionListener.h
             PVRTypes.h
             PVRChannelNumberInputHandler.h
             PVRJobs.h
-            PVRGUIChannelNavigator.h)
+            PVRGUIChannelNavigator.h
+            PVRGUIProgressHandler.h)
 
 core_add_library(pvr)

--- a/xbmc/pvr/PVRGUIProgressHandler.cpp
+++ b/xbmc/pvr/PVRGUIProgressHandler.cpp
@@ -1,0 +1,104 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PVRGUIProgressHandler.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "dialogs/GUIDialogExtendedProgressBar.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/WindowIDs.h"
+
+namespace PVR
+{
+  CPVRGUIProgressHandler::CPVRGUIProgressHandler(const std::string& strTitle)
+  : CThread("PVRGUIProgressHandler"),
+    m_strTitle(strTitle),
+    m_fProgress(0.0f),
+    m_bChanged(false)
+  {
+    Create(true /* bAutoDelete */);
+  }
+
+  void CPVRGUIProgressHandler::UpdateProgress(const std::string &strText, float fProgress)
+  {
+    CSingleLock lock(m_critSection);
+    m_bChanged = true;
+    m_strText = strText;
+    m_fProgress = fProgress;
+  }
+
+  void CPVRGUIProgressHandler::UpdateProgress(const std::string &strText, int iCurrent, int iMax)
+  {
+    float fPercentage = (iCurrent * 100.0f) / iMax;
+    if (!std::isnan(fPercentage))
+      fPercentage = std::min(100.0f, fPercentage);
+
+    UpdateProgress(strText, fPercentage);
+  }
+
+  void CPVRGUIProgressHandler::DestroyProgress()
+  {
+    CSingleLock lock(m_critSection);
+    m_bStop = true;
+    m_bChanged = false;
+  }
+
+  void CPVRGUIProgressHandler::Process()
+  {
+    CGUIDialogExtendedProgressBar* progressBar = g_windowManager.GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
+    if (m_bStop || !progressBar)
+      return;
+
+    CGUIDialogProgressBarHandle* progressHandle = progressBar->GetHandle(m_strTitle);
+    if (!progressHandle)
+      return;
+
+    while (!m_bStop)
+    {
+      float fProgress = 0.0;
+      std::string strText;
+      bool bUpdate = false;
+
+      {
+        CSingleLock lock(m_critSection);
+        if (m_bChanged)
+        {
+          m_bChanged = false;
+          fProgress = m_fProgress;
+          strText = m_strText;
+          bUpdate = true;
+        }
+      }
+
+      if (bUpdate)
+      {
+        progressHandle->SetPercentage(fProgress);
+        progressHandle->SetText(strText);
+      }
+
+      Sleep(100); // Intentionally ignore some changes that come in too fast. Humans cannot read as fast as Mr. Data ;-)
+    }
+
+    progressHandle->MarkFinished();
+  }
+
+} // namespace PVR

--- a/xbmc/pvr/PVRGUIProgressHandler.h
+++ b/xbmc/pvr/PVRGUIProgressHandler.h
@@ -1,0 +1,73 @@
+#pragma once
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "threads/CriticalSection.h"
+#include "threads/Thread.h"
+
+namespace PVR
+{
+  class CPVRGUIProgressHandler : private CThread
+  {
+  public:
+    CPVRGUIProgressHandler() = delete;
+
+    /*!
+     * @brief Creates and asynchronously shows a progress dialog with the given title.
+     * @param strTitle The title for the progress dialog.
+     */
+    explicit CPVRGUIProgressHandler(const std::string& strTitle);
+
+    /*!
+     * @brief Update the progress dialogs's content.
+     * @param strText The new progress text.
+     * @param fProgress The new progress value, in a range from 0.0 to 100.0.
+     */
+    void UpdateProgress(const std::string &strText, float fProgress);
+
+    /*!
+     * @brief Update the progress dialogs's content.
+     * @param strText The new progress text.
+     * @param iCurrent The new current progress value, must be less or equal iMax.
+     * @param iMax The new maximum progress value, must be greater or equal iCurrent.
+     */
+    void UpdateProgress(const std::string &strText, int iCurrent, int iMax);
+
+    /*!
+     * @brief Destroy the progress dialog. This happens asynchrounous, instance must not be touched anymore after calling this method.
+     */
+    void DestroyProgress();
+
+    // CThread implementation
+    void Process() override;
+
+  private:
+    ~CPVRGUIProgressHandler() override = default; // prevent creation of stack instances
+
+    CCriticalSection m_critSection;
+    const std::string m_strTitle;
+    std::string m_strText;
+    float m_fProgress;
+    bool m_bChanged;
+  };
+
+} // namespace PVR

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -40,8 +40,6 @@
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/recordings/PVRRecording.h"
 
-class CGUIDialogExtendedProgressBar;
-class CGUIDialogProgressBarHandle;
 class CStopWatch;
 class CVariant;
 
@@ -479,13 +477,6 @@ namespace PVR
      */
     void PublishEvent(PVREvent state);
 
-    /*!
-     * @brief Show an extended progress bar dialog.
-     * @param strTitle the title for the dialog.
-     * @return the handle that can be used to control the progress dialog.
-     */
-    CGUIDialogProgressBarHandle* ShowProgressDialog(const std::string &strTitle) const;
-
   protected:
     /*!
      * @brief PVR update and control thread.
@@ -509,18 +500,6 @@ namespace PVR
      * @brief Executes "pvrpowermanagement.setwakeupcmd"
      */
     bool SetWakeupCommand(void);
-
-    /*!
-     * @brief Show or update the progress dialog.
-     * @param strText The current status.
-     * @param iProgress The current progress in %.
-     */
-    void ShowProgressDialog(const std::string &strText, int iProgress);
-
-    /*!
-     * @brief Hide the progress dialog if it's visible.
-     */
-    void HideProgressDialog(void);
 
     /*!
      * @brief Load at least one client and load all other PVR data after loading the client.
@@ -588,8 +567,6 @@ namespace PVR
     CCriticalSection                m_critSection;                 /*!< critical section for all changes to this class, except for changes to triggers */
     bool                            m_bFirstStart;                 /*!< true when the PVR manager was started first, false otherwise */
     bool                            m_bEpgsCreated;                /*!< true if epg data for channels has been created */
-    CGUIDialogExtendedProgressBar * m_progressBar;                 /*!< extended progress dialog instance pointer */
-    CGUIDialogProgressBarHandle *   m_progressHandle;              /*!< progress dialog that is displayed while the pvrmanager is loading */
 
     CCriticalSection                m_managerStateMutex;
     ManagerState                    m_managerState;

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -31,7 +31,6 @@
 #include "pvr/epg/EpgDatabase.h"
 
 class CFileItemList;
-class CGUIDialogProgressBarHandle;
 
 namespace PVR
 {
@@ -165,25 +164,6 @@ namespace PVR
     unsigned int NextEpgId(void);
 
     /*!
-     * @brief Close the progress bar if it's visible.
-     */
-    void CloseProgressDialog(void);
-
-    /*!
-     * @brief Show the progress bar
-     * @param bUpdating True if updating epg entries, false if just loading them from db
-     */
-    void ShowProgressDialog(bool bUpdating = true);
-
-    /*!
-     * @brief Update the progress bar.
-     * @param iCurrent The current position.
-     * @param iMax The maximum position.
-     * @param strText The text to display.
-     */
-    void UpdateProgressDialog(int iCurrent, int iMax, const std::string &strText);
-
-    /*!
      * @return True to not to store EPG entries in the database.
      */
     bool IgnoreDB() const;
@@ -292,7 +272,6 @@ namespace PVR
     EPGMAP       m_epgs;                   /*!< the EPGs in this container */
     //@}
 
-    CGUIDialogProgressBarHandle *  m_progressHandle; /*!< the progress dialog that is visible when updating the first time */
     CCriticalSection               m_critSection;    /*!< a critical section for changes to this container */
     CEvent                         m_updateEvent;    /*!< trigger when an update finishes */
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -111,7 +111,7 @@ void CGUIWindowPVRBase::Notify(const Observable &obs, const ObservableMessage ms
   if (msg == ObservableMessageManagerStopped)
     ClearData();
 
-  if (IsActive())
+  if (m_active)
   {
     CGUIMessage m(GUI_MSG_REFRESH_LIST, GetID(), 0, msg);
     CApplicationMessenger::GetInstance().SendGUIMessage(m);


### PR DESCRIPTION
Commit 1: Deadlock 1 (one out of many with the same root cause): Disabling a PVR addon using addon information dialog:

+ T1: `CPVRManager::Stop` gets called and waits blocking for its worker thread (`CPVRManager::Process`) to exit. During this time, no `CApplicationMessenger` messages will be dispatched!
+ T34: `CPVRManager::Process` waits blocking for the response of a message sent using `CApplicationMessenger` to open a progress dialog. Message result will never be returned due to blocking T1. Thus, worker thread will never exit.

<pre>
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fff7da1ae7e libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x0000000107df26b2 libsystem_pthread.dylib`_pthread_cond_wait + 732
    frame #2: 0x00000001001fbed7 kodi.bin`XbmcThreads::ConditionVariable::wait(this=0x000000010b0a4958, lock=0x000000010b0a4998, milliseconds=4294967295) at Condition.h:84
    frame #3: 0x00000001001fbd16 kodi.bin`bool XbmcThreads::TightConditionVariable<bool volatile&>::wait<CCriticalSection>(this=0x000000010b0a4988, lock=0x000000010b0a4998, milliseconds=4294967295) at Condition.h:65
    frame #4: 0x00000001001cac24 kodi.bin`CEvent::WaitMSec(this=0x000000010b0a4900, milliSeconds=4294967295) at Event.h:88
    frame #5: 0x0000000101cf34e2 kodi.bin`CThread::WaitForThreadExit(this=0x000000010b0a4800, milliseconds=4294967295) at ThreadImpl.cpp:217
    frame #6: 0x0000000101cf4e06 kodi.bin`CThread::StopThread(this=0x000000010b0a4800, bWait=true) at Thread.cpp:167
    frame #7: 0x00000001019098b6 kodi.bin`PVR::CPVRManager::Stop(this=0x000000010b0a4800) at PVRManager.cpp:339
    frame #8: 0x00000001019095b9 kodi.bin`PVR::CPVRManager::Start(this=0x000000010b0a4800) at PVRManager.cpp:293
    frame #9: 0x000000010191f75a kodi.bin`PVR::CPVRClients::UpdateAddons(this=0x0000000108a5b230) at PVRClients.cpp:1092
    frame #10: 0x000000010055d1d7 kodi.bin`PVR::CPVRClient::OnDisabled(this=0x0000000109648018) at PVRClient.cpp:75
    frame #11: 0x0000000100460204 kodi.bin`ADDON::OnDisabled(addon=std::__1::shared_ptr<ADDON::IAddon>::element_type @ 0x0000000109648018 strong=3 weak=2) at Addon.cpp:403
    frame #12: 0x00000001004dd9ad kodi.bin`ADDON::CAddonMgr::DisableAddon(this=0x0000000113504710, id="pvr.demo") at AddonManager.cpp:839
    frame #13: 0x000000010051e745 kodi.bin`CGUIDialogAddonInfo::OnEnableDisable(this=0x00000001090a4a00) at GUIDialogAddonInfo.cpp:468
...
    frame #53: 0x00000001001b7e64 kodi.bin`CApplication::OnEvent(newEvent=0x00007ffeefbfe618) at Application.cpp:344
    frame #54: 0x00000001022d2309 kodi.bin`CWinEventsSDL::MessagePump(this=0x0000000104c02d80) at WinEventsSDL.cpp:103
    frame #55: 0x00000001022c7295 kodi.bin`CWinEvents::MessagePump() at WinEvents.cpp:71
    frame #56: 0x00000001001e58db kodi.bin`CApplication::FrameMove(this=0x0000000109804200, processEvents=true, processGUI=true) at Application.cpp:2691
    frame #57: 0x0000000100440bd6 kodi.bin`CXBApplicationEx::Run(this=0x0000000109804200, params=0x00007ffeefbfebb8) at XBApplicationEx.cpp:116
    frame #58: 0x00000001017e0d69 kodi.bin`::XBMC_Run(renderGUI=true, params=0x00007ffeefbfebb8) at xbmc.cpp:88
    frame #59: 0x000000010000a3da kodi.bin`::SDL_main(argc=1, argv=0x0000000108a00870) at main.cpp:115
    frame #60: 0x0000000100009659 kodi.bin`main(argc=1, argv=0x00007ffeefbfefe8) at SDLMain.mm:571
    frame #61: 0x00007fff7d8cb145 libdyld.dylib`start + 1
    frame #62: 0x00007fff7d8cb145 libdyld.dylib`start + 1
 
  thread #34
    frame #0: 0x00007fff7da1ae7e libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x0000000107df26b2 libsystem_pthread.dylib`_pthread_cond_wait + 732
    frame #2: 0x000000010133b275 kodi.bin`XbmcThreads::ConditionVariable::wait(this=0x0000000116693b08, lock=0x0000000116693b48) at Condition.h:62
    frame #3: 0x000000010133b223 kodi.bin`void XbmcThreads::TightConditionVariable<bool volatile&>::wait<CCriticalSection>(this=0x0000000116693b38, lock=0x0000000116693b48) at Condition.h:49
    frame #4: 0x0000000101338de5 kodi.bin`CEvent::Wait(this=0x0000000116693ab0) at Event.h:96
    frame #5: 0x0000000101338b24 kodi.bin`KODI::MESSAGING::CApplicationMessenger::SendMsg(this=0x0000000104bfbe58, message=0x000070000443e580, wait=true) at ApplicationMessenger.cpp:152
    frame #6: 0x0000000101339143 kodi.bin`KODI::MESSAGING::CApplicationMessenger::SendMsg(this=0x0000000104bfbe58, messageId=134217729, param1=-1, param2=-1, payload=0x000000010909a800, strParam=<unavailable>) at ApplicationMessenger.cpp:171
    frame #7: 0x0000000100ddfa39 kodi.bin`CGUIDialog::Open(this=0x000000010909a800, param="") at GUIDialog.cpp:222
    frame #8: 0x0000000100a648ef kodi.bin`CGUIDialogExtendedProgressBar::GetHandle(this=0x000000010909a800, strTitle="PVR manager is starting up") at GUIDialogExtendedProgressBar.cpp:75
    frame #9: 0x000000010190bc77 kodi.bin`PVR::CPVRManager::ShowProgressDialog(this=0x000000010b0a4800, strText="Loading channels from clients", iProgress=0) at PVRManager.cpp:594
    frame #10: 0x000000010190ab06 kodi.bin`PVR::CPVRManager::Load(this=0x000000010b0a4800, bShowProgress=true) at PVRManager.cpp:559
    frame #11: 0x000000010190a72f kodi.bin`PVR::CPVRManager::Process(this=0x000000010b0a4800) at PVRManager.cpp:435
    frame #12: 0x0000000101cf4840 kodi.bin`CThread::Action(this=0x000000010b0a4800) at Thread.cpp:221
    frame #13: 0x0000000101cf2e89 kodi.bin`CThread::staticThread(data=0x000000010b0a4800) at Thread.cpp:131
    frame #14: 0x0000000107df16c9 libsystem_pthread.dylib`_pthread_body + 340
    frame #15: 0x0000000107df1575 libsystem_pthread.dylib`_pthread_start + 377
    frame #16: 0x0000000107df0c65 libsystem_pthread.dylib`thread_start + 13
</pre>

=> Gist of the fix is to execute the problematic calls to the progress dialog in another thread, not blocking the PVR manager thread worker.


Commit 2: Deadlock 2 (one out of many with the same root cause): Disabling a PVR addon using addon information dialog:

+ T1: waits for addon manager mutex, while holding global graphics mutex.
+ T38: waits for global graphics mutex, while holding addon manager mutex.

<pre>
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fff7da1aeae libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000107df3c16 libsystem_pthread.dylib`_pthread_mutex_lock_wait + 102
    frame #2: 0x0000000107df1427 libsystem_pthread.dylib`_pthread_mutex_lock_slow + 254
    frame #3: 0x00000001000ee435 kodi.bin`XbmcThreads::pthreads::RecursiveMutex::lock(this=0x000000010984c870) at CriticalSection.h:49
    frame #4: 0x00000001000ee409 kodi.bin`XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock(this=0x000000010984c870) at Lockables.h:60
    frame #5: 0x00000001000ee3ea kodi.bin`XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(this=0x00007ffeefbdbb40, lockable=0x000000010984c870) at Lockables.h:127
    frame #6: 0x00000001000ee3b8 kodi.bin`CSingleLock::CSingleLock(this=0x00007ffeefbdbb40, cs=0x000000010984c870) at SingleLock.h:38
    frame #7: 0x00000001000ee35d kodi.bin`CSingleLock::CSingleLock(this=0x00007ffeefbdbb40, cs=0x000000010984c870) at SingleLock.h:38
    frame #8: 0x00000001004d4be9 kodi.bin`ADDON::CAddonMgr::GetAddon(this=0x000000010984c810, str="", addon=nullptr, type=0x00007ffeefbdd42c, enabledOnly=false) at AddonManager.cpp:630
    frame #9: 0x00000001003211cb kodi.bin`CGUIInfoManager::GetItemLabel(this=0x0000000105352d98, item=0x000000011640fdc8, info=35177, fallback="") at GUIInfoManager.cpp:10441
    frame #10: 0x00000001002ec15f kodi.bin`CGUIInfoManager::GetLabel(this=0x0000000105352d98, info=35177, contextWindow=10146, fallback="") at GUIInfoManager.cpp:5915
    frame #11: 0x0000000100341455 kodi.bin`CGUIInfoManager::GetImage(this=0x0000000105352d98, info=35177, contextWindow=10146, fallback="") at GUIInfoManager.cpp:8218
    frame #12: 0x000000010033a15f kodi.bin`CGUIInfoManager::GetMultiInfoBool(this=0x0000000105352d98, info=0x000000010a6837b8, contextWindow=10146, item=0x0000000000000000) at GUIInfoManager.cpp:7476
    frame #13: 0x00000001003324d7 kodi.bin`CGUIInfoManager::GetBool(this=0x0000000105352d98, condition1=40378, contextWindow=10146, item=0x0000000000000000) at GUIInfoManager.cpp:7026
    frame #14: 0x00000001011114cb kodi.bin`INFO::InfoSingle::Update(this=0x0000000116c992c8, item=0x0000000000000000) at InfoExpression.cpp:37
    frame #15: 0x0000000100ddfd7c kodi.bin`INFO::InfoBool::Get(this=0x0000000116c992c8, item=0x0000000000000000) at InfoBool.h:52
    frame #16: 0x0000000101113377 kodi.bin`INFO::InfoExpression::InfoLeaf::Evaluate(this=0x0000000116c98448, item=0x0000000000000000) at InfoExpression.cpp:74
    frame #17: 0x000000010111332a kodi.bin`INFO::InfoExpression::Update(this=0x0000000116c991c8, item=0x0000000000000000) at InfoExpression.cpp:51
    frame #18: 0x0000000100ddfd7c kodi.bin`INFO::InfoBool::Get(this=0x0000000116c991c8, item=0x0000000000000000) at InfoBool.h:52
    frame #19: 0x0000000100daa284 kodi.bin`CGUIControl::UpdateVisibility(this=0x0000000116c98e40, item=0x0000000000000000) at GUIControl.cpp:601
    frame #20: 0x0000000100dcebf6 kodi.bin`CGUIControlGroupList::Process(this=0x0000000116c97ee0, currentTime=23120, dirtyregions=size=1) at GUIControlGroupList.cpp:57
    frame #21: 0x0000000100da7762 kodi.bin`CGUIControl::DoProcess(this=0x0000000116c97ee0, currentTime=23120, dirtyregions=size=1) at GUIControl.cpp:143
    frame #22: 0x0000000100dc4ee3 kodi.bin`CGUIControlGroup::Process(this=0x0000000116cdbec0, currentTime=23120, dirtyregions=size=1) at GUIControlGroup.cpp:105
    frame #23: 0x0000000100da7762 kodi.bin`CGUIControl::DoProcess(this=0x0000000116cdbec0, currentTime=23120, dirtyregions=size=1) at GUIControl.cpp:143
    frame #24: 0x0000000100dc4ee3 kodi.bin`CGUIControlGroup::Process(this=0x0000000116d74dd0, currentTime=23120, dirtyregions=size=1) at GUIControlGroup.cpp:105
    frame #25: 0x0000000100da7762 kodi.bin`CGUIControl::DoProcess(this=0x0000000116d74dd0, currentTime=23120, dirtyregions=size=1) at GUIControl.cpp:143
    frame #26: 0x0000000100dc4ee3 kodi.bin`CGUIControlGroup::Process(this=0x000000010a900e00, currentTime=23120, dirtyregions=size=1) at GUIControlGroup.cpp:105
    frame #27: 0x0000000100da7762 kodi.bin`CGUIControl::DoProcess(this=0x000000010a900e00, currentTime=23120, dirtyregions=size=1) at GUIControl.cpp:143
    frame #28: 0x0000000100ee55fd kodi.bin`CGUIWindow::DoProcess(this=0x000000010a900e00, currentTime=23120, dirtyregions=size=1) at GUIWindow.cpp:350
    frame #29: 0x0000000100ddfa67 kodi.bin`CGUIDialog::DoProcess(this=0x000000010a900e00, currentTime=23120, dirtyregions=size=1) at GUIDialog.cpp:141
    frame #30: 0x0000000100efec8a kodi.bin`CGUIWindowManager::Process(this=0x0000000109908610, currentTime=23120) at GUIWindowManager.cpp:1103
    frame #31: 0x00000001001e5e44 kodi.bin`CApplication::FrameMove(this=0x000000010a002600, processEvents=true, processGUI=true) at Application.cpp:2739
    frame #32: 0x0000000100f00e87 kodi.bin`CGUIWindowManager::ProcessRenderLoop(this=0x0000000109908610, renderOnly=false) at GUIWindowManager.cpp:1288
    frame #33: 0x0000000100de02fa kodi.bin`CGUIDialog::ProcessRenderLoop(this=0x000000010a900400, renderOnly=false) at GUIDialog.cpp:262
    frame #34: 0x0000000100a571ba kodi.bin`CGUIDialogBusy::WaitOnEvent(event=0x000000011e2988e0, displaytime=100, allowCancel=false) at GUIDialogBusy.cpp:74
    frame #35: 0x0000000100a5702b kodi.bin`CBusyWaiter::Wait(this=0x00007ffeefbf4fa8, displaytime=100, allowCancel=false) at GUIDialogBusy.cpp:39
    frame #36: 0x0000000100a56eb5 kodi.bin`CGUIDialogBusy::Wait(runnable=0x00007ffeefbf53e0, displaytime=100, allowCancel=false) at GUIDialogBusy.cpp:58
    frame #37: 0x00000001005265f5 kodi.bin`AsyncAddonEnableDisable::EnableDisableAddon(this=0x00007ffeefbf53e0, strAddonID="pvr.hts", bEnable=false) at GUIDialogAddonInfo.cpp:476
    frame #38: 0x0000000100525cdf kodi.bin`AsyncAddonEnableDisable::DisableAddon(this=0x00007ffeefbf53e0, strAddonID="pvr.hts") at GUIDialogAddonInfo.cpp:463
    frame #39: 0x000000010051e847 kodi.bin`CGUIDialogAddonInfo::OnEnableDisable(this=0x000000010a900e00) at GUIDialogAddonInfo.cpp:505
...
    frame #80: 0x00000001022d2d79 kodi.bin`CWinEventsSDL::MessagePump(this=0x0000000104c03e60) at WinEventsSDL.cpp:103
    frame #81: 0x00000001022c7d05 kodi.bin`CWinEvents::MessagePump() at WinEvents.cpp:71
    frame #82: 0x00000001001e59db kodi.bin`CApplication::FrameMove(this=0x000000010a002600, processEvents=true, processGUI=true) at Application.cpp:2691
    frame #83: 0x0000000100440cd6 kodi.bin`CXBApplicationEx::Run(this=0x000000010a002600, params=0x00007ffeefbfebb8) at XBApplicationEx.cpp:116
    frame #84: 0x00000001017e1169 kodi.bin`::XBMC_Run(renderGUI=true, params=0x00007ffeefbfebb8) at xbmc.cpp:88
    frame #85: 0x000000010000a4da kodi.bin`::SDL_main(argc=1, argv=0x000000010993c310) at main.cpp:115
    frame #86: 0x0000000100009759 kodi.bin`main(argc=1, argv=0x00007ffeefbfefe8) at SDLMain.mm:571
    frame #87: 0x00007fff7d8cb145 libdyld.dylib`start + 1
    frame #88: 0x00007fff7d8cb145 libdyld.dylib`start + 1

  thread #38
    frame #0: 0x00007fff7da1aeae libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000107df3c16 libsystem_pthread.dylib`_pthread_mutex_lock_wait + 102
    frame #2: 0x0000000107df1427 libsystem_pthread.dylib`_pthread_mutex_lock_slow + 254
    frame #3: 0x00000001000ee435 kodi.bin`XbmcThreads::pthreads::RecursiveMutex::lock(this=0x0000000109907378) at CriticalSection.h:49
    frame #4: 0x00000001000ee409 kodi.bin`XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock(this=0x0000000109907378) at Lockables.h:60
    frame #5: 0x00000001000ee3ea kodi.bin`XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(this=0x000070000d4e7558, lockable=0x0000000109907378) at Lockables.h:127
    frame #6: 0x00000001000ee3b8 kodi.bin`CSingleLock::CSingleLock(this=0x000070000d4e7558, cs=0x0000000109907378) at SingleLock.h:38
    frame #7: 0x00000001000ee35d kodi.bin`CSingleLock::CSingleLock(this=0x000070000d4e7558, cs=0x0000000109907378) at SingleLock.h:38
    frame #8: 0x0000000100f019ac kodi.bin`CGUIWindowManager::IsWindowActive(this=0x0000000109908610, id=10700, ignoreClosing=true) const at GUIWindowManager.cpp:1539
    frame #9: 0x0000000100ee988e kodi.bin`CGUIWindow::IsActive(this=0x0000000108097200) const at GUIWindow.cpp:876
    frame #10: 0x0000000101ad8c88 kodi.bin`PVR::CGUIWindowPVRBase::Notify(this=0x0000000108097200, obs=0x0000000108067200, msg=ObservableMessageManagerStopped) at GUIWindowPVRBase.cpp:114
    frame #11: 0x0000000101ad8d85 kodi.bin`non-virtual thunk to PVR::CGUIWindowPVRBase::Notify(this=0x0000000108097200, obs=0x0000000108067200, msg=ObservableMessageManagerStopped) at GUIWindowPVRBase.cpp:0
    frame #12: 0x0000000101e6e728 kodi.bin`Observable::SendMessage(this=0x0000000108067200, message=ObservableMessageManagerStopped) at Observer.cpp:81
    frame #13: 0x0000000101e6e538 kodi.bin`Observable::NotifyObservers(this=0x0000000108067200, message=ObservableMessageManagerStopped) at Observer.cpp:67
    frame #14: 0x000000010190a998 kodi.bin`PVR::CPVRManager::SetState(this=0x0000000108067200, state=ManagerStateStopped) at PVRManager.cpp:407
    frame #15: 0x000000010190a7bd kodi.bin`PVR::CPVRManager::Stop(this=0x0000000108067200) at PVRManager.cpp:336
    frame #16: 0x000000010190a3d9 kodi.bin`PVR::CPVRManager::Start(this=0x0000000108067200) at PVRManager.cpp:280
    frame #17: 0x00000001019204da kodi.bin`PVR::CPVRClients::UpdateAddons(this=0x000000011350b1e0) at PVRClients.cpp:1092
    frame #18: 0x000000010055d5d7 kodi.bin`PVR::CPVRClient::OnDisabled(this=0x000000010aa15e18) at PVRClient.cpp:75
    frame #19: 0x0000000100460304 kodi.bin`ADDON::OnDisabled(addon=std::__1::shared_ptr<ADDON::IAddon>::element_type @ 0x000000010aa15e18 strong=7 weak=3) at Addon.cpp:403
    frame #20: 0x00000001004ddaad kodi.bin`ADDON::CAddonMgr::DisableAddon(this=0x000000010984c810, id="pvr.hts") at AddonManager.cpp:839
    frame #21: 0x0000000100526566 kodi.bin`AsyncAddonEnableDisable::Run(this=0x00007ffeefbf53e0) at GUIDialogAddonInfo.cpp:485
    frame #22: 0x0000000101cf5915 kodi.bin`CThread::Process(this=0x00007ffeefbf4fa8) at Thread.cpp:179
    frame #23: 0x0000000100a57969 kodi.bin`CBusyWaiter::Process(this=0x00007ffeefbf4fa8) at GUIDialogBusy.cpp:47
    frame #24: 0x0000000101cf52b0 kodi.bin`CThread::Action(this=0x00007ffeefbf4fa8) at Thread.cpp:221
    frame #25: 0x0000000101cf38f9 kodi.bin`CThread::staticThread(data=0x00007ffeefbf4fa8) at Thread.cpp:131
    frame #26: 0x0000000107df36c9 libsystem_pthread.dylib`_pthread_body + 340
    frame #27: 0x0000000107df3575 libsystem_pthread.dylib`_pthread_start + 377
    frame #28: 0x0000000107df2c65 libsystem_pthread.dylib`thread_start + 13
</pre>

==> Gist of the fix is never to call functions trying to obtain the global graphics mutex from inside any PVR window's `Notify` implementation.

Changes have been runtime-tested for some time already on macOS and Linux, latest kodi master.

@Jalle19 for review?