### PR TITLE
Websocket: fix handshake parser

### DIFF
--- a/xbmc/network/websocket/WebSocketV13.cpp
+++ b/xbmc/network/websocket/WebSocketV13.cpp
@@ -101,8 +101,9 @@ bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &resp
   }
 
   // There must be a "Connection" header with the value "Upgrade"
-  value = header.getValue(WS_HEADER_CONNECTION_LC);
-  if (value == NULL || strnicmp(value, WS_HEADER_UPGRADE, strlen(WS_HEADER_UPGRADE)) != 0)
+  std::string valueLower(header.getValue(WS_HEADER_CONNECTION_LC));
+  StringUtils::ToLower(valueLower);
+  if (valueLower.find(WS_HEADER_UPGRADE_LC) == std::string::npos)
   {
     CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_CONNECTION_LC);
     return true;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Correct websocket connection header check after #11267 to allow other tokens beside "Upgrade" in the "Connection" header field.

## Description
<!--- Describe your change in detail -->
Implements strtstr() like parsing again and adds case insensitivity by converting the sent string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Firefox i.e. sends `Connection: keep-alive, Upgrade` 

Fixes Chorus2 "Lost Websocket Connection" error as reported [here](https://forum.kodi.tv/showthread.php?tid=308456) and [here](https://github.com/xbmc/chorus2/issues/274) and let the [PlayThis Plugin](https://github.com/anxdpanic/plugin.video.playthis) work again.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
