### PR TITLE
Fix for PR#13004 in kodi.sh.in

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -68,6 +68,9 @@ if [ "$WINDOWING" = "auto" ]; then
     # GBM/DRM
     elif [ -z $DISPLAY ] && [ -z $WAYLAND_DISPLAY ] && [ -x $LIBDIR/${bin_name}/${bin_name}-gbm ]; then
         KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-gbm
+    # Default kodi.bin
+    else
+        KODI_BINARY=${APP_BINARY}
     fi
 elif [ -n $WINDOWING ]; then
     KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-${WINDOWING}


### PR DESCRIPTION
## Description
After doing a little debugging, I found that KODI_BINARY=${APP_BINARY} was not caught at the current position.
Copied it up to WINDOWING=auto after GBM.

## Motivation and Context
Was unable to launch kodi with ENABLE_APP_AUTONAME=OFF set.
With this change, the Error message is displayed if kodi.bin or any other kodi* doesn't exist.

## How Has This Been Tested?
Tested on Mageia 6 x86_64 after kodi.bin was renamed to kodi.bin.1.
Reached the Error message.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
