### PR TITLE
[python-api] - BUG - cancel of a preselect dialog behaving badly

### DIFF
--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -125,6 +125,8 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       else if (iControl == CONTROL_CANCEL_BUTTON)
       {
         m_selectedItem = nullptr;
+        m_vecList->Clear();
+        m_selectedItems.clear();
         m_bConfirmed = false;
         Close();
       }
@@ -164,6 +166,7 @@ void CGUIDialogSelect::OnSelect(int idx)
 bool CGUIDialogSelect::OnBack(int actionID)
 {
   m_selectedItem = nullptr;
+  m_vecList->Clear();
   m_selectedItems.clear();
   m_bConfirmed = false;
   return CGUIDialogBoxBase::OnBack(actionID);


### PR DESCRIPTION
## Description
The internal list maintenance structures were not being totally cleared when a user canceled a select or multiselect dialog. My change ensures the list is fully cleared.

## Motivation and Context
The preselect parameter was added to `Dialog().select()` and `Dialog().multiselect()` methods in PR #9666.

It turns out that canceling a `Dialog().select()` or `Dialog().multiselect()` that has the `preselect` parameter specified incorrectly returns the indexes of the preselected items as opposed to an indication of being canceled. This is true whether the dialog is canceled via the dialog's cancel button or the `back` key on the remote/keyboard.

This bug has been mentioned in the Kodi forums on a few threads:

[Thread: BUG - Dialog Preselect prevents cancel](https://forum.kodi.tv/showthread.php?tid=288460)
[Thread: select dialog, detect cancel?](https://forum.kodi.tv/showthread.php?tid=305479)

## How Has This Been Tested?
I created a small add-on that presented both single and multi select dialogs. I tested canceling with the dialog's cancel button as well as the remote/keyboard back button. I also made sure that selection worked properly when I didn't cancel the dialog.

## Screenshots (if appropriate):
N/A

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
