### PR TITLE
Joysticks: Fix accelerometers preventing screensaver

### DIFF
--- a/xbmc/input/joysticks/JoystickMonitor.h
+++ b/xbmc/input/joysticks/JoystickMonitor.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "IDriverHandler.h"
+#include "IInputHandler.h"
 
 namespace KODI
 {
@@ -30,14 +30,18 @@ namespace JOYSTICK
    * \brief Monitors joystick input and resets screensaver/shutdown timers
    *        whenever motion occurs.
    */
-  class CJoystickMonitor : public IDriverHandler
+  class CJoystickMonitor : public IInputHandler
   {
   public:
-    // implementation of IDriverHandler
-    virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
-    virtual bool OnHatMotion(unsigned int hatIndex, HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
-    virtual void ProcessAxisMotions(void) override { }
+    // implementation of IInputHandler
+    virtual std::string ControllerID() const override;
+    virtual bool HasFeature(const FeatureName& feature) const override { return true; }
+    virtual bool AcceptsInput(const FeatureName& feature) const override;
+    virtual bool OnButtonPress(const FeatureName& feature, bool bPressed) override;
+    virtual void OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs) override { }
+    virtual bool OnButtonMotion(const FeatureName& feature, float magnitude, unsigned int motionTimeMs) override;
+    virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs) override;
+    virtual bool OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z) override { return false; }
 
   private:
     /*!

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -78,14 +78,15 @@ CScalarFeature::CScalarFeature(const FeatureName& name, IInputHandler* handler, 
 
 bool CScalarFeature::OnDigitalMotion(const CDriverPrimitive& source, bool bPressed)
 {
-  bool bHandled = false;
+  // Feature must accept input to be considered handled
+  bool bHandled = AcceptsInput(bPressed);
 
   if (m_inputType == INPUT_TYPE::DIGITAL)
-    bHandled = OnDigitalMotion(bPressed);
+    bHandled &= OnDigitalMotion(bPressed);
   else if (m_inputType == INPUT_TYPE::ANALOG)
-    bHandled = OnAnalogMotion(bPressed ? 1.0f : 0.0f);
+    bHandled &= OnAnalogMotion(bPressed ? 1.0f : 0.0f);
 
-  return bHandled && AcceptsInput(bPressed);
+  return bHandled;
 }
 
 bool CScalarFeature::OnAnalogMotion(const CDriverPrimitive& source, float magnitude)
@@ -98,14 +99,15 @@ bool CScalarFeature::OnAnalogMotion(const CDriverPrimitive& source, float magnit
   if (magnitude != 0.0f && magnitude != 1.0f)
     m_bDiscrete = false;
 
-  bool bHandled = false;
+  // Feature must accept input to be considered handled
+  bool bHandled = AcceptsInput(magnitude > 0.0f);
 
   if (m_inputType == INPUT_TYPE::DIGITAL)
-    bHandled = OnDigitalMotion(magnitude >= ANALOG_DIGITAL_THRESHOLD);
+    bHandled &= OnDigitalMotion(magnitude >= ANALOG_DIGITAL_THRESHOLD);
   else if (m_inputType == INPUT_TYPE::ANALOG)
-    bHandled = OnAnalogMotion(magnitude);
+    bHandled &= OnAnalogMotion(magnitude);
 
-  return bHandled && AcceptsInput(magnitude > 0.0f);
+  return bHandled;
 }
 
 void CScalarFeature::ProcessMotions(void)
@@ -231,25 +233,22 @@ bool CAnalogStick::OnAnalogMotion(const CDriverPrimitive& source, float magnitud
     }
   }
 
-  bool bHandled = false;
+  // Feature must accept input to be considered handled
+  bool bHandled = AcceptsInput(magnitude > 0.0f);
 
   switch (direction)
   {
   case ANALOG_STICK_DIRECTION::UP:
     m_vertAxis.SetPositiveDistance(magnitude);
-    bHandled = true;
     break;
   case ANALOG_STICK_DIRECTION::DOWN:
     m_vertAxis.SetNegativeDistance(magnitude);
-    bHandled = true;
     break;
   case ANALOG_STICK_DIRECTION::RIGHT:
     m_horizAxis.SetPositiveDistance(magnitude);
-    bHandled = true;
     break;
   case ANALOG_STICK_DIRECTION::LEFT:
     m_horizAxis.SetNegativeDistance(magnitude);
-    bHandled = true;
     break;
   default:
     // Just in case, avoid sticking
@@ -258,7 +257,7 @@ bool CAnalogStick::OnAnalogMotion(const CDriverPrimitive& source, float magnitud
     break;
   }
 
-  return bHandled && AcceptsInput(magnitude != 0.0f);
+  return bHandled;
 }
 
 void CAnalogStick::ProcessMotions(void)
@@ -319,7 +318,8 @@ bool CAccelerometer::OnDigitalMotion(const CDriverPrimitive& source, bool bPress
 
 bool CAccelerometer::OnAnalogMotion(const CDriverPrimitive& source, float magnitude)
 {
-  bool bHandled = false;
+  // Feature must accept input to be considered handled
+  bool bHandled = AcceptsInput(true);
 
   CDriverPrimitive positiveX;
   CDriverPrimitive positiveY;
@@ -330,17 +330,14 @@ bool CAccelerometer::OnAnalogMotion(const CDriverPrimitive& source, float magnit
   if (source == positiveX)
   {
     m_xAxis.SetPositiveDistance(magnitude);
-    bHandled = true;
   }
   else if (source == positiveY)
   {
     m_yAxis.SetPositiveDistance(magnitude);
-    bHandled = true;
   }
   else if (source == positiveZ)
   {
     m_zAxis.SetPositiveDistance(magnitude);
-    bHandled = true;
   }
   else
   {
@@ -350,7 +347,7 @@ bool CAccelerometer::OnAnalogMotion(const CDriverPrimitive& source, float magnit
     m_yAxis.Reset();
   }
 
-  return bHandled && AcceptsInput(true);
+  return bHandled;
 }
 
 void CAccelerometer::ProcessMotions(void)

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -21,7 +21,9 @@
 #include "PeripheralJoystick.h"
 #include "input/joysticks/keymaps/KeymapHandling.h"
 #include "input/joysticks/DeadzoneFilter.h"
+#include "input/joysticks/IDriverHandler.h"
 #include "input/joysticks/JoystickIDs.h"
+#include "input/joysticks/JoystickMonitor.h"
 #include "input/joysticks/JoystickTranslator.h"
 #include "input/joysticks/RumbleGenerator.h"
 #include "input/InputManager.h"
@@ -57,7 +59,8 @@ CPeripheralJoystick::CPeripheralJoystick(CPeripherals& manager, const Peripheral
 CPeripheralJoystick::~CPeripheralJoystick(void)
 {
   m_rumbleGenerator->AbortRumble();
-  UnregisterJoystickDriverHandler(&m_joystickMonitor);
+  UnregisterInputHandler(m_joystickMonitor.get());
+  m_joystickMonitor.reset();
   m_rumbleGenerator->AbortRumble();
   m_appInput.reset();
   m_deadzoneFilter.reset();
@@ -83,7 +86,8 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
 
         // Give joystick monitor priority over default controller
         m_appInput.reset(new CKeymapHandling(this, false, CServiceBroker::GetInputManager().KeymapEnvironment()));
-        RegisterJoystickDriverHandler(&m_joystickMonitor, false);
+        m_joystickMonitor.reset(new CJoystickMonitor);
+        RegisterInputHandler(m_joystickMonitor.get(), false);
       }
     }
     else if (feature == FEATURE_RUMBLE)

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -21,7 +21,6 @@
 
 #include "Peripheral.h"
 #include "input/joysticks/IDriverReceiver.h"
-#include "input/joysticks/JoystickMonitor.h"
 #include "input/joysticks/JoystickTypes.h"
 #include "threads/CriticalSection.h"
 
@@ -40,6 +39,7 @@ namespace JOYSTICK
   class CRumbleGenerator;
   class IButtonMap;
   class IDriverHandler;
+  class IInputHandler;
 }
 }
 
@@ -128,7 +128,7 @@ namespace PERIPHERALS
     bool                                m_supportsPowerOff;
     std::unique_ptr<KODI::JOYSTICK::CKeymapHandling> m_appInput;
     std::unique_ptr<KODI::JOYSTICK::CRumbleGenerator> m_rumbleGenerator;
-    KODI::JOYSTICK::CJoystickMonitor          m_joystickMonitor;
+    std::unique_ptr<KODI::JOYSTICK::IInputHandler> m_joystickMonitor;
     std::unique_ptr<KODI::JOYSTICK::IButtonMap>      m_buttonMap;
     std::unique_ptr<KODI::JOYSTICK::CDeadzoneFilter> m_deadzoneFilter;
     std::vector<DriverHandler>          m_driverHandlers;


### PR DESCRIPTION
Accelerometers interfere with the screensaver-waking monitor because both accelerometers and analog sticks are mapped to analog axes in the driver. To fix this, we make the monitor aware of input events for the default controller, which every hardware controller maps to. As long as accelerometers are not mapped to a button or analog stick, they should be harmless.

## Motivation and Context
Reported here (https://github.com/xbmc/peripheral.joystick/issues/124) and countless times on the forum.

## How Has This Been Tested?
Tested on Windows and RPi. No amount of shaking my PS4 controller could wake the screensaver.

Confirmed no regressions -  buttons, hats and analog sticks still wake the screen saver, and button and hat presses are absorbed so that the waking action has no GUI action.

## What bugs remain?
A minor bug still exists, analog sticks still have GUI actions starting after the frame after being woke. We should disable analog sticks until they return to rest again.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
