### PR TITLE
smbclient changes for smb minprotocol and legacysecurity

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -20373,25 +20373,25 @@ msgctxt "#36622"
 msgid "Set the maximum SMB protocol version to negotiate when making connections. Forcing SMBv2 or SMBv1 compatibility may be required with older NAS and Windows shares."
 msgstr ""
 
-#. Values for setting with label #36621 "Maximum protocol version" - none means "no protocol version is forced"
+#. Values for setting with label #36621 and #36628 "Minimum/Maximum protocol version" - none means "no protocol version is forced"
 #: system/settings/settings.xml
 msgctxt "#36623"
 msgid "None"
 msgstr ""
 
-#. Values for setting with label #36621 "Maximum protocol version"
+#. Values for setting with label #36621 and #36628 "Minimum/Maximum protocol version"
 #: system/settings/settings.xml
 msgctxt "#36624"
 msgid "SMBv1"
 msgstr ""
 
-#. Values for setting with label #36621 "Maximum protocol version"
+#. Values for setting with label #36621 and #36628 "Minimum/Maximum protocol version"
 #: system/settings/settings.xml
 msgctxt "#36625"
 msgid "SMBv2"
 msgstr ""
 
-#. Values for setting with label #36621 "Maximum protocol version"
+#. Values for setting with label #36621 and #36628 "Minimum/Maximum protocol version"
 #: system/settings/settings.xml
 msgctxt "#36626"
 msgid "SMBv3"
@@ -20403,7 +20403,31 @@ msgctxt "#36627"
 msgid "Client"
 msgstr ""
 
-#empty strings from id 36628 to 36898
+#. Label of a setting, allow the minimum smbclient protocol to be configured
+#: system/settings/settings.xml
+msgctxt "#36628"
+msgid "Minimum protocol version"
+msgstr ""
+
+#. Description of setting with label #36628 "Minimum protocol version"
+#: system/settings/settings.xml
+msgctxt "#36629"
+msgid "Set the minimum SMB protocol version to negotiate when making connections. Forcing SMBv2 may be required to prevent SMBv1 use on some OS."
+msgstr ""
+
+#. Label of a setting, sets additional config required for some proprietary SMBv1 implementations (mostly routers)
+#: system/settings/settings.xml
+msgctxt "#36630"
+msgid "Use legacy security"
+msgstr ""
+
+#. Description of setting with label #36630 "Use legacy security"
+#: system/settings/settings.xml
+msgctxt "#36631"
+msgid "Force weak SMBv1 security for compatibility with the USB sharing features on some WiFi routers and NAS devices."
+msgstr ""
+
+#empty strings from id 36632 to 36898
 
 #. Description of setting with label #729 "Enable SSL"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1988,6 +1988,19 @@
           <default>0.0.0.0</default>
           <control type="edit" format="ip" />
         </setting>
+        <setting id="smb.minprotocol" type="integer" label="36628" help="36629">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="36623">0</option>
+              <option label="36624">1</option>
+              <option label="36625">2</option>
+              <option label="36626">3</option>
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
+        </setting>
         <setting id="smb.maxprotocol" type="integer" label="36621" help="36622">
           <level>2</level>
           <default>3</default>
@@ -2000,6 +2013,16 @@
             </options>
           </constraints>
           <control type="list" format="integer" />
+        </setting>
+        <setting id="smb.legacysecurity" type="boolean" label="36630" help="36631">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="enable">
+                <condition setting="smb.maxprotocol" operator="is">1</condition>
+            </dependency>
+          </dependencies>
         </setting>
       </group>
     </category>

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -118,6 +118,15 @@ void CSMB::Init()
 
         fprintf(f, "\tlock directory = %s/.smb/\n", home.c_str());
 
+        // set minimum smbclient protocol version
+        if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SMB_MINPROTOCOL) > 0)
+        {
+          if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SMB_MINPROTOCOL) == 1)
+            fprintf(f, "\tclient min protocol = NT1\n");
+          else
+            fprintf(f, "\tclient min protocol = SMB%d\n", CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SMB_MINPROTOCOL));
+        }
+
         // set maximum smbclient protocol version
         if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SMB_MAXPROTOCOL) > 0)
         {
@@ -125,6 +134,13 @@ void CSMB::Init()
             fprintf(f, "\tclient max protocol = NT1\n");
           else
             fprintf(f, "\tclient max protocol = SMB%d\n", CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SMB_MAXPROTOCOL));
+        }
+
+        // set legacy security options
+        if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SMB_LEGACYSECURITY) && (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_SMB_MAXPROTOCOL) == 1))
+        {
+          fprintf(f, "\tclient NTLMv2 auth = no\n");
+          fprintf(f, "\tclient use spnego = no\n");
         }
 
         // set wins server if there's one. name resolve order defaults to 'lmhosts host wins bcast'.

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -424,7 +424,9 @@ void CNetworkServices::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 #endif // HAS_WEB_SERVER
   if (settingId == CSettings::SETTING_SMB_WINSSERVER ||
       settingId == CSettings::SETTING_SMB_WORKGROUP ||
-      settingId == CSettings::SETTING_SMB_MAXPROTOCOL)
+      settingId == CSettings::SETTING_SMB_MINPROTOCOL ||
+      settingId == CSettings::SETTING_SMB_MAXPROTOCOL ||
+      settingId == CSettings::SETTING_SMB_LEGACYSECURITY)
   {
     // okey we really don't need to restart, only deinit samba, but that could be damn hard if something is playing
     //! @todo - General way of handling setting changes that require restart

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -342,7 +342,9 @@ const std::string CSettings::SETTING_SERVICES_AIRPLAYPASSWORD = "services.airpla
 const std::string CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT = "services.airplayvideosupport";
 const std::string CSettings::SETTING_SMB_WINSSERVER = "smb.winsserver";
 const std::string CSettings::SETTING_SMB_WORKGROUP = "smb.workgroup";
+const std::string CSettings::SETTING_SMB_MINPROTOCOL = "smb.minprotocol";
 const std::string CSettings::SETTING_SMB_MAXPROTOCOL = "smb.maxprotocol";
+const std::string CSettings::SETTING_SMB_LEGACYSECURITY = "smb.legacysecurity";
 const std::string CSettings::SETTING_VIDEOSCREEN_MONITOR = "videoscreen.monitor";
 const std::string CSettings::SETTING_VIDEOSCREEN_SCREEN = "videoscreen.screen";
 const std::string CSettings::SETTING_VIDEOSCREEN_RESOLUTION = "videoscreen.resolution";
@@ -995,7 +997,9 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_SERVICES_ESCONTINUOUSDELAY);
   settingSet.insert(CSettings::SETTING_SMB_WINSSERVER);
   settingSet.insert(CSettings::SETTING_SMB_WORKGROUP);
+  settingSet.insert(CSettings::SETTING_SMB_MINPROTOCOL);
   settingSet.insert(CSettings::SETTING_SMB_MAXPROTOCOL);
+  settingSet.insert(CSettings::SETTING_SMB_LEGACYSECURITY);
   GetSettingsManager()->RegisterCallback(&CNetworkServices::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -289,7 +289,9 @@ public:
   static const std::string SETTING_SERVICES_AIRPLAYVIDEOSUPPORT;
   static const std::string SETTING_SMB_WINSSERVER;
   static const std::string SETTING_SMB_WORKGROUP;
+  static const std::string SETTING_SMB_MINPROTOCOL;
   static const std::string SETTING_SMB_MAXPROTOCOL;
+  static const std::string SETTING_SMB_LEGACYSECURITY;
   static const std::string SETTING_VIDEOSCREEN_MONITOR;
   static const std::string SETTING_VIDEOSCREEN_SCREEN;
   static const std::string SETTING_VIDEOSCREEN_RESOLUTION;


### PR DESCRIPTION
## Description
Support feedback from LE8.2 shows a need for `client min protocol` to ensure smbclient can never make SMB1 connections to some servers. We've also had users report issues with older routers and NAS boxes that contain ancient Samba versions for USB drive sharing that cannot handle NTLMv2 so the "legacy security" option (only visible when max protocol is SMB1) allows older NTLM(v1) auth for compatibility.

## How Has This Been Tested?
Krypton versions of the same patch are in LE 8.2.1 which has been tested over the last week. These are the same changes tweaked for different CSettings in Leia.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed