### PR TITLE
[fix][websocket] Connection header must include not match Upgrade

### DIFF
--- a/xbmc/network/websocket/WebSocketV13.cpp
+++ b/xbmc/network/websocket/WebSocketV13.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include <algorithm>
 #include <string>
 #include <sstream>
 
@@ -102,7 +103,10 @@ bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &resp
 
   // There must be a "Connection" header with the value "Upgrade"
   value = header.getValue(WS_HEADER_CONNECTION_LC);
-  if (value == NULL || strnicmp(value, WS_HEADER_UPGRADE, strlen(WS_HEADER_UPGRADE)) != 0)
+  std::vector<std::string> elements;
+  if (value != nullptr)
+    elements = StringUtils::Split(value, ",");
+  if (elements.empty() || !std::any_of(elements.begin(), elements.end(), [](std::string& elem) { return StringUtils::EqualsNoCase(StringUtils::Trim(elem), WS_HEADER_UPGRADE); }))
   {
     CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_CONNECTION_LC);
     return true;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
RFC 6455 4.1. Client Requirements
The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.
<!--- Describe your change in detail -->

## Motivation and Context
newer Firefox versions send `Connection: keep-alive, Upgrade`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested with Firefox 56.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
