### PR TITLE
RetroPlayer: Fix black screen on OpenGL

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -139,16 +139,16 @@ int CRenderContext::GUIShaderGetUniCol()
   return -1;
 }
 
-#if defined(HAS_DX)
 CGUIShaderDX* CRenderContext::GetGUIShader()
 {
+#if defined(HAS_DX)
   CRenderSystemDX *renderingDX = dynamic_cast<CRenderSystemDX*>(m_rendering);
   if (renderingDX != nullptr)
     return renderingDX->GetGUIShader();
+#endif
 
   return nullptr;
 }
-#endif
 
 bool CRenderContext::UseLimitedColor()
 {

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -24,6 +24,13 @@
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "windowing/WindowingFactory.h"
+#include "system_gl.h"
+
+#if defined(HAS_GL)
+#include "rendering/gl/RenderSystemGL.h"
+#elif HAS_GLES >= 2
+#include "rendering/gles/RenderSystemGLES.h"
+#endif
 
 using namespace KODI;
 using namespace RETRO;
@@ -61,48 +68,76 @@ void CRenderContext::ApplyStateBlock()
   m_rendering->ApplyStateBlock();
 }
 
-#if HAS_GLES >= 2
-void CRenderContext::EnableGUIShader(ESHADERMETHOD method)
+void CRenderContext::EnableGUIShader()
 {
+#if defined(HAS_GL)
+  CRenderSystemGL *rendering = dynamic_cast<CRenderSystemGL*>(m_rendering);
+  if (rendering != nullptr)
+    rendering->EnableShader(SM_TEXTURE);
+#elif HAS_GLES >= 2
   CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
   if (renderingGLES != nullptr)
-    renderingGLES->EnableGUIShader(method);
+    renderingGLES->EnableGUIShader(SM_TEXTURE);
+#endif
 }
 
 void CRenderContext::DisableGUIShader()
 {
+#if defined(HAS_GL)
+  CRenderSystemGL *renderingGL = dynamic_cast<CRenderSystemGL*>(m_rendering);
+  if (renderingGL != nullptr)
+    renderingGL->DisableShader();
+#elif HAS_GLES >= 2
   CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
   if (renderingGLES != nullptr)
     renderingGLES->DisableGUIShader();
-}
-
-GLint CRenderContext::GUIShaderGetPos()
-{
-  CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
-  if (renderingGLES != nullptr)
-    return renderingGLES->GUIShaderGetPos();
-
-  return -1;
-}
-
-GLint CRenderContext::GUIShaderGetCoord0()
-{
-  CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
-  if (renderingGLES != nullptr)
-    return renderingGLES->GUIShaderGetCoord0();
-
-  return -1;
-}
-
-GLint CRenderContext::GUIShaderGetUniCol()
-{
-  CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
-  if (renderingGLES != nullptr)
-    return renderingGLES->GUIShaderGetUniCol();
-
-  return -1;
-}
 #endif
+}
+
+int CRenderContext::GUIShaderGetPos()
+{
+#if defined(HAS_GL)
+  CRenderSystemGL *renderingGL = dynamic_cast<CRenderSystemGL*>(m_rendering);
+  if (renderingGL != nullptr)
+    return static_cast<int>(renderingGL->ShaderGetPos());
+#elif HAS_GLES >= 2
+  CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
+  if (renderingGLES != nullptr)
+    return static_cast<int>(renderingGLES->GUIShaderGetPos());
+#endif
+
+  return -1;
+}
+
+int CRenderContext::GUIShaderGetCoord0()
+{
+#if defined(HAS_GL)
+  CRenderSystemGL *renderingGL = dynamic_cast<CRenderSystemGL*>(m_rendering);
+  if (renderingGL != nullptr)
+    return static_cast<int>(renderingGL->ShaderGetCoord0());
+#elif HAS_GLES >= 2
+  CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
+  if (renderingGLES != nullptr)
+    return static_cast<int>(renderingGLES->GUIShaderGetCoord0());
+#endif
+
+  return -1;
+}
+
+int CRenderContext::GUIShaderGetUniCol()
+{
+#if defined(HAS_GL)
+  CRenderSystemGL *renderingGL = dynamic_cast<CRenderSystemGL*>(m_rendering);
+  if (renderingGL != nullptr)
+    return static_cast<int>(renderingGL->ShaderGetUniCol());
+#elif HAS_GLES >= 2
+  CRenderSystemGLES *renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
+  if (renderingGLES != nullptr)
+    return static_cast<int>(renderingGLES->GUIShaderGetUniCol());
+#endif
+
+  return -1;
+}
 
 #if defined(HAS_DX)
 CGUIShaderDX* CRenderContext::GetGUIShader()

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -27,14 +27,11 @@ class CCriticalSection;
 class CDisplaySettings;
 class CGameSettings;
 class CGraphicContext;
+class CGUIShaderDX;
 class CMediaSettings;
 class CRenderSystemBase;
 class CWinSystemBase;
 class TransformMatrix;
-
-#if defined(HAS_DX)
-class CGUIShaderDX;
-#endif
 
 namespace KODI
 {
@@ -66,10 +63,8 @@ namespace RETRO
     int GUIShaderGetCoord0();
     int GUIShaderGetUniCol();
 
-#if defined(HAS_DX)
     // DirectX rendering functions
     CGUIShaderDX* GetGUIShader();
-#endif
 
     // Windowing functions
     bool UseLimitedColor();

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -22,11 +22,6 @@
 #include "guilib/Geometry.h"
 #include "guilib/Resolution.h"
 #include "rendering/RenderSystemTypes.h"
-#include "system_gl.h"
-
-#if HAS_GLES >= 2
-#include "rendering/gles/RenderSystemGLES.h" // for ESHADERMETHOD
-#endif
 
 class CCriticalSection;
 class CDisplaySettings;
@@ -64,14 +59,12 @@ namespace RETRO
     void SetScissors(const CRect &rect);
     void ApplyStateBlock();
 
-#if HAS_GLES >= 2
-    // OpenGLES rendering functions
-    void EnableGUIShader(ESHADERMETHOD method);
+    // OpenGL(ES) rendering functions
+    void EnableGUIShader();
     void DisableGUIShader();
-    GLint GUIShaderGetPos();
-    GLint GUIShaderGetCoord0();
-    GLint GUIShaderGetUniCol();
-#endif
+    int GUIShaderGetPos();
+    int GUIShaderGetCoord0();
+    int GUIShaderGetUniCol();
 
 #if defined(HAS_DX)
     // DirectX rendering functions

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/MMALRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/MMALRenderer.cpp
@@ -32,6 +32,7 @@
 #include <interface/mmal/util/mmal_util_params.h>
 
 #include <assert.h>
+#include <math.h>
 
 using namespace KODI;
 using namespace RETRO;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -30,6 +30,8 @@
 using namespace KODI;
 using namespace RETRO;
 
+#define BUFFER_OFFSET(i) (static_cast<char*>(NULL) + (i))
+
 // --- CRendererFactoryGuiTexture ------------------------------------------------
 
 CRPBaseRenderer *CRendererFactoryGuiTexture::CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool)
@@ -137,13 +139,93 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
 
 #elif defined(HAS_GL)
 
-  // Removed OpenGL rendering due to presence of deprecated code
-  (void)renderBuffer;
-  (void)u1;
-  (void)u2;
-  (void)v1;
-  (void)v2;
-  (void)color;
+  renderBuffer->BindToUnit(0);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glEnable(GL_BLEND);
+
+  m_context.EnableGUIShader();
+
+  GLubyte colour[4];
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of the vertices
+  GLuint vertexVBO;
+  GLuint indexVBO;
+
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  } vertex[4];
+
+  // Setup vertex position values
+  vertex[0].x = m_rotatedDestCoords[0].x;
+  vertex[0].y = m_rotatedDestCoords[0].y;
+  vertex[0].z = 0;
+  vertex[0].u1 = u1;
+  vertex[0].v1 = v1;
+
+  vertex[1].x = m_rotatedDestCoords[1].x;
+  vertex[1].y = m_rotatedDestCoords[1].y;
+  vertex[1].z = 0;
+  vertex[1].u1 = u2;
+  vertex[1].v1 = v1;
+
+  vertex[2].x = m_rotatedDestCoords[2].x;
+  vertex[2].y = m_rotatedDestCoords[2].y;
+  vertex[2].z = 0;
+  vertex[2].u1 = u2;
+  vertex[2].v1 = v2;
+
+  vertex[3].x = m_rotatedDestCoords[3].x;
+  vertex[3].y = m_rotatedDestCoords[3].y;
+  vertex[3].z = 0;
+  vertex[3].u1 = u1;
+  vertex[3].v1 = v2;
+
+  GLint posLoc = m_context.GUIShaderGetPos();
+  GLint tex0Loc = m_context.GUIShaderGetCoord0();
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+
+  glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, u1)));
+
+  glEnableVertexAttribArray(posLoc);
+  glEnableVertexAttribArray(tex0Loc);
+
+  // Setup Colour values
+  colour[0] = static_cast<GLubyte>(GET_R(color));
+  colour[1] = static_cast<GLubyte>(GET_G(color));
+  colour[2] = static_cast<GLubyte>(GET_B(color));
+  colour[3] = static_cast<GLubyte>(GET_A(color));
+
+  if (m_context.UseLimitedColor())
+  {
+    colour[0] = (235 - 16) * colour[0] / 255;
+    colour[1] = (235 - 16) * colour[1] / 255;
+    colour[2] = (235 - 16) * colour[2] / 255;
+  }
+
+  glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f),
+                         (colour[2] / 255.0f), (colour[3] / 255.0f));
+
+  glGenBuffers(1, &indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+  glDisableVertexAttribArray(posLoc);
+  glDisableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &indexVBO);
+
+  m_context.DisableGUIShader();
 
 #elif defined(HAS_GLES)
 
@@ -152,7 +234,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
   glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
   glEnable(GL_BLEND); // Turn blending On
 
-  m_context.EnableGUIShader(SM_TEXTURE);
+  m_context.EnableGUIShader();
 
   GLubyte col[4];
   GLfloat ver[4][3];

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -39,7 +39,7 @@
 #endif // HAS_GLX
 
 #include "cores/RetroPlayer/process/X11/RPProcessInfoX11.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/Process/X11/ProcessInfoX11.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
@@ -223,7 +223,7 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
 
   VIDEOPLAYER::CProcessInfoX11::Register();
   RETRO::CRPProcessInfoX11::Register();
-  RETRO::CRPProcessInfoX11::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
+  RETRO::CRPProcessInfoX11::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
   CDVDFactoryCodec::ClearHWAccels();
   VIDEOPLAYER::CRendererFactory::ClearRenderer();
   CLinuxRendererGL::Register();

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -27,7 +27,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "CompileInfo.h"
 #include "cores/RetroPlayer/process/osx/RPProcessInfoOSX.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/VTB.h"
 #include "cores/VideoPlayer/Process/osx/ProcessInfoOSX.h"
@@ -791,7 +791,7 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   CRendererVTB::Register();
   VIDEOPLAYER::CProcessInfoOSX::Register();
   RETRO::CRPProcessInfoOSX::Register();
-  RETRO::CRPProcessInfoOSX::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
+  RETRO::CRPProcessInfoOSX::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
 
   return true;
 }

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -23,7 +23,7 @@
 #include <EGL/egl.h>
 
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "utils/log.h"
 
@@ -42,7 +42,7 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   }
 
   CLinuxRendererGL::Register();
-  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
+  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
 
 #if defined(HAVE_LIBVA)
   bool general, hevc;


### PR DESCRIPTION
After #12841, RetroPlayer on OpenGL systems shows a black screen. My solution here is to switch to using a GUI texture and slideshow code like we do for OpenGLES. Long term, Kodi should get first-class OpenGL(ES) renderers, but I won't be able to work on this until after DevCon.

## How Has This Been Tested?
Tested on Linux and OSX.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
