### PR TITLE
windowing/gbm: fix setting drm mode after gbm surface is created

### DIFF
--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -51,8 +51,6 @@ static drmEventContext m_drm_evctx;
 
 bool CDRMLegacy::SetVideoMode(RESOLUTION_INFO res)
 {
-  CDRMUtils::GetMode(res);
-
   gbm_surface_release_buffer(m_gbm->surface, m_bo);
 
   m_bo = gbm_surface_lock_front_buffer(m_gbm->surface);

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -42,7 +42,7 @@ static drmModeConnectorPtr m_drm_connector = nullptr;
 static drmModeEncoderPtr m_drm_encoder = nullptr;
 static drmModeCrtcPtr m_orig_crtc = nullptr;
 
-bool CDRMUtils::GetMode(RESOLUTION_INFO res)
+bool CDRMUtils::SetMode(RESOLUTION_INFO res)
 {
   m_drm->mode = &m_drm_connector->modes[atoi(res.strId.c_str())];
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -67,9 +67,9 @@ public:
   static bool InitDrm(drm *drm);
   static void DestroyDrm();
   static bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
+  static bool SetMode(RESOLUTION_INFO res);
 
 protected:
-  static bool GetMode(RESOLUTION_INFO res);
   static drm_fb * DrmFbGetFromBo(struct gbm_bo *bo);
 
 private:

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -64,7 +64,13 @@ bool CWinSystemGbm::CreateNewWindow(const std::string& name,
                                     bool fullScreen,
                                     RESOLUTION_INFO& res)
 {
-  if (!CGBMUtils::InitGbm(&m_gbm, m_drm.mode->hdisplay, m_drm.mode->vdisplay))
+  if(!CDRMUtils::SetMode(res))
+  {
+    CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to set DRM mode", __FUNCTION__);
+    return false;
+  }
+
+  if(!CGBMUtils::InitGbm(&m_gbm, m_drm.mode->hdisplay, m_drm.mode->vdisplay))
   {
     CLog::Log(LOGERROR, "CWinSystemGbm::%s - failed to initialize GBM", __FUNCTION__);
     return false;


### PR DESCRIPTION
Setting the drm mode after creating the gbm surface results in a size mismatch in some cases. Setting the drm mode before the surface is created fixes this issue.

thanks @a1rwulf for testing.