### PR TITLE
[Music]Fix cancelling of music library export

### DIFF
--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -173,6 +173,15 @@ void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
   SetInvalid();
 }
 
+bool CGUIDialogProgress::Wait(int progresstime /*= 10*/)
+{
+  CEvent m_done;
+  while (!m_done.WaitMSec(progresstime) && m_active && !m_bCanceled)
+    Progress();
+
+  return !m_bCanceled;
+}
+
 void CGUIDialogProgress::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (m_bInvalidated)

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -39,6 +39,15 @@ public:
   void SetPercentage(int iPercentage);
   int GetPercentage() const { return m_percentage; };
   void ShowProgressBar(bool bOnOff);
+  
+  /*! \brief Wait for the progress dialog to be closed or canceled, while regularly
+   rendering to allow for pointer movement or progress to be shown. Used when showing
+   the progress of a process that is taking place on a separate thread and may be 
+   reporting progress infrequently.
+   \param progresstime the time in ms to wait between rendering the dialog (defaults to 10ms)
+   \return true if the dialog is closed, false if the user cancels early.
+   */
+  bool Wait(int progresstime = 10);
 
   // Implements IProgressCallback
   void SetProgressMax(int iMax) override;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6671,10 +6671,12 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
           }
         }
 
-        if ((current % 50) == 0 && progressDialog != NULL)
+        if ((current % 50) == 0 && progressDialog)
         {
           progressDialog->SetLine(1, CVariant{ album.strAlbum });
           progressDialog->SetPercentage(current * 100 / total);
+          if (progressDialog->IsCanceled())
+            return;
         }
         current++;
       }
@@ -6786,10 +6788,12 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
             xmlDoc.InsertEndChild(decl);
           }
         }
-        if ((current % 50) == 0 && progressDialog != NULL)
+        if ((current % 50) == 0 && progressDialog)
         {
           progressDialog->SetLine(1, CVariant{ artist.strArtist });
           progressDialog->SetPercentage(current * 100 / total);
+          if (progressDialog->IsCanceled())
+            return;
         }
         current++;
       }

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -73,12 +73,11 @@ void CMusicLibraryQueue::ExportLibrary(const CLibExportSettings& settings, bool 
 
     if (progress)
     {
-      // Render and wait for export to complete or be cancelled
-      while (progress->IsActive() && !progress->IsCanceled())
+      // Wait for export to complete or be canceled, but render every 10 milliseconds so 
+      // that pointer movements work on dialog even when export is reporting progress infrequently
+      CEvent m_done;
+      while (!m_done.WaitMSec(10) && progress->IsActive() && !progress->IsCanceled())
         progress->Progress();
-      // Finally close progress dialog
-      if (progress->IsActive())
-        progress->Close();
     }
   }
   else

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -71,14 +71,10 @@ void CMusicLibraryQueue::ExportLibrary(const CLibExportSettings& settings, bool 
   {    
     AddJob(exportJob);
 
+    // Wait for export to complete or be canceled, but render every 10ms so that the 
+    // pointer movements work on dialog even when export is reporting progress infrequently
     if (progress)
-    {
-      // Wait for export to complete or be canceled, but render every 10 milliseconds so 
-      // that pointer movements work on dialog even when export is reporting progress infrequently
-      CEvent m_done;
-      while (!m_done.WaitMSec(10) && progress->IsActive() && !progress->IsCanceled())
-        progress->Progress();
-    }
+      progress->Wait();
   }
   else
   {

--- a/xbmc/music/jobs/MusicLibraryExportJob.cpp
+++ b/xbmc/music/jobs/MusicLibraryExportJob.cpp
@@ -29,6 +29,7 @@ CMusicLibraryExportJob::CMusicLibraryExportJob(const CLibExportSettings& setting
 { 
   if (progressDialog)
     SetProgressIndicators(NULL, progressDialog);
+  SetAutoClose(true);
 }
 
 CMusicLibraryExportJob::~CMusicLibraryExportJob() = default;


### PR DESCRIPTION
Library export process was continuing in background after cancel button clicked on progress dialog.