### PR TITLE
[backport] osx: fix high cpu usage when obscured

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/WinSystemOSXGL.mm
@@ -42,6 +42,11 @@ void CWinSystemOSXGL::PresentRenderImpl(bool rendered)
   if (rendered)
     FlushBuffer();
   
+  // FlushBuffer does not block if window is obscured
+  // in this case we need to throttle the render loop
+  if (IsObscured())
+    usleep(10000);
+
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {
     m_delayDispReset = false;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Backport of #13016 
<!--- Describe your change in detail -->

## Motivation and Context
On OSX FlushBuffer does not block if window is obscured.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

<!--## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

<!--## Screenshots (if appropriate):-->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
