### PR TITLE
[PVR] Global direct channel number input & global unique channel numbers

### DIFF
--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -191,6 +191,9 @@ bool CPVRActionListener::OnAction(const CAction &action)
       const CPVRChannelGroupPtr selectedGroup = CServiceBroker::GetPVRManager().ChannelGroups()->Get(currentChannel->IsRadio())->GetSelectedGroup();
       const CFileItemPtr item(selectedGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber)));
 
+      if (!item)
+        return false;
+
       CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(item, false);
       return true;
     }

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1205,7 +1205,7 @@ namespace PVR
     }
 
     // if we have a last played channel, start playback
-    if (channel && channel->HasPVRChannelInfoTag())
+    if (channel)
     {
       return SwitchToChannel(channel, true);
     }
@@ -1246,7 +1246,7 @@ namespace PVR
 
     // get the last played channel or fallback to first channel
     CFileItemPtr item(group->GetLastPlayedChannel());
-    if (item->HasPVRChannelInfoTag())
+    if (item)
     {
       group = groups->GetLastPlayedGroup(item->GetPVRChannelInfoTag()->ChannelID());
     }
@@ -1690,7 +1690,7 @@ namespace PVR
           const CPVRChannelGroupPtr group = CServiceBroker::GetPVRManager().GetPlayingGroup(bRadio);
           CFileItemPtr channel = group->GetByChannelNumber(channelNumber);
 
-          if (!channel || !channel->HasPVRChannelInfoTag())
+          if (!channel)
           {
             // channel number present in any group?
             const CPVRChannelGroups* groupAccess = CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio);
@@ -1707,7 +1707,7 @@ namespace PVR
             }
           }
 
-          if (channel && channel->HasPVRChannelInfoTag())
+          if (channel)
           {
             CApplicationMessenger::GetInstance().PostMsg(
               TMSG_GUI_ACTION, WINDOW_INVALID, -1,
@@ -1732,7 +1732,7 @@ namespace PVR
         {
           CServiceBroker::GetPVRManager().SetPlayingGroup(group);
           const CFileItemPtr channel(group->GetLastPlayedChannel(playingChannel->ChannelID()));
-          if (channel && channel->HasPVRChannelInfoTag())
+          if (channel)
           {
             const CPVRChannelNumber channelNumber = channel->GetPVRChannelInfoTag()->ChannelNumber();
             CApplicationMessenger::GetInstance().SendMsg(

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -445,8 +445,7 @@ CFileItemPtr CPVRChannelGroup::GetLastPlayedChannel(int iCurrentChannel /* = -1 
     }
   }
 
-  CFileItemPtr retVal = CFileItemPtr(returnChannel ? new CFileItem(returnChannel) : new CFileItem);
-  return retVal;
+  return CFileItemPtr(returnChannel ? new CFileItem(returnChannel) : nullptr);
 }
 
 CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(const CPVRChannelPtr &channel) const
@@ -467,8 +466,6 @@ CFileItemPtr CPVRChannelGroup::GetByChannelNumber(const CPVRChannelNumber &chann
       retval = CFileItemPtr(new CFileItem((*it).channel));
   }
 
-  if (!retval)
-    retval = CFileItemPtr(new CFileItem);
   return retval;
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -303,9 +303,7 @@ CFileItemPtr CPVRChannelGroupsContainer::GetLastPlayedChannel(void) const
   CFileItemPtr channelRadio = m_groupsRadio->GetGroupAll()->GetLastPlayedChannel();
 
   if (!channelTV ||
-      !channelTV->HasPVRChannelInfoTag() ||
-      (channelRadio && channelRadio->HasPVRChannelInfoTag() &&
-       channelRadio->GetPVRChannelInfoTag()->LastWatched() > channelTV->GetPVRChannelInfoTag()->LastWatched()))
+      (channelRadio && channelRadio->GetPVRChannelInfoTag()->LastWatched() > channelTV->GetPVRChannelInfoTag()->LastWatched()))
      return channelRadio;
 
   return channelTV;


### PR DESCRIPTION
First commit implements a feature that was requested in the forum and that makes Kodi behave like other settop boxes: if direct channel number input is used to switch channels and the currently active channel group does not contain a channel with the requested number, PVR tries to obtain the channel with the entered number from the "All channels" group, sets this group active and then switches to the requested channel.

Second commit also implements a feature common to other settop boxes - to use the same channel number for a channel  in all channel groups where this channel appears:

![screenshot002](https://user-images.githubusercontent.com/3226626/33571965-e5df6bb2-d931-11e7-8b80-57fe8f6c2431.png)
![screenshot003](https://user-images.githubusercontent.com/3226626/33625042-a52bd964-d9f6-11e7-98f7-141d5747cbe6.png)

These changes are runtime-tested on macOS, latest Kodi master.

@xhaggi mind doing the code review?