### PR TITLE
FIX: [droid] pick toolchain gcc at depends configure time

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -14,9 +14,6 @@ passed_cxxflags="$CXXFLAGS"
 
 m4_include([m4/xbmc_arch.m4])
 m4_include([m4/ax_cxx_compile_stdcxx_11.m4])
-AX_CXX_COMPILE_STDCXX_11(,[mandatory])
-c11_flags=$(echo "$CFLAGS" | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ //g')
-cxx11_flags=$(echo "$CXXFLAGS" | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ //g')
 
 # check for not same cpu value
 AC_DEFUN([MC_CHECK_NOT_CPU],
@@ -99,6 +96,16 @@ AC_ARG_ENABLE([wayland],
   [build libraries needed for Wayland. default is no])],
   [enable_wayland=$enableval],
   [enable_wayland=no])
+
+
+OLD_PATH="${PATH}"
+if test -n "$use_toolchain"; then
+  PATH="${use_toolchain}/bin:${use_toolchain}/usr/bin:$PATH"
+fi
+AX_CXX_COMPILE_STDCXX_11(,[mandatory])
+c11_flags=$(echo "$CFLAGS" | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ //g')
+cxx11_flags=$(echo "$CXXFLAGS" | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ //g')
+PATH="${OLD_PATH}"
 
 if test "$use_ccache" = "yes"; then
   AC_CHECK_PROG(HAVE_CCACHE,ccache,"yes","no",)
@@ -637,6 +644,7 @@ if test "$platform_os" == "android"; then
     AC_MSG_ERROR(unable to create $prefix/$deps_dir/lib/$use_sdk. verify that the path and permissions are correct.)
   fi
 fi
+
 
 # remove unwanted optimization flags
 tmp_cflags=$(echo $c11_flags $platform_cflags | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ \{2,\}//g')


### PR DESCRIPTION
There is a bug since forever that the depends configure uses the host gcc rather than the target one:
```
onfigure:2158: checking for arm-linux-androideabi-g++
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-c++
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-gpp
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-aCC
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-CC
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-cxx
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-cc++
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-cl.exe
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-FCC
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-KCC
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-RCC
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-xlC_r
configure:2188: result: no
configure:2158: checking for arm-linux-androideabi-xlC
configure:2188: result: no
configure:2202: checking for g++
configure:2218: found /usr/bin/g++
configure:2229: result: g++
configure:2256: checking for C++ compiler version
configure:2265: g++ --version >&5
g++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609
```

It now bites because gcc6(?) has c++11 builtin, so the proper "--std=" is not added when building on such systems

gcc5:
```
configure:2659: checking whether g++ supports C++11 features by default
[...]
configure:2700: result: no
configure:2709: checking whether g++ supports C++11 features with -std=gnu++11
configure:2745: g++ -c -g -O2 -std=gnu++11  conftest.cpp >&5
configure:2745: $? = 0
configure:2754: result: yes
```

I don't have gcc6, but garbear has, and the result is "yes", so "std=gnu++11" is not added and builds fail with the 4.9 of the toolchain

Thanks to @wsnipex for the final solution