### PR TITLE
add archive:// to list of url types with encoded hostname

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -276,6 +276,7 @@ bool URIUtils::HasParentInHostname(const CURL& url)
 {
   return url.IsProtocol("zip")
       || url.IsProtocol("rar")
+      || url.IsProtocol("archive")
       || url.IsProtocol("apk")
       || url.IsProtocol("bluray")
       || url.IsProtocol("udf")


### PR DESCRIPTION
From a strictly purist point of view this is not correct, since archive:// is a url type for a vfs addon (https://github.com/notspiff/vfs.libarchive). however, from a more pragmatic (and imho; sane) pov of it would require a lot of infrastructure for very little gain to do this properly.