### PR TITLE
[cmake] adjust json-rpc build method

### DIFF
--- a/cmake/scripts/common/GenerateVersionedFiles.cmake
+++ b/cmake/scripts/common/GenerateVersionedFiles.cmake
@@ -11,14 +11,12 @@ function(generate_versioned_file _SRC _DEST)
   file(WRITE ${CMAKE_BINARY_DIR}/${_DEST} "${file_content}")
 endfunction()
 
+# workaround for xbmc.json
+file(STRINGS ${CORE_SOURCE_DIR}/xbmc/interfaces/json-rpc/schema/version.txt jsonrpc_version)
+
 # add-on xml's
 file(GLOB ADDON_XML_IN_FILE ${CORE_SOURCE_DIR}/addons/*/addon.xml.in)
 foreach(loop_var ${ADDON_XML_IN_FILE})
-  # prevent 'xbmc.json'; will be obtained from 'xbmc/interfaces/json-rpc/schema/CMakeLists.txt'.
-  if(loop_var MATCHES "xbmc.json")
-    continue()
-  endif()
-
   list(GET loop_var 0 xml_name)
 
   string(REPLACE "/addon.xml.in" "" source_dir ${xml_name})

--- a/xbmc/interfaces/json-rpc/schema/CMakeLists.txt
+++ b/xbmc/interfaces/json-rpc/schema/CMakeLists.txt
@@ -10,18 +10,8 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ServiceDescripti
                    DEPENDS ${JSON_SRCS}
                    COMMENT "Generating ServiceDescription.h")
 
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/addons/xbmc.json/addon.xml
-                   COMMAND ${CMAKE_COMMAND}
-                           -DCMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}
-                           -DCORE_BINARY_DIR=${CMAKE_BINARY_DIR}
-                           -P ${CMAKE_CURRENT_SOURCE_DIR}/GenerateAddonXml.cmake
-                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                   DEPENDS ${JSON_SRCS} ${CMAKE_SOURCE_DIR}/addons/xbmc.json/addon.xml.in
-                   COMMENT "Generating xbmc.json/addon.xml")
-
 add_custom_target(generate_json_header ALL
-                  DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ServiceDescription.h
-                          ${CMAKE_BINARY_DIR}/addons/xbmc.json/addon.xml)
+                  DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ServiceDescription.h)
 set_target_properties(generate_json_header PROPERTIES FOLDER "Build Utilities")
 
 if(BOOTSTRAP_IN_TREE)

--- a/xbmc/interfaces/json-rpc/schema/GenerateAddonXml.cmake
+++ b/xbmc/interfaces/json-rpc/schema/GenerateAddonXml.cmake
@@ -1,5 +1,0 @@
-file(STRINGS ${CMAKE_SOURCE_DIR}/xbmc/interfaces/json-rpc/schema/version.txt jsonrpc_version)
-
-execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${CORE_BINARY_DIR}/addons/xbmc.json/addon.xml)
-configure_file(${CMAKE_SOURCE_DIR}/addons/xbmc.json/addon.xml.in
-               ${CORE_BINARY_DIR}/addons/xbmc.json/addon.xml @ONLY)


### PR DESCRIPTION
This allows kodi to be built with ninja

ninja fails because cmake calls another instance of cmake without the `-GNinja` export command. So the addon.xml never gets generated because ninja doesn't know about it. Then the install of the addon.xml fails because it was never generated.

