### PR TITLE
Some CFileItem cleaning

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2973,7 +2973,7 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string &player, int iPl
       }
     }
   }
-  else if (item.IsPVR())
+  else if (item.IsType("pvr://"))
   {
     return CServiceBroker::GetPVRManager().GUIActions()->PlayMedia(CFileItemPtr(new CFileItem(item)));
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3275,7 +3275,7 @@ void CApplication::PlaybackCleanup()
   }
 
   // DVD ejected while playing in vis ?
-  if (!m_appPlayer.IsPlayingAudio() && (m_itemCurrentFile->IsCDDA() || m_itemCurrentFile->IsOnDVD()) && !g_mediaManager.IsDiscInDrive() && CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION)
+  if (!m_appPlayer.IsPlayingAudio() && (m_itemCurrentFile->IsType("cdda://") || m_itemCurrentFile->IsOnDVD()) && !g_mediaManager.IsDiscInDrive() && CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION)
   {
     // yes, disable vis
     m_ServiceManager->GetSettings().Save();    // save vis settings

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4210,7 +4210,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
     }
     CFileItem item(actionStr, false);
 #ifdef HAS_PYTHON
-    if (item.IsPythonScript())
+    if (item.IsType(".py"))
     { // a python script
       CScriptInvocationManager::GetInstance().ExecuteAsync(item.GetPath());
     }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2047,7 +2047,7 @@ bool CApplication::OnAction(const CAction &action)
 
   // Now check with the player if action can be handled.
   bool bIsPlayingPVRChannel = (CServiceBroker::GetPVRManager().IsStarted() &&
-                               CurrentFileItem().IsPVRChannel());
+                               CurrentFileItem().HasPVRChannelInfoTag());
 
   bool bNotifyPlayer = false;
   if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3077,7 +3077,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   // if we have a stacked set of files, we need to setup our stack routines for
   // "seamless" seeking and total time of the movie etc.
   // will recall with restart set to true
-  if (item.IsStack())
+  if (item.IsType("stack://"))
     return PlayStack(item, bRestart);
 
   CPlayerOptions options;

--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -75,7 +75,7 @@ void CApplicationStackHelper::OnPlayBackStarted(const CFileItem& item)
 
 bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
 {
-  if (!item.IsStack())
+  if (!item.IsType("stack://"))
     return false;
 
   CFileItemPtr stack(new CFileItem(item));

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -396,7 +396,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
       if (!pItem->m_bIsFolder && pItem->IsVideo())
       {
         bPlaying = true;
-        if (pItem->IsStack())
+        if (pItem->IsType("stack://"))
         {
           //! @todo remove this once the app/player is capable of handling stacks immediately
           CStackDirectory dir;

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -28,7 +28,7 @@ namespace CONTEXTMENU
   bool CEjectDisk::IsVisible(const CFileItem& item) const
   {
 #ifdef HAS_DVD_DRIVE
-    return item.IsRemovable() && (item.IsDVD() || item.IsCDDA());
+    return item.IsRemovable() && (item.IsDVD() || item.IsType("cdda://"));
 #else
     return false;
 #endif
@@ -45,7 +45,7 @@ namespace CONTEXTMENU
   bool CEjectDrive::IsVisible(const CFileItem& item) const
   {
     // Must be HDD
-    return item.IsRemovable() && !item.IsDVD() && !item.IsCDDA();
+    return item.IsRemovable() && !item.IsDVD() && !item.IsType("cdda://");
   }
 
   bool CEjectDrive::Execute(const CFileItemPtr& item) const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1112,11 +1112,6 @@ bool CFileItem::IsZIP() const
   return URIUtils::IsZIP(m_strPath);
 }
 
-bool CFileItem::IsCBZ() const
-{
-  return URIUtils::HasExtension(m_strPath, ".cbz");
-}
-
 bool CFileItem::IsCBR() const
 {
   return URIUtils::HasExtension(m_strPath, ".cbr");

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1128,11 +1128,6 @@ bool CFileItem::IsOnLAN() const
   return URIUtils::IsOnLAN(m_strPath);
 }
 
-bool CFileItem::IsISO9660() const
-{
-  return URIUtils::IsISO9660(m_strPath);
-}
-
 bool CFileItem::IsRemote() const
 {
   return URIUtils::IsRemote(m_strPath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -830,11 +830,6 @@ bool CFileItem::IsVideo() const
   return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
 }
 
-bool CFileItem::IsPVRChannel() const
-{
-  return HasPVRChannelInfoTag();
-}
-
 bool CFileItem::IsPVRRecording() const
 {
   return HasPVRRecordingInfoTag();
@@ -1296,7 +1291,7 @@ void CFileItem::FillInDefaultIcon()
        * in mind the complexity of the code behind the check in the
        * case of IsWhatever() returns false.
        */
-      if (IsPVRChannel())
+      if (HasPVRChannelInfoTag())
       {
         if (GetPVRChannelInfoTag()->IsRadio())
           SetIconImage("DefaultAudio.png");

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1093,11 +1093,6 @@ bool CFileItem::IsRSS() const
       || m_mimetype == "application/rss+xml";
 }
 
-bool CFileItem::IsStack() const
-{
-  return URIUtils::IsStack(m_strPath);
-}
-
 bool CFileItem::IsScript() const
 {
   return URIUtils::IsScript(m_strPath);
@@ -2932,7 +2927,7 @@ std::string CFileItem::GetTBNFile() const
   std::string thumbFile;
   std::string strFile = m_strPath;
 
-  if (IsStack())
+  if (IsType("stack://"))
   {
     std::string strPath, strReturn;
     URIUtils::GetParentPath(m_strPath,strPath);
@@ -3017,7 +3012,7 @@ std::string CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) c
     return "";
 
   std::string strFile = m_strPath;
-  if (IsStack())
+  if (IsType("stack://"))
   {
 /*    CFileItem item(CStackDirectory::GetFirstStackedFile(strFile),false);
     std::string localArt = item.GetLocalArt(artFile);
@@ -3069,7 +3064,7 @@ std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.
 {
   std::string strFolder = m_strPath;
 
-  if (IsStack() ||
+  if (IsType("stack://") ||
       URIUtils::IsInRAR(strFolder) ||
       URIUtils::IsInZIP(strFolder))
   {
@@ -3151,7 +3146,7 @@ std::string CFileItem::GetLocalFanart() const
 
   std::string strFile2;
   std::string strFile = m_strPath;
-  if (IsStack())
+  if (IsType("stack://"))
   {
     std::string strPath;
     URIUtils::GetParentPath(m_strPath,strPath);
@@ -3424,7 +3419,7 @@ std::string CFileItem::FindTrailer() const
 {
   std::string strFile2;
   std::string strFile = m_strPath;
-  if (IsStack())
+  if (IsType("stack://"))
   {
     std::string strPath;
     URIUtils::GetParentPath(m_strPath,strPath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1093,11 +1093,6 @@ bool CFileItem::IsRSS() const
       || m_mimetype == "application/rss+xml";
 }
 
-bool CFileItem::IsScript() const
-{
-  return URIUtils::IsScript(m_strPath);
-}
-
 bool CFileItem::IsDVD() const
 {
   return URIUtils::IsDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_DVD;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1163,11 +1163,6 @@ bool CFileItem::IsHD() const
   return URIUtils::IsHD(m_strPath);
 }
 
-bool CFileItem::IsMusicDb() const
-{
-  return URIUtils::IsMusicDb(m_strPath);
-}
-
 bool CFileItem::IsVideoDb() const
 {
   return URIUtils::IsVideoDb(m_strPath);
@@ -1449,7 +1444,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       return ((GetVideoInfoTag()->m_iDbId == item->GetVideoInfoTag()->m_iDbId) &&
         (GetVideoInfoTag()->m_type == item->GetVideoInfoTag()->m_type));
   }
-  if (IsMusicDb() && HasMusicInfoTag())
+  if (IsType("musicdb://") && HasMusicInfoTag())
   {
     CFileItem dbItem(m_musicInfoTag->GetURL(), false);
     if (HasProperty("item_start"))
@@ -1463,7 +1458,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       dbItem.SetProperty("item_start", GetProperty("item_start"));
     return dbItem.IsSamePath(item);
   }
-  if (item->IsMusicDb() && item->HasMusicInfoTag())
+  if (item->IsType("musicdb://") && item->HasMusicInfoTag())
   {
     CFileItem dbItem(item->m_musicInfoTag->GetURL(), false);
     if (item->HasProperty("item_start"))
@@ -2862,7 +2857,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
   if (IsCDDA() || IsOnDVD())
     return StringUtils::Format("special://temp/archive_cache/r-%08x.fi", crc);
 
-  if (IsMusicDb())
+  if (IsType("musicdb://"))
     return StringUtils::Format("special://temp/archive_cache/mdb-%08x.fi", crc);
 
   if (IsVideoDb())
@@ -2880,7 +2875,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
 bool CFileItemList::AlwaysCache() const
 {
   // some database folders are always cached
-  if (IsMusicDb())
+  if (IsType("musicdb://"))
     return CMusicDatabaseDirectory::CanCache(GetPath());
   if (IsVideoDb())
     return CVideoDatabaseDirectory::CanCache(GetPath());
@@ -2902,7 +2897,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
    || IsType("addons://")
    || IsLibraryFolder()
    || IsParentFolder()
-   || IsMusicDb())
+   || IsType("musicdb://"))
     return "";
 
   // we first check for <filename>.tbn or <foldername>.tbn

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1051,11 +1051,6 @@ bool CFileItem::IsType(const char *ext) const
   return StringUtils::StartsWithNoCase(GetDynPath(), ext);
 }
 
-bool CFileItem::IsNFO() const
-{
-  return URIUtils::HasExtension(m_strPath, ".nfo");
-}
-
 bool CFileItem::IsDiscImage() const
 {
   return URIUtils::HasExtension(m_strPath, ".img|.iso|.nrg|.udf");
@@ -2688,7 +2683,7 @@ void CFileItemList::StackFiles()
     // skip folders, nfo files, playlists
     if (item1->m_bIsFolder
       || item1->IsParentFolder()
-      || item1->IsNFO()
+      || item1->IsType(".nfo")
       || item1->IsPlayList()
       )
     {
@@ -2728,7 +2723,7 @@ void CFileItemList::StackFiles()
           // skip folders, nfo files, playlists
           if (item2->m_bIsFolder
             || item2->IsParentFolder()
-            || item2->IsNFO()
+            || item2->IsType(".nfo")
             || item2->IsPlayList()
             )
           {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1098,11 +1098,6 @@ bool CFileItem::IsScript() const
   return URIUtils::IsScript(m_strPath);
 }
 
-bool CFileItem::IsMultiPath() const
-{
-  return URIUtils::IsMultiPath(m_strPath);
-}
-
 bool CFileItem::IsDVD() const
 {
   return URIUtils::IsDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_DVD;
@@ -3021,7 +3016,7 @@ std::string CFileItem::GetLocalArt(const std::string &artFile, bool useFolder) c
     strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(strFile));
   }
 
-  if (IsMultiPath())
+  if (IsType("multipath://"))
     strFile = CMultiPathDirectory::GetFirstPath(m_strPath);
 
   if (IsOpticalMediaFile())
@@ -3061,7 +3056,7 @@ std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.
     URIUtils::GetParentPath(m_strPath,strFolder);
   }
 
-  if (IsMultiPath())
+  if (IsType("multipath://"))
     strFolder = CMultiPathDirectory::GetFirstPath(m_strPath);
 
   if (IsType("plugin://"))
@@ -3101,7 +3096,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 {
   std::string strMovieName = m_strPath;
 
-  if (IsMultiPath())
+  if (IsType("multipath://"))
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
 
   if (IsOpticalMediaFile())

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -763,7 +763,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
    || IsType("pvr://"))
     return true;
 
-  if (IsVideoDb() && HasVideoInfoTag())
+  if (IsType("videodb://") && HasVideoInfoTag())
   {
     CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath : GetVideoInfoTag()->m_strFileNameAndPath, m_bIsFolder);
     return dbItem.Exists();
@@ -847,7 +847,7 @@ bool CFileItem::IsInProgressPVRRecording() const
 
 bool CFileItem::IsDiscStub() const
 {
-  if (IsVideoDb() && HasVideoInfoTag())
+  if (IsType("videodb://") && HasVideoInfoTag())
   {
     CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath : GetVideoInfoTag()->m_strFileNameAndPath, m_bIsFolder);
     return dbItem.IsDiscStub();
@@ -1163,11 +1163,6 @@ bool CFileItem::IsHD() const
   return URIUtils::IsHD(m_strPath);
 }
 
-bool CFileItem::IsVideoDb() const
-{
-  return URIUtils::IsVideoDb(m_strPath);
-}
-
 bool CFileItem::IsVirtualDirectoryRoot() const
 {
   return (m_bIsFolder && m_strPath.empty());
@@ -1451,7 +1446,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       dbItem.SetProperty("item_start", GetProperty("item_start"));
     return dbItem.IsSamePath(item);
   }
-  if (IsVideoDb() && HasVideoInfoTag())
+  if (IsType("videodb://") && HasVideoInfoTag())
   {
     CFileItem dbItem(GetVideoInfoTag()->m_strFileNameAndPath, false);
     if (HasProperty("item_start"))
@@ -1465,7 +1460,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       dbItem.SetProperty("item_start", item->GetProperty("item_start"));
     return IsSamePath(&dbItem);
   }
-  if (item->IsVideoDb() && item->HasVideoInfoTag())
+  if (item->IsType("videodb://") && item->HasVideoInfoTag())
   {
     CFileItem dbItem(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
     if (item->HasProperty("item_start"))
@@ -2860,7 +2855,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
   if (IsType("musicdb://"))
     return StringUtils::Format("special://temp/archive_cache/mdb-%08x.fi", crc);
 
-  if (IsVideoDb())
+  if (IsType("videodb://"))
     return StringUtils::Format("special://temp/archive_cache/vdb-%08x.fi", crc);
 
   if (IsSmartPlayList())
@@ -2877,7 +2872,7 @@ bool CFileItemList::AlwaysCache() const
   // some database folders are always cached
   if (IsType("musicdb://"))
     return CMusicDatabaseDirectory::CanCache(GetPath());
-  if (IsVideoDb())
+  if (IsType("videodb://"))
     return CVideoDatabaseDirectory::CanCache(GetPath());
   if (HasEPGInfoTag())
     return true; // always cache
@@ -3146,7 +3141,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 
 std::string CFileItem::GetLocalFanart() const
 {
-  if (IsVideoDb())
+  if (IsType("videodb://"))
   {
     if (!HasVideoInfoTag())
       return ""; // nothing can be done

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1038,11 +1038,6 @@ bool CFileItem::IsPlayList() const
   return CPlayListFactory::IsPlaylist(*this);
 }
 
-bool CFileItem::IsPythonScript() const
-{
-  return URIUtils::HasExtension(m_strPath, ".py");
-}
-
 bool CFileItem::IsType(const char *ext) const
 {
   if (*ext == '.')
@@ -1304,7 +1299,7 @@ void CFileItem::FillInDefaultIcon()
       {
         SetIconImage("DefaultPlaylist.png");
       }
-      else if ( IsPythonScript() )
+      else if (IsType(".py"))
       {
         SetIconImage("DefaultScript.png");
       }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -874,7 +874,7 @@ bool CFileItem::IsAudio() const
   if (HasGameInfoTag())
     return false;
 
-  if (IsCDDA())
+  if (IsType("cdda://"))
     return true;
 
   if(StringUtils::StartsWithNoCase(m_mimetype, "application/"))
@@ -1103,11 +1103,6 @@ bool CFileItem::IsMultiPath() const
   return URIUtils::IsMultiPath(m_strPath);
 }
 
-bool CFileItem::IsCDDA() const
-{
-  return URIUtils::IsCDDA(m_strPath);
-}
-
 bool CFileItem::IsDVD() const
 {
   return URIUtils::IsDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_DVD;
@@ -1160,7 +1155,7 @@ bool CFileItem::IsVirtualDirectoryRoot() const
 
 bool CFileItem::IsRemovable() const
 {
-  return IsOnDVD() || IsCDDA() || m_iDriveType == CMediaSource::SOURCE_TYPE_REMOVABLE;
+  return IsOnDVD() || IsType("cdda://") || m_iDriveType == CMediaSource::SOURCE_TYPE_REMOVABLE;
 }
 
 bool CFileItem::IsReadOnly() const
@@ -2839,7 +2834,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
   uint32_t crc = Crc32::ComputeFromLowerCase(strPath);
 
   std::string cacheFile;
-  if (IsCDDA() || IsOnDVD())
+  if (IsType("cdda://") || IsOnDVD())
     return StringUtils::Format("special://temp/archive_cache/r-%08x.fi", crc);
 
   if (IsType("musicdb://"))
@@ -3257,7 +3252,7 @@ bool CFileItem::LoadMusicTag()
       return true;
   }
   // no tag - try some other things
-  if (IsCDDA())
+  if (IsType("cdda://"))
   {
     // we have the tracknumber...
     int iTrack = GetMusicInfoTag()->GetTrackNumber();

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -991,7 +991,6 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
   {
     if(IsSmartPlayList()
     || (IsPlayList() && g_advancedSettings.m_playlistAsFolders)
-    || IsAPK()
     || IsZIP()
     || IsRAR()
     || IsRSS()
@@ -1100,11 +1099,6 @@ bool CFileItem::IsBDFile() const
 bool CFileItem::IsRAR() const
 {
   return URIUtils::IsRAR(m_strPath);
-}
-
-bool CFileItem::IsAPK() const
-{
-  return URIUtils::IsAPK(m_strPath);
 }
 
 bool CFileItem::IsZIP() const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1113,11 +1113,6 @@ bool CFileItem::IsScript() const
   return URIUtils::IsScript(m_strPath);
 }
 
-bool CFileItem::IsSourcesPath() const
-{
-  return URIUtils::IsSourcesPath(m_strPath);
-}
-
 bool CFileItem::IsMultiPath() const
 {
   return URIUtils::IsMultiPath(m_strPath);
@@ -2516,7 +2511,7 @@ void CFileItemList::Stack(bool stackFiles /* = true */)
   // not allowed here
   if (IsVirtualDirectoryRoot() ||
       IsLiveTV() ||
-      IsSourcesPath() ||
+      IsType("sources://") ||
       IsLibraryFolder())
     return;
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -845,11 +845,6 @@ bool CFileItem::IsInProgressPVRRecording() const
   return (m_pvrRecordingInfoTag && m_pvrRecordingInfoTag->IsInProgress());
 }
 
-bool CFileItem::IsPVRTimer() const
-{
-  return HasPVRTimerInfoTag();
-}
-
 bool CFileItem::IsPVRRadioRDS() const
 {
   return HasPVRRadioRDSInfoTag();
@@ -1271,7 +1266,7 @@ void CFileItem::FillInDefaultIcon()
         // video
         SetIconImage("DefaultVideo.png");
       }
-      else if (IsPVRTimer())
+      else if (HasPVRTimerInfoTag())
       {
         SetIconImage("DefaultVideo.png");
       }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -983,11 +983,6 @@ bool CFileItem::IsSubtitle() const
   return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions());
 }
 
-bool CFileItem::IsCUESheet() const
-{
-  return URIUtils::HasExtension(m_strPath, ".cue");
-}
-
 bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const
 {
   if (HasProperty("IsHTTPDirectory"))
@@ -2487,7 +2482,7 @@ void CFileItemList::FilterCueItems()
     CFileItemPtr pItem = m_items[i];
     if (!pItem->m_bIsFolder)
     { // see if it's a .CUE sheet
-      if (pItem->IsCUESheet())
+      if (pItem->IsType(".cue"))
       {
         CCueDocumentPtr cuesheet(new CCueDocument);
         if (cuesheet->ParseFile(pItem->GetPath()))
@@ -2526,7 +2521,7 @@ void CFileItemList::FilterCueItems()
                   {
                     strMediaFile = URIUtils::ReplaceExtension(pItem->GetPath(), *i);
                     CFileItem item(strMediaFile, false);
-                    if (!item.IsCUESheet() && !item.IsPlayList() && Contains(strMediaFile))
+                    if (!item.IsType(".cue") && !item.IsPlayList() && Contains(strMediaFile))
                     {
                       bFoundMediaFile = true;
                       break;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -830,11 +830,6 @@ bool CFileItem::IsVideo() const
   return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
 }
 
-bool CFileItem::IsEPG() const
-{
-  return HasEPGInfoTag();
-}
-
 bool CFileItem::IsPVRChannel() const
 {
   return HasPVRChannelInfoTag();
@@ -2960,7 +2955,7 @@ bool CFileItemList::AlwaysCache() const
     return CMusicDatabaseDirectory::CanCache(GetPath());
   if (IsVideoDb())
     return CVideoDatabaseDirectory::CanCache(GetPath());
-  if (IsEPG())
+  if (HasEPGInfoTag())
     return true; // always cache
   return false;
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -845,11 +845,6 @@ bool CFileItem::IsInProgressPVRRecording() const
   return (m_pvrRecordingInfoTag && m_pvrRecordingInfoTag->IsInProgress());
 }
 
-bool CFileItem::IsPVRRadioRDS() const
-{
-  return HasPVRRadioRDSInfoTag();
-}
-
 bool CFileItem::IsDiscStub() const
 {
   if (IsVideoDb() && HasVideoInfoTag())

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1112,11 +1112,6 @@ bool CFileItem::IsZIP() const
   return URIUtils::IsZIP(m_strPath);
 }
 
-bool CFileItem::IsCBR() const
-{
-  return URIUtils::HasExtension(m_strPath, ".cbr");
-}
-
 bool CFileItem::IsRSS() const
 {
   return StringUtils::StartsWithNoCase(m_strPath, "rss://") || URIUtils::HasExtension(m_strPath, ".rss")

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1108,11 +1108,6 @@ bool CFileItem::IsRSS() const
       || m_mimetype == "application/rss+xml";
 }
 
-bool CFileItem::IsAndroidApp() const
-{
-  return URIUtils::IsAndroidApp(m_strPath);
-}
-
 bool CFileItem::IsStack() const
 {
   return URIUtils::IsStack(m_strPath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -804,7 +804,7 @@ bool CFileItem::IsVideo() const
     return false;
 
   // only tv recordings are videos...
-  if (IsPVRRecording())
+  if (HasPVRRecordingInfoTag())
     return !GetPVRRecordingInfoTag()->IsRadio();
 
   // ... all other PVR items are not.
@@ -828,11 +828,6 @@ bool CFileItem::IsVideo() const
   // file before assuming it is video.
 
   return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
-}
-
-bool CFileItem::IsPVRRecording() const
-{
-  return HasPVRRecordingInfoTag();
 }
 
 bool CFileItem::IsUsablePVRRecording() const
@@ -3061,7 +3056,7 @@ bool CFileItem::SkipLocalArt() const
        || IsLibraryFolder()
        || IsParentFolder()
        || IsLiveTV()
-       || IsPVRRecording()
+       || HasPVRRecordingInfoTag()
        || IsDVD());
 }
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -759,7 +759,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
    || IsInternetStream()
    || IsParentFolder()
    || IsVirtualDirectoryRoot()
-   || IsPlugin()
+   || IsType("plugin://")
    || IsPVR())
     return true;
 
@@ -1111,11 +1111,6 @@ bool CFileItem::IsRSS() const
 bool CFileItem::IsStack() const
 {
   return URIUtils::IsStack(m_strPath);
-}
-
-bool CFileItem::IsPlugin() const
-{
-  return URIUtils::IsPlugin(m_strPath);
 }
 
 bool CFileItem::IsScript() const
@@ -2933,7 +2928,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
    || IsInternetStream()
    || URIUtils::IsUPnP(m_strPath)
    || (URIUtils::IsFTP(m_strPath) && !g_advancedSettings.m_bFTPThumbs)
-   || IsPlugin()
+   || IsType("plugin://")
    || IsAddonsPath()
    || IsLibraryFolder()
    || IsParentFolder()
@@ -3025,7 +3020,7 @@ bool CFileItem::SkipLocalArt() const
        || IsInternetStream()
        || URIUtils::IsUPnP(m_strPath)
        || (URIUtils::IsFTP(m_strPath) && !g_advancedSettings.m_bFTPThumbs)
-       || IsPlugin()
+       || IsType("plugin://")
        || IsAddonsPath()
        || IsLibraryFolder()
        || IsParentFolder()
@@ -3124,7 +3119,7 @@ std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.
   if (IsMultiPath())
     strFolder = CMultiPathDirectory::GetFirstPath(m_strPath);
 
-  if (IsPlugin())
+  if (IsType("plugin://"))
     return "";
 
   return URIUtils::AddFileToFolder(strFolder, folderJPG);
@@ -3132,7 +3127,7 @@ std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.
 
 std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 {
-  if (IsPlugin() && HasVideoInfoTag() && !GetVideoInfoTag()->m_strTitle.empty())
+  if (IsType("plugin://") && HasVideoInfoTag() && !GetVideoInfoTag()->m_strTitle.empty())
     return GetVideoInfoTag()->m_strTitle;
 
   if (IsLabelPreformatted())
@@ -3221,7 +3216,7 @@ std::string CFileItem::GetLocalFanart() const
    || URIUtils::IsUPnP(strFile)
    || URIUtils::IsBluray(strFile)
    || IsLiveTV()
-   || IsPlugin()
+   || IsType("plugin://")
    || IsAddonsPath()
    || IsDVD()
    || (URIUtils::IsFTP(strFile) && !g_advancedSettings.m_bFTPThumbs)
@@ -3494,7 +3489,7 @@ std::string CFileItem::FindTrailer() const
    || URIUtils::IsUPnP(strFile)
    || URIUtils::IsBluray(strFile)
    || IsLiveTV()
-   || IsPlugin()
+   || IsType("plugin://")
    || IsDVD())
     return "";
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1066,10 +1066,10 @@ bool CFileItem::IsPythonScript() const
 
 bool CFileItem::IsType(const char *ext) const
 {
-  if (!m_strDynPath.empty())
-    return URIUtils::HasExtension(m_strDynPath, ext);
+  if (*ext == '.')
+    return URIUtils::HasExtension(GetDynPath(), ext);
 
-  return URIUtils::HasExtension(m_strPath, ext);
+  return StringUtils::StartsWithNoCase(GetDynPath(), ext);
 }
 
 bool CFileItem::IsNFO() const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1113,11 +1113,6 @@ bool CFileItem::IsScript() const
   return URIUtils::IsScript(m_strPath);
 }
 
-bool CFileItem::IsAddonsPath() const
-{
-  return URIUtils::IsAddonsPath(m_strPath);
-}
-
 bool CFileItem::IsSourcesPath() const
 {
   return URIUtils::IsSourcesPath(m_strPath);
@@ -2919,7 +2914,7 @@ std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, b
    || URIUtils::IsUPnP(m_strPath)
    || (URIUtils::IsFTP(m_strPath) && !g_advancedSettings.m_bFTPThumbs)
    || IsType("plugin://")
-   || IsAddonsPath()
+   || IsType("addons://")
    || IsLibraryFolder()
    || IsParentFolder()
    || IsMusicDb())
@@ -3011,7 +3006,7 @@ bool CFileItem::SkipLocalArt() const
        || URIUtils::IsUPnP(m_strPath)
        || (URIUtils::IsFTP(m_strPath) && !g_advancedSettings.m_bFTPThumbs)
        || IsType("plugin://")
-       || IsAddonsPath()
+       || IsType("addons://")
        || IsLibraryFolder()
        || IsParentFolder()
        || IsLiveTV()
@@ -3207,7 +3202,7 @@ std::string CFileItem::GetLocalFanart() const
    || URIUtils::IsBluray(strFile)
    || IsLiveTV()
    || IsType("plugin://")
-   || IsAddonsPath()
+   || IsType("addons://")
    || IsDVD()
    || (URIUtils::IsFTP(strFile) && !g_advancedSettings.m_bFTPThumbs)
    || m_strPath.empty())

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -760,7 +760,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
    || IsParentFolder()
    || IsVirtualDirectoryRoot()
    || IsType("plugin://")
-   || IsPVR())
+   || IsType("pvr://"))
     return true;
 
   if (IsVideoDb() && HasVideoInfoTag())
@@ -808,7 +808,7 @@ bool CFileItem::IsVideo() const
     return !GetPVRRecordingInfoTag()->IsRadio();
 
   // ... all other PVR items are not.
-  if (IsPVR())
+  if (IsType("pvr://"))
     return false;
 
   if (URIUtils::IsDVD(m_strPath))
@@ -929,7 +929,7 @@ bool CFileItem::IsGame() const
   if (HasPictureInfoTag())
     return false;
 
-  if (IsPVR())
+  if (IsType("pvr://"))
     return false;
 
   if (HasAddonInfo())
@@ -1171,11 +1171,6 @@ bool CFileItem::IsSmb() const
 bool CFileItem::IsURL() const
 {
   return URIUtils::IsURL(m_strPath);
-}
-
-bool CFileItem::IsPVR() const
-{
-  return CUtil::IsPVR(m_strPath);
 }
 
 bool CFileItem::IsLiveTV() const

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -217,7 +217,6 @@ public:
   bool IsRemote() const;
   bool IsSmb() const;
   bool IsURL() const;
-  bool IsMultiPath() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;
   bool IsInProgressPVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -221,7 +221,6 @@ public:
   bool IsURL() const;
   bool IsStack() const;
   bool IsMultiPath() const;
-  bool IsVideoDb() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;
   bool IsInProgressPVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -215,7 +215,6 @@ public:
   bool IsRAR() const;
   bool IsAPK() const;
   bool IsZIP() const;
-  bool IsCBZ() const;
   bool IsCBR() const;
   bool IsISO9660() const;
   bool IsCDDA() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -231,7 +231,6 @@ public:
   bool IsMultiPath() const;
   bool IsMusicDb() const;
   bool IsVideoDb() const;
-  bool IsEPG() const;
   bool IsPVRChannel() const;
   bool IsPVRRecording() const;
   bool IsUsablePVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -198,7 +198,6 @@ public:
   bool IsAudioBook() const;
 
   bool IsGame() const;
-  bool IsCUESheet() const;
   bool IsInternetStream(const bool bStrictCheck = false) const;
   bool IsPlayList() const;
   bool IsSmartPlayList() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -209,7 +209,6 @@ public:
   bool IsBDFile() const;
   bool IsRAR() const;
   bool IsZIP() const;
-  bool IsISO9660() const;
   bool IsCDDA() const;
   bool IsDVD() const;
   bool IsOnDVD() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -240,7 +240,12 @@ public:
   bool IsInProgressPVRRecording() const;
   bool IsPVRTimer() const;
   bool IsPVRRadioRDS() const;
+
+  //! \brief Check if path item points to has a given extension or protocol type.
+  //! \param[in] ext Extension or protocol type
+  //! \details If ext contains a '.', it is an extension, else it is a protocol.
   bool IsType(const char *ext) const;
+
   bool IsVirtualDirectoryRoot() const;
   bool IsReadOnly() const;
   bool CanQueue() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -219,7 +219,6 @@ public:
   bool IsRemote() const;
   bool IsSmb() const;
   bool IsURL() const;
-  bool IsStack() const;
   bool IsMultiPath() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -207,7 +207,6 @@ public:
   bool IsScript() const;
   bool IsAddonsPath() const;
   bool IsSourcesPath() const;
-  bool IsNFO() const;
   bool IsDiscImage() const;
   bool IsOpticalMediaFile() const;
   bool IsDVDFile(bool bVobs = true, bool bIfos = true) const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -202,7 +202,6 @@ public:
   bool IsPlayList() const;
   bool IsSmartPlayList() const;
   bool IsLibraryFolder() const;
-  bool IsPythonScript() const;
   bool IsScript() const;
   bool IsAddonsPath() const;
   bool IsSourcesPath() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -248,7 +248,6 @@ public:
   bool IsPVR() const;
   bool IsLiveTV() const;
   bool IsRSS() const;
-  bool IsAndroidApp() const;
 
   void RemoveExtension();
   void CleanString();

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -215,7 +215,6 @@ public:
   bool IsRAR() const;
   bool IsAPK() const;
   bool IsZIP() const;
-  bool IsCBR() const;
   bool IsISO9660() const;
   bool IsCDDA() const;
   bool IsDVD() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -209,7 +209,6 @@ public:
   bool IsBDFile() const;
   bool IsRAR() const;
   bool IsZIP() const;
-  bool IsCDDA() const;
   bool IsDVD() const;
   bool IsOnDVD() const;
   bool IsOnLAN() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -202,7 +202,6 @@ public:
   bool IsPlayList() const;
   bool IsSmartPlayList() const;
   bool IsLibraryFolder() const;
-  bool IsScript() const;
   bool IsDiscImage() const;
   bool IsOpticalMediaFile() const;
   bool IsDVDFile(bool bVobs = true, bool bIfos = true) const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -213,7 +213,6 @@ public:
   bool IsDVDFile(bool bVobs = true, bool bIfos = true) const;
   bool IsBDFile() const;
   bool IsRAR() const;
-  bool IsAPK() const;
   bool IsZIP() const;
   bool IsISO9660() const;
   bool IsCDDA() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -231,7 +231,6 @@ public:
   bool IsMultiPath() const;
   bool IsMusicDb() const;
   bool IsVideoDb() const;
-  bool IsPVRRecording() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;
   bool IsInProgressPVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -226,7 +226,6 @@ public:
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;
   bool IsInProgressPVRRecording() const;
-  bool IsPVRRadioRDS() const;
 
   //! \brief Check if path item points to has a given extension or protocol type.
   //! \param[in] ext Extension or protocol type

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -231,7 +231,6 @@ public:
   bool IsMultiPath() const;
   bool IsMusicDb() const;
   bool IsVideoDb() const;
-  bool IsPVRChannel() const;
   bool IsPVRRecording() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -221,7 +221,6 @@ public:
   bool IsURL() const;
   bool IsStack() const;
   bool IsMultiPath() const;
-  bool IsMusicDb() const;
   bool IsVideoDb() const;
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -203,7 +203,6 @@ public:
   bool IsSmartPlayList() const;
   bool IsLibraryFolder() const;
   bool IsScript() const;
-  bool IsSourcesPath() const;
   bool IsDiscImage() const;
   bool IsOpticalMediaFile() const;
   bool IsDVDFile(bool bVobs = true, bool bIfos = true) const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -203,7 +203,6 @@ public:
   bool IsSmartPlayList() const;
   bool IsLibraryFolder() const;
   bool IsPythonScript() const;
-  bool IsPlugin() const;
   bool IsScript() const;
   bool IsAddonsPath() const;
   bool IsSourcesPath() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -203,7 +203,6 @@ public:
   bool IsSmartPlayList() const;
   bool IsLibraryFolder() const;
   bool IsScript() const;
-  bool IsAddonsPath() const;
   bool IsSourcesPath() const;
   bool IsDiscImage() const;
   bool IsOpticalMediaFile() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -243,7 +243,6 @@ public:
   bool IsParentFolder() const;
   bool IsFileFolder(EFileFolderType types = EFILEFOLDER_MASK_ALL) const;
   bool IsRemovable() const;
-  bool IsPVR() const;
   bool IsLiveTV() const;
   bool IsRSS() const;
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -226,7 +226,6 @@ public:
   bool IsUsablePVRRecording() const;
   bool IsDeletedPVRRecording() const;
   bool IsInProgressPVRRecording() const;
-  bool IsPVRTimer() const;
   bool IsPVRRadioRDS() const;
 
   //! \brief Check if path item points to has a given extension or protocol type.

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -308,7 +308,7 @@ bool CPlayListPlayer::Play(int iSong, std::string player, bool bAutoPlay /* = fa
 
   m_iCurrentSong = iSong;
   CFileItemPtr item = playlist[m_iCurrentSong];
-  if (item->IsVideoDb() && !item->HasVideoInfoTag())
+  if (item->IsType("videodb://") && !item->HasVideoInfoTag())
     *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetPath()));
 
   playlist.SetPlayed(true);

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -213,7 +213,7 @@ CBaseTexture *CTextureCacheJob::LoadImage(const std::string &image, unsigned int
   // Validate file URL to see if it is an image
   CFileItem file(image, false);
   file.FillInMimeType();
-  if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsType(".cbz") ))
+  if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsType(".cbr") || file.IsType(".cbz") ))
       && !StringUtils::StartsWithNoCase(file.GetMimeType(), "image/") && !StringUtils::EqualsNoCase(file.GetMimeType(), "application/octet-stream")) // ignore non-pictures
     return NULL;
 

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -213,7 +213,7 @@ CBaseTexture *CTextureCacheJob::LoadImage(const std::string &image, unsigned int
   // Validate file URL to see if it is an image
   CFileItem file(image, false);
   file.FillInMimeType();
-  if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ() ))
+  if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsType(".cbz") ))
       && !StringUtils::StartsWithNoCase(file.GetMimeType(), "image/") && !StringUtils::EqualsNoCase(file.GetMimeType(), "application/octet-stream")) // ignore non-pictures
     return NULL;
 

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -117,7 +117,7 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
 
 std::string CProgramThumbLoader::GetLocalThumb(const CFileItem &item)
 {
-  if (item.IsAddonsPath())
+  if (item.IsType("addons://"))
     return "";
 
   // look for the thumb

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -519,11 +519,6 @@ std::string CUtil::GetHomePath(std::string strTarget)
   return ::GetHomePath(strTarget, strPath);
 }
 
-bool CUtil::IsPVR(const std::string& strFile)
-{
-  return StringUtils::StartsWithNoCase(strFile, "pvr:");
-}
-
 bool CUtil::IsLiveTV(const std::string& strFile)
 {
   if (StringUtils::StartsWithNoCase(strFile, "pvr://channels"))

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2282,7 +2282,7 @@ void CUtil::ScanForExternalDemuxSub(const std::string& videoPath, std::vector<st
   if (item.IsInternetStream()
     || item.IsPlayList()
     || item.IsLiveTV()
-    || item.IsPVR()
+    || item.IsType("pvr://")
     || !item.IsVideo())
     return;
 
@@ -2306,7 +2306,7 @@ void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::
   if ( item.IsInternetStream()
    ||  item.IsPlayList()
    ||  item.IsLiveTV()
-   ||  item.IsPVR()
+   ||  item.IsType("pvr://")
    || !item.IsVideo())
     return;
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -60,7 +60,6 @@ public:
   static void GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename);
   static void RunShortcut(const char* szPath);
   static std::string GetHomePath(std::string strTarget = "KODI_HOME"); // default target is "KODI_HOME"
-  static bool IsPVR(const std::string& strFile);
   static bool IsHTSP(const std::string& strFile);
   static bool IsLiveTV(const std::string& strFile);
   static bool IsTVRecording(const std::string& strFile);

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -632,7 +632,7 @@ PVR_ERROR CPVRClient::CallMenuHook(const PVR_MENUHOOK &hook, const CFileItemPtr 
         hookData.cat = PVR_MENUHOOK_DELETED_RECORDING;
         WriteClientRecordingInfo(*item->GetPVRRecordingInfoTag(), hookData.data.recording);
       }
-      else if (item->IsPVRTimer())
+      else if (item->HasPVRTimerInfoTag())
       {
         hookData.cat = PVR_MENUHOOK_TIMER;
         WriteClientTimerInfo(*item->GetPVRTimerInfoTag(), hookData.data.timer);

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -617,7 +617,7 @@ PVR_ERROR CPVRClient::CallMenuHook(const PVR_MENUHOOK &hook, const CFileItemPtr 
         hookData.cat = PVR_MENUHOOK_EPG;
         hookData.data.iEpgUid = item->GetEPGInfoTag()->UniqueBroadcastID();
       }
-      else if (item->IsPVRChannel())
+      else if (item->HasPVRChannelInfoTag())
       {
         hookData.cat = PVR_MENUHOOK_CHANNEL;
         WriteClientChannelInfo(item->GetPVRChannelInfoTag(), hookData.data.channel);

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -612,7 +612,7 @@ PVR_ERROR CPVRClient::CallMenuHook(const PVR_MENUHOOK &hook, const CFileItemPtr 
 
     if (item)
     {
-      if (item->IsEPG())
+      if (item->HasEPGInfoTag())
       {
         hookData.cat = PVR_MENUHOOK_EPG;
         hookData.data.iEpgUid = item->GetEPGInfoTag()->UniqueBroadcastID();

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -392,7 +392,7 @@ void CExternalPlayer::Process()
   g_application.ResetScreenSaver();
   g_application.WakeUpScreenSaverAndDPMS();
 
-  if (!ret || (m_playOneStackItem && g_application.CurrentFileItem().IsStack()))
+  if (!ret || (m_playOneStackItem && g_application.CurrentFileItem().IsType("stack://")))
     m_callback.OnPlayBackStopped();
   else
     m_callback.OnPlayBackEnded();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
 
   if (fileitem.IsDVDFile(false, true))
     return std::shared_ptr<CDVDInputStreamNavigator>(new CDVDInputStreamNavigator(pPlayer, fileitem));
-  else if (fileitem.IsPVRChannel() && StringUtils::StartsWithNoCase(file, "pvr://"))
+  else if (fileitem.HasPVRChannelInfoTag() && StringUtils::StartsWithNoCase(file, "pvr://"))
     return std::shared_ptr<CInputStreamPVRChannel>(new CInputStreamPVRChannel(pPlayer, fileitem));
   else if (fileitem.IsUsablePVRRecording() && StringUtils::StartsWithNoCase(file, "pvr://"))
     return std::shared_ptr<CInputStreamPVRRecording>(new CInputStreamPVRRecording(pPlayer, fileitem));

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -132,7 +132,7 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFrameRa
 
     bFound = ReadPvr(fileItem);
   }
-  else if (fileItem.IsEPG())
+  else if (fileItem.HasEPGInfoTag())
   {
     CLog::Log(LOGDEBUG, "%s - Checking for edit decision list (EDL) for EPG entry: %s",
       __FUNCTION__, strMovie.c_str());

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -100,7 +100,7 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFrameRa
    */
   const std::string strMovie = fileItem.GetDynPath();
   if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
-      !fileItem.IsPVRRecording() &&
+      !fileItem.HasPVRRecordingInfoTag() &&
       !URIUtils::IsInternetStream(strMovie))
   {
     CLog::Log(LOGDEBUG, "%s - Checking for edit decision lists (EDL) on local drive or remote share for: %s",
@@ -125,7 +125,7 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFrameRa
   /*
    * PVR Recordings
    */
-  else if (fileItem.IsPVRRecording())
+  else if (fileItem.HasPVRRecordingInfoTag())
   {
     CLog::Log(LOGDEBUG, "%s - Checking for edit decision list (EDL) for PVR recording: %s",
       __FUNCTION__, strMovie.c_str());

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3190,7 +3190,7 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   bool restore = true;
 
   int64_t time = GetTime();
-  if(g_application.CurrentFileItem().IsStack() &&
+  if(g_application.CurrentFileItem().IsType("stack://") &&
      (seekTarget > m_processInfo->GetMaxTime() || seekTarget < 0))
   {
     g_application.SeekTime((seekTarget - time) * 0.001 + g_application.GetTime());

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -279,7 +279,7 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 void PAPlayer::UpdateCrossfadeTime(const CFileItem& file)
 {
   // we explicitly disable crossfading for audio cds
-  if (file.IsCDDA())
+  if (file.IsType("cdda://"))
    m_upcomingCrossfadeMS = 0;
   else
     m_upcomingCrossfadeMS = m_defaultCrossfadeMS = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MUSICPLAYER_CROSSFADE) * 1000;
@@ -396,7 +396,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
 
   si->m_prepareNextAtFrame = 0;
   // cd drives don't really like it to be crossfaded or prepared
-  if(!file.IsCDDA())
+  if(!file.IsType("cdda://"))
   {
     if (streamTotalTime >= TIME_TO_CACHE_NEXT_FILE + m_defaultCrossfadeMS)
       si->m_prepareNextAtFrame = (int)((streamTotalTime - TIME_TO_CACHE_NEXT_FILE - m_defaultCrossfadeMS) * si->m_audioFormat.m_sampleRate / 1000.0f);

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -313,7 +313,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         if (IsActive())
         {
           if((message.GetStringParam() == m_Directory->GetPath()) ||
-             (m_Directory->IsMultiPath() && XFILE::CMultiPathDirectory::HasPath(m_Directory->GetPath(), message.GetStringParam())))
+             (m_Directory->IsType("multipath://") && XFILE::CMultiPathDirectory::HasPath(m_Directory->GetPath(), message.GetStringParam())))
           {
             int iItem = m_viewControl.GetSelectedItem();
             Update(m_Directory->GetPath());

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -64,7 +64,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
     return true;
 
   std::string path;
-  if (item.IsVideoDb())
+  if (item.IsType("videodb://"))
     path = item.GetVideoInfoTag()->m_strFileNameAndPath;
   else
     path = item.GetPath();

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -213,7 +213,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
     execute = StringUtils::Format("StartAndroidActivity(%s)", StringUtils::Paramify(item.GetPath().substr(26)).c_str());
   else  // assume a media file
   {
-    if (item.IsVideoDb() && item.HasVideoInfoTag())
+    if (item.IsType("videodb://") && item.HasVideoInfoTag())
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
     else if (item.IsType("musicdb://") && item.HasMusicInfoTag())
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -204,7 +204,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
   //! @todo STRING_CLEANUP
   else if (item.IsScript() && item.GetPath().size() > 9) // script://<foo>
     execute = StringUtils::Format("RunScript(%s)", StringUtils::Paramify(item.GetPath().substr(9)).c_str());
-  else if (item.IsAddonsPath() && item.GetPath().size() > 9) // addons://<foo>
+  else if (item.IsType("addons://") && item.GetPath().size() > 9) // addons://<foo>
   {
     CURL url(item.GetPath());
     execute = StringUtils::Format("RunAddon(%s)", url.GetFileName().c_str());

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -215,7 +215,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
   {
     if (item.IsVideoDb() && item.HasVideoInfoTag())
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath).c_str());
-    else if (item.IsMusicDb() && item.HasMusicInfoTag())
+    else if (item.IsType("musicdb://") && item.HasMusicInfoTag())
       execute = StringUtils::Format("PlayMedia(%s)", StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()).c_str());
     else if (item.IsPicture())
       execute = StringUtils::Format("ShowPicture(%s)", StringUtils::Paramify(item.GetPath()).c_str());

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -202,7 +202,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
       execute = StringUtils::Format("ActivateWindow(%s,%s,return)", contextWindow.c_str(), StringUtils::Paramify(item.GetPath()).c_str());
   }
   //! @todo STRING_CLEANUP
-  else if (item.IsScript() && item.GetPath().size() > 9) // script://<foo>
+  else if (item.IsType("script://") && item.GetPath().size() > 9) // script://<foo>
     execute = StringUtils::Format("RunScript(%s)", StringUtils::Paramify(item.GetPath().substr(9)).c_str());
   else if (item.IsType("addons://") && item.GetPath().size() > 9) // addons://<foo>
   {

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -209,7 +209,7 @@ std::string CFavouritesService::GetExecutePath(const CFileItem &item, const std:
     CURL url(item.GetPath());
     execute = StringUtils::Format("RunAddon(%s)", url.GetFileName().c_str());
   }
-  else if (item.IsAndroidApp() && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>
+  else if (item.IsType("androidapp://") && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>
     execute = StringUtils::Format("StartAndroidActivity(%s)", StringUtils::Paramify(item.GetPath().substr(26)).c_str());
   else  // assume a media file
   {

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -292,7 +292,7 @@ bool CDirectory::GetDirectory(const CURL& url, std::shared_ptr<IDirectory> pDire
 
     //  Should any of the files we read be treated as a directory?
     //  Disable for database folders, as they already contain the extracted items
-    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsType("musicdb://") && !items.IsVideoDb() && !items.IsSmartPlayList())
+    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsType("musicdb://") && !items.IsType("videodb://") && !items.IsSmartPlayList())
       FilterFileDirectories(items, hints.mask);
 
     // Correct items for path substitution

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -292,7 +292,7 @@ bool CDirectory::GetDirectory(const CURL& url, std::shared_ptr<IDirectory> pDire
 
     //  Should any of the files we read be treated as a directory?
     //  Disable for database folders, as they already contain the extracted items
-    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsMusicDb() && !items.IsVideoDb() && !items.IsSmartPlayList())
+    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsType("musicdb://") && !items.IsVideoDb() && !items.IsSmartPlayList())
       FilterFileDirectories(items, hints.mask);
 
     // Correct items for path substitution

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -77,7 +77,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
     else if (   pItem->IsPath("special://musicplaylists/")
              || pItem->IsPath("special://videoplaylists/"))
       strIcon = "DefaultPlaylist.png";
-    else if (   pItem->IsVideoDb()
+    else if (   pItem->IsType("videodb://")
              || pItem->IsType("musicdb://")
              || pItem->IsType("plugin://")
              || pItem->IsPath("musicsearch://"))

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -84,7 +84,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       strIcon = "DefaultFolder.png";
     else if (pItem->IsRemote())
       strIcon = "DefaultNetwork.png";
-    else if (pItem->IsISO9660())
+    else if (pItem->IsType("iso9660://"))
       strIcon = "DefaultDVDRom.png";
     else if (pItem->IsDVD())
       strIcon = "DefaultDVDFull.png";

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -79,7 +79,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       strIcon = "DefaultPlaylist.png";
     else if (   pItem->IsVideoDb()
              || pItem->IsMusicDb()
-             || pItem->IsPlugin()
+             || pItem->IsType("plugin://")
              || pItem->IsPath("musicsearch://"))
       strIcon = "DefaultFolder.png";
     else if (pItem->IsRemote())

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -78,7 +78,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
              || pItem->IsPath("special://videoplaylists/"))
       strIcon = "DefaultPlaylist.png";
     else if (   pItem->IsVideoDb()
-             || pItem->IsMusicDb()
+             || pItem->IsType("musicdb://")
              || pItem->IsType("plugin://")
              || pItem->IsPath("musicsearch://"))
       strIcon = "DefaultFolder.png";

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -88,7 +88,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       strIcon = "DefaultDVDRom.png";
     else if (pItem->IsDVD())
       strIcon = "DefaultDVDFull.png";
-    else if (pItem->IsCDDA())
+    else if (pItem->IsType("cdda://"))
       strIcon = "DefaultCDDA.png";
     else if (pItem->IsRemovable() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture("DefaultRemovableDisk.png"))
       strIcon = "DefaultRemovableDisk.png";

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -320,7 +320,7 @@ void CGUIWindowGames::OnItemInfo(int itemNumber)
 
   if (!m_vecItems->IsType("plugin://"))
   {
-    if (item->IsType("plugin://") || item->IsScript())
+    if (item->IsType("plugin://") || item->IsType("script://"))
       CGUIDialogAddonInfo::ShowForItem(item);
   }
 

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -186,7 +186,7 @@ void CGUIWindowGames::GetContextButtons(int itemNumber, CContextButtons &buttons
 
   if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
-    if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->IsSourcesPath())
+    if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->IsType("sources://"))
     {
       // Context buttons for a sources path, like "Add Source", "Remove Source", etc.
       CGUIDialogContextMenu::GetContextButtons("games", item, buttons);
@@ -214,7 +214,7 @@ bool CGUIWindowGames::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   CFileItemPtr item = m_vecItems->Get(itemNumber);
   if (item)
   {
-    if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->IsSourcesPath())
+    if (m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->IsType("sources://"))
     {
       if (CGUIDialogContextMenu::OnContextButton("games", item, button))
       {

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -117,7 +117,7 @@ bool CGUIWindowGames::OnClickMsg(int controlId, int actionId)
   }
   case ACTION_SHOW_INFO:
   {
-    if (!m_vecItems->IsPlugin())
+    if (!m_vecItems->IsType("plugin://"))
     {
       if (pItem->HasAddonInfo())
       {
@@ -270,7 +270,7 @@ bool CGUIWindowGames::GetDirectory(const std::string &strDirectory, CFileItemLis
   if (items.GetContent().empty())
   {
     if (!items.IsVirtualDirectoryRoot() && // Don't set content for root directory
-        !items.IsPlugin())                 // Don't set content for plugins
+        !items.IsType("plugin://"))        // Don't set content for plugins
     {
       content = "games";
     }
@@ -318,9 +318,9 @@ void CGUIWindowGames::OnItemInfo(int itemNumber)
   if (!item)
     return;
 
-  if (!m_vecItems->IsPlugin())
+  if (!m_vecItems->IsType("plugin://"))
   {
-    if (item->IsPlugin() || item->IsScript())
+    if (item->IsType("plugin://") || item->IsScript())
       CGUIDialogAddonInfo::ShowForItem(item);
   }
 

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -275,7 +275,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_FILENAME:
       case LISTITEM_FILE_EXTENSION:
-        if (item->IsMusicDb())
+        if (item->IsType("musicdb://"))
           value = URIUtils::GetFileName(tag->GetURL());
         else
           value = URIUtils::GetFileName(item->GetPath());
@@ -288,7 +288,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_FOLDERNAME:
       case LISTITEM_PATH:
-        if (item->IsMusicDb())
+        if (item->IsType("musicdb://"))
           value = URIUtils::GetDirectory(tag->GetURL());
         else
           URIUtils::GetParentPath(item->GetPath(), value);
@@ -302,7 +302,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         }
         return true;
       case LISTITEM_FILENAME_AND_PATH:
-        if (item->IsMusicDb())
+        if (item->IsType("musicdb://"))
           value = tag->GetURL();
         else
           value = item->GetPath();

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -166,7 +166,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
     {
       case LISTITEM_PICTURE_PATH:
       {
-        if (!item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsCBR())
+        if (!item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsType(".cbr"))
         {
           value = item->GetPath();
           return true;

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -166,7 +166,7 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
     {
       case LISTITEM_PICTURE_PATH:
       {
-        if (!item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR())
+        if (!item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsCBR())
         {
           value = item->GetPath();
           return true;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -419,7 +419,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_FILENAME:
       case LISTITEM_FILE_EXTENSION:
-        if (item->IsVideoDb())
+        if (item->IsType("videodb://"))
           value = URIUtils::GetFileName(tag->m_strFileNameAndPath);
         else
           value = URIUtils::GetFileName(item->GetPath());
@@ -432,7 +432,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_FOLDERNAME:
       case LISTITEM_PATH:
-        if (item->IsVideoDb())
+        if (item->IsType("videodb://"))
         {
           if (item->m_bIsFolder)
             value = tag->m_strPath;
@@ -451,7 +451,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         }
         return true;
       case LISTITEM_FILENAME_AND_PATH:
-        if (item->IsVideoDb())
+        if (item->IsType("videodb://"))
           value = tag->m_strFileNameAndPath;
         else
           value = item->GetPath();

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -433,7 +433,7 @@ static int PlayMedia(const std::vector<std::string>& params)
     }
   }
 
-  if (!item.m_bIsFolder && item.IsPlugin())
+  if (!item.m_bIsFolder && item.IsType("plugin://"))
     item.SetProperty("IsPlayable", true);
 
   if ( askToResume == true )

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -230,7 +230,7 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
       }
       else if (player == Audio)
       {
-        if (fileItem->IsMusicDb())
+        if (fileItem->IsType("musicdb://"))
         {
           CMusicDatabase musicdb;
           CFileItemList items;

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -465,7 +465,7 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
   }
   else
   {
-    if (items.IsVideoDb() && items.Size() > (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_SHOWPARENTDIRITEMS)?1:0))
+    if (items.IsType("videodb://") && items.Size() > (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_SHOWPARENTDIRITEMS)?1:0))
     {
       XFILE::VIDEODATABASEDIRECTORY::CQueryParams params;
       XFILE::CVideoDatabaseDirectory::GetQueryParams(items[CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_SHOWPARENTDIRITEMS)?1:0]->GetPath(),params);

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -225,7 +225,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
             pItem->SetArt("thumb", song.strThumb);
         }
       }
-      else if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICFILES_USETAGS) || pItem->IsCDDA())
+      else if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICFILES_USETAGS) || pItem->IsType("cdda://"))
       { // Nothing found, load tag from file,
         // always try to load cddb info
         // get correct tag parser

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -213,7 +213,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         if (!it->second.strThumb.empty())
           pItem->SetArt("thumb", it->second.strThumb);
       }
-      else if (pItem->IsMusicDb())
+      else if (pItem->IsType("musicdb:///"))
       { // a music db item that doesn't have tag loaded - grab details from the database
         XFILE::MUSICDATABASEDIRECTORY::CQueryParams param;
         XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(pItem->GetPath(),param);

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -84,7 +84,7 @@ void CMusicInfoLoader::OnLoaderStart()
 bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 {
   if (!pItem || (pItem->m_bIsFolder && !pItem->IsAudio()) ||
-      pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+      pItem->IsPlayList() || pItem->IsType(".nfo") || pItem->IsInternetStream())
     return false;
 
   if (pItem->GetProperty("hasfullmusictag") == "true")
@@ -158,7 +158,7 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
 bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
 {
   if ((pItem->m_bIsFolder && !pItem->IsAudio()) ||
-       pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+       pItem->IsPlayList() || pItem->IsType(".nfo") || pItem->IsInternetStream())
     return false;
 
   // Get thumb for item
@@ -173,7 +173,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
     m_pProgressCallback->SetProgressAdvance();
 
   if ((pItem->m_bIsFolder && !pItem->IsAudio()) || pItem->IsPlayList() ||
-       pItem->IsNFO() || pItem->IsInternetStream())
+       pItem->IsType(".nfo") || pItem->IsInternetStream())
     return false;
 
   if (!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded())

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -1019,7 +1019,7 @@ void CGUIDialogMusicInfo::ShowFor(CFileItem* pItem)
   }
 
   // We have a folder album/artist info dialog only shown for db items
-  if (pItem->IsMusicDb())
+  if (pItem->IsType("musicdb://"))
   {
     if (!pItem->HasMusicInfoTag() || pItem->GetMusicInfoTag()->GetDatabaseId() < 1)
     {

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -380,7 +380,7 @@ void CGUIDialogSongInfo::OnGetArt()
   if (type == "thumb")
   { // Local thumb type art held in <filename>.tbn (for non-library items)
     localThumb = m_song->GetUserMusicThumb(true);
-    if (m_song->IsMusicDb())
+    if (m_song->IsType("musicdb://"))
     {
       CFileItem item(m_song->GetMusicInfoTag()->GetURL(), false);
       localThumb = item.GetUserMusicThumb(true);
@@ -500,7 +500,7 @@ void CGUIDialogSongInfo::ShowFor(CFileItem* pItem)
 {
   if (pItem->m_bIsFolder)
     return;
-  if (!pItem->IsMusicDb())
+  if (!pItem->IsType("musicdb://"))
     pItem->LoadMusicTag();
   if (!pItem->HasMusicInfoTag())
     return;

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -246,7 +246,7 @@ void CGUIDialogSongInfo::OnInitWindow()
   CONTROL_ENABLE_ON_CONDITION(CONTROL_ALBUMINFO, m_albumId > 0);
 
   // Disable music user rating button for plugins as they don't have tables to save this
-  if (m_song->IsPlugin())
+  if (m_song->IsType("plugin://"))
     CONTROL_DISABLE(CONTROL_USERRATING);
   else
     CONTROL_ENABLE(CONTROL_USERRATING);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1244,7 +1244,7 @@ int CMusicInfoScanner::GetPathHash(const CFileItemList &items, std::string &hash
     digest.Update((unsigned char *)&pItem->m_dwSize, sizeof(pItem->m_dwSize));
     FILETIME time = pItem->m_dateTime;
     digest.Update((unsigned char *)&time, sizeof(FILETIME));
-    if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsNFO())
+    if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsType(".nfo"))
       count++;
   }
   hash = digest.Finalize();
@@ -2259,7 +2259,7 @@ int CMusicInfoScanner::CountFiles(const CFileItemList &items, bool recursive)
 
     if (recursive && pItem->m_bIsFolder)
       count+=CountFilesRecursively(pItem->GetPath());
-    else if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsNFO())
+    else if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsType(".nfo"))
       count++;
   }
   return count;

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -46,7 +46,7 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& i
   if (item.IsInternetStream())
     return NULL;
 
-  if (item.IsMusicDb())
+  if (item.IsType("musicdb://"))
     return new CMusicInfoTagLoaderDatabase();
 
   std::string strExtension = URIUtils::GetExtension(item.GetPath());

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -417,7 +417,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
   // fast lookup is needed here
   queuedItems.SetFastLookup(true);
 
-  if (pItem->IsMusicDb() && pItem->m_bIsFolder && !pItem->IsParentFolder())
+  if (pItem->IsType("musicdb://") && pItem->m_bIsFolder && !pItem->IsParentFolder())
   { // we have a music database folder, just grab the "all" item underneath it
     CMusicDatabaseDirectory dir;
     if (!dir.ContainsSongs(pItem->GetPath()))
@@ -503,7 +503,7 @@ void CGUIWindowMusicBase::UpdateButtons()
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNSCAN,
                               !(m_vecItems->IsVirtualDirectoryRoot() ||
-                                m_vecItems->IsMusicDb()));
+                                m_vecItems->IsType("musicdb://")));
 
   if (g_application.IsMusicScanning())
     SET_CONTROL_LABEL(CONTROL_BTNSCAN, 14056); // Stop Scan
@@ -561,11 +561,11 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
         else if (item->IsPlayList() || m_vecItems->IsPlayList())
           buttons.Add(CONTEXT_BUTTON_EDIT, 586);
       }
-      if (!m_vecItems->IsMusicDb() && !m_vecItems->IsInternetStream()           &&
-          !item->IsPath("add") && !item->IsParentFolder() &&
-          !item->IsType("plugin://") && !item->IsMusicDb()         &&
-          !item->IsLibraryFolder() &&
-          !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
+      if (!m_vecItems->IsType("musicdb://") && !m_vecItems->IsInternetStream() &&
+          !item->IsPath("add") && !item->IsParentFolder()                      &&
+          !item->IsType("plugin://") && !item->IsType("musicdb://")            &&
+          !item->IsLibraryFolder()                                             &&
+          !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")         &&
           (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
@@ -865,7 +865,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
 /// \param items File items to fill
 void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
 {
-  if (items.GetFolderCount()==items.Size() || items.IsMusicDb() ||
+  if (items.GetFolderCount()==items.Size() || items.IsType("musicdb://") ||
      (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICFILES_USETAGS) && !items.IsCDDA()))
   {
     return;
@@ -1002,7 +1002,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
 bool CGUIWindowMusicBase::CheckFilterAdvanced(CFileItemList &items) const
 {
   std::string content = items.GetContent();
-  if ((items.IsMusicDb() || CanContainFilter(m_strFilterPath)) &&
+  if ((items.IsType("musicdb://") || CanContainFilter(m_strFilterPath)) &&
       (StringUtils::EqualsNoCase(content, "artists") ||
        StringUtils::EqualsNoCase(content, "albums")  ||
        StringUtils::EqualsNoCase(content, "songs")))
@@ -1120,7 +1120,7 @@ void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
 {
   CGUIMediaWindow::OnPrepareFileItems(items);
 
-  if (!items.IsMusicDb() && !items.IsSmartPlayList())
+  if (!items.IsType("musicdb://") && !items.IsSmartPlayList())
     RetrieveMusicInfo();
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -572,7 +572,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
 #ifdef HAS_DVD_DRIVE
       // enable Rip CD Audio or Track button if we have an audio disc
-      if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsCDDA())
+      if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsType("cdda://"))
       {
         // those cds can also include Audio Tracks: CDExtra and MixedMode!
         MEDIA_DETECT::CCdInfo *pCdInfo = g_mediaManager.GetCdInfo();
@@ -583,7 +583,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
     }
 
     // enable CDDB lookup if the current dir is CDDA
-    if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsCDDA() &&
+    if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsType("cdda://") &&
        (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       buttons.Add(CONTEXT_BUTTON_CDDB, 16002);
@@ -710,7 +710,7 @@ void CGUIWindowMusicBase::OnRipCD()
 {
   if(g_mediaManager.IsAudio())
   {
-    if (!g_application.CurrentFileItem().IsCDDA())
+    if (!g_application.CurrentFileItem().IsType("cdda://"))
     {
 #ifdef HAS_CDDA_RIPPER
       CCDDARipper::GetInstance().RipCD();
@@ -725,7 +725,7 @@ void CGUIWindowMusicBase::OnRipTrack(int iItem)
 {
   if(g_mediaManager.IsAudio())
   {
-    if (!g_application.CurrentFileItem().IsCDDA())
+    if (!g_application.CurrentFileItem().IsType("cdda://"))
     {
 #ifdef HAS_CDDA_RIPPER
       CFileItemPtr item = m_vecItems->Get(iItem);
@@ -866,7 +866,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
 void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
 {
   if (items.GetFolderCount()==items.Size() || items.IsType("musicdb://") ||
-     (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICFILES_USETAGS) && !items.IsCDDA()))
+     (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICFILES_USETAGS) && !items.IsType("cdda://")))
   {
     return;
   }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -484,7 +484,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
       // python files can be played
       queuedItems.Add(pItem);
     }
-    else if (!pItem->IsNFO() && (pItem->IsAudio() || pItem->IsVideo()))
+    else if (!pItem->IsType(".nfo") && (pItem->IsAudio() || pItem->IsVideo()))
     {
       CFileItemPtr itemCheck = queuedItems.Get(pItem->GetPath());
       if (!itemCheck || itemCheck->m_lStartOffset != pItem->m_lStartOffset)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -292,7 +292,7 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
     return;
   }
 
-  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
   {
     CGUIDialogAddonInfo::ShowForItem(item);
     return;
@@ -479,7 +479,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     { // just queue the internet stream, it will be expanded on play
       queuedItems.Add(pItem);
     }
-    else if (pItem->IsPlugin() && pItem->GetProperty("isplayable") == "true")
+    else if (pItem->IsType("plugin://") && pItem->GetProperty("isplayable") == "true")
     {
       // python files can be played
       queuedItems.Add(pItem);
@@ -563,7 +563,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
       if (!m_vecItems->IsMusicDb() && !m_vecItems->IsInternetStream()           &&
           !item->IsPath("add") && !item->IsParentFolder() &&
-          !item->IsPlugin() && !item->IsMusicDb()         &&
+          !item->IsType("plugin://") && !item->IsMusicDb()         &&
           !item->IsLibraryFolder() &&
           !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
           (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
@@ -753,7 +753,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
 #endif
 
   // if its a folder, build a playlist
-  if (pItem->m_bIsFolder && !pItem->IsPlugin())
+  if (pItem->m_bIsFolder && !pItem->IsType("plugin://"))
   {
     // make a copy so that we can alter the queue state
     CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -286,7 +286,7 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
 
   CFileItemPtr item = m_vecItems->Get(iItem);
 
-  if (item->IsVideoDb())
+  if (item->IsType("videodb://"))
   { // Music video on a mixed current playlist
     OnContextButton(iItem, CONTEXT_BUTTON_INFO);
     return;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -525,7 +525,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
     if (item && !item->IsParentFolder())
     {
-      if (item->CanQueue() && !item->IsAddonsPath() && !item->IsScript())
+      if (item->CanQueue() && !item->IsType("addons://") && !item->IsScript())
       {
         buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 13347); //queue
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -292,7 +292,7 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
     return;
   }
 
-  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsType("script://")))
   {
     CGUIDialogAddonInfo::ShowForItem(item);
     return;
@@ -525,7 +525,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
     if (item && !item->IsParentFolder())
     {
-      if (item->CanQueue() && !item->IsType("addons://") && !item->IsScript())
+      if (item->CanQueue() && !item->IsType("addons://") && !item->IsType("script://"))
       {
         buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 13347); //queue
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -490,7 +490,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
   else if (items.IsAddonsPath())
     items.SetContent("addons");
   else if (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() &&
-           !items.IsLibraryFolder() && !items.IsPlugin() && !items.IsSmartPlayList())
+           !items.IsLibraryFolder() && !items.IsType("plugin://") && !items.IsSmartPlayList())
     items.SetContent("files");
 
   return bResult;
@@ -544,7 +544,7 @@ void CGUIWindowMusicNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsPlugin() && !m_vecItems->IsScript());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
 }
 
 void CGUIWindowMusicNav::PlayItem(int iItem)
@@ -608,7 +608,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
 #endif
       if (!inPlaylists && !m_vecItems->IsInternetStream() &&
         !item->IsPath("add") && !item->IsParentFolder() &&
-        !item->IsPlugin() &&
+        !item->IsType("plugin://") &&
         !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
         (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
@@ -625,7 +625,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       if (!item->IsParentFolder() && !dir.IsAllItem(item->GetPath()))
       {
         if (item->m_bIsFolder && !item->IsVideoDb() &&
-          !item->IsPlugin() && !StringUtils::StartsWithNoCase(item->GetPath(), "musicsearch://"))
+          !item->IsType("plugin://") && !StringUtils::StartsWithNoCase(item->GetPath(), "musicsearch://"))
         {
           if (item->IsAlbum())
             // enable query all albums button only in album view
@@ -673,7 +673,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
         if (item->HasVideoInfoTag() && !item->m_bIsFolder)
         {
-          if ((profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
+          if ((profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsType("plugin://"))
           {
             buttons.Add(CONTEXT_BUTTON_RENAME, 16105);
             buttons.Add(CONTEXT_BUTTON_DELETE, 646);

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -489,7 +489,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
     items.SetContent("plugins");
   else if (items.IsType("addons://"))
     items.SetContent("addons");
-  else if (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() &&
+  else if (!items.IsType("sources://") && !items.IsVirtualDirectoryRoot() &&
            !items.IsLibraryFolder() && !items.IsType("plugin://") && !items.IsSmartPlayList())
     items.SetContent("files");
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -421,7 +421,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
   }
 
   // update our content in the info manager
-  if (StringUtils::StartsWithNoCase(strDirectory, "videodb://") || items.IsVideoDb())
+  if (StringUtils::StartsWithNoCase(strDirectory, "videodb://") || items.IsType("videodb://"))
   {
     CVideoDatabaseDirectory dir;
     VIDEODATABASEDIRECTORY::NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());
@@ -624,7 +624,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
 
       if (!item->IsParentFolder() && !dir.IsAllItem(item->GetPath()))
       {
-        if (item->m_bIsFolder && !item->IsVideoDb() &&
+        if (item->m_bIsFolder && !item->IsType("videodb://") &&
           !item->IsType("plugin://") && !StringUtils::StartsWithNoCase(item->GetPath(), "musicsearch://"))
         {
           if (item->IsAlbum())
@@ -706,7 +706,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   {
   case CONTEXT_BUTTON_INFO:
     {
-      if (!item->IsVideoDb())
+      if (!item->IsType("videodb://"))
         return CGUIWindowMusicBase::OnContextButton(itemNumber,button);
 
       // music videos - artists
@@ -787,7 +787,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
 
   case CONTEXT_BUTTON_RENAME:
-    if (!item->IsVideoDb() && !item->IsReadOnly())
+    if (!item->IsType("videodb://") && !item->IsReadOnly())
       OnRenameItem(itemNumber);
 
     CGUIDialogVideoInfo::UpdateVideoItemTitle(item);
@@ -803,7 +803,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (gui && gui->ConfirmDelete(item->GetPath()))
         CFileUtils::DeleteItem(item);
     }
-    else if (!item->IsVideoDb())
+    else if (!item->IsType("videodb://"))
       OnDeleteItem(itemNumber);
     else
     {

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -487,7 +487,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
     items.SetContent("playlists");
   else if (URIUtils::PathEquals(strDirectory, "plugin://music/"))
     items.SetContent("plugins");
-  else if (items.IsAddonsPath())
+  else if (items.IsType("addons://"))
     items.SetContent("addons");
   else if (!items.IsSourcesPath() && !items.IsVirtualDirectoryRoot() &&
            !items.IsLibraryFolder() && !items.IsType("plugin://") && !items.IsSmartPlayList())
@@ -544,7 +544,7 @@ void CGUIWindowMusicNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsType("addons://") && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
 }
 
 void CGUIWindowMusicNav::PlayItem(int iItem)

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -544,7 +544,7 @@ void CGUIWindowMusicNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsType("addons://") && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsType("addons://") && !m_vecItems->IsType("plugin://") && !m_vecItems->IsType("script://"));
 }
 
 void CGUIWindowMusicNav::PlayItem(int iItem)

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -388,7 +388,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem, const std::string &player /* = "" */
     }
     return true;
   }
-  if (item->IsMusicDb() && !item->m_bIsFolder)
+  if (item->IsType("musicdb://") && !item->m_bIsFolder)
     m_musicdatabase.SetPropertiesForFileItem(*item);
 
   return CGUIWindowMusicBase::OnClick(iItem, player);
@@ -447,7 +447,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
     else
       items.SetContent("");
   }
-  else if (StringUtils::StartsWithNoCase(strDirectory, "musicdb://") || items.IsMusicDb())
+  else if (StringUtils::StartsWithNoCase(strDirectory, "musicdb://") || items.IsType("musicdb://"))
   {
     CMusicDatabaseDirectory dir;
     NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -593,7 +593,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       CGUIDialogContextMenu::GetContextButtons("music", item, buttons);
 #ifdef HAS_DVD_DRIVE
       // enable Rip CD an audio disc
-      if (g_mediaManager.IsDiscInDrive() && item->IsCDDA())
+      if (g_mediaManager.IsDiscInDrive() && item->IsType("cdda://"))
       {
         // those cds can also include Audio Tracks: CDExtra and MixedMode!
         MEDIA_DETECT::CCdInfo *pCdInfo = g_mediaManager.GetCdInfo();

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -326,7 +326,7 @@ void CGUIWindowMusicPlayList::SavePlayList()
 
       //  Musicdatabase items should contain the real path instead of a musicdb url
       //  otherwise the user can't save and reuse the playlist when the musicdb gets deleted
-      if (pItem->IsMusicDb())
+      if (pItem->IsType("musicdb://"))
         pItem->SetPath(pItem->GetMusicInfoTag()->GetURL());
 
       playlist.Add(pItem);

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -31,7 +31,7 @@ using namespace XFILE::MUSICDATABASEDIRECTORY;
 
 bool CMusicFileItemListModifier::CanModify(const CFileItemList &items) const
 {
-  if (items.IsMusicDb())
+  if (items.IsType("musicdb://"))
     return true;
 
   return false;
@@ -47,7 +47,7 @@ bool CMusicFileItemListModifier::Modify(CFileItemList &items) const
 //  depending on the child node
 void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
 {
-  if (!items.IsMusicDb())
+  if (!items.IsType("musicdb://"))
     return;
 
   auto directoryNode = CDirectoryNode::ParseURL(items.GetPath());

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -150,7 +150,7 @@ GetMimeType(const CFileItem& item,
     if (mime.IsEmpty()) {
         if (item.IsVideo() || item.IsVideoDb() )
             mime = "video/" + ext;
-        else if (item.IsAudio() || item.IsMusicDb() )
+        else if (item.IsAudio() || item.IsType("musicdb://") )
             mime = "audio/" + ext;
         else if (item.IsPicture() )
             mime = "image/" + ext;
@@ -392,7 +392,7 @@ BuildObject(CFileItem&                    item,
         object->m_ObjectID = item.GetPath().c_str();
 
         /* Setup object type */
-        if (item.IsMusicDb() || item.IsAudio()) {
+        if (item.IsType("musicdb://") || item.IsAudio()) {
             object->m_ObjectClass.type = "object.item.audioItem.musicTrack";
 
             if (item.HasMusicInfoTag()) {
@@ -467,7 +467,7 @@ BuildObject(CFileItem&                    item,
         container->m_ChildrenCount = -1;
 
         /* this might be overkill, but hey */
-        if (item.IsMusicDb()) {
+        if (item.IsType("musicdb://")) {
             MUSICDATABASEDIRECTORY::NODE_TYPE node = CMusicDatabaseDirectory::GetDirectoryType(item.GetPath());
             switch(node) {
                 case MUSICDATABASEDIRECTORY::NODE_TYPE_ARTIST: {

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -148,7 +148,7 @@ GetMimeType(const CFileItem& item,
 
     /* fallback to generic mime type if not found */
     if (mime.IsEmpty()) {
-        if (item.IsVideo() || item.IsVideoDb() )
+        if (item.IsVideo() || item.IsType("videodb://") )
             mime = "video/" + ext;
         else if (item.IsAudio() || item.IsType("musicdb://") )
             mime = "audio/" + ext;
@@ -399,7 +399,7 @@ BuildObject(CFileItem&                    item,
                 CMusicInfoTag *tag = (CMusicInfoTag*)item.GetMusicInfoTag();
                 PopulateObjectFromTag(*tag, *object, &file_path, &resource, quirks, upnp_service);
             }
-        } else if (item.IsVideoDb() || item.IsVideo()) {
+        } else if (item.IsType("videodb://") || item.IsVideo()) {
             object->m_ObjectClass.type = "object.item.videoItem";
 
             if(quirks & ECLIENTQUIRKS_UNKNOWNSERIES)
@@ -511,7 +511,7 @@ BuildObject(CFileItem&                    item,
                 default:
                   break;
             }
-        } else if (item.IsVideoDb()) {
+        } else if (item.IsType("videodb://")) {
             VIDEODATABASEDIRECTORY::NODE_TYPE node = CVideoDatabaseDirectory::GetDirectoryType(item.GetPath());
             CVideoInfoTag &tag = *(CVideoInfoTag*)item.GetVideoInfoTag();
             switch(node) {

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -215,7 +215,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
 
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
 
-  if (file.IsVideoDb())
+  if (file.IsType("videodb://"))
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
   else if (item.IsType("musicdb://"))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
@@ -404,7 +404,7 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
   NPT_String path(file.GetPath().c_str());
   NPT_String tmp;
 
-  if (file.IsVideoDb())
+  if (file.IsType("videodb://"))
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
   else if (item.IsType("musicdb://"))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -217,7 +217,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file, const CPlayerOptions& options, 
 
   if (file.IsVideoDb())
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-  else if (item.IsMusicDb())
+  else if (item.IsType("musicdb://"))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
   obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);
@@ -406,7 +406,7 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
 
   if (file.IsVideoDb())
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-  else if (item.IsMusicDb())
+  else if (item.IsType("musicdb://"))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
 

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -598,7 +598,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
         if (item->IsVideoDb()) {
             thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
         }
-        else if (item->IsMusicDb()) {
+        else if (item->IsType("musicdb://")) {
             thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
         }
         if (!thumb_loader.IsNull()) {
@@ -1108,7 +1108,7 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
             updated.SetFromVideoInfoTag(tag);
         }
 
-    } else if (updated.IsMusicDb()) {
+    } else if (updated.IsType("musicdb://")) {
       //! @todo implement this
 
     } else {
@@ -1121,7 +1121,7 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
         updated.SetPath(path);
         if (updated.IsVideoDb())
              CUtil::DeleteVideoDatabaseDirectoryCache();
-        else if (updated.IsMusicDb())
+        else if (updated.IsType("musicdb://"))
              CUtil::DeleteMusicDatabaseDirectoryCache();
 
         CFileItemPtr msgItem(new CFileItem(updated));

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -595,7 +595,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
             else parent = "sources://video/"; // this can only match video sources
         }
 
-        if (item->IsVideoDb()) {
+        if (item->IsType("videodb://")) {
             thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
         }
         else if (item->IsType("musicdb://")) {
@@ -1037,7 +1037,7 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
     NPT_CHECK_LABEL(FindServiceById("urn:upnp-org:serviceId:ContentDirectory", service), error);
     NPT_CHECK_LABEL(service->PauseEventing(), error);
 
-    if (updated.IsVideoDb()) {
+    if (updated.IsType("videodb://")) {
         CVideoDatabase db;
         NPT_CHECK_LABEL(!db.Open(), error);
 
@@ -1119,7 +1119,7 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
 
     if (updatelisting) {
         updated.SetPath(path);
-        if (updated.IsVideoDb())
+        if (updated.IsType("videodb://"))
              CUtil::DeleteVideoDatabaseDirectoryCache();
         else if (updated.IsType("musicdb://"))
              CUtil::DeleteMusicDatabaseDirectoryCache();
@@ -1310,7 +1310,7 @@ CUPnPServer::SortItems(CFileItemList& items, const char* sort_criteria)
 void
 CUPnPServer::DefaultSortItems(CFileItemList& items)
 {
-  CGUIViewState* viewState = CGUIViewState::GetViewState(items.IsVideoDb() ? WINDOW_VIDEO_NAV : -1, items);
+  CGUIViewState* viewState = CGUIViewState::GetViewState(items.IsType("videodb://") ? WINDOW_VIDEO_NAV : -1, items);
   if (viewState)
   {
     SortDescription sorting = viewState->GetSortMethod();

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -297,7 +297,7 @@ bool CGUIWindowPictures::GetDirectory(const std::string &strDirectory, CFileItem
   if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("pictures"), &label))
     items.SetLabel(label);
 
-  if (items.GetContent().empty() && !items.IsVirtualDirectoryRoot() && !items.IsPlugin())
+  if (items.GetContent().empty() && !items.IsVirtualDirectoryRoot() && !items.IsType("plugin://"))
     items.SetContent("images");
   return true;
 }
@@ -483,7 +483,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
-      if (!item->IsPlugin() && !item->IsScript() && !m_vecItems->IsPlugin())
+      if (!item->IsType("plugin://") && !item->IsScript() && !m_vecItems->IsType("plugin://"))
         buttons.Add(CONTEXT_BUTTON_SWITCH_MEDIA, 523);
     }
   }
@@ -586,7 +586,7 @@ void CGUIWindowPictures::OnItemInfo(int itemNumber)
   CFileItemPtr item = m_vecItems->Get(itemNumber);
   if (!item)
     return;
-  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
   {
     CGUIDialogAddonInfo::ShowForItem(item);
     return;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -271,10 +271,10 @@ bool CGUIWindowPictures::OnClick(int iItem, const std::string &player)
   if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return true;
   CFileItemPtr pItem = m_vecItems->Get(iItem);
 
-  if (pItem->IsCBZ() || pItem->IsCBR())
+  if (pItem->IsType(".cbz") || pItem->IsCBR())
   {
     CURL pathToUrl;
-    if (pItem->IsCBZ())
+    if (pItem->IsType(".cbz"))
       pathToUrl = URIUtils::CreateArchivePath("zip", pItem->GetURL(), "");
     else
       pathToUrl = URIUtils::CreateArchivePath("rar", pItem->GetURL(), "");
@@ -465,7 +465,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (item)
       {
-        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || item->IsScript()))
+        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsCBR() || item->IsScript()))
         {
           if (item->IsPicture())
             buttons.Add(CONTEXT_BUTTON_INFO, 13406); // picture info
@@ -570,7 +570,7 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
     {
       CFileItemPtr pItem = playlist[i];
       //CLog::Log(LOGDEBUG,"-- playlist item: %s", pItem->GetPath().c_str());
-      if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBZ() || pItem->IsCBR()))
+      if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsType(".cbz") || pItem->IsCBR()))
         pSlideShow->Add(pItem.get());
     }
 
@@ -591,7 +591,7 @@ void CGUIWindowPictures::OnItemInfo(int itemNumber)
     CGUIDialogAddonInfo::ShowForItem(item);
     return;
   }
-  if (item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || !item->IsPicture())
+  if (item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsCBR() || !item->IsPicture())
     return;
   CGUIDialogPictureInfo *pictureInfo = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPictureInfo>(WINDOW_DIALOG_PICTURE_INFO);
   if (pictureInfo)

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -465,7 +465,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (item)
       {
-        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsType(".cbr") || item->IsScript()))
+        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsType(".cbr") || item->IsType("script://")))
         {
           if (item->IsPicture())
             buttons.Add(CONTEXT_BUTTON_INFO, 13406); // picture info
@@ -483,7 +483,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
-      if (!item->IsType("plugin://") && !item->IsScript() && !m_vecItems->IsType("plugin://"))
+      if (!item->IsType("plugin://") && !item->IsType("script://") && !m_vecItems->IsType("plugin://"))
         buttons.Add(CONTEXT_BUTTON_SWITCH_MEDIA, 523);
     }
   }
@@ -586,7 +586,7 @@ void CGUIWindowPictures::OnItemInfo(int itemNumber)
   CFileItemPtr item = m_vecItems->Get(itemNumber);
   if (!item)
     return;
-  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsType("script://")))
   {
     CGUIDialogAddonInfo::ShowForItem(item);
     return;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -271,7 +271,7 @@ bool CGUIWindowPictures::OnClick(int iItem, const std::string &player)
   if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return true;
   CFileItemPtr pItem = m_vecItems->Get(iItem);
 
-  if (pItem->IsType(".cbz") || pItem->IsCBR())
+  if (pItem->IsType(".cbz") || pItem->IsType(".cbr"))
   {
     CURL pathToUrl;
     if (pItem->IsType(".cbz"))
@@ -465,7 +465,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (item)
       {
-        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsCBR() || item->IsScript()))
+        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsType(".cbr") || item->IsScript()))
         {
           if (item->IsPicture())
             buttons.Add(CONTEXT_BUTTON_INFO, 13406); // picture info
@@ -570,7 +570,7 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
     {
       CFileItemPtr pItem = playlist[i];
       //CLog::Log(LOGDEBUG,"-- playlist item: %s", pItem->GetPath().c_str());
-      if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsType(".cbz") || pItem->IsCBR()))
+      if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsType(".cbz") || pItem->IsType(".cbr")))
         pSlideShow->Add(pItem.get());
     }
 
@@ -591,7 +591,7 @@ void CGUIWindowPictures::OnItemInfo(int itemNumber)
     CGUIDialogAddonInfo::ShowForItem(item);
     return;
   }
-  if (item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsCBR() || !item->IsPicture())
+  if (item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsType(".cbz") || item->IsType(".cbr") || !item->IsPicture())
     return;
   CGUIDialogPictureInfo *pictureInfo = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPictureInfo>(WINDOW_DIALOG_PICTURE_INFO);
   if (pictureInfo)

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -60,7 +60,7 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CPictureInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsType(".cbz") || pItem->IsInternetStream() || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())
@@ -83,7 +83,7 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsType(".cbz") || pItem->IsInternetStream() || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -60,7 +60,7 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CPictureInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsType(".cbz") || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsType(".cbr") || pItem->IsType(".cbz") || pItem->IsInternetStream() || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())
@@ -83,7 +83,7 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsType(".cbz") || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsType(".cbr") || pItem->IsType(".cbz") || pItem->IsInternetStream() || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -168,7 +168,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       pathToUrl = URIUtils::CreateArchivePath("zip",pItem->GetURL(),"");
       thumb = "cover.jpg";
     }
-    if (pItem->IsMultiPath())
+    if (pItem->IsType("multipath://"))
       pathToUrl = CURL(CMultiPathDirectory::GetFirstPath(pItem->GetPath()));
     thumb = URIUtils::AddFileToFolder(pathToUrl.Get(), thumb);
     if (CFile::Exists(thumb))

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -80,11 +80,11 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
   }
 
   std::string thumb;
-  if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsType(".cbz") && !pItem->IsCBR() && !pItem->IsPlayList())
+  if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsType(".cbz") && !pItem->IsType(".cbr") && !pItem->IsPlayList())
   { // load the thumb from the image file
     thumb = pItem->HasArt("thumb") ? pItem->GetArt("thumb") : CTextureUtils::GetWrappedThumbURL(pItem->GetPath());
   }
-  else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsType(".cbz") && !pItem->IsCBR() && !pItem->IsPlayList())
+  else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsType(".cbz") && !pItem->IsType(".cbr") && !pItem->IsPlayList())
   { // video
     CVideoThumbLoader loader;
     if (!loader.FillThumb(*pItem))
@@ -141,7 +141,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
   CTextureDatabase db;
   db.Open();
-  if (pItem->IsCBR() || pItem->IsType(".cbz"))
+  if (pItem->IsType(".cbr") || pItem->IsType(".cbz"))
   {
     std::string strTBN(URIUtils::ReplaceExtension(pItem->GetPath(),".tbn"));
     if (CFile::Exists(strTBN))
@@ -152,13 +152,13 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       return;
     }
   }
-  if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsType(".cbz")) && !pItem->m_bIsShareOrDrive
+  if ((pItem->m_bIsFolder || pItem->IsType(".cbr") || pItem->IsType(".cbz")) && !pItem->m_bIsShareOrDrive
       && !pItem->IsParentFolder() && !pItem->IsPath("add"))
   {
     // first check for a folder.jpg
     std::string thumb = "folder.jpg";
     CURL pathToUrl = pItem->GetURL();
-    if (pItem->IsCBR())
+    if (pItem->IsType(".cbr"))
     {
       pathToUrl = URIUtils::CreateArchivePath("rar",pItem->GetURL(),"");
       thumb = "cover.jpg";
@@ -202,7 +202,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       if (items.IsEmpty())
       {
-        if (pItem->IsType(".cbz") || pItem->IsCBR())
+        if (pItem->IsType(".cbz") || pItem->IsType(".cbr"))
         {
           CDirectory::GetDirectory(pathToUrl, items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS);
           for (int i=0;i<items.Size();++i)
@@ -223,7 +223,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       // randomize them
       items.Randomize();
 
-      if (items.Size() < 4 || pItem->IsCBR() || pItem->IsType(".cbz"))
+      if (items.Size() < 4 || pItem->IsType(".cbr") || pItem->IsType(".cbz"))
       { // less than 4 items, so just grab the first thumb
         items.Sort(SortByLabel, SortOrderAscending);
         std::string thumb = CTextureUtils::GetWrappedThumbURL(items[0]->GetPath());

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -80,11 +80,11 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
   }
 
   std::string thumb;
-  if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
+  if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsType(".cbz") && !pItem->IsCBR() && !pItem->IsPlayList())
   { // load the thumb from the image file
     thumb = pItem->HasArt("thumb") ? pItem->GetArt("thumb") : CTextureUtils::GetWrappedThumbURL(pItem->GetPath());
   }
-  else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
+  else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsType(".cbz") && !pItem->IsCBR() && !pItem->IsPlayList())
   { // video
     CVideoThumbLoader loader;
     if (!loader.FillThumb(*pItem))
@@ -141,7 +141,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
   CTextureDatabase db;
   db.Open();
-  if (pItem->IsCBR() || pItem->IsCBZ())
+  if (pItem->IsCBR() || pItem->IsType(".cbz"))
   {
     std::string strTBN(URIUtils::ReplaceExtension(pItem->GetPath(),".tbn"));
     if (CFile::Exists(strTBN))
@@ -152,7 +152,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       return;
     }
   }
-  if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsCBZ()) && !pItem->m_bIsShareOrDrive
+  if ((pItem->m_bIsFolder || pItem->IsCBR() || pItem->IsType(".cbz")) && !pItem->m_bIsShareOrDrive
       && !pItem->IsParentFolder() && !pItem->IsPath("add"))
   {
     // first check for a folder.jpg
@@ -163,7 +163,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       pathToUrl = URIUtils::CreateArchivePath("rar",pItem->GetURL(),"");
       thumb = "cover.jpg";
     }
-    if (pItem->IsCBZ())
+    if (pItem->IsType(".cbz"))
     {
       pathToUrl = URIUtils::CreateArchivePath("zip",pItem->GetURL(),"");
       thumb = "cover.jpg";
@@ -202,7 +202,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       if (items.IsEmpty())
       {
-        if (pItem->IsCBZ() || pItem->IsCBR())
+        if (pItem->IsType(".cbz") || pItem->IsCBR())
         {
           CDirectory::GetDirectory(pathToUrl, items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), DIR_FLAG_NO_FILE_DIRS);
           for (int i=0;i<items.Size();++i)
@@ -223,7 +223,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       // randomize them
       items.Randomize();
 
-      if (items.Size() < 4 || pItem->IsCBR() || pItem->IsCBZ())
+      if (items.Size() < 4 || pItem->IsCBR() || pItem->IsType(".cbz"))
       { // less than 4 items, so just grab the first thumb
         items.Sort(SortByLabel, SortOrderAscending);
         std::string thumb = CTextureUtils::GetWrappedThumbURL(items[0]->GetPath());

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -178,7 +178,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       pItem->SetArt("thumb", thumb);
       return;
     }
-    if (!pItem->IsPlugin())
+    if (!pItem->IsType("plugin://"))
     {
       // we load the directory, grab 4 random thumb files (if available) and then generate
       // the thumb.

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1052,7 +1052,7 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
     else
     {
       CFileItem* item = new CFileItem(targetFile, false);
-      if (item->IsVideoDb())
+      if (item->IsType("videodb://"))
       {
         *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item->GetPath()));
         item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -516,7 +516,7 @@ void CPlayList::UpdateItem(const CFileItem *item)
 
 const std::string& CPlayList::ResolveURL(const CFileItemPtr &item ) const
 {
-  if (item->IsMusicDb() && item->HasMusicInfoTag())
+  if (item->IsType("musicdb://") && item->HasMusicInfoTag())
     return item->GetMusicInfoTag()->GetURL();
   else
     return item->GetPath();

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -362,7 +362,7 @@ int CPlayList::RemoveDVDItems()
   while (it != m_vecItems.end() )
   {
     CFileItemPtr item = *it;
-    if ( item->IsCDDA() || item->IsOnDVD() )
+    if ( item->IsType("cdda://") || item->IsOnDVD() )
     {
       vecFilenames.push_back( item->GetPath() );
     }

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -188,7 +188,7 @@ void CGUIWindowPrograms::OnItemInfo(int iItem)
     return;
 
   CFileItemPtr item = m_vecItems->Get(iItem);
-  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
   {
     CGUIDialogAddonInfo::ShowForItem(item);
   }

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -188,7 +188,7 @@ void CGUIWindowPrograms::OnItemInfo(int iItem)
     return;
 
   CFileItemPtr item = m_vecItems->Get(iItem);
-  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsType("script://")))
   {
     CGUIDialogAddonInfo::ShowForItem(item);
   }

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1409,7 +1409,7 @@ namespace PVR
         else
           return false;
       }
-      else if (item->IsPVRChannel())
+      else if (item->HasPVRChannelInfoTag())
       {
         iClientID = item->GetPVRChannelInfoTag()->ClientID();
         menuCategory = PVR_MENUHOOK_CHANNEL;

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1399,7 +1399,7 @@ namespace PVR
 
     if (item)
     {
-      if (item->IsEPG())
+      if (item->HasEPGInfoTag())
       {
         if (item->GetEPGInfoTag()->HasChannel())
         {

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -221,7 +221,7 @@ namespace PVR
 
   bool CPVRGUIActions::ShowRecordingInfo(const CFileItemPtr &item) const
   {
-    if (!item->IsPVRRecording())
+    if (!item->HasPVRRecordingInfoTag())
     {
       CLog::Log(LOGERROR, "CPVRGUIActions - %s - no recording!", __FUNCTION__);
       return false;
@@ -947,7 +947,7 @@ namespace PVR
 
   bool CPVRGUIActions::DeleteRecording(const CFileItemPtr &item) const
   {
-    if ((!item->IsPVRRecording() && !item->m_bIsFolder) || item->IsParentFolder())
+    if ((!item->HasPVRRecordingInfoTag() && !item->m_bIsFolder) || item->IsParentFolder())
       return false;
 
     if (!ConfirmDeleteRecording(item))

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1424,7 +1424,7 @@ namespace PVR
         iClientID = item->GetPVRRecordingInfoTag()->m_iClientId;
         menuCategory = PVR_MENUHOOK_RECORDING;
       }
-      else if (item->IsPVRTimer())
+      else if (item->HasPVRTimerInfoTag())
       {
         iClientID = item->GetPVRTimerInfoTag()->m_iClientId;
         menuCategory = PVR_MENUHOOK_TIMER;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1165,7 +1165,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
           bValue = timer->IsRecording();
         return true;
       }
-      else if (item->IsPVRRecording())
+      else if (item->HasPVRRecordingInfoTag())
       {
         bValue = item->GetPVRRecordingInfoTag()->IsInProgress();
         return true;
@@ -1274,7 +1274,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case VIDEOPLAYER_CAN_RESUME_LIVE_TV:
-      if (item->IsPVRRecording())
+      if (item->HasPVRRecordingInfoTag())
       {
         const CPVRRecordingPtr recording = item->GetPVRRecordingInfoTag();
         const CPVREpgInfoTagPtr epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(recording->Channel(), recording->BroadcastUid());

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -501,7 +501,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
 
   CPVREpgInfoTagPtr epgTag;
   CPVRChannelPtr channel;
-  if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->IsPVRTimer())
+  if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->HasPVRTimerInfoTag())
   {
     switch (info.m_info)
     {
@@ -1158,7 +1158,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
         bValue = item->GetPVRChannelInfoTag()->IsRecording();
         return true;
       }
-      else if (item->HasEPGInfoTag() || item->IsPVRTimer())
+      else if (item->HasEPGInfoTag() || item->HasPVRTimerInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1190,7 +1190,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASTIMERSCHEDULE:
-      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->IsPVRTimer())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->HasPVRTimerInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1235,7 +1235,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HAS_EPG:
-      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->IsPVRTimer())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->HasPVRTimerInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         bValue = (epgTag != nullptr);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -501,7 +501,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
 
   CPVREpgInfoTagPtr epgTag;
   CPVRChannelPtr channel;
-  if (item->IsPVRChannel() || item->HasEPGInfoTag() || item->IsPVRTimer())
+  if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->IsPVRTimer())
   {
     switch (info.m_info)
     {
@@ -1082,7 +1082,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem *item, const CGUIInfo 
   switch (info.m_info)
   {
     case LISTITEM_PROGRESS:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1101,7 +1101,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem *item, const CGUIInfo &info, int& iV
   {
     case PVR_EPG_EVENT_DURATION:
     {
-      const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const CPVREpgInfoTagPtr epgTag = (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag && epgTag != m_playingEpgTag)
         iValue = epgTag->GetDuration();
       else
@@ -1110,7 +1110,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem *item, const CGUIInfo &info, int& iV
     }
     case PVR_EPG_EVENT_PROGRESS:
     {
-      const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const CPVREpgInfoTagPtr epgTag = (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag && epgTag != m_playingEpgTag)
         iValue = std::lrintf(epgTag->ProgressPercentage());
       else
@@ -1153,7 +1153,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
   switch (info.m_info)
   {
     case LISTITEM_ISRECORDING:
-      if (item->IsPVRChannel())
+      if (item->HasPVRChannelInfoTag())
       {
         bValue = item->GetPVRChannelInfoTag()->IsRecording();
         return true;
@@ -1172,7 +1172,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_INPROGRESS:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1181,7 +1181,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASTIMER:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1190,7 +1190,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASTIMERSCHEDULE:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag() || item->IsPVRTimer())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->IsPVRTimer())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1199,7 +1199,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_TIMERISACTIVE:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1208,7 +1208,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_TIMERHASCONFLICT:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1217,7 +1217,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_TIMERHASERROR:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1226,7 +1226,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASRECORDING:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1235,7 +1235,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HAS_EPG:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag() || item->IsPVRTimer())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag() || item->IsPVRTimer())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         bValue = (epgTag != nullptr);
@@ -1243,7 +1243,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_ISENCRYPTED:
-      if (item->IsPVRChannel() || item->HasEPGInfoTag())
+      if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
       {
         const CPVRChannelPtr channel = CPVRItem(item).GetChannel();
         if (channel)
@@ -1253,21 +1253,21 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       break;
     case MUSICPLAYER_CONTENT:
     case VIDEOPLAYER_CONTENT:
-      if (item->IsPVRChannel())
+      if (item->HasPVRChannelInfoTag())
       {
         bValue = StringUtils::EqualsNoCase(info.GetData3(), "livetv");
         return bValue; // if no match for this provider, other providers shall be asked.
       }
       break;
     case VIDEOPLAYER_HAS_INFO:
-      if (item->IsPVRChannel())
+      if (item->HasPVRChannelInfoTag())
       {
         bValue = !item->GetPVRChannelInfoTag()->IsEmpty();
         return true;
       }
       break;
     case VIDEOPLAYER_HAS_EPG:
-      if (item->IsPVRChannel())
+      if (item->HasPVRChannelInfoTag())
       {
         bValue = (item->GetPVRChannelInfoTag()->GetEPGNow() != nullptr);
         return true;
@@ -1283,7 +1283,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case PLAYER_IS_CHANNEL_PREVIEW_ACTIVE:
-      if (item->IsPVRChannel())
+      if (item->HasPVRChannelInfoTag())
       {
         if (CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreviewAndShowInfo())
         {
@@ -1434,7 +1434,7 @@ void CPVRGUIInfo::CharInfoTimeshiftOffset(TIME_FORMAT format, std::string &strVa
 void CPVRGUIInfo::CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
   int iDuration = 0;
-  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+  const CPVREpgInfoTagPtr epgTag = (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iDuration = epgTag->GetDuration();
   else
@@ -1446,7 +1446,7 @@ void CPVRGUIInfo::CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT fo
 void CPVRGUIInfo::CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
   int iElapsed = 0;
-  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+  const CPVREpgInfoTagPtr epgTag = (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iElapsed = epgTag->Progress();
   else
@@ -1458,7 +1458,7 @@ void CPVRGUIInfo::CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT
 int CPVRGUIInfo::GetRemainingTime(const CFileItem *item) const
 {
   int iRemaining = 0;
-  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+  const CPVREpgInfoTagPtr epgTag = (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iRemaining = epgTag->GetDuration() - epgTag->Progress();
   else

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -501,7 +501,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem *item, const CGUIInf
 
   CPVREpgInfoTagPtr epgTag;
   CPVRChannelPtr channel;
-  if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
+  if (item->IsPVRChannel() || item->HasEPGInfoTag() || item->IsPVRTimer())
   {
     switch (info.m_info)
     {
@@ -1082,7 +1082,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem *item, const CGUIInfo 
   switch (info.m_info)
   {
     case LISTITEM_PROGRESS:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1101,7 +1101,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem *item, const CGUIInfo &info, int& iV
   {
     case PVR_EPG_EVENT_DURATION:
     {
-      const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag && epgTag != m_playingEpgTag)
         iValue = epgTag->GetDuration();
       else
@@ -1110,7 +1110,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem *item, const CGUIInfo &info, int& iV
     }
     case PVR_EPG_EVENT_PROGRESS:
     {
-      const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag && epgTag != m_playingEpgTag)
         iValue = std::lrintf(epgTag->ProgressPercentage());
       else
@@ -1158,7 +1158,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
         bValue = item->GetPVRChannelInfoTag()->IsRecording();
         return true;
       }
-      else if (item->IsEPG() || item->IsPVRTimer())
+      else if (item->HasEPGInfoTag() || item->IsPVRTimer())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1172,7 +1172,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_INPROGRESS:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1181,7 +1181,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASTIMER:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1190,7 +1190,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASTIMERSCHEDULE:
-      if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag() || item->IsPVRTimer())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1199,7 +1199,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_TIMERISACTIVE:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1208,7 +1208,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_TIMERHASCONFLICT:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1217,7 +1217,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_TIMERHASERROR:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVRTimerInfoTagPtr timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
@@ -1226,7 +1226,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HASRECORDING:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
@@ -1235,7 +1235,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_HAS_EPG:
-      if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag() || item->IsPVRTimer())
       {
         const CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
         bValue = (epgTag != nullptr);
@@ -1243,7 +1243,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem *item, const CGUIInfo
       }
       break;
     case LISTITEM_ISENCRYPTED:
-      if (item->IsPVRChannel() || item->IsEPG())
+      if (item->IsPVRChannel() || item->HasEPGInfoTag())
       {
         const CPVRChannelPtr channel = CPVRItem(item).GetChannel();
         if (channel)
@@ -1434,7 +1434,7 @@ void CPVRGUIInfo::CharInfoTimeshiftOffset(TIME_FORMAT format, std::string &strVa
 void CPVRGUIInfo::CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
   int iDuration = 0;
-  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iDuration = epgTag->GetDuration();
   else
@@ -1446,7 +1446,7 @@ void CPVRGUIInfo::CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT fo
 void CPVRGUIInfo::CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
   int iElapsed = 0;
-  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iElapsed = epgTag->Progress();
   else
@@ -1458,7 +1458,7 @@ void CPVRGUIInfo::CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT
 int CPVRGUIInfo::GetRemainingTime(const CFileItem *item) const
 {
   int iRemaining = 0;
-  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+  const CPVREpgInfoTagPtr epgTag = (item->IsPVRChannel() || item->HasEPGInfoTag()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iRemaining = epgTag->GetDuration() - epgTag->Progress();
   else

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -35,7 +35,7 @@ namespace PVR
 {
   CPVREpgInfoTagPtr CPVRItem::GetEpgInfoTag() const
   {
-    if (m_item->IsEPG())
+    if (m_item->HasEPGInfoTag())
     {
       return m_item->GetEPGInfoTag();
     }
@@ -56,7 +56,7 @@ namespace PVR
 
   CPVREpgInfoTagPtr CPVRItem::GetNextEpgInfoTag() const
   {
-    if (m_item->IsEPG())
+    if (m_item->HasEPGInfoTag())
     {
       return m_item->GetEPGInfoTag()->GetNextEvent();
     }
@@ -83,7 +83,7 @@ namespace PVR
     {
       return m_item->GetPVRChannelInfoTag();
     }
-    else if (m_item->IsEPG())
+    else if (m_item->HasEPGInfoTag())
     {
       return m_item->GetEPGInfoTag()->Channel();
     }
@@ -104,7 +104,7 @@ namespace PVR
     {
       return m_item->GetPVRTimerInfoTag();
     }
-    else if (m_item->IsEPG())
+    else if (m_item->HasEPGInfoTag())
     {
       return m_item->GetEPGInfoTag()->Timer();
     }
@@ -133,7 +133,7 @@ namespace PVR
     {
       return m_item->GetPVRRecordingInfoTag();
     }
-    else if (m_item->IsEPG())
+    else if (m_item->HasEPGInfoTag())
     {
       return m_item->GetEPGInfoTag()->Recording();
     }
@@ -150,7 +150,7 @@ namespace PVR
     {
       return m_item->GetPVRChannelInfoTag()->IsRadio();
     }
-    else if (m_item->IsEPG())
+    else if (m_item->HasEPGInfoTag())
     {
       const CPVRChannelPtr channel(m_item->GetEPGInfoTag()->Channel());
       return (channel && channel->IsRadio());

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -43,7 +43,7 @@ namespace PVR
     {
       return m_item->GetPVRChannelInfoTag()->GetEPGNow();
     }
-    else if (m_item->IsPVRTimer())
+    else if (m_item->HasPVRTimerInfoTag())
     {
       return m_item->GetPVRTimerInfoTag()->GetEpgInfoTag();
     }
@@ -87,7 +87,7 @@ namespace PVR
     {
       return m_item->GetEPGInfoTag()->Channel();
     }
-    else if (m_item->IsPVRTimer())
+    else if (m_item->HasPVRTimerInfoTag())
     {
       return m_item->GetPVRTimerInfoTag()->Channel();
     }
@@ -100,7 +100,7 @@ namespace PVR
 
   CPVRTimerInfoTagPtr CPVRItem::GetTimerInfoTag() const
   {
-    if (m_item->IsPVRTimer())
+    if (m_item->HasPVRTimerInfoTag())
     {
       return m_item->GetPVRTimerInfoTag();
     }

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -39,7 +39,7 @@ namespace PVR
     {
       return m_item->GetEPGInfoTag();
     }
-    else if (m_item->IsPVRChannel())
+    else if (m_item->HasPVRChannelInfoTag())
     {
       return m_item->GetPVRChannelInfoTag()->GetEPGNow();
     }
@@ -60,7 +60,7 @@ namespace PVR
     {
       return m_item->GetEPGInfoTag()->GetNextEvent();
     }
-    else if (m_item->IsPVRChannel())
+    else if (m_item->HasPVRChannelInfoTag())
     {
       return m_item->GetPVRChannelInfoTag()->GetEPGNext();
     }
@@ -79,7 +79,7 @@ namespace PVR
 
   CPVRChannelPtr CPVRItem::GetChannel() const
   {
-    if (m_item->IsPVRChannel())
+    if (m_item->HasPVRChannelInfoTag())
     {
       return m_item->GetPVRChannelInfoTag();
     }
@@ -108,7 +108,7 @@ namespace PVR
     {
       return m_item->GetEPGInfoTag()->Timer();
     }
-    else if (m_item->IsPVRChannel())
+    else if (m_item->HasPVRChannelInfoTag())
     {
       CPVRTimerInfoTagPtr timer;
       const CPVREpgInfoTagPtr epgTag(m_item->GetPVRChannelInfoTag()->GetEPGNow());
@@ -146,7 +146,7 @@ namespace PVR
 
   bool CPVRItem::IsRadio() const
   {
-    if (m_item->IsPVRChannel())
+    if (m_item->HasPVRChannelInfoTag())
     {
       return m_item->GetPVRChannelInfoTag()->IsRadio();
     }

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -64,7 +64,7 @@ namespace PVR
     {
       return m_item->GetPVRChannelInfoTag()->GetEPGNext();
     }
-    else if (m_item->IsPVRTimer())
+    else if (m_item->HasPVRRecordingInfoTag())
     {
       const CPVREpgInfoTagPtr current = m_item->GetPVRTimerInfoTag()->GetEpgInfoTag();
       if (current)
@@ -129,7 +129,7 @@ namespace PVR
 
   CPVRRecordingPtr CPVRItem::GetRecording() const
   {
-    if (m_item->IsPVRRecording())
+    if (m_item->HasPVRRecordingInfoTag())
     {
       return m_item->GetPVRRecordingInfoTag();
     }
@@ -155,7 +155,7 @@ namespace PVR
       const CPVRChannelPtr channel(m_item->GetEPGInfoTag()->Channel());
       return (channel && channel->IsRadio());
     }
-    else if (m_item->IsPVRRecording())
+    else if (m_item->HasPVRRecordingInfoTag())
     {
       return m_item->GetPVRRecordingInfoTag()->IsRadio();
     }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -891,7 +891,7 @@ bool CPVRManager::FillStreamFileItem(CFileItem &fileItem)
   const CPVRClientPtr client = GetClient(fileItem);
   if (client)
   {
-    if (fileItem.IsPVRChannel())
+    if (fileItem.HasPVRChannelInfoTag())
       return client->FillChannelStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
     else if (fileItem.IsPVRRecording())
       return client->FillRecordingStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -893,7 +893,7 @@ bool CPVRManager::FillStreamFileItem(CFileItem &fileItem)
   {
     if (fileItem.HasPVRChannelInfoTag())
       return client->FillChannelStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
-    else if (fileItem.IsPVRRecording())
+    else if (fileItem.HasPVRRecordingInfoTag())
       return client->FillRecordingStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
     else if (fileItem.HasEPGInfoTag())
       return client->FillEpgTagStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -895,7 +895,7 @@ bool CPVRManager::FillStreamFileItem(CFileItem &fileItem)
       return client->FillChannelStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
     else if (fileItem.IsPVRRecording())
       return client->FillRecordingStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
-    else if (fileItem.IsEPG())
+    else if (fileItem.HasEPGInfoTag())
       return client->FillEpgTagStreamFileItem(fileItem) == PVR_ERROR_NO_ERROR;
   }
   return false;

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -228,7 +228,7 @@ bool CPVRRecordings::DeleteDirectory(const CFileItem& directory)
 
 bool CPVRRecordings::DeleteRecording(const CFileItem &item)
 {
-  if (!item.IsPVRRecording())
+  if (!item.HasPVRRecordingInfoTag())
   {
     CLog::Log(LOGERROR, "CPVRRecordings - %s - cannot delete file: no valid recording tag", __FUNCTION__);
     return false;

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -198,7 +198,7 @@ void CSaveFileState::DoWork(CFileItem& item,
 
           // UPnP announce resume point changes to clients
           // however not if playcount is modified as that already announces
-          if (item.IsMusicDb())
+          if (item.IsType("musicdb://"))
           {
             CVariant data;
             data["id"] = item.GetMusicInfoTag()->GetDatabaseId();

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -72,7 +72,7 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
   if (item.m_bIsFolder) // Only allow video db content, video and recording folders to be updated recursively
   {
     if (item.HasVideoInfoTag())
-      return item.IsVideoDb();
+      return item.IsType("videodb://");
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
@@ -98,7 +98,7 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
   if (item.m_bIsFolder) // Only allow video db content, video and recording folders to be updated recursively
   {
     if (item.HasVideoInfoTag())
-      return item.IsVideoDb();
+      return item.IsType("videodb://");
     else if (item.GetProperty("IsVideoFolder").asBoolean())
       return true;
     else
@@ -132,7 +132,7 @@ bool CResume::IsVisible(const CFileItem& itemIn) const
 
 static void SetPathAndPlay(CFileItem& item)
 {
-  if (item.IsVideoDb())
+  if (item.IsType("videodb://"))
   {
     item.SetProperty("original_listitem_url", item.GetPath());
     item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -37,7 +37,7 @@ bool CVideoInfo::IsVisible(const CFileItem& item) const
   if (!item.HasVideoInfoTag())
     return false;
 
-  if (item.IsPVRRecording())
+  if (item.HasPVRRecordingInfoTag())
     return false; // pvr recordings have its own implementation for this
 
   return item.GetVideoInfoTag()->m_type == m_mediaType;

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -149,7 +149,7 @@ bool CResume::Execute(const CFileItemPtr& itemIn) const
 {
   CFileItem item(itemIn->GetItemToPlay());
 #ifdef HAS_DVD_DRIVE
-  if (item.IsDVD() || item.IsCDDA())
+  if (item.IsDVD() || item.IsType("cdda://"))
     return MEDIA_DETECT::CAutorun::PlayDisc(item.GetPath(), true, false);
 #endif
 
@@ -177,14 +177,14 @@ bool CPlay::IsVisible(const CFileItem& itemIn) const
   if (item.m_bIsFolder)
     return false; //! @todo implement
 
-  return item.IsVideo() || item.IsLiveTV() || item.IsDVD() || item.IsCDDA();
+  return item.IsVideo() || item.IsLiveTV() || item.IsDVD() || item.IsType("cdda://");
 }
 
 bool CPlay::Execute(const CFileItemPtr& itemIn) const
 {
   CFileItem item(itemIn->GetItemToPlay());
 #ifdef HAS_DVD_DRIVE
-  if (item.IsDVD() || item.IsCDDA())
+  if (item.IsDVD() || item.IsType("cdda://"))
     return MEDIA_DETECT::CAutorun::PlayDisc(item.GetPath(), true, true);
 #endif
   SetPathAndPlay(item);

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -80,7 +80,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
     SetSortOrder(SortOrderNone);
   }
-  else if (items.IsVideoDb())
+  else if (items.IsType("videodb://"))
   {
     NODE_TYPE NodeType=CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath());
     CQueryParams params;
@@ -334,7 +334,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
 void CGUIViewStateWindowVideoNav::SaveViewState()
 {
-  if (m_items.IsVideoDb())
+  if (m_items.IsType("videodb://"))
   {
     NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.GetPath());
     CQueryParams params;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -904,7 +904,7 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath)
 
 int CVideoDatabase::AddFile(const CFileItem& item)
 {
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if (item.IsType("videodb://") && item.HasVideoInfoTag())
   {
     if (item.GetVideoInfoTag()->m_iFileId != -1)
       return item.GetVideoInfoTag()->m_iFileId;
@@ -1086,7 +1086,7 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
 
 int CVideoDatabase::GetFileId(const CFileItem &item)
 {
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if (item.IsType("videodb://") && item.HasVideoInfoTag())
   {
     if (item.GetVideoInfoTag()->m_iFileId != -1)
       return item.GetVideoInfoTag()->m_iFileId;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5371,7 +5371,7 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
       CFileItemPtr item = items.Get(path);
       if (item)
       {
-        if (!items.IsPlugin() || !item->GetVideoInfoTag()->IsPlayCountSet())
+        if (!items.IsType("plugin://") || !item->GetVideoInfoTag()->IsPlayCountSet())
           item->GetVideoInfoTag()->SetPlayCount(m_pDS->fv(1).get_asInt());
 
         if (!item->GetVideoInfoTag()->GetResumePoint().IsSet())

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -512,7 +512,7 @@ namespace VIDEO
     std::string strPath = pItem->GetPath();
     if (pItem->m_bIsFolder)
       idTvShow = m_database.GetTvShowId(strPath);
-    else if (pItem->IsPlugin() && pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iIdShow >= 0)
+    else if (pItem->IsType("plugin://") && pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iIdShow >= 0)
     {
       // for plugin source we cannot get idTvShow from episode path with URIUtils::GetDirectory() in all cases
       // so use m_iIdShow from video info tag if possible
@@ -811,7 +811,7 @@ namespace VIDEO
       {
         CVideoInfoDownloader loader(scraper);
         loader.GetArtwork(showInfo);
-        GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !item->IsPlugin());
+        GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !item->IsType("plugin://"));
         for (std::map<int, std::map<std::string, std::string> >::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
         {
           int seasonID = m_database.AddSeason(showID, i->first);
@@ -841,7 +841,7 @@ namespace VIDEO
         m_pathsToScan.erase(it);
 
       std::string hash, dbHash;
-      if (item->IsPlugin())
+      if (item->IsType("plugin://"))
       {
         // if plugin has already calculated a hash for directory contents - use it
         // in this case we don't need to get directory listing from plugin for hash checking
@@ -998,7 +998,7 @@ namespace VIDEO
       isValid = true;
 
     // episode 0 with non-zero season is valid! (e.g. prequel episode)
-    if (item->IsPlugin() && tag->m_iSeason > 0 && tag->m_iEpisode >= 0)
+    if (item->IsType("plugin://") && tag->m_iSeason > 0 && tag->m_iEpisode >= 0)
       isValid = true;
 
     if (isValid)
@@ -1009,7 +1009,7 @@ namespace VIDEO
       episode.iEpisode = tag->m_iEpisode;
       episode.isFolder = false;
       // save full item for plugin source
-      if (item->IsPlugin())
+      if (item->IsType("plugin://"))
         episode.item = std::make_shared<CFileItem>(*item);
       episodeList.push_back(episode);
       CLog::Log(LOGDEBUG, "%s - found match for: %s. Season %d, Episode %d", __FUNCTION__,
@@ -1277,7 +1277,7 @@ namespace VIDEO
       return -1;
 
     if (!libraryImport)
-      GetArtwork(pItem, content, videoFolder, useLocal && !pItem->IsPlugin(), showInfo ? showInfo->m_strPath : "");
+      GetArtwork(pItem, content, videoFolder, useLocal && !pItem->IsType("plugin://"), showInfo ? showInfo->m_strPath : "");
 
     // ensure the art map isn't completely empty by specifying an empty thumb
     std::map<std::string, std::string> art = pItem->GetArt();
@@ -1346,7 +1346,7 @@ namespace VIDEO
         std::map<int, std::map<std::string, std::string> > seasonArt;
 
         if (!libraryImport)
-          GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !pItem->IsPlugin());
+          GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason), useLocal && !pItem->IsType("plugin://"));
 
         lResult = m_database.SetDetailsForTvShow(paths, movieDetails, art, seasonArt);
         movieDetails.m_iDbId = lResult;
@@ -1814,7 +1814,7 @@ namespace VIDEO
     {
       const CFileItemPtr pItem = items[i];
       digest.Update(pItem->GetPath());
-      if (pItem->IsPlugin())
+      if (pItem->IsType("plugin://"))
       {
         // allow plugin to calculate hash itself using strings rather than binary data for size and date
         // according to ListItem.setInfo() documentation date format should be "d.m.Y"
@@ -1838,7 +1838,7 @@ namespace VIDEO
 
   bool CVideoInfoScanner::CanFastHash(const CFileItemList &items, const std::vector<std::string> &excludes) const
   {
-    if (!g_advancedSettings.m_bVideoLibraryUseFastHash || items.IsPlugin())
+    if (!g_advancedSettings.m_bVideoLibraryUseFastHash || items.IsType("plugin://"))
       return false;
 
     for (int i = 0; i < items.Size(); ++i)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -621,7 +621,7 @@ namespace VIDEO
                                           CScraperUrl* pURL,
                                           CGUIDialogProgress* pDlgProgress)
   {
-    if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsNFO() ||
+    if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsType(".nfo") ||
        (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
       return INFO_NOT_NEEDED;
 
@@ -700,7 +700,7 @@ namespace VIDEO
                                                CScraperUrl* pURL,
                                                CGUIDialogProgress* pDlgProgress)
   {
-    if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsNFO() ||
+    if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsType(".nfo") ||
        (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
       return INFO_NOT_NEEDED;
 
@@ -1829,7 +1829,7 @@ namespace VIDEO
         FILETIME time = pItem->m_dateTime;
         digest.Update(&time, sizeof(FILETIME));
       }
-      if (pItem->IsVideo() && !pItem->IsPlayList() && !pItem->IsNFO())
+      if (pItem->IsVideo() && !pItem->IsPlayList() && !pItem->IsType(".nfo"))
         count++;
     }
     hash = digest.Finalize();

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -67,7 +67,7 @@ CThumbExtractor::CThumbExtractor(const CFileItem& item,
   if (item.IsType("videodb://") && item.HasVideoInfoTag())
     m_item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
 
-  if (m_item.IsStack())
+  if (m_item.IsType("stack://"))
     m_item.SetPath(CStackDirectory::GetFirstStackedFile(m_item.GetPath()));
 }
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -90,7 +90,7 @@ bool CThumbExtractor::DoWork()
   if (m_item.IsLiveTV()
   // Due to a pvr addon api design flaw (no support for multiple concurrent streams
   // per addon instance), pvr recording thumbnail extraction does not work (reliably).
-  ||  m_item.IsPVRRecording()
+  ||  m_item.HasPVRRecordingInfoTag()
   ||  URIUtils::IsUPnP(m_item.GetPath())
   ||  URIUtils::IsBluray(m_item.GetPath())
   ||  m_item.IsBDFile()

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -64,7 +64,7 @@ CThumbExtractor::CThumbExtractor(const CFileItem& item,
   m_pos = pos;
   m_fillStreamDetails = fillStreamDetails;
 
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if (item.IsType("videodb://") && item.HasVideoInfoTag())
     m_item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
 
   if (m_item.IsStack())
@@ -214,7 +214,7 @@ void CVideoThumbLoader::OnLoaderFinish()
 static void SetupRarOptions(CFileItem& item, const std::string& path)
 {
   std::string path2(path);
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if (item.IsType("videodb://") && item.HasVideoInfoTag())
     path2 = item.GetVideoInfoTag()->m_strFileNameAndPath;
   CURL url(path2);
   std::string opts = url.GetOptions();
@@ -225,7 +225,7 @@ static void SetupRarOptions(CFileItem& item, const std::string& path)
   else
     opts = "?flags=8";
   url.SetOptions(opts);
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if (item.IsType("videodb://") && item.HasVideoInfoTag())
     item.GetVideoInfoTag()->m_strFileNameAndPath = url.Get();
   else
     item.SetPath(url.Get());
@@ -591,7 +591,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
 std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
 {
   std::string path(item.GetPath());
-  if (item.IsVideoDb() && item.HasVideoInfoTag())
+  if (item.IsType("videodb://") && item.HasVideoInfoTag())
     path = item.GetVideoInfoTag()->m_strFileNameAndPath;
   if (URIUtils::IsStack(path))
     path = CStackDirectory::GetFirstStackedFile(path);
@@ -674,7 +674,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
   if (stereoMode.empty())
   {
     std::string path = item.GetPath();
-    if (item.IsVideoDb() && item.HasVideoInfoTag())
+    if (item.IsType("videodb://") && item.HasVideoInfoTag())
       path = item.GetVideoInfoTag()->GetPath();
 
     // check for custom stereomode setting in video settings

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -136,7 +136,7 @@ bool CThumbExtractor::DoWork()
       }
     }
   }
-  else if (!m_item.IsPlugin() &&
+  else if (!m_item.IsType("plugin://") &&
            (!m_item.HasVideoInfoTag() ||
            !m_item.GetVideoInfoTag()->HasStreamDetails()))
   {

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -336,7 +336,7 @@ void CGUIDialogSubtitles::Search(const std::string &search/*=""*/)
     url.SetOption("languages", setting->ToString());
 
   // Check for stacking
-  if (g_application.CurrentFileItem().IsStack())
+  if (g_application.CurrentFileItem().IsType("stack://"))
     url.SetOption("stack", "1");
 
   std::string preferredLanguage = CServiceBroker::GetSettings().GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
@@ -478,7 +478,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
       strCurrentFilePath = URIUtils::GetDirectory(strCurrentFile);
 
     // Handle stacks
-    if (g_application.CurrentFileItem().IsStack() && items->Size() > 1)
+    if (g_application.CurrentFileItem().IsType("stack://") && items->Size() > 1)
     {
       CStackDirectory::GetPaths(g_application.CurrentFileItem().GetPath(), vecFiles);
       // Make sure (stack) size is the same as the size of the items handed to us, else fallback to single item

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -257,7 +257,7 @@ void CGUIDialogVideoInfo::OnInitWindow()
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   // Disable video user rating button for plugins as they don't have tables to save this
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsType("plugin://"));
 
   VIDEODB_CONTENT_TYPE type = static_cast<VIDEODB_CONTENT_TYPE>(m_movieItem->GetVideoContentType());
   if (type == VIDEODB_CONTENT_TVSHOWS || type == VIDEODB_CONTENT_MOVIES)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1072,7 +1072,7 @@ void CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, c
 
 int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
 {
-  if (item == nullptr || !item->IsVideoDb() || !item->HasVideoInfoTag() || item->GetVideoInfoTag()->m_iDbId < 0)
+  if (item == nullptr || !item->IsType("videodb://") || !item->HasVideoInfoTag() || item->GetVideoInfoTag()->m_iDbId < 0)
     return -1;
 
   CVideoDatabase database;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1429,7 +1429,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
       item->SetPath(strDeletePath);
 
       // HACK: stacked files need to be treated as folders in order to be deleted
-      if (item->IsStack())
+      if (item->IsType("stack://"))
         item->m_bIsFolder = true;
 
       CGUIComponent *gui = CServiceBroker::GetGUI();

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -111,7 +111,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       {
         std::unique_ptr<CVideoInfoTag> tag(new CVideoInfoTag());
         nfoResult = loader->Load(*tag, false);
-        if (nfoResult == CInfoScanner::FULL_NFO && m_item->IsPlugin() && scraper->ID() == "metadata.local")
+        if (nfoResult == CInfoScanner::FULL_NFO && m_item->IsType("plugin://") && scraper->ID() == "metadata.local")
         {
           // get video info and art from plugin source with metadata.local scraper
           if (scraper->Content() == CONTENT_TVSHOWS && !m_item->m_bIsFolder && tag->m_iIdShow < 0)

--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
@@ -37,7 +37,7 @@ IVideoInfoTagLoader* CVideoInfoTagLoaderFactory::CreateLoader(const CFileItem& i
   if (item.IsInternetStream())
     return nullptr;
 
-  if (item.IsPlugin() && info && info->ID() == "metadata.local")
+  if (item.IsType("plugin://") && info && info->ID() == "metadata.local")
   {
     // Direct loading from plugin source with metadata.local scraper
     CVideoTagLoaderPlugin* plugin = new CVideoTagLoaderPlugin(item, forceRefresh);

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -189,7 +189,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
       int numNFO = -1;
       for (int i = 0; i < items.Size(); i++)
       {
-        if (items[i]->IsNFO())
+        if (items[i]->IsType(".nfo"))
         {
           if (numNFO == -1)
             numNFO = i;

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -116,7 +116,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
     // grab the folder path
     std::string strPath = URIUtils::GetDirectory(item.GetPath());
 
-    if (movieFolder && !item.IsStack())
+    if (movieFolder && !item.IsType("stack://"))
     { // looking up by folder name - movie.nfo takes priority - but not for stacked items (handled below)
       nfoFile = URIUtils::AddFileToFolder(strPath, "movie.nfo");
       if (CFile::Exists(nfoFile))
@@ -124,7 +124,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
     }
 
     // try looking for .nfo file for a stacked item
-    if (item.IsStack())
+    if (item.IsType("stack://"))
     {
       // first try .nfo file matching first file in stack
       CStackDirectory dir;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1147,7 +1147,7 @@ void CGUIWindowVideoBase::OnDeleteItem(int iItem)
 void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
 {
   // HACK: stacked files need to be treated as folders in order to be deleted
-  if (item->IsStack())
+  if (item->IsType("stack://"))
     item->m_bIsFolder = true;
 
   const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
@@ -1290,7 +1290,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
   if (info && info->Content() == CONTENT_TVSHOWS)
     m_stackingAvailable = false;
 
-  if (m_stackingAvailable && !items.IsStack() && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_STACKVIDEOS))
+  if (m_stackingAvailable && !items.IsType("stack://") && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_STACKVIDEOS))
     items.Stack();
 
   return bResult;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -551,7 +551,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
       CFileItemPtr item(new CFileItem(*pItem->GetVideoInfoTag()));
       queuedItems.Add(item);
     }
-    else if (!pItem->IsNFO() && pItem->IsVideo())
+    else if (!pItem->IsType(".nfo") && pItem->IsVideo())
     {
       queuedItems.Add(pItem);
     }
@@ -567,7 +567,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int64_t& st
   startoffset = 0;
   partNumber = 0;
 
-  if (!item->IsNFO() && !item->IsPlayList())
+  if (!item->IsType(".nfo") && !item->IsPlayList())
   {
     if (item->GetCurrentResumeTimeAndPartNumber(startoffset, partNumber))
     {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -701,7 +701,7 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
      (item->IsPlayList() && !URIUtils::HasExtension(item->GetDynPath(), ".strm")))
     return false;
 
-  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsType("script://")))
     return CGUIDialogAddonInfo::ShowForItem(item);
 
   ADDON::ScraperPtr scraper;
@@ -829,7 +829,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
       if (!item->IsPath("add") && !item->IsType("plugin://") &&
-          !item->IsScript() && !item->IsType("addons://") && !item->IsLiveTV())
+          !item->IsType("script://") && !item->IsType("addons://") && !item->IsLiveTV())
       {
         if (URIUtils::IsStack(path))
         {
@@ -877,7 +877,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       //if the item isn't a folder or script, is a member of a list rather than a single item
       //and we're not on the last element of the list,
       //then add add either 'play from here' or 'play only this' depending on default behaviour
-      if (!(item->m_bIsFolder || item->IsScript()) && m_vecItems->Size() > 1 && itemNumber < m_vecItems->Size()-1)
+      if (!(item->m_bIsFolder || item->IsType("script://")) && m_vecItems->Size() > 1 && itemNumber < m_vecItems->Size()-1)
       {
         if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM))
           buttons.Add(CONTEXT_BUTTON_PLAY_AND_QUEUE, 13412);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -829,7 +829,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
       if (!item->IsPath("add") && !item->IsType("plugin://") &&
-          !item->IsScript() && !item->IsAddonsPath() && !item->IsLiveTV())
+          !item->IsScript() && !item->IsType("addons://") && !item->IsLiveTV())
       {
         if (URIUtils::IsStack(path))
         {
@@ -1299,7 +1299,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
 bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items)
 {
   CURL url(items.GetPath());
-  return !(items.IsType("plugin://") || items.IsAddonsPath()  ||
+  return !(items.IsType("plugin://") || items.IsType("addons://")  ||
            items.IsRSS() || items.IsInternetStream() ||
            items.IsVideoDb() || url.IsProtocol("playlistvideo"));
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -208,7 +208,7 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
 
   CFileItem item(fileItem);
   bool fromDB = false;
-  if ((item.IsVideoDb() && item.HasVideoInfoTag()) ||
+  if ((item.IsType("videodb://") && item.HasVideoInfoTag()) ||
       (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId != -1))
   {
     if (item.GetVideoInfoTag()->m_type == MediaTypeSeason)
@@ -381,7 +381,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     {
       item = pDlgInfo->GetCurrentListItem();
 
-      if (item->IsVideoDb() && item->HasVideoInfoTag())
+      if (item->IsType("videodb://") && item->HasVideoInfoTag())
         item->SetPath(item->GetVideoInfoTag()->GetPath());
     }
   }
@@ -545,7 +545,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     { // a playable python files
       queuedItems.Add(pItem);
     }
-    else if (pItem->IsVideoDb())
+    else if (pItem->IsType("videodb://"))
     { // this case is needed unless we allow IsVideo() to return true for videodb items,
       // but then we have issues with playlists of videodb items
       CFileItemPtr item(new CFileItem(*pItem->GetVideoInfoTag()));
@@ -577,7 +577,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int64_t& st
     {
       CBookmark bookmark;
       std::string strPath = item->GetPath();
-      if ((item->IsVideoDb() || item->IsDVD()) && item->HasVideoInfoTag())
+      if ((item->IsType("videodb://") || item->IsDVD()) && item->HasVideoInfoTag())
         strPath = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
       CVideoDatabase db;
@@ -641,7 +641,7 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, int action, std::string player
     {
       CContextButtons choices;
 
-      if (item->IsVideoDb())
+      if (item->IsType("videodb://"))
       {
         std::string itemPath(item->GetPath());
         itemPath = item->GetVideoInfoTag()->m_strFileNameAndPath;
@@ -708,8 +708,8 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
   if (!m_vecItems->IsType("plugin://") && !m_vecItems->IsRSS() && !m_vecItems->IsLiveTV())
   {
     std::string strDir;
-    if (item->IsVideoDb()       &&
-        item->HasVideoInfoTag() &&
+    if (item->IsType("videodb://")  &&
+        item->HasVideoInfoTag()     &&
         !item->GetVideoInfoTag()->m_strPath.empty())
     {
       strDir = item->GetVideoInfoTag()->m_strPath;
@@ -825,7 +825,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
     if (!item->IsParentFolder())
     {
       std::string path(item->GetPath());
-      if (item->IsVideoDb() && item->HasVideoInfoTag())
+      if (item->IsType("videodb://") && item->HasVideoInfoTag())
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
       if (!item->IsPath("add") && !item->IsType("plugin://") &&
@@ -858,7 +858,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
 
         // get players
         std::vector<std::string> players;
-        if (item->IsVideoDb())
+        if (item->IsType("videodb://"))
         {
           CFileItem item2(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
           playerCoreFactory.GetPlayers(item2, players);
@@ -898,7 +898,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
 
   CFileItemPtr stack = m_vecItems->Get(iItem);
   std::string path(stack->GetPath());
-  if (stack->IsVideoDb())
+  if (stack->IsType("videodb://"))
     path = stack->GetVideoInfoTag()->m_strFileNameAndPath;
 
   if (!URIUtils::IsStack(path))
@@ -996,7 +996,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
 
       std::vector<std::string> players;
-      if (item->IsVideoDb())
+      if (item->IsType("videodb://"))
       {
         CFileItem item2(*item->GetVideoInfoTag());
         playerCoreFactory.GetPlayers(item2, players);
@@ -1033,10 +1033,10 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       SScanSettings settings;
       GetScraperForItem(item.get(), info, settings);
       std::string strPath = item->GetPath();
-      if (item->IsVideoDb() && (!item->m_bIsFolder || item->GetVideoInfoTag()->m_strPath.empty()))
+      if (item->IsType("videodb://") && (!item->m_bIsFolder || item->GetVideoInfoTag()->m_strPath.empty()))
         return false;
 
-      if (item->IsVideoDb())
+      if (item->IsType("videodb://"))
         strPath = item->GetVideoInfoTag()->m_strPath;
 
       if (!info || info->Content() == CONTENT_NONE)
@@ -1096,7 +1096,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
 
   CFileItem item(*pItem);
-  if (pItem->IsVideoDb())
+  if (pItem->IsType("videodb://"))
   {
     item.SetPath(pItem->GetVideoInfoTag()->m_strFileNameAndPath);
     item.SetProperty("original_listitem_url", pItem->GetPath());
@@ -1301,7 +1301,7 @@ bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items)
   CURL url(items.GetPath());
   return !(items.IsType("plugin://") || items.IsType("addons://")  ||
            items.IsRSS() || items.IsInternetStream() ||
-           items.IsVideoDb() || url.IsProtocol("playlistvideo"));
+           items.IsType("videodb://") || url.IsProtocol("playlistvideo"));
 }
 
 void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
@@ -1346,7 +1346,7 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
 bool CGUIWindowVideoBase::CheckFilterAdvanced(CFileItemList &items) const
 {
   std::string content = items.GetContent();
-  if ((items.IsVideoDb() || CanContainFilter(m_strFilterPath)) &&
+  if ((items.IsType("videodb://") || CanContainFilter(m_strFilterPath)) &&
       (StringUtils::EqualsNoCase(content, "movies")   ||
        StringUtils::EqualsNoCase(content, "tvshows")  ||
        StringUtils::EqualsNoCase(content, "episodes") ||
@@ -1490,7 +1490,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
 
     Update(strParentPath);
 
-    if (pSelItem->IsVideoDb() && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_FLATTEN))
+    if (pSelItem->IsType("videodb://") && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_FLATTEN))
       SetHistoryForPath("");
     else
       SetHistoryForPath(strParentPath);
@@ -1516,7 +1516,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
 
     Update(strPath);
 
-    if (pSelItem->IsVideoDb() && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_FLATTEN))
+    if (pSelItem->IsType("videodb://") && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_FLATTEN))
       SetHistoryForPath("");
     else
       SetHistoryForPath(strPath);
@@ -1525,7 +1525,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
       CURL url(pItem->GetPath());
-      if (pSelItem->IsVideoDb())
+      if (pSelItem->IsType("videodb://"))
         url.SetOptions("");
       if (url.Get() == pSelItem->GetPath())
       {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -767,7 +767,7 @@ std::string CGUIWindowVideoBase::GetResumeString(const CFileItem &item)
 
 bool CGUIWindowVideoBase::ShowResumeMenu(CFileItem &item)
 {
-  if (!item.m_bIsFolder && !item.IsPVR())
+  if (!item.m_bIsFolder && !item.IsType("pvr://"))
   {
     std::string resumeString = GetResumeString(item);
     if (!resumeString.empty())

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -541,7 +541,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     { // just queue the internet stream, it will be expanded on play
       queuedItems.Add(pItem);
     }
-    else if (pItem->IsPlugin() && pItem->GetProperty("isplayable") == "true")
+    else if (pItem->IsType("plugin://") && pItem->GetProperty("isplayable") == "true")
     { // a playable python files
       queuedItems.Add(pItem);
     }
@@ -701,11 +701,11 @@ bool CGUIWindowVideoBase::OnItemInfo(int iItem)
      (item->IsPlayList() && !URIUtils::HasExtension(item->GetDynPath(), ".strm")))
     return false;
 
-  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  if (!m_vecItems->IsType("plugin://") && (item->IsType("plugin://") || item->IsScript()))
     return CGUIDialogAddonInfo::ShowForItem(item);
 
   ADDON::ScraperPtr scraper;
-  if (!m_vecItems->IsPlugin() && !m_vecItems->IsRSS() && !m_vecItems->IsLiveTV())
+  if (!m_vecItems->IsType("plugin://") && !m_vecItems->IsRSS() && !m_vecItems->IsLiveTV())
   {
     std::string strDir;
     if (item->IsVideoDb()       &&
@@ -828,7 +828,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       if (item->IsVideoDb() && item->HasVideoInfoTag())
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
-      if (!item->IsPath("add") && !item->IsPlugin() &&
+      if (!item->IsPath("add") && !item->IsType("plugin://") &&
           !item->IsScript() && !item->IsAddonsPath() && !item->IsLiveTV())
       {
         if (URIUtils::IsStack(path))
@@ -1203,7 +1203,7 @@ void CGUIWindowVideoBase::PlayItem(int iItem, const std::string &player)
 
   const CFileItemPtr pItem = m_vecItems->Get(iItem);
   // if its a folder, build a temp playlist
-  if (pItem->m_bIsFolder && !pItem->IsPlugin())
+  if (pItem->m_bIsFolder && !pItem->IsType("plugin://"))
   {
     // take a copy so we can alter the queue state
     CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));
@@ -1299,7 +1299,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
 bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items)
 {
   CURL url(items.GetPath());
-  return !(items.IsPlugin() || items.IsAddonsPath()  ||
+  return !(items.IsType("plugin://") || items.IsAddonsPath()  ||
            items.IsRSS() || items.IsInternetStream() ||
            items.IsVideoDb() || url.IsProtocol("playlistvideo"));
 }
@@ -1542,7 +1542,7 @@ int CGUIWindowVideoBase::GetScraperForItem(CFileItem *item, ADDON::ScraperPtr &i
   if (!item)
     return 0;
 
-  if (m_vecItems->IsPlugin() || m_vecItems->IsRSS())
+  if (m_vecItems->IsType("plugin://") || m_vecItems->IsRSS())
   {
     info.reset();
     return 0;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -846,7 +846,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
         }
 
         if (!m_vecItems->GetPath().empty() && !StringUtils::StartsWithNoCase(item->GetPath(), "newsmartplaylist://") && !StringUtils::StartsWithNoCase(item->GetPath(), "newtag://")
-            && !m_vecItems->IsSourcesPath())
+            && !m_vecItems->IsType("sources://"))
         {
           buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 13347);      // Add to Playlist
         }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -715,7 +715,7 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsType("addons://") && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsType("addons://") && !m_vecItems->IsType("plugin://") && !m_vecItems->IsType("script://"));
 }
 
 bool CGUIWindowVideoNav::GetFilteredItems(const std::string &filter, CFileItemList &items)

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -166,7 +166,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
             // We are here if the item is filtered out in the nav window
             std::string path = message.GetStringParam(0);
             CFileItem item(path, URIUtils::HasSlashAtEnd(path));
-            if (item.IsVideoDb())
+            if (item.IsType("videodb://"))
             {
               *(item.GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item.GetPath()));
               if (!item.GetVideoInfoTag()->IsEmpty())
@@ -256,7 +256,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
 
 SelectFirstUnwatchedItem CGUIWindowVideoNav::GetSettingSelectFirstUnwatchedItem()
 {
-  if (m_vecItems->IsVideoDb())
+  if (m_vecItems->IsType("videodb://"))
   {
     NODE_TYPE nodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_vecItems->GetPath());
 
@@ -377,7 +377,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
   if (bResult)
   {
-    if (items.IsVideoDb())
+    if (items.IsType("videodb://"))
     {
       XFILE::CVideoDatabaseDirectory dir;
       CQueryParams params;
@@ -698,7 +698,7 @@ void CGUIWindowVideoNav::UpdateButtons()
   else if (m_vecItems->IsPath("sources://video/"))
     strLabel = g_localizeStrings.Get(744);
   // everything else is from a videodb:// path
-  else if (m_vecItems->IsVideoDb())
+  else if (m_vecItems->IsType("videodb://"))
   {
     CVideoDatabaseDirectory dir;
     dir.GetLabel(m_vecItems->GetPath(), strLabel);
@@ -809,7 +809,7 @@ void CGUIWindowVideoNav::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr
   if (!scraper || scraper->Content() == CONTENT_NONE)
   {
     m_database.Open(); // since we can be called from the music library without being inited
-    if (fileItem.IsVideoDb())
+    if (fileItem.IsType("videodb://"))
       scraper = m_database.GetScraperForPath(fileItem.GetVideoInfoTag()->m_strPath);
     else
     {
@@ -827,7 +827,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
   if (m_vecItems->IsParentFolder())
     return;
 
-  if (!m_vecItems->IsVideoDb() && !pItem->IsVideoDb())
+  if (!m_vecItems->IsType("videodb://") && !pItem->IsType("videodb://"))
   {
     if (!pItem->IsPath("newsmartplaylist://video") &&
         !pItem->IsPath("special://videoplaylists/") &&
@@ -974,7 +974,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       // can we update the database?
       if (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
       {
-        if (!g_application.IsVideoScanning() && item->IsVideoDb() && item->HasVideoInfoTag() &&
+        if (!g_application.IsVideoScanning() && item->IsType("videodb://") && item->HasVideoInfoTag() &&
            (item->GetVideoInfoTag()->m_type == MediaTypeMovie ||          // movies
             item->GetVideoInfoTag()->m_type == MediaTypeTvShow ||         // tvshows
             item->GetVideoInfoTag()->m_type == MediaTypeSeason ||         // seasons
@@ -999,7 +999,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
-      if (!m_vecItems->IsVideoDb() && !m_vecItems->IsVirtualDirectoryRoot())
+      if (!m_vecItems->IsType("videodb://") && !m_vecItems->IsVirtualDirectoryRoot())
       { // non-video db items, file operations are allowed
         if ((CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION) &&
             CUtil::SupportsWriteFileOperations(item->GetPath())) ||
@@ -1010,7 +1010,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
         }
         // add "Set/Change content" to folders
-        if (item->m_bIsFolder && !item->IsVideoDb() && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() && !item->IsType("plugin://") && !item->IsType("addons://") && !URIUtils::IsUPnP(item->GetPath()))
+        if (item->m_bIsFolder && !item->IsType("videodb://") && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() && !item->IsType("plugin://") && !item->IsType("addons://") && !URIUtils::IsUPnP(item->GetPath()))
         {
           if (info && info->Content() != CONTENT_NONE)
             buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20442);
@@ -1130,7 +1130,7 @@ bool CGUIWindowVideoNav::OnAddMediaSource()
 bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
 {
   CFileItemPtr item = m_vecItems->Get(iItem);
-  if (!item->m_bIsFolder && item->IsVideoDb() && !item->Exists())
+  if (!item->m_bIsFolder && item->IsType("videodb://") && !item->Exists())
   {
     CLog::Log(LOGDEBUG, "%s called on '%s' but file doesn't exist", __FUNCTION__, item->GetPath().c_str());
 
@@ -1292,7 +1292,7 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
   ||  node == NODE_TYPE_RECENTLY_ADDED_MOVIES
   ||  node == NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS)
     filterWatched = true;
-  if (!items.IsVideoDb())
+  if (!items.IsType("videodb://"))
     filterWatched = true;
   if (items.GetContent() == "tvshows" &&
      (items.IsSmartPlayList() || items.IsLibraryFolder()))

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -541,7 +541,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
       std::string label;
       if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("video"), &label))
         items.SetLabel(label);
-      if (!items.IsSourcesPath() && !items.IsLibraryFolder())
+      if (!items.IsType("sources://") && !items.IsLibraryFolder())
         LoadVideoInfo(items);
     }
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -568,7 +568,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
 {
   //! @todo this could possibly be threaded as per the music info loading,
   //!       we could also cache the info
-  if (!items.GetContent().empty() && !items.IsPlugin())
+  if (!items.GetContent().empty() && !items.IsType("plugin://"))
     return; // don't load for listings that have content set and weren't created from plugins
 
   std::string content = items.GetContent();
@@ -576,7 +576,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &dat
   if (content.empty())
   {
     content = database.GetContentForPath(items.GetPath());
-    items.SetContent((content.empty() && !items.IsPlugin()) ? "files" : content);
+    items.SetContent((content.empty() && !items.IsType("plugin://")) ? "files" : content);
   }
 
   /*
@@ -715,7 +715,7 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsPlugin() && !m_vecItems->IsScript());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
 }
 
 bool CGUIWindowVideoNav::GetFilteredItems(const std::string &filter, CFileItemList &items)
@@ -1010,7 +1010,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
         }
         // add "Set/Change content" to folders
-        if (item->m_bIsFolder && !item->IsVideoDb() && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() && !item->IsPlugin() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
+        if (item->m_bIsFolder && !item->IsVideoDb() && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() && !item->IsType("plugin://") && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
         {
           if (info && info->Content() != CONTENT_NONE)
             buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20442);
@@ -1037,7 +1037,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   if (CGUIDialogContextMenu::OnContextButton("video", item, button))
   {
     //! @todo should we search DB for entries from plugins?
-    if (button == CONTEXT_BUTTON_REMOVE_SOURCE && !item->IsPlugin()
+    if (button == CONTEXT_BUTTON_REMOVE_SOURCE && !item->IsType("plugin://")
         && !item->IsLiveTV() &&!item->IsRSS() && !URIUtils::IsUPnP(item->GetPath()))
     {
       // if the source has been properly removed, remove the cached source list because the list has changed

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -715,7 +715,7 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsAddonsPath() && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_UPDATE_LIBRARY, !m_vecItems->IsType("addons://") && !m_vecItems->IsType("plugin://") && !m_vecItems->IsScript());
 }
 
 bool CGUIWindowVideoNav::GetFilteredItems(const std::string &filter, CFileItemList &items)
@@ -920,7 +920,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       database.Open();
       ADDON::ScraperPtr info = database.GetScraperForPath(item->GetPath());
 
-      if (!item->IsLiveTV() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
+      if (!item->IsLiveTV() && !item->IsType("addons://") && !URIUtils::IsUPnP(item->GetPath()))
       {
         if (info && info->Content() != CONTENT_NONE)
         {
@@ -1010,7 +1010,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
         }
         // add "Set/Change content" to folders
-        if (item->m_bIsFolder && !item->IsVideoDb() && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() && !item->IsType("plugin://") && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
+        if (item->m_bIsFolder && !item->IsVideoDb() && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() && !item->IsType("plugin://") && !item->IsType("addons://") && !URIUtils::IsUPnP(item->GetPath()))
         {
           if (info && info->Content() != CONTENT_NONE)
             buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20442);

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -411,7 +411,7 @@ void CGUIWindowVideoPlaylist::GetContextButtons(int itemNumber, CContextButtons 
 
       // check what players we have, if we have multiple display play with option
       std::vector<std::string> players;
-      if (item->IsVideoDb())
+      if (item->IsType("videodb://"))
       {
         CFileItem item2(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
         playerCoreFactory.GetPlayers(item2, players);
@@ -459,7 +459,7 @@ bool CGUIWindowVideoPlaylist::OnContextButton(int itemNumber, CONTEXT_BUTTON but
       const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
 
       std::vector<std::string> players;
-      if (item->IsVideoDb())
+      if (item->IsType("videodb://"))
       {
         CFileItem item2(*item->GetVideoInfoTag());
         playerCoreFactory.GetPlayers(item2, players);

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -32,7 +32,7 @@ using namespace XFILE::VIDEODATABASEDIRECTORY;
 
 bool CVideoFileItemListModifier::CanModify(const CFileItemList &items) const
 {
-  if (items.IsVideoDb())
+  if (items.IsType("videodb://"))
     return true;
 
   return false;
@@ -48,7 +48,7 @@ bool CVideoFileItemListModifier::Modify(CFileItemList &items) const
 //  depending on the child node
 void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
 {
-  if (!items.IsVideoDb())
+  if (!items.IsType("videodb://"))
     return;
 
   auto directoryNode = CDirectoryNode::ParseURL(items.GetPath());

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -76,7 +76,7 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
 
   const CURL url=items.GetURL();
 
-  if (items.IsAddonsPath())
+  if (items.IsType("addons://"))
     return new CGUIViewStateAddonBrowser(items);
 
   if (items.HasSortDetails())

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -596,7 +596,7 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
-  if (items.IsPlugin())
+  if (items.IsType("plugin://"))
   {
     CURL url(items.GetPath());
     AddonPtr addon;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -438,7 +438,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         if (IsActive())
         {
           if((message.GetStringParam() == m_vecItems->GetPath()) ||
-             (m_vecItems->IsMultiPath() && XFILE::CMultiPathDirectory::HasPath(m_vecItems->GetPath(), message.GetStringParam())))
+             (m_vecItems->IsType("multipath://") && XFILE::CMultiPathDirectory::HasPath(m_vecItems->GetPath(), message.GetStringParam())))
             Refresh();
         }
       }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -358,7 +358,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       else if (message.GetParam1() == GUI_MSG_REMOVED_MEDIA)
       {
         if ((m_vecItems->IsVirtualDirectoryRoot() ||
-             m_vecItems->IsSourcesPath()) && IsActive())
+             m_vecItems->IsType("sources://")) && IsActive())
         {
           int iItem = m_viewControl.GetSelectedItem();
           Refresh();
@@ -382,7 +382,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       else if (message.GetParam1()==GUI_MSG_UPDATE_SOURCES)
       { // State of the sources changed, so update our view
         if ((m_vecItems->IsVirtualDirectoryRoot() ||
-             m_vecItems->IsSourcesPath()) && IsActive())
+             m_vecItems->IsType("sources://")) && IsActive())
         {
           if (m_vecItemsUpdating)
           {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1102,7 +1102,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 
     return true;
   }
-  else if (pItem->IsPlugin() && !pItem->GetProperty("isplayable").asBoolean())
+  else if (pItem->IsType("plugin://") && !pItem->GetProperty("isplayable").asBoolean())
   {
     bool resume = pItem->m_lStartOffset == STARTOFFSET_RESUME;
     return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath(), resume);
@@ -1135,7 +1135,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 
     bool autoplay = m_guiState.get() && m_guiState->AutoPlayNextItem();
 
-    if (m_vecItems->IsPlugin())
+    if (m_vecItems->IsType("plugin://"))
     {
       CURL url(m_vecItems->GetPath());
       AddonPtr addon;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1031,7 +1031,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     delete pFileDirectory;
   }
 
-  if (pItem->IsScript())
+  if (pItem->IsType("script://"))
   {
     // execute the script
     CURL url(pItem->GetPath());

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1108,7 +1108,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath(), resume);
   }
 #if defined(TARGET_ANDROID)
-  else if (pItem->IsAndroidApp())
+  else if (pItem->IsType("androidapp://"))
   {
     std::string appName = URIUtils::GetFileName(pItem->GetPath());
     CLog::Log(LOGDEBUG, "CGUIMediaWindow::OnClick Trying to run: %s",appName.c_str());

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -618,7 +618,7 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
     CURL pathToUrl = URIUtils::CreateArchivePath("zip", pItem->GetURL(), "");
     Update(iList, pathToUrl.Get());
   }
-  else if (pItem->IsRAR() || pItem->IsCBR())
+  else if (pItem->IsRAR() || pItem->IsType(".cbr"))
   {
     CURL pathToUrl = URIUtils::CreateArchivePath("rar", pItem->GetURL(), "");
     Update(iList, pathToUrl.Get());

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -613,7 +613,7 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
     if (!Update(iList, strPath))
       ShowShareErrorMessage(pItem.get());
   }
-  else if (pItem->IsZIP() || pItem->IsCBZ()) // mount zip archive
+  else if (pItem->IsZIP() || pItem->IsType(".cbz")) // mount zip archive
   {
     CURL pathToUrl = URIUtils::CreateArchivePath("zip", pItem->GetURL(), "");
     Update(iList, pathToUrl.Get());

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -662,7 +662,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
     return ;
   }
 #ifdef HAS_PYTHON
-  if (pItem->IsPythonScript())
+  if (pItem->IsType(".py"))
   {
     CScriptInvocationManager::GetInstance().ExecuteAsync(pItem->GetPath());
     return ;


### PR DESCRIPTION
I was asked to assist with CFileItem restructuring on slack. Everything from performance to desktop search to inheritance issues was mentioned, but nobody could really tell me what they wanted done.
Until a clear idea is formulated for what this restructuring entails, I chose to at least reduce the amount of code that has to be restructured. By making CFileItem::IsType() being able to check for either extensions or protocols, we can get rid of a lot of trivial member functions.

I expect some breakage in platform code, I'm sure jenkins will yell.