### PR TITLE
VideoPlayer: add OnAVChange callback

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3618,6 +3618,10 @@ void CApplication::OnPlayBackSeekChapter(int iChapter)
 #endif
 }
 
+void CApplication::OnAVChange()
+{
+}
+
 void CApplication::RequestVideoSettings(const CFileItem &fileItem)
 {
   CVideoDatabase dbs;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -176,6 +176,7 @@ public:
   void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) override;
   void OnPlayBackSeekChapter(int iChapter) override;
   void OnPlayBackSpeedChanged(int iSpeed) override;
+  void OnAVChange() override;
   void RequestVideoSettings(const CFileItem &fileItem) override;
   void StoreVideoSettings(const CFileItem &fileItem, CVideoSettings vs) override;
 

--- a/xbmc/cores/IPlayerCallback.h
+++ b/xbmc/cores/IPlayerCallback.h
@@ -39,6 +39,7 @@ public:
   virtual void OnPlayBackSeek(int64_t iTime, int64_t seekOffset) {};
   virtual void OnPlayBackSeekChapter(int iChapter) {};
   virtual void OnPlayBackSpeedChanged(int iSpeed) {};
+  virtual void OnAVChange() {};
   virtual void RequestVideoSettings(const CFileItem &fileItem) {};
   virtual void StoreVideoSettings(const CFileItem &fileItem, CVideoSettings vs) {};
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2937,6 +2937,10 @@ void CVideoPlayer::HandleMessages()
     {
       CServiceBroker::GetDataCacheCore().SignalAudioInfoChange();
       CServiceBroker::GetDataCacheCore().SignalVideoInfoChange();
+      IPlayerCallback *cb = &m_callback;
+      CJobManager::GetInstance().Submit([=]() {
+        cb->OnAVChange();
+      }, CJob::PRIORITY_NORMAL);
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_ABORT))
     {


### PR DESCRIPTION
This event can be used by clients interested in the state of a/v streams. On this event they can query CDataCacheCore for current state of streams.

@da-anda this can be used by i.e. StereoScopicManager