### PR TITLE
[cmake] git update-index should run in ${CMAKE_SOURCE_DIR} too

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -583,7 +583,8 @@ function(core_find_git_rev stamp)
   else()
     find_package(Git)
     if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
-      execute_process(COMMAND ${GIT_EXECUTABLE} update-index --ignore-submodules --refresh -q)
+      execute_process(COMMAND ${GIT_EXECUTABLE} update-index --ignore-submodules -q --refresh
+                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
       execute_process(COMMAND ${GIT_EXECUTABLE} diff-files --ignore-submodules --quiet --
                       RESULT_VARIABLE status_code
                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
`git update-index` should be forced to run in ${CMAKE_SOURCE_DIR} too

## Motivation and Context
If cmake is pointed to a build directory outside Kodi source tree update-index will fail (not fatal),
if Kodi is a part of larger project (submodule) and build dir is inside bigger git tree
`git update-index` will spam "$filename needs update" with files actually unrelated to Kodi.
This is mostly cosmetic.

## How Has This Been Tested?
Build test.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
