### PR TITLE
[infoscanner] ensure we're only checking for .nomedia in folders (fixes #17651)

### DIFF
--- a/xbmc/InfoScanner.cpp
+++ b/xbmc/InfoScanner.cpp
@@ -28,18 +28,12 @@
 bool CInfoScanner::HasNoMedia(const std::string &strDirectory) const
 {
   std::string noMediaFile = URIUtils::AddFileToFolder(strDirectory, ".nomedia");
-  return XFILE::CFile::Exists(noMediaFile);
-}
 
-bool CInfoScanner::IsExcluded(const std::string& strDirectory, const std::vector<std::string> &regexps)
-{
-  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
-    return true;
-
-  if (!URIUtils::IsPlugin(strDirectory) && HasNoMedia(strDirectory))
+  if (!URIUtils::IsPlugin(strDirectory) && XFILE::CFile::Exists(noMediaFile))
   {
     CLog::Log(LOGWARNING, "Skipping item '%s' with '.nomedia' file in parent directory, it won't be added to the library.", CURL::GetRedacted(strDirectory).c_str());
     return true;
   }
+
   return false;
 }

--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -64,10 +64,9 @@ public:
 
   /*! \brief Check if the folder is excluded from scanning process
    \param strDirectory Directory to scan
-   \param regexps Regular expression to exclude from the scan
-   \return true if there is a .nomedia file or one of the regexps is a match
+   \return true if there is a .nomedia file
    */
-  bool IsExcluded(const std::string& strDirectory, const std::vector<std::string> &regexps);
+  bool HasNoMedia(const std::string& strDirectory) const;
 
   //! \brief Set whether or not to show a progress dialog.
   void ShowDialog(bool show) { m_showDialog = show; }
@@ -85,7 +84,4 @@ protected:
   bool m_bRunning = false; //!< Whether or not scanner is running
   bool m_bCanInterrupt = false; //!< Whether or not scanner is currently interruptable
   bool m_bClean = false; //!< Whether or not to perform cleaning during scanning
-
-private:
-  bool HasNoMedia(const std::string& strDirectory) const;
 };

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -483,7 +483,10 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   // Discard all excluded files defined by m_musicExcludeRegExps
   const std::vector<std::string> &regexps = g_advancedSettings.m_audioExcludeFromScanRegExps;
 
-  if (IsExcluded(strDirectory, regexps))
+  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+    return true;
+
+  if (HasNoMedia(strDirectory))
     return true;
 
   // load subfolder

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -262,7 +262,10 @@ namespace VIDEO
     const std::vector<std::string> &regexps = content == CONTENT_TVSHOWS ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
                                                          : g_advancedSettings.m_moviesExcludeFromScanRegExps;
 
-    if (IsExcluded(strDirectory, regexps))
+    if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+      return true;
+
+    if (HasNoMedia(strDirectory))
       return true;
 
     bool ignoreFolder = !m_scanAll && settings.noupdate;
@@ -422,8 +425,12 @@ namespace VIDEO
       if (!info2) // skip
         continue;
 
+      // Discard all .nomedia folders
+      if (pItem->m_bIsFolder && HasNoMedia(pItem->GetPath()))
+        continue;
+
       // Discard all exclude files defined by regExExclude
-      if (IsExcluded(pItem->GetPath(), (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
+      if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
                                                                     : g_advancedSettings.m_moviesExcludeFromScanRegExps))
         continue;
 
@@ -966,7 +973,7 @@ namespace VIDEO
         continue;
 
       // Discard all exclude files defined by regExExcludes
-      if (IsExcluded(items[i]->GetPath(), regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
         continue;
 
       /*


### PR DESCRIPTION
Ensure we're not doing pointless .nomedia checks on files. Regression was introduced with https://github.com/xbmc/xbmc/pull/12772

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://trac.kodi.tv/ticket/17651

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Briefly tested on Linux.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
