### PR TITLE
[Backport] Joysticks: Fix accelerometers preventing screensaver

### DIFF
--- a/xbmc/input/joysticks/JoystickMonitor.cpp
+++ b/xbmc/input/joysticks/JoystickMonitor.cpp
@@ -19,12 +19,28 @@
  */
 
 #include "JoystickMonitor.h"
+#include "DefaultJoystick.h"
 #include "Application.h"
 #include "input/InputManager.h"
 
+#include <cmath>
+
 using namespace JOYSTICK;
 
-bool CJoystickMonitor::OnButtonMotion(unsigned int buttonIndex, bool bPressed)
+#define AXIS_DEADZONE  0.05f
+
+std::string CJoystickMonitor::ControllerID() const
+{
+  return DEFAULT_CONTROLLER_ID;
+}
+
+bool CJoystickMonitor::AcceptsInput()
+{
+  // Only accept input when screen saver is active
+  return g_application.IsInScreenSaver();
+}
+
+bool CJoystickMonitor::OnButtonPress(const FeatureName& feature, bool bPressed)
 {
   if (bPressed)
   {
@@ -35,9 +51,9 @@ bool CJoystickMonitor::OnButtonMotion(unsigned int buttonIndex, bool bPressed)
   return false;
 }
 
-bool CJoystickMonitor::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
+bool CJoystickMonitor::OnButtonMotion(const FeatureName& feature, float magnitude)
 {
-  if (state != HAT_STATE::UNPRESSED)
+  if (std::fabs(magnitude) > AXIS_DEADZONE)
   {
     CInputManager::GetInstance().SetMouseActive(false);
     return ResetTimers();
@@ -46,9 +62,10 @@ bool CJoystickMonitor::OnHatMotion(unsigned int hatIndex, HAT_STATE state)
   return false;
 }
 
-bool CJoystickMonitor::OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range)
+bool CJoystickMonitor::OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs)
 {
-  if (position)
+  // Analog stick deadzone already processed
+  if (x != 0.0f || y != 0.0f)
   {
     CInputManager::GetInstance().SetMouseActive(false);
     return ResetTimers();

--- a/xbmc/input/joysticks/JoystickMonitor.h
+++ b/xbmc/input/joysticks/JoystickMonitor.h
@@ -19,7 +19,7 @@
  */
 #pragma once
 
-#include "IDriverHandler.h"
+#include "IInputHandler.h"
 
 namespace JOYSTICK
 {
@@ -28,14 +28,19 @@ namespace JOYSTICK
    * \brief Monitors joystick input and resets screensaver/shutdown timers
    *        whenever motion occurs.
    */
-  class CJoystickMonitor : public IDriverHandler
+  class CJoystickMonitor : public IInputHandler
   {
   public:
-    // implementation of IDriverHandler
-    virtual bool OnButtonMotion(unsigned int buttonIndex, bool bPressed) override;
-    virtual bool OnHatMotion(unsigned int hatIndex, HAT_STATE state) override;
-    virtual bool OnAxisMotion(unsigned int axisIndex, float position, int center, unsigned int range) override;
-    virtual void ProcessAxisMotions(void) override { }
+    // implementation of IInputHandler
+    virtual std::string ControllerID() const override;
+    virtual bool HasFeature(const FeatureName& feature) const override { return true; }
+    virtual bool AcceptsInput(void) override;
+    virtual INPUT_TYPE GetInputType(const FeatureName& feature) const override { return INPUT_TYPE::ANALOG; }
+    virtual bool OnButtonPress(const FeatureName& feature, bool bPressed) override;
+    virtual void OnButtonHold(const FeatureName& feature, unsigned int holdTimeMs) override { }
+    virtual bool OnButtonMotion(const FeatureName& feature, float magnitude) override;
+    virtual bool OnAnalogStickMotion(const FeatureName& feature, float x, float y, unsigned int motionTimeMs) override;
+    virtual bool OnAccelerometerMotion(const FeatureName& feature, float x, float y, float z) override { return false; }
 
   private:
     /*!

--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -51,10 +51,6 @@ bool CJoystickFeature::AcceptsInput(bool bActivation)
   {
     if (m_handler->AcceptsInput())
       bAcceptsInput = true;
-
-    // Avoid sticking
-    if (!bActivation)
-      bAcceptsInput = true;
   }
 
   return bAcceptsInput;

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -22,7 +22,6 @@
 #include "Peripheral.h"
 #include "input/joysticks/DefaultJoystick.h"
 #include "input/joysticks/IDriverReceiver.h"
-#include "input/joysticks/JoystickMonitor.h"
 #include "input/joysticks/JoystickTypes.h"
 #include "threads/CriticalSection.h"
 
@@ -37,6 +36,7 @@ namespace JOYSTICK
   class CDeadzoneFilter;
   class IButtonMap;
   class IDriverHandler;
+  class IInputHandler;
 }
 
 namespace PERIPHERALS
@@ -119,7 +119,7 @@ namespace PERIPHERALS
     unsigned int                        m_motorCount;
     bool                                m_supportsPowerOff;
     JOYSTICK::CDefaultJoystick          m_defaultInputHandler;
-    JOYSTICK::CJoystickMonitor          m_joystickMonitor;
+    std::unique_ptr<JOYSTICK::IInputHandler> m_joystickMonitor;
     std::unique_ptr<JOYSTICK::IButtonMap>      m_buttonMap;
     std::unique_ptr<JOYSTICK::CDeadzoneFilter> m_deadzoneFilter;
     std::vector<DriverHandler>          m_driverHandlers;


### PR DESCRIPTION
This is a backport of the first commit of #12892. The second commit only affects the newer keymap handling added in #12366.

Also included is a backport of #12179, which is needed after the #12892 backport.

## How Has This Been Tested?
No regressions with normal controller on OSX. Haven't tested with PS4 controller yet.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
