### PR TITLE
Fix Back button in Android TV Remote Control app

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -85,7 +85,8 @@
   <FullscreenVideo>
     <joystick profile="game.controller.default">
       <a>Pause</a>
-      <b>Stop</b>
+      <b>Fullscreen</b>
+      <b holdtime="500">Stop</b>
       <x>OSD</x>
       <y>FullScreen</y>
       <start>Info</start>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -70,6 +70,12 @@
       <rightstick direction="down">VolumeDown</rightstick>
     </joystick>
   </global>
+  <Home>
+    <joystick profile="game.controller.default">
+      <b>Back</b>
+      <b holdtime="500">ActivateWindow(ShutdownMenu)</b>
+    </joystick>
+  </Home>
   <FileManager>
     <joystick profile="game.controller.default">
       <rightbumper>Highlight</rightbumper>

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -96,7 +96,7 @@ bool CGUIDialogButtonCapture::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
     std::string feature;
     if (buttonMap->GetFeature(primitive, feature))
     {
-      const auto &actions = keymap->GetActions(JOYSTICK::CJoystickUtils::MakeKeyName(feature));
+      const auto &actions = keymap->GetActions(JOYSTICK::CJoystickUtils::MakeKeyName(feature)).actions;
       if (!actions.empty())
       {
         switch (actions.begin()->actionId)

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -206,7 +206,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
       std::string feature;
       if (buttonMap->GetFeature(primitive, feature))
       {
-        const auto &actions = keymap->GetActions(CJoystickUtils::MakeKeyName(feature));
+        const auto &actions = keymap->GetActions(CJoystickUtils::MakeKeyName(feature)).actions;
         if (!actions.empty())
         {
           //! @todo Handle multiple actions mapped to the same key

--- a/xbmc/input/IKeymap.h
+++ b/xbmc/input/IKeymap.h
@@ -54,7 +54,7 @@ public:
    *
    * \return A list of actions associated with the given key
    */
-  virtual const KODI::JOYSTICK::KeymapActions& GetActions(const std::string& keyName) const = 0;
+  virtual const KODI::JOYSTICK::KeymapActionGroup& GetActions(const std::string& keyName) const = 0;
 };
 
 /*!
@@ -91,5 +91,5 @@ public:
    *
    * \return A list of actions associated with the given key for the given window
    */
-  virtual const KODI::JOYSTICK::KeymapActions& GetActions(int windowId, const std::string& keyName) const = 0;
+  virtual const KODI::JOYSTICK::KeymapActionGroup& GetActions(int windowId, const std::string& keyName) const = 0;
 };

--- a/xbmc/input/Keymap.cpp
+++ b/xbmc/input/Keymap.cpp
@@ -34,28 +34,28 @@ std::string CKeymap::ControllerID() const
   return m_keymap->ControllerID();
 }
 
-const JOYSTICK::KeymapActions &CKeymap::GetActions(const std::string& keyName) const
+const JOYSTICK::KeymapActionGroup &CKeymap::GetActions(const std::string& keyName) const
 {
   const int windowId = m_environment->GetWindowID();
-  const JOYSTICK::KeymapActions& actions = m_keymap->GetActions(windowId, keyName);
-  if (!actions.empty())
+  const auto &actions = m_keymap->GetActions(windowId, keyName);
+  if (!actions.actions.empty())
     return actions;
 
   const int fallbackWindowId = m_environment->GetFallthrough(windowId);
   if (fallbackWindowId >= 0)
   {
-    const JOYSTICK::KeymapActions& fallbackActions = m_keymap->GetActions(fallbackWindowId, keyName);
-    if (!fallbackActions.empty())
+    const auto &fallbackActions = m_keymap->GetActions(fallbackWindowId, keyName);
+    if (!fallbackActions.actions.empty())
       return fallbackActions;
   }
 
   if (m_environment->UseGlobalFallthrough())
   {
-    const JOYSTICK::KeymapActions& globalActions = m_keymap->GetActions(-1, keyName);
-    if (!globalActions.empty())
+    const auto &globalActions = m_keymap->GetActions(-1, keyName);
+    if (!globalActions.actions.empty())
       return globalActions;
   }
 
-  static const JOYSTICK::KeymapActions empty;
+  static const JOYSTICK::KeymapActionGroup empty{};
   return empty;
 }

--- a/xbmc/input/Keymap.h
+++ b/xbmc/input/Keymap.h
@@ -33,7 +33,7 @@ public:
   // implementation of IKeymap
   virtual std::string ControllerID() const override ;
   virtual const IKeymapEnvironment *Environment() const override { return m_environment; }
-  const KODI::JOYSTICK::KeymapActions &GetActions(const std::string& keyName) const override;
+  const KODI::JOYSTICK::KeymapActionGroup &GetActions(const std::string& keyName) const override;
 
 private:
   // Construction parameters

--- a/xbmc/input/WindowKeymap.cpp
+++ b/xbmc/input/WindowKeymap.cpp
@@ -29,10 +29,13 @@ CWindowKeymap::CWindowKeymap(const std::string &controllerId) :
 
 void CWindowKeymap::MapAction(int windowId, const std::string &keyName, JOYSTICK::KeymapAction action)
 {
-  m_windowKeymap[windowId][keyName].insert(std::move(action));
+  auto &actionGroup = m_windowKeymap[windowId][keyName];
+
+  actionGroup.windowId = windowId;
+  actionGroup.actions.insert(std::move(action));
 }
 
-const JOYSTICK::KeymapActions &CWindowKeymap::GetActions(int windowId, const std::string& keyName) const
+const JOYSTICK::KeymapActionGroup &CWindowKeymap::GetActions(int windowId, const std::string& keyName) const
 {
   auto it = m_windowKeymap.find(windowId);
   if (it != m_windowKeymap.end())
@@ -43,6 +46,6 @@ const JOYSTICK::KeymapActions &CWindowKeymap::GetActions(int windowId, const std
       return it2->second;
   }
 
-  static const JOYSTICK::KeymapActions empty;
+  static const JOYSTICK::KeymapActionGroup empty{};
   return empty;
 }

--- a/xbmc/input/WindowKeymap.h
+++ b/xbmc/input/WindowKeymap.h
@@ -33,14 +33,14 @@ public:
   // implementation of IWindowKeymap
   virtual std::string ControllerID() const override { return m_controllerId; }
   virtual void MapAction(int windowId, const std::string &keyName, KODI::JOYSTICK::KeymapAction action) override;
-  virtual const KODI::JOYSTICK::KeymapActions &GetActions(int windowId, const std::string& keyName) const override;
+  virtual const KODI::JOYSTICK::KeymapActionGroup &GetActions(int windowId, const std::string& keyName) const override;
 
 private:
   // Construction parameter
   const std::string m_controllerId;
 
   using KeyName = std::string;
-  using Keymap = std::map<KeyName, KODI::JOYSTICK::KeymapActions>;
+  using Keymap = std::map<KeyName, KODI::JOYSTICK::KeymapActionGroup>;
 
   using WindowID = int;
   using WindowMap = std::map<WindowID, Keymap>;

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -170,6 +170,10 @@ namespace JOYSTICK
    * \ingroup joystick
    * \brief Container that sorts action entries by their holdtime
    */
-  using KeymapActions = std::set<KeymapAction>;
+  struct KeymapActionGroup
+  {
+    int windowId = -1;
+    std::set<KeymapAction> actions;
+  };
 }
 }

--- a/xbmc/input/joysticks/JoystickUtils.h
+++ b/xbmc/input/joysticks/JoystickUtils.h
@@ -67,8 +67,6 @@ public:
    * \param dir      The direction for analog sticks, or ignored otherwise
    *
    * \return A valid name for a key in the joystick keymap
-   *
-   * \sa ParseKeyName()
    */
   static std::string MakeKeyName(const FeatureName &feature, ANALOG_STICK_DIRECTION dir = ANALOG_STICK_DIRECTION::UNKNOWN);
 

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -269,7 +269,7 @@ CButtonMapping::CButtonMapping(IButtonMapper* buttonMapper, IButtonMap* buttonMa
     {
       bool bIsSelectAction = false;
 
-      const auto &actions = m_keymap->GetActions(CJoystickUtils::MakeKeyName(feature.Name()));
+      const auto &actions = m_keymap->GetActions(CJoystickUtils::MakeKeyName(feature.Name())).actions;
       if (!actions.empty() && actions.begin()->actionId == ACTION_SELECT_ITEM)
         bIsSelectAction = true;
 

--- a/xbmc/input/joysticks/keymaps/KeyHandler.h
+++ b/xbmc/input/joysticks/keymaps/KeyHandler.h
@@ -55,10 +55,10 @@ namespace JOYSTICK
   private:
     void Reset();
 
-    bool HandleActions(std::vector<const KeymapAction*> actions, float magnitude, unsigned int holdTimeMs);
-    bool HandleRelease(std::vector<const KeymapAction*> actions);
+    bool HandleActions(std::vector<const KeymapAction*> actions, int windowId, float magnitude, unsigned int holdTimeMs);
+    bool HandleRelease(std::vector<const KeymapAction*> actions, int windowId);
 
-    bool HandleAction(const KeymapAction& action, float magnitude, unsigned int holdTimeMs);
+    bool HandleAction(const KeymapAction& action, int windowId, float magnitude, unsigned int holdTimeMs);
 
     // Check criteria for sending a repeat action
     bool SendRepeatAction(unsigned int holdTimeMs);
@@ -79,6 +79,7 @@ namespace JOYSTICK
     unsigned int m_lastHoldTimeMs;
     bool m_bActionSent;
     unsigned int m_lastActionMs;
+    int m_activeWindowId = -1; // Window that activated the key
   };
 }
 }

--- a/xbmc/input/joysticks/keymaps/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/keymaps/KeymapHandler.cpp
@@ -173,7 +173,7 @@ bool CKeymapHandler::HasAction(const std::string &keyName) const
 {
   bool bHasAction = false;
 
-  const auto &actions = m_keymap->GetActions(keyName);
+  const auto &actions = m_keymap->GetActions(keyName).actions;
   for (const auto &action : actions)
   {
     if (HotkeysPressed(action.hotkeys))


### PR DESCRIPTION
The Back button shows up as a joystick button, which is mapped to the B button in https://github.com/xbmc/peripheral.joystick/pull/129 (and backported to Krypton).

This PR makes the B button behave like the Backspace button on a keyboard, which is how the button is interpreted when peripheral.joystick is disabled. Now, the Back button should work the same whether it's operating as a joystick or keyboard.

This required two steps: changing joystick.xml to match keyboard.xml and fixing a joystick bug. The bug caused the FullscreenVideo window to close immediately upon reopening from the Home screen.

## Motivation and Context
Reported here: https://forum.kodi.tv/showthread.php?tid=308480&pid=2667452#pid2667452

## How Has This Been Tested?
* Tested on Shield TV with Android TV Remote Control app
* Tested on Linux with Xbox 360 controller

## Screenshots (if appropriate):
Android TV Remote Control:
![android tv remote control](https://user-images.githubusercontent.com/531482/32703036-fea95e94-c7a4-11e7-8114-d96b8ab352df.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
