### PR TITLE
[PVR] Handle addon enabled|disabled via CAddonMgr events. …

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -393,16 +393,6 @@ AddonVersion CAddon::GetDependencyVersion(const std::string &dependencyID) const
   return AddonVersion("0.0.0");
 }
 
-void OnEnabled(const AddonPtr& addon)
-{
-  addon->OnEnabled();
-}
-
-void OnDisabled(const AddonPtr& addon)
-{
-  addon->OnDisabled();
-}
-
 void OnPreInstall(const AddonPtr& addon)
 {
   //Fallback to the pre-install callback in the addon.

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -36,12 +36,10 @@ namespace ADDON
 
   const char* const ORIGIN_SYSTEM = "b6a50484-93a0-4afb-a01c-8d17e059feda";
 
-void OnEnabled(const AddonPtr& addon);
-void OnDisabled(const AddonPtr& addon);
-void OnPreInstall(const AddonPtr& addon);
-void OnPostInstall(const AddonPtr& addon, bool update, bool modal);
-void OnPreUnInstall(const AddonPtr& addon);
-void OnPostUnInstall(const AddonPtr& addon);
+  void OnPreInstall(const AddonPtr& addon);
+  void OnPostInstall(const AddonPtr& addon, bool update, bool modal);
+  void OnPreUnInstall(const AddonPtr& addon);
+  void OnPostUnInstall(const AddonPtr& addon);
 
 class CAddon : public IAddon
 {
@@ -193,16 +191,6 @@ public:
    */
   bool MeetsVersion(const AddonVersion &version) const override { return m_addonInfo.MeetsVersion(version); }
   bool ReloadSettings() override;
-
-  /*! \brief callback for when this add-on is disabled.
-   Use to perform any needed actions (e.g. stop a service)
-   */
-  void OnDisabled() override {};
-
-  /*! \brief callback for when this add-on is enabled.
-   Use to perform any needed actions (e.g. start a service)
-   */
-  void OnEnabled() override {};
 
   /*! \brief retrieve the running instance of an add-on if it persists while running.
    */

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -836,7 +836,6 @@ bool CAddonMgr::DisableAddon(const std::string& id)
   AddonPtr addon;
   if (GetAddon(id, addon, ADDON_UNKNOWN, false) && addon != NULL)
   {
-    ADDON::OnDisabled(addon);
     CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24141)));
   }
 
@@ -865,7 +864,6 @@ bool CAddonMgr::EnableSingle(const std::string& id)
   if (!m_database.DisableAddon(id, false))
     return false;
   m_disabled.erase(id);
-  ADDON::OnEnabled(addon);
 
   CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24064)));
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -89,8 +89,6 @@ namespace ADDON
     virtual AddonVersion GetDependencyVersion(const std::string &dependencyID) const =0;
     virtual bool MeetsVersion(const AddonVersion &version) const =0;
     virtual bool ReloadSettings() =0;
-    virtual void OnDisabled() =0;
-    virtual void OnEnabled() =0;
     virtual AddonPtr GetRunningInstance() const=0;
     virtual void OnPreInstall() =0;
     virtual void OnPostInstall(bool update, bool modal) =0;

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -69,18 +69,6 @@ CPVRClient::~CPVRClient(void)
   Destroy();
 }
 
-void CPVRClient::OnDisabled()
-{
-  CAddon::OnDisabled();
-  CServiceBroker::GetPVRManager().Clients()->UpdateAddons();
-}
-
-void CPVRClient::OnEnabled()
-{
-  CAddon::OnEnabled();
-  CServiceBroker::GetPVRManager().Clients()->UpdateAddons();
-}
-
 void CPVRClient::StopRunningInstance()
 {
   const ADDON::AddonPtr addon(GetRunningInstance());

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -211,8 +211,6 @@ namespace PVR
     explicit CPVRClient(ADDON::CAddonInfo addonInfo);
     ~CPVRClient(void) override;
 
-    void OnDisabled() override;
-    void OnEnabled() override;
     void OnPreInstall() override;
     void OnPostInstall(bool update, bool modal) override;
     void OnPreUnInstall() override;

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -57,6 +57,7 @@ CPVRClients::CPVRClients(void) :
 
 CPVRClients::~CPVRClients(void)
 {
+  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
   CServiceBroker::GetAddonMgr().UnregisterAddonMgrCallback(ADDON_PVRDLL);
   Unload();
 }
@@ -64,7 +65,7 @@ CPVRClients::~CPVRClients(void)
 void CPVRClients::Start(void)
 {
   CServiceBroker::GetAddonMgr().RegisterAddonMgrCallback(ADDON_PVRDLL, this);
-
+  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CPVRClients::OnAddonEvent);
   UpdateAddons();
 }
 
@@ -1457,4 +1458,13 @@ void CPVRClients::OnPowerSavingDeactivated()
   /* propagate event to each client */
   for (auto &client : clients)
     client.second->OnPowerSavingDeactivated();
+}
+
+void CPVRClients::OnAddonEvent(const AddonEvent& event)
+{
+  if (typeid(event) == typeid(AddonEvents::Enabled) ||
+      typeid(event) == typeid(AddonEvents::Disabled))
+  {
+    UpdateAddons();
+  }
 }

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -30,6 +30,11 @@
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/recordings/PVRRecording.h"
 
+namespace ADDON
+{
+  struct AddonEvent;
+}
+
 namespace PVR
 {
   class CPVREpg;
@@ -705,6 +710,12 @@ namespace PVR
     void OnSystemWake();
     void OnPowerSavingActivated();
     void OnPowerSavingDeactivated();
+
+    /*!
+     * @brief Handle addon events (enable, disable, ...).
+     * @param event The addon event.
+     */
+    void OnAddonEvent(const ADDON::AddonEvent& event);
 
   private:
     /*!


### PR DESCRIPTION
Fixes a shitload of different deadlocks while enabling and disabling PVR addons using the addon information dialog. I have dozens of such  #stack traces on my hard disk. Calling CPVRManager::Stop (which has to wait for his worker thread to exit) from the 'main thread' or another thread with many frames and lots of different instances involved never can work reliably! ;-)

Example (one out of many):
<pre>
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fff78157e7e libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x0000000107e106b2 libsystem_pthread.dylib`_pthread_cond_wait + 732
    frame #2: 0x00000001001fc697 kodi.bin`XbmcThreads::ConditionVariable::wait(this=0x00000001090c6b58, lock=0x00000001090c6b98, milliseconds=4294967295) at Condition.h:84
    frame #3: 0x00000001001fc4d6 kodi.bin`bool XbmcThreads::TightConditionVariable<bool volatile&>::wait<CCriticalSection>(this=0x00000001090c6b88, lock=0x00000001090c6b98, milliseconds=4294967295) at Condition.h:65
    frame #4: 0x00000001001cb3e4 kodi.bin`CEvent::WaitMSec(this=0x00000001090c6b00, milliSeconds=4294967295) at Event.h:88
    frame #5: 0x0000000101cfe832 kodi.bin`CThread::WaitForThreadExit(this=0x00000001090c6a00, milliseconds=4294967295) at ThreadImpl.cpp:217
    frame #6: 0x0000000101d00156 kodi.bin`CThread::StopThread(this=0x00000001090c6a00, bWait=true) at Thread.cpp:167
    frame #7: 0x0000000101915de6 kodi.bin`PVR::CPVRManager::Stop(this=0x00000001090c6a00) at PVRManager.cpp:327
    frame #8: 0x0000000101915ae9 kodi.bin`PVR::CPVRManager::Start(this=0x00000001090c6a00) at PVRManager.cpp:281
    frame #9: 0x000000010192bb9a kodi.bin`PVR::CPVRClients::UpdateAddons(this=0x0000000108880dd0) at PVRClients.cpp:1092
    frame #10: 0x000000010055dcb7 kodi.bin`PVR::CPVRClient::OnEnabled(this=0x000000012ca4c218) at PVRClient.cpp:81
    frame #11: 0x0000000100461124 kodi.bin`ADDON::OnEnabled(addon=std::__1::shared_ptr<ADDON::IAddon>::element_type @ 0x000000012ca4c218 strong=1 weak=2) at Addon.cpp:398
    frame #12: 0x00000001004dfa1d kodi.bin`ADDON::CAddonMgr::EnableSingle(this=0x0000000107f63ca0, id="pvr.hts") at AddonManager.cpp:868
    frame #13: 0x00000001004dd87d kodi.bin`ADDON::CAddonMgr::EnableAddon(this=0x0000000107f63ca0, id="pvr.hts") at AddonManager.cpp:888
    frame #14: 0x000000010051f7d3 kodi.bin`CGUIDialogAddonInfo::OnEnableDisable(this=0x000000010b145200) at GUIDialogAddonInfo.cpp:471
    frame #15: 0x000000010051b865 kodi.bin`CGUIDialogAddonInfo::OnMessage(this=0x000000010b145200, message=0x00007ffeefbf5698) at GUIDialogAddonInfo.cpp:115
    frame #16: 0x0000000100da8b8b kodi.bin`CGUIControl::SendWindowMessage(this=0x00000001092f8c00, message=0x00007ffeefbf5698) const at GUIControl.cpp:310
    frame #17: 0x0000000100da0bef kodi.bin`CGUIButtonControl::OnClick(this=0x00000001092f8c00) at GUIButtonControl.cpp:359
    frame #18: 0x0000000100d9f37a kodi.bin`CGUIButtonControl::OnAction(this=0x00000001092f8c00, action=0x00007ffeefbf7880) at GUIButtonControl.cpp:184
    frame #19: 0x0000000100e9d67d kodi.bin`CGUIRadioButtonControl::OnAction(this=0x00000001092f8c00, action=0x00007ffeefbf7880) at GUIRadioButtonControl.cpp:112
    frame #20: 0x0000000100eeedc9 kodi.bin`CGUIWindow::OnAction(this=0x000000010b145200, action=0x00007ffeefbf7880) at GUIWindow.cpp:441
    frame #21: 0x0000000100ddfd6c kodi.bin`CGUIDialog::OnAction(this=0x000000010b145200, action=0x00007ffeefbf7880) at GUIDialog.cpp:93
    frame #22: 0x0000000100522301 kodi.bin`CGUIDialogAddonInfo::OnAction(this=0x000000010b145200, action=0x00007ffeefbf7880) at GUIDialogAddonInfo.cpp:161
    frame #23: 0x0000000100f07543 kodi.bin`CGUIWindowManager::HandleAction(this=0x0000000108c01880, action=0x00007ffeefbf7880) const at GUIWindowManager.cpp:1059
    frame #24: 0x0000000100f0737b kodi.bin`CGUIWindowManager::OnAction(this=0x0000000108c01880, action=0x00007ffeefbf7880) const at GUIWindowManager.cpp:1028
    frame #25: 0x00000001001b9320 kodi.bin`CApplication::OnAction(this=0x000000010b000600, action=0x00007ffeefbf7880) at Application.cpp:2007
    frame #26: 0x000000010101d46c kodi.bin`CInputManager::ExecuteInputAction(this=0x00000001088856b0, action=0x00007ffeefbf7880) at InputManager.cpp:719
    frame #27: 0x000000010101b79c kodi.bin`CInputManager::OnKey(this=0x00000001088856b0, key=0x00007ffeefbf80e0) at InputManager.cpp:668
    frame #28: 0x000000010101ea69 kodi.bin`CInputManager::OnEvent(this=0x00000001088856b0, newEvent=0x00007ffeefbf8808) at InputManager.cpp:425
    frame #29: 0x00000001001b8624 kodi.bin`CApplication::OnEvent(newEvent=0x00007ffeefbf8808) at Application.cpp:345
    frame #30: 0x00000001022e5c49 kodi.bin`CWinEventsSDL::MessagePump(this=0x0000000104c17fc0) at WinEventsSDL.cpp:103
    frame #31: 0x00000001022dabd5 kodi.bin`CWinEvents::MessagePump() at WinEvents.cpp:71
    frame #32: 0x00000001001e609b kodi.bin`CApplication::FrameMove(this=0x000000010b000600, processEvents=true, processGUI=true) at Application.cpp:2692
    frame #33: 0x0000000100f09f27 kodi.bin`CGUIWindowManager::ProcessRenderLoop(this=0x0000000108c01880, renderOnly=false) at GUIWindowManager.cpp:1288
    frame #34: 0x0000000100de0891 kodi.bin`CGUIDialog::Open_Internal(this=0x000000010b145200, bProcessRenderLoop=true, param="") at GUIDialog.cpp:211
    frame #35: 0x0000000100de0611 kodi.bin`CGUIDialog::Open_Internal(this=0x000000010b145200, param="") at GUIDialog.cpp:176
    frame #36: 0x0000000100de05ad kodi.bin`CGUIDialog::Open(this=0x000000010b145200, param="") at GUIDialog.cpp:225
    frame #37: 0x0000000100526c7d kodi.bin`CGUIDialogAddonInfo::ShowForItem(item=std::__1::shared_ptr<CFileItem>::element_type @ 0x000000012a7690c0 strong=6 weak=1) at GUIDialogAddonInfo.cpp:564
    frame #38: 0x000000010053e972 kodi.bin`CGUIWindowAddonBrowser::OnClick(this=0x000000010b141000, iItem=4, player="") at GUIWindowAddonBrowser.cpp:229
    frame #39: 0x000000010230a36c kodi.bin`CGUIMediaWindow::OnSelect(this=0x000000010b141000, item=4) at GUIMediaWindow.cpp:1105
    frame #40: 0x00000001022f7c93 kodi.bin`CGUIMediaWindow::OnMessage(this=0x000000010b141000, message=0x00007ffeefbfb038) at GUIMediaWindow.cpp:289
    frame #41: 0x000000010053ac14 kodi.bin`CGUIWindowAddonBrowser::OnMessage(this=0x000000010b141000, message=0x00007ffeefbfb038) at GUIWindowAddonBrowser.cpp:153
    frame #42: 0x0000000100da8b8b kodi.bin`CGUIControl::SendWindowMessage(this=0x0000000127cd9e70, message=0x00007ffeefbfb038) const at GUIControl.cpp:310
    frame #43: 0x0000000100d8dc1f kodi.bin`CGUIBaseContainer::OnClick(this=0x0000000127cd9e70, actionID=7) at GUIBaseContainer.cpp:789
    frame #44: 0x0000000100d8c484 kodi.bin`CGUIBaseContainer::OnAction(this=0x0000000127cd9e70, action=0x00007ffeefbfd690) at GUIBaseContainer.cpp:403
    frame #45: 0x0000000100df3a9c kodi.bin`CGUIFixedListContainer::OnAction(this=0x0000000127cd9e70, action=0x00007ffeefbfd690) at GUIFixedListContainer.cpp:80
    frame #46: 0x0000000100eeedc9 kodi.bin`CGUIWindow::OnAction(this=0x000000010b141000, action=0x00007ffeefbfd690) at GUIWindow.cpp:441
    frame #47: 0x00000001022f6a4f kodi.bin`CGUIMediaWindow::OnAction(this=0x000000010b141000, action=0x00007ffeefbfd690) at GUIMediaWindow.cpp:172
    frame #48: 0x0000000100f076d5 kodi.bin`CGUIWindowManager::HandleAction(this=0x0000000108c01880, action=0x00007ffeefbfd690) const at GUIWindowManager.cpp:1078
    frame #49: 0x0000000100f0737b kodi.bin`CGUIWindowManager::OnAction(this=0x0000000108c01880, action=0x00007ffeefbfd690) const at GUIWindowManager.cpp:1028
    frame #50: 0x00000001001b9320 kodi.bin`CApplication::OnAction(this=0x000000010b000600, action=0x00007ffeefbfd690) at Application.cpp:2007
    frame #51: 0x000000010101d46c kodi.bin`CInputManager::ExecuteInputAction(this=0x00000001088856b0, action=0x00007ffeefbfd690) at InputManager.cpp:719
    frame #52: 0x000000010101b79c kodi.bin`CInputManager::OnKey(this=0x00000001088856b0, key=0x00007ffeefbfdef0) at InputManager.cpp:668
    frame #53: 0x000000010101ea69 kodi.bin`CInputManager::OnEvent(this=0x00000001088856b0, newEvent=0x00007ffeefbfe618) at InputManager.cpp:425
    frame #54: 0x00000001001b8624 kodi.bin`CApplication::OnEvent(newEvent=0x00007ffeefbfe618) at Application.cpp:345
    frame #55: 0x00000001022e5c49 kodi.bin`CWinEventsSDL::MessagePump(this=0x0000000104c17fc0) at WinEventsSDL.cpp:103
    frame #56: 0x00000001022dabd5 kodi.bin`CWinEvents::MessagePump() at WinEvents.cpp:71
    frame #57: 0x00000001001e609b kodi.bin`CApplication::FrameMove(this=0x000000010b000600, processEvents=true, processGUI=true) at Application.cpp:2692
    frame #58: 0x0000000100441b26 kodi.bin`CXBApplicationEx::Run(this=0x000000010b000600, params=0x00007ffeefbfebb8) at XBApplicationEx.cpp:116
    frame #59: 0x00000001017ec809 kodi.bin`::XBMC_Run(renderGUI=true, params=0x00007ffeefbfebb8) at xbmc.cpp:88
    frame #60: 0x000000010000ab9a kodi.bin`::SDL_main(argc=1, argv=0x0000000108c05700) at main.cpp:115
    frame #61: 0x0000000100009e19 kodi.bin`main(argc=1, argv=0x00007ffeefbfefe8) at SDLMain.mm:571
    frame #62: 0x00007fff78008145 libdyld.dylib`start + 1
    frame #63: 0x00007fff78008145 libdyld.dylib`start + 1

  thread #48
    frame #0: 0x00007fff78157eae libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000107e0fc16 libsystem_pthread.dylib`_pthread_mutex_lock_wait + 102
    frame #2: 0x0000000107e0d427 libsystem_pthread.dylib`_pthread_mutex_lock_slow + 254
    frame #3: 0x00000001000eeaf5 kodi.bin`XbmcThreads::pthreads::RecursiveMutex::lock(this=0x0000000107f63d00) at CriticalSection.h:49
    frame #4: 0x00000001000eeac9 kodi.bin`XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex>::lock(this=0x0000000107f63d00) at Lockables.h:60
    frame #5: 0x00000001000eeaaa kodi.bin`XbmcThreads::UniqueLock<CCriticalSection>::UniqueLock(this=0x00007000043e66c0, lockable=0x0000000107f63d00) at Lockables.h:127
    frame #6: 0x00000001000eea78 kodi.bin`CSingleLock::CSingleLock(this=0x00007000043e66c0, cs=0x0000000107f63d00) at SingleLock.h:38
    frame #7: 0x00000001000eea1d kodi.bin`CSingleLock::CSingleLock(this=0x00007000043e66c0, cs=0x0000000107f63d00) at SingleLock.h:38
    frame #8: 0x00000001004db56e kodi.bin`ADDON::CAddonMgr::IsAddonDisabled(this=0x0000000107f63ca0, ID="pvr.hts") at AddonManager.cpp:895
    frame #9: 0x000000010192e82c kodi.bin`PVR::CPVRClients::EnabledClientAmount(this=0x0000000108880dd0) const at PVRClients.cpp:182
    frame #10: 0x00000001019576f2 kodi.bin`PVR::CPVRChannelGroup::Renumber(this=0x00000001276a9140) at PVRChannelGroup.cpp:877
    frame #11: 0x000000010195515c kodi.bin`PVR::CPVRChannelGroup::SortAndRenumber(this=0x00000001276a9140) at PVRChannelGroup.cpp:373
    frame #12: 0x0000000101977622 kodi.bin`PVR::CPVRChannelGroupInternal::AddAndUpdateChannels(this=0x00000001276a9140, channels=0x00007000043e7340, bUseBackendChannelNumbers=true) at PVRChannelGroupInternal.cpp:280
    frame #13: 0x00000001019618a8 kodi.bin`PVR::CPVRChannelGroup::UpdateGroupEntries(this=0x00000001276a9140, channels=0x00007000043e7340) at PVRChannelGroup.cpp:716
    frame #14: 0x00000001019776ab kodi.bin`PVR::CPVRChannelGroupInternal::UpdateGroupEntries(this=0x00000001276a9140, channels=0x00007000043e7340) at PVRChannelGroupInternal.cpp:289
    frame #15: 0x0000000101975c5e kodi.bin`PVR::CPVRChannelGroupInternal::Update(this=0x00000001276a9140) at PVRChannelGroupInternal.cpp:127
    frame #16: 0x0000000101954eae kodi.bin`PVR::CPVRChannelGroup::Load(this=0x00000001276a9140) at PVRChannelGroup.cpp:161
    frame #17: 0x000000010197433f kodi.bin`PVR::CPVRChannelGroupInternal::Load(this=0x00000001276a9140) at PVRChannelGroupInternal.cpp:64
    frame #18: 0x0000000101980ef8 kodi.bin`PVR::CPVRChannelGroups::Load(this=0x000000011526aab0) at PVRChannelGroups.cpp:307
    frame #19: 0x000000010198b476 kodi.bin`PVR::CPVRChannelGroupsContainer::Load(this=0x000000011524b920) at PVRChannelGroupsContainer.cpp:70
    frame #20: 0x0000000101917108 kodi.bin`PVR::CPVRManager::LoadComponents(this=0x00000001090c6a00, bShowProgress=true) at PVRManager.cpp:555
    frame #21: 0x0000000101916c62 kodi.bin`PVR::CPVRManager::Process(this=0x00000001090c6a00) at PVRManager.cpp:423
    frame #22: 0x0000000101cffb90 kodi.bin`CThread::Action(this=0x00000001090c6a00) at Thread.cpp:221
    frame #23: 0x0000000101cfe1d9 kodi.bin`CThread::staticThread(data=0x00000001090c6a00) at Thread.cpp:131
    frame #24: 0x0000000107e0f6c9 libsystem_pthread.dylib`_pthread_body + 340
    frame #25: 0x0000000107e0f575 libsystem_pthread.dylib`_pthread_start + 377
    frame #26: 0x0000000107e0ec65 libsystem_pthread.dylib`thread_start + 13
</pre>

This has been runtime tested on macOS, latest kodi master.

Please note that this only handles 'enable' and 'disable' addon use cases as I see these cases as non problematic (compared to 'update' and 'uninstall', where shared library unloading  comes into play). Maybe the latter is even possible to change toi addon manager events, but I want to make small steps here. Let's discuss this outside of this PR, please.

Also, this change cleans up the code a bit as `CPVRClient` having to know about `CPVRClients` (its container) is imo bad design.  This PR removes two code places with this architectural flaw.

@tamland, @AlwinEsch your review comments are welcome.

@tamland yeah, you were right with your comment in the other PR. That was simple. ;-) 