### PR TITLE
[uwp] remoe Real Media Files from FileType in manifest

### DIFF
--- a/project/Win32BuildSetup/AppxManifest.xml.in
+++ b/project/Win32BuildSetup/AppxManifest.xml.in
@@ -114,10 +114,6 @@
               <uap:FileType>.pxml</uap:FileType>
               <uap:FileType>.rcv</uap:FileType>
               <uap:FileType>.rec</uap:FileType>
-              <uap:FileType>.rm</uap:FileType>
-              <uap:FileType>.rma</uap:FileType>
-              <uap:FileType>.rmt</uap:FileType>
-              <uap:FileType>.rmvb</uap:FileType>
               <uap:FileType>.rsd</uap:FileType>
               <uap:FileType>.rss</uap:FileType>
               <uap:FileType>.pva</uap:FileType>


### PR DESCRIPTION
Win Store complained we had Real Media files in manifest while we couldn't play them. Since i don't want to test let's just remove them