### PR TITLE
fix MusicPlaylistEditor

### DIFF
--- a/addons/skin.estouchy/xml/MyMusicPlaylistEditor.xml
+++ b/addons/skin.estouchy/xml/MyMusicPlaylistEditor.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol allways="true">6</defaultcontrol>
+	<views>50</views>
 	<onunload>ClearProperty(PopupMenuVisible,Home)</onunload>
 	<controls>
 		<include>CommonBackground</include>

--- a/addons/skin.estuary/xml/MyMusicPlaylistEditor.xml
+++ b/addons/skin.estuary/xml/MyMusicPlaylistEditor.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<defaultcontrol always="true">6</defaultcontrol>
+	<views>50</views>
 	<menucontrol>9000</menucontrol>
 	<controls>
 		<include>DefaultBackground</include>


### PR DESCRIPTION
the removal of the automatic view detection code in https://github.com/xbmc/xbmc/pull/11114 broke the MusicPlaylistEditor window.

this can easily be fixed by adding an explicit view id definition to the skin xml file.

@phil65 