### PR TITLE
[PVR] Make EPG database threadsafe.

### DIFF
--- a/xbmc/pvr/PVRTypes.h
+++ b/xbmc/pvr/PVRTypes.h
@@ -26,6 +26,9 @@ namespace PVR
   class CPVRDatabase;
   typedef std::shared_ptr<CPVRDatabase> CPVRDatabasePtr;
 
+  class CPVREpgDatabase;
+  typedef std::shared_ptr<CPVREpgDatabase> CPVREpgDatabasePtr;
+
   class CPVRChannel;
   typedef std::shared_ptr<CPVRChannel> CPVRChannelPtr;
 

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -320,9 +320,9 @@ void CPVREpg::AddEntry(const CPVREpgInfoTag &tag)
 bool CPVREpg::Load(void)
 {
   bool bReturn(false);
-  CPVREpgDatabase *database = CServiceBroker::GetPVRManager().EpgContainer().GetDatabase();
+  CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
 
-  if (!database || !database->IsOpen())
+  if (!database)
   {
     CLog::Log(LOGERROR, "EPG - %s - could not open the database", __FUNCTION__);
     return bReturn;
@@ -380,31 +380,25 @@ bool CPVREpg::UpdateEntries(const CPVREpg &epg, bool bStoreInDb /* = true */)
 
 CDateTime CPVREpg::GetLastScanTime(void)
 {
+  bool bIgnore = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT);
+  CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
+
   CDateTime lastScanTime;
   {
     CSingleLock lock(m_critSection);
 
     if (!m_lastScanTime.IsValid())
     {
-      if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_EPG_IGNOREDBFORCLIENT))
-      {
-        CPVREpgDatabase *database = CServiceBroker::GetPVRManager().EpgContainer().GetDatabase();
-        CDateTime dtReturn; dtReturn.SetValid(false);
-
-        if (database && database->IsOpen())
-          database->GetLastEpgScanTime(m_iEpgID, &m_lastScanTime);
-      }
+      if (!bIgnore && database)
+        database->GetLastEpgScanTime(m_iEpgID, &m_lastScanTime);
 
       if (!m_lastScanTime.IsValid())
-      {
         m_lastScanTime.SetDateTime(1970, 1, 1, 0, 0, 0);
-        assert(m_lastScanTime.IsValid());
-      }
     }
     lastScanTime = m_lastScanTime;
   }
 
-  return m_lastScanTime;
+  return lastScanTime;
 }
 
 bool CPVREpg::UpdateEntry(const EPG_TAG *data, int iClientId, bool bUpdateDatabase)
@@ -600,12 +594,14 @@ bool CPVREpg::Persist(void)
   CLog::Log(LOGDEBUG, "persist table '%s' (#%d) changed=%d deleted=%d", Name().c_str(), m_iEpgID, m_changedTags.size(), m_deletedTags.size());
 #endif
 
-  CPVREpgDatabase *database = CServiceBroker::GetPVRManager().EpgContainer().GetDatabase();
-  if (!database || !database->IsOpen())
+  CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
+  if (!database)
   {
     CLog::Log(LOGERROR, "EPG - %s - could not open the database", __FUNCTION__);
     return false;
   }
+
+  database->Lock();
 
   {
     CSingleLock lock(m_critSection);
@@ -632,7 +628,10 @@ bool CPVREpg::Persist(void)
     m_bUpdateLastScanTime = false;
   }
 
-  return database->CommitInsertQueries();
+  bool bRet = database->CommitInsertQueries();
+
+  database->Unlock();
+  return bRet;
 }
 
 CDateTime CPVREpg::GetFirstDate(void) const

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -27,6 +27,7 @@
 #include "utils/Observer.h"
 
 #include "pvr/PVRSettings.h"
+#include "pvr/PVRTypes.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgDatabase.h"
 
@@ -56,7 +57,7 @@ namespace PVR
      * @brief Get a pointer to the database instance.
      * @return A pointer to the database instance.
      */
-    CPVREpgDatabase *GetDatabase(void) { return &m_database; }
+    CPVREpgDatabasePtr GetEpgDatabase() const;
 
     /*!
      * @brief Start the EPG update thread.
@@ -255,7 +256,7 @@ namespace PVR
 
     void InsertFromDatabase(int iEpgID, const std::string &strName, const std::string &strScraperName);
 
-    CPVREpgDatabase m_database; /*!< the EPG database */
+    CPVREpgDatabasePtr m_database; /*!< the EPG database */
 
     /** @name Class state properties */
     //@{

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -21,6 +21,7 @@
 
 #include "XBDateTime.h"
 #include "dbwrappers/Database.h"
+#include "threads/CriticalSection.h"
 
 #include "pvr/epg/Epg.h"
 
@@ -48,7 +49,22 @@ namespace PVR
      * @brief Open the database.
      * @return True if it was opened successfully, false otherwise.
      */
-    bool Open(void) override;
+    bool Open() override;
+
+    /*!
+     * @brief Close the database.
+     */
+    void Close() override;
+
+    /*!
+     * @brief Lock the database.
+     */
+    void Lock();
+
+    /*!
+     * @brief Unlock the database.
+     */
+    void Unlock();
 
     /*!
      * @brief Get the minimal database version that is required to operate correctly.
@@ -122,8 +138,6 @@ namespace PVR
      */
     bool PersistLastEpgScanTime(int iEpgId = 0, bool bQueueWrite = false);
 
-    bool Persist(const EPGMAP &epgs);
-
     /*!
      * @brief Persist an EPG table. It's entries are not persisted.
      * @param epg The table to persist.
@@ -147,7 +161,7 @@ namespace PVR
 
     //@}
 
-  protected:
+  private:
     /*!
      * @brief Create the EPG database tables.
      */
@@ -165,5 +179,7 @@ namespace PVR
     void UpdateTables(int version) override;
 
     int GetMinSchemaVersion() const override { return 4; }
+
+    CCriticalSection m_critSection;
   };
 }

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -687,8 +687,8 @@ bool CPVREpgInfoTag::Persist(bool bSingleUpdate /* = true */)
   CLog::Log(LOGDEBUG, "Epg - %s - Infotag '%s' %s, persisting...", __FUNCTION__, m_strTitle.c_str(), m_iBroadcastId > 0 ? "has changes" : "is new");
 #endif
 
-  CPVREpgDatabase *database = CServiceBroker::GetPVRManager().EpgContainer().GetDatabase();
-  if (!database || (bSingleUpdate && !database->IsOpen()))
+  CPVREpgDatabasePtr database = CServiceBroker::GetPVRManager().EpgContainer().GetEpgDatabase();
+  if (!database)
   {
     CLog::Log(LOGERROR, "%s - could not open the database", __FUNCTION__);
     return bReturn;


### PR DESCRIPTION
class `CPVREpgDatabase` had no concurrency protection features but is accessed simultaneously from multiple threads. :-/ This PR introduces basic concurrency support for `CPVREpgDatabase`.

Example:
<pre>
  thread #17, stop reason = EXC_BAD_ACCESS (code=1, address=0x210a05d7e0)
    frame #0: 0x0000000100a23025 kodi.bin`dbiplus::Dataset::get_field_value(this=0x0000000117ff1720, f_name="iFirstAired") at dataset.cpp:386
    frame #1: 0x00000001013a6b49 kodi.bin`dbiplus::Dataset::fv(this=0x0000000117ff1720, f="iFirstAired") at dataset.h:392
    frame #2: 0x0000000101a3e95f kodi.bin`PVR::CPVREpgDatabase::Get(this=0x000000010a86c7c8, epg=0x0000000128246c10) at EpgDatabase.cpp:231
    frame #3: 0x0000000101a197f1 kodi.bin`PVR::CPVREpg::Load(this=0x0000000128246c10) at Epg.cpp:332
    frame #4: 0x0000000101a2a730 kodi.bin`PVR::CPVREpgContainer::LoadFromDB(this=0x000000010a86c410) at EpgContainer.cpp:327
    frame #5: 0x0000000101a29daa kodi.bin`PVR::CPVREpgContainer::Start(this=0x000000010a86c410, bAsync=false) at EpgContainer.cpp:245
    frame #6: 0x0000000101a35283 kodi.bin`PVR::CPVREpgContainerStartJob::DoWork(this=0x0000000117fee8d0) at EpgContainer.cpp:215
    frame #7: 0x0000000101dc05ef kodi.bin`CJobWorker::Process(this=0x0000000107fbbf50) at JobManager.cpp:69
    frame #8: 0x0000000101d023c0 kodi.bin`CThread::Action(this=0x0000000107fbbf50) at Thread.cpp:221
    frame #9: 0x0000000101d00a09 kodi.bin`CThread::staticThread(data=0x0000000107fbbf50) at Thread.cpp:131
    frame #10: 0x0000000107e156c9 libsystem_pthread.dylib`_pthread_body + 340
    frame #11: 0x0000000107e15575 libsystem_pthread.dylib`_pthread_start + 377
    frame #12: 0x0000000107e14c65 libsystem_pthread.dylib`thread_start + 13

* thread #20
    frame #0: 0x00007fff781c76b2 libsystem_malloc.dylib`tiny_free_no_lock + 404
    frame #1: 0x00007fff781c8254 libsystem_malloc.dylib`free_tiny + 628
    frame #2: 0x0000000100a44929 kodi.bin`dbiplus::field_value::~field_value(this=0x00000001081926f0) at qry_dat.cpp:164
    frame #3: 0x0000000100a44945 kodi.bin`dbiplus::field_value::~field_value(this=0x00000001081926f0) at qry_dat.cpp:164
    frame #4: 0x0000000100a27d8e kodi.bin`std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~__vector_base() [inlined] std::__1::allocator<dbiplus::field_value>::destroy(this=0x000000012a446dc0, __p=0x00000001081926f0) at memory:1807
    frame #5: 0x0000000100a27d85 kodi.bin`std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~__vector_base() [inlined] void std::__1::allocator_traits<std::__1::allocator<dbiplus::field_value> >::__destroy<dbiplus::field_value>(__a=0x000000012a446dc0, __p=0x00000001081926f0) at memory:1680
    frame #6: 0x0000000100a27d6f kodi.bin`std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~__vector_base() [inlined] void std::__1::allocator_traits<std::__1::allocator<dbiplus::field_value> >::destroy<dbiplus::field_value>(__a=0x000000012a446dc0, __p=0x00000001081926f0) at memory:1548
    frame #7: 0x0000000100a27d53 kodi.bin`std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~__vector_base() [inlined] std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::__destruct_at_end(this=0x000000012a446db0, __new_last=0x0000000108192600) at vector:425
    frame #8: 0x0000000100a27cde kodi.bin`std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~__vector_base() [inlined] std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::clear(this=0x000000012a446db0) at vector:369
    frame #9: 0x0000000100a27cbf kodi.bin`std::__1::__vector_base<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~__vector_base(this=0x000000012a446db0) at vector:452
    frame #10: 0x0000000100a27c75 kodi.bin`std::__1::vector<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~vector(this=0x000000012a446db0 size=5) at vector:458
    frame #11: 0x0000000100a27c55 kodi.bin`std::__1::vector<dbiplus::field_value, std::__1::allocator<dbiplus::field_value> >::~vector(this=0x000000012a446db0 size=5) at vector:458
    frame #12: 0x0000000100a27952 kodi.bin`dbiplus::result_set::clear(this=0x0000000117ff1748) at qry_dat.h:235
    frame #13: 0x0000000100a515be kodi.bin`dbiplus::SqliteDataset::close(this=0x0000000117ff1720) at sqlitedataset.cpp:720
    frame #14: 0x0000000100a065b1 kodi.bin`CDatabase::Close(this=0x000000010a86c7c8) at Database.cpp:534
  * frame #15: 0x0000000101a29354 kodi.bin`PVR::CPVREpgContainer::Stop(this=0x000000010a86c410) at EpgContainer.cpp:274
    frame #16: 0x0000000101915f51 kodi.bin`PVR::CPVRManager::Stop(this=0x000000010a86c000) at PVRManager.cpp:320
    frame #17: 0x0000000101915ca9 kodi.bin`PVR::CPVRManager::Start(this=0x000000010a86c000) at PVRManager.cpp:281
    frame #18: 0x000000010192cf5a kodi.bin`PVR::CPVRClients::UpdateAddons(this=0x0000000109888730) at PVRClients.cpp:1093
    frame #19: 0x000000010192b56d kodi.bin`PVR::CPVRClients::Start(this=0x0000000109888730) at PVRClients.cpp:69
    frame #20: 0x000000010190f422 kodi.bin`PVR::CPVRStartupJob::DoWork(this=0x000000011753a280) at PVRJobs.cpp:130
    frame #21: 0x0000000101dc05ef kodi.bin`CJobWorker::Process(this=0x0000000117d8e6f0) at JobManager.cpp:69
    frame #22: 0x0000000101d023c0 kodi.bin`CThread::Action(this=0x0000000117d8e6f0) at Thread.cpp:221
    frame #23: 0x0000000101d00a09 kodi.bin`CThread::staticThread(data=0x0000000117d8e6f0) at Thread.cpp:131
    frame #24: 0x0000000107e156c9 libsystem_pthread.dylib`_pthread_body + 340
    frame #25: 0x0000000107e15575 libsystem_pthread.dylib`_pthread_start + 377
    frame #26: 0x0000000107e14c65 libsystem_pthread.dylib`thread_start + 13
</pre>

This should fix several occasional crashes reported in the forum and elsewhere.

I runtime-tested this change on macOS, latest Kodi master.

@Jalle19 for review?