### PR TITLE
[music] Support originaldate / originalyear tags

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1863,7 +1863,7 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
           song.strCueSheet = tag.GetCueSheet();
 
         SYSTEMTIME dateTime;
-        tag.GetReleaseDate(dateTime);
+        tag.GetOriginalReleaseDate(dateTime);
         if (dateTime.wYear)
           song.iYear = dateTime.wYear;
         if (song.embeddedArt.Empty() && !tag.GetCoverArtInfo().Empty())

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -34,7 +34,7 @@ CAlbum::CAlbum(const CFileItem& item)
   Reset();
   const CMusicInfoTag& tag = *item.GetMusicInfoTag();
   SYSTEMTIME stTime;
-  tag.GetReleaseDate(stTime);
+  tag.GetOriginalReleaseDate(stTime);
   strAlbum = tag.GetAlbum();
   strMusicBrainzAlbumID = tag.GetMusicBrainzAlbumID();
   strReleaseGroupMBID = tag.GetMusicBrainzReleaseGroupID();

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -20,7 +20,7 @@ CSong::CSong(CFileItem& item)
 {
   CMusicInfoTag& tag = *item.GetMusicInfoTag();
   SYSTEMTIME stTime;
-  tag.GetReleaseDate(stTime);
+  tag.GetOriginalReleaseDate(stTime);
   strTitle = tag.GetTitle();
   genre = tag.GetGenre();
   std::vector<std::string> artist = tag.GetArtist();

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -133,9 +133,27 @@ void CMusicInfoTag::GetReleaseDate(SYSTEMTIME& dateTime) const
   memcpy(&dateTime, &m_dwReleaseDate, sizeof(m_dwReleaseDate));
 }
 
+void CMusicInfoTag::GetOriginalReleaseDate(SYSTEMTIME& dateTime) const
+{
+  /* Fall back to ReleaseDate if OriginalReleaseDate is unset. */
+  if (m_dwOriginalReleaseDate.wYear > 0)
+    memcpy(&dateTime, &m_dwOriginalReleaseDate, sizeof(m_dwOriginalReleaseDate));
+  else
+    this->GetReleaseDate(dateTime);
+}
+
 int CMusicInfoTag::GetYear() const
 {
   return m_dwReleaseDate.wYear;
+}
+
+int CMusicInfoTag::GetOriginalYear() const
+{
+  /* Fall back to Year if OriginalYear is unset. */
+  if (m_dwOriginalReleaseDate.wYear > 0)
+    return m_dwOriginalReleaseDate.wYear;
+  else
+    return this->GetYear();
 }
 
 int CMusicInfoTag::GetDatabaseId() const
@@ -344,6 +362,12 @@ void CMusicInfoTag::SetYear(int year)
   m_dwReleaseDate.wYear = year;
 }
 
+void CMusicInfoTag::SetOriginalYear(int year)
+{
+  memset(&m_dwOriginalReleaseDate, 0, sizeof(m_dwOriginalReleaseDate));
+  m_dwOriginalReleaseDate.wYear = year;
+}
+
 void CMusicInfoTag::SetDatabaseId(long id, const std::string &type)
 {
   m_iDbId = id;
@@ -353,6 +377,11 @@ void CMusicInfoTag::SetDatabaseId(long id, const std::string &type)
 void CMusicInfoTag::SetReleaseDate(SYSTEMTIME& dateTime)
 {
   memcpy(&m_dwReleaseDate, &dateTime, sizeof(m_dwReleaseDate) );
+}
+
+void CMusicInfoTag::SetOriginalReleaseDate(SYSTEMTIME& dateTime)
+{
+  memcpy(&m_dwOriginalReleaseDate, &dateTime, sizeof(m_dwOriginalReleaseDate));
 }
 
 void CMusicInfoTag::SetTrackNumber(int iTrack)

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -48,10 +48,12 @@ public:
   int GetTrackAndDiscNumber() const;
   int GetDuration() const;  // may be set even if Loaded() returns false
   int GetYear() const;
+  int GetOriginalYear() const;
   int GetDatabaseId() const;
   const std::string &GetType() const;
 
   void GetReleaseDate(SYSTEMTIME& dateTime) const;
+  void GetOriginalReleaseDate(SYSTEMTIME& dateTime) const;
   std::string GetYearString() const;
   const std::string& GetMusicBrainzTrackID() const;
   const std::vector<std::string>& GetMusicBrainzArtistID() const;
@@ -94,8 +96,10 @@ public:
   void SetGenre(const std::string& strGenre, bool bTrim = false);
   void SetGenre(const std::vector<std::string>& genres, bool bTrim = false);
   void SetYear(int year);
+  void SetOriginalYear(int year);
   void SetDatabaseId(long id, const std::string &type);
   void SetReleaseDate(SYSTEMTIME& dateTime);
+  void SetOriginalReleaseDate(SYSTEMTIME& dateTime);
   void SetTrackNumber(int iTrack);
   void SetDiscNumber(int iDiscNumber);
   void SetTrackAndDiscNumber(int iTrackAndDisc);
@@ -213,6 +217,7 @@ protected:
   int m_iTimesPlayed;
   int m_iAlbumId;
   SYSTEMTIME m_dwReleaseDate;
+  SYSTEMTIME m_dwOriginalReleaseDate;
   CAlbum::ReleaseType m_albumReleaseType;
 
   EmbeddedArtInfo m_coverArt; ///< art information

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -178,6 +178,8 @@ bool CTagLoaderTagLib::ParseTag(ASF::Tag *asf, EmbeddedArt *art, CMusicInfoTag& 
     {} // Known unsupported, suppress warnings
     else if (it->first == "WM/Year")
       tag.SetYear(atoi(it->second.front().toString().toCString(true)));
+    else if (it->first == "WM/OriginalReleaseYear")
+      tag.SetOriginalYear(atoi(it->second.front().toString().toCString(true)));
     else if (it->first == "MusicBrainz/Artist Id")
       tag.SetMusicBrainzArtistID(SplitMBID(GetASFStringList(it->second)));
     else if (it->first == "MusicBrainz/Album Id")
@@ -495,6 +497,8 @@ bool CTagLoaderTagLib::ParseTag(APE::Tag *ape, EmbeddedArt *art, CMusicInfoTag& 
       tag.SetDiscNumber(it->second.toString().toInt());
     else if (it->first == "YEAR")
       tag.SetYear(it->second.toString().toInt());
+    else if (it->first == "ORIGINALYEAR")
+      tag.SetYear(it->second.toString().toInt());
     else if (it->first == "GENRE")
       SetGenre(tag, StringListToVectorString(it->second.toStringList()));
     else if (it->first == "MOOD")
@@ -608,6 +612,8 @@ bool CTagLoaderTagLib::ParseTag(Ogg::XiphComment *xiph, EmbeddedArt *art, CMusic
       tag.SetYear(it->second.front().toInt());
     else if (it->first == "DATE")
       tag.SetYear(it->second.front().toInt());
+    else if (it->first == "ORIGINALYEAR")
+      tag.SetOriginalYear(it->second.front().toInt());
     else if (it->first == "GENRE")
       SetGenre(tag, StringListToVectorString(it->second));
     else if (it->first == "MOOD")


### PR DESCRIPTION
## Description
The [MusicBrainz Picard](https://picard.musicbrainz.org/) application places the release date of an album in its `date` tag. But a given album can have several releases over the years and most users expect to see the *original* release date of an album, which Picard places in its `originaldate` tag.

See: https://picard.musicbrainz.org/docs/mappings/

For example, a 1994 re-release of Led Zeppelin IV:
```
$ metaflac --export-tags-to - "1 - Black Dog.flac" | sort
...
DATE=1994-07-19
...
ORIGINALDATE=1971-11-08
ORIGINALYEAR=1971
```
Parse various tag formats for the *original* release date or year and prefer that over the release date, when updating the music database.

To see the changes take effect, users will need to touch all music files and then rebuild the music library.

## How Has This Been Tested?
Built Kodi locally on Linux/x86_64, tested changes against various **.flac** and **.ogg** files in my personal library, relied on [Picard documentation](https://picard.musicbrainz.org/docs/mappings/) for the rest.

## Screenshots
**Before** (re-release year shown)
![before-screenshot](https://user-images.githubusercontent.com/56718/31278015-6431150a-aa71-11e7-8e0a-5cf7dea8421d.png)

**After** (original year shown)
![after-screenshot](https://user-images.githubusercontent.com/56718/31278026-6b9ba756-aa71-11e7-9af5-53fdd772ea82.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
