### PR TITLE
RetroPlayer: Cache/pre-compile output shaders

### DIFF
--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -53,6 +53,16 @@ CRPProcessInfo::CRPProcessInfo() :
     RenderBufferPoolVector bufferPools = rendererFactory->CreateBufferPools();
     m_renderBufferManager->RegisterPools(rendererFactory.get(), std::move(bufferPools));
   }
+
+  // Initialize default scaling method
+  for (auto scalingMethod : GetScalingMethods())
+  {
+    if (HasScalingMethod(scalingMethod))
+    {
+      m_defaultScalingMethod = scalingMethod;
+      break;
+    }
+  }
 }
 
 CRPProcessInfo::~CRPProcessInfo() = default;
@@ -124,6 +134,19 @@ void CRPProcessInfo::ResetInfo()
     m_dataCache->SetVideoRender(false); //! @todo
     m_dataCache->SetPlayTimes(0, 0, 0, 0);
   }
+}
+
+bool CRPProcessInfo::HasScalingMethod(ESCALINGMETHOD scalingMethod) const
+{
+  return m_renderBufferManager->HasScalingMethod(scalingMethod);
+}
+
+std::vector<ESCALINGMETHOD> CRPProcessInfo::GetScalingMethods()
+{
+  return {
+    VS_SCALINGMETHOD_NEAREST,
+    VS_SCALINGMETHOD_LINEAR,
+  };
 }
 
 //******************************************************************************

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -68,9 +68,10 @@ namespace RETRO
     void ResetInfo();
 
     // rendering info
-    virtual ESCALINGMETHOD GetDefaultScalingMethod() const { return VS_SCALINGMETHOD_NEAREST; }
     CRenderContext &GetRenderContext() { return *m_renderContext; }
     CRenderBufferManager &GetBufferManager() { return *m_renderBufferManager; }
+    bool HasScalingMethod(ESCALINGMETHOD scalingMethod) const;
+    ESCALINGMETHOD GetDefaultScalingMethod() const { return m_defaultScalingMethod; }
 
     // player video
     void SetVideoPixelFormat(AVPixelFormat pixFormat);
@@ -89,6 +90,8 @@ namespace RETRO
   protected:
     CRPProcessInfo();
 
+    static std::vector<ESCALINGMETHOD> GetScalingMethods();
+
     static CreateRPProcessControl m_processControl;
     static std::vector<std::unique_ptr<IRendererFactory>> m_rendererFactories;
     static CCriticalSection m_createSection;
@@ -99,6 +102,7 @@ namespace RETRO
 
   private:
     std::unique_ptr<CRenderContext> m_renderContext;
+    ESCALINGMETHOD m_defaultScalingMethod = VS_SCALINGMETHOD_AUTO;
   };
 
 }

--- a/xbmc/cores/RetroPlayer/process/RenderBufferManager.cpp
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferManager.cpp
@@ -20,6 +20,7 @@
 
 #include "RenderBufferManager.h"
 #include "IRenderBufferPool.h"
+#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "threads/SingleLock.h"
 
 #include <algorithm>
@@ -81,4 +82,19 @@ void CRenderBufferManager::FlushPools()
     for (const auto &pool : pools.pools)
       pool->Flush();
   }
+}
+
+bool CRenderBufferManager::HasScalingMethod(ESCALINGMETHOD scalingMethod) const
+{
+  CRenderVideoSettings videoSettings;
+  videoSettings.SetScalingMethod(scalingMethod);
+
+  for (const auto &pools : m_pools)
+  {
+    for (const auto &pool : pools.pools)
+      if (pool->IsCompatible(videoSettings))
+        return true;
+  }
+
+  return false;
 }

--- a/xbmc/cores/RetroPlayer/process/RenderBufferManager.h
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferManager.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "cores/RetroPlayer/RetroPlayerTypes.h"
+#include "cores/IPlayer.h"
 #include "threads/CriticalSection.h"
 
 #include <memory>
@@ -43,7 +44,11 @@ namespace RETRO
     std::vector<IRenderBufferPool*> GetBufferPools();
     void FlushPools();
 
+    bool HasScalingMethod(ESCALINGMETHOD scalingMethod) const;
+
   protected:
+    static std::vector<ESCALINGMETHOD> GetScalingMethods();
+
     struct RenderBufferPools
     {
       IRendererFactory* factory;

--- a/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.cpp
+++ b/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.cpp
@@ -33,8 +33,3 @@ void CRPProcessInfoWin::Register()
 {
   CRPProcessInfo::RegisterProcessControl(CRPProcessInfoWin::Create);
 }
-
-ESCALINGMETHOD CRPProcessInfoWin::GetDefaultScalingMethod() const
-{
-  return CRPWinRenderer::DEFAULT_SCALING_METHOD;
-}

--- a/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.h
+++ b/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.h
@@ -31,9 +31,6 @@ namespace RETRO
   public:
     static CRPProcessInfo* Create();
     static void Register();
-
-    // implementation of CRPProcessInfo
-    ESCALINGMETHOD GetDefaultScalingMethod() const override;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/rendering/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES GUIGameRenderManager.cpp
             RenderContext.cpp
             RenderGeometry.cpp
             RenderSettings.cpp
+            RenderTranslator.cpp
             RenderVideoSettings.cpp
             RPRenderManager.cpp
 )
@@ -23,6 +24,7 @@ set(HEADERS GUIGameRenderManager.h
             RenderContext.h
             RenderGeometry.h
             RenderSettings.h
+            RenderTranslator.h
             RenderVideoSettings.h
             RPRenderManager.h
 )

--- a/xbmc/cores/RetroPlayer/rendering/GUIGameSettings.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/GUIGameSettings.cpp
@@ -74,6 +74,9 @@ void CGUIGameSettings::UpdateSettings()
   ViewMode viewMode = m_guiSettings.ViewMode();
 
   // Save settings for renderer
-  m_renderSettings.VideoSettings().SetScalingMethod(scalingMethod);
+  if (m_processInfo.HasScalingMethod(scalingMethod))
+    m_renderSettings.VideoSettings().SetScalingMethod(scalingMethod);
+  else
+    m_renderSettings.VideoSettings().SetScalingMethod(m_processInfo.GetDefaultScalingMethod());
   m_renderSettings.VideoSettings().SetRenderViewMode(viewMode);
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderTranslator.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderTranslator.cpp
@@ -1,0 +1,39 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RenderTranslator.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+const char *CRenderTranslator::TranslateScalingMethod(ESCALINGMETHOD scalingMethod)
+{
+  switch (scalingMethod)
+  {
+  case VS_SCALINGMETHOD_NEAREST:
+    return "nearest";
+  case VS_SCALINGMETHOD_LINEAR:
+    return "linear";
+  default:
+    break;
+  }
+
+  return "";
+}

--- a/xbmc/cores/RetroPlayer/rendering/RenderTranslator.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderTranslator.h
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "cores/IPlayer.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+  class CRenderTranslator
+  {
+  public:
+    /*!
+     * \brief Translate a scaling method to a string suitable for logging
+     */
+    static const char *TranslateScalingMethod(ESCALINGMETHOD scalingMethod);
+  };
+}
+}

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -84,7 +84,7 @@ namespace RETRO
   class CWinRenderBufferPool : public CBaseRenderBufferPool
   {
   public:
-    CWinRenderBufferPool() = default;
+    CWinRenderBufferPool();
     ~CWinRenderBufferPool() override = default;
 
     // implementation of IRenderBufferPool via CRenderBufferPoolSysMem
@@ -95,9 +95,15 @@ namespace RETRO
 
     // DirectX interface
     bool ConfigureDX(DXGI_FORMAT dxFormat);
+    CRPWinOutputShader *GetShader(ESCALINGMETHOD scalingMethod) const;
 
   private:
+    static const std::vector<ESCALINGMETHOD> &GetScalingMethods();
+
+    void CompileOutputShaders();
+
     DXGI_FORMAT m_targetDxFormat = DXGI_FORMAT_UNKNOWN;
+    std::map<ESCALINGMETHOD, std::unique_ptr<CRPWinOutputShader>> m_outputShaders;
   };
 
   class CRPWinRenderer : public CRPBaseRenderer
@@ -123,12 +129,7 @@ namespace RETRO
     void RenderInternal(bool clear, uint8_t alpha) override;
 
   private:
-    void CompileOutputShader(ESCALINGMETHOD scalingMethod);
-    void HandleScalingChange();
     void Render(CD3DTexture *target);
-
-    std::unique_ptr<CRPWinOutputShader> m_outputShader;
-    ESCALINGMETHOD m_prevScalingMethod = VS_SCALINGMETHOD_AUTO;
   };
 }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
* Prevents stutering induced from the compilation of output shaders, when switching between them in the Video Filters OSD.

* Also fixes a bug where the shaders would compile continously in the Video Filters OSD.

I initially started working on an `RPWinOutputShaderManager` that would hold the output shaders and map them to scaling methods to make `RPWinRenderer` usage of shaders simpler, but it was getting a bit out of hand so I just did the logic in the renderer.

We won't have many other supported scaling types for this anyway, plus the output shader probably won't be used very much when [video shaders](https://github.com/garbear/xbmc/pull/86) are merged :)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
UI stuttering should be avoided when possible and in this case it was pretty trivial to do.

Also fixes the aforementioned bug. Sorry about that, I'll test stuff better next time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested by loading a game, going into the filters osd and switching between the 2 scaling options.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
