### PR TITLE
changed: use IsOnLAN to check for local network

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -98,9 +98,7 @@ bool CEdl::ReadEditDecisionLists(const std::string& strMovie, const float fFrame
    * Only check for edit decision lists if the movie is on the local hard drive, or accessed over a
    * network share.
    */
-  if ((URIUtils::IsHD(strMovie)  || 
-       URIUtils::IsSmb(strMovie) || 
-       URIUtils::IsNfs(strMovie))         &&
+  if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
       !URIUtils::IsPVRRecording(strMovie) &&
       !URIUtils::IsInternetStream(strMovie))
   {


### PR DESCRIPTION
motivation: getting rid of the IsNfs usage to prepare for
nfs addonification. this changes behavior for nfs over the internet,
which should not be encouraged in any case.