### PR TITLE
Sanitize filenames for mkv font attachments

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -687,7 +687,7 @@ void CUtil::ClearTempFonts()
     return;
 
   CFileItemList items;
-  CDirectory::GetDirectory(searchPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE);
+  CDirectory::GetDirectory(searchPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE | DIR_FLAG_GET_HIDDEN);
 
   for (const auto &item : items)
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -28,6 +28,7 @@
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
+#include "Util.h"
 
 #include <sstream>
 #include <utility>
@@ -1675,7 +1676,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           }
           else
           {
-            fileName += nameTag->value;
+            fileName += CUtil::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
             XFILE::CFile file;
             if (pStream->codecpar->extradata && file.OpenForWrite(fileName))
             {


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Kodi extracts fonts embedded in mkv files to ~/kodi/temp/fonts/ and uses the attachment name as filename without checking if it's a valid filename.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This can cause two problems:
1) Writing fails if the attachment name contains invalid characters. The rendered subtitles will look bad because the font is missing.
2) Using an attachment name like "../../../whatever.sh" will write outside the fonts folder. So it's possible to overwrite arbitrary files by just playing a video file in kodi. The mime-type in the mkv file has to be "application/x-truetype-font" but the content can be something else.

The patch replaces all invalid characters with _ and also changes ClearTempFonts() to also remove hidden files in the temp folder.

A different solution would be to use the [ass_add_font()](https://github.com/libass/libass/blob/73284b676b12b47e17af2ef1b430527299e10c17/libass/ass.h#L629) function of libass to provide fonts without writing them to a file first.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Play https://0x0.st/s-bQ.mkv in kodi.
In an unpatched version both subtitle lines will look the same. Also kodi will write a file "test.txt" to your home folder.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
