### PR TITLE
FFmpeg: Bump to 3.4.1-Leia-Alpha-1 after rebase

### DIFF
--- a/tools/depends/target/ffmpeg/FFMPEG-VERSION
+++ b/tools/depends/target/ffmpeg/FFMPEG-VERSION
@@ -1,5 +1,5 @@
 LIBNAME=ffmpeg
 BASE_URL=https://github.com/xbmc/FFmpeg
-VERSION=3.4-Leia-Alpha-1
+VERSION=3.4.1-Leia-Alpha-1
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
 GNUTLS_VER=3.4.14


### PR DESCRIPTION
Rebase ffmpeg on latest 3.4 branch using version 3.4.1 now.