### PR TITLE
drop OSX specific keyboard hack

### DIFF
--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -133,9 +133,6 @@
 // Message sent to CGUIWindowSlideshow to show picture
 #define GUI_MSG_SHOW_PICTURE          GUI_MSG_USER + 36
 
-// Sent to text field to support 'input method'
-#define GUI_MSG_INPUT_TEXT_EDIT       GUI_MSG_USER + 38
-
 // Sent to CGUIWindowEventLog
 #define GUI_MSG_EVENT_ADDED        GUI_MSG_USER + 39
 #define GUI_MSG_EVENT_REMOVED      GUI_MSG_USER + 40

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -100,7 +100,6 @@ CGUIDialogKeyboardGeneric::CGUIDialogKeyboardGeneric()
 
 void CGUIDialogKeyboardGeneric::OnWindowLoaded()
 {
-  CServiceBroker::GetWinSystem().EnableTextInput(false);
   CGUIEditControl *edit = static_cast<CGUIEditControl*>(GetControl(CTL_EDIT));
   if (edit)
   {
@@ -315,7 +314,6 @@ bool CGUIDialogKeyboardGeneric::OnMessage(CGUIMessage& message)
     break;
 
   case GUI_MSG_SET_TEXT:
-  case GUI_MSG_INPUT_TEXT_EDIT:
     {
       // the edit control only handles these messages if it is either focused
       // or its specific control ID is set in the message. As neither is the

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -100,14 +100,6 @@ bool CGUIEditControl::OnMessage(CGUIMessage &message)
     SetLabel2(message.GetLabel());
     UpdateText();
   }
-  else if (message.GetMessage() == GUI_MSG_INPUT_TEXT_EDIT && HasFocus())
-  {
-    g_charsetConverter.utf8ToW(message.GetLabel(), m_edit);
-    m_editOffset = message.GetParam1();
-    m_editLength = message.GetParam2();
-    UpdateText(false);
-    return true;
-  }
   return CGUIButtonControl::OnMessage(message);
 }
 
@@ -258,12 +250,9 @@ bool CGUIEditControl::OnAction(const CAction &action)
         }
       default:
         {
-          if (!CServiceBroker::GetWinSystem().IsTextInputEnabled())
-          {
-            ClearMD5();
-            m_edit.clear();
-            m_text2.insert(m_text2.begin() + m_cursorPos++, (WCHAR)action.GetUnicode());
-          }
+          ClearMD5();
+          m_edit.clear();
+          m_text2.insert(m_text2.begin() + m_cursorPos++, (WCHAR)action.GetUnicode());
           break;
         }
       }
@@ -744,7 +733,6 @@ void CGUIEditControl::ValidateInput()
 void CGUIEditControl::SetFocus(bool focus)
 {
   m_smsTimer.Stop();
-  CServiceBroker::GetWinSystem().EnableTextInput(focus);
   CGUIControl::SetFocus(focus);
   SetInvalid();
 }

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -3,9 +3,6 @@
 \brief
 */
 
-#ifndef GUILIB_GUIEditControl_H
-#define GUILIB_GUIEditControl_H
-
 #pragma once
 
 /*
@@ -141,4 +138,3 @@ protected:
   static const char*        smsLetters[10];
   static const unsigned int smsDelay;
 };
-#endif

--- a/xbmc/platform/darwin/osx/OSXTextInputResponder.mm
+++ b/xbmc/platform/darwin/osx/OSXTextInputResponder.mm
@@ -48,10 +48,11 @@ void SendKeyboardText(const char *text)
 
 void SendEditingText(const char *text, unsigned int location, unsigned int length)
 {
+  //@todo fix this hack
 //  CLog::Log(LOGDEBUG, "SendEditingText(%s, %u, %u)", text, location, length);
-  CGUIMessage msg(GUI_MSG_INPUT_TEXT_EDIT, 0, 0, location, length);
-  msg.SetLabel(text);
-  g_windowManager.SendThreadMessage(msg, g_windowManager.GetFocusedWindow());
+//  CGUIMessage msg(GUI_MSG_INPUT_TEXT_EDIT, 0, 0, location, length);
+//  msg.SetLabel(text);
+//  g_windowManager.SendThreadMessage(msg, g_windowManager.GetFocusedWindow());
 }
 
 @implementation OSXTextInputResponder

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -132,8 +132,6 @@ public:
   virtual bool HasCalibration(const RESOLUTION_INFO &resInfo) { return true; };
 
   // text input interface
-  virtual void EnableTextInput(bool bEnable) {}
-  virtual bool IsTextInputEnabled() { return false; }
   virtual std::string GetClipboardText(void);
 
   // Display event callback

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -59,9 +59,6 @@ public:
   virtual bool Show(bool raise = true) override;
   virtual void OnMove(int x, int y) override;
 
-  virtual void EnableTextInput(bool bEnable) override;
-  virtual bool IsTextInputEnabled() override;
-
   virtual std::string GetClipboardText(void) override;
 
   void Register(IDispResource *resource) override;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1717,20 +1717,7 @@ std::unique_ptr<IOSScreenSaver> CWinSystemOSX::GetOSScreenSaverImpl()
   return std::unique_ptr<IOSScreenSaver> (new COSScreenSaverOSX);
 }
 
-void CWinSystemOSX::EnableTextInput(bool bEnable)
-{
-  if (bEnable)
-    StartTextInput();
-  else
-    StopTextInput();
-}
-
 OSXTextInputResponder *g_textInputResponder = nil;
-
-bool CWinSystemOSX::IsTextInputEnabled()
-{
-  return g_textInputResponder != nil && [[g_textInputResponder superview] isEqual: [[NSApp keyWindow] contentView]];
-}
 
 void CWinSystemOSX::StartTextInput()
 {


### PR DESCRIPTION
This removes a OSX specific hack. Adding methods to an interface that are only used by a single platform is wrong. 

@Memphiz OSX might lose some special feature but going further with windowing has higher prio. Platforms are not supposed to bypass the normal way of sending kayboard events to the application.