### PR TITLE
CHG: Allow to downgrade resolution

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21205,3 +21205,11 @@ msgstr ""
 msgctxt "#39109"
 msgid "Select Program"
 msgstr ""
+
+msgctxt "#39110"
+msgid "Also allow resolution switch"
+msgstr ""
+
+msgctxt "#39111"
+msgid "Allow also the resolution to be adjusted to closely match the source material"
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -46,6 +46,11 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="videoplayer.adjustresolution" type="boolean" label="39110" help="39111">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usedisplayasclock" type="boolean" label="13510" help="36166">
           <level>1</level>
           <default>false</default>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -143,6 +143,7 @@ const std::string CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM = "videoplayer
 const std::string CSettings::SETTING_VIDEOPLAYER_SEEKSTEPS = "videoplayer.seeksteps";
 const std::string CSettings::SETTING_VIDEOPLAYER_SEEKDELAY = "videoplayer.seekdelay";
 const std::string CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE = "videoplayer.adjustrefreshrate";
+const std::string CSettings::SETTING_VIDEOPLAYER_ADJUSTRESOLUTION = "videoplayer.adjustresolution";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK = "videoplayer.usedisplayasclock";
 const std::string CSettings::SETTING_VIDEOPLAYER_ERRORINASPECT = "videoplayer.errorinaspect";
 const std::string CSettings::SETTING_VIDEOPLAYER_STRETCH43 = "videoplayer.stretch43";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -97,6 +97,7 @@ public:
   static const std::string SETTING_VIDEOPLAYER_SEEKSTEPS;
   static const std::string SETTING_VIDEOPLAYER_SEEKDELAY;
   static const std::string SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE;
+  static const std::string SETTING_VIDEOPLAYER_ADJUSTRESOLUTION;
   static const std::string SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK;
   static const std::string SETTING_VIDEOPLAYER_ERRORINASPECT;
   static const std::string SETTING_VIDEOPLAYER_STRETCH43;

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.h"
 #include "utils/MathUtils.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/DisplaySettings.h"
 #include <cstdlib>
 
@@ -195,6 +196,7 @@ void CResolutionUtils::FindResolutionFromFpsMatch(float fps, int width, bool is3
 RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is3D, float multiplier, RESOLUTION current, float& weight)
 {
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(current);
+  bool adjustReso = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_ADJUSTRESOLUTION);
   float fRefreshRate = fps;
 
   int curr_diff = curr.iScreenWidth - width;
@@ -217,7 +219,12 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) ||
         info.fRefreshRate < (fRefreshRate * multiplier / 1.001) - 0.001)
     {
-      // evaluate all higher modes and evaluate them
+      // If not allowed to switch reso, ignore the ones
+      // not equal to the current one
+      if (!adjustReso && (info.iScreenWidth != curr.iScreenWidth || info.iScreenHeight != curr.iScreenHeight))
+        continue;
+
+      // evaluate all higher modes and evalute them
       // concerning dimension and refreshrate weight
       // skip lower resolutions
       // don't change resolutions when 3D is wanted
@@ -225,9 +232,7 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
          (info.iScreenHeight < 720) || // ignore < 720p
          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) || // don't switch to interlaced modes
          (info.iScreen != curr.iScreen)) // skip not current displays
-      {
         continue;
-      }
     }
 
     // Allow switching to a matching resolution:

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -224,6 +224,10 @@ RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is
       if (!adjustReso && (info.iScreenWidth != curr.iScreenWidth || info.iScreenHeight != curr.iScreenHeight))
         continue;
 
+      // If 3D, only consider 1080p
+      if (is3D && (info.iScreenWidth != 1920 || info.iScreenHeight != 1080))
+        continue;
+
       // evaluate all higher modes and evalute them
       // concerning dimension and refreshrate weight
       // skip lower resolutions


### PR DESCRIPTION
Kodi already allows to "upgrade" resolution, eg from 1080p to 2160p.

This also allows Kodi to "downgrade" the resolution, eg from 1080p to 720p.
Reasoning is that the TV will always do a better job at upscaling than we do, so better switch to a resolution closest to the one of the video.

I'm not sure of the reasoning for the 3D specific handling, tbh, so that might need rework.
My only personal use case is HTAB/HSBS, whose format is always 1080p.
The HDMI ref only define a 1080p 3D mode, so we might want to force to 1080p, possibly.