### PR TITLE
fix windows build order for first build

### DIFF
--- a/tools/buildsteps/windows/make-mingwlibs.sh
+++ b/tools/buildsteps/windows/make-mingwlibs.sh
@@ -96,15 +96,6 @@ echo " TOOLCHAIN = $TOOLS"
 echo
 echo "-------------------------------------------------------------------------------"
 
-echo -ne "\033]0;building FFmpeg $TRIPLET\007"
-echo "-------------------------------------------------"
-echo " building FFmpeg $TRIPLET"
-echo "-------------------------------------------------"
-./buildffmpeg.sh $MAKECLEAN
-checkfiles avcodec-57.dll avformat-57.dll avutil-55.dll postproc-54.dll swscale-4.dll avfilter-6.dll swresample-2.dll
-echo "-------------------------------------------------"
-echo " building of FFmpeg $TRIPLET done..."
-echo "-------------------------------------------------"
 if [[ $win10 != "yes" ]]; then # currently disabled for uwp
 echo -ne "\033]0;building libdvd $TRIPLET\007"
 echo "-------------------------------------------------"
@@ -116,6 +107,15 @@ echo "-------------------------------------------------"
 echo " building of libdvd $TRIPLET done..."
 echo "-------------------------------------------------"
 fi
+echo -ne "\033]0;building FFmpeg $TRIPLET\007"
+echo "-------------------------------------------------"
+echo " building FFmpeg $TRIPLET"
+echo "-------------------------------------------------"
+./buildffmpeg.sh $MAKECLEAN
+checkfiles avcodec-57.dll avformat-57.dll avutil-55.dll postproc-54.dll swscale-4.dll avfilter-6.dll swresample-2.dll
+echo "-------------------------------------------------"
+echo " building of FFmpeg $TRIPLET done..."
+echo "-------------------------------------------------"
 echo "-------------------------------------------------------------------------------"
 echo " compile mingw libs $TRIPLET done..."
 echo "-------------------------------------------------------------------------------"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
ffmpeg build search for libdvd on my windows build setup

## Motivation and Context
the changed order is needed for the first build run

## How Has This Been Tested?
I did prepair 1 windows 10 64bit host to test the 64bit build setup without uwp (if win10 check is missleading, it does mean if uwp build)

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
