### PR TITLE
Fix MacOSX 10.13 SDK build

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -322,6 +322,7 @@ case $host in
           10.10);;
           10.11);;
           10.12);;
+          10.13);;
           *)
             AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
         esac

--- a/tools/depends/native/cmake-native/01-osx-utimensat.diff
+++ b/tools/depends/native/cmake-native/01-osx-utimensat.diff
@@ -1,0 +1,35 @@
+--- a/Source/kwsys/kwsysPlatformTestsCXX.cxx
++++ b/Source/kwsys/kwsysPlatformTestsCXX.cxx
+@@ -265,6 +265,12 @@ int main()
+ #ifdef TEST_KWSYS_CXX_HAS_UTIMENSAT
+ #include <fcntl.h>
+ #include <sys/stat.h>
++#if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 101300
++#error "utimensat not available on macOS < 10.13"
++#endif
++#endif
+ int main()
+ {
+   struct timespec times[2] = { { 0, UTIME_OMIT }, { 0, UTIME_NOW } };
+--- a/Utilities/cmlibarchive/libarchive/archive_platform.h
++++ b/Utilities/cmlibarchive/libarchive/archive_platform.h
+@@ -52,6 +52,17 @@
+ #error Oops: No config.h and no pre-built configuration in archive_platform.h.
+ #endif
+ 
++/* On macOS check for some symbols based on the deployment target version.  */
++#if defined(__APPLE__)
++# undef HAVE_FUTIMENS
++# undef HAVE_UTIMENSAT
++# include <AvailabilityMacros.h>
++# if MAC_OS_X_VERSION_MIN_REQUIRED >= 101300
++#  define HAVE_FUTIMENS 1
++#  define HAVE_UTIMENSAT 1
++# endif
++#endif
++
+ /* It should be possible to get rid of this by extending the feature-test
+  * macros to cover Windows API functions, probably along with non-trivial
+  * refactoring of code to find structures that sit more cleanly on top of

--- a/tools/depends/native/cmake-native/Makefile
+++ b/tools/depends/native/cmake-native/Makefile
@@ -1,9 +1,9 @@
 include ../../Makefile.include
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-osx-utimensat.diff
 
 APPNAME=cmake
-VERSION=3.6.2
+VERSION=3.9.4
 SOURCE=$(APPNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
@@ -33,6 +33,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../01-osx-utimensat.diff
 	cd $(PLATFORM); $(SETENV) $(CONFIGURE)
 
 $(APP): $(PLATFORM)

--- a/tools/depends/native/config.site.native.in
+++ b/tools/depends/native/config.site.native.in
@@ -31,5 +31,9 @@ if test "@platform_os@" = "osx" ; then
   ac_cv_search_clock_gettime=no
   ac_cv_func_clock_gettime=no
   ac_cv_func_getentropy=no
+  ac_cv_func_futimes=no
+  ac_cv_func_futimesat=no
+  ac_cv_func_futimens=no
+  ac_cv_func_utimensat=no
 fi
 

--- a/tools/depends/target/libgcrypt/04-fix-macosx10.13-optimization.patch
+++ b/tools/depends/target/libgcrypt/04-fix-macosx10.13-optimization.patch
@@ -1,0 +1,11 @@
+--- random/Makefile.am.orig	2017-10-20 09:40:33.000000000 +0200
++++ random/Makefile.am	2017-10-20 09:40:45.000000000 +0200
+@@ -55,7 +55,7 @@
+ 
+ # The rndjent module needs to be compiled without optimization.  */
+ if ENABLE_O_FLAG_MUNGING
+-o_flag_munging = sed -e 's/-O\([1-9s][1-9s]*\)/-O0/g' -e 's/-Ofast/-O0/g'
++o_flag_munging = sed -e 's/-O\([1-9sg][1-9sg]*\)/-O0/g' -e 's/-Ofast/-O0/g'
+ else
+ o_flag_munging = cat
+ endif

--- a/tools/depends/target/libgcrypt/Makefile
+++ b/tools/depends/target/libgcrypt/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include 01-gcrypt-android-select.patch 02-fix-armv7-neon.patch 03-remove-cipher-gcm-armv8.patch Makefile
+DEPS= ../../Makefile.include 01-gcrypt-android-select.patch 02-fix-armv7-neon.patch 03-remove-cipher-gcm-armv8.patch 04-fix-macosx10.13-optimization.patch Makefile
 
 # lib name, version
 LIBNAME=libgcrypt
@@ -38,6 +38,9 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../02-fix-armv7-neon.patch
 ifneq ($(findstring arm64, $(CPU)), arm64)
 	cd $(PLATFORM); patch -p0 < ../03-remove-cipher-gcm-armv8.patch
+endif
+ifeq ($(OS),osx)
+	cd $(PLATFORM); patch -p0 < ../04-fix-macosx10.13-optimization.patch
 endif
 	# do not build the tests or docs
 	sed -ie "s|doc tests||" "$(PLATFORM)/Makefile.am"


### PR DESCRIPTION
Fix the build on MacOS when using the 10.13 SDK Version with XCode 9 but still using 10.12 MacOS

## Description
When updating XCode to the new version it also updated to the SDK Version 10.13, but the OS itself is still on 10.12 . After working on this issue for a day with @Rechi and @FernetMenta this is what I had to change to make the build work again.

What was fixed:

Error: `configure: error: error in configure of --with-sdk=10.13`
Fixed by adding SDK Version 10.13 Support

Error: libgcrypt: `The CPU Jitter random number generator must not be compiled with optimizations. See documentation. Use the compiler switch -O0 for compiling jitterentropy-base.c.`
Most likely caused by the recent update of libgcrypt. Fixed by patching the Makefile to also replace the -Og flag with -O0

Error:
````
dyld: lazy symbol binding failed: Symbol not found: _utimensat
  Referenced from: /Users/Shared/xbmc-depends/x86_64-darwin16.7.0-native/bin/cmake
  Expected in: /usr/lib/libSystem.B.dylib
````
Fixed build issue by updating CMake to 3.9.4, patching it to address the issues on macos and adding additional parameters for the native toolchain build.

I am not sure which of those changes we want to get into master right now. 
The SDK Part is no problem.
The libgcrypt should also not cause any issues on other systems, as the patch is only executed on MacOS. But I can only test it on my mac.
The CMake update worked by just increasing the version number and built without issues. So I assume it is OK for other systems also. I think Windows is also using those dependencies, or? Needs to be tested. Also, the CMake tar.gz needs to be put onto the mirror if merged.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
