### PR TITLE
fix typo (*VAApi()->VAApi*()) and function signature of VAAPIRegister…

### DIFF
--- a/xbmc/windowing/wayland/OptionalsReg.cpp
+++ b/xbmc/windowing/wayland/OptionalsReg.cpp
@@ -88,12 +88,12 @@ void WAYLAND::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
 
 }
 
-void WAYLAND::RegisterVAAPI(CVaapiProxy *winSystem, bool hevc)
+void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
 {
 
 }
 
-void WAYLAND::RegisterVAAPIRender(CVaapiProxy *winSystem, void* dpy,
+void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, void* dpy,
                          void* eglDisplay, bool &general, bool &hevc)
 {
 


### PR DESCRIPTION
…Render(), fixes build without VAAPI

This is basically the same as commit 8efa2a9a6e0cef78c5114e9967301d270c1ad34f - just for Wayland instead of X11

Signed-off-by: Thomas Rohloff <v10lator@myway.de>