### PR TITLE
[Music]Fix album genre inconsistencies

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -340,7 +340,7 @@ public:
   /////////////////////////////////////////////////
   // Genres
   /////////////////////////////////////////////////
-  int AddGenre(const std::string& strGenre);
+  int AddGenre(std::string& strGenre);
   std::string GetGenreById(int id);
   int GetGenreByName(const std::string& strGenre);
 
@@ -363,12 +363,10 @@ public:
   bool GetArtistsBySong(int idSong, std::vector<int>& artists);
   bool DeleteSongArtistsBySong(int idSong);
 
-  bool AddSongGenre(int idGenre, int idSong, int iOrder);
+  bool AddSongGenres(int idSong, const std::vector<std::string>& genres);
   bool GetGenresBySong(int idSong, std::vector<int>& genres);
 
-  bool AddAlbumGenre(int idGenre, int idAlbum, int iOrder);
   bool GetGenresByAlbum(int idAlbum, std::vector<int>& genres);
-  bool DeleteAlbumGenresByAlbum(int idAlbum);
 
   bool GetGenresByArtist(int idArtist, CFileItem* item);
   bool GetIsAlbumArtist(int idArtist, CFileItem* item);

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -446,17 +446,20 @@ void CMusicInfoTag::SetAlbumArtistSort(const std::string& strAlbumArtistSort)
   m_strAlbumArtistSort = strAlbumArtistSort;
 }
 
-void CMusicInfoTag::SetGenre(const std::string& strGenre)
+void CMusicInfoTag::SetGenre(const std::string& strGenre, bool bTrim /* = false*/)
 {
   if (!strGenre.empty())
-    SetGenre(StringUtils::Split(strGenre, g_advancedSettings.m_musicItemSeparator));
+    SetGenre(StringUtils::Split(strGenre, g_advancedSettings.m_musicItemSeparator), bTrim);
   else
     m_genre.clear();
 }
 
-void CMusicInfoTag::SetGenre(const std::vector<std::string>& genres)
+void CMusicInfoTag::SetGenre(const std::vector<std::string>& genres, bool bTrim /* = false*/)
 {
   m_genre = genres;
+  if (bTrim)
+    for (auto genre : m_genre)
+      StringUtils::Trim(genre);
 }
 
 void CMusicInfoTag::SetYear(int year)

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -108,8 +108,8 @@ public:
   void SetAlbumArtist(const std::vector<std::string>& albumArtists, bool FillDesc = false);
   void SetAlbumArtistDesc(const std::string& strAlbumArtistDesc);
   void SetAlbumArtistSort(const std::string& strAlbumArtistSort);
-  void SetGenre(const std::string& strGenre);
-  void SetGenre(const std::vector<std::string>& genres);
+  void SetGenre(const std::string& strGenre, bool bTrim = false);
+  void SetGenre(const std::vector<std::string>& genres, bool bTrim = false);
   void SetYear(int year);
   void SetDatabaseId(long id, const std::string &type);
   void SetReleaseDate(SYSTEMTIME& dateTime);

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -271,7 +271,7 @@ bool CTagLoaderTagLib::ParseTag(ID3v1::Tag *id3v1, EmbeddedArt *art, CMusicInfoT
   tag.SetArtist(id3v1->artist().to8Bit(true));
   tag.SetAlbum(id3v1->album().to8Bit(true));
   tag.SetComment(id3v1->comment().to8Bit(true));
-  tag.SetGenre(id3v1->genre().to8Bit(true));
+  tag.SetGenre(id3v1->genre().to8Bit(true), true);
   tag.SetYear(id3v1->year());
   tag.SetTrackNumber(id3v1->track());
   return true;
@@ -1025,9 +1025,9 @@ void CTagLoaderTagLib::SetGenre(CMusicInfoTag &tag, const std::vector<std::strin
     genres.push_back(genre);
   }
   if (genres.size() == 1)
-    tag.SetGenre(genres[0]);
+    tag.SetGenre(genres[0], true);
   else
-    tag.SetGenre(genres);
+    tag.SetGenre(genres, true);
 }
 
 void CTagLoaderTagLib::SetReleaseType(CMusicInfoTag &tag, const std::vector<std::string> &values)

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -826,7 +826,7 @@ std::string CSmartPlaylistRule::FormatWhereClause(const std::string &negate, con
     {
       query = negate + " (EXISTS (SELECT DISTINCT song_artist.idArtist FROM song_artist, song_genre, genre WHERE song_artist.idArtist = " + GetField(FieldId, strType) + " AND song_artist.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
       query += " OR ";
-      query += "EXISTS (SELECT DISTINCT album_artist.idArtist FROM album_artist, album_genre, genre WHERE album_artist.idArtist = " + GetField(FieldId, strType) + " AND album_artist.idAlbum = album_genre.idAlbum AND album_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + "))";
+      query += "EXISTS (SELECT DISTINCT album_artist.idArtist FROM album_artist, song, song_genre, genre WHERE album_artist.idArtist = " + GetField(FieldId, strType) + " AND song.idAlbum = album_artist.idAlbum AND song.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + "))";
     }
     else if (m_field == FieldRole)
     {


### PR DESCRIPTION
Fixing the inconsistent way album genre data is handled.

In Musicdb (since Eden) the album table has field `strGenres`, and there is a link table `album_genre` resolving a many to many relationship between album and genre. One could think that `strGenres` is a denormalised copy of what is in `album_genre`, but that is not always true:
1. Both are initially populated using genre values of the songs of the album. However while `strGenres` is set to a concatenation of the genre values of either the first song (if music files have Musicbrainz id tags) or last song (no mbids), `album_genre` is filled with a union of genre values from _all_ the songs.
2. Scraping can then update the `strGenres` string, but `album_genre` and `genre` tables are not updated.
3. The `strGenres` string could also be updated using JSON API (although I don't know of any app that does), but again `album_genre` and `genre` tables are not updated.

So what is in `strGenres` and `album_genre` can diverge wildly. This has gone largely unnoticed by users because:
a) All filtering by genre, and values listed on the Genres node, is based on song genre (queried from the `song_genre` link table). The value in `strGenres` is simply used as a display string.
b) Most songs on an album will all have the same genre(s),
c) Overwriting with scraped genre(s) from NFO files or online sources is reasonably rare.

Point a) is significant. Since both all filtering by genre and the Genres node, are based on querying the `song_genre`  table, the data in the `album_genre` table is actually **unused by Kodi**. There is no  reason to codify album genre values hence the `album_genre` table can be removed from the schema. 

This makes album genre similar to artist genre (or album mood, style and theme)  - a discriptive string that happens to have the name "genre" but can be completely different from the song genre values of related songs. [Note I had originally thought that both artist genre and album genres should be codified, but there simply is no need to associate ids with these strings, much like mood, style and theme, since we are not using them to navigate the library]

Continuing to initially fill the album genre from song genre values, in the same way we fill year and label from song,  makes sense to me rather than leave it blank until scraping. As a user I want to see (song) genres when listing an album, after all that could have been the filter criteria, but it is a perhaps "dirty" way to achieve that. As a user I also want my albums to have genres from the way I tagged my music files, not have to either manaually edit NFO files to match, or put-up with the genre mess that comes from online sources. Allocation of genre to music is a very personal and subjective thing.  But I would rather fix the data inconsistency first, then have a separate discussion about how and when these genre fields get populated. 

This PR also fixes the genre aspects of the long outstanding bug in SetSongDetails()  https://trac.kodi.tv/ticket/15247 reported in 2014. However this method still has other faults - updating artists is not done correctly, and it has album fields that are beyond the scope of updating a song and should be removed.

**JSON API** also needs updating because is exposes  `strGenres` and the union of song genre ids as if they are matching pairs when they are not. This is covered in a separate PR.