### PR TITLE
Don't terminate player on sleep

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3752,6 +3752,19 @@ void CApplication::UpdateFileState()
   }
 }
 
+void CApplication::IdlePlaying()
+{
+  //pause if possible but don't trigger timeshift
+  if(m_pPlayer->CanPause() && !m_itemCurrentFile->IsLiveTV())
+  {
+    m_pPlayer->Pause();
+  }
+  else
+  {
+    StopPlaying();
+  }
+}
+
 void CApplication::StopPlaying()
 {
   int iWin = g_windowManager.GetActiveWindow();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -185,6 +185,7 @@ public:
   PlayBackRet PlayFile(CFileItem item, const std::string& player, bool bRestart = false);
   void SaveFileState(bool bForeground = false);
   void UpdateFileState();
+  void IdlePlaying();
   void StopPlaying();
   void Restart(bool bSamePosition = true);
   void DelayedPlayerRestart();

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -256,7 +256,7 @@ void CPowerManager::OnSleep()
 
   CServiceBroker::GetPVRManager().OnSleep();
   g_application.SaveFileState(true);
-  g_application.StopPlaying();
+  g_application.IdlePlaying();
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();
   g_application.CloseNetworkShares();


### PR DESCRIPTION
## Description
If possible pause the player. Only if pause is not possible or would trigger timeshift, we use the old way to terminate the player.
It does pause the player onsleep. And it does not terminate a already paused player.

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=324710
If you want to resume your movie, you would like to keep the player instead of terminating it on sleep.
And you can't change this behaivor with an addon, because you don't know the last player state after or on sleep. It's not possible to differentiate between user did close the player or kodi did close the player on sleep. And the addon solution "restart terminated player" was odd anyway if you use sleep.

## How Has This Been Tested?
It got testet on Windows 10 64bit with an Intel Apollo Lake and the intel graphic driver 15.60.

If you trigger onsleep from outside with power button, it does still fail to enter sleep sometimes, like it does with the old code. My change does not fix this bug. I did try to fix this as well during implementiung my improvement but even if the pause or stop action is the first action onsleep it does still don't work some times.

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [?] All new and existing tests passed
I did not find a documentation about kodi tests on local environments.
