### PR TITLE
airplay: disable video/pictures support by default

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1957,7 +1957,7 @@
         </setting>
         <setting id="services.airplayvideosupport" type="boolean" parent="services.airplay" label="1268" help="36549">
           <level>3</level>
-          <default>true</default>
+          <default>false</default>
           <dependencies>
             <dependency type="enable" setting="services.airplay">true</dependency>
           </dependencies>


### PR DESCRIPTION
Kodi currently defaults to Airplay Video and Pictures support enabled but this prevents Kodi from appearing as an Audio target on devices running iOS 9.x and higher. iOS 9 released in Sept '15 and we are now on iOS 11.x so the default should be switched so the sole (Audio) feature that works on recent generations of iOS device works "out of box" without extra configuration. Users with legacy iOS 8.x and older devices can always turn Video/Picture support back on.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed