### PR TITLE
Make Player.HasVideo exclusive for video

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -88,7 +88,7 @@
 						<height>100</height>
 						<width>auto</width>
 						<visible>!String.isempty(Player.Duration)</visible>
-						<visible>Player.HasVideo + ![Player.HasGame | VideoPlayer.HasEpg]</visible>
+						<visible>Player.HasVideo + !VideoPlayer.HasEpg</visible>
 					</control>
 					<control type="label">
 						<label>$INFO[PVR.EpgEventFinishTime,$LOCALIZE[31080]: ]</label>

--- a/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
@@ -148,7 +148,7 @@
 					<label>$INFO[Player.Process(pixformat),[COLOR button_focus]$LOCALIZE[31140]:[/COLOR] ]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>Player.HasVideo | Player.HasGame</visible>
 				</control>
 				<control type="label">
 					<width>1600</width>
@@ -166,7 +166,7 @@
 					<label>$INFO[Player.Process(videowidth),[COLOR button_focus]$LOCALIZE[38031]:[/COLOR] ,x]$INFO[Player.Process(videoheight),, px]$INFO[Player.Process(videodar),$COMMA , AR]$INFO[Player.Process(videofps),$COMMA , FPS]</label>
 					<font>font14</font>
 					<shadowcolor>black</shadowcolor>
-					<visible>Player.HasVideo</visible>
+					<visible>Player.HasVideo | Player.HasGame</visible>
 				</control>
 				<control type="label">
 					<width>1600</width>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1125,7 +1125,7 @@
 					<include>ColoredBackgroundImages</include>
 				</control>
 				<control type="group" id="31111">
-					<visible>![Player.HasVideo | [Player.HasAudio + Visualisation.Enabled + !String.IsEmpty(Visualisation.Name)]] | !String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
+					<visible>![Player.HasVideo | Player.HasGame | [Player.HasAudio + Visualisation.Enabled + !String.IsEmpty(Visualisation.Name)]] | !String.IsEmpty(Window(Videos).Property(PlayingBackgroundMedia))</visible>
 					<depth>DepthBackground</depth>
 					<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 					<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1111,6 +1111,12 @@
 				<visible>Player.HasVideo</visible>
 				<visible>!Slideshow.IsActive</visible>
 			</control>
+			<control type="gamewindow">
+				<depth>DepthBackground</depth>
+				<include>FullScreenDimensions</include>
+				<visible>Player.HasGame</visible>
+				<visible>!Slideshow.IsActive</visible>
+			</control>
 			<control type="visualisation">
 				<include>FullScreenDimensions</include>
 				<visible>!Slideshow.IsActive</visible>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2666,9 +2666,12 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     {
       CSingleExit ex(g_graphicsContext);
       m_frameMoveGuard.unlock();
+
       // Calculate a window size between 2 and 10ms, 4 continuous requests let the window grow by 1ms
-      // WHen not playing video we allow it to increase to 80ms
-      unsigned int max_sleep = m_appPlayer.IsPlayingVideo() && !m_appPlayer.IsPausedPlayback() ? 10 : 80;
+      // When not playing video we allow it to increase to 80ms
+      unsigned int max_sleep = 10;
+      if (!m_appPlayer.IsPlayingVideo() || m_appPlayer.IsPausedPlayback())
+        max_sleep = 80;
       unsigned int sleepTime = std::max(static_cast<unsigned int>(2), std::min(m_ProcessedExternalCalls >> 2, max_sleep));
       Sleep(sleepTime);
       m_frameMoveGuard.lock();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4001,8 +4001,14 @@ bool CApplication::OnMessage(CGUIMessage& message)
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file, false);
 
       // Don't queue if next media type is different from current one
-      if ((!file.IsVideo() && m_appPlayer.IsPlayingVideo())
-          || ((!file.IsAudio() || file.IsVideo()) && m_appPlayer.IsPlayingAudio()))
+      bool bNothingToQueue = false;
+
+      if (!file.IsVideo() && m_appPlayer.IsPlayingVideo())
+        bNothingToQueue = true;
+      else if ((!file.IsAudio() || file.IsVideo()) && m_appPlayer.IsPlayingAudio())
+        bNothingToQueue = true;
+
+      if (bNothingToQueue)
       {
         m_appPlayer.OnNothingToQueueNotify();
         return true;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3808,10 +3808,20 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
 
   // disable screensaver lock from the login screen
   m_iScreenSaveLock = g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN ? 1 : 0;
+
   // set to Dim in the case of a dialog on screen or playing video
-  if (!forceType && (g_windowManager.HasModalDialog() ||
-                     (m_appPlayer.IsPlayingVideo() && m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE)) ||
-                     CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan()))
+  bool bUseDim = false;
+  if (!forceType)
+  {
+    if (g_windowManager.HasModalDialog())
+      bUseDim = true;
+    else if (m_appPlayer.IsPlayingVideo() && m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE))
+      bUseDim = true;
+    else if (CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan())
+      bUseDim = true;
+  }
+
+  if (bUseDim)
     m_screensaverIdInUse = "screensaver.xbmc.builtin.dim";
   else // Get Screensaver Mode
     m_screensaverIdInUse = m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2075,15 +2075,36 @@ bool CApplication::OnAction(const CAction &action)
   bool bIsPlayingPVRChannel = (CServiceBroker::GetPVRManager().IsStarted() &&
                                CurrentFileItem().IsPVRChannel());
 
-  if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
-      g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
-      (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION && bIsPlayingPVRChannel) ||
-      ((g_windowManager.GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD || (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_MUSIC_OSD && bIsPlayingPVRChannel)) &&
-        (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM || action.GetID() == ACTION_CHANNEL_UP || action.GetID() == ACTION_CHANNEL_DOWN)) ||
-      action.GetID() == ACTION_STOP)
+  bool bNotifyPlayer = false;
+  if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
+    bNotifyPlayer = true;
+  else if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME)
+    bNotifyPlayer = true;
+  else if (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION && bIsPlayingPVRChannel)
+    bNotifyPlayer = true;
+  else if (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD ||
+          (g_windowManager.GetActiveWindow() == WINDOW_DIALOG_MUSIC_OSD && bIsPlayingPVRChannel))
+  {
+    switch (action.GetID())
+    {
+      case ACTION_NEXT_ITEM:
+      case ACTION_PREV_ITEM:
+      case ACTION_CHANNEL_UP:
+      case ACTION_CHANNEL_DOWN:
+        bNotifyPlayer = true;
+        break;
+      default:
+        break;
+    }
+  }
+  else if (action.GetID() == ACTION_STOP)
+    bNotifyPlayer = true;
+
+  if (bNotifyPlayer)
   {
     if (m_appPlayer.OnAction(action))
       return true;
+
     // Player ignored action; popup the OSD
     if ((action.GetID() == ACTION_MOUSE_MOVE && (action.GetAmount(2) || action.GetAmount(3)))  // filter "false" mouse move from touch
         || action.GetID() == ACTION_MOUSE_LEFT_CLICK)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3710,20 +3710,37 @@ void CApplication::CheckOSScreenSaverInhibitionSetting()
 
 void CApplication::CheckScreenSaverAndDPMS()
 {
-  bool maybeScreensaver =
-      !m_dpmsIsActive && !m_screensaverActive
-      && !m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE).empty();
-  bool maybeDPMS =
-      !m_dpmsIsActive && m_dpms->IsSupported()
-      && m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF) > 0;
+  bool maybeScreensaver = true;
+  if (m_dpmsIsActive)
+    maybeScreensaver = false;
+  else if (m_screensaverActive)
+    maybeScreensaver = false;
+  else if (m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE).empty())
+    maybeScreensaver = false;
+
+  bool maybeDPMS = true;
+  if (m_dpmsIsActive)
+    maybeDPMS = false;
+  else if (!m_dpms->IsSupported())
+    maybeDPMS = false;
+  else if (m_ServiceManager->GetSettings().GetInt(CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF) <= 0)
+    maybeDPMS = false;
+
   // whether the current state of the application should be regarded as active even when there is no
   // explicit user activity such as input
-  bool haveIdleActivity =
-    // * Are we playing a video and it is not paused?
-    (m_appPlayer.IsPlayingVideo() && !m_appPlayer.IsPaused())
-    // * Are we playing some music in fullscreen vis?
-    || (m_appPlayer.IsPlayingAudio() && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION
-        && !m_ServiceManager->GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty());
+  bool haveIdleActivity = false;
+
+  // Are we playing a video and it is not paused?
+  if (m_appPlayer.IsPlayingVideo() && !m_appPlayer.IsPaused())
+    haveIdleActivity = true;
+
+  // Are we playing some music in fullscreen vis?
+  else if (m_appPlayer.IsPlayingAudio() &&
+           g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION &&
+           !m_ServiceManager->GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty())
+  {
+    haveIdleActivity = true;
+  }
 
   // Handle OS screen saver state
   if (haveIdleActivity && CServiceBroker::GetWinSystem().GetOSScreenSaver())

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -252,12 +252,12 @@ bool CApplicationPlayer::IsPausedPlayback()
 
 bool CApplicationPlayer::IsPlayingAudio() const
 {
-  return (IsPlaying() && !HasVideo() && HasAudio());
+  return (IsPlaying() && !HasVideo() && !HasGame() && HasAudio());
 }
 
 bool CApplicationPlayer::IsPlayingVideo() const
 {
-  return (IsPlaying() && HasVideo());
+  return (IsPlaying() && !HasGame() && HasVideo());
 }
 
 bool CApplicationPlayer::IsPlayingGame() const
@@ -778,7 +778,7 @@ void CApplicationPlayer::SetPlaySpeed(float speed)
   if (!player)
     return;
 
-  if (!IsPlayingAudio() && !IsPlayingVideo())
+  if (!IsPlaying())
     return ;
 
   SetSpeed(speed);

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -66,8 +66,18 @@ CAutorun::~CAutorun() = default;
 
 void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool ignoreplaying, bool startFromBeginning )
 {
-  if ((!ignoreplaying && (g_application.GetAppPlayer().IsPlayingAudio() || g_application.GetAppPlayer().IsPlayingVideo() || g_windowManager.HasModalDialog())) || g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN)
-    return ;
+  if (!ignoreplaying)
+  {
+    if (g_application.GetAppPlayer().IsPlayingAudio() ||
+        g_application.GetAppPlayer().IsPlayingVideo() ||
+        g_windowManager.HasModalDialog())
+    {
+      return;
+    }
+  }
+
+  if (g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN)
+    return;
 
   CCdInfo* pInfo = g_mediaManager.GetCdInfo(path);
 

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -68,8 +68,7 @@ void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool
 {
   if (!ignoreplaying)
   {
-    if (g_application.GetAppPlayer().IsPlayingAudio() ||
-        g_application.GetAppPlayer().IsPlayingVideo() ||
+    if (g_application.GetAppPlayer().IsPlaying() ||
         g_windowManager.HasModalDialog())
     {
       return;

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -359,8 +359,20 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
 
   if (m_bFullScreenRoot)
   {
-    bool allowDesktopRes = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) == ADJUST_REFRESHRATE_ALWAYS;
-    if (m_bFullScreenVideo || (!allowDesktopRes && g_application.GetAppPlayer().IsPlayingVideo()))
+    bool bTriggerUpdateRes = false;
+    if (m_bFullScreenVideo)
+      bTriggerUpdateRes = true;
+    else
+    {
+      bool allowDesktopRes = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) == ADJUST_REFRESHRATE_ALWAYS;
+      if (!allowDesktopRes)
+      {
+        if (g_application.GetAppPlayer().IsPlayingVideo())
+          bTriggerUpdateRes = true;
+      }
+    }
+
+    if (bTriggerUpdateRes)
       g_application.GetAppPlayer().TriggerUpdateResolution();
     else if (CDisplaySettings::GetInstance().GetCurrentResolution() > RES_DESKTOP)
       SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution(), false);

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -367,7 +367,7 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
       bool allowDesktopRes = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) == ADJUST_REFRESHRATE_ALWAYS;
       if (!allowDesktopRes)
       {
-        if (g_application.GetAppPlayer().IsPlayingVideo())
+        if (g_application.GetAppPlayer().IsPlayingVideo() || g_application.GetAppPlayer().IsPlayingGame())
           bTriggerUpdateRes = true;
       }
     }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -76,6 +76,14 @@ JSONRPC_STATUS CPlayerOperations::GetActivePlayers(const std::string &method, IT
     picture["type"] = "picture";
     result.append(picture);
   }
+  if (activePlayers & Game)
+  {
+    CVariant game = CVariant(CVariant::VariantTypeObject);
+    game["playerid"] = PLAYLIST_NONE;
+    game["type"] = "game";
+    result.append(game);
+  }
+
 
   return OK;
 }
@@ -1078,6 +1086,8 @@ int CPlayerOperations::GetActivePlayers()
     activePlayers |= Audio;
   if (g_windowManager.IsWindowActive(WINDOW_SLIDESHOW))
     activePlayers |= Picture;
+  if (g_application.GetAppPlayer().IsPlayingGame())
+    activePlayers |= Game;
 
   return activePlayers;
 }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.h
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.h
@@ -34,7 +34,8 @@ namespace JSONRPC
     None = 0,
     Video = 0x1,
     Audio = 0x2,
-    Picture = 0x4
+    Picture = 0x4,
+    Game = 0x8,
   };
 
   static const int PlayerImplicit = (Video | Audio | Picture);

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -314,6 +314,12 @@ namespace XBMCAddon
       return g_application.GetAppPlayer().IsPlayingVideo();
     }
 
+    bool Player::isPlayingGame()
+    {
+      XBMC_TRACE;
+      return g_application.GetAppPlayer().IsPlayingGame();
+    }
+
     bool Player::isPlayingRDS()
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -407,6 +407,20 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Player
+      /// @brief \python_func{ isPlayingGame() }
+      ///-----------------------------------------------------------------------
+      /// Check for playing game.
+      ///
+      /// @return                    True if Kodi is playing a game.
+      ///
+      isPlayingGame();
+#else
+      bool isPlayingGame();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Player
       /// @brief \python_func{ isPlayingRDS() }
       ///-----------------------------------------------------------------------
       /// Check for playing radio data system (RDS).

--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -550,10 +550,13 @@ void CDarwinUtils::SetScheduling(int message)
   policy = SCHED_OTHER;
   thread_extended_policy_data_t theFixedPolicy={true};
 
-  if (message == GUI_MSG_PLAYBACK_STARTED && g_application.GetAppPlayer().IsPlayingVideo())
+  if (message == GUI_MSG_PLAYBACK_STARTED)
   {
-    policy = SCHED_RR;
-    theFixedPolicy.timeshare = false;
+    if (g_application.GetAppPlayer().IsPlayingVideo() || g_application.GetAppPlayer().IsPlayingGame())
+    {
+      policy = SCHED_RR;
+      theFixedPolicy.timeshare = false;
+    }
   }
 
   thread_policy_set(pthread_mach_thread_np(this_pthread_self),

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -88,7 +88,8 @@ void CDetectDVDMedia::Process()
 
   while (( !m_bStop ))
   {
-    if (g_application.GetAppPlayer().IsPlayingVideo())
+    if (g_application.GetAppPlayer().IsPlayingVideo() ||
+        g_application.GetAppPlayer().IsPlayingGame())
     {
       Sleep(10000);
     }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -645,7 +645,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
     CGUIWindowSlideShow *pSlideShow = g_windowManager.GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
     if (!pSlideShow)
       return ;
-    if (g_application.GetAppPlayer().IsPlayingVideo())
+    if (g_application.GetAppPlayer().IsPlayingVideo() || g_application.GetAppPlayer().IsPlayingGame())
       g_application.StopPlaying();
 
     pSlideShow->Reset();


### PR DESCRIPTION
Currently, `Player.HasVideo` will return true if a game is being played. This causes a bug in the FullscreenGame window where the `Fullscreen` action attempts to open FullscreenVideo instead of leaving FullscreenGame for the GUI.

## Motivation and Context
Technically, games have video. I relied on this technicality in the original RetroPlayer PR to reduce the amount of code. Just imagine trying to rebase these hundreds of lines of changes spread throughout Kodi every month...

Thanks to @AchimTuran for reporting this bug during DevCon.

## How Has This Been Tested?
The bug causing the following screenshot no longer occurs on OSX.

The logic refactors will need another set of eyes. When I split FullscreenGame and FullscreenVideo, a small bug snuck in, so it's possible I missed something again.

## Screenshots (if appropriate):
<img width="1073" alt="screen shot 2017-11-02 at 11 30 51 pm" src="https://user-images.githubusercontent.com/531482/32361802-073c835a-c021-11e7-986a-6ee3a2521423.png">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
