### PR TITLE
[PVR] PVR manager: last PVR core component is now free from GUI code.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2028,7 +2028,7 @@ bool CApplication::OnAction(const CAction &action)
   if (action.GetID() == ACTION_BUILT_IN_FUNCTION)
   {
     if (!CBuiltins::GetInstance().IsSystemPowerdownCommand(action.GetName()) ||
-        CServiceBroker::GetPVRManager().CanSystemPowerdown())
+        CServiceBroker::GetPVRManager().GUIActions()->CanSystemPowerdown())
     {
       CBuiltins::GetInstance().Execute(action.GetName());
       m_navigationTimer.StartZero();
@@ -2359,7 +2359,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   uint32_t msg = pMsg->dwMessage;
   if (msg == TMSG_SYSTEM_POWERDOWN)
   {
-    if (CServiceBroker::GetPVRManager().CanSystemPowerdown())
+    if (CServiceBroker::GetPVRManager().GUIActions()->CanSystemPowerdown())
       msg = pMsg->param1; // perform requested shutdown action
     else
       return; // no shutdown
@@ -4076,7 +4076,7 @@ void CApplication::CheckShutdown()
       || m_musicInfoScanner->IsScanning()
       || CVideoLibraryQueue::GetInstance().IsRunning()
       || g_windowManager.IsWindowActive(WINDOW_DIALOG_PROGRESS) // progress dialog is onscreen
-      || !CServiceBroker::GetPVRManager().CanSystemPowerdown(false))
+      || !CServiceBroker::GetPVRManager().GUIActions()->CanSystemPowerdown(false))
   {
     m_shutdownTimer.StartZero();
     return;
@@ -4349,7 +4349,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
   if (CBuiltins::GetInstance().HasCommand(actionStr))
   {
     if (!CBuiltins::GetInstance().IsSystemPowerdownCommand(actionStr) ||
-        CServiceBroker::GetPVRManager().CanSystemPowerdown())
+        CServiceBroker::GetPVRManager().GUIActions()->CanSystemPowerdown())
       CBuiltins::GetInstance().Execute(actionStr);
   }
   else

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1794,6 +1794,21 @@ namespace PVR
     return (delta <= idle);
   }
 
+  void CPVRGUIActions::SetSelectedItemPath(bool bRadio, const std::string &path)
+  {
+    CSingleLock lock(m_critSection);
+    if (bRadio)
+      m_selectedItemPathRadio = path;
+    else
+      m_selectedItemPathTV = path;
+  }
+
+  std::string CPVRGUIActions::GetSelectedItemPath(bool bRadio) const
+  {
+    CSingleLock lock(m_critSection);
+    return bRadio ? m_selectedItemPathRadio : m_selectedItemPathTV;
+  }
+
   CPVRChannelNumberInputHandler &CPVRGUIActions::GetChannelNumberInputHandler()
   {
     // window/dialog specific input handler
@@ -1808,6 +1823,27 @@ namespace PVR
   CPVRGUIChannelNavigator &CPVRGUIActions::GetChannelNavigator()
   {
     return m_channelNavigator;
+  }
+
+  void CPVRGUIActions::OnPlaybackStarted(const CFileItemPtr &item)
+  {
+    if (item->HasPVRChannelInfoTag())
+    {
+      const CPVRChannelPtr channel = item->GetPVRChannelInfoTag();
+      m_channelNavigator.SetPlayingChannel(channel);
+      SetSelectedItemPath(channel->IsRadio(), channel->Path());
+    }
+  }
+
+  void CPVRGUIActions::OnPlaybackStopped(const CFileItemPtr &item)
+  {
+    if (item->HasPVRChannelInfoTag())
+    {
+      m_channelNavigator.ClearPlayingChannel();
+
+      // store channel settings
+      g_application.SaveFileState();
+    }
   }
 
   void CPVRChannelSwitchingInputHandler::OnInputDone()

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -332,6 +332,18 @@ namespace PVR
     bool CheckParentalPIN() const;
 
     /*!
+     * @brief Check whether the system Kodi is running on can be powered down
+     *        (shutdown/reboot/suspend/hibernate) without stopping any active
+     *        recordings and/or without preventing the start of recordings
+     *        scheduled for now + pvrpowermanagement.backendidletime.
+     * @param bAskUser True to informs user in case of potential
+     *        data loss. User can decide to allow powerdown anyway. False to
+     *        not to ask user and to not confirm power down.
+     * @return True if system can be safely powered down, false otherwise.
+     */
+    bool CanSystemPowerdown(bool bAskUser = true) const;
+
+    /*!
      * @brief Get the currently active channel number input handler.
      * @return the handler.
      */
@@ -448,7 +460,10 @@ namespace PVR
      */
     void StartPlayback(CFileItem *item, bool bFullscreen) const;
 
-  private:
+    bool AllLocalBackendsIdle(CPVRTimerInfoTagPtr& causingEvent) const;
+    bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
+    bool IsNextEventWithinBackendIdleTime(void) const;
+
     CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
     bool m_bChannelScanRunning;
     CPVRSettings m_settings;

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -22,6 +22,8 @@
 #include <memory>
 #include <string>
 
+#include "threads/CriticalSection.h"
+
 #include "pvr/PVRChannelNumberInputHandler.h"
 #include "pvr/PVRGUIChannelNavigator.h"
 #include "pvr/PVRSettings.h"
@@ -344,6 +346,20 @@ namespace PVR
     bool CanSystemPowerdown(bool bAskUser = true) const;
 
     /*!
+     * @brief Get the currently selected item path; used across several windows/dialogs to share item selection.
+     * @param bRadio True to query the selected path for PVR radio, false for Live TV.
+     * @return the path.
+     */
+    std::string GetSelectedItemPath(bool bRadio) const;
+
+    /*!
+     * @brief Set the currently selected item path; used across several windows/dialogs to share item selection.
+     * @param bRadio True to set the selected path for PVR radio, false for Live TV.
+     * @param path The new path to set.
+     */
+    void SetSelectedItemPath(bool bRadio, const std::string &path);
+
+    /*!
      * @brief Get the currently active channel number input handler.
      * @return the handler.
      */
@@ -354,6 +370,18 @@ namespace PVR
      * @return the navigator.
      */
     CPVRGUIChannelNavigator &GetChannelNavigator();
+
+    /*!
+     * @brief Inform GUI actions that playback of an item just started.
+     * @param item The item that started to play.
+     */
+    void OnPlaybackStarted(const CFileItemPtr &item);
+
+    /*!
+     * @brief Inform GUI actions manager that playback of an item was stopped due to user interaction.
+     * @param item The item that stopped to play.
+     */
+    void OnPlaybackStopped(const CFileItemPtr &item);
 
   private:
     CPVRGUIActions(const CPVRGUIActions&) = delete;
@@ -464,10 +492,13 @@ namespace PVR
     bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
     bool IsNextEventWithinBackendIdleTime(void) const;
 
+    CCriticalSection m_critSection;
     CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
     bool m_bChannelScanRunning;
     CPVRSettings m_settings;
     CPVRGUIChannelNavigator m_channelNavigator;
+    std::string m_selectedItemPathTV;
+    std::string m_selectedItemPathRadio;
   };
 
 } // namespace PVR

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -22,7 +22,6 @@
 
 #include <utility>
 
-#include "Application.h"
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
@@ -47,7 +46,6 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimers.h"
-#include "pvr/windows/GUIWindowPVRBase.h"
 
 using namespace PVR;
 using namespace ANNOUNCEMENT;
@@ -761,13 +759,8 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
     const CPVRChannelPtr channel(item->GetPVRChannelInfoTag());
 
     m_playingChannel = channel;
-
-    m_guiActions->GetChannelNavigator().SetPlayingChannel(channel);
     SetPlayingGroup(channel);
     UpdateLastWatched(channel);
-
-    // set channel as selected item
-    CGUIWindowPVRBase::SetSelectedItemPath(channel->IsRadio(), channel->Path());
   }
   else if (item->HasPVRRecordingInfoTag())
   {
@@ -777,6 +770,8 @@ void CPVRManager::OnPlaybackStarted(const CFileItemPtr item)
   {
     m_playingEpgTag = item->GetEPGInfoTag();
   }
+
+  m_guiActions->OnPlaybackStarted(item);
 }
 
 void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
@@ -786,12 +781,7 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
   if (item->HasPVRChannelInfoTag() && item->GetPVRChannelInfoTag() == m_playingChannel)
   {
     UpdateLastWatched(item->GetPVRChannelInfoTag());
-
-    // store channel settings
-    g_application.SaveFileState();
-
     m_playingChannel.reset();
-    m_guiActions->GetChannelNavigator().ClearPlayingChannel();
   }
   else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag() == m_playingRecording)
   {
@@ -801,6 +791,8 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr item)
   {
     m_playingEpgTag.reset();
   }
+
+  m_guiActions->OnPlaybackStopped(item);
 }
 
 void CPVRManager::OnPlaybackEnded(const CFileItemPtr item)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -338,18 +338,6 @@ namespace PVR
     bool IsRecording(void) const;
 
     /*!
-     * @brief Check whether the system Kodi is running on can be powered down
-     *        (shutdown/reboot/suspend/hibernate) without stopping any active
-     *        recordings and/or without preventing the start of recordings
-     *        scheduled for now + pvrpowermanagement.backendidletime.
-     * @param bAskUser True to informs user in case of potential
-     *        data loss. User can decide to allow powerdown anyway. False to
-     *        not to ask user and to not confirm power down.
-     * @return True if system can be safely powered down, false otherwise.
-     */
-    bool CanSystemPowerdown(bool bAskUser = true) const;
-
-    /*!
      * @brief Set the current playing group, used to load the right channel.
      * @param group The new group.
      */
@@ -563,10 +551,6 @@ namespace PVR
      * @param state the new state.
      */
     void SetState(ManagerState state);
-
-    bool AllLocalBackendsIdle(CPVRTimerInfoTagPtr& causingEvent) const;
-    bool EventOccursOnLocalBackend(const CFileItemPtr& item) const;
-    bool IsNextEventWithinBackendIdleTime(void) const;
 
     /** @name containers */
     //@{

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -32,7 +32,6 @@
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
-#include "pvr/windows/GUIWindowPVRBase.h"
 
 using namespace PVR;
 using namespace KODI::MESSAGING;
@@ -122,7 +121,7 @@ void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
 {
   if (m_group)
   {
-    CGUIWindowPVRBase::SetSelectedItemPath(m_group->IsRadio(), m_viewControl.GetSelectedItemPath());
+    CServiceBroker::GetPVRManager().GUIActions()->SetSelectedItemPath(m_group->IsRadio(), m_viewControl.GetSelectedItemPath());
 
     // next OnInitWindow will set the group which is then selected
     m_group.reset();
@@ -199,7 +198,7 @@ void CGUIDialogPVRChannelsOSD::Update()
       if (!m_group)
       {
         m_group = group;
-        m_viewControl.SetSelectedItem(CGUIWindowPVRBase::GetSelectedItemPath(channel->IsRadio()));
+        m_viewControl.SetSelectedItem(CServiceBroker::GetPVRManager().GUIActions()->GetSelectedItemPath(channel->IsRadio()));
         SaveSelectedItemPath(group->GroupID());
       }
     }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -47,9 +47,6 @@
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
-CCriticalSection CGUIWindowPVRBase::m_selectedItemPathsLock;
-std::string CGUIWindowPVRBase::m_selectedItemPaths[2];
-
 CGUIWindowPVRBase::CGUIWindowPVRBase(bool bRadio, int id, const std::string &xmlFile) :
   CGUIMediaWindow(id, xmlFile.c_str()),
   m_bRadio(bRadio),
@@ -57,9 +54,6 @@ CGUIWindowPVRBase::CGUIWindowPVRBase(bool bRadio, int id, const std::string &xml
 {
   // prevent removable drives to appear in directory listing (base class default behavior).
   m_rootDir.AllowNonLocalSources(false);
-
-  m_selectedItemPaths[false] = "";
-  m_selectedItemPaths[true] = "";
 
   RegisterObservers();
 }
@@ -69,22 +63,9 @@ CGUIWindowPVRBase::~CGUIWindowPVRBase(void)
   UnregisterObservers();
 }
 
-void CGUIWindowPVRBase::SetSelectedItemPath(bool bRadio, const std::string &path)
-{
-  CSingleLock lock(m_selectedItemPathsLock);
-  m_selectedItemPaths[bRadio] = path;
-}
-
-std::string CGUIWindowPVRBase::GetSelectedItemPath(bool bRadio)
-{
-  CSingleLock lock(m_selectedItemPathsLock);
-  return m_selectedItemPaths[bRadio];
-}
-
 void CGUIWindowPVRBase::UpdateSelectedItemPath()
 {
-  CSingleLock lock(m_selectedItemPathsLock);
-  m_selectedItemPaths[m_bRadio] = m_viewControl.GetSelectedItemPath();
+  CServiceBroker::GetPVRManager().GUIActions()->SetSelectedItemPath(m_bRadio, m_viewControl.GetSelectedItemPath());
 }
 
 void CGUIWindowPVRBase::RegisterObservers(void)
@@ -163,7 +144,7 @@ void CGUIWindowPVRBase::OnInitWindow(void)
     CGUIMediaWindow::OnInitWindow();
 
     // mark item as selected by channel path
-    m_viewControl.SetSelectedItem(GetSelectedItemPath(m_bRadio));
+    m_viewControl.SetSelectedItem(CServiceBroker::GetPVRManager().GUIActions()->GetSelectedItemPath(m_bRadio));
   }
   else
   {

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -69,9 +69,6 @@ namespace PVR
     void SetInvalid() override;
     bool CanBeActivated() const override;
 
-    static std::string GetSelectedItemPath(bool bRadio);
-    static void SetSelectedItemPath(bool bRadio, const std::string &path);
-
     /*!
      * @brief Refresh window content.
      * @return true, if refresh succeeded, false otherwise.
@@ -108,9 +105,6 @@ namespace PVR
 
     void RegisterObservers(void);
     void UnregisterObservers(void);
-
-    static CCriticalSection m_selectedItemPathsLock;
-    static std::string m_selectedItemPaths[2];
 
     CCriticalSection m_critSection;
     bool m_bRadio;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -67,7 +67,7 @@ void CGUIWindowPVRGuideBase::Init()
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
   {
-    m_bChannelSelectionRestored = epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
+    m_bChannelSelectionRestored = epgGridContainer->SetChannel(CServiceBroker::GetPVRManager().GUIActions()->GetSelectedItemPath(m_bRadio));
     epgGridContainer->GoToNow();
   }
 
@@ -178,7 +178,7 @@ void CGUIWindowPVRGuideBase::UpdateSelectedItemPath()
   {
     CPVRChannelPtr channel(epgGridContainer->GetSelectedChannel());
     if (channel)
-      SetSelectedItemPath(m_bRadio, channel->Path());
+      CServiceBroker::GetPVRManager().GUIActions()->SetSelectedItemPath(m_bRadio, channel->Path());
   }
 }
 
@@ -197,7 +197,7 @@ bool CGUIWindowPVRGuideBase::Update(const std::string &strDirectory, bool update
   {
     CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (epgGridContainer)
-      m_bChannelSelectionRestored = epgGridContainer->SetChannel(GetSelectedItemPath(m_bRadio));
+      m_bChannelSelectionRestored = epgGridContainer->SetChannel(CServiceBroker::GetPVRManager().GUIActions()->GetSelectedItemPath(m_bRadio));
   }
 
   return bReturn;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -48,6 +48,7 @@
 #include "profiles/Profile.h"
 #include "profiles/ProfilesManager.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
+#include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -152,7 +153,7 @@ bool CGUIWindowLoginScreen::OnAction(const CAction &action)
     std::string actionName = action.GetName();
     StringUtils::ToLower(actionName);
     if ((actionName.find("shutdown") != std::string::npos) &&
-        CServiceBroker::GetPVRManager().CanSystemPowerdown())
+        CServiceBroker::GetPVRManager().GUIActions()->CanSystemPowerdown())
       CBuiltins::GetInstance().Execute(action.GetName());
     return true;
   }


### PR DESCRIPTION
Moved the last GUI code from PVR Manager to PVR GUI Actions, no functional changes.

I runtime-tested the changes on macOS, latest Kodi master.

@Jalle19 mind taking a look.