### PR TITLE
Several compiler warnings and code improvements

### DIFF
--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 class CFileItem;
 
 class IPlayerCallback

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -43,7 +43,7 @@ CRenderContext::CRenderContext(CRenderSystemBase *rendering,
 
 void CRenderContext::SetViewPort(const CRect& viewPort)
 {
-  m_rendering->SetViewPort(const_cast<CRect&>(viewPort)); //! @todo Remove const cast
+  m_rendering->SetViewPort(viewPort);
 }
 
 void CRenderContext::GetViewPort(CRect &viewPort)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -69,7 +69,6 @@ protected:
   void UpdateName();
   bool SetPictureParams(VideoPicture* pVideoPicture);
 
-  IHardwareDecoder* CreateVideoDecoderHW(AVPixelFormat pixfmt, CProcessInfo &processInfo);
   bool HasHardware() { return m_pHardware != nullptr; };
   void SetHardware(IHardwareDecoder *hardware);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -191,10 +191,13 @@ bool CVDPAUContext::CreateContext()
 
   int mScreen;
   { CSingleLock lock(g_graphicsContext);
+
     if (!m_display)
       m_display = XOpenDisplay(NULL);
-      if (!m_display)
-        return false;
+
+    if (!m_display)
+      return false;
+
     mScreen = g_Windowing.GetCurrentScreen();
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -1084,21 +1084,6 @@ bool CWinRenderer::ConfigChanged(const VideoPicture& picture)
   return false;
 }
 
-bool CWinRenderer::HandlesVideoBuffer(CVideoBuffer* buffer)
-{
-  AVPixelFormat format = buffer->GetFormat();
-  if ( format == AV_PIX_FMT_D3D11VA_VLD
-    || format == AV_PIX_FMT_NV12
-    || format == AV_PIX_FMT_P010
-    || format == AV_PIX_FMT_P016
-    || format == AV_PIX_FMT_YUV420P
-    || format == AV_PIX_FMT_YUV420P10
-    || format == AV_PIX_FMT_YUV420P16)
-    return true;
-
-  return false;
-}
-
 CRenderInfo CWinRenderer::GetRenderInfo()
 {
   CRenderInfo info;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -76,8 +76,6 @@ public:
   bool WantsDoublePass() override;
   bool ConfigChanged(const VideoPicture& picture) override;
 
-  static bool HandlesVideoBuffer(CVideoBuffer *buffer);
-
 protected:
   void PreInit();
   virtual void Render(DWORD flags, CD3DTexture* target);

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -117,7 +117,7 @@ void CDialogGameVolume::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char
 {
   if (flag == ANNOUNCEMENT::Application && strcmp(message, "OnVolumeChanged") == 0)
   {
-    const float volumePercent = data["volume"].asDouble();
+    const float volumePercent = static_cast<float>(data["volume"].asDouble());
 
     if (std::fabs(volumePercent - m_volumePercent) > 0.1f)
     {

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -134,7 +134,6 @@ protected:
 
   int ScrollCorrectionRange() const;
   inline float Size() const;
-  void MoveToRow(int row);
   void FreeMemory(int keepStart, int keepEnd);
   void GetCurrentLayouts();
   CGUIListItemLayout *GetFocusedLayout() const;

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -120,7 +120,7 @@ public:
 
 private:
   // no copy constructor
-  CBaseTexture(const CBaseTexture &copy);
+  CBaseTexture(const CBaseTexture &copy) = delete;
 
 protected:
   bool LoadFromFileInMem(unsigned char* buffer, size_t size, const std::string& mimeType,

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -70,7 +70,7 @@ public:
   virtual bool ClearBuffers(color_t color) = 0;
   virtual bool IsExtSupported(const char* extension) = 0;
 
-  virtual void SetViewPort(CRect& viewPort) = 0;
+  virtual void SetViewPort(const CRect& viewPort) = 0;
   virtual void GetViewPort(CRect& viewPort) = 0;
   virtual void RestoreViewPort() {};
 

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -477,7 +477,7 @@ void CRenderSystemDX::GetViewPort(CRect& viewPort)
   viewPort.y2 = m_viewPort.TopLeftY + m_viewPort.Height;
 }
 
-void CRenderSystemDX::SetViewPort(CRect& viewPort)
+void CRenderSystemDX::SetViewPort(const CRect& viewPort)
 {
   if (!m_bRenderCreated)
     return;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -57,7 +57,7 @@ public:
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
   bool ClearBuffers(color_t color) override;
-  void SetViewPort(CRect& viewPort) override;
+  void SetViewPort(const CRect& viewPort) override;
   void GetViewPort(CRect& viewPort) override;
   void RestoreViewPort() override;
   CRect ClipRectToScissorRect(const CRect &rect) override;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -489,7 +489,7 @@ void CRenderSystemGL::GetViewPort(CRect& viewPort)
   viewPort.y2 = viewPort.y1 + m_viewPort[3];
 }
 
-void CRenderSystemGL::SetViewPort(CRect& viewPort)
+void CRenderSystemGL::SetViewPort(const CRect& viewPort)
 {
   if (!m_bRenderCreated)
     return;

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -43,7 +43,7 @@ public:
   void SetVSync(bool vsync);
   void ResetVSync() { m_bVsyncInit = false; }
 
-  void SetViewPort(CRect& viewPort) override;
+  void SetViewPort(const CRect& viewPort) override;
   void GetViewPort(CRect& viewPort) override;
 
   void SetScissors(const CRect &rect) override;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -460,7 +460,7 @@ void CRenderSystemGLES::GetViewPort(CRect& viewPort)
 }
 
 // FIXME make me const so that I can accept temporary objects
-void CRenderSystemGLES::SetViewPort(CRect& viewPort)
+void CRenderSystemGLES::SetViewPort(const CRect& viewPort)
 {
   if (!m_bRenderCreated)
     return;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -459,7 +459,6 @@ void CRenderSystemGLES::GetViewPort(CRect& viewPort)
   viewPort.y2 = viewPort.y1 + m_viewPort[3];
 }
 
-// FIXME make me const so that I can accept temporary objects
 void CRenderSystemGLES::SetViewPort(const CRect& viewPort)
 {
   if (!m_bRenderCreated)

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -63,7 +63,7 @@ public:
   void SetVSync(bool vsync);
   void ResetVSync() { m_bVsyncInit = false; }
 
-  void SetViewPort(CRect& viewPort) override;
+  void SetViewPort(const CRect& viewPort) override;
   void GetViewPort(CRect& viewPort) override;
 
   bool ScissorsCanEffectClipping() override;

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HEADERS Bookmark.h
             VideoInfoScanner.h
             VideoInfoTag.h
             VideoLibraryQueue.h
-            VideoThumbLoader.h)
+            VideoThumbLoader.h
+            ViewModeSettings.h)
 
 core_add_library(video)


### PR DESCRIPTION
This PR contains the following compiler warning fixes:

* Misleading code indendation
* Type narrowing conversion

Build system improvements:

* Missing header in CMakeLists.txt

Code improvements:

* Remove several unused functions
* Const-correctness
* Missing `delete` operator
* Missing include
