### PR TITLE
kill g_powerManager global

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -403,7 +403,7 @@ bool CApplication::Create(const CAppParamParser &params)
   // some of the serives depend on the WinSystem :(
   std::unique_ptr<CWinSystemBase> winSystem = CWinSystemBase::CreateWinSystem();
   m_ServiceManager->SetWinSystem(std::move(winSystem));
-  
+
   if (!m_ServiceManager->InitStageOne())
   {
     return false;
@@ -576,8 +576,6 @@ bool CApplication::Create(const CAppParamParser &params)
   avformat_network_init();
   // set avutil callback
   av_log_set_callback(ff_avutil_log);
-
-  g_powerManager.Initialize();
 
   // Initialize default Settings - don't move
   CLog::Log(LOGNOTICE, "load settings...");
@@ -2377,7 +2375,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   {
   case TMSG_POWERDOWN:
     Stop(EXITCODE_POWERDOWN);
-    g_powerManager.Powerdown();
+    CServiceBroker::GetPowerManager().Powerdown();
     break;
 
   case TMSG_QUIT:
@@ -2393,17 +2391,17 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     break;
 
   case TMSG_HIBERNATE:
-    g_powerManager.Hibernate();
+    CServiceBroker::GetPowerManager().Hibernate();
     break;
 
   case TMSG_SUSPEND:
-    g_powerManager.Suspend();
+    CServiceBroker::GetPowerManager().Suspend();
     break;
 
   case TMSG_RESTART:
   case TMSG_RESET:
     Stop(EXITCODE_REBOOT);
-    g_powerManager.Reboot();
+    CServiceBroker::GetPowerManager().Reboot();
     break;
 
   case TMSG_RESTARTAPP:
@@ -4384,7 +4382,7 @@ void CApplication::Process()
 // We get called every 500ms
 void CApplication::ProcessSlow()
 {
-  g_powerManager.ProcessEvents();
+  CServiceBroker::GetPowerManager().ProcessEvents();
 
 #if defined(TARGET_DARWIN_OSX)
   // There is an issue on OS X that several system services ask the cursor to become visible

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6895,7 +6895,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
       value = CServiceBroker::GetPVRManager().TranslateIntInfo(info);
       return true;
     case SYSTEM_BATTERY_LEVEL:
-      value = g_powerManager.BatteryLevel();
+      value = CServiceBroker::GetPowerManager().BatteryLevel();
       return true;
   }
   return false;
@@ -7037,13 +7037,13 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     bReturn = g_mediaManager.GetDriveStatus() == DRIVE_OPEN;
 #endif
   else if (condition == SYSTEM_CAN_POWERDOWN)
-    bReturn = g_powerManager.CanPowerdown();
+    bReturn = CServiceBroker::GetPowerManager().CanPowerdown();
   else if (condition == SYSTEM_CAN_SUSPEND)
-    bReturn = g_powerManager.CanSuspend();
+    bReturn = CServiceBroker::GetPowerManager().CanSuspend();
   else if (condition == SYSTEM_CAN_HIBERNATE)
-    bReturn = g_powerManager.CanHibernate();
+    bReturn = CServiceBroker::GetPowerManager().CanHibernate();
   else if (condition == SYSTEM_CAN_REBOOT)
-    bReturn = g_powerManager.CanReboot();
+    bReturn = CServiceBroker::GetPowerManager().CanReboot();
   else if (condition == SYSTEM_SCREENSAVER_ACTIVE)
     bReturn = g_application.IsInScreenSaver();
   else if (condition == SYSTEM_DPMS_ACTIVE)

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -152,3 +152,8 @@ CRenderSystemBase& CServiceBroker::GetRenderSystem()
   CRenderSystemBase &renderSystem = dynamic_cast<CRenderSystemBase&>(g_application.m_ServiceManager->GetWinSystem());
   return renderSystem;
 }
+
+CPowerManager& CServiceBroker::GetPowerManager()
+{
+  return g_application.m_ServiceManager->GetPowerManager();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -59,6 +59,7 @@ class CFileExtensionProvider;
 class CNetwork;
 class CWinSystemBase;
 class CRenderSystemBase;
+class CPowerManager;
 
 namespace KODI
 {
@@ -107,4 +108,5 @@ public:
   static CNetwork& GetNetwork();
   static CWinSystemBase& GetWinSystem();
   static CRenderSystemBase& GetRenderSystem();
+  static CPowerManager& GetPowerManager();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -42,6 +42,7 @@
 #include "settings/Settings.h"
 #include "utils/FileExtensionProvider.h"
 #include "windowing/WinSystem.h"
+#include "powermanagement/PowerManager.h"
 
 using namespace KODI;
 
@@ -143,6 +144,10 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
 
   m_fileExtensionProvider.reset(new CFileExtensionProvider());
 
+  m_powerManager.reset(new CPowerManager());
+  m_powerManager->Initialize();
+  m_powerManager->SetDefaults();
+
   init_level = 2;
   return true;
 }
@@ -207,6 +212,7 @@ void CServiceManager::DeinitStageTwo()
 {
   init_level = 1;
 
+  m_powerManager.reset();
   m_fileExtensionProvider.reset();
   m_gameRenderManager.reset();
   m_peripherals.reset();
@@ -360,6 +366,11 @@ CWinSystemBase &CServiceManager::GetWinSystem()
 void CServiceManager::SetWinSystem(std::unique_ptr<CWinSystemBase> winSystem)
 {
   m_winSystem = std::move(winSystem);
+}
+
+CPowerManager &CServiceManager::GetPowerManager()
+{
+  return *m_powerManager;
 }
 
 // deleters for unique_ptr

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -63,6 +63,7 @@ class IAE;
 class CFavouritesService;
 class CNetwork;
 class CWinSystemBase;
+class CPowerManager;
 
 namespace KODI
 {
@@ -137,6 +138,8 @@ public:
   CWinSystemBase &GetWinSystem();
   void SetWinSystem(std::unique_ptr<CWinSystemBase> winSystem);
 
+  CPowerManager &GetPowerManager();
+
 protected:
   struct delete_dataCacheCore
   {
@@ -187,4 +190,5 @@ protected:
   std::unique_ptr<CFileExtensionProvider> m_fileExtensionProvider;
   std::unique_ptr<CNetwork> m_network;
   std::unique_ptr<CWinSystemBase> m_winSystem;
+  std::unique_ptr<CPowerManager> m_powerManager;
 };

--- a/xbmc/interfaces/json-rpc/SystemOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SystemOperations.cpp
@@ -53,7 +53,7 @@ JSONRPC_STATUS CSystemOperations::EjectOpticalDrive(const std::string &method, I
 
 JSONRPC_STATUS CSystemOperations::Shutdown(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  if (g_powerManager.CanPowerdown())
+  if (CServiceBroker::GetPowerManager().CanPowerdown())
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_POWERDOWN);
     return ACK;
@@ -64,7 +64,7 @@ JSONRPC_STATUS CSystemOperations::Shutdown(const std::string &method, ITransport
 
 JSONRPC_STATUS CSystemOperations::Suspend(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  if (g_powerManager.CanSuspend())
+  if (CServiceBroker::GetPowerManager().CanSuspend())
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_SUSPEND);
     return ACK;
@@ -75,7 +75,7 @@ JSONRPC_STATUS CSystemOperations::Suspend(const std::string &method, ITransportL
 
 JSONRPC_STATUS CSystemOperations::Hibernate(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  if (g_powerManager.CanHibernate())
+  if (CServiceBroker::GetPowerManager().CanHibernate())
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_HIBERNATE);
     return ACK;
@@ -86,7 +86,7 @@ JSONRPC_STATUS CSystemOperations::Hibernate(const std::string &method, ITranspor
 
 JSONRPC_STATUS CSystemOperations::Reboot(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  if (g_powerManager.CanReboot())
+  if (CServiceBroker::GetPowerManager().CanReboot())
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_RESTART);
     return ACK;
@@ -98,13 +98,13 @@ JSONRPC_STATUS CSystemOperations::Reboot(const std::string &method, ITransportLa
 JSONRPC_STATUS CSystemOperations::GetPropertyValue(int permissions, const std::string &property, CVariant &result)
 {
   if (property == "canshutdown")
-    result = g_powerManager.CanPowerdown() && (permissions & ControlPower);
+    result = CServiceBroker::GetPowerManager().CanPowerdown() && (permissions & ControlPower);
   else if (property == "cansuspend")
-    result = g_powerManager.CanSuspend() && (permissions & ControlPower);
+    result = CServiceBroker::GetPowerManager().CanSuspend() && (permissions & ControlPower);
   else if (property == "canhibernate")
-    result = g_powerManager.CanHibernate() && (permissions & ControlPower);
+    result = CServiceBroker::GetPowerManager().CanHibernate() && (permissions & ControlPower);
   else if (property == "canreboot")
-    result = g_powerManager.CanReboot() && (permissions & ControlPower);
+    result = CServiceBroker::GetPowerManager().CanReboot() && (permissions & ControlPower);
   else
     return InvalidParams;
 

--- a/xbmc/interfaces/json-rpc/SystemOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SystemOperations.cpp
@@ -23,6 +23,7 @@
 #include "interfaces/builtins/Builtins.h"
 #include "utils/Variant.h"
 #include "powermanagement/PowerManager.h"
+#include "ServiceBroker.h"
 
 using namespace JSONRPC;
 using namespace KODI::MESSAGING;

--- a/xbmc/interfaces/json-rpc/XBMCOperations.cpp
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.cpp
@@ -68,15 +68,15 @@ JSONRPC_STATUS CXBMCOperations::GetInfoBooleans(const std::string &method, ITran
     // Need to override power management of whats in infomanager since jsonrpc
     // have a security layer aswell.
     if (field == "system.canshutdown")
-      result[parameterObject["booleans"][i].asString()] = (g_powerManager.CanPowerdown() && CanControlPower);
+      result[parameterObject["booleans"][i].asString()] = (CServiceBroker::GetPowerManager().CanPowerdown() && CanControlPower);
     else if (field == "system.canpowerdown")
-      result[parameterObject["booleans"][i].asString()] = (g_powerManager.CanPowerdown() && CanControlPower);
+      result[parameterObject["booleans"][i].asString()] = (CServiceBroker::GetPowerManager().CanPowerdown() && CanControlPower);
     else if (field == "system.cansuspend")
-      result[parameterObject["booleans"][i].asString()] = (g_powerManager.CanSuspend() && CanControlPower);
+      result[parameterObject["booleans"][i].asString()] = (CServiceBroker::GetPowerManager().CanSuspend() && CanControlPower);
     else if (field == "system.canhibernate")
-      result[parameterObject["booleans"][i].asString()] = (g_powerManager.CanHibernate() && CanControlPower);
+      result[parameterObject["booleans"][i].asString()] = (CServiceBroker::GetPowerManager().CanHibernate() && CanControlPower);
     else if (field == "system.canreboot")
-      result[parameterObject["booleans"][i].asString()] = (g_powerManager.CanReboot() && CanControlPower);
+      result[parameterObject["booleans"][i].asString()] = (CServiceBroker::GetPowerManager().CanReboot() && CanControlPower);
     else
       info.push_back(parameterObject["booleans"][i].asString());
   }

--- a/xbmc/interfaces/json-rpc/XBMCOperations.cpp
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.cpp
@@ -22,6 +22,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "utils/Variant.h"
 #include "powermanagement/PowerManager.h"
+#include "ServiceBroker.h"
 
 using namespace JSONRPC;
 using namespace KODI::MESSAGING;

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -59,8 +59,6 @@ extern HWND g_hWnd;
 
 using namespace ANNOUNCEMENT;
 
-CPowerManager g_powerManager;
-
 CPowerManager::CPowerManager()
 {
   m_instance = NULL;
@@ -137,30 +135,30 @@ void CPowerManager::SetDefaults()
         defaultShutdown = POWERSTATE_SHUTDOWN;
     break;
     case POWERSTATE_HIBERNATE:
-      if (!g_powerManager.CanHibernate())
+      if (!CServiceBroker::GetPowerManager().CanHibernate())
       {
-        if (g_powerManager.CanSuspend())
+        if (CServiceBroker::GetPowerManager().CanSuspend())
           defaultShutdown = POWERSTATE_SUSPEND;
         else
-          defaultShutdown = g_powerManager.CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
+          defaultShutdown = CServiceBroker::GetPowerManager().CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
       }
     break;
     case POWERSTATE_SUSPEND:
-      if (!g_powerManager.CanSuspend())
+      if (!CServiceBroker::GetPowerManager().CanSuspend())
       {
-        if (g_powerManager.CanHibernate())
+        if (CServiceBroker::GetPowerManager().CanHibernate())
           defaultShutdown = POWERSTATE_HIBERNATE;
         else
-          defaultShutdown = g_powerManager.CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
+          defaultShutdown = CServiceBroker::GetPowerManager().CanPowerdown() ? POWERSTATE_SHUTDOWN : POWERSTATE_QUIT;
       }
     break;
     case POWERSTATE_SHUTDOWN:
-      if (!g_powerManager.CanPowerdown())
+      if (!CServiceBroker::GetPowerManager().CanPowerdown())
       {
-        if (g_powerManager.CanSuspend())
+        if (CServiceBroker::GetPowerManager().CanSuspend())
           defaultShutdown = POWERSTATE_SUSPEND;
         else
-          defaultShutdown = g_powerManager.CanHibernate() ? POWERSTATE_HIBERNATE : POWERSTATE_QUIT;
+          defaultShutdown = CServiceBroker::GetPowerManager().CanHibernate() ? POWERSTATE_HIBERNATE : POWERSTATE_QUIT;
       }
     break;
   }
@@ -312,11 +310,11 @@ void CPowerManager::OnLowBattery()
 
 void CPowerManager::SettingOptionsShutdownStatesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
-  if (g_powerManager.CanPowerdown())
+  if (CServiceBroker::GetPowerManager().CanPowerdown())
     list.push_back(make_pair(g_localizeStrings.Get(13005), POWERSTATE_SHUTDOWN));
-  if (g_powerManager.CanHibernate())
+  if (CServiceBroker::GetPowerManager().CanHibernate())
     list.push_back(make_pair(g_localizeStrings.Get(13010), POWERSTATE_HIBERNATE));
-  if (g_powerManager.CanSuspend())
+  if (CServiceBroker::GetPowerManager().CanSuspend())
     list.push_back(make_pair(g_localizeStrings.Get(13011), POWERSTATE_SUSPEND));
   if (!g_application.IsStandAlone())
   {

--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -81,7 +81,7 @@ public:
   bool CanSuspend();
   bool CanHibernate();
   bool CanReboot();
-  
+
   int  BatteryLevel();
 
   void ProcessEvents();
@@ -96,6 +96,3 @@ private:
 
   IPowerSyscall *m_instance;
 };
-
-extern CPowerManager g_powerManager;
-

--- a/xbmc/powermanagement/osx/CocoaPowerSyscall.cpp
+++ b/xbmc/powermanagement/osx/CocoaPowerSyscall.cpp
@@ -336,7 +336,7 @@ void CCocoaPowerSyscall::OSPowerCallBack(void *refcon, io_service_t service, nat
       ctx->m_OnSuspend = true;
       // force processing of this power event. This callback runs
       // in main thread so we can do this.
-      g_powerManager.ProcessEvents();
+      CServiceBroker::GetPowerManager().ProcessEvents();
       IOAllowPowerChange(ctx->m_root_port, (long)msg_arg);
       //CLog::Log(LOGDEBUG, "%s - kIOMessageSystemWillSleep", __FUNCTION__);
       // let XBMC know system will sleep

--- a/xbmc/powermanagement/osx/CocoaPowerSyscall.cpp
+++ b/xbmc/powermanagement/osx/CocoaPowerSyscall.cpp
@@ -26,6 +26,7 @@ typedef unsigned char BYTE;
 #include "utils/SystemInfo.h"
 #include "Application.h"
 #include "powermanagement/PowerManager.h"
+#include "ServiceBroker.h"
 #include "CocoaPowerSyscall.h"
 
 #if defined(TARGET_DARWIN_OSX)

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -666,8 +666,6 @@ void CSettings::InitializeDefaults()
 
   if (g_application.IsStandAlone())
     std::static_pointer_cast<CSettingInt>(GetSettingsManager()->GetSetting(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE))->SetDefault(POWERSTATE_SHUTDOWN);
-
-  g_powerManager.SetDefaults();
 }
 
 void CSettings::InitializeOptionFillers()

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -310,7 +310,7 @@ std::string CSysInfoJob::GetVideoEncoder()
 
 std::string CSysInfoJob::GetBatteryLevel()
 {
-  return StringUtils::Format("%d%%", g_powerManager.BatteryLevel());
+  return StringUtils::Format("%d%%", CServiceBroker::GetPowerManager().BatteryLevel());
 }
 
 double CSysInfoJob::GetCPUFrequency()


### PR DESCRIPTION
This one was pretty simple. I've built and it runs.

~~One thing that is an issues is I wanted to init the CPowerManager in `initstagetwo` not `initstageone` however I get a segfault when SetDefaults() is called due to `CPowerManager` not being initialized yet~~
```
Thread 1 (Thread 0x7fe245a626c0 (LWP 6327)):
#0  0x0000000000ae53dc in CPowerManager::CanPowerdown() ()
#1  0x0000000000ae553b in CPowerManager::SetDefaults() ()
#2  0x0000000000cee688 in CSettings::InitializeDefaults() ()
#3  0x0000000000cedf76 in CSettings::InitializeDefinitions() ()
#4  0x0000000000cee279 in CSettings::Initialize() ()
#5  0x0000000000c441c5 in CApplication::Create(CAppParamParser const&) ()
#6  0x0000000000af60b7 in XBMC_Run ()
#7  0x000000000081781d in main ()
```
~~and the problem of having it in `initstageone` is that some of the logging is missed.~~

~~Is there a better solution? I'll try and look for one.~~

Solved it by moving the `SetDefaults()` call. Should it be in the `CPowerManager::Initialize()` instead?

`CPowerManager` is initilized a bit later now but I don't think there is any problems with that.