### PR TITLE
[GUI]Add optional 3rd button to YesNoDialog 

### DIFF
--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -100,6 +100,17 @@ public:
    */
   static bool ShowAndGetInput(CVariant heading, CVariant text, bool &bCanceled, CVariant noLabel, CVariant yesLabel, unsigned int autoCloseTime);
 
+  /*! \brief Show a yes-no dialog with 3rd custom button, then wait for user to dismiss it.
+  \param heading Localized label id or string for the heading of the dialog
+  \param text Localized label id or string for the dialog message
+  \param noLabel Localized label id or string for the no button
+  \param yesLabel Localized label id or string for the yes button
+  \param customLabel Localized label id or string for the custom button
+  \param autoCloseTime Time in ms before the dialog becomes automatically closed
+  \return -1 for cancelled, 0 for No, 1 for Yes and 2 for custom button
+  */
+  static int ShowAndGetInput(CVariant heading, CVariant text, CVariant noLabel, CVariant yesLabel, CVariant customLabel, unsigned int autoCloseTime);
+
   /*!
     \brief Open a Yes/No dialog and wait for input
 
@@ -116,4 +127,5 @@ protected:
   int GetDefaultLabelID(int controlId) const override;
 
   bool m_bCanceled;
+  bool m_bCustom;
 };

--- a/xbmc/messaging/helpers/DialogHelper.cpp
+++ b/xbmc/messaging/helpers/DialogHelper.cpp
@@ -32,13 +32,19 @@ namespace HELPERS
 {
 DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noLabel, CVariant yesLabel, uint32_t autoCloseTimeout)
 {
+  return ShowYesNoCustomDialog(heading, text, noLabel, yesLabel, "", autoCloseTimeout);
+}
+
+DialogResponse ShowYesNoCustomDialog(CVariant heading, CVariant text, CVariant noLabel, CVariant yesLabel, CVariant customLabel, uint32_t autoCloseTimeout)
+{
   DialogYesNoMessage options;
   options.heading = std::move(heading);
   options.text = std::move(text);
   options.noLabel = std::move(noLabel);
   options.yesLabel = std::move(yesLabel);
+  options.customLabel = std::move(customLabel);
   options.autoclose = autoCloseTimeout;
-  
+
   switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
   {
   case -1:
@@ -47,6 +53,8 @@ DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noL
     return DialogResponse::NO;
   case 1:
     return DialogResponse::YES;
+  case 2:
+    return DialogResponse::CUSTOM;
   default:
     //If we get here someone changed the return values without updating this code
     assert(false);
@@ -56,7 +64,8 @@ DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noL
   return DialogResponse::CANCELLED;
 }
 
-DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2, CVariant noLabel, CVariant yesLabel, uint32_t autoCloseTimeout)
+DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant line1, CVariant line2,
+  CVariant noLabel, CVariant yesLabel, uint32_t autoCloseTimeout)
 {
   DialogYesNoMessage options;
   options.heading = std::move(heading);
@@ -65,6 +74,7 @@ DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant l
   options.lines[2] = std::move(line2);
   options.noLabel = std::move(noLabel);
   options.yesLabel = std::move(yesLabel);
+  options.customLabel = "";
   options.autoclose = autoCloseTimeout;
 
   switch (CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_DIALOG_YESNO, -1, -1, static_cast<void*>(&options)))
@@ -75,6 +85,8 @@ DialogResponse ShowYesNoDialogLines(CVariant heading, CVariant line0, CVariant l
     return DialogResponse::NO;
   case 1:
     return DialogResponse::YES;
+  case 2:
+    return DialogResponse::CUSTOM;
   default:
     //If we get here someone changed the return values without updating this code
     assert(false);

--- a/xbmc/messaging/helpers/DialogHelper.h
+++ b/xbmc/messaging/helpers/DialogHelper.h
@@ -35,7 +35,8 @@ enum class DialogResponse
 {
   CANCELLED,
   YES,
-  NO
+  NO,
+  CUSTOM
 };
 
 /*! \struct DialogYesNoMessage DialogHelper.h "messaging/helpers/DialogHelper.h"
@@ -51,6 +52,7 @@ struct DialogYesNoMessage
   std::array<CVariant, 3> lines;  //!< Body text to be displayed, specified as three lines. This is mutually exclusive with the text above
   CVariant yesLabel;  //!< Text to show on the yes button
   CVariant noLabel; //!< Text to show on the no button
+  CVariant customLabel; //!< Text to show on the 3rd custom button
   uint32_t autoclose{0}; //!< Time in milliseconds before autoclosing the dialog, 0 means don't autoclose
 };
 
@@ -72,6 +74,27 @@ struct DialogYesNoMessage
 */
 DialogResponse ShowYesNoDialogText(CVariant heading, CVariant text, CVariant noLabel = CVariant(),
                                    CVariant yesLabel = CVariant(), uint32_t autoCloseTimeout = 0);
+
+/*!
+\brief This is a helper method to send a threadmessage to open a Yes/No dialog box with a cutom button
+
+\param[in]  heading           The text to display as the dialog box header
+\param[in]  text              The text to display in the dialog body
+\param[in]  noLabel           The text to display on the No button
+                              defaults to No
+\param[in]  yesLabel          The text to display on the Yes button
+                              defaults to Yes
+\param[in]  customLabel       The text to display on the optional 3rd custom button
+                              defaults to empty and button not shown
+\param[in]  autoCloseTimeout  The time before the dialog closes
+                              defaults to 0 show indefinitely
+\return -1 on cancelled, 0 on no, 1 on yes and 2 on 3rd custom response
+\sa ShowYesNoDialogLines
+\sa CGUIDialogYesNo::ShowAndGetInput
+\sa DialogYesNoMessage
+*/
+DialogResponse ShowYesNoCustomDialog(CVariant heading, CVariant text, CVariant noLabel = CVariant(), CVariant yesLabel = CVariant(),
+                                        CVariant customLabel = CVariant(), uint32_t autoCloseTimeout = 0);
 
 /*!
   \brief This is a helper method to send a threadmessage to open a Yes/No dialog box


### PR DESCRIPTION
The potential for a 3rd button on YesNoDialog was suggested and included in refactoring of various dialogs into  DialogConfirm.xml in #8865. This makes the 3rd button fully availalble to calling routines.

It adds an overload of `CGUIDialogYesNo::ShowAndGetInput` that enables and labels the 3rd button.

~~It modifies the interface to `HELPERS::ShowYesNoDialogText` and `ShowYesNoDialogLines` to do the same. Since the parameters are all variants I have checked every call to these routines and adjusted those that need it to allow for having inserted a parameter.~~
It adds convenience method `HELPERS::ShowYesNoCustomDialog` to invoke a 3 btton dialog, so avoiding a empty parameter or changes to existing calls.

@ronie, @phil65 and @Paxxi perhaps you could check this.

I have a use for the 3rd button in a separate PR,  and have tested it using that.

![](https://i.imgur.com/yDktiRU.jpg)