### PR TITLE
fix typo (*VAApi()->VAApi*()) and function signature of VAAPIRegister…

### DIFF
--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -115,12 +115,12 @@ void GBM::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
 
 }
 
-void GBM::RegisterVAAPI(CVaapiProxy *winSystem, bool hevc)
+void GBM::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
 {
 
 }
 
-void GBM::RegisterVAAPIRender(CVaapiProxy *winSystem, void* dpy,
+void GBM::VAAPIRegisterRender(CVaapiProxy *winSystem, void* dpy,
                          void* eglDisplay, bool &general, bool &hevc)
 {
 


### PR DESCRIPTION
…Render(), fixes build without VAAPI

See: #13173 