### PR TITLE
add auto resume of last used media (after sleep)

### DIFF
--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "IPowerSyscall.h"
+#include "FileItem.h"
 
 class CSetting;
 
@@ -95,4 +96,6 @@ private:
   void OnLowBattery() override;
 
   IPowerSyscall *m_instance;
+  std::unique_ptr<CFileItem> m_lastFileItem;
+  std::string m_lastPlayer;
 };


### PR DESCRIPTION
## Description
auto resume the media which was used during enter sleep mode and resumes it on wake with forced play (playerstate handling is already implemented as part of resume point but I don't know why the player state is allways empty, this issue does force play on my PR)
But this is only the first step, a very basic solution which could be improved step by step.

We do already have something similar for PVR resume called startupaction:

If we disable startupaction liveTV it does the following onwakeup:
- [x] resume to home screen
- [x] resume to settings screen
- [x] resume to libary screen
- [x] resume to any subpages of the screens
- [x] resume to list selection
- [ ] resume to any player pause
- [ ] resume to any player playback
- [ ] resume to LiveTV player playback

if we enable autostart action LiveTV it does this onwakeup:
- [ ] resume to home screen
- [ ] resume to settings screen
- [ ] resume to libary screen
- [ ] resume to any subpages of the screens
- [ ] resume to list selection
- [ ] resume to any player pause
- [ ] resume to any player playback
- [x] resume to LiveTV player playback

As you see, enable startupaction LiveTV is even worse because it doesn't resume anything except LiveTV.

This PR used to fix
- resume to any player pause
- resume to any player playback
but the first step would be only player playback

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=324710
If you want to resume your paused movie after kodi did enter sleep mode.
You can't change this behaivor with an addon, because you don't know the last player state because our sleep handling does change it. It's not possible to differentiate between user did close the player or kodi did close the player on sleep. 
Don't miss this discussion: https://github.com/xbmc/xbmc/pull/13133

**More about my usecase:**
I did install kodi on my pvr server which mean I can't force sleep because running recordings and other clients watching tv would block this
Usecase is the following: I do pause a video, host is going into standby because of idle and on resume I want to find my paused video.

On resume I want to see my last player state without forcing play because I don't want to playback if the server was just started by PVR.

My stop watching action is also special. Instead of sleep which is not possible during recording or other clients watching TV, I use to call a prepair idle script on my IR Remote power button to put everything into idle to trigger autostandby when PVR is done.
On start watching action my script does send play if player existing or open LiveTV if no player is online. The start watching script gets triggered by IR Remote power button as well. In detail there are 2 ways to trigger start watching on IR wakeup action  or if the host is already running it gets executed during recive IR power button. PVR recording wakeup and client WOL request don't trigger Start watching script.

My current problem is that I am loosing my paused video on sleep. And you can't fix this with Python because Python gets an stopPlayer and I don't know did user hit stop or did kodi hit stop which result into an unknown last player state.

The straight forward solution would be to get rid off of the player termination, this would fix it. But as we point out there are some plugins which can't go on if player was to long in idle.
@FernetMenta did point the following out about skip player termination
> This won't work with most content streamed over network. The socket connections will fail on sleep and won't recover on wake. Even if the code were ready to recover, the connections may have become invalid/expired.

Instead of make all the plugins able to reconnect to the stream we decided to terminate the player and reconstruct it as I did in this PR.

My next PR could maybe an speed improvement where I do check if we really need the player termination.

> if(isLocalFile || isSMBFile || isOpticalDisc)
>   pause player //if the player surive the sleep, it does skip the PlayerResume handling
> else
>  terminate player //for players which can't resume after cutting network connections

This would make kodi player behaive like every other local file video player like MPC-HC, VLC or WMP but the else would still fix our existing plugins which can't handle closed network connections or sessiontimeouts.

This braking change would case an issue for users who don't handle PVR wakeups and WOL wakeups:
An resume to play would cause an media playback during PVR recordings and during WOL.
This is only an issue for Kodi users because only kodi did implement a player termination on sleep and users are not aware of needed wakeup handling.
Other PVR clients like DVB Viewer do already resume play if you don't implement any exit action on sleep. Which means non kodi users would know who to handle this, but it's an unknown thing for kodi users.
What do you think about this issue? Should we disable it by default with an hint about this issue with PVR recordings and WOL?

A new setting like startup window would handle this as well as all other issues of my braking change:
wakeup action setting:
- close player (default, because this is the current behaivor but it would not apply livetv)
- player force playback (warning: PVR recording or WOL event would couse kodi to playback your last file)
- keep player state (warning: if you enter stanby on state play an PVR recording or WOL event would couse kodi to playback your last file)
- startupaction (is used to reenable the existing startupaction feature)

There is another way to fix my problem:
create a python event onsleep which get fired before player termination to grep the last player state with python. But there could be a issue with the python sleep event, if to many plugins do subscribe this event we may get problems with our sleep handling.

## How Has This Been Tested?
It got testet on Windows 10 64bit with an Intel Apollo Lake and the intel graphic driver 15.60.

This is only poorly tested and should not get applied until I did some more tests. But it did work 5 times in a row.

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
I did not find a documentation about kodi tests on local environments.

Please have a look befor I go deeper with testing or improving. I did create some inline questions in my change.
The Commits will be squashed after required improvements are done.