### PR TITLE
[backport] FIX: [python] droid libs

### DIFF
--- a/tools/depends/target/python27/Makefile
+++ b/tools/depends/target/python27/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.include
 DEPS= ../../Makefile.include Makefile Python-2.7.12-crosscompile.patch Python-2.7.10-android.patch Python-no-export-path.patch \
-       Python-setup.patch fix-datetime.patch Python-2.6.5-urllib.diff modules.setup make-fork-optional.patch
+       Python-setup.patch fix-datetime.patch Python-2.6.5-urllib.diff modules.setup make-fork-optional.patch android-binmodule.patch
 
 # lib name, version
 LIBNAME=Python
@@ -39,6 +39,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	cd $(PLATFORM); patch -p0 < ../Python-2.7.10-android.patch
 	cd $(PLATFORM); patch -p0 < ../Python-no-export-path.patch
 	cd $(PLATFORM); patch -p0 < ../fix-ffi.patch
+	cd $(PLATFORM); patch -p1 -i ../android-binmodule.patch
 ifeq ($(OS),ios)
 	cd $(PLATFORM); patch -p0 < ../make-fork-optional.patch
 	cd $(PLATFORM); patch -p0 < ../Python-2.6.5-urllib.diff

--- a/tools/depends/target/python27/android-binmodule.patch
+++ b/tools/depends/target/python27/android-binmodule.patch
@@ -1,0 +1,31 @@
+--- a/Python/dynload_shlib.c
++++ b/Python/dynload_shlib.c
+@@ -112,10 +112,6 @@
+     dlopenflags = PyThreadState_GET()->interp->dlopenflags;
+ #endif
+ 
+-    if (Py_VerboseFlag)
+-        PySys_WriteStderr("dlopen(\"%s\", %x);\n", pathname,
+-                          dlopenflags);
+-
+ #ifdef __VMS
+     /* VMS currently don't allow a pathname, use a logical name instead */
+     /* Concatenate 'python_module_' and shortname */
+@@ -125,8 +121,17 @@
+     PyOS_snprintf(pathbuf, sizeof(pathbuf), "python_module_%-.200s",
+                   shortname);
+     pathname = pathbuf;
++#elif defined(ANDROID)
++    /* Android does not allow a pathname and wants lib*.so */
++    PyOS_snprintf(pathbuf, sizeof(pathbuf), "lib%-.200s.so", 
++                  shortname);
++    pathname = pathbuf;
+ #endif
+ 
++    if (Py_VerboseFlag)
++        PySys_WriteStderr("dlopen(\"%s\", %x);\n", pathname,
++                          dlopenflags);
++
+     handle = dlopen(pathname, dlopenflags);
+ 
+     if (handle == NULL) {


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
partial backport of #11885
@koying FYI
<!--- Describe your change in detail -->

## Motivation and Context
currently using script.module.pil fails on android
At the change from python 2.6 to 2.7 this patch got accidentally removed.
Later it was added to master again, but forgotten to backport.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Confirmed working at https://forum.kodi.tv/showthread.php?tid=322184&pid=2661268#pid2661268
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
