### PR TITLE
Game client dialog: Append "Saved" if emulator has a savestate

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17513,7 +17513,13 @@ msgctxt "#35258"
 msgid "Select emulator for {0:s} file"
 msgstr ""
 
-#empty strings from id 35259 to 35504
+#. Label on emulators with a savestate in the emulator selection dialog
+#: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+msgctxt "#35259"
+msgid "Saved"
+msgstr ""
+
+#empty strings from id 35260 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -70,6 +70,8 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(candidate, candidate->ID()));
       item->SetLabel2(g_localizeStrings.Get(35257)); // "Installed"
+      if (item->GetPath() == selected)
+        item->SetLabel2(item->GetLabel2() + ", " + g_localizeStrings.Get(35259)); // "Saved"
       items.Add(std::move(item));
     }
     for (const auto &addon : installable)

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -50,14 +50,18 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &
   std::string extension = URIUtils::GetExtension(gamePath);
   std::string xmlPath = CSavestateUtils::MakeMetadataPath(gamePath);
 
-  std::string selected;
+  // Load savestate
   CSavestate save;
   CSavestateDatabase db;
   CLog::Log(LOGDEBUG, "Select game client dialog: Loading savestate metadata %s", CURL::GetRedacted(xmlPath).c_str());
-  if (db.GetSavestate(xmlPath, save))
+  const bool bLoaded = db.GetSavestate(xmlPath, save);
+
+  // Get savestate game client
+  std::string saveGameClient;
+  if (bLoaded)
   {
-    selected = save.GameClient();
-    CLog::Log(LOGDEBUG, "Select game client dialog: Auto-selecting %s", selected.c_str());
+    saveGameClient = save.GameClient();
+    CLog::Log(LOGDEBUG, "Select game client dialog: Auto-selecting %s", saveGameClient.c_str());
   }
 
   // "Select emulator for {0:s}"
@@ -70,7 +74,7 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(candidate, candidate->ID()));
       item->SetLabel2(g_localizeStrings.Get(35257)); // "Installed"
-      if (item->GetPath() == selected)
+      if (item->GetPath() == saveGameClient)
         item->SetLabel2(item->GetLabel2() + ", " + g_localizeStrings.Get(35259)); // "Saved"
       items.Add(std::move(item));
     }
@@ -85,7 +89,7 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string &
 
     for (int i = 0; i < items.Size(); i++)
     {
-      if (items[i]->GetPath() == selected)
+      if (items[i]->GetPath() == saveGameClient)
         dialog->SetSelected(i);
     }
 


### PR DESCRIPTION
This adds a "Saved" label next to the game client that has a savestate.

## Description
Until we get the Saved Game Manager, only one save per game is possible. Saves are not cross-emulator compatible, so starting another emulator will erase the save. Before this happens Kodi will inform you what emulator you should use, but it would be much better to indicate this in the dialog before the trial-and-error attempts occur.

## Motivation and Context
A single savestate per game isn't ideal, but until we have a Saved Game Manager it's what we're stuck with. The change here should make this limitation slightly less painful.

## Screenshots (if appropriate):
<img width="1073" alt="screen shot 2017-11-02 at 6 45 11 pm" src="https://user-images.githubusercontent.com/531482/32671735-636fcf06-c5fd-11e7-8565-0fe52fb3744d.png">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
