### PR TITLE
[Estuary] A bunch of small fixes & consistency improvements

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -235,7 +235,7 @@
 				<width>800</width>
 				<top>190</top>
 				<height>25</height>
-				<label>$INFO[VideoPlayer.NextTitle,[COLOR grey]$LOCALIZE[19031]: [/COLOR], - ][COLOR button_focus]$INFO[VideoPlayer.NextStartTime]$INFO[VideoPlayer.NextEndTime: ][/COLOR]</label>
+				<label>$INFO[VideoPlayer.NextTitle,[COLOR grey]$LOCALIZE[19031]: [/COLOR], ]($INFO[VideoPlayer.NextStartTime] - $INFO[VideoPlayer.NextEndTime])</label>
 				<align>right</align>
 				<aligny>center</aligny>
 				<visible>VideoPlayer.HasEpg</visible>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -204,11 +204,11 @@
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<animation effect="slide" end="0,-80" time="150" condition="Control.IsVisible(6000)">conditional</animation>
 			<bottom>0</bottom>
-			<height>380</height>
+			<height>450</height>
 			<control type="image">
 				<left>0</left>
 				<width>100%</width>
-				<height>240</height>
+				<height>310</height>
 				<texture>dialogs/dialog-bg-nobo.png</texture>
 			</control>
 			<control type="image">
@@ -233,7 +233,7 @@
 			<control type="label">
 				<right>20</right>
 				<width>800</width>
-				<top>190</top>
+				<top>260</top>
 				<height>25</height>
 				<label>$INFO[VideoPlayer.NextTitle,[COLOR grey]$LOCALIZE[19031]: [/COLOR], ]($INFO[VideoPlayer.NextStartTime] - $INFO[VideoPlayer.NextEndTime])</label>
 				<align>right</align>
@@ -244,20 +244,20 @@
 				<left>260</left>
 				<top>20</top>
 				<right>50</right>
-				<height>155</height>
+				<height>225</height>
 				<label fallback="416">$INFO[VideoPlayer.Plot]</label>
 				<align>justify</align>
 				<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
 			</control>
 			<control type="grouplist">
 				<left>260</left>
-				<top>175</top>
+				<top>245</top>
 				<width>600</width>
 				<height>100</height>
 				<align>left</align>
 				<orientation>horizontal</orientation>
 				<itemgap>10</itemgap>
-				<visible>![Player.ChannelPreviewActive | Window.IsActive(videoosd)]</visible>
+				<visible>!Player.ChannelPreviewActive</visible>
 				<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
 				<include content="MediaFlag">
 					<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -328,7 +328,7 @@
 				<include>Animation_BottomSlide</include>
 				<orientation>horizontal</orientation>
 				<itemgap>10</itemgap>
-				<visible>!Player.ChannelPreviewActive</visible>
+				<visible>![Player.ChannelPreviewActive | Window.IsActive(videoosd)]</visible>
 				<include content="MediaFlag">
 					<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
 				</include>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -98,7 +98,7 @@
 					<wrapmultiline>true</wrapmultiline>
 					<animation effect="fade" time="200">VisibleChange</animation>
 					<label>$INFO[Player.TimeRemaining,[COLOR button_focus]$LOCALIZE[31134]:[CR][/COLOR]]</label>
-					<visible>!Player.ShowInfo</visible>
+					<visible>![Player.ShowInfo | Window.IsVisible(playerprocessinfo)]</visible>
 				</control>
 			</control>
 			<control type="label">
@@ -200,6 +200,7 @@
 			</control>
 		</control>
 		<control type="group">
+			<visible>!Window.IsVisible(playerprocessinfo)</visible>
 			<visible>Player.ShowInfo + VideoPlayer.Content(LiveTV) + Window.IsActive(fullscreenvideo)</visible>
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<animation effect="slide" end="0,-80" time="150" condition="Control.IsVisible(6000)">conditional</animation>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -22,10 +22,10 @@
 				<visible>!Window.IsVisible(videoosd) + !Window.IsVisible(musicosd)</visible>
 				<animation effect="fade" time="200">VisibleChange</animation>
 				<control type="image">
-					<left>30</left>
+					<right>20</right>
 					<top>90</top>
 					<width>120</width>
-					<height>99</height>
+					<height>100</height>
 					<texture>$INFO[MusicPlayer.Codec,flags/audiocodec/,.png]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>!Player.ChannelPreviewActive</visible>

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -64,8 +64,7 @@
 						<left>300</left>
 						<right>60</right>
 						<height>30</height>
-						<textcolor>button_focus</textcolor>
-						<label>$INFO[ListItem.StartTime,, - ]$INFO[ListItem.EndTime]$INFO[ListItem.EpgEventTitle,  [COLOR white],[/COLOR]]$INFO[ListItem.EpisodeName, [COLOR grey](,)[/COLOR]]$INFO[ListItem.Genre,      $LOCALIZE[515]: [COLOR grey],[/COLOR]]</label>
+						<label>[COLOR button_focus]$INFO[ListItem.StartTime][/COLOR]$INFO[ListItem.EndTime,[COLOR button_focus] - ,[/COLOR]] $INFO[ListItem.EpgEventTitle]$INFO[ListItem.EpisodeName, (,)]$INFO[ListItem.Genre,      [COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
 					</control>
 					<control type="textbox">
 						<left>300</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -269,7 +269,7 @@
 		<value condition="Window.IsActive(visualisation) + Integer.IsGreater(Playlist.Length,1)">$LOCALIZE[554] $INFO[Playlist.Position] / $INFO[Playlist.Length]</value>
 		<value condition="VideoPlayer.Content(musicvideos)">$INFO[VideoPlayer.Artist]$INFO[VideoPlayer.Album, - ]</value>
 		<value condition="VideoPlayer.Content(episodes)">$INFO[VideoPlayer.Season,[COLOR button_focus]S,[/COLOR]]$INFO[VideoPlayer.Episode,[COLOR button_focus]E,: [/COLOR]]$INFO[VideoPlayer.TVShowTitle]</value>
-		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording | PVR.IsPlayingEpgTag">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR=blue],[/COLOR]) ]$INFO[VideoPlayer.ChannelName] $INFO[VideoPlayer.EpisodeName, - ]</value>
+		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording | PVR.IsPlayingEpgTag">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR button_focus],[/COLOR]) ]$INFO[VideoPlayer.ChannelName] $INFO[VideoPlayer.EpisodeName, - ]</value>
 		<value>$INFO[VideoPlayer.Genre]</value>
 	</variable>
 	<variable name="PlayerClearLogoVar">


### PR DESCRIPTION
Some random stuff I stumbled over:

1. PVR: OSD sub label: Fix hardcoded channel number color.

before:
![screenshot000](https://user-images.githubusercontent.com/3226626/33796187-ed0c26b6-dcef-11e7-87f9-8e68f8c68861.png)

after:
![screenshot001](https://user-images.githubusercontent.com/3226626/33796184-e7552862-dcef-11e7-86cb-a08a2b1c8369.png)

2. PVR: Seek bar: Fix next(title|starttime|endtime) colors and content. End time did not work due to xml error. "Next" label now is grey, like (almost) all other labels in PVR GUI.

before:
![screenshot006](https://user-images.githubusercontent.com/3226626/33796201-57f23272-dcf0-11e7-8667-afdcd543a4b2.png)

after:
![screenshot005](https://user-images.githubusercontent.com/3226626/33796209-706e7892-dcf0-11e7-8262-0fcbed6289c1.png)

3. PVR: Guide window: Fix epg event details time/title/genre colors.

before:
![screenshot002](https://user-images.githubusercontent.com/3226626/33796231-a923e2bc-dcf0-11e7-9413-a583b9b8c493.png)

after:
![screenshot007](https://user-images.githubusercontent.com/3226626/33796233-b3431556-dcf0-11e7-9100-fc061232ddc0.png)

4. Video: seek bar: Hide video/audio info if player controls get activated (like we do with the chapter info).

before:
![screenshot009](https://user-images.githubusercontent.com/3226626/33796246-f0d35eee-dcf0-11e7-8f98-1504a845e503.png)

after:
![screenshot008](https://user-images.githubusercontent.com/3226626/33796253-fdc02a06-dcf0-11e7-9dd7-0e92aba11ddd.png)

5. PVR: seek bar: Increase height for pvr epg event plot area (now has same height as 'normal' video's plot area).

comparism Video/PVR:
![screenshot009](https://user-images.githubusercontent.com/3226626/33796417-21142fae-dcf4-11e7-9fb2-30ef79bfc337.png)

6. Music: seek bar: Move audio info for music to lower right, like it is for video.

before:
![screenshot010](https://user-images.githubusercontent.com/3226626/33796283-87892436-dcf1-11e7-8db5-4e3492863c67.png)

after:
![screenshot011](https://user-images.githubusercontent.com/3226626/33796287-9056b70e-dcf1-11e7-84d4-8340b9b2db28.png)

8: PVR: Seek bar: Hide info display if player process info gets opened.

before:
![screenshot000](https://user-images.githubusercontent.com/3226626/33796552-d48f8f9a-dcf6-11e7-98ed-b06598d2e8e7.png)

after:
![screenshot002](https://user-images.githubusercontent.com/3226626/33796577-8376279e-dcf7-11e7-8936-02e60d2f6ab9.png)

