### PR TITLE
added: let the text viewer dialog hold a monospace font as well

### DIFF
--- a/addons/skin.estuary/xml/DialogTextViewer.xml
+++ b/addons/skin.estuary/xml/DialogTextViewer.xml
@@ -21,6 +21,7 @@
 				<shadowcolor>black</shadowcolor>
 				<pagecontrol>3000</pagecontrol>
 				<font>font14</font>
+				<monofont>mono30</monofont>
 			</control>
 			<control type="scrollbar" id="3000">
 				<include>HiddenObject</include>

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -30,7 +30,6 @@
 #include "addons/settings/GUIDialogAddonSettings.h"
 #include "cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.h"
 #include "dialogs/GUIDialogContextMenu.h"
-#include "dialogs/GUIDialogTextViewer.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "games/GameUtils.h"

--- a/xbmc/dialogs/GUIDialogTextViewer.cpp
+++ b/xbmc/dialogs/GUIDialogTextViewer.cpp
@@ -32,11 +32,6 @@ CGUIDialogTextViewer::CGUIDialogTextViewer(void)
 
 CGUIDialogTextViewer::~CGUIDialogTextViewer(void) = default;
 
-bool CGUIDialogTextViewer::OnAction(const CAction &action)
-{
-  return CGUIDialog::OnAction(action);
-}
-
 bool CGUIDialogTextViewer::OnMessage(CGUIMessage& message)
 {
   switch ( message.GetMessage() )
@@ -46,6 +41,7 @@ bool CGUIDialogTextViewer::OnMessage(CGUIMessage& message)
       CGUIDialog::OnMessage(message);
       SetHeading();
       SetText();
+      UseMonoFont(m_mono);
       return true;
     }
     break;
@@ -76,6 +72,13 @@ void CGUIDialogTextViewer::SetHeading()
 {
   CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_HEADING);
   msg.SetLabel(m_strHeading);
+  OnMessage(msg);
+}
+
+void CGUIDialogTextViewer::UseMonoFont(bool use)
+{
+  m_mono = use;
+  CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CONTROL_TEXTAREA, use ? 1 : 0);
   OnMessage(msg);
 }
 

--- a/xbmc/dialogs/GUIDialogTextViewer.h
+++ b/xbmc/dialogs/GUIDialogTextViewer.h
@@ -29,14 +29,15 @@ public:
   CGUIDialogTextViewer(void);
   ~CGUIDialogTextViewer(void) override;
   bool OnMessage(CGUIMessage& message) override;
-  bool OnAction(const CAction &action) override;
   void SetText(const std::string& strText) { m_strText = strText; }
   void SetHeading(const std::string& strHeading) { m_strHeading = strHeading; }
+  void UseMonoFont(bool use);
 protected:
   void OnDeinitWindow(int nextWindowID) override;
 
   std::string m_strText;
   std::string m_strHeading;
+  bool m_mono = false;
 
   void SetText();
   void SetHeading();

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -745,7 +745,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   bool scrollOut = true;
   int preloadItems = 0;
 
-  CLabelInfo labelInfo;
+  CLabelInfo labelInfo, labelInfoMono;
 
   CGUIInfoColor hitColor(0xFFFFFFFF);
   CGUIInfoColor textColor3;
@@ -847,9 +847,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   XMLUtils::GetFloat(pControlNode, "textoffsety", labelInfo.offsetY);
   int angle = 0;  // use the negative angle to compensate for our vertically flipped cartesian plane
   if (XMLUtils::GetInt(pControlNode, "angle", angle)) labelInfo.angle = (float)-angle;
-  std::string strFont;
+  std::string strFont, strMonoFont;
   if (XMLUtils::GetString(pControlNode, "font", strFont))
     labelInfo.font = g_fontManager.GetFont(strFont);
+  XMLUtils::GetString(pControlNode, "monofont", strMonoFont);
   uint32_t alignY = 0;
   if (GetAlignmentY(pControlNode, "aligny", alignY))
     labelInfo.align |= alignY;
@@ -1407,9 +1408,14 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     break;
   case CGUIControl::GUICONTROL_TEXTBOX:
     {
+      if (!strMonoFont.empty())
+      {
+        labelInfoMono = labelInfo;
+        labelInfoMono.font = g_fontManager.GetFont(strMonoFont);
+      }
       control = new CGUITextBox(
         parentID, id, posX, posY, width, height,
-        labelInfo, scrollTime);
+        labelInfo, scrollTime, strMonoFont.empty() ? nullptr : &labelInfoMono);
 
       CGUITextBox* tcontrol = static_cast<CGUITextBox*>(control);
 

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -28,7 +28,8 @@
 #include <algorithm>
 
 CGUITextBox::CGUITextBox(int parentID, int controlID, float posX, float posY, float width, float height,
-                         const CLabelInfo& labelInfo, int scrollTime)
+                         const CLabelInfo& labelInfo, int scrollTime,
+                         const CLabelInfo* labelInfoMono)
     : CGUIControl(parentID, controlID, posX, posY, width, height)
     , CGUITextLayout(labelInfo.font, true)
     , m_label(labelInfo)
@@ -48,6 +49,8 @@ CGUITextBox::CGUITextBox(int parentID, int controlID, float posX, float posY, fl
   m_autoScrollRepeatAnim = NULL;
   m_minHeight = 0;
   m_renderHeight = height;
+  if (labelInfoMono)
+    SetMonoFont(labelInfoMono->font);
 }
 
 CGUITextBox::CGUITextBox(const CGUITextBox &from)
@@ -292,6 +295,12 @@ bool CGUITextBox::OnMessage(CGUIMessage& message)
         Scroll(message.GetParam1());
         return true;
       }
+    }
+
+    if (message.GetMessage() == GUI_MSG_SET_TYPE)
+    {
+      UseMonoFont(message.GetParam1() == 1 ? true : false);
+      return true;
     }
   }
 

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -43,7 +43,8 @@ class CGUITextBox : public CGUIControl, public CGUITextLayout
 {
 public:
   CGUITextBox(int parentID, int controlID, float posX, float posY, float width, float height,
-              const CLabelInfo &labelInfo, int scrollTime = 200);
+              const CLabelInfo &labelInfo, int scrollTime = 200,
+              const CLabelInfo* labelInfoMono = nullptr);
   CGUITextBox(const CGUITextBox &from);
   ~CGUITextBox(void) override;
   CGUITextBox *Clone() const override { return new CGUITextBox(*this); };

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -41,7 +41,7 @@ std::string CGUIString::GetAsString() const
 
 CGUITextLayout::CGUITextLayout(CGUIFont *font, bool wrap, float fHeight, CGUIFont *borderFont)
 {
-  m_font = font;
+  m_varFont = m_font = font;
   m_borderFont = borderFont;
   m_textColor = 0;
   m_wrap = wrap;

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -123,6 +123,12 @@ protected:
    \return utf8 text
    */
   std::string GetText() const;
+
+  //! \brief Set the monospaced font to use
+  void SetMonoFont(CGUIFont* font) { m_monoFont = font; }
+
+  //! \brief Set whether or not to use the monospace font
+  void UseMonoFont(bool use) { m_font = use && m_monoFont ? m_monoFont : m_varFont; }
   
   // our text to render
   vecColors m_colors;
@@ -132,6 +138,8 @@ protected:
   // the layout and font details
   CGUIFont *m_font;        // has style, colour info
   CGUIFont *m_borderFont;  // only used for outlined text
+  CGUIFont* m_monoFont = nullptr; //!< Mono-space font to use
+  CGUIFont* m_varFont;    //!< Varible-space font to use
 
   bool  m_wrap;            // wrapping (true if justify is enabled!)
   float m_maxHeight;

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -185,7 +185,7 @@ namespace XBMCAddon
       return HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{line1}, CVariant{line2}, CVariant{line3});
     }
 
-    void Dialog::textviewer(const String& heading, const String& text)
+    void Dialog::textviewer(const String& heading, const String& text, bool usemono)
     {
       DelayedCallGuard dcguard(languageHook);
 
@@ -196,6 +196,7 @@ namespace XBMCAddon
         pDialog->SetHeading(heading);
       if (!text.empty())
         pDialog->SetText(text);
+      pDialog->UseMonoFont(usemono);
       pDialog->Open();
     }
 

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -280,20 +280,22 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Dialog
-      /// \python_func{ xbmcgui.Dialog().textviewer(heading, text) }
+      /// \python_func{ xbmcgui.Dialog().textviewer(heading, text, usemono) }
       ///------------------------------------------------------------------------
       ///
-      /// **TextViewe dialog**
+      /// **TextViewer dialog**
       ///
       /// The text viewer dialog can be used to display descriptions, help texts
       /// or other larger texts.
       ///
       /// @param heading       string or unicode - dialog heading.
       /// @param text          string or unicode - text.
+      /// @param usemono       [opt] bool - use monospace font
       ///
       ///
       ///------------------------------------------------------------------------
       /// @python_v16 New function added.
+      /// @python_v18 New optional param added **usemono**.
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -305,7 +307,7 @@ namespace XBMCAddon
       ///
       textviewer(...);
 #else
-      void textviewer(const String& heading, const String& text);
+      void textviewer(const String& heading, const String& text, bool usemono = false);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS


### PR DESCRIPTION
add 't' keymap to toggle between monospace and variable space
add a bool param to the python method to allow setting the default