### PR TITLE
VideoPlayer: drop some outdated and unsafe(threading) code

### DIFF
--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -318,15 +318,6 @@ void CApplicationPlayer::SeekTimeRelative(int64_t iTime)
   }
 }
 
-std::string CApplicationPlayer::GetPlayingTitle()
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    return player->GetPlayingTitle();
-  else
-    return "";
-}
-
 int64_t CApplicationPlayer::GetTime() const
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -114,7 +114,6 @@ public:
   int64_t GetChapterPos(int chapterIdx=-1);
   float GetPercentage() const;
   std::string GetPlayerState();
-  std::string GetPlayingTitle();
   int   GetPreferredPlaylist() const;
   int   GetSubtitle();
   void  GetSubtitleCapabilities(std::vector<int> &subCaps);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6127,17 +6127,10 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
           return m_currentFile->GetVideoInfoTag()->m_strTitle;
         if (m_currentFile->HasMusicInfoTag() && !m_currentFile->GetMusicInfoTag()->GetTitle().empty())
           return m_currentFile->GetMusicInfoTag()->GetTitle();
-        // don't have the title, so use VideoPlayer, label, or drop down to title from path
-        if (!g_application.m_pPlayer->GetPlayingTitle().empty())
-          return g_application.m_pPlayer->GetPlayingTitle();
+        // don't have the title, so use label or drop down to title from path
         if (!m_currentFile->GetLabel().empty())
           return m_currentFile->GetLabel();
         return CUtil::GetTitleFromPath(m_currentFile->GetPath());
-      }
-      else
-      {
-        if (!g_application.m_pPlayer->GetPlayingTitle().empty())
-          return g_application.m_pPlayer->GetPlayingTitle();
       }
     }
     break;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -205,8 +205,6 @@ public:
   virtual std::string GetPlayerState() { return ""; };
   virtual bool SetPlayerState(const std::string& state) { return false;};
   
-  virtual std::string GetPlayingTitle() { return ""; };
-
   virtual void GetAudioCapabilities(std::vector<int> &audioCaps) { audioCaps.assign(1,IPC_AUD_ALL); };
   /*!
    \brief define the subtitle capabilities of the player

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -115,7 +115,6 @@ namespace RETRO
     bool OnAction(const CAction &action) override;
     std::string GetPlayerState() override;
     bool SetPlayerState(const std::string& state) override;
-    //virtual std::string GetPlayingTitle() override { return ""; }
     //virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel) override { return false; }
     //virtual void GetAudioCapabilities(std::vector<int> &audioCaps) override { audioCaps.assign(1,IPC_AUD_ALL); }
     //virtual void GetSubtitleCapabilities(std::vector<int> &subCaps) override { subCaps.assign(1,IPC_SUBS_ALL); }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4947,16 +4947,6 @@ bool CVideoPlayer::Record(bool bOnOff)
   return false;
 }
 
-std::string CVideoPlayer::GetPlayingTitle()
-{
-  /* Currently we support only Title Name from Teletext line 30 */
-  TextCacheStruct_t* ttcache = m_VideoPlayerTeletext->GetTeletextCache();
-  if (ttcache && !ttcache->line30.empty())
-    return ttcache->line30;
-
-  return "";
-}
-
 CVideoSettings CVideoPlayer::GetVideoSettings()
 {
   return m_processInfo->GetVideoSettings();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -369,8 +369,6 @@ public:
   std::string GetPlayerState() override;
   bool SetPlayerState(const std::string& state) override;
 
-  std::string GetPlayingTitle() override;
-
   void FrameMove() override;
   void Render(bool clear, uint32_t alpha = 255, bool gui = true) override;
   void FlushRenderer() override;

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -592,11 +592,6 @@ failed:
   return 0;
 };
 
-std::string CUPnPPlayer::GetPlayingTitle()
-{
-  return "";
-};
-
 bool CUPnPPlayer::OnAction(const CAction &action)
 {
   switch (action.GetID())

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -69,7 +69,6 @@ public:
   void DoAudioWork() override;
   bool OnAction(const CAction &action) override;
 
-  std::string GetPlayingTitle() override;
   void FrameMove() override;
 
   int PlayFile(const CFileItem& file, const CPlayerOptions& options, CGUIDialogBusy*& dialog, XbmcThreads::EndTime& timeout);


### PR DESCRIPTION
I don't think there is anybody who needs a fallback method for playing title that requires teletext. It wasn't implemented properly anyway.