### PR TITLE
[Krypton] Fix crash on startup when peripheral.joystick is disabled

### DIFF
--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -51,8 +51,11 @@ CPeripheralJoystick::CPeripheralJoystick(const PeripheralScanResult& scanResult,
 CPeripheralJoystick::~CPeripheralJoystick(void)
 {
   m_defaultInputHandler.AbortRumble();
-  UnregisterJoystickInputHandler(m_joystickMonitor.get());
-  m_joystickMonitor.reset();
+  if (m_joystickMonitor)
+  {
+    UnregisterJoystickInputHandler(m_joystickMonitor.get());
+    m_joystickMonitor.reset();
+  }
   UnregisterJoystickInputHandler(&m_defaultInputHandler);
   m_deadzoneFilter.reset();
   m_buttonMap.reset();


### PR DESCRIPTION
Backport of #12951