### PR TITLE
Fix crash on POSIX that happens if HOME is not set.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -433,7 +433,17 @@ bool CApplication::Create(const CAppParamParser &params)
   //! @todo - move to CPlatformXXX
   #if defined(TARGET_POSIX)
     // set special://envhome
-    CSpecialProtocol::SetEnvHomePath(getenv("HOME"));
+    if (getenv("HOME"))
+    {
+      CSpecialProtocol::SetEnvHomePath(getenv("HOME"));
+    }
+    else
+    {
+      fprintf(stderr, "The HOME environment variable is not set!\n");
+      /* Cleanup. Leaving this out would lead to another crash */
+      m_ServiceManager->DeinitStageOne();
+      return false;
+    }
   #endif
 
   // only the InitDirectories* for the current platform should return true


### PR DESCRIPTION
Kodi crashes if no HOME is set on Linux, as getenv() will return NULL then. The fix uses same logic that
is used in other places and assumes that if HOME is not set, then the path shall be "root".

This is just one suggestion to fix the crash.