### PR TITLE
VideoPlayer: keyframes

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -219,7 +219,7 @@ void CDVDAudioCodecPassthrough::GetData(DVDAudioFrame &frame)
 int CDVDAudioCodecPassthrough::GetData(uint8_t** dst)
 {
   if (!m_dataSize)
-    AddData(DemuxPacket(nullptr, 0, DVD_NOPTS_VALUE, DVD_NOPTS_VALUE));
+    AddData(DemuxPacket());
 
   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
     *dst = m_trueHDBuffer.get();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -594,6 +594,9 @@ bool CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
     Reset();
   }
 
+  if (packet.recoveryPoint)
+    m_started = true;
+
   m_dts = packet.dts;
   m_pCodecContext->reordered_opaque = pts_dtoi(packet.pts);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -100,7 +100,7 @@ protected:
   IHardwareDecoder *m_pHardware;
   int m_iLastKeyframe;
   double m_dts;
-  bool   m_started;
+  bool m_started = false;
   std::vector<AVPixelFormat> m_formats;
   double m_decoderPts;
   int    m_skippedDeint;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -213,6 +213,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput, bool streaminfo, bool filein
   m_currentPts = DVD_NOPTS_VALUE;
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_program = UINT_MAX;
+  m_seekToKeyFrame = false;
 
   const AVIOInterruptCB int_cb = { interrupt_cb, this };
 
@@ -626,6 +627,7 @@ void CDVDDemuxFFmpeg::Flush()
 
   m_displayTime = 0;
   m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
+  m_seekToKeyFrame = false;
 }
 
 void CDVDDemuxFFmpeg::Abort()
@@ -904,6 +906,9 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
       // timeout, probably no real error, return empty packet
       bReturnEmpty = true;
     }
+    else if (m_pkt.result == AVERROR_EOF)
+    {
+    }
     else if (m_pkt.result < 0)
     {
       Flush();
@@ -1076,6 +1081,8 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
         // content has changed
         stream = AddStream(pPacket->iStreamId);
       }
+      pPacket->recoveryPoint = m_seekToKeyFrame;
+      m_seekToKeyFrame = false;
     }
     if (!stream)
     {
@@ -1152,7 +1159,12 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double *startpts)
       ret = 0;
 
     if (ret >= 0)
+    {
+      if (m_pFormatContext->iformat->read_seek)
+        m_seekToKeyFrame = true;
+
       UpdateCurrentPTS();
+    }
   }
 
   if(m_currentPts == DVD_NOPTS_VALUE)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -168,5 +168,6 @@ protected:
   bool m_checkvideo;
   int m_displayTime = 0;
   double m_dtsAtDisplayTime;
+  bool m_seekToKeyFrame = false;
 };
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
@@ -43,6 +43,7 @@ typedef struct DemuxPacket
   double dts = DVD_NOPTS_VALUE;
   double duration = 0; // duration in DVD_TIME_BASE if available
   int dispTime = 0;
+  bool recoveryPoint = false;
 
   std::shared_ptr<DemuxCryptoInfo> cryptoInfo;
 } DemuxPacket;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "../TimingConstants.h"
 #include <cstdint>
 #include <memory>
 
@@ -32,24 +33,16 @@ typedef struct DemuxPacket
 {
   DemuxPacket() = default;
 
-  DemuxPacket(unsigned char *pData, int const iSize, double const pts, double const dts)
-    : pData(pData)
-    , iSize(iSize)
-    , pts(pts)
-    , dts(dts)
-  {};
-
-  unsigned char *pData;   // data
-  int iSize;     // data size
-  int iStreamId; // integer representing the stream index
+  unsigned char *pData = nullptr;
+  int iSize = 0;
+  int iStreamId = -1;
   int64_t demuxerId; // id of the demuxer that created the packet
-  int iGroupId;  // the group this data belongs to, used to group data from different streams together
+  int iGroupId = -1; // the group this data belongs to, used to group data from different streams together
 
-  double pts; // pts in DVD_TIME_BASE
-  double dts; // dts in DVD_TIME_BASE
-  double duration; // duration in DVD_TIME_BASE if available
-
-  int dispTime;
+  double pts = DVD_NOPTS_VALUE;
+  double dts = DVD_NOPTS_VALUE;
+  double duration = 0; // duration in DVD_TIME_BASE if available
+  int dispTime = 0;
 
   std::shared_ptr<DemuxCryptoInfo> cryptoInfo;
 } DemuxPacket;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -48,47 +48,30 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
 
 DemuxPacket* CDVDDemuxUtils::AllocateDemuxPacket(int iDataSize)
 {
-  DemuxPacket* pPacket = new DemuxPacket;
-  if (!pPacket) return NULL;
+  DemuxPacket* pPacket = new DemuxPacket();
 
-  try
+  if (iDataSize > 0)
   {
-    memset(pPacket, 0, sizeof(DemuxPacket));
-
-    if (iDataSize > 0)
+    // need to allocate a few bytes more.
+    // From avcodec.h (ffmpeg)
+    /**
+     * Required number of additionally allocated bytes at the end of the input bitstream for decoding.
+     * this is mainly needed because some optimized bitstream readers read
+     * 32 or 64 bit at once and could read over the end<br>
+     * Note, if the first 23 bits of the additional bytes are not 0 then damaged
+     * MPEG bitstreams could cause overread and segfault
+     */
+    pPacket->pData =(uint8_t*)_aligned_malloc(iDataSize + FF_INPUT_BUFFER_PADDING_SIZE, 16);
+    if (!pPacket->pData)
     {
-      // need to allocate a few bytes more.
-      // From avcodec.h (ffmpeg)
-      /**
-        * Required number of additionally allocated bytes at the end of the input bitstream for decoding.
-        * this is mainly needed because some optimized bitstream readers read
-        * 32 or 64 bit at once and could read over the end<br>
-        * Note, if the first 23 bits of the additional bytes are not 0 then damaged
-        * MPEG bitstreams could cause overread and segfault
-        */
-      pPacket->pData =(uint8_t*)_aligned_malloc(iDataSize + FF_INPUT_BUFFER_PADDING_SIZE, 16);
-      if (!pPacket->pData)
-      {
-        FreeDemuxPacket(pPacket);
-        return NULL;
-      }
-
-      // reset the last 8 bytes to 0;
-      memset(pPacket->pData + iDataSize, 0, FF_INPUT_BUFFER_PADDING_SIZE);
+      FreeDemuxPacket(pPacket);
+      return NULL;
     }
 
-    // setup defaults
-    pPacket->dts       = DVD_NOPTS_VALUE;
-    pPacket->pts       = DVD_NOPTS_VALUE;
-    pPacket->iStreamId = -1;
-    pPacket->dispTime = 0;
+    // reset the last 8 bytes to 0;
+    memset(pPacket->pData + iDataSize, 0, FF_INPUT_BUFFER_PADDING_SIZE);
   }
-  catch(...)
-  {
-    CLog::Log(LOGERROR, "%s - Exception thrown", __FUNCTION__);
-    FreeDemuxPacket(pPacket);
-    pPacket = NULL;
-  }
+
   return pPacket;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1539,8 +1539,8 @@ void CVideoPlayer::Process()
       SetCaching(CACHESTATE_DONE);
 
       // while players are still playing, keep going to allow seekbacks
-      if(m_VideoPlayerAudio->HasData()
-      || m_VideoPlayerVideo->HasData())
+      if (m_VideoPlayerAudio->HasData() ||
+          m_VideoPlayerVideo->HasData())
       {
         Sleep(100);
         continue;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -653,6 +653,15 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
 
   if (decoderState == CDVDVideoCodec::VC_EOF)
   {
+    if (m_syncState == IDVDStreamPlayer::SYNC_STARTING)
+    {
+      SStartMsg msg;
+      msg.player = VideoPlayer_VIDEO;
+      msg.cachetime = DVD_MSEC_TO_TIME(50);
+      msg.cachetotal = DVD_MSEC_TO_TIME(100);
+      msg.timestamp = DVD_NOPTS_VALUE;
+      m_messageParent.Put(new CDVDMsgType<SStartMsg>(CDVDMsg::PLAYER_STARTED, msg));
+    }
     return false;
   }
 


### PR DESCRIPTION
Allow demuxes supporting indexed search to set recovery point on demux packet.
Fix for: trac 17613