### PR TITLE
FIXED: ListItem::setSubtitles if more than one subtitle is given

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -823,7 +823,7 @@ namespace XBMCAddon
       unsigned int i = 1;
       for (const auto& it: paths)
       {
-        String property = StringUtils::Format("subtitle:%u", i);
+        String property = StringUtils::Format("subtitle:%u", i++);
         item->SetProperty(property, it);
       }
     }


### PR DESCRIPTION
## Description
Every subtitle in the list which is passed via ListItem::setSubtitles gets a different number now.

## Motivation and Context
If more than one subtitle is set via ListItem::setSubtitles only one subtitle is available.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
