### PR TITLE
[buildtools][windows] don't fail if patch was already applied

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -129,7 +129,12 @@ do_download() {
   for patch in ${patches[@]}; do
     echo "Applying patch ${patch}"
     if [[ -f $patch ]]; then
-      patch -d $LOCALSRCDIR -i $patch -N -r - || exit $?
+      patch -d $LOCALSRCDIR --dry-run --reverse --force -i $patch 2>&1 > /dev/null
+      if [ $? == 0 ]; then
+        echo "  Patch already applied - skipping."
+      else
+        patch -d $LOCALSRCDIR -i $patch -N -r - || exit $?
+      fi
     fi
   done
 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Skip a patch if it was already applied in a previous run
<!--- Describe your change in detail -->

## Motivation and Context
With cd670240 the script exits if applying a  patch fails.
Patch also returns a non zero exit status for already applied patches (even if invoked with the `--forward`  / `-N` parameter).
Therefore check if the patch was already applied and skip it in that case.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
run make-mingwlibs more then once
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
