### PR TITLE
[VideoPlayerAudio] fix audio codec info

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -119,8 +119,6 @@ void CVideoPlayerAudio::OpenStream(CDVDStreamInfo &hints, CDVDAudioCodec* codec)
   SAFE_DELETE(m_pAudioCodec);
   m_pAudioCodec = codec;
 
-  m_processInfo.ResetAudioCodecInfo();
-
   /* store our stream hints */
   m_streaminfo = hints;
 


### PR DESCRIPTION
I removed ResetAudioInfo() to avoid wash out already set audio codec info.