### PR TITLE
[PVR][Estuary] radio recordings fix + improvement

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -50,7 +50,7 @@
 					<visible>player.chaptercount</visible>
 				</control>
 				<control type="group">
-					<visible>PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
+					<visible>Window.IsActive(fullscreenvideo) + PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
 					<control type="image">
 						<top>100</top>
 						<left>20</left>
@@ -61,6 +61,25 @@
 					<control type="label">
 						<top>110</top>
 						<left>90</left>
+						<width>400</width>
+						<height>50</height>
+						<aligny>center</aligny>
+						<font>font25_title</font>
+						<label>$LOCALIZE[19158]</label>
+					</control>
+				</control>
+				<control type="group">
+					<visible>Window.IsActive(visualisation) + PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
+					<control type="image">
+						<top>100</top>
+						<left>170</left>
+						<width>74</width>
+						<height>74</height>
+						<texture>osd/fullscreen/buttons/record.png</texture>
+					</control>
+					<control type="label">
+						<top>110</top>
+						<left>240</left>
 						<width>400</width>
 						<height>50</height>
 						<aligny>center</aligny>

--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -75,6 +75,26 @@
 					<onclick>PlayerControl(Next)</onclick>
 					<visible>MusicPlayer.HasNext</visible>
 				</control>
+				<control type="radiobutton" id="606">
+					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>
+					<textureradioonnofocus>osd/fullscreen/buttons/record-white.png</textureradioonnofocus>
+					<textureradioofffocus colordiffuse="white">osd/fullscreen/buttons/record.png</textureradioofffocus>
+					<textureradiooffnofocus>osd/fullscreen/buttons/record.png</textureradiooffnofocus>
+					<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
+					<width>76</width>
+					<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back">Focus</animation>
+					<height>76</height>
+					<radiowidth>74</radiowidth>
+					<radioheight>74</radioheight>
+					<font></font>
+					<texturenofocus />
+					<radioposx>1</radioposx>
+					<radioposy>0</radioposy>
+					<selected>!PVR.IsRecordingPlayingChannel</selected>
+					<onclick>PVR.ToggleRecordPlayingChannel</onclick>
+					<visible>PVR.CanRecordPlayingChannel</visible>
+					<visible>VideoPlayer.Content(livetv)</visible>
+				</control>
 			</control>
 			<control type="grouplist" id="202">
 				<right>20</right>
@@ -87,7 +107,7 @@
 				<orientation>horizontal</orientation>
 				<onup>87</onup>
 				<ondown>noop</ondown>
-				<onleft>605</onleft>
+				<onleft>606</onleft>
 				<onright>600</onright>
 				<control type="radiobutton" id="620">
 					<include content="OSDButton">


### PR DESCRIPTION
First commit adds a "record" button for PVR radio to music OSD:

![screenshot000](https://user-images.githubusercontent.com/3226626/33525702-5c7e3472-d835-11e7-8fc5-97d28954f037.png)

Second commit fixes a display glitch for the "currently recording" indicator for PVR radio:

![screenshot001](https://user-images.githubusercontent.com/3226626/33525711-83789e3c-d835-11e7-94ad-3a727925ffa8.png)
![screenshot002](https://user-images.githubusercontent.com/3226626/33525712-83905f2c-d835-11e7-90be-c482902b66c6.png)

@phil65 good to go?
