### PR TITLE
[Music]Cleaning and scanning using music job queue

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -102,7 +102,7 @@ public:
   bool CommitTransaction() override;
   void EmptyCache();
   void Clean();
-  int  Cleanup(bool bShowProgress=true);
+  int  Cleanup(CGUIDialogProgress* progressDialog = nullptr);
   bool LookupCDDBInfo(bool bRequery=false);
   void DeleteCDDBInfo();
 
@@ -572,7 +572,7 @@ private:
   void GetFileItemFromDataset(CFileItem* item, const CMusicDbUrl &baseUrl);
   void GetFileItemFromDataset(const dbiplus::sql_record* const record, CFileItem* item, const CMusicDbUrl &baseUrl);
   void GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item);
-  bool CleanupSongs();
+  bool CleanupSongs(CGUIDialogProgress* progressDialog = nullptr);
   bool CleanupSongsByIds(const std::string &strSongIds);
   bool CleanupPaths();
   bool CleanupAlbums();

--- a/xbmc/music/MusicLibraryQueue.h
+++ b/xbmc/music/MusicLibraryQueue.h
@@ -48,11 +48,57 @@ public:
   static CMusicLibraryQueue& GetInstance();
 
   /*!
-  \brief Enqueue a music library export job.
-  \param[in] settings   Library export settings
-  \param[in] showDialog Show a progress dialog while (asynchronously) exporting, otherwise export in synchronous
+   \brief Enqueue a music library export job.
+   \param[in] settings   Library export settings
+   \param[in] showDialog Show a progress dialog while (asynchronously) exporting, otherwise export in synchronous
   */
   void ExportLibrary(const CLibExportSettings& settings, bool showDialog = false);
+
+  /*!
+   \brief Enqueue a music library update job, scanning tags embedded in music files and optionally scraping additional data.
+   \param[in] strDirectory Directory to scan or "" (empty string) for a global scan.
+   \param[in] flags Flags for controlling the scanning process.  See xbmc/music/infoscanner/MusicInfoScanner.h for possible values.
+   \param[in] showProgress Whether or not to show a progress dialog. Defaults to true
+   */
+  void ScanLibrary(const std::string& strDirectory, int flags = 0, bool showProgress = true);
+
+  /*!
+   \brief Enqueue an album scraping job fetching additional album data.
+   \param[in] strDirectory Virtual path that identifies which albums to process or "" (empty string) for all albums
+   \param[in] refresh Whether or not to refresh data for albums that have previously been scraped
+  */
+  void StartAlbumScan(const std::string& strDirectory, bool refresh = false);
+  
+  /*!
+   \brief Enqueue an artist scraping job fetching additional artist data.
+   \param[in] strDirectory Virtual path that identifies which artists to process or "" (empty string) for all artists
+   \param[in] refresh Whether or not to refresh data for artists that have previously been scraped
+   */
+  void StartArtistScan(const std::string& strDirectory, bool refresh = false);
+
+  /*!
+   \brief Check if a library scan or cleaning is in progress.
+   \return True if a scan or clean is in progress, false otherwise
+   */
+  bool IsScanningLibrary() const;
+
+  /*!
+   \brief Stop and dequeue all scanning jobs.
+   */
+  void StopLibraryScanning();
+
+  /*!
+   \brief Enqueue an asynchronous library cleaning job.
+   \param[in] showDialog Show a model progress dialog while cleaning. Default is false.
+   */
+  void CleanLibrary(bool showDialog = false);
+
+  /*!
+   \brief Executes a library cleaning with a modal dialog.
+   However UI rendering of dialog is on same thread as the cleaning process, so mouse movement
+   is stilted and opportunities to cancel the process limited
+   */
+  void CleanLibraryModal();
   
   /*!
    \brief Adds the given job to the queue.
@@ -97,4 +143,5 @@ private:
 
   bool m_modal;
   bool m_exporting;
+  bool m_cleaning;
 };

--- a/xbmc/music/jobs/CMakeLists.txt
+++ b/xbmc/music/jobs/CMakeLists.txt
@@ -1,9 +1,13 @@
 set(SOURCES MusicLibraryJob.cpp
             MusicLibraryProgressJob.cpp
-            MusicLibraryExportJob.cpp)
+            MusicLibraryCleaningJob.cpp
+            MusicLibraryExportJob.cpp
+            MusicLibraryScanningJob.cpp)
 
 set(HEADERS MusicLibraryJob.h
             MusicLibraryProgressJob.h
-            MusicLibraryExportJob.h)
+            MusicLibraryCleaningJob.h
+            MusicLibraryExportJob.h
+            MusicLibraryScanningJob.h)
 
 core_add_library(music_jobs)

--- a/xbmc/music/jobs/MusicLibraryCleaningJob.cpp
+++ b/xbmc/music/jobs/MusicLibraryCleaningJob.cpp
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MusicLibraryCleaningJob.h"
+#include "dialogs/GUIDialogProgress.h"
+#include "music/MusicDatabase.h"
+
+CMusicLibraryCleaningJob::CMusicLibraryCleaningJob(CGUIDialogProgress* progressDialog)
+  : CMusicLibraryProgressJob(nullptr)
+{ 
+  if (progressDialog)
+    SetProgressIndicators(nullptr, progressDialog);
+  SetAutoClose(true);
+}
+
+CMusicLibraryCleaningJob::~CMusicLibraryCleaningJob() = default;
+
+bool CMusicLibraryCleaningJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  const CMusicLibraryCleaningJob* cleaningJob = dynamic_cast<const CMusicLibraryCleaningJob*>(job);
+  if (cleaningJob == nullptr)
+    return false;
+
+  return true;
+}
+
+bool CMusicLibraryCleaningJob::Work(CMusicDatabase &db)
+{
+  db.Cleanup(GetProgressDialog());
+  return true;
+}

--- a/xbmc/music/jobs/MusicLibraryCleaningJob.h
+++ b/xbmc/music/jobs/MusicLibraryCleaningJob.h
@@ -1,0 +1,49 @@
+#pragma once
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <set>
+
+#include "music/jobs/MusicLibraryProgressJob.h"
+
+/*!
+ \brief Music library job implementation for cleaning the video library.
+*/
+class CMusicLibraryCleaningJob : public CMusicLibraryProgressJob
+{
+public:
+  /*!
+   \brief Creates a new music library cleaning job.
+   \param[in] progressDialog Progress dialog to be used to display the cleaning progress
+  */
+  CMusicLibraryCleaningJob(CGUIDialogProgress* progressDialog);
+  ~CMusicLibraryCleaningJob() override;
+
+  // specialization of CJob
+  const char *GetType() const override { return "MusicLibraryCleaningJob"; }
+  bool operator==(const CJob* job) const override;
+
+protected:
+  // implementation of CMusicLibraryJob
+  bool Work(CMusicDatabase &db) override;
+
+private:
+ 
+};

--- a/xbmc/music/jobs/MusicLibraryScanningJob.cpp
+++ b/xbmc/music/jobs/MusicLibraryScanningJob.cpp
@@ -1,0 +1,69 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MusicLibraryScanningJob.h"
+#include "music/MusicDatabase.h"
+
+CMusicLibraryScanningJob::CMusicLibraryScanningJob(const std::string& directory, int flags, bool showProgress /* = true */) 
+  : m_scanner(),
+    m_directory(directory),
+    m_showProgress(showProgress),
+    m_flags(flags)
+{ }
+
+CMusicLibraryScanningJob::~CMusicLibraryScanningJob() = default;
+
+bool CMusicLibraryScanningJob::Cancel()
+{
+  if (!m_scanner.IsScanning())
+    return true;
+
+  m_scanner.Stop();
+  return true;
+}
+
+bool CMusicLibraryScanningJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  const CMusicLibraryScanningJob* scanningJob = dynamic_cast<const CMusicLibraryScanningJob*>(job);
+  if (scanningJob == nullptr)
+    return false;
+
+  return m_directory == scanningJob->m_directory &&
+         m_flags == scanningJob->m_flags;
+}
+
+bool CMusicLibraryScanningJob::Work(CMusicDatabase &db)
+{
+  m_scanner.ShowDialog(m_showProgress);
+  if (m_flags & MUSIC_INFO::CMusicInfoScanner::SCAN_ALBUMS)
+    // Scrape additional album information
+    m_scanner.FetchAlbumInfo(m_directory, m_flags & MUSIC_INFO::CMusicInfoScanner::SCAN_RESCAN);
+  else if (m_flags & MUSIC_INFO::CMusicInfoScanner::SCAN_ARTISTS)
+    // Scrape additional artist information
+    m_scanner.FetchArtistInfo(m_directory, m_flags & MUSIC_INFO::CMusicInfoScanner::SCAN_RESCAN);
+  else
+    // Scan tags from music files, and optionally scrape artist and album info
+    m_scanner.Start(m_directory, m_flags);
+
+  return true;
+}

--- a/xbmc/music/jobs/MusicLibraryScanningJob.h
+++ b/xbmc/music/jobs/MusicLibraryScanningJob.h
@@ -1,0 +1,61 @@
+#pragma once
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "music/infoscanner/MusicInfoScanner.h"
+#include "music/jobs/MusicLibraryJob.h"
+
+/*!
+ \brief Music library job implementation for scanning items.
+ Uses CMusicInfoScanner for scanning and can be run with  or 
+ without a visible progress bar.
+ */
+class CMusicLibraryScanningJob : public CMusicLibraryJob
+{
+public:
+  /*!
+   \brief Creates a new music library tag scanning and data scraping job.
+   \param[in] directory Directory to be scanned for new items
+   \param[in] flags What kind of scan to do
+   \param[in] showProgress Whether to show a progress bar or not
+   */
+  CMusicLibraryScanningJob(const std::string& directory, int flags, bool showProgress = true);
+  ~CMusicLibraryScanningJob() override;
+
+  // specialization of CMusicLibraryJob
+  bool CanBeCancelled() const override { return true; }
+  bool Cancel() override;
+
+  // specialization of CJob
+  const char *GetType() const override { return "MusicLibraryScanningJob"; }
+  bool operator==(const CJob* job) const override;
+
+protected:
+  // implementation of CMusicLibraryJob
+  bool Work(CMusicDatabase &db) override;
+
+private:
+  MUSIC_INFO::CMusicInfoScanner m_scanner;
+  std::string m_directory;
+  bool m_showProgress;
+  int m_flags;
+};


### PR DESCRIPTION
A little more separation of music DB processing from the UI thread. 

**Cleaning**
Music library cleaning (when initiated by the user, not that part of tag scanning) was done on the same thread as the UI and could cause it to lock. Cleaning that can be slow on large music databases, and despite showing a cancel button on the progress dialog the user had no practical way to cancel cleaning other than shutdown. Progress reporting is also infrequent, so the pointer staggers when moved because rendering is infrequent. 

This PR moves the cleaning process onto the music job queue introduced by #12891, and solves all those issues.

**Scanning**
Although previously CMusicScanner ran on a separate thread anyway, it makes sense replicate what Montellese did for video in #6406 and move this processing to the music job queue too.

@notspiff perhaps you could take a look since you are doing other scanner changes. 
But also the kind of change I would like to get into nighly soonest, to maximise testing