### PR TITLE
kodi.sh: Properly quote eventually empty variables

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -60,19 +60,19 @@ done
 # Your distribution might provide extra packages for those
 if [ "$WINDOWING" = "auto" ]; then
     # Wayland
-    if [ -n $WAYLAND_DISPLAY ] && [ -x $LIBDIR/${bin_name}/${bin_name}-wayland ]; then
+    if [ -n "$WAYLAND_DISPLAY" ] && [ -x $LIBDIR/${bin_name}/${bin_name}-wayland ]; then
         KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-wayland
     # X11
     elif echo $DISPLAY | grep -qE ":[0-9]+" && [ -x $LIBDIR/${bin_name}/${bin_name}-x11 ]; then
         KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-x11
     # GBM/DRM
-    elif [ -z $DISPLAY ] && [ -z $WAYLAND_DISPLAY ] && [ -x $LIBDIR/${bin_name}/${bin_name}-gbm ]; then
+    elif [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ] && [ -x $LIBDIR/${bin_name}/${bin_name}-gbm ]; then
         KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-gbm
     # Default kodi.bin
     else
         KODI_BINARY=${APP_BINARY}
     fi
-elif [ -n $WINDOWING ]; then
+elif [ -n "$WINDOWING" ]; then
     KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-${WINDOWING}
 else
     KODI_BINARY=${APP_BINARY}


### PR DESCRIPTION
## Motivation and Context
On Ubuntu a #!/bin/sh shebang results in a pretty minimal shell that handles empty variables not as graceful as bash. Quoting helps here.

## How Has This Been Tested?
Tested in an Ubuntu Artful X.org session where `kodi.sh` selected Wayland erroneously. It properly selected X11 after my change. 

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
