### PR TITLE
[CURL] Implement FILE_PROPERTY_EFFECTIVE_URL retrieval

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/Filesystem.h
@@ -241,7 +241,9 @@ typedef enum FilePropertyTypes
   /// Get file content charset
   ADDON_FILE_PROPERTY_CONTENT_CHARSET,
   /// Get file mime type
-  ADDON_FILE_PROPERTY_MIME_TYPE
+  ADDON_FILE_PROPERTY_MIME_TYPE,
+  /// Get file effective URL (last one if redirected)
+  ADDON_FILE_PROPERTY_EFFECTIVE_URL
 } FilePropertyTypes;
 //------------------------------------------------------------------------------
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1931,6 +1931,12 @@ const std::string CCurlFile::GetProperty(XFILE::FileProperty type, const std::st
     return m_state->m_httpheader.GetCharset();
   case FILE_PROPERTY_MIME_TYPE:
     return m_state->m_httpheader.GetMimeType();
+  case FILE_PROPERTY_EFFECTIVE_URL:
+  {
+    char *url = nullptr;
+    g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL, &url);
+    return url ? url : "";
+  }
   default:
     return "";
   }

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -107,7 +107,8 @@ enum FileProperty
   FILE_PROPERTY_RESPONSE_HEADER,            /**< Get response Header value  */
   FILE_PROPERTY_CONTENT_TYPE,               /**< Get file content-type  */
   FILE_PROPERTY_CONTENT_CHARSET,            /**< Get file content charset  */
-  FILE_PROPERTY_MIME_TYPE                   /**< Get file mime type  */
+  FILE_PROPERTY_MIME_TYPE,                  /**< Get file mime type  */
+  FILE_PROPERTY_EFFECTIVE_URL               /**< Get effective URL for redirected streams  */
 };
 
 }


### PR DESCRIPTION
This PR extends the CURLFile::GetProperty by EFFECTIVEURL.
Effective_URL is the URL wich is finally taken if a request is redirected.

## Motivation and Context
Multi-Bitrate Manifests (e.g. DASH) include in general relative paths to media files.
The media files has to be retrieved by concatting the effective (redirected) URL + relative path.

## How Has This Been Tested?
Teleboy Addon

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
