### PR TITLE
[amlogic] Fix RetroPlayer on AMLogic hardware

### DIFF
--- a/cmake/treedata/optional/common/aml.txt
+++ b/cmake/treedata/optional/common/aml.txt
@@ -1,2 +1,3 @@
+xbmc/cores/RetroPlayer/process/amlogic cores/RetroPlayer/process/amlogic # AML
 xbmc/windowing/amlogic windowing/amlogic # AML
 

--- a/xbmc/cores/RetroPlayer/process/amlogic/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/process/amlogic/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(CORE_PLATFORM_NAME_LC STREQUAL aml)
+  set(SOURCES RPProcessInfoAmlogic.cpp)
+  set(HEADERS RPProcessInfoAmlogic.h)
+
+  core_add_library(rp-process-amlogic)
+endif()

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
@@ -1,0 +1,34 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RPProcessInfoAmlogic.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CRPProcessInfo* CRPProcessInfoAmlogic::Create()
+{
+  return new CRPProcessInfoAmlogic();
+}
+
+void CRPProcessInfoAmlogic::Register()
+{
+  CRPProcessInfo::RegisterProcessControl(CRPProcessInfoAmlogic::Create);
+}

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CRPProcessInfoAmlogic : public CRPProcessInfo
+  {
+  public:
+    static CRPProcessInfo* Create();
+    static void Register();
+  };
+}
+}

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -24,7 +24,7 @@
 #include <float.h>
 
 #include "ServiceBroker.h"
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
@@ -87,7 +87,8 @@ bool CWinSystemAmlogic::InitWindowSystem()
 
   CDVDVideoCodecAmlogic::Register();
   CLinuxRendererGLES::Register();
-  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoAmlogic::Register();
+  RETRO::CRPProcessInfoAmlogic::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
   CRendererAML::Register();
 
   return CWinSystemBase::InitWindowSystem();


### PR DESCRIPTION
This fixes the following error on AMLogic:

```
ERROR: Failed to create RetroPlayer - no process info registered
```

The problem is that I used the VP registration as a template, and if no ProcessInfo is registered for VP it uses a default one.

RP, on the other hand, has no default ProcessInfo, so it must be registered explicitly.

## Motivation and Context
Reported in the LE slack.

## How Has This Been Tested?
Untested.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
