### PR TITLE
Fix two skin-related crashes

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -919,8 +919,10 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
   if ((m_layout && m_layout->CheckCondition() != m_layoutCondition) ||
       (m_focusedLayout && m_focusedLayout->CheckCondition() != m_focusedLayoutCondition))
   {
-    m_layoutCondition = m_layout->CheckCondition();
-    m_focusedLayoutCondition = m_focusedLayout->CheckCondition();
+    if (m_layout)
+      m_layoutCondition = m_layout->CheckCondition();
+    if (m_focusedLayout)
+      m_focusedLayoutCondition = m_focusedLayout->CheckCondition();
 
     int itemIndex = GetSelectedItem();
     UpdateLayout(true); // true to refresh all items

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -117,6 +117,6 @@ bool CStaticListProvider::AlwaysFocusDefaultItem() const
 
 bool CStaticListProvider::OnClick(const CGUIListItemPtr &item)
 {
-  CGUIStaticItemPtr staticItem = std::static_pointer_cast<CGUIStaticItem>(item);
+  CGUIStaticItem *staticItem = static_cast<CGUIStaticItem*>(item.get());
   return staticItem->GetClickActions().ExecuteActions(0, m_parentID);
 }


### PR DESCRIPTION
This PR contains two fixes:

* Fix segfault in guilib when `<itemlayout>` or `<focuslayout>` are missing or incomplete
* Fix segfault on skin reload due to accessing items after their owner has been destroyed

## How Has This Been Tested?
Fixes have been in my branch through most of the game OSD development.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
