### PR TITLE
[PVR] CPVRRecordings: Do not open video database in CPVRRecordings ct…

### DIFF
--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -321,7 +321,7 @@ CBookmark CPVRRecording::GetResumePoint() const
 
 void CPVRRecording::UpdateMetadata(CVideoDatabase &db)
 {
-  if (m_bGotMetaData)
+  if (m_bGotMetaData || !db.IsOpen())
     return;
 
   if (!CServiceBroker::GetPVRManager().Clients()->GetClientCapabilities(m_iClientId).SupportsRecordingsPlayCount())

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -20,6 +20,7 @@
  */
 
 #include <map>
+#include <memory>
 
 #include "FileItem.h"
 #include "video/VideoDatabase.h"
@@ -103,7 +104,7 @@ namespace PVR
     bool m_bIsUpdating;
     PVR_RECORDINGMAP m_recordings;
     unsigned int m_iLastId;
-    CVideoDatabase m_database;
+    std::unique_ptr<CVideoDatabase> m_database;
     bool m_bDeletedTVRecordings;
     bool m_bDeletedRadioRecordings;
     unsigned int m_iTVRecordings;
@@ -113,6 +114,12 @@ namespace PVR
     std::string TrimSlashes(const std::string &strOrig) const;
     bool IsDirectoryMember(const std::string &strDirectory, const std::string &strEntryDirectory, bool bGrouped) const;
     void GetSubDirectories(const CPVRRecordingsPath &recParentPath, CFileItemList *results);
+
+    /**
+     * @brief Get/Open the video database.
+     * @return A reference to the video database.
+     */
+    CVideoDatabase& GetVideoDatabase();
 
     /**
      * @brief recursively deletes all recordings in the specified directory


### PR DESCRIPTION
…or. The latter might be called before Kodi's databases are initialized. Open the db in demand, instead.

This fixes a regression I introduced with https://github.com/xbmc/xbmc/commit/c59eb7c44429cc05c595db12668406cd60fe8cbb

I runtime-tested the changes on macOS, recent Kodi master.

@notspiff we talked about this earlier this morning. Good to go?