### PR TITLE
Websocket: fix handshake parser

### DIFF
--- a/xbmc/network/websocket/WebSocketV13.cpp
+++ b/xbmc/network/websocket/WebSocketV13.cpp
@@ -101,8 +101,9 @@ bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &resp
   }
 
   // There must be a "Connection" header with the value "Upgrade"
-  value = header.getValue(WS_HEADER_CONNECTION_LC);
-  if (value == NULL || strnicmp(value, WS_HEADER_UPGRADE, strlen(WS_HEADER_UPGRADE)) != 0)
+  std::string valueLower(header.getValue(WS_HEADER_CONNECTION_LC));
+  StringUtils::ToLower(valueLower);
+  if (valueLower.find(WS_HEADER_UPGRADE_LC) == std::string::npos)
   {
     CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_CONNECTION_LC);
     return true;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Correct websocket connection header check after #11267 to allow other tokens beside "Upgrade" in the "Connection" header field.

Backport of #12934


