### PR TITLE
[wayland] Actually read from event interrupt pipe to fix CPU hogging

### DIFF
--- a/xbmc/windowing/wayland/WinEventsWayland.cpp
+++ b/xbmc/windowing/wayland/WinEventsWayland.cpp
@@ -187,6 +187,13 @@ private:
           m_display.roundtrip_queue(*roundtripQueue);
           m_roundtripQueueEvent.Set();
         }
+        if (cancelPoll.revents & POLLIN)
+        {
+          // Read away the char so we don't get another notification
+          // Indepentent from m_roundtripQueue so there are no races
+          char c;
+          read(m_pipeRead, &c, 1); 
+        }
       }
 
       CLog::Log(LOGDEBUG, "Wayland message pump stopped");


### PR DESCRIPTION
@wsnipex @fritsch

## Description
The roundtrip interrupt pipe must be read to avoid poll() returning immediately all the time. 

## Motivation and Context
Fix 100% idle CPU usage on Wayland

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
