### PR TITLE
RetroPlayer: Fix keyboard input

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -386,25 +386,19 @@
     <keyboard>
       <f>FastForward</f>
       <r>Rewind</r>
-      <period>StepForward</period>
-      <comma>StepBack</comma>
-      <backspace>Fullscreen</backspace>
+      <backspace>OSD</backspace>
       <backspace mod="longpress">Stop</backspace>
-      <browser_back>Fullscreen</browser_back>
+      <browser_back>OSD</browser_back>
       <browser_back mod="longpress">Stop</browser_back>
       <return>OSD</return>
       <enter>OSD</enter>
-      <return mod="longpress">PlayPause</return>
-      <enter mod="longpress">PlayPause</enter>
       <m>OSD</m>
       <menu>OSD</menu>
       <i>Info</i>
       <o>CodecInfo</o>
       <z>AspectRatio</z>
       <zoom>AspectRatio</zoom>
-      <left>StepBack</left>
-      <right>StepForward</right>
-      <escape>Fullscreen</escape>
+      <escape>OSD</escape>
     </keyboard>
   </FullscreenGame>
   <GameOSD>

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -93,32 +93,32 @@ public:
   ~CInputManager() override;
 
   /*! \brief decode an input event from remote controls.
-
-   \param windowId Currently active window
-   \return true if event is handled, false otherwise
-  */
+   *
+   * \param windowId Currently active window
+   * \return true if event is handled, false otherwise
+   */
   bool ProcessRemote(int windowId);
 
   /*! \brief decode a mouse event and reset idle timers.
-
-  \param windowId Currently active window
-  \return true if event is handled, false otherwise
-  */
+   *
+   * \param windowId Currently active window
+   * \return true if event is handled, false otherwise
+   */
   bool ProcessMouse(int windowId);
 
   /*! \brief decode an event from the event service, this can be mouse, key, joystick, reset idle timers.
-
-  \param windowId Currently active window
-  \param frameTime Time in seconds since last call
-  \return true if event is handled, false otherwise
-  */
+   *
+   * \param windowId Currently active window
+   * \param frameTime Time in seconds since last call
+   * \return true if event is handled, false otherwise
+   */
   bool ProcessEventServer(int windowId, float frameTime);
 
   /*! \brief decode an event from peripherals.
-
-  \param frameTime Time in seconds since last call
-  \return true if event is handled, false otherwise
-  */
+   *
+   * \param frameTime Time in seconds since last call
+   * \return true if event is handled, false otherwise
+   */
   bool ProcessPeripherals(float frameTime);
 
   /*! \brief Process all inputs
@@ -230,8 +230,9 @@ public:
    */
   void SetRemoteControlName(const std::string& name);
 
-  /*! \brief Returns whether or not we can handle a given built-in command. */
-
+  /*! \brief Returns whether or not we can handle a given built-in command.
+   *
+   */
   bool HasBuiltin(const std::string& command);
 
   /*! \brief Parse a builtin command and execute any input action
@@ -295,43 +296,43 @@ public:
 private:
 
   /*! \brief Process keyboard event and translate into an action
-  *
-  * \param CKey keypress details
-  * \return true on successfully handled event
-  * \sa CKey
-  */
+   *
+   * \param key keypress details
+   * \return true on successfully handled event
+   * \sa CKey
+   */
   bool OnKey(const CKey& key);
 
   /*! \brief Process key up event
    *
-   * \param CKey details of released key
+   * \param key details of released key
    * \sa CKey
    */
   void OnKeyUp(const CKey& key);
 
   /*! \brief Handle keypress
    *
-   * \param CKey keypress details
+   * \param key keypress details
    * \return true on successfully handled event
    */
   bool HandleKey(const CKey& key);
 
   /*! \brief Determine if an action should be processed or just
-  *   cancel the screensaver
-  *
-  * \param action Action that is about to be processed
-  * \return true on any poweractions such as shutdown/reboot/sleep/suspend, false otherwise
-  * \sa CAction
-  */
+   *   cancel the screensaver
+   *
+   * \param action Action that is about to be processed
+   * \return true on any poweractions such as shutdown/reboot/sleep/suspend, false otherwise
+   * \sa CAction
+   */
   bool AlwaysProcess(const CAction& action);
 
   /*! \brief Send the Action to CApplication for further handling,
-  *   play a sound before or after sending the action.
-  *
-  * \param action Action to send to CApplication
-  * \return result from CApplication::OnAction
-  * \sa CAction
-  */
+   *   play a sound before or after sending the action.
+   *
+   * \param action Action to send to CApplication
+   * \return result from CApplication::OnAction
+   * \sa CAction
+   */
   bool ExecuteInputAction(const CAction &action);
 
   /*! \brief Dispatch actions queued since the last call to Process()

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -309,6 +309,13 @@ private:
    */
   void OnKeyUp(const CKey& key);
 
+  /*! \brief Handle keypress
+   *
+   * \param CKey keypress details
+   * \return true on successfully handled event
+   */
+  bool HandleKey(const CKey& key);
+
   /*! \brief Determine if an action should be processed or just
   *   cancel the screensaver
   *

--- a/xbmc/peripherals/devices/PeripheralJoystickEmulation.h
+++ b/xbmc/peripherals/devices/PeripheralJoystickEmulation.h
@@ -23,6 +23,8 @@
 #include "input/keyboard/IKeyboardHandler.h"
 #include "threads/CriticalSection.h"
 
+#include <vector>
+
 namespace PERIPHERALS
 {
   class CPeripheralJoystickEmulation : public CPeripheral,
@@ -50,11 +52,12 @@ namespace PERIPHERALS
   private:
     struct KeyboardHandle
     {
+      KODI::JOYSTICK::IDriverHandler* joystickHandler;
       KODI::KEYBOARD::IKeyboardHandler* handler;
       bool bPromiscuous;
     };
 
-    typedef std::map<KODI::JOYSTICK::IDriverHandler*, KeyboardHandle> KeyboardHandlers;
+    using KeyboardHandlers = std::vector<KeyboardHandle>;
 
     KeyboardHandlers m_keyboardHandlers;
     CCriticalSection m_mutex;


### PR DESCRIPTION
This fixes some keyboard bugs during gameplay:

* Period tries to skip ahead and does nothing
* Comma glitches out and erases 10 seconds of gameplay after a small timeout
* Escape caused the bug in #12995
* Pressing enter brought up the OSD, but holding enter just paused without a menu
* Keyboard input broke entirely after #12366

## Motivation and Context
11 hours in a plane with infinite coffee and the wrong controller adapter means every damn keyboard bug is fixed.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
