### PR TITLE
[dxva] add VP9 profile 0 hardware decoder

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -99,6 +99,9 @@ static const std::vector<dxva2_mode_t> dxva2_modes = {
     { "HEVC / H.265 variable-length decoder, main",   &D3D11_DECODER_PROFILE_HEVC_VLD_MAIN,   AV_CODEC_ID_HEVC },
     { "HEVC / H.265 variable-length decoder, main10", &D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10, AV_CODEC_ID_HEVC },
 
+    /* VP9 */
+    { "VP9 VLD, Profile 0", &D3D11_DECODER_PROFILE_VP9_VLD_PROFILE0, AV_CODEC_ID_VP9 },
+
 #ifdef FF_DXVA2_WORKAROUND_INTEL_CLEARVIDEO
     /* Intel specific modes (only useful on older GPUs) */
     { "Intel H.264 VLD, no FGT",                                      &DXVADDI_Intel_ModeH264_E, AV_CODEC_ID_H264 },

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -59,7 +59,7 @@ typedef struct {
 } dxva2_mode_t;
 
 /* XXX Prefered modes must come first */
-static const dxva2_mode_t dxva2_modes[] = {
+static const std::vector<dxva2_mode_t> dxva2_modes = {
     { "MPEG2 VLD",    &D3D11_DECODER_PROFILE_MPEG2_VLD,     AV_CODEC_ID_MPEG2VIDEO },
     { "MPEG1/2 VLD",  &D3D11_DECODER_PROFILE_MPEG2and1_VLD, AV_CODEC_ID_MPEG2VIDEO },
     { "MPEG2 MoComp", &D3D11_DECODER_PROFILE_MPEG2_MOCOMP,  0 },
@@ -106,8 +106,6 @@ static const dxva2_mode_t dxva2_modes[] = {
     { "Intel H.264 motion compensation (MoComp), no FGT",             &DXVADDI_Intel_ModeH264_A, 0 },
     { "Intel VC-1 VLD",                                               &DXVADDI_Intel_ModeVC1_E,  0 },
 #endif
-
-    { nullptr, nullptr, 0 }
 };
 
 // Prefered targets must be first
@@ -198,11 +196,12 @@ static std::string GUIDToString(const GUID& guid)
 
 static const dxva2_mode_t *dxva2_find_mode(const GUID *guid)
 {
-    for (unsigned i = 0; dxva2_modes[i].name; i++) {
-        if (IsEqualGUID(*dxva2_modes[i].guid, *guid))
-            return &dxva2_modes[i];
-    }
-    return nullptr;
+  for (const dxva2_mode_t& mode : dxva2_modes)
+  {
+    if (IsEqualGUID(*mode.guid, *guid))
+      return &mode;
+  }
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -332,14 +331,14 @@ bool CDXVAContext::GetInputAndTarget(int codec, bool bHighBitdepth, GUID &inGuid
 
   // iterate through our predefined dxva modes and find the first matching for desired codec
   // once we found a mode, get a target we support in render_targets_dxgi DXGI_FORMAT_UNKNOWN
-  for (const dxva2_mode_t* mode = dxva2_modes; mode->name && outFormat == DXGI_FORMAT_UNKNOWN; mode++)
+  for (const dxva2_mode_t& mode : dxva2_modes)
   {
-    if (mode->codec != codec)
+    if (mode.codec != codec)
       continue;
 
     for (unsigned i = 0; i < m_input_count && outFormat == DXGI_FORMAT_UNKNOWN; i++)
     {
-      bool supported = IsEqualGUID(m_input_list[i], *mode->guid) != 0;
+      bool supported = IsEqualGUID(m_input_list[i], *mode.guid) != 0;
       if (codec == AV_CODEC_ID_HEVC)
       {
         if (bHighBitdepth && !IsEqualGUID(m_input_list[i], D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10))
@@ -350,7 +349,7 @@ bool CDXVAContext::GetInputAndTarget(int codec, bool bHighBitdepth, GUID &inGuid
       if (!supported)
         continue;
 
-      CLog::LogFunction(LOGDEBUG, "DXVA", "trying '%s'.", mode->name);
+      CLog::LogFunction(LOGDEBUG, "DXVA", "trying '%s'.", mode.name);
       for (unsigned j = 0; render_targets_dxgi[j] != DXGI_FORMAT_UNKNOWN && outFormat == DXGI_FORMAT_UNKNOWN; j++)
       {
         BOOL supported;
@@ -373,6 +372,9 @@ bool CDXVAContext::GetInputAndTarget(int codec, bool bHighBitdepth, GUID &inGuid
         }
       }
     }
+
+  if (outFormat != DXGI_FORMAT_UNKNOWN)
+    break;
   }
 
   if (outFormat == DXGI_FORMAT_UNKNOWN)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
add VP9 profile 0 hardware decoder for dxva/Windows
<!--- Describe your change in detail -->

## Motivation and Context
FFmpeg already has a VP9 DXVA hardware decoder, but Kodi hasn't used it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested on a Kaby Lake and Windows 10 with a VP9 video.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
