### PR TITLE
fix copying of script.module.pil and script.module.pycryptodome

### DIFF
--- a/cmake/installdata/windows/addons.txt
+++ b/cmake/installdata/windows/addons.txt
@@ -1,2 +1,3 @@
 addons/repository.pvr-win32.xbmc.org/*
-project/BuildDependencies/${ARCH}/addons KEEP_DIR_STRUCTURE addons
+project/BuildDependencies/${ARCH}/addons/script.module.pil KEEP_DIR_STRUCTURE addons
+project/BuildDependencies/${ARCH}/addons/script.module.pycryptodome KEEP_DIR_STRUCTURE addons


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

<!--## Description-->
<!--- Describe your change in detail -->

## Motivation and Context
script.module.pil and script.module.pycryptodome aren't packed anymore for win32 since #12933
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
