### PR TITLE
[PVR] Cleanup: No more GUI stuff in class CPVRTimerInfoTag

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9701,7 +9701,6 @@ msgstr ""
 
 #. message box text stating that an epg event is already being recorded
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19067"
 msgid "This event is already being recorded."
 msgstr ""
@@ -9959,21 +9958,19 @@ msgid "Fallback framerate"
 msgstr ""
 
 #. message box text stating that a timer could not be saved
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 #: xbmc/pvr/PVRGUIActions.cpp
 msgctxt "#19109"
-msgid "Couldn't save timer. Check the log for more information about this message."
+msgid "Could not save the timer. Check the log for more information about this message."
 msgstr ""
 
-#. message box text stating that an unexpected error occured
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+#. message box text stating that a timer could not be deleted
+#: xbmc/pvr/PVRGUIActions.cpp
 msgctxt "#19110"
-msgid "An unexpected error occurred. Try again later or check the log for more information."
+msgid "Could not delete the timer. Check the log for more information about this message."
 msgstr ""
 
 #. message box text stating that a PVR backend error occured
 #: xbmc/pvr/PVRGUIActions.cpp
-#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
 msgctxt "#19111"
 msgid "PVR backend error. Check the log for more information about this message."
 msgstr ""
@@ -10279,7 +10276,7 @@ msgstr ""
 #. error box text stating that recording could not be started
 #: xbmc/pvr/PVRGUIActions.cpp
 msgctxt "#19164"
-msgid "Can't start recording. Check the log for more information about this message."
+msgid "Could not start recording. Check the log for more information about this message."
 msgstr ""
 
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -10312,7 +10309,11 @@ msgctxt "#19169"
 msgid "Hide video information box"
 msgstr ""
 
-#empty string with id 19170
+#. error box text stating that recording could not be stopped
+#: xbmc/pvr/PVRGUIActions.cpp
+msgctxt "#19170"
+msgid "Could not stop recording. Check the log for more information about this message."
+msgstr ""
 
 #. pvr settings "start playback full screen" setting label
 #: system/settings/settings.xml
@@ -10860,7 +10861,11 @@ msgctxt "#19262"
 msgid "Parental control. Enter PIN:"
 msgstr ""
 
-#empty string with id 19263
+#. message box text stating that a timer could not be updated
+#: xbmc/pvr/PVRGUIActions.cpp
+msgctxt "#19263"
+msgid "Could not update the timer. Check the log for more information about this message."
+msgstr ""
 
 #. label for 'incorrect pin' error dialog header
 #: xbmc/pvr/PVRGUIActions.cpp

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -365,7 +365,7 @@ JSONRPC_STATUS CPVROperations::DeleteTimer(const std::string &method, ITransport
   if (!timer)
     return InvalidParams;
 
-  if (timers->DeleteTimer(timer, timer->IsRecording(), false))
+  if (timers->DeleteTimer(timer, timer->IsRecording(), false) == TimerOperationResult::OK)
     return ACK;
 
   return FailedToExecute;
@@ -390,7 +390,7 @@ JSONRPC_STATUS CPVROperations::ToggleTimer(const std::string &method, ITransport
       timer = CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer);
 
     if (timer)
-      sentOkay = CServiceBroker::GetPVRManager().Timers()->DeleteTimer(timer, timer->IsRecording(), false);
+      sentOkay = (CServiceBroker::GetPVRManager().Timers()->DeleteTimer(timer, timer->IsRecording(), false) == TimerOperationResult::OK);
   }
   else
   {

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -367,6 +367,15 @@ namespace PVR
     bool DeleteTimer(const CFileItemPtr &item, bool bIsRecording, bool bDeleteRule) const;
 
     /*!
+     * @brief Delete a timer or timer rule, showing a confirmation dialog in case a timer currently recording shall be deleted.
+     * @param timer containing a timer or timer rule to delete.
+     * @param bIsRecording denotes whether the timer is currently recording (controls correct confirmation dialog).
+     * @param bDeleteRule denotes to delete a timer rule. For convenience, one can pass a timer created by a rule.
+     * @return true, if the timer or timer rule was deleted successfully, false otherwise.
+     */
+    bool DeleteTimer(const CPVRTimerInfoTagPtr &timer, bool bIsRecording, bool bDeleteRule) const;
+
+    /*!
      * @brief Open a dialog to confirm timer delete.
      * @param timer the timer to delete.
      * @param bDeleteRule in: ignored

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -792,7 +792,7 @@ namespace PVR
      */
     PVR_ERROR GetCreatedClients(CPVRClientMap &clientsReady, std::vector<int> &clientsNotReady) const;
 
-    typedef std::function<PVR_ERROR(const CPVRClientPtr &client)> PVRClientFunction;
+    typedef std::function<PVR_ERROR(const CPVRClientPtr&)> PVRClientFunction;
 
     /*!
      * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.
@@ -806,7 +806,7 @@ namespace PVR
      * @brief Wraps calls to all created clients in order to do common pre and post function invocation actions.
      * @param strFunctionName The function name, for logging purposes.
      * @param function The function to wrap. It has to have return type PVR_ERROR and must take a const reference to a CPVRClientPtr as parameter.
-     * @param faildeClients Contains a list of the ids of clients for that the call failed, if any.
+     * @param failedClients Contains a list of the ids of clients for that the call failed, if any.
      * @return PVR_ERROR_NO_ERROR on success, any other PVR_ERROR_* value otherwise.
      */
     PVR_ERROR ForCreatedClients(const char* strFunctionName, PVRClientFunction function, std::vector<int> &failedClients) const;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -45,6 +45,13 @@ class CVariant;
 
 namespace PVR
 {
+  enum class TimerOperationResult
+  {
+    OK,
+    FAILED,
+    RECORDING // The timer was not deleted because it is currently recording (see DeleteTimer).
+  };
+
   class CPVRTimerInfoTag : public ISerializable
   {
   public:
@@ -59,8 +66,6 @@ namespace PVR
     void Serialize(CVariant &value) const override;
 
     void UpdateSummary(void);
-
-    void DisplayError(PVR_ERROR err) const;
 
     std::string GetStatus() const;
     std::string GetTypeAsString() const;
@@ -220,10 +225,31 @@ namespace PVR
      */
     unsigned int UniqueBroadcastID() const { return m_iEpgUid; }
 
-    /* Client control functions */
+    /*!
+     * @brief Add this timer to the backend, transferring all local data of this timer to the backend.
+     * @return True on success, false otherwise.
+     */
     bool AddToClient() const;
-    bool DeleteFromClient(bool bForce = false) const;
+
+    /*!
+     * @brief Delete this timer on the backend.
+     * @param bForce Control what to do in case the timer is currently recording.
+     *        True to force to delete the timer, false to return TimerDeleteResult::RECORDING.
+     * @return The result.
+     */
+    TimerOperationResult DeleteFromClient(bool bForce = false) const;
+
+    /*!
+     * @brief Rename this timer on the backend, transferring all local data of this timer to the backend.
+     * @param strNewName The new name.
+     * @return True on success, false otherwise.
+     */
     bool RenameOnClient(const std::string &strNewName);
+
+    /*!
+     * @brief Update this timer on the backend, transferring all local data of this timer to the backend.
+     * @return True on success, false otherwise.
+     */
     bool UpdateOnClient();
 
     /*!

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -659,7 +659,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
         if (bDeleteActiveItem && bDeleteTimerRuleItem && bChannelsMatch)
         {
           CLog::Log(LOGDEBUG,"PVRTimers - %s - deleted timer %d on client %d", __FUNCTION__, (*timerIt)->m_iClientIndex, (*timerIt)->m_iClientId);
-          bReturn = (*timerIt)->DeleteFromClient(true) || bReturn;
+          bReturn = ((*timerIt)->DeleteFromClient(true) == TimerOperationResult::OK) || bReturn;
           bChanged = true;
         }
       }
@@ -676,15 +676,15 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannelPtr &channel, bool bDele
 
 /********** static methods **********/
 
-bool CPVRTimers::AddTimer(const CPVRTimerInfoTagPtr &item)
+bool CPVRTimers::AddTimer(const CPVRTimerInfoTagPtr &tag)
 {
-  return item->AddToClient();
+  return tag->AddToClient();
 }
 
-bool CPVRTimers::DeleteTimer(const CPVRTimerInfoTagPtr &tag, bool bForce /* = false */, bool bDeleteRule /* = false */)
+TimerOperationResult CPVRTimers::DeleteTimer(const CPVRTimerInfoTagPtr &tag, bool bForce /* = false */, bool bDeleteRule /* = false */)
 {
   if (!tag)
-    return false;
+    return TimerOperationResult::FAILED;
 
   if (bDeleteRule)
   {
@@ -693,33 +693,21 @@ bool CPVRTimers::DeleteTimer(const CPVRTimerInfoTagPtr &tag, bool bForce /* = fa
     if (!ruleTag)
     {
       CLog::Log(LOGERROR, "PVRTimers - %s - unable to obtain timer rule for given timer", __FUNCTION__);
-      return false;
+      return TimerOperationResult::FAILED;
     }
-    return ruleTag->DeleteFromClient(bForce);
   }
 
   return tag->DeleteFromClient(bForce);
 }
 
-bool CPVRTimers::RenameTimer(CFileItem &item, const std::string &strNewName)
+bool CPVRTimers::RenameTimer(const CPVRTimerInfoTagPtr &tag, const std::string &strNewName)
 {
-  /* Check if a CPVRTimerInfoTag is inside file item */
-  if (!item.IsPVRTimer())
-  {
-    CLog::Log(LOGERROR, "PVRTimers - %s - no TimerInfoTag given", __FUNCTION__);
-    return false;
-  }
-
-  CPVRTimerInfoTagPtr tag = item.GetPVRTimerInfoTag();
-  if (!tag)
-    return false;
-
   return tag->RenameOnClient(strNewName);
 }
 
-bool CPVRTimers::UpdateTimer(const CPVRTimerInfoTagPtr &item)
+bool CPVRTimers::UpdateTimer(const CPVRTimerInfoTagPtr &tag)
 {
-  return item->UpdateOnClient();
+  return tag->UpdateOnClient();
 }
 
 bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel &channel) const

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -218,28 +218,34 @@ namespace PVR
 
     /*!
      * @brief Add a timer to the client. Doesn't add the timer to the container. The backend will do this.
+     * @param tag The timer to add.
      * @return True if timer add request was sent correctly, false if not.
      */
-     static bool AddTimer(const CPVRTimerInfoTagPtr &item);
+     static bool AddTimer(const CPVRTimerInfoTagPtr &tag);
 
     /*!
      * @brief Delete a timer on the client. Doesn't delete the timer from the container. The backend will do this.
+     * @param tag The timer to delete.
+     * @param bForce Control what to do in case the timer is currently recording.
+     *        True to force to delete the timer, false to return TimerDeleteResult::RECORDING.
      * @param bDeleteRule Also delete the timer rule that scheduled the timer instead of single timer only.
-     * @return True if timer delete request was sent correctly, false if not.
+     * @return The result.
      */
-    static bool DeleteTimer(const CPVRTimerInfoTagPtr &tag, bool bForce = false, bool bDeleteRule = false);
+    static TimerOperationResult DeleteTimer(const CPVRTimerInfoTagPtr &tag, bool bForce = false, bool bDeleteRule = false);
 
     /*!
      * @brief Rename a timer on the client. Doesn't update the timer in the container. The backend will do this.
+     * @param tag The timer to rename.
      * @return True if timer rename request was sent correctly, false if not.
      */
-    static bool RenameTimer(CFileItem &item, const std::string &strNewName);
+    static bool RenameTimer(const CPVRTimerInfoTagPtr &tag, const std::string &strNewName);
 
     /*!
      * @brief Update the timer on the client. Doesn't update the timer in the container. The backend will do this.
+     * @param tag The timer to update.
      * @return True if timer update request was sent correctly, false if not.
      */
-    static bool UpdateTimer(const CPVRTimerInfoTagPtr &item);
+    static bool UpdateTimer(const CPVRTimerInfoTagPtr &tag);
 
     /*!
      * @brief Get the timer tag that matches the given epg tag.


### PR DESCRIPTION
This was the last step to remove GUI stuff from PVR core classes. Plus some doxy and naming cleanup along the line...

As always, runtime-tested on macOS, latest Kodi master.

@Jalle19 good to go?