### PR TITLE
[PVR] Fix PVR startup / shutdown.

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -47,7 +47,6 @@ CPVRGUIInfo::CPVRGUIInfo(void) :
 
 CPVRGUIInfo::~CPVRGUIInfo(void)
 {
-  Stop();
 }
 
 void CPVRGUIInfo::ResetProperties(void)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -125,11 +125,6 @@ namespace PVR
     void Init(void);
 
     /*!
-     * @brief Reinit PVRManager.
-     */
-    void Reinit(void);
-
-    /*!
      * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
      */
     void Start();

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -279,7 +279,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   CServiceBroker::GetServiceAddons().Stop();
 
   // stop PVR related services
-  CServiceBroker::GetPVRManager().Unload();
+  CServiceBroker::GetPVRManager().Stop();
 
   if (profile != 0 || !CProfilesManager::GetInstance().IsMasterProfile())
   {
@@ -326,7 +326,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   CServiceBroker::GetContextMenuManager().Init();
 
   // restart PVR services
-  CServiceBroker::GetPVRManager().Reinit();
+  CServiceBroker::GetPVRManager().Init();
 
   CServiceBroker::GetFavouritesService().ReInit(CProfilesManager::GetInstance().GetProfileUserDataFolder());
 


### PR DESCRIPTION
Couple of fixes to prevent crashes / deadlocks while starting / stopping PVR Manager (Kodi startup/shutdown, Profile switch, PVR client addon enable/disable/install/uninstall).

- Make startup and shutdown actions "symmetric".
- Prevent startup if another startup is already in progress (we had that already for stop, btw)
- Make `CPVRClients::UpdateAddons` threadsafe
- On addon manager enable/disable event, restart PVR Mananger asynchronously
- Fix a bug with addon manager event subscription, that resulted in one additional subscriber per PVR Manager restart  
- some logging improvements for PVR Manager startup and shutdown

I carefully tested this on macOS, latest Kodi master, especially together with another WIP of mine - improvements for multiple enabled PVr addons (which increases complexity and deadlock/crash risk).