### PR TITLE
Fix usage of CompareNoCase

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -233,11 +233,11 @@ void CDVDSubtitleTagSami::LoadHead(CDVDSubtitleStream* samiStream)
     std::string line = cLine;
     StringUtils::Trim(line);
 
-   if (!StringUtils::CompareNoCase(line, "<BODY>"))
+   if (StringUtils::EqualsNoCase(line, "<BODY>"))
       break;
     if (inSTYLE)
     {
-      if (!StringUtils::CompareNoCase(line, "</STYLE>"))
+      if (StringUtils::EqualsNoCase(line, "</STYLE>"))
         break;
       else
       {
@@ -257,7 +257,7 @@ void CDVDSubtitleTagSami::LoadHead(CDVDSubtitleStream* samiStream)
     }
     else
     {
-      if (!StringUtils::CompareNoCase(line, "<STYLE TYPE=\"text/css\">"))
+      if (StringUtils::EqualsNoCase(line, "<STYLE TYPE=\"text/css\">"))
         inSTYLE = true;
     }
   }

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -72,22 +72,18 @@ bool IDirectory::IsAllowed(const CURL& url) const
     std::string folder = URIUtils::GetDirectory(fileName);
     URIUtils::RemoveSlashAtEnd(folder);
     folder = URIUtils::GetFileName(folder);
-    if (folder.size() <= 3) // cannot be a vcd variant
-      return true;
-
     if (StringUtils::EqualsNoCase(folder, "vcd") ||
-        StringUtils::EqualsNoCase(folder, "MPEGAV") ||
-        StringUtils::EqualsNoCase(folder, "CDDA"))
-      return true;
-
-    // Allow filenames of the form AVSEQ##(#).DAT, ITEM###(#).DAT
-    // and MUSIC##(#).DAT
-    return (fileName.length() == 11 || fileName.length() == 12) &&
-           (StringUtils::StartsWithNoCase(fileName, "AVSEQ") ||
-            StringUtils::StartsWithNoCase(fileName, "MUSIC") ||
-            StringUtils::StartsWithNoCase(fileName, "ITEM"));
+        StringUtils::EqualsNoCase(folder, "mpegav") ||
+        StringUtils::EqualsNoCase(folder, "cdda"))
+    {
+      // Allow filenames of the form AVSEQ##(#).DAT, ITEM###(#).DAT
+      // and MUSIC##(#).DAT
+      return (fileName.length() == 11 || fileName.length() == 12) &&
+             (StringUtils::StartsWithNoCase(fileName, "AVSEQ") ||
+              StringUtils::StartsWithNoCase(fileName, "MUSIC") ||
+              StringUtils::StartsWithNoCase(fileName, "ITEM"));
+    }
   }
-
   return true;
 }
 

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -75,9 +75,9 @@ bool IDirectory::IsAllowed(const CURL& url) const
     if (folder.size() <= 3) // cannot be a vcd variant
       return true;
 
-    if (!StringUtils::CompareNoCase(folder, "vcd") &&
-        !StringUtils::CompareNoCase(folder, "MPEGAV") &&
-        !StringUtils::CompareNoCase(folder, "CDDA"))
+    if (StringUtils::EqualsNoCase(folder, "vcd") ||
+        StringUtils::EqualsNoCase(folder, "MPEGAV") ||
+        StringUtils::EqualsNoCase(folder, "CDDA"))
       return true;
 
     // Allow filenames of the form AVSEQ##(#).DAT, ITEM###(#).DAT

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -652,7 +652,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
               bool match = false;
               for (auto entry : possiblePlayers)
               {
-                if (StringUtils::CompareNoCase(entry, playername))
+                if (StringUtils::EqualsNoCase(entry, playername))
                 {
                   match = true;
                   break;

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -429,7 +429,7 @@ void CAirTunesServer::SetupRemoteControl()
   std::vector<CZeroconfBrowser::ZeroconfService> services = CZeroconfBrowser::GetInstance()->GetFoundServices();
   for (auto service : services )
   {
-    if (StringUtils::CompareNoCase(service.GetType(), std::string(ZEROCONF_DACP_SERVICE) + ".") == 0)
+    if (StringUtils::EqualsNoCase(service.GetType(), std::string(ZEROCONF_DACP_SERVICE) + "."))
     {
 #define DACP_NAME_PREFIX "iTunes_Ctrl_"
       // name has the form "iTunes_Ctrl_56B29BB6CB904862"

--- a/xbmc/storage/android/AndroidStorageProvider.cpp
+++ b/xbmc/storage/android/AndroidStorageProvider.cpp
@@ -182,7 +182,7 @@ void CAndroidStorageProvider::GetRemovableDrives(VECSOURCES &removableDrives)
             break;
           }
           StringUtils::Trim(share.strName);
-          if (share.strName.empty() || share.strName == "?" || StringUtils::CompareNoCase(share.strName, "null") == 0)
+          if (share.strName.empty() || share.strName == "?" || StringUtils::EqualsNoCase(share.strName, "null"))
             share.strName = URIUtils::GetFileName(share.strPath);
           share.m_ignore = true;
           droidDrives.push_back(share);

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -274,7 +274,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
       strHTML = converted;
     }
   }
-  else if (ftype == CMime::FileTypePlainText || StringUtils::CompareNoCase(mimeType.substr(0, 5), "text/") == 0)
+  else if (ftype == CMime::FileTypePlainText || StringUtils::EqualsNoCase(mimeType.substr(0, 5), "text/"))
   {
     std::string realTextCharset, converted;
     CCharsetDetection::ConvertPlainTextToUtf8(strHTML, converted, reportedCharset, realTextCharset);


### PR DESCRIPTION
In most cases EqualsNoCase is the better fit. While scanning the code, there were other broken uses of CompareNoCase - I marked those commits: review needed.