### PR TITLE
Update game client selection dialog (shown before game)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17430,20 +17430,7 @@ msgctxt "#35252"
 msgid "Edit game source"
 msgstr ""
 
-#: xbmc/games/windows/GUIWindowGames.cpp
-msgctxt "#35253"
-msgid "Install emulator"
-msgstr ""
-
-#: xbmc/games/windows/GUIWindowGames.cpp
-msgctxt "#35254"
-msgid "Manage emulators"
-msgstr ""
-
-#: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
-msgctxt "#35255"
-msgid "Browse all emulators"
-msgstr ""
+#empty strings from id 35253 to 35255
 
 #. Error message when a game client fails to install when a game is being launched
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -17451,7 +17438,19 @@ msgctxt "#35256"
 msgid "Failed to install add-on."
 msgstr ""
 
-#empty strings from id 35257 to 35504
+#. Label on installed emulators in the emulator selection dialog
+#: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+msgctxt "#35257"
+msgid "Installed"
+msgstr ""
+
+#. Title of the dialog to select an emulator for the current game. {0:s} - game file extension
+#: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+msgctxt "#35258"
+msgid "Select emulator for {0:s} file"
+msgstr ""
+
+#empty strings from id 35259 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -195,12 +195,17 @@ bool CRetroPlayer::CloseFile(bool reopen /* = false */)
   CLog::Log(LOGDEBUG, "RetroPlayer: Closing file");
 
   m_autoSave.reset();
-  GetPlayerState();
 
   CSingleLock lock(m_mutex);
 
   if (m_gameClient)
   {
+    std::string savePath = m_gameClient->GetPlayback()->CreateSavestate();
+    if (!savePath.empty())
+      CLog::Log(LOGDEBUG, "Saved state to %s", CURL::GetRedacted(savePath).c_str());
+    else
+      CLog::Log(LOGDEBUG, "Failed to save state at close");
+
     UnregisterWindowCallbacks();
     m_gameClient->CloseFile();
     m_gameClient->Unload();

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -78,7 +78,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   // Currently this may prompt the user, the goal is to figure this out silently
   if (!GAME::CGameUtils::FillInGameClient(fileCopy, true))
   {
-    CLog::Log(LOGINFO, "CApplication: Failed to select a game client, aborting playback");
+    CLog::Log(LOGINFO, "RetroPlayer: No compatible game client selected, aborting playback");
     return false;
   }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -36,7 +36,10 @@ CRetroPlayerAutoSave::CRetroPlayerAutoSave(GAME::CGameClient &gameClient) :
   Create(false);
 }
 
-CRetroPlayerAutoSave::~CRetroPlayerAutoSave() = default;
+CRetroPlayerAutoSave::~CRetroPlayerAutoSave()
+{
+  StopThread();
+}
 
 void CRetroPlayerAutoSave::Process()
 {

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -73,7 +73,7 @@ bool CGameUtils::FillInGameClient(CFileItem &item, bool bPrompt)
       }
       else
       {
-        std::string gameClient = CGUIDialogSelectGameClient::ShowAndGetGameClient(candidates, installable);
+        std::string gameClient = CGUIDialogSelectGameClient::ShowAndGetGameClient(item.GetPath(), candidates, installable);
         if (!gameClient.empty())
           item.GetGameInfoTag()->SetGameClient(gameClient);
       }

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -19,160 +19,163 @@
  */
 
 #include "GUIDialogSelectGameClient.h"
-#include "ServiceBroker.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
-#include "addons/GUIWindowAddonBrowser.h"
-#include "dialogs/GUIDialogContextMenu.h"
+#include "dialogs/GUIDialogSelect.h"
+#include "filesystem/AddonsDirectory.h"
+#include "games/addons/savestates/Savestate.h"
+#include "games/addons/savestates/SavestateDatabase.h"
+#include "games/addons/savestates/SavestateUtils.h"
 #include "games/addons/GameClient.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/helpers/DialogOKHelper.h" 
 #include "utils/log.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "ServiceBroker.h"
+#include "URL.h"
 
 using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace GAME;
 
-std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const GameClientVector& candidates, const GameClientVector& installable)
+std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &gamePath, const GameClientVector& candidates, const GameClientVector& installable)
 {
   std::string gameClient;
 
-  CLog::Log(LOGDEBUG, "Select game client dialog: Found %lu candidates", candidates.size());
-  for (const auto& gameClient : candidates)
-    CLog::Log(LOGDEBUG, "Adding %s as a candidate", gameClient->ID().c_str());
+  LogGameClients(candidates, installable);
 
-  if (!installable.empty())
+  std::string extension = URIUtils::GetExtension(gamePath);
+  std::string xmlPath = CSavestateUtils::MakeMetadataPath(gamePath);
+
+  std::string selected;
+  CSavestate save;
+  CSavestateDatabase db;
+  CLog::Log(LOGDEBUG, "Select game client dialog: Loading savestate metadata %s", CURL::GetRedacted(xmlPath).c_str());
+  if (db.GetSavestate(xmlPath, save))
   {
-    CLog::Log(LOGDEBUG, "Select game client dialog: Found %lu installable clients", installable.size());
-    for (const auto& gameClient : installable)
-      CLog::Log(LOGDEBUG, "Adding %s as an installable client", gameClient->ID().c_str());
+    selected = save.GameClient();
+    CLog::Log(LOGDEBUG, "Select game client dialog: Auto-selecting %s", selected.c_str());
   }
 
-  CContextButtons choiceButtons;
-
-  // Add emulators
-  int i = 0;
-  for (const GameClientPtr& gameClient : candidates)
-    choiceButtons.Add(i++, gameClient->Name());
-
-  // Add button to install emulators
-  const int iInstallEmulator = i++;
-  if (!installable.empty())
-    choiceButtons.Add(iInstallEmulator, 35253); // "Install emulator"
-
-  // Add button to manage emulators
-  const int iAddonMgr = i++;
-  choiceButtons.Add(iAddonMgr, 35254); // "Manage emulators"
-
-  // Do modal
-  int result = CGUIDialogContextMenu::ShowAndGetChoice(choiceButtons);
-
-  if (0 <= result && result < static_cast<int>(candidates.size()))
+  // "Select emulator for {0:s}"
+  CGUIDialogSelect *dialog = GetDialog(StringUtils::Format(g_localizeStrings.Get(35258), extension));
+  if (dialog != nullptr)
   {
-    // Handle emulator
-    gameClient = candidates[result]->ID();
-  }
-  else if (result == iInstallEmulator)
-  {
-    // Install emulator
-    gameClient = InstallGameClient(installable);
-  }
-  else if (result == iAddonMgr)
-  {
-    // Go to add-on manager to manage emulators
-    ActivateAddonMgr();
-  }
-  else
-  {
-    CLog::Log(LOGDEBUG, "Select game client dialog: User cancelled game client selection");
+    // Turn the addons into items
+    CFileItemList items;
+    for (const auto &candidate : candidates)
+    {
+      CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(candidate, candidate->ID()));
+      item->SetLabel2(g_localizeStrings.Get(35257)); // "Installed"
+      items.Add(std::move(item));
+    }
+    for (const auto &addon : installable)
+    {
+      CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(addon, addon->ID()));
+      items.Add(std::move(item));
+    }
+    items.Sort(SortByLabel, SortOrderAscending);
+
+    dialog->SetItems(items);
+
+    for (int i = 0; i < items.Size(); i++)
+    {
+      if (items[i]->GetPath() == selected)
+        dialog->SetSelected(i);
+    }
+
+    dialog->Open();
+
+    // If the "Get More" button has been pressed, show a list of installable addons
+    if (dialog->IsConfirmed())
+    {
+      int selectedIndex = dialog->GetSelectedItem();
+
+      if (0 <= selectedIndex && selectedIndex < items.Size())
+      {
+        gameClient = items[selectedIndex]->GetPath();
+
+        CLog::Log(LOGDEBUG, "Select game client dialog: User selected emulator %s", gameClient.c_str());
+
+        if (Install(gameClient))
+        {
+          // If the addon is disabled we need to enable it
+          if (!Enable(gameClient))
+            CLog::Log(LOGDEBUG, "Failed to enable game client %s", gameClient.c_str());
+        }
+        else
+          CLog::Log(LOGDEBUG, "Failed to install game client: %s", gameClient.c_str());
+      }
+      else
+      {
+        CLog::Log(LOGDEBUG, "Select game client dialog: User selected invalid emulator %d", selectedIndex);
+      }
+    }
+    else
+    {
+      CLog::Log(LOGDEBUG, "Select game client dialog: User cancelled game client installation");
+    }
   }
 
   return gameClient;
 }
 
-std::string CGUIDialogSelectGameClient::InstallGameClient(const GameClientVector& installable)
+bool CGUIDialogSelectGameClient::Install(const std::string &gameClient)
 {
-  using namespace ADDON;
-
-  std::string gameClient;
-
-  //! @todo Switch to add-on browser when more emulators have icons
-  /*
-  std::string chosenClientId;
-  if (CGUIWindowAddonBrowser::SelectAddonID(ADDON_GAMEDLL, chosenClientId, false, true, false, true, false) >= 0 && !chosenClientId.empty())
+  // If the addon isn't installed we need to install it
+  bool bInstalled = CServiceBroker::GetAddonMgr().IsAddonInstalled(gameClient);
+  if (!bInstalled)
   {
-    CLog::Log(LOGDEBUG, "Select game client dialog: User installed %s", chosenClientId.c_str());
-    AddonPtr addon;
-    if (CServiceBroker::GetAddonMgr().GetAddon(chosenClientId, addon, ADDON_GAMEDLL))
-      gameClient = addon->ID();
-
-    if (gameClient.empty())
-      CLog::Log(LOGERROR, "Select game client dialog: Failed to get addon %s", chosenClientId.c_str());
-  }
-  */
-
-  CContextButtons choiceButtons;
-
-  // Add emulators
-  int i = 0;
-  for (const GameClientPtr& gameClient : installable)
-    choiceButtons.Add(i++, gameClient->Name());
-
-  // Add button to browser all emulators
-  const int iAddonBrowser = i++;
-  choiceButtons.Add(iAddonBrowser, 35255); // "Browse all emulators"
-
-  // Do modal
-  int result = CGUIDialogContextMenu::ShowAndGetChoice(choiceButtons);
-
-  if (0 <= result && result < static_cast<int>(installable.size()))
-  {
-    std::string gameClientId = installable[result]->ID();
-    CLog::Log(LOGDEBUG, "Select game client dialog: Installing %s", gameClientId.c_str());
-    AddonPtr installedAddon;
-    if (CAddonInstaller::GetInstance().InstallModal(gameClientId, installedAddon, false))
+    ADDON::AddonPtr installedAddon;
+    bInstalled = CAddonInstaller::GetInstance().InstallModal(gameClient, installedAddon, false);
+    if (!bInstalled)
     {
-      CLog::Log(LOGDEBUG, "Select game client dialog: Successfully installed %s", installedAddon->ID().c_str());
-
-      // if the addon is disabled we need to enable it
-      if (CServiceBroker::GetAddonMgr().IsAddonDisabled(installedAddon->ID()))
-        CServiceBroker::GetAddonMgr().EnableAddon(installedAddon->ID());
-
-      gameClient = installedAddon->ID();
-    }
-    else
-    {
-      CLog::Log(LOGERROR, "Select game client dialog: Failed to install %s", gameClientId.c_str());
+      CLog::Log(LOGERROR, "Select game client dialog: Failed to install %s", gameClient.c_str());
       // "Error"
       // "Failed to install add-on."
       HELPERS::ShowOKDialogText(257, 35256);
     }
   }
-  else if (result == iAddonBrowser)
-  {
-    ActivateAddonBrowser();
-  }
-  else
-  {
-    CLog::Log(LOGDEBUG, "Select game client dialog: User cancelled game client installation");
-  }
 
-  return gameClient;
+  return bInstalled;
 }
 
-void CGUIDialogSelectGameClient::ActivateAddonMgr()
+bool CGUIDialogSelectGameClient::Enable(const std::string &gameClient)
 {
-  CLog::Log(LOGDEBUG, "User chose to go to the add-on manager");
-  std::vector<std::string> params;
-  params.push_back("addons://user/category.emulators");
-  g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
+  bool bSuccess = true;
+
+  if (CServiceBroker::GetAddonMgr().IsAddonDisabled(gameClient))
+    bSuccess = CServiceBroker::GetAddonMgr().EnableAddon(gameClient);
+
+  return bSuccess;
 }
 
-void CGUIDialogSelectGameClient::ActivateAddonBrowser()
+CGUIDialogSelect *CGUIDialogSelectGameClient::GetDialog(const std::string &title)
 {
-  CLog::Log(LOGDEBUG, "User chose to go to the add-on browser");
-  std::vector<std::string> params;
-  params.push_back("addons://all/category.emulators");
-  g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
+  CGUIDialogSelect *dialog = g_windowManager.GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+  if (dialog != nullptr)
+  {
+    dialog->Reset();
+    dialog->SetHeading(CVariant{ title });
+    dialog->SetUseDetails(true);
+  }
+
+  return dialog;
+}
+
+void CGUIDialogSelectGameClient::LogGameClients(const GameClientVector& candidates, const GameClientVector& installable)
+{
+  CLog::Log(LOGDEBUG, "Select game client dialog: Found %u candidates", static_cast<unsigned int>(candidates.size()));
+  for (const auto& gameClient : candidates)
+    CLog::Log(LOGDEBUG, "Adding %s as a candidate", gameClient->ID().c_str());
+
+  if (!installable.empty())
+  {
+    CLog::Log(LOGDEBUG, "Select game client dialog: Found %u installable clients", static_cast<unsigned int>(installable.size()));
+    for (const auto& gameClient : installable)
+      CLog::Log(LOGDEBUG, "Adding %s as an installable client", gameClient->ID().c_str());
+  }
 }

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.h
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.h
@@ -23,6 +23,8 @@
 
 #include <string>
 
+class CGUIDialogSelect;
+
 namespace KODI
 {
 namespace GAME
@@ -30,20 +32,59 @@ namespace GAME
   class CGUIDialogSelectGameClient
   {
   public:
-    static std::string ShowAndGetGameClient(const GameClientVector& candidates, const GameClientVector& installable);
+    /*!
+     * \brief Show a series of dialogs that results in a game client being
+     *        selected
+     *
+     * \param gamePath    The path of the file being played
+     * \param candidates  A list of installed candidates that the user can
+     *                    select from
+     * \param installable A list of installable candidates that the user can
+     *                    select from
+     *
+     * \return The ID of the selected game client, or empty if no game client
+     *         was selected
+     */
+    static std::string ShowAndGetGameClient(const std::string &gamePath, const GameClientVector& candidates, const GameClientVector& installable);
 
   private:
-    static std::string InstallGameClient(const GameClientVector& installable);
+    /*!
+     * \brief Install the specified game client
+     *
+     * If the game client is not installed, a model dialog is shown installing
+     * the game client. If the installation fails, an error dialog is shown.
+     *
+     * \param gameClient The game client to install
+     *
+     * \return True if the game client is installed, false otherwise
+     */
+    static bool Install(const std::string &gameClient);
 
     /*!
-     * \brief Utility function to load the add-on manager for installed emulators
+     * \brief Enable the specified game client
+     *
+     * \param gameClient the game client to enable
+     *
+     * \return True if the game client is enabled, false otherwise
      */
-    static void ActivateAddonMgr();
+    static bool Enable(const std::string &gameClient);
 
     /*!
-     * \brief Utility function to load the add-on manager for all emulators
+     * \brief Get an initialized select dialog
+     *
+     * \param title The title of the select dialog
+     *
+     * \return A select dialog with its properties initialized, or nullptr if
+     *         the dialog isn't found
      */
-    static void ActivateAddonBrowser();
+    static CGUIDialogSelect *GetDialog(const std::string &title);
+
+    /*!
+     * \brief Log the candidates and installable game clients
+     *
+     * Other than logging, this has no side effects.
+     */
+    static void LogGameClients(const GameClientVector& candidates, const GameClientVector& installable);
   };
 }
 }


### PR DESCRIPTION
This switches the dialog from DialogContext to DialogSelect, and as a result we get emulator icons and more legible names.

The navigation flow has been drastically simplified. Instead of going through two dialogs to install game clients, there is only one dialog containing both installed and remote game clients. Installed clients are indicated with an "Installed" label2.

An additional feature is that the game client last used to save the game is auto-selected.

## Motivation and Context
The end goal is to hide this dialog entirely and automatically select a game client. However, this is a long ways off and requires a game database, so in the meantime I've improved the existing dialog.

## How Has This Been Tested?
Tested on Windows, Linux and RPi.

## Screenshots (if appropriate):
Before:
![screenshot000](https://user-images.githubusercontent.com/531482/31404986-8017b140-adb2-11e7-988c-7d0e1438c3c3.png)

After:
![game client selection](https://user-images.githubusercontent.com/531482/31404884-2a952388-adb2-11e7-8287-0fc922f60a25.png)

# Remaining work
We should probably switch to platform icons for consistency instead of emulator icons, especially because most emulators don't have icons.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
