### PR TITLE
windowing/gbm: allow scanning /dev/dri/card[0-9] to find the correct device

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -77,6 +77,7 @@ private:
   static bool GetConnector();
   static bool GetEncoder();
   static bool GetPreferredMode();
+  static int Open(const char* device);
   static bool RestoreOriginalMode();
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
 };


### PR DESCRIPTION
previously I just hardcoded /dev/dri/card0

This scans through /dev/dri/card[0-9] and tries to open it with a set of modules.

This also allows you to have multiple cards but will only continue if one has a connector/encoder.

I wish libdrm had a helper here but this is how they do it also
https://cgit.freedesktop.org/mesa/drm/tree/tests/util/kms.c#n153