### PR TITLE
added: action to toggle between monospaced and variable spaced font in text viewer dialog

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -779,4 +779,9 @@
       <o>PlayerProcessInfo</o>
     </keyboard>
   </PlayerProcessInfo>
+  <TextViewer>
+    <keyboard>
+      <t>ToggleFont</t>
+    </keyboard>
+  </TextViewer>
 </keymap>

--- a/xbmc/dialogs/GUIDialogTextViewer.cpp
+++ b/xbmc/dialogs/GUIDialogTextViewer.cpp
@@ -22,6 +22,8 @@
 #include "GUIUserMessages.h"
 #include "filesystem/File.h"
 #include "guilib/GUIWindowManager.h"
+#include "input/Action.h"
+#include "input/ActionIDs.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 
@@ -37,6 +39,17 @@ CGUIDialogTextViewer::CGUIDialogTextViewer(void)
 }
 
 CGUIDialogTextViewer::~CGUIDialogTextViewer(void) = default;
+
+bool CGUIDialogTextViewer::OnAction(const CAction &action)
+{
+  if (action.GetID() == ACTION_TOGGLE_FONT)
+  {
+    UseMonoFont(!m_mono);
+    return true;
+  }
+
+  return CGUIDialog::OnAction(action);
+}
 
 bool CGUIDialogTextViewer::OnMessage(CGUIMessage& message)
 {

--- a/xbmc/dialogs/GUIDialogTextViewer.h
+++ b/xbmc/dialogs/GUIDialogTextViewer.h
@@ -39,6 +39,7 @@ public:
   static void ShowForFile(const std::string& path, bool useMonoFont);
 protected:
   void OnDeinitWindow(int nextWindowID) override;
+  bool OnAction(const CAction &action) override;
 
   std::string m_strText;
   std::string m_strHeading;

--- a/xbmc/input/ActionIDs.h
+++ b/xbmc/input/ActionIDs.h
@@ -275,6 +275,8 @@
 
 #define ACTION_PLAYER_RESET           248 //!< Send a reset command to the active game
 
+#define ACTION_TOGGLE_FONT            249 //!< Toggle font. Used in TextViewer dialog
+
 // Voice actions
 #define ACTION_VOICE_RECOGNIZE        300
 

--- a/xbmc/input/ActionTranslator.cpp
+++ b/xbmc/input/ActionTranslator.cpp
@@ -200,6 +200,7 @@ static const std::map<ActionName, ActionID> ActionMappings =
     { "createepisodebookmark"    , ACTION_CREATE_EPISODE_BOOKMARK },
     { "settingsreset"            , ACTION_SETTINGS_RESET },
     { "settingslevelchange"      , ACTION_SETTINGS_LEVEL_CHANGE },
+    { "togglefont"               , ACTION_TOGGLE_FONT},
 
     // 3D movie playback/GUI
     { "stereomode"               , ACTION_STEREOMODE_SELECT },   // cycle 3D modes, for now an alias for next


### PR DESCRIPTION
i am absolutely stoked that removal of this can be stated as a condition for merging of https://github.com/xbmc/xbmc/pull/13092 

i thus open this separate pr for your consideration.

i find this functionality very useful, you will recognize it from a lot of file managers such as total commander etc.