### PR TITLE
[Estuary] Rework PVR seekbar + Fix PVR info dialog.

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -119,7 +119,7 @@
 			</control>
 			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$INFO[ListItem.Title]" />
-				<param name="sub_label" value="$INFO[ListItem.Season, [COLOR grey]S[/COLOR]]$INFO[ListItem.Episode, [COLOR grey]E[/COLOR],: ]$INFO[ListItem.EpisodeName,[B],[/B]]" />
+				<param name="sub_label" value="$VAR[SeasonEpisodeLabel]" />
 				<param name="posy" value="40" />
 			</include>
 		</control>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -28,7 +28,8 @@
 					<height>100</height>
 					<texture>$INFO[MusicPlayer.Codec,flags/audiocodec/,.png]</texture>
 					<aspectratio>keep</aspectratio>
-					<visible>!Player.ChannelPreviewActive</visible>
+					<visible>Player.ShowInfo + !Player.ChannelPreviewActive + Window.IsActive(visualisation)</visible>
+					<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
 				</control>
 				<control type="image">
 					<left>200</left>
@@ -58,7 +59,7 @@
 					<include>Animation_BottomSlide</include>
 					<orientation>horizontal</orientation>
 					<itemgap>10</itemgap>
-					<visible>Player.ShowInfo + Window.IsActive(fullscreenvideo) + !Player.ChannelPreviewActive</visible>
+					<visible>Player.ShowInfo + !Player.ChannelPreviewActive + Window.IsActive(fullscreenvideo)</visible>
 					<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
 					<include content="MediaFlag">
 						<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
@@ -74,7 +75,7 @@
 					</include>
 				</control>
 				<control type="group">
-					<visible>Window.IsActive(fullscreenvideo) + PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
+					<visible>PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
 					<control type="image">
 						<top>100</top>
 						<left>20</left>
@@ -85,25 +86,6 @@
 					<control type="label">
 						<top>110</top>
 						<left>90</left>
-						<width>400</width>
-						<height>50</height>
-						<aligny>center</aligny>
-						<font>font25_title</font>
-						<label>$LOCALIZE[19158]</label>
-					</control>
-				</control>
-				<control type="group">
-					<visible>Window.IsActive(visualisation) + PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
-					<control type="image">
-						<top>100</top>
-						<left>170</left>
-						<width>74</width>
-						<height>74</height>
-						<texture>osd/fullscreen/buttons/record.png</texture>
-					</control>
-					<control type="label">
-						<top>110</top>
-						<left>240</left>
 						<width>400</width>
 						<height>50</height>
 						<aligny>center</aligny>
@@ -225,7 +207,7 @@
 		</control>
 		<control type="group">
 			<visible>!Window.IsVisible(playerprocessinfo)</visible>
-			<visible>Player.ShowInfo + VideoPlayer.Content(LiveTV) + Window.IsActive(fullscreenvideo)</visible>
+			<visible>Player.ShowInfo + VideoPlayer.Content(LiveTV)</visible>
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<animation effect="slide" end="0,-80" time="150" condition="Control.IsVisible(6000)">conditional</animation>
 			<bottom>0</bottom>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -49,6 +49,30 @@
 					<label>[COLOR button_focus]$LOCALIZE[21396]:[CR][/COLOR]$INFO[player.chapter]$INFO[player.chaptercount, / ]</label>
 					<visible>player.chaptercount</visible>
 				</control>
+				<control type="grouplist">
+					<right>20</right>
+					<top>110</top>
+					<width>1000</width>
+					<height>100</height>
+					<align>right</align>
+					<include>Animation_BottomSlide</include>
+					<orientation>horizontal</orientation>
+					<itemgap>10</itemgap>
+					<visible>Player.ShowInfo + Window.IsActive(fullscreenvideo) + !Player.ChannelPreviewActive</visible>
+					<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
+					<include content="MediaFlag">
+						<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
+					</include>
+					<include content="MediaFlag">
+						<param name="texture" value="$INFO[VideoPlayer.AudioCodec,flags/audiocodec/,.png]" />
+					</include>
+					<include content="MediaFlag">
+						<param name="texture" value="$INFO[VideoPlayer.VideoAspect,flags/aspectratio/,.png]" />
+					</include>
+					<include content="MediaFlag">
+						<param name="texture" value="$INFO[VideoPlayer.VideoCodec,flags/videocodec/,.png]" />
+					</include>
+				</control>
 				<control type="group">
 					<visible>Window.IsActive(fullscreenvideo) + PVR.IsRecordingPlayingChannel + !Player.ChannelPreviewActive</visible>
 					<control type="image">
@@ -205,21 +229,7 @@
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<animation effect="slide" end="0,-80" time="150" condition="Control.IsVisible(6000)">conditional</animation>
 			<bottom>0</bottom>
-			<height>450</height>
-			<control type="image">
-				<left>0</left>
-				<width>100%</width>
-				<height>310</height>
-				<texture>dialogs/dialog-bg-nobo.png</texture>
-			</control>
-			<control type="image">
-				<left>30</left>
-				<top>20</top>
-				<width>200</width>
-				<height>200</height>
-				<aspectratio aligny="center">keep</aspectratio>
-				<texture>$INFO[Player.Art(thumb)]</texture>
-			</control>
+			<height>380</height>
 			<control type="label">
 				<left>20</left>
 				<width>220</width>
@@ -231,51 +241,35 @@
 				<font>WeatherTemp</font>
 				<aligny>center</aligny>
 			</control>
-			<control type="label">
-				<right>20</right>
-				<width>800</width>
-				<top>260</top>
-				<height>25</height>
-				<label>$INFO[VideoPlayer.NextTitle,[COLOR grey]$LOCALIZE[19031]: [/COLOR], ]($INFO[VideoPlayer.NextStartTime] - $INFO[VideoPlayer.NextEndTime])</label>
-				<align>right</align>
-				<aligny>center</aligny>
-				<visible>VideoPlayer.HasEpg</visible>
+			<control type="image">
+				<left>0</left>
+				<width>100%</width>
+				<height>240</height>
+				<texture>dialogs/dialog-bg-nobo.png</texture>
+			</control>
+			<control type="image">
+				<left>30</left>
+				<top>20</top>
+				<width>200</width>
+				<height>200</height>
+				<aspectratio aligny="center">keep</aspectratio>
+				<texture>$INFO[Player.Art(thumb)]</texture>
 			</control>
 			<control type="textbox">
 				<left>260</left>
-				<top>20</top>
-				<right>50</right>
-				<height>225</height>
-				<label fallback="416">$INFO[VideoPlayer.Plot]</label>
+				<top>10</top>
+				<right>30</right>
+				<height>160</height>
+				<label fallback="19055">$INFO[VideoPlayer.Plot]</label>
 				<align>justify</align>
 				<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
 			</control>
-			<control type="grouplist">
+			<control type="label">
 				<left>260</left>
-				<top>245</top>
-				<width>600</width>
-				<height>100</height>
-				<align>left</align>
-				<orientation>horizontal</orientation>
-				<itemgap>10</itemgap>
-				<visible>!Player.ChannelPreviewActive</visible>
-				<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
-					<param name="visible" value="!String.IsEmpty(VideoPlayer.AudioChannels)" />
-				</include>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.AudioCodec,flags/audiocodec/,.png]" />
-					<param name="visible" value="!String.IsEmpty(VideoPlayer.AudioCodec)" />
-				</include>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.VideoAspect,flags/aspectratio/,.png]" />
-					<param name="visible" value="!String.IsEmpty(VideoPlayer.VideoAspect)" />
-				</include>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.VideoCodec,flags/videocodec/,.png]" />
-					<param name="visible" value="!String.IsEmpty(VideoPlayer.VideoCodec)" />
-				</include>
+				<top>180</top>
+				<height>25</height>
+        <label>[COLOR grey]$LOCALIZE[19031]:[/COLOR] $INFO[VideoPlayer.NextStartTime] - $INFO[VideoPlayer.NextEndTime]: $INFO[VideoPlayer.NextTitle]</label>
+				<visible>VideoPlayer.HasEpg</visible>
 			</control>
 		</control>
 		<control type="group">
@@ -320,30 +314,6 @@
 					</control>
 				</control>
 			</control>
-			<control type="grouplist">
-				<right>20</right>
-				<top>155</top>
-				<width>1000</width>
-				<height>100</height>
-				<align>right</align>
-				<include>Animation_BottomSlide</include>
-				<orientation>horizontal</orientation>
-				<itemgap>10</itemgap>
-				<visible>![Player.ChannelPreviewActive | Window.IsActive(videoosd)]</visible>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.AudioChannels,flags/audiochannel/,.png]" />
-				</include>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.AudioCodec,flags/audiocodec/,.png]" />
-				</include>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.VideoAspect,flags/aspectratio/,.png]" />
-				</include>
-				<include content="MediaFlag">
-					<param name="texture" value="$INFO[VideoPlayer.VideoCodec,flags/videocodec/,.png]" />
-				</include>
-			</control>
 		</control>
-
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -43,6 +43,7 @@
 						<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 					</include>
 					<onclick>PlayerControl(Previous)</onclick>
+					<visible>!MusicPlayer.Content(livetv)</visible>
 				</control>
 				<control type="radiobutton" id="602">
 					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/play.png</textureradioonfocus>
@@ -73,7 +74,7 @@
 						<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 					</include>
 					<onclick>PlayerControl(Next)</onclick>
-					<visible>MusicPlayer.HasNext</visible>
+					<visible>MusicPlayer.HasNext + !MusicPlayer.Content(livetv)</visible>
 				</control>
 				<control type="radiobutton" id="606">
 					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>
@@ -93,7 +94,7 @@
 					<selected>!PVR.IsRecordingPlayingChannel</selected>
 					<onclick>PVR.ToggleRecordPlayingChannel</onclick>
 					<visible>PVR.CanRecordPlayingChannel</visible>
-					<visible>VideoPlayer.Content(livetv)</visible>
+					<visible>MusicPlayer.Content(livetv)</visible>
 				</control>
 			</control>
 			<control type="grouplist" id="202">

--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -31,7 +31,7 @@
 				<left>33</left>
 				<top>200</top>
 				<include>Visible_Left</include>
-				<visible>Player.ShowInfo | Window.IsActive(musicosd)</visible>
+				<visible>[Player.ShowInfo | Window.IsActive(musicosd)] + !MusicPlayer.Content(livetv)</visible>
 				<width>500</width>
 				<height>500</height>
 				<fadetime>400</fadetime>
@@ -42,7 +42,7 @@
 			</control>
 			<control type="group">
 				<top>-30</top>
-				<visible>[Player.ShowInfo | Window.IsActive(musicosd)] + !Window.IsActive(playerprocessinfo)</visible>
+				<visible>[Player.ShowInfo | Window.IsActive(musicosd)] + ![Window.IsActive(playerprocessinfo) | MusicPlayer.Content(livetv)]</visible>
 				<include>Visible_Left</include>
 				<control type="group">
 					<left>30</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -407,6 +407,11 @@
 		<value condition="ListItem.HasTimerSchedule">icons/pvr/PVR-HasTimerSchedule.png</value>
 		<value condition="ListItem.HasTimer">icons/pvr/PVR-HasTimer.png</value>
 	</variable>
+	<variable name="SeasonEpisodeLabel">
+		<value condition="String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode)">$INFO[ListItem.EpisodeName,[B],[/B]]</value>
+		<value condition="String.IsEmpty(ListItem.EpisodeName)">$INFO[ListItem.Season,[COLOR grey]S,[/COLOR]]$INFO[ListItem.Episode,[COLOR grey]E,[/COLOR]]</value>
+		<value>$INFO[ListItem.Season,[COLOR grey]S,[/COLOR]]$INFO[ListItem.Episode,[COLOR grey]E,[/COLOR]]: [B]$INFO[ListItem.EpisodeName][/B]</value>
+	</variable>
 	<variable name="ExpirationDateTimeLabel">
 		<value condition="!String.IsEmpty(ListItem.ExpirationDate)">[COLOR grey]$LOCALIZE[19299]:[/COLOR] $INFO[ListItem.ExpirationDate] $INFO[ListItem.ExpirationTime][CR]</value>
 	</variable>


### PR DESCRIPTION
1. Rework seekbar for Live TV.

* Remove special handling for PVR audio and video stream info. Move it to lower right, where it resides for all (?) other media.
* Rearrange channel number and next event info for more readability.

before:
![screenshot001](https://user-images.githubusercontent.com/3226626/33799728-cb444580-dd31-11e7-90a0-13fbd39c22a0.png)

after:
![screenshot000](https://user-images.githubusercontent.com/3226626/33799727-c62e53e2-dd31-11e7-9997-e9209403532d.png)

2. Seekbar for PVR radio now is aligned with PVR Live TV, not 'normal' music anymore.

before:
![screenshot001](https://user-images.githubusercontent.com/3226626/33800273-bcea8520-dd3c-11e7-8a13-6b547a2e5be2.png)

after:
![screenshot000](https://user-images.githubusercontent.com/3226626/33800275-c8f519ca-dd3c-11e7-9b5e-d3f9fd715a08.png)

3. PVR info dialog: Fix sesaon/episode/episodetitle string composition. Fixes https://github.com/phil65/skin.estuary/issues/246