### PR TITLE
add additional binary support to BUILD_DIR support in addon helper

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -353,6 +353,12 @@ macro (build_addon target prefix libs)
                        COMMAND ${CMAKE_COMMAND} -E copy
                                    ${LIBRARY_LOCATION}
                                    ${${APP_NAME_UC}_BUILD_DIR}/addons/${target}/${LIBRARY_FILENAME})
+    if(${prefix}_ADDITIONAL_BINARY)
+        add_custom_command(TARGET ${target} POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                   ${${prefix}_ADDITIONAL_BINARY}
+                                   ${${APP_NAME_UC}_BUILD_DIR}/addons/${target})
+    endif()
   endif()
 endmacro()
 


### PR DESCRIPTION
I use build_dir when developing addons. The lack of support hurt..