### PR TITLE
[darwin] debugging doesn't work in Xcode with -Og flag

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -651,11 +651,17 @@ tmp_cflags=$(echo $c11_flags $platform_cflags | sed 's/-O@<:@123@:>@//g;s/-g //g
 tmp_cxxflags=$(echo $cxx11_flags $platform_cxxflags | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ \{2,\}//g')
 
 release_cflags="-DNDEBUG=1"
-CFLAGS="$tmp_cflags -Og -g -D_DEBUG"
-AC_COMPILE_IFELSE(
-  [AC_LANG_SOURCE([int foo;])],
-  [debug_cflags="-Og -g -D_DEBUG"],
-  [debug_cflags="-g -D_DEBUG"])
+
+# newer xcode version accept -Og flag, but debugging doesn't work with it
+if test "$platform_os" = "osx" || test "$platform_os" = "ios"; then
+  debug_cflags="-g -D_DEBUG"
+else
+  CFLAGS="$tmp_cflags -Og -g -D_DEBUG"
+  AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([int foo;])],
+    [debug_cflags="-Og -g -D_DEBUG"],
+    [debug_cflags="-g -D_DEBUG"])
+fi
 
 # add user supplied flags to the end, so they override our defaults
 platform_cflags_release="$tmp_cflags $relase_cflags $optimize_flags $passed_cflags"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
don't add `-Og` flag on darwin, source level debugging doesn't work with it in Xcode
<!--- Describe your change in detail -->

## Motivation and Context
@ksooo told me
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
