### PR TITLE
[windows] WinRenderBuffer: clear loaded state on release.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderBuffer.cpp
@@ -65,6 +65,7 @@ CRenderBuffer::~CRenderBuffer()
 
 void CRenderBuffer::Release()
 {
+  loaded = false;
   SAFE_RELEASE(videoBuffer);
   SAFE_RELEASE(m_staging);
   for (unsigned i = 0; i < m_activePlanes; i++)


### PR DESCRIPTION
fix an error when after flushing renderer it has mistakenly "loaded" buffers