### PR TITLE
Fix missing add-on description for repo add-ons

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -647,7 +647,7 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
     builder.SetVersion(AddonVersion(m_pDS2->fv(3).get_asString()));
     builder.SetName(m_pDS2->fv(4).get_asString());
     builder.SetSummary(m_pDS2->fv(5).get_asString());
-    builder.SetDescription(m_pDS2->fv(6).get_asString());
+    builder.SetDescription(m_pDS2->fv("description").get_asString());
     DeserializeMetadata(m_pDS2->fv(1).get_asString(), builder);
     addon = builder.Build();
     return addon != nullptr;
@@ -732,7 +732,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
       builder.SetVersion(version);
       builder.SetName(m_pDS->fv(4).get_asString());
       builder.SetSummary(m_pDS->fv(5).get_asString());
-      builder.SetDescription(m_pDS->fv(6).get_asString());
+      builder.SetDescription(m_pDS->fv("description").get_asString());
       DeserializeMetadata(m_pDS->fv(1).get_asString(), builder);
 
       auto addon = builder.Build();

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -392,11 +392,11 @@ void CAddonDatabase::GetInstalled(std::vector<CAddonBuilder>& addons)
     while (!m_pDS->eof())
     {
       auto it = addons.emplace(addons.end());
-      it->SetId(m_pDS->fv(1).get_asString());
-      it->SetInstallDate(CDateTime::FromDBDateTime(m_pDS->fv(3).get_asString()));
-      it->SetLastUpdated(CDateTime::FromDBDateTime(m_pDS->fv(4).get_asString()));
-      it->SetLastUsed(CDateTime::FromDBDateTime(m_pDS->fv(5).get_asString()));
-      it->SetOrigin(m_pDS->fv(6).get_asString());
+      it->SetId(m_pDS->fv("addonID").get_asString());
+      it->SetInstallDate(CDateTime::FromDBDateTime(m_pDS->fv("installDate").get_asString()));
+      it->SetLastUpdated(CDateTime::FromDBDateTime(m_pDS->fv("lastUpdated").get_asString()));
+      it->SetLastUsed(CDateTime::FromDBDateTime(m_pDS->fv("lastUsed").get_asString()));
+      it->SetOrigin(m_pDS->fv("origin").get_asString());
       m_pDS->next();
     }
     m_pDS->close();
@@ -643,12 +643,12 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
       return false;
 
     CAddonBuilder builder;
-    builder.SetId(m_pDS2->fv(2).get_asString());
-    builder.SetVersion(AddonVersion(m_pDS2->fv(3).get_asString()));
-    builder.SetName(m_pDS2->fv(4).get_asString());
-    builder.SetSummary(m_pDS2->fv(5).get_asString());
+    builder.SetId(m_pDS2->fv("addonID").get_asString());
+    builder.SetVersion(AddonVersion(m_pDS2->fv("version").get_asString()));
+    builder.SetName(m_pDS2->fv("name").get_asString());
+    builder.SetSummary(m_pDS2->fv("summary").get_asString());
     builder.SetDescription(m_pDS2->fv("description").get_asString());
-    DeserializeMetadata(m_pDS2->fv(1).get_asString(), builder);
+    DeserializeMetadata(m_pDS2->fv("metadata").get_asString(), builder);
     addon = builder.Build();
     return addon != nullptr;
   }
@@ -717,8 +717,8 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
     VECADDONS result;
     while (!m_pDS->eof())
     {
-      std::string addonId = m_pDS->fv(2).get_asString();
-      AddonVersion version(m_pDS->fv(3).get_asString());
+      std::string addonId = m_pDS->fv("addonID").get_asString();
+      AddonVersion version(m_pDS->fv("version").get_asString());
 
       if (!result.empty() && result.back()->ID() == addonId && result.back()->Version() >= version)
       {
@@ -730,10 +730,10 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
       CAddonBuilder builder;
       builder.SetId(addonId);
       builder.SetVersion(version);
-      builder.SetName(m_pDS->fv(4).get_asString());
-      builder.SetSummary(m_pDS->fv(5).get_asString());
+      builder.SetName(m_pDS->fv("name").get_asString());
+      builder.SetSummary(m_pDS->fv("summary").get_asString());
       builder.SetDescription(m_pDS->fv("description").get_asString());
-      DeserializeMetadata(m_pDS->fv(1).get_asString(), builder);
+      DeserializeMetadata(m_pDS->fv("metadata").get_asString(), builder);
 
       auto addon = builder.Build();
       if (addon)


### PR DESCRIPTION
This must have broke when we added the News field to the add-on database.

## Motivation and Context
Gotta have those sexy descriptions for the game controller museum.

## How Has This Been Tested?
See screenshots.

## Screenshots (if appropriate):
Before:
![screenshot000](https://user-images.githubusercontent.com/531482/32495160-54ccd22c-c379-11e7-8f1c-59b49304cdf0.png)


After:
![screenshot001](https://user-images.githubusercontent.com/531482/32495166-59d2cc18-c379-11e7-944a-7ddcc30ed50d.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
