### PR TITLE
Fix image panning using a joystick

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -239,10 +239,10 @@
       <down>ZoomOut</down>
       <left>PreviousPicture</left>
       <right>NextPicture</right>
-      <leftstick direction="left">AnalogMoveX</leftstick>
-      <leftstick direction="right">AnalogMoveX</leftstick>
-      <leftstick direction="up">AnalogMoveY</leftstick>
-      <leftstick direction="down">AnalogMoveY</leftstick>
+      <leftstick direction="left">AnalogMoveXLeft</leftstick>
+      <leftstick direction="right">AnalogMoveXRight</leftstick>
+      <leftstick direction="up">AnalogMoveYUp</leftstick>
+      <leftstick direction="down">AnalogMoveYDown</leftstick>
       <lefttrigger>ZoomOut</lefttrigger>
       <righttrigger>ZoomIn</righttrigger>
     </joystick>

--- a/xbmc/input/ActionIDs.h
+++ b/xbmc/input/ActionIDs.h
@@ -80,7 +80,7 @@
 #define ACTION_CALIBRATE_SWAP_ARROWS  47 //!< select next arrow. Can b used in: settingsScreenCalibration.xml windowid=11
 #define ACTION_CALIBRATE_RESET        48 //!< reset calibration to defaults. Can b used in: `settingsScreenCalibration.xml` windowid=11/settingsUICalibration.xml windowid=10
 #define ACTION_ANALOG_MOVE            49 //!< analog thumbstick move. Can b used in: `slideshow.xml` windowid=2007/settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
-                                         //!< @note see also ACTION_ANALOG_MOVE_X, ACTION_ANALOG_MOVE_Y
+                                         //!< @note see also ACTION_ANALOG_MOVE_X_LEFT, ACTION_ANALOG_MOVE_X_RIGHT, ACTION_ANALOG_MOVE_Y_UP, ACTION_ANALOG_MOVE_Y_DOWN
 #define ACTION_ROTATE_PICTURE_CW      50 //!< rotate current picture clockwise during slideshow. Can be used in slideshow.xml window id=2007
 #define ACTION_ROTATE_PICTURE_CCW     51 //!< rotate current picture counterclockwise during slideshow. Can be used in slideshow.xml window id=2007
 
@@ -302,8 +302,10 @@
 #define ACTION_GESTURE_END            599
 
 // other, non-gesture actions
-#define ACTION_ANALOG_MOVE_X            601 //!< analog thumbstick move, horizontal axis; see ACTION_ANALOG_MOVE
-#define ACTION_ANALOG_MOVE_Y            602 //!< analog thumbstick move, vertical axis; see ACTION_ANALOG_MOVE
+#define ACTION_ANALOG_MOVE_X_LEFT       601 //!< analog thumbstick move, horizontal axis, left; see ACTION_ANALOG_MOVE
+#define ACTION_ANALOG_MOVE_X_RIGHT      602 //!< analog thumbstick move, horizontal axis, right; see ACTION_ANALOG_MOVE
+#define ACTION_ANALOG_MOVE_Y_UP         603 //!< analog thumbstick move, vertical axis, up; see ACTION_ANALOG_MOVE
+#define ACTION_ANALOG_MOVE_Y_DOWN       604 //!< analog thumbstick move, vertical axis, down; see ACTION_ANALOG_MOVE
 //@}
 
 // The NOOP action can be specified to disable an input event. This is

--- a/xbmc/input/ActionTranslator.cpp
+++ b/xbmc/input/ActionTranslator.cpp
@@ -86,8 +86,10 @@ static const std::map<ActionName, ActionID> ActionMappings =
     { "nextcalibration"          , ACTION_CALIBRATE_SWAP_ARROWS },
     { "resetcalibration"         , ACTION_CALIBRATE_RESET },
     { "analogmove"               , ACTION_ANALOG_MOVE },
-    { "analogmovex"              , ACTION_ANALOG_MOVE_X },
-    { "analogmovey"              , ACTION_ANALOG_MOVE_Y },
+    { "analogmovexleft"          , ACTION_ANALOG_MOVE_X_LEFT },
+    { "analogmovexright"         , ACTION_ANALOG_MOVE_X_RIGHT },
+    { "analogmoveyup"            , ACTION_ANALOG_MOVE_Y_UP },
+    { "analogmoveydown"          , ACTION_ANALOG_MOVE_Y_DOWN },
     { "rotate"                   , ACTION_ROTATE_PICTURE_CW },
     { "rotateccw"                , ACTION_ROTATE_PICTURE_CCW },
     { "close"                    , ACTION_NAV_BACK },            // backwards compatibility
@@ -267,8 +269,10 @@ bool CActionTranslator::IsAnalog(unsigned int actionID)
   case ACTION_ANALOG_FORWARD:
   case ACTION_ANALOG_REWIND:
   case ACTION_ANALOG_MOVE:
-  case ACTION_ANALOG_MOVE_X:
-  case ACTION_ANALOG_MOVE_Y:
+  case ACTION_ANALOG_MOVE_X_LEFT:
+  case ACTION_ANALOG_MOVE_X_RIGHT:
+  case ACTION_ANALOG_MOVE_Y_UP:
+  case ACTION_ANALOG_MOVE_Y_DOWN:
   case ACTION_CURSOR_LEFT:
   case ACTION_CURSOR_RIGHT:
   case ACTION_VOLUME_UP:

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -878,12 +878,17 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     // this action is used and works, when CAction object provides both x and y coordinates
     Move(action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG, -action.GetAmount(1)*PICTURE_MOVE_AMOUNT_ANALOG);
     break;
-  case ACTION_ANALOG_MOVE_X:
-    // this and following action are used and work, when CAction object provides either x of y coordinate
+  case ACTION_ANALOG_MOVE_X_LEFT:
+    Move(-action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG, 0.0f);
+    break;
+  case ACTION_ANALOG_MOVE_X_RIGHT:
     Move(action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG, 0.0f);
     break;
-  case ACTION_ANALOG_MOVE_Y:
-    Move(0.0f, action.GetAmount(0)*PICTURE_MOVE_AMOUNT_ANALOG);
+  case ACTION_ANALOG_MOVE_Y_UP:
+    Move(0.0f, -action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG);
+    break;
+  case ACTION_ANALOG_MOVE_Y_DOWN:
+    Move(0.0f, action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG);
     break;
 
   default:


### PR DESCRIPTION
This PR enables slide show images to be panned in all directions using a joystick with analog sticks.

## Description
When an image is viewed in a full screen slide show, it can be zoomed in/out and panned.  Since the move to the new peripheral architecture, this feature has been working incorrectly when using a joystick with analog sticks for panning.  Specifically, it has only been possible to pan the image right and down, no matter in which direction the analog sticks were tilted.

The issue is caused by the analog motion handlers only being called with positive magnitudes (at least this is my understanding, judging from `std::fabs()` calls inside `CKeymapHandler::OnAnalogStickMotion()`).  This PR attempts to fix the issue by adding additional action IDs:
  * `ANALOG_MOVE_X` is split into `ANALOG_MOVE_X_LEFT` and `ANALOG_MOVE_X_RIGHT`,
  * `ANALOG_MOVE_Y` is split into `ANALOG_MOVE_Y_UP` and `ANALOG_MOVE_Y_DOWN`.

## Motivation and Context
Image panning using a joystick is not fully functional.

## How Has This Been Tested?
Using a Logitech Cordless RumblePad 2, with current master built from source on Arch Linux.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
