### PR TITLE
Fix seek on left with some SNES controllers

### DIFF
--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -162,7 +162,6 @@ static const std::vector<FallbackWindowMapping> FallbackWindows =
 {
     { WINDOW_FULLSCREEN_LIVETV   , WINDOW_FULLSCREEN_VIDEO },
     { WINDOW_FULLSCREEN_RADIO    , WINDOW_VISUALISATION },
-    { WINDOW_FULLSCREEN_GAME     , WINDOW_FULLSCREEN_VIDEO }
 };
 } // anonymous namespace
 

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -118,18 +118,27 @@ void CScalarFeature::ProcessMotions(void)
 
 bool CScalarFeature::OnDigitalMotion(bool bPressed)
 {
+  bool bHandled = false;
+
   if (m_bDigitalState != bPressed)
   {
     m_bDigitalState = bPressed;
     m_motionStartTimeMs = 0; // This is set in ProcessMotions()
 
-    CLog::Log(LOGDEBUG, "FEATURE [ %s ] on %s %s", m_name.c_str(), m_handler->ControllerID().c_str(),
-              bPressed ? "pressed" : "released");
+    bHandled = m_bInitialPressHandled = m_handler->OnButtonPress(m_name, bPressed);
 
-    return m_handler->OnButtonPress(m_name, bPressed);
+    if (m_bDigitalState)
+      CLog::Log(LOGDEBUG, "FEATURE [ %s ] on %s pressed (%s)", m_name.c_str(), m_handler->ControllerID().c_str(),
+        bHandled ? "handled" : "ignored");
+    else
+      CLog::Log(LOGDEBUG, "FEATURE [ %s ] on %s released", m_name.c_str(), m_handler->ControllerID().c_str());
+  }
+  else if (m_bDigitalState)
+  {
+    bHandled = m_bInitialPressHandled;
   }
 
-  return false;
+  return bHandled;
 }
 
 bool CScalarFeature::OnAnalogMotion(float magnitude)

--- a/xbmc/input/joysticks/generic/FeatureHandling.h
+++ b/xbmc/input/joysticks/generic/FeatureHandling.h
@@ -118,6 +118,7 @@ namespace JOYSTICK
     INPUT_TYPE       m_inputType = INPUT_TYPE::UNKNOWN;
     bool             m_bDigitalState;
     unsigned int     m_motionStartTimeMs;
+    bool             m_bInitialPressHandled = false;
 
     // Analog state variables
     float            m_analogState; // The current magnitude


### PR DESCRIPTION
This fixes a problem where the StepBack command was sent during gameplay when the left direction was pressed on a SNES dpad. Two analog axes are used instead of four buttons, and because axis events are sent very frame, axis events after the first were ignored by the game. This caused them to fall through to the GUI action.

Normally this wouldn't be fatal, because no GUI actions are defined for a FullscreenGame window. However, a second bug was causing FullscreenVideo actions to be mapped to FullscreenGame also.

## How Has This Been Tested?
Tested by pressing Left with a SNES controller on windows.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
