### PR TITLE
[addons][fix] Generate proj. files on Release mode

### DIFF
--- a/tools/windows/prepare-binary-addons-dev.bat
+++ b/tools/windows/prepare-binary-addons-dev.bat
@@ -77,7 +77,7 @@ IF "%addon%" NEQ "" (
 
 rem execute cmake to generate Visual Studio 12 project files
 cmake "%ADDONS_PATH%" -G "Visual Studio 14" ^
-      -DCMAKE_BUILD_TYPE=Debug ^
+      -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^
       -DCMAKE_INSTALL_PREFIX=%WORKDIR%\addons ^


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This is a fix that binary add-on devs have had to do manually for a while now for the build system to work.
For some reason no-one has PR'ed it yet, so I did.

It's referred to in the build guide for game.libretro [here](https://github.com/kodi-game/game.libretro#developing-on-windows), and many other binary add-ons.
Credits: @Montellese who suggested it 2 years ago [here](https://forum.kodi.tv/showthread.php?tid=173361&pid=2097898#pid2097898).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The binary add-on build system doesn't work without this.
It was an inconvencience having to manually do it every so often.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tried to build a binary add-on from start to finish.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
