### PR TITLE
Add access protectors

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -331,7 +331,10 @@ void CAddonDll::DestroyInstance(const std::string& instanceID)
 
 AddonPtr CAddonDll::GetRunningInstance() const
 {
-  return CServiceBroker::GetBinaryAddonManager().GetRunningAddon(ID());
+  if (CServiceBroker::IsBinaryAddonCacheUp())
+    return CServiceBroker::GetBinaryAddonManager().GetRunningAddon(ID());
+
+  return AddonPtr();
 }
 
 bool CAddonDll::DllLoaded(void) const

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -61,7 +61,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
 
   std::string strExtension=URIUtils::GetExtension(url);
   StringUtils::ToLower(strExtension);
-  if (!strExtension.empty())
+  if (!strExtension.empty() && CServiceBroker::IsBinaryAddonCacheUp())
   {
     BinaryAddonBaseList addonInfos;
     CServiceBroker::GetBinaryAddonManager().GetAddonInfos(addonInfos, true, ADDON_AUDIODECODER);

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -210,23 +210,23 @@ bool CPowerManager::Reboot()
 
 bool CPowerManager::CanPowerdown()
 {
-  return m_instance->CanPowerdown();
+  return m_instance ? m_instance->CanPowerdown() : false;
 }
 bool CPowerManager::CanSuspend()
 {
-  return m_instance->CanSuspend();
+  return m_instance ? m_instance->CanSuspend() : false;
 }
 bool CPowerManager::CanHibernate()
 {
-  return m_instance->CanHibernate();
+  return m_instance ? m_instance->CanHibernate() : false;
 }
 bool CPowerManager::CanReboot()
 {
-  return m_instance->CanReboot();
+  return m_instance ? m_instance->CanReboot() : false;
 }
 int CPowerManager::BatteryLevel()
 {
-  return m_instance->BatteryLevel();
+  return m_instance ? m_instance->BatteryLevel() : 0;
 }
 void CPowerManager::ProcessEvents()
 {

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -41,12 +41,14 @@ CFileExtensionProvider::CFileExtensionProvider()
 
   SetAddonExtensions();
 
-  CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CFileExtensionProvider::OnAddonEvent);
+  if (CServiceBroker::IsBinaryAddonCacheUp())
+    CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CFileExtensionProvider::OnAddonEvent);
 }
 
 CFileExtensionProvider::~CFileExtensionProvider()
 {
-  CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
+  if (CServiceBroker::IsBinaryAddonCacheUp())
+    CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
 
   m_advancedSettings.reset();
   m_addonExtensions.clear();
@@ -131,6 +133,9 @@ void CFileExtensionProvider::SetAddonExtensions()
 
 void CFileExtensionProvider::SetAddonExtensions(const TYPE& type)
 {
+  if (!CServiceBroker::IsBinaryAddonCacheUp())
+    return;
+
   std::vector<std::string> extensions;
   std::vector<std::string> fileFolderExtensions;
   BinaryAddonBaseList addonInfos;


### PR DESCRIPTION
Check that various components are available before deref.