### PR TITLE
windowing/wayland: add EGL_KHR_platform_wayland check

### DIFF
--- a/xbmc/windowing/wayland/GLContextEGL.cpp
+++ b/xbmc/windowing/wayland/GLContextEGL.cpp
@@ -35,7 +35,8 @@ CGLContextEGL::CGLContextEGL()
   {
     throw std::runtime_error("EGL implementation does not support EGL_EXT_platform_base, cannot continue");
   }
-  if (m_clientExtensions.find("EGL_EXT_platform_wayland") == m_clientExtensions.end())
+  if (m_clientExtensions.find("EGL_EXT_platform_wayland") == m_clientExtensions.end() &&
+      m_clientExtensions.find("EGL_KHR_platform_wayland") == m_clientExtensions.end())
   {
     throw std::runtime_error("EGL implementation does not support EGL_EXT_platform_wayland, cannot continue");
   }


### PR DESCRIPTION
## Description
This adds a check for the `EGL_KHR_platform_wayland` client extension as an alternative to the `EGL_EXT_platform_wayland` client extension.

From https://www.khronos.org/registry/EGL/extensions/KHR/EGL_KHR_platform_wayland.txt
>    Version 1, 2014/01/22 (Jon Leech)
>        - Promote EGL_EXT_platform_wayland to KHR to go with EGL 1.5.

## Motivation and Context
Fixes use of wayland windowing system using Mali EGL drivers on Rockchip platform.

Without this change Kodi would stop with `EGL implementation does not support EGL_EXT_platform_wayland, cannot continue` error message.

## How Has This Been Tested?
Running a LibreELEC wayland/weston image on a ROCK64 device.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
