### PR TITLE
[PVR] Set default sort order for recordings to ascending

### DIFF
--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -199,7 +199,7 @@
 									<shadowcolor>text_shadow</shadowcolor>
 								</control>
 							</itemlayout>
-							<content sortby="date" sortorder="descending">$INFO[ListItem.FilenameAndPath]</content>
+							<content sortby="date" sortorder="ascending">$INFO[ListItem.FilenameAndPath]</content>
 						</control>
 					</control>
 				</control>

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -59,6 +59,7 @@ CGUIViewStateWindowPVRRecordings::CGUIViewStateWindowPVRRecordings(const int win
 
   // Default sorting
   SetSortMethod(SortByDate);
+  SetSortOrder(SortOrderAscending);
 
   LoadViewState(items.GetPath(), m_windowId);
 }


### PR DESCRIPTION
Usually TV series are broadcast and watched in the same order. It's
easier to change the sorting of the top folder once than for every
series folder.

## Description
Changes both PVR Recordings window and Estuary theme for the right-hand panel.
Happy to split these if needed.

## Motivation and Context
I realise this may be a personal preference but there are at least a couple other requests:
https://forum.kodi.tv/showthread.php?tid=192541&highlight=pvr+recordings+sort+order
https://trac.kodi.tv/ticket/15336

## How Has This Been Tested?
Tested by using on 17.6.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
