### PR TITLE
changed: drop enumeration and hardcoding for supported protocols

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21292,3 +21292,8 @@ msgstr ""
 msgctxt "#39102"
 msgid "Play Radio"
 msgstr ""
+
+#: xbmc/network/GUIDialogNetworkSetup.cpp
+msgctxt "#39103"
+msgid "Unable to configure network location. Invalid path given."
+msgstr ""

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -25,17 +25,19 @@
 class CGUIDialogNetworkSetup : public CGUIDialogSettingsManualBase
 {
 public:
-  enum NET_PROTOCOL { NET_PROTOCOL_SMB = 0,
-                      NET_PROTOCOL_XBMSP,
-                      NET_PROTOCOL_FTP,
-                      NET_PROTOCOL_HTTP,
-                      NET_PROTOCOL_HTTPS,
-                      NET_PROTOCOL_DAV,
-                      NET_PROTOCOL_DAVS,
-                      NET_PROTOCOL_UPNP,
-                      NET_PROTOCOL_RSS,
-                      NET_PROTOCOL_SFTP,
-                      NET_PROTOCOL_NFS};
+  //! \brief A structure encapsulating properties of a supported protocol.
+  struct Protocol
+  {
+    bool supportPath;      //!< Protocol has path in addition to server name
+    bool supportUsername;  //!< Protocol uses logins
+    bool supportPassword;  //!< Protocol supports passwords
+    bool supportPort;      //!< Protocol supports port customization
+    bool supportBrowsing;  //!< Protocol supports server browsing
+    int defaultPort;       //!< Default port to use for protocol
+    std::string type;      //!< URL type for protocol
+    int label;             //!< String ID to use as label in dialog
+  };
+
   CGUIDialogNetworkSetup(void);
   ~CGUIDialogNetworkSetup(void) override;
   bool OnMessage(CGUIMessage& message) override;
@@ -46,7 +48,7 @@ public:
   static bool ShowAndGetNetworkAddress(std::string &path);
 
   std::string ConstructPath() const;
-  void SetPath(const std::string &path);
+  bool SetPath(const std::string &path);
   bool IsConfirmed() const override { return m_confirmed; };
 
 protected:
@@ -67,8 +69,10 @@ protected:
   void OnOK();
   void OnCancel() override;
   void UpdateButtons();
+  void Reset();
 
-  NET_PROTOCOL m_protocol;
+  int m_protocol; //!< Currently selected protocol
+  std::vector<Protocol> m_protocols; //!< List of available protocols
   std::string m_server;
   std::string m_path;
   std::string m_username;


### PR DESCRIPTION
instead use a descriptor struct for supported protocols

this is a preparatory step to allow reading this info for vfs add-ons

<!--- Provide a general summary of your change in the Title above -->

## Description
Drop enumeration and hardcoded if statements. instead encode properties of protocols in a descriptor struct. this will allow reading the same info from vfs add-ons so stuff only shows up if available.

i think this is better than having an installation query at this time since we cannot actually perform that installation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
It gives the same entries as before.