### PR TITLE
FIX: Only remove options for actual URL in URIUtils::Split (fixes #17627)

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -218,16 +218,19 @@ void URIUtils::Split(const std::string& strFileNameAndPath,
   // everything to the right of the directory separator
   strFileName = strFileNameAndPath.substr(i+1);
 
-  // ignore options
-  i = strFileName.size() - 1;
-  while (i > 0)
+  // if actual uri, ignore options
+  if (IsURL(strFileNameAndPath))
   {
-    char ch = strFileName[i];
-    if (ch == '?') break;
-    else i--;
+    i = strFileName.size() - 1;
+    while (i > 0)
+    {
+      char ch = strFileName[i];
+      if (ch == '?') break;
+      else i--;
+    }
+    if (i > 0)
+      strFileName = strFileName.substr(0, i);
   }
-  if (i > 0)
-    strFileName = strFileName.substr(0, i);
 }
 
 std::vector<std::string> URIUtils::SplitPath(const std::string& strPath)

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -124,7 +124,15 @@ TEST_F(TestURIUtils, Split)
 
   std::string varpathOptional, varfileOptional;
 
-  URIUtils::Split("/path/to/movie.avi?showinfo=true", varpathOptional, varfileOptional);
+  refpath = "/path/to/";
+  reffile = "movie?movie.avi";
+  URIUtils::Split("/path/to/movie?movie.avi", varpathOptional, varfileOptional);
+  EXPECT_STREQ(refpath.c_str(), varpathOptional.c_str());
+  EXPECT_STREQ(reffile.c_str(), varfileOptional.c_str());
+
+  refpath = "file:///path/to/";
+  reffile = "movie.avi";
+  URIUtils::Split("file:///path/to/movie.avi?showinfo=true", varpathOptional, varfileOptional);
   EXPECT_STREQ(refpath.c_str(), varpathOptional.c_str());
   EXPECT_STREQ(reffile.c_str(), varfileOptional.c_str());
 }


### PR DESCRIPTION
@mkortstiege @Razzeee 

Quick fix for the issue we discussed about.
Untested, so if you could make it tested, somehow...