### PR TITLE
 VideoPlayer: add DRM PRIME video codec and renderer

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/CMakeLists.txt
@@ -51,4 +51,9 @@ if(CORE_SYSTEM_NAME STREQUAL android)
   list(APPEND HEADERS DVDVideoCodecAndroidMediaCodec.h)
 endif()
 
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
+  list(APPEND SOURCES DVDVideoCodecDRMPRIME.cpp)
+  list(APPEND HEADERS DVDVideoCodecDRMPRIME.h)
+endif()
+
 core_add_library(dvdvideocodecs)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -1,0 +1,324 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DVDVideoCodecDRMPRIME.h"
+
+#include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
+#include "threads/SingleLock.h"
+#include "utils/log.h"
+
+extern "C" {
+#include "libavcodec/avcodec.h"
+#include "libavutil/pixdesc.h"
+}
+
+//------------------------------------------------------------------------------
+// Video Buffers
+//------------------------------------------------------------------------------
+
+CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id)
+  : CVideoBuffer(id)
+{
+  m_pFrame = av_frame_alloc();
+}
+
+CVideoBufferDRMPRIME::~CVideoBufferDRMPRIME()
+{
+  Unref();
+  av_frame_free(&m_pFrame);
+}
+
+void CVideoBufferDRMPRIME::SetRef(AVFrame* frame)
+{
+  av_frame_move_ref(m_pFrame, frame);
+}
+
+void CVideoBufferDRMPRIME::Unref()
+{
+  av_frame_unref(m_pFrame);
+}
+
+//------------------------------------------------------------------------------
+
+class CVideoBufferPoolDRMPRIME
+  : public IVideoBufferPool
+{
+public:
+  ~CVideoBufferPoolDRMPRIME() override;
+  void Return(int id) override;
+  CVideoBuffer* Get() override;
+
+protected:
+  CCriticalSection m_critSection;
+  std::vector<CVideoBufferDRMPRIME*> m_all;
+  std::deque<int> m_used;
+  std::deque<int> m_free;
+};
+
+CVideoBufferPoolDRMPRIME::~CVideoBufferPoolDRMPRIME()
+{
+  for (auto buf : m_all)
+    delete buf;
+}
+
+CVideoBuffer* CVideoBufferPoolDRMPRIME::Get()
+{
+  CSingleLock lock(m_critSection);
+
+  CVideoBufferDRMPRIME* buf = nullptr;
+  if (!m_free.empty())
+  {
+    int idx = m_free.front();
+    m_free.pop_front();
+    m_used.push_back(idx);
+    buf = m_all[idx];
+  }
+  else
+  {
+    int id = m_all.size();
+    buf = new CVideoBufferDRMPRIME(*this, id);
+    m_all.push_back(buf);
+    m_used.push_back(id);
+  }
+
+  buf->Acquire(GetPtr());
+  return buf;
+}
+
+void CVideoBufferPoolDRMPRIME::Return(int id)
+{
+  CSingleLock lock(m_critSection);
+
+  m_all[id]->Unref();
+  auto it = m_used.begin();
+  while (it != m_used.end())
+  {
+    if (*it == id)
+    {
+      m_used.erase(it);
+      break;
+    }
+    else
+      ++it;
+  }
+  m_free.push_back(id);
+}
+
+//------------------------------------------------------------------------------
+// main class
+//------------------------------------------------------------------------------
+
+CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
+  : CDVDVideoCodec(processInfo)
+{
+  m_pFrame = av_frame_alloc();
+  m_videoBufferPool = std::make_shared<CVideoBufferPoolDRMPRIME>();
+}
+
+CDVDVideoCodecDRMPRIME::~CDVDVideoCodecDRMPRIME()
+{
+  av_frame_free(&m_pFrame);
+  avcodec_free_context(&m_pCodecContext);
+}
+
+CDVDVideoCodec* CDVDVideoCodecDRMPRIME::Create(CProcessInfo& processInfo)
+{
+  return new CDVDVideoCodecDRMPRIME(processInfo);
+}
+
+void CDVDVideoCodecDRMPRIME::Register()
+{
+  CDVDFactoryCodec::RegisterHWVideoCodec("drm_prime", CDVDVideoCodecDRMPRIME::Create);
+}
+
+AVCodec* CDVDVideoCodecDRMPRIME::FindDecoder(CDVDStreamInfo& hints)
+{
+  AVCodec* codec = nullptr;
+  while ((codec = av_codec_next(codec)))
+  {
+    if (av_codec_is_decoder(codec) && codec->id == hints.codec && codec->pix_fmts)
+    {
+      const AVPixelFormat* fmt = codec->pix_fmts;
+      while (*fmt != AV_PIX_FMT_NONE)
+      {
+        if (*fmt == AV_PIX_FMT_DRM_PRIME)
+          return codec;
+        fmt++;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
+{
+  AVCodec* pCodec = FindDecoder(hints);
+  if (!pCodec)
+  {
+    CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::%s - unable to find decoder for codec %d", __FUNCTION__, hints.codec);
+    return false;
+  }
+
+  CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - using decoder %s", __FUNCTION__, pCodec->long_name ? pCodec->long_name : pCodec->name);
+
+  m_pCodecContext = avcodec_alloc_context3(pCodec);
+  if (!m_pCodecContext)
+    return false;
+
+  m_pCodecContext->codec_tag = hints.codec_tag;
+  m_pCodecContext->coded_width = hints.width;
+  m_pCodecContext->coded_height = hints.height;
+  m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
+
+  if (hints.extradata && hints.extrasize > 0)
+  {
+    m_pCodecContext->extradata_size = hints.extrasize;
+    m_pCodecContext->extradata = (uint8_t*)av_mallocz(hints.extrasize + AV_INPUT_BUFFER_PADDING_SIZE);
+    memcpy(m_pCodecContext->extradata, hints.extradata, hints.extrasize);
+  }
+
+  if (avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0)
+  {
+    CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unable to open codec", __FUNCTION__);
+    avcodec_free_context(&m_pCodecContext);
+    return false;
+  }
+
+  const char* pixFmtName = av_get_pix_fmt_name(m_pCodecContext->pix_fmt);
+  m_processInfo.SetVideoPixelFormat(pixFmtName ? pixFmtName : "");
+  m_processInfo.SetVideoDimensions(hints.width, hints.height);
+  m_processInfo.SetVideoDeintMethod("none");
+  m_processInfo.SetVideoDAR(hints.aspect);
+
+  if (pCodec->name)
+    m_name = std::string("ff-") + pCodec->name;
+  else
+    m_name = "ffmpeg";
+
+  m_processInfo.SetVideoDecoderName(m_name, true);
+
+  return true;
+}
+
+bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
+{
+  if (!m_pCodecContext)
+    return true;
+
+  AVPacket avpkt;
+  av_init_packet(&avpkt);
+  avpkt.data = packet.pData;
+  avpkt.size = packet.iSize;
+  avpkt.dts = (packet.dts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
+  avpkt.pts = (packet.pts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
+  // TODO: avpkt.side_data = static_cast<AVPacketSideData*>(packet.pSideData);
+  // TODO: avpkt.side_data_elems = packet.iSideDataElems;
+
+  int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
+  if (ret == AVERROR(EAGAIN))
+    return false;
+  else if (ret)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::%s - send packet failed, ret:%d", __FUNCTION__, ret);
+    return false;
+  }
+
+  return true;
+}
+
+void CDVDVideoCodecDRMPRIME::Reset()
+{
+  if (!m_pCodecContext)
+    return;
+
+  avcodec_flush_buffers(m_pCodecContext);
+  av_frame_unref(m_pFrame);
+  m_codecControlFlags = 0;
+}
+
+void CDVDVideoCodecDRMPRIME::Drain()
+{
+  AVPacket avpkt;
+  av_init_packet(&avpkt);
+  avpkt.data = nullptr;
+  avpkt.size = 0;
+  avcodec_send_packet(m_pCodecContext, &avpkt);
+}
+
+void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
+{
+  pVideoPicture->iWidth = m_pFrame->width;
+  pVideoPicture->iHeight = m_pFrame->height;
+
+  double aspect_ratio = (float)pVideoPicture->iWidth / (float)pVideoPicture->iHeight;
+  pVideoPicture->iDisplayWidth = ((int)lrint(pVideoPicture->iHeight * aspect_ratio)) & -3;
+  pVideoPicture->iDisplayHeight = pVideoPicture->iHeight;
+  if (pVideoPicture->iDisplayWidth > pVideoPicture->iWidth)
+  {
+    pVideoPicture->iDisplayWidth = pVideoPicture->iWidth;
+    pVideoPicture->iDisplayHeight = ((int)lrint(pVideoPicture->iWidth / aspect_ratio)) & -3;
+  }
+
+  pVideoPicture->color_range = m_pFrame->color_range;
+  pVideoPicture->color_primaries = m_pFrame->color_primaries;
+  pVideoPicture->color_transfer = m_pFrame->color_trc;
+  pVideoPicture->color_matrix = m_pFrame->colorspace;
+
+  pVideoPicture->iFlags = 0;
+  pVideoPicture->iFlags |= m_pFrame->interlaced_frame ? DVP_FLAG_INTERLACED : 0;
+  pVideoPicture->iFlags |= m_pFrame->top_field_first ? DVP_FLAG_TOP_FIELD_FIRST: 0;
+  pVideoPicture->iFlags |= m_pFrame->data[0] ? 0 : DVP_FLAG_DROPPED;
+
+  int64_t pts = m_pFrame->pts;
+  if (pts == AV_NOPTS_VALUE)
+    pts = av_frame_get_best_effort_timestamp(m_pFrame);
+  pVideoPicture->pts = (pts == AV_NOPTS_VALUE) ? DVD_NOPTS_VALUE : (double)pts * DVD_TIME_BASE / AV_TIME_BASE;
+  pVideoPicture->dts = DVD_NOPTS_VALUE;
+}
+
+CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideoPicture)
+{
+  if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
+    Drain();
+
+  int ret = avcodec_receive_frame(m_pCodecContext, m_pFrame);
+  if (ret == AVERROR(EAGAIN))
+    return VC_BUFFER;
+  else if (ret == AVERROR_EOF)
+    return VC_EOF;
+  else if (ret)
+  {
+    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::%s - receive frame failed, ret:%d", __FUNCTION__, ret);
+    return VC_ERROR;
+  }
+
+  if (pVideoPicture->videoBuffer)
+    pVideoPicture->videoBuffer->Release();
+  pVideoPicture->videoBuffer = nullptr;
+
+  SetPictureParams(pVideoPicture);
+
+  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_videoBufferPool->Get());
+  buffer->SetRef(m_pFrame);
+  pVideoPicture->videoBuffer = buffer;
+
+  return VC_PICTURE;
+}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -1,0 +1,79 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include "cores/VideoPlayer/DVDStreamInfo.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "cores/VideoPlayer/Process/VideoBuffer.h"
+
+extern "C" {
+#include "libavutil/frame.h"
+#include "libavutil/hwcontext_drm.h"
+}
+
+class CVideoBufferPoolDRMPRIME;
+
+class CVideoBufferDRMPRIME
+  : public CVideoBuffer
+{
+public:
+  CVideoBufferDRMPRIME(IVideoBufferPool& pool, int id);
+  virtual ~CVideoBufferDRMPRIME();
+  void SetRef(AVFrame* frame);
+  void Unref();
+
+  AVDRMFrameDescriptor* GetDescriptor() const { return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]); }
+  uint32_t GetWidth() const { return m_pFrame->width; }
+  uint32_t GetHeight() const { return m_pFrame->height; }
+protected:
+  AVFrame* m_pFrame = nullptr;
+};
+
+class CDVDVideoCodecDRMPRIME
+  : public CDVDVideoCodec
+{
+public:
+  explicit CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo);
+  ~CDVDVideoCodecDRMPRIME() override;
+
+  static CDVDVideoCodec* Create(CProcessInfo& processInfo);
+  static void Register();
+
+  bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
+  bool AddData(const DemuxPacket& packet) override;
+  void Reset() override;
+  CDVDVideoCodec::VCReturn GetPicture(VideoPicture* pVideoPicture) override;
+  const char* GetName() override { return m_name.c_str(); };
+  unsigned GetAllowedReferences() override { return 4; };
+  void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
+
+protected:
+  virtual AVCodec* FindDecoder(CDVDStreamInfo& hints);
+  virtual void Drain();
+  virtual void SetPictureParams(VideoPicture* pVideoPicture);
+
+  std::string m_name;
+  int m_codecControlFlags = 0;
+  AVCodecContext* m_pCodecContext = nullptr;
+  AVFrame* m_pFrame = nullptr;
+  std::shared_ptr<CVideoBufferPoolDRMPRIME> m_videoBufferPool;
+};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -41,6 +41,9 @@ public:
   void SetRef(AVFrame* frame);
   void Unref();
 
+  uint32_t m_fb_id = 0;
+  uint32_t m_handles[AV_DRM_MAX_PLANES] = {0};
+
   AVDRMFrameDescriptor* GetDescriptor() const { return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]); }
   uint32_t GetWidth() const { return m_pFrame->width; }
   uint32_t GetHeight() const { return m_pFrame->height; }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
@@ -49,6 +49,11 @@ if(CORE_SYSTEM_NAME STREQUAL android)
                       RendererMediaCodecSurface.h)
 endif()
 
+if(CORE_PLATFORM_NAME_LC STREQUAL gbm)
+  list(APPEND SOURCES RendererDRMPRIME.cpp)
+  list(APPEND HEADERS RendererDRMPRIME.h)
+endif()
+
 # we might want to build on linux systems
 # with ENABLE_VDPAU=OFF and ENABLE_VAAPI=OFF
 if(SOURCES)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -1,0 +1,165 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RendererDRMPRIME.h"
+
+#include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
+#include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "utils/log.h"
+
+CRendererDRMPRIME::CRendererDRMPRIME()
+{
+}
+
+CRendererDRMPRIME::~CRendererDRMPRIME()
+{
+  Reset();
+}
+
+CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
+{
+  if (buffer && dynamic_cast<CVideoBufferDRMPRIME*>(buffer))
+    return new CRendererDRMPRIME();
+
+  return nullptr;
+}
+
+bool CRendererDRMPRIME::Register()
+{
+  VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
+  return true;
+}
+
+bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsigned flags, unsigned int orientation)
+{
+  m_format = picture.videoBuffer->GetFormat();
+  m_sourceWidth = picture.iWidth;
+  m_sourceHeight = picture.iHeight;
+  m_renderOrientation = orientation;
+
+  // Save the flags.
+  m_iFlags = flags;
+
+  // Calculate the input frame aspect ratio.
+  CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);
+  SetViewMode(m_videoSettings.m_ViewMode);
+  ManageRenderArea();
+
+  Reset();
+
+  m_bConfigured = true;
+  return true;
+}
+
+void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index, double currentClock)
+{
+  BUFFER& buf = m_buffers[index];
+  buf.videoBuffer = picture.videoBuffer;
+  buf.videoBuffer->Acquire();
+}
+
+void CRendererDRMPRIME::Reset()
+{
+  for (int i = 0; i < m_numRenderBuffers; i++)
+    ReleaseBuffer(i);
+
+  m_iLastRenderBuffer = -1;
+}
+
+void CRendererDRMPRIME::ReleaseBuffer(int index)
+{
+  BUFFER& buf = m_buffers[index];
+  if (buf.videoBuffer)
+  {
+    CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(buf.videoBuffer);
+    if (buffer)
+      buffer->Release();
+    buf.videoBuffer = nullptr;
+  }
+}
+
+bool CRendererDRMPRIME::NeedBuffer(int index)
+{
+  return m_iLastRenderBuffer == index;
+}
+
+CRenderInfo CRendererDRMPRIME::GetRenderInfo()
+{
+  CRenderInfo info;
+  info.max_buffer_size = m_numRenderBuffers;
+  info.optimal_buffer_size = m_numRenderBuffers;
+  info.opaque_pointer = (void*)this;
+  return info;
+}
+
+void CRendererDRMPRIME::Update()
+{
+  if (!m_bConfigured)
+    return;
+
+  ManageRenderArea();
+}
+
+void CRendererDRMPRIME::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
+{
+  if (m_iLastRenderBuffer == index)
+    return;
+
+  CVideoBufferDRMPRIME* buffer = dynamic_cast<CVideoBufferDRMPRIME*>(m_buffers[index].videoBuffer);
+  if (buffer)
+    SetVideoPlane(buffer);
+
+  m_iLastRenderBuffer = index;
+}
+
+bool CRendererDRMPRIME::RenderCapture(CRenderCapture* capture)
+{
+  capture->BeginRender();
+  capture->EndRender();
+  return true;
+}
+
+bool CRendererDRMPRIME::ConfigChanged(const VideoPicture& picture)
+{
+  if (picture.videoBuffer->GetFormat() != m_format)
+    return true;
+
+  return false;
+}
+
+bool CRendererDRMPRIME::Supports(ERENDERFEATURE feature)
+{
+  if (feature == RENDERFEATURE_ZOOM ||
+      feature == RENDERFEATURE_STRETCH ||
+      feature == RENDERFEATURE_PIXEL_RATIO)
+    return true;
+
+  return false;
+}
+
+bool CRendererDRMPRIME::Supports(ESCALINGMETHOD method)
+{
+  return false;
+}
+
+void CRendererDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer)
+{
+  // TODO: implement
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "system.h"
+
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
+
+class CRendererDRMPRIME
+  : public CBaseRenderer
+{
+public:
+  CRendererDRMPRIME();
+  virtual ~CRendererDRMPRIME();
+
+  // Registration
+  static CBaseRenderer* Create(CVideoBuffer* buffer);
+  static bool Register();
+
+  // Player functions
+  bool Configure(const VideoPicture& picture, float fps, unsigned flags, unsigned int orientation) override;
+  bool IsConfigured() override { return m_bConfigured; };
+  void AddVideoPicture(const VideoPicture& picture, int index, double currentClock) override;
+  void UnInit() override {};
+  void Reset() override;
+  void ReleaseBuffer(int idx) override;
+  bool NeedBuffer(int idx) override;
+  bool IsGuiLayer() override { return false; };
+  CRenderInfo GetRenderInfo() override;
+  void Update() override;
+  void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
+  bool RenderCapture(CRenderCapture* capture) override;
+  bool ConfigChanged(const VideoPicture& picture) override;
+
+  // Feature support
+  bool SupportsMultiPassRendering() override { return false; };
+  bool Supports(ERENDERFEATURE feature) override;
+  bool Supports(ESCALINGMETHOD method) override;
+
+private:
+  void SetVideoPlane(CVideoBufferDRMPRIME* buffer);
+
+  bool m_bConfigured = false;
+  int m_iLastRenderBuffer = -1;
+  static const int m_numRenderBuffers = 4;
+
+  struct BUFFER
+  {
+    BUFFER() : videoBuffer(nullptr) {};
+    CVideoBuffer* videoBuffer;
+  } m_buffers[m_numRenderBuffers];
+};

--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <drm/drm_mode.h>
+#include <drm_mode.h>
 #include <EGL/egl.h>
 #include <unistd.h>
 

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -391,7 +391,10 @@ bool CDRMUtils::GetModes(std::vector<RESOLUTION_INFO> &resolutions)
     res.iHeight = m_drm_connector->modes[i].vdisplay;
     res.iScreenWidth = m_drm_connector->modes[i].hdisplay;
     res.iScreenHeight = m_drm_connector->modes[i].vdisplay;
-    res.fRefreshRate = m_drm_connector->modes[i].vrefresh;
+    if (m_drm_connector->modes[i].clock % 10 != 0)
+      res.fRefreshRate = (float)m_drm_connector->modes[i].vrefresh * (1000.0f/1001.0f);
+    else
+      res.fRefreshRate = m_drm_connector->modes[i].vrefresh;
     res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
     res.fPixelRatio = 1.0f;
     res.bFullScreen = true;

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -24,8 +24,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <drm/drm_fourcc.h>
-#include <drm/drm_mode.h>
+#include <drm_fourcc.h>
+#include <drm_mode.h>
 #include <EGL/egl.h>
 #include <unistd.h>
 

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -43,6 +43,14 @@ static drmModeConnectorPtr m_drm_connector = nullptr;
 static drmModeEncoderPtr m_drm_encoder = nullptr;
 static drmModeCrtcPtr m_orig_crtc = nullptr;
 
+void CDRMUtils::WaitVBlank()
+{
+  drmVBlank vbl;
+  vbl.request.type = DRM_VBLANK_RELATIVE;
+  vbl.request.sequence = 1;
+  drmWaitVBlank(m_drm->fd, &vbl);
+}
+
 bool CDRMUtils::SetMode(RESOLUTION_INFO res)
 {
   m_drm->mode = &m_drm_connector->modes[atoi(res.strId.c_str())];

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -43,6 +43,11 @@ static drmModeConnectorPtr m_drm_connector = nullptr;
 static drmModeEncoderPtr m_drm_encoder = nullptr;
 static drmModeCrtcPtr m_orig_crtc = nullptr;
 
+struct drm *CDRMUtils::GetDrm()
+{
+  return m_drm;
+}
+
 void CDRMUtils::WaitVBlank()
 {
   drmVBlank vbl;

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -53,6 +53,7 @@ struct drm
   drmModeModeInfo *mode;
   uint32_t crtc_id;
   uint32_t connector_id;
+  uint32_t video_plane_id;
 };
 
 struct drm_fb

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -70,6 +70,7 @@ public:
   static bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
   static bool SetMode(RESOLUTION_INFO res);
   static void WaitVBlank();
+  static struct drm *GetDrm();
 
 protected:
   static drm_fb * DrmFbGetFromBo(struct gbm_bo *bo);

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -69,6 +69,7 @@ public:
   static void DestroyDrm();
   static bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
   static bool SetMode(RESOLUTION_INFO res);
+  static void WaitVBlank();
 
 protected:
   static drm_fb * DrmFbGetFromBo(struct gbm_bo *bo);

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -25,7 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <drm/drm_mode.h>
+#include <drm_mode.h>
 #include <EGL/egl.h>
 #include <unistd.h>
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -153,6 +153,11 @@ void CWinSystemGbm::FlipPage(CGLContextEGL *pGLContext)
   m_DRM.FlipPage(pGLContext);
 }
 
+void CWinSystemGbm::WaitVBlank()
+{
+  CDRMUtils::WaitVBlank();
+}
+
 void* CWinSystemGbm::GetVaDisplay()
 {
 #if defined(HAVE_LIBVA)

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -49,6 +49,7 @@ public:
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   void FlipPage(CGLContextEGL *m_pGLContext);
+  void WaitVBlank();
 
   void UpdateResolutions() override;
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -134,12 +134,19 @@ bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
   return true;
 }
 
-void CWinSystemGbmGLESContext::PresentRenderImpl(bool rendered)
+void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 {
+  if (!m_bRenderCreated)
+    return;
+
   if (rendered)
   {
     m_pGLContext.SwapBuffers();
     CWinSystemGbm::FlipPage(&m_pGLContext);
+  }
+  else
+  {
+    CWinSystemGbm::WaitVBlank();
   }
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -24,6 +24,9 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h"
 #endif
 
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h"
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h"
+
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
@@ -61,6 +64,9 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
     VAAPI::CDecoder::Register(hevc);
   }
 #endif
+
+  CRendererDRMPRIME::Register();
+  CDVDVideoCodecDRMPRIME::Register();
 
   return true;
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -38,13 +38,14 @@ public:
                        RESOLUTION_INFO& res) override;
 
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  void PresentRender(bool rendered, bool videoLayer) override;
   EGLDisplay GetEGLDisplay() const;
   EGLSurface GetEGLSurface() const;
   EGLContext GetEGLContext() const;
   EGLConfig  GetEGLConfig() const;
 protected:
   void SetVSyncImpl(bool enable) override { return; };
-  void PresentRenderImpl(bool rendered) override;
+  void PresentRenderImpl(bool rendered) override {};
 
 private:
   CGLContextEGL m_pGLContext;


### PR DESCRIPTION
## Description
This adds a new DRM PRIME video codec and renderer for zero-copy video rendering on embedded linux devices with multi-plane drm support (focus have been on Rockchip SoCs but it is generic for use with other vendors SoCs)
EGL/GLES and video frames is rendered on two different drm planes and blended using the hw compositor

**How does this work?**
- A FFmpeg decoder supporting the requested video codec and the drm prime pixel format is located
- The decoder produces frames with a `AVDRMFrameDescriptor` struct containing a PRIME file descriptor and other information needed to import the video frame into EGL or add it to a drm plane
- The video frame is added to a secondary drm plane (behind the gui drm plane)
- A HW compositor is blending the gui and video planes before scanout

**Work for another day**
- Atomic DRM support (work-in-progress by @lrusak)
- Disable EGL/GLES drm plane when video is playing and no osd/subtitle is shown to save memory bandwidth
- Limit EGL/GLES to 720/1080p and scale using the hw compositor to support weak GPUs
- A wayland renderer for linux desktop support

Special thanks to @LongChair for rkmpp/drm prime work in ffmpeg and mpv, @lrusak for drm/kms and v4l2m2m work and @FernetMenta for Video Player guidance and help

## Motivation and Context
Makes it possible to render 4K video frames on ARM devices with a weak GPU but a powerfull VPU

## How Has This Been Tested?
This has been tested using LibreELEC on Rockchip devices (Rock64 and Tinker Board)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
