### PR TITLE
Dvd autoplay during active player

### DIFF
--- a/xbmc/Autorun.h
+++ b/xbmc/Autorun.h
@@ -65,7 +65,7 @@ public:
   void Enable();
   void Disable();
   void HandleAutorun();
-  static void ExecuteAutorun(const std::string& path = "", bool bypassSettings = false, bool ignoreplaying = false, bool startFromBeginning = false);
+  static void ExecuteAutorun(const std::string& path = "", bool bypassSettings = false, bool ignoreplaying = true, bool startFromBeginning = false);
 
   static void SettingOptionAudioCdActionsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
enable unused code to be able to autorun optical disk during listening video or audio

## Motivation and Context
https://forum.kodi.tv/showthread.php?tid=324604
It does take a while until the optical disk is recognized. It's nice to be able to listen musik or tv during the optical drive is searching for content.

## How Has This Been Tested?
Does work with my host on Windows 10 64Bit on Apollo Lake with PVR Client and Movie Playback from SMB without any issues. External and internal player does work very well.

## Screenshots (if appropriate):

## Types of change
- not a Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- not a New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
http://kodi.wiki/view/Settings/Videos
http://kodi.wiki/view/Settings/Player/Discs
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

I did ask for needed settings because this is a breaking change. But it's may not needed to make this configureable.