### PR TITLE
TexturePacker: exception fix

### DIFF
--- a/tools/depends/native/TexturePacker/src/SimpleFS.h
+++ b/tools/depends/native/TexturePacker/src/SimpleFS.h
@@ -20,9 +20,9 @@
  *
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 class CFile
 {

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -22,7 +22,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+#include <cinttypes>
 #define platform_stricmp _stricmp
 #else
 #define platform_stricmp stricmp

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
@@ -19,14 +19,14 @@
  */
 
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+#include <cinttypes>
 #if defined(TARGET_FREEBSD) || defined(TARGET_DARWIN)
-#include <stdlib.h>
+#include <cstdlib>
 #elif !defined(TARGET_DARWIN)
 #include <malloc.h>
 #endif
 #include <memory.h>
-#include <string.h>
+#include <cstring>
 
 #include "XBTFWriter.h"
 #include "guilib/XBTFReader.h"

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.h
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.h
@@ -23,7 +23,7 @@
 
 #include <vector>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 
 #include "guilib/XBTF.h"
 

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -18,10 +18,10 @@
  *
  */
 
-#include "GifHelper.h"
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include "GifHelper.h"
 
 #define UNSIGNED_LITTLE_ENDIAN(lo, hi)	((lo) | ((hi) << 8))
 #define GIF_MAX_MEMORY 82944000U // about 79 MB, which is equivalent to 10 full hd frames.

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -20,7 +20,7 @@
 
 #include "GifHelper.h"
 #include <algorithm>
-#include <stdlib.h>
+#include <cstdlib>
 #include <cstring>
 
 #define UNSIGNED_LITTLE_ENDIAN(lo, hi)	((lo) | ((hi) << 8))

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
@@ -72,7 +72,6 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   struct jpeg_decompress_struct cinfo;
   struct jpeg_error_mgr jerr;
   
-  char *linha;
   int ImageSize;
   
   cinfo.err = jpeg_std_error(&jerr);
@@ -89,7 +88,6 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   DecodedFrame frame;
   
   frame.rgbaImage.pixels = (char *)new char[ImageSize];
-  linha = (char *)frame.rgbaImage.pixels;
   
   unsigned char *scanlinebuff = new unsigned char[3 * cinfo.image_width];
   unsigned char *dst = (unsigned char *)frame.rgbaImage.pixels;

--- a/tools/depends/native/TexturePacker/src/md5.h
+++ b/tools/depends/native/TexturePacker/src/md5.h
@@ -23,8 +23,8 @@
 #ifndef MD5_H
 #define MD5_H
 
-#include <string.h>		/* for memcpy() */
-#include <stdint.h>
+#include <cstring>		/* for memcpy() */
+#include <cstdint>
 
 struct MD5Context 
 {


### PR DESCRIPTION
## Description

When building TexturePacker in LibreELEC on Ubuntu 17.10 we are experiencing the following build failure:

```
      BUILD    TexturePacker (host)
Executing (host): cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/etc/cmake-x86_64-linux-gnu.conf -DCMAKE_INSTALL_PREFIX=/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain -Wno-dev /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker
-- The C compiler identification is GNU 7.2.0
-- The CXX compiler identification is GNU 7.2.0
-- Check for working C compiler: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/bin/host-gcc
-- Check for working C compiler: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/bin/host-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/bin/host-g++
-- Check for working CXX compiler: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/bin/host-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Lzo2: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/lib/liblzo2.a  
-- Found ZLIB: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/lib/libz.so (found version "1.2.11") 
-- Found PNG: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/lib/libpng.a (found version "1.6.29") 
-- Found GIF: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/lib/libgif.a  
-- Found JPEG: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/lib/libjpeg.a  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/TexturePacker-0/.x86_64-linux-gnu
Executing (host): ninja 
[1/10] Building CXX object CMakeFiles/TexturePacker.dir/src/md5.o
[2/10] Building CXX object CMakeFiles/TexturePacker.dir/src/DecoderManager.o
[3/10] Building CXX object CMakeFiles/TexturePacker.dir/src/decoder/JPGDecoder.o
/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp: In member function 'virtual bool JPGDecoder::LoadFile(const string&, DecodedFrames&)':
/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp:75:9: warning: variable 'linha' set but not used [-Wunused-but-set-variable]
   char *linha;
         ^~~~~
[4/10] Building CXX object CMakeFiles/TexturePacker.dir/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/xbmc/guilib/XBTF.o
[5/10] Building CXX object CMakeFiles/TexturePacker.dir/src/decoder/GIFDecoder.o
[6/10] Building CXX object CMakeFiles/TexturePacker.dir/src/XBTFWriter.o
[7/10] Building CXX object CMakeFiles/TexturePacker.dir/src/decoder/PNGDecoder.o
[8/10] Building CXX object CMakeFiles/TexturePacker.dir/src/TexturePacker.o
[9/10] Building CXX object CMakeFiles/TexturePacker.dir/src/decoder/GifHelper.o
FAILED: CMakeFiles/TexturePacker.dir/src/decoder/GifHelper.o 
/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/bin/host-g++    -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/include -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/../../../../xbmc -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/../../../../lib -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder -O2 -Wall -pipe -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/include -Wno-format-security -std=c++11 -DTARGET_POSIX -DTARGET_LINUX -D_LINUX -I/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/xbmc/linux -MD -MT CMakeFiles/TexturePacker.dir/src/decoder/GifHelper.o -MF CMakeFiles/TexturePacker.dir/src/decoder/GifHelper.o.d -o CMakeFiles/TexturePacker.dir/src/decoder/GifHelper.o -c /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
In file included from /usr/include/c++/7/cstdlib:75:0,
                 from /usr/include/c++/7/ext/string_conversions.h:41,
                 from /usr/include/c++/7/bits/basic_string.h:6349,
                 from /usr/include/c++/7/string:52,
                 from /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h:45,
                 from /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp:21:
/usr/include/stdlib.h:443:14: error: declaration of 'void* reallocarray(void*, size_t, size_t) throw ()' has a different exception specifier
 extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
              ^~~~~~~~~~~~
In file included from /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h:23:0,
                 from /home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/kodi-9e64d1b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp:21:
/home/neil/projects/LibreELEC.tv/build.LibreELEC-Generic.x86_64-9.0-devel/toolchain/include/gif_lib.h:248:1: note: from previous declaration 'void* reallocarray(void*, size_t, size_t)'
 reallocarray(void *optr, size_t nmemb, size_t size);
 ^~~~~~~~~~~~
ninja: build stopped: subcommand failed.
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 1
```

The first commit moves the `GifHelper` header after the system headers, which resolves the build failure.

It was also suggested on Slack to change to use C++ headers, hence the second commit. This second commit is not required to fix the build failure.

## Motivation and Context

This is an issue cross-compiling on certain systems with recent glibc 2.26 which now includes `reallocarray` (https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html).

## How Has This Been Tested?

TexturePacker now builds successfully for LibreELEC, and continues to build Kodi for Ubuntu (both 17.10). 

TexturePacker continues to building on older systems (eg. Ubuntu 16.04)

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
