### PR TITLE
[depends/osx] - fix the regex for finding the SDK verson ...

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -258,7 +258,7 @@ case $host in
       prefix=/Users/Shared/xbmc-depends
     fi
 
-    native_platform_min_version=-mmacosx-version-min=`sw_vers | grep ProductVersion | sed "s/.*:.*\(10\..*\)\..*/\1/"`
+    native_platform_min_version=-mmacosx-version-min=`sw_vers | grep ProductVersion | sed -E "s/.*:.*(10\..*)\.?.*/\1/"`
     use_xcodepath=`xcode-select -print-path`
     use_xcodebuild=$use_xcodepath/usr/bin/xcodebuild
     use_xcode=[`$use_xcodebuild -version | grep Xcode | awk '{ print $2}'`]


### PR DESCRIPTION
… suitable for… the running host (make both Major.Minor.Patch and Major.Minor strings work) - fixes compiling with xcode9 under MacOS High Sierra (10.13)

Couldn't test this case during devcon (no high sierra installed).

