### PR TITLE
Controller dialog: Fix race condition when stopping/starting button mapping

### DIFF
--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -96,19 +96,17 @@ void CGUIConfigurationWizard::OnUnfocus(IFeatureButton* button)
 
 bool CGUIConfigurationWizard::Abort(bool bWait /* = true */)
 {
-  if (!m_bStop)
-  {
-    StopThread(false);
+  bool bWasRunning = !m_bStop;
 
-    m_inputEvent.Set();
-    m_motionlessEvent.Set();
+  StopThread(false);
 
-    if (bWait)
-      StopThread(true);
+  m_inputEvent.Set();
+  m_motionlessEvent.Set();
 
-    return true;
-  }
-  return false;
+  if (bWait)
+    StopThread(true);
+
+  return bWasRunning;
 }
 
 void CGUIConfigurationWizard::Process(void)


### PR DESCRIPTION
This fixes a segfault due to a race condition in the controller dialog. I discovered this on a touch screen device, when touching a button to start mapping it while another button is being mapped. The first prompt is aborted asynchronously, but the next prompt fails to synchronously wait for it to finish. As a result, the second prompt tries to spin up a thread that is already created, causing things to go boom.

This doesn't show up with the mouse, because you'd have to be a serious ninja to cancel the prompt and start the next one in the same frame.

## Motivation and Context
Discovered this while testing on the Galaxy S8 that samsung sponsored for me, so thanks Samsung.

## How Has This Been Tested?
Touched the shit out of buttons, no more crashes.

The prompt can be aborted with the escape key, and the return value is to prevent escape from also closing the dialog. Still need to test that this hasn't been broken.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Eligible for Krypton backport, if we're still doing that.