### PR TITLE
DVDVideoCodecAmlogic: remove pts-based frame rate tracking

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -85,7 +85,6 @@ CDVDVideoCodecAmlogic::CDVDVideoCodecAmlogic(CProcessInfo &processInfo)
   , m_pFormatName("amcodec")
   , m_opened(false)
   , m_codecControlFlags(0)
-  , m_last_pts(0.0)
   , m_frame_queue(NULL)
   , m_queue_depth(0)
   , m_framerate(0.0)
@@ -567,69 +566,6 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
       cur_pts = m_frame_queue->dts;
 
     pthread_mutex_unlock(&m_queue_mutex);
-
-    float duration = cur_pts - m_last_pts;
-    m_last_pts = cur_pts;
-
-    // clamp duration to sensible range,
-    // 66 fsp to 20 fsp
-    if (duration >= 15000.0 && duration <= 50000.0)
-    {
-      double framerate;
-      switch((int)(0.5 + duration))
-      {
-        // 59.940 (16683.333333)
-        case 16000 ... 17000:
-          framerate = 60000.0 / 1001.0;
-          break;
-
-        // 50.000 (20000.000000)
-        case 20000:
-          framerate = 50000.0 / 1000.0;
-          break;
-
-        // 49.950 (20020.000000)
-        case 20020:
-          framerate = 50000.0 / 1001.0;
-          break;
-
-        // 29.970 (33366.666656)
-        case 32000 ... 35000:
-          framerate = 30000.0 / 1001.0;
-          break;
-
-        // 25.000 (40000.000000)
-        case 39900 ... 40100:
-          framerate = 25000.0 / 1000.0;
-          break;
-
-        // 23.976 (41708.33333)
-        case 40200 ... 43200:
-          // 23.976 seems to have the crappiest encodings :)
-          framerate = 24000.0 / 1001.0;
-          break;
-
-        default:
-          framerate = 0.0;
-          //CLog::Log(LOGDEBUG, "%s: unknown duration(%f), cur_pts(%f)",
-          //  __MODULE_NAME__, duration, cur_pts);
-          break;
-      }
-
-      if (framerate > 0.0 && (int)m_framerate != (int)framerate)
-      {
-        m_framerate = framerate;
-        m_video_rate = (int)(0.5 + (96000.0 / framerate));
-
-        if (m_Codec)
-          m_Codec->SetVideoRate(m_video_rate);
-
-        m_processInfo.SetVideoFps(m_framerate);
-
-        CLog::Log(LOGDEBUG, "%s: detected new framerate(%f), video_rate(%d)",
-          __MODULE_NAME__, m_framerate, m_video_rate);
-      }
-    }
 
     FrameQueuePop();
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -100,7 +100,6 @@ protected:
   bool            m_opened;
   int             m_codecControlFlags;
   CDVDStreamInfo  m_hints;
-  double          m_last_pts;
   frame_queue    *m_frame_queue;
   int32_t         m_queue_depth;
   pthread_mutex_t m_queue_mutex;


### PR DESCRIPTION
In most cases frame tracking based on pts provided by amcodec is wrong, causing unnecessary frame rate switch. We can simply rely on frame rate provided by ffmpeg.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
LibreELEC community builds with Kodi Krypton and Kodi master branch.
The incorrect behaviour without the patch applied can be reproduced with first samples from Kodi Wiki: http://kodi.wiki/view/Samples#Codecs.2C_Framerates_and_Subtitles
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
