### PR TITLE
 [MediaManager/gui] Cache disc label

### DIFF
--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -506,6 +506,11 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
   auto cached = m_mapDiscInfo.find(mediaPath);
   if (cached != m_mapDiscInfo.end())
     return cached->second.name;
+  
+  // try to minimize the chance of a "device not ready" dialog
+  std::string drivePath = g_mediaManager.TranslateDevicePath(devicePath, true);
+  if (g_mediaManager.GetDriveStatus(drivePath) != DRIVE_CLOSED_MEDIA_PRESENT)
+    return "";
 
   DiscInfo info;
   info = GetDiscInfo(mediaPath);

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -122,6 +122,8 @@ private:
   };
 
   DiscInfo GetDiscInfo(const std::string& mediaPath);
+  void RemoveDiscInfo(const std::string& devicePath);
+  std::map<std::string, DiscInfo> m_mapDiscInfo;
 };
 
 extern class CMediaManager g_mediaManager;


### PR DESCRIPTION
Commit 1:  The gui is repeatedly querying the disc label. This leads to frequent disc accesses and therefore to lags when the disc button is selected, e.g. on the home screen.

Commit 2: If the user ejects the disc while the gui is querying the disc label there's a very high chance that the  "device not ready" dialog of the os (windows error 21) is shown.