### PR TITLE
[GUI] Fix scrollbar initial value for FixedList and MediaWindow

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -805,7 +805,7 @@
 					<width>462</width>
 					<bottom>-10</bottom>
 					<movement>6</movement>
-					<focusposition>1</focusposition>
+					<focusposition>0</focusposition>
 					<onfocus>ClearProperty(listposition,home)</onfocus>
 					<onright>SetFocus($INFO[Container(9000).ListItem.Property(menu_id)])</onright>
 					<onup>700</onup>

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -857,7 +857,6 @@ void CGUIBaseContainer::AllocResources()
   if (m_listProvider)
   {
     UpdateListProvider(true);
-    SelectItem(m_listProvider->GetDefaultItem());
   }
 }
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1828,15 +1828,6 @@ void CGUIMediaWindow::UpdateFilterPath(const std::string &strDirectory, const CF
 
 void CGUIMediaWindow::OnFilterItems(const std::string &filter)
 {
-  CFileItemPtr currentItem;
-  std::string currentItemPath;
-  int item = m_viewControl.GetSelectedItem();
-  if (item >= 0 && item < m_vecItems->Size())
-  {
-    currentItem = m_vecItems->Get(item);
-    currentItemPath = currentItem->GetPath();
-  }
-  
   m_viewControl.Clear();
   
   CFileItemList items;
@@ -1864,6 +1855,15 @@ void CGUIMediaWindow::OnFilterItems(const std::string &filter)
   
   GetGroupedItems(*m_vecItems);
   FormatAndSort(*m_vecItems);
+
+  CFileItemPtr currentItem;
+  std::string currentItemPath;
+  int item = m_viewControl.GetSelectedItem();
+  if (item >= 0 && item < m_vecItems->Size())
+  {
+    currentItem = m_vecItems->Get(item);
+    currentItemPath = currentItem->GetPath();
+  }
 
   // get the "filter" option
   std::string filterOption;


### PR DESCRIPTION
## Description
PR fixes scrolling issues in main menu (GUIFixedListContainer) and GUIMediaWindow
Depending of the system performance multiple, partly false, scoll events are send to GUIControls.

## Motivation and Context
Bug report from @HitcherUK 

## How can it been reproduced

- Disable Esturay slide animations
- Select Movies
- Select File folder
- Select Shift View (for example, same for other views)
- Select a movie != first one
- Press [ESC] : Main menue scolls
- Enter again File Folder: Movies are scrolling

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
