### PR TITLE
Reenable advanced settings forcevaapienabled

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 #include "Application.h"
 #include "VideoSyncDRM.h"
+#include "settings/AdvancedSettings.h"
 
 #ifdef HAS_GLX
 #include "VideoSyncGLX.h"
@@ -237,7 +238,7 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
     if (vend)
       gpuvendor = vend;
     std::transform(gpuvendor.begin(), gpuvendor.end(), gpuvendor.begin(), ::tolower);
-    if (gpuvendor.compare(0, 5, "intel") == 0)
+    if (gpuvendor.compare(0, 5, "intel") == 0 || g_advancedSettings.m_videoVAAPIforced)
     {
 #if defined (HAVE_LIBVA)
       EGLDisplay eglDpy = static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay;


### PR DESCRIPTION
	modified:   xbmc/windowing/X11/WinSystemX11GLContext.cpp

Kodi has an advancedsetting option "forcevaapienabled" in 17.x. It got disabled in kodi 18-git because of code-move.

Reenable the option for people that "know what they are doing"

This code is no bugfix nor really a new feature.
It is for people (like me) that saw options in the documentation and don't understand why nothing shows in the debug log files. Once enabled, they can check how things work with their hardware.

