### PR TITLE
VideoPlayer: add demuxer id to StreamInfo

### DIFF
--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -75,6 +75,7 @@ bool CAudioSinkAE::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool
   if (!m_pAudioStream)
     return false;
 
+  m_dataFormat = audioframe.format.m_dataFormat;
   m_sampleRate = audioframe.format.m_sampleRate;
   m_iBitsPerSample = audioframe.bits_per_sample;
   m_bPassthrough = audioframe.passthrough;
@@ -239,9 +240,10 @@ bool CAudioSinkAE::IsValidFormat(const DVDAudioFrame &audioframe)
   if (audioframe.passthrough != m_bPassthrough)
     return false;
 
-  if (m_sampleRate != audioframe.format.m_sampleRate ||
-     m_iBitsPerSample != audioframe.bits_per_sample ||
-     m_channelLayout != audioframe.format.m_channelLayout)
+  if (m_dataFormat != audioframe.format.m_dataFormat ||
+      m_sampleRate != audioframe.format.m_sampleRate ||
+      m_iBitsPerSample != audioframe.bits_per_sample ||
+      m_channelLayout != audioframe.format.m_channelLayout)
     return false;
 
   return true;

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -83,6 +83,7 @@ protected:
   double m_resampleRatio = 0.0; // invalid
   CCriticalSection m_critSection;
 
+  AEDataFormat m_dataFormat;
   unsigned int m_sampleRate;
   int m_iBitsPerSample;
   bool m_bPassthrough;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -84,6 +84,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, bool withextradata)
   if( codec     != right.codec
   ||  type      != right.type
   ||  uniqueId  != right.uniqueId
+  ||  demuxerId != right.demuxerId
   ||  realtime  != right.realtime
   ||  codec_tag != right.codec_tag
   ||  flags     != right.flags)
@@ -140,6 +141,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   codec = right.codec;
   type = right.type;
   uniqueId = right.uniqueId;
+  demuxerId = right.demuxerId;
   realtime = right.realtime;
   codec_tag = right.codec_tag;
   flags = right.flags;
@@ -200,6 +202,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
   codec = right.codec;
   type = right.type;
   uniqueId = right.uniqueId;
+  demuxerId = right.demuxerId;
   realtime = right.realtime;
   codec_tag = right.codec_fourcc;
   profile   = right.profile;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -51,6 +51,7 @@ public:
   AVCodecID codec;
   StreamType type;
   int uniqueId;
+  int demuxerId = -1;
   bool realtime;
   int flags;
   std::string filename;


### PR DESCRIPTION
fixes audio issue when playing a file with DTS HD after one with DTS