### PR TITLE
 RendererDRMPRIME: add atomic support

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -206,6 +206,8 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   m_pCodecContext->coded_width = hints.width;
   m_pCodecContext->coded_height = hints.height;
   m_pCodecContext->bits_per_coded_sample = hints.bitsperpixel;
+  m_pCodecContext->time_base.num = 1;
+  m_pCodecContext->time_base.den = DVD_TIME_BASE;
 
   if (hints.extradata && hints.extrasize > 0)
   {

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -37,7 +37,7 @@ public:
 private:
   bool AddConnectorProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
   bool AddCrtcProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
-  bool DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
+  void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
 
   bool m_need_modeset;
 };

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -27,16 +27,17 @@ class CDRMAtomic : public CDRMUtils
 public:
   CDRMAtomic() = default;
   ~CDRMAtomic() { DestroyDrm(); };
-  virtual void FlipPage(struct gbm_bo *bo) override;
+  virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override;
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
   virtual bool InitDrm() override;
   virtual void DestroyDrm() override;
 
+  bool AddPlaneProperty(drmModeAtomicReq *req, struct plane *obj, const char *name, int value);
+
 private:
   bool AddConnectorProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
   bool AddCrtcProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
-  bool AddPlaneProperty(drmModeAtomicReq *req, struct plane *obj, const char *name, int value);
-  bool DrmAtomicCommit(int fb_id, int flags);
+  bool DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
 
   bool m_need_modeset;
 };

--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -149,7 +149,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
   return true;
 }
 
-void CDRMLegacy::FlipPage(struct gbm_bo *bo)
+void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
 {
   flip_happening = QueueFlip(bo);
   WaitingForFlip();

--- a/xbmc/windowing/gbm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/DRMLegacy.h
@@ -27,7 +27,7 @@ class CDRMLegacy : public CDRMUtils
 public:
   CDRMLegacy() = default;
   ~CDRMLegacy() { DestroyDrm(); };
-  virtual void FlipPage(struct gbm_bo *bo) override;
+  virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override;
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
   virtual bool InitDrm() override;
 

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -32,6 +32,7 @@
 #include "WinSystemGbmGLESContext.h"
 #include "guilib/gui3d.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 
 #include "DRMUtils.h"
 
@@ -630,7 +631,6 @@ bool CDRMUtils::GetModes(std::vector<RESOLUTION_INFO> &resolutions)
     res.iSubtitles = static_cast<int>(0.965 * res.iHeight);
     res.fPixelRatio = 1.0f;
     res.bFullScreen = true;
-    res.strMode = m_connector->connector->modes[i].name;
     res.strId = std::to_string(i);
 
     if(m_connector->connector->modes[i].flags & DRM_MODE_FLAG_3D_MASK)
@@ -654,6 +654,8 @@ bool CDRMUtils::GetModes(std::vector<RESOLUTION_INFO> &resolutions)
       res.dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
     }
 
+    res.strMode = StringUtils::Format("%dx%d%s @ %.6f Hz", res.iScreenWidth, res.iScreenHeight,
+                                      res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "", res.fRefreshRate);
     resolutions.push_back(res);
   }
 

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -66,7 +66,7 @@ class CDRMUtils
 public:
   CDRMUtils();
   virtual ~CDRMUtils() = default;
-  virtual void FlipPage(struct gbm_bo *bo) {};
+  virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) {};
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) { return false; };
   virtual bool InitDrm();
   virtual void DestroyDrm();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -205,11 +205,11 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   return result;
 }
 
-void CWinSystemGbm::FlipPage()
+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 {
   struct gbm_bo *bo = m_GBM->LockFrontBuffer();
 
-  m_DRM->FlipPage(bo);
+  m_DRM->FlipPage(bo, rendered, videoLayer);
 
   m_GBM->ReleaseBuffer();
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -48,7 +48,7 @@ public:
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
-  void FlipPage();
+  void FlipPage(bool rendered, bool videoLayer);
   void WaitVBlank();
 
   void UpdateResolutions() override;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -144,10 +144,11 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   if (!m_bRenderCreated)
     return;
 
-  if (rendered)
+  if (rendered || videoLayer)
   {
-    m_pGLContext.SwapBuffers();
-    CWinSystemGbm::FlipPage();
+    if (rendered)
+      m_pGLContext.SwapBuffers();
+    CWinSystemGbm::FlipPage(rendered, videoLayer);
   }
   else
   {


### PR DESCRIPTION
Add atomic support to RendererDRMPRIME

This allows us to to switch between primary and overlay planes in the same atomic commit. We need to do this so that the video is playing behind the overlay (Kodi gui). I would leave the Kodi gui on the overlay plane however this causes issues when the dim screensaver kicks in.

@Kwiboo for review. (This is pretty much what we have been testing for the last month, just rebased against current master changes).