### PR TITLE
Bring up a minimal amount of services in test environment

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -51,6 +51,32 @@ CServiceManager::CServiceManager()
 
 CServiceManager::~CServiceManager() = default;
 
+bool CServiceManager::InitForTesting()
+{
+  m_settings.reset(new CSettings());
+  m_network.reset(SetupNetwork());
+  m_fileExtensionProvider.reset(new CFileExtensionProvider());
+
+  m_addonMgr.reset(new ADDON::CAddonMgr());
+  if (!m_addonMgr->Init())
+  {
+    CLog::Log(LOGFATAL, "CServiceManager::%s: Unable to start CAddonMgr", __FUNCTION__);
+    return false;
+  }
+
+  init_level = 1;
+  return true;
+}
+
+void CServiceManager::DeinitTesting()
+{
+  init_level = 0;
+  m_addonMgr.reset();
+  m_fileExtensionProvider.reset();
+  m_network.reset();
+  m_settings.reset();
+}
+
 bool CServiceManager::InitStageOne()
 {
   m_announcementManager.reset(new ANNOUNCEMENT::CAnnouncementManager());

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -92,12 +92,14 @@ public:
   CServiceManager();
   ~CServiceManager();
 
+  bool InitForTesting();
   bool InitStageOne();
   bool InitStageTwo(const CAppParamParser &params);
   bool CreateAudioEngine();
   bool DestroyAudioEngine();
   bool StartAudioEngine();
   bool InitStageThree();
+  void DeinitTesting();
   void DeinitStageThree();
   void DeinitStageTwo();
   void DeinitStageOne();

--- a/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
+++ b/xbmc/music/tags/test/TestTagLoaderTagLib.cpp
@@ -149,8 +149,8 @@ TYPED_TEST(TestTagParser, FooProperties) {
   EXPECT_EQ("foo", tag.GetTitle());
 }
 
-class TestCTagLoaderTagLib : public ::testing::Test, public CTagLoaderTagLib {};
-TEST_F(TestCTagLoaderTagLib, SetGenre)
+class TestTagLoaderTagLib : public ::testing::Test, public CTagLoaderTagLib {};
+TEST_F(TestTagLoaderTagLib, SetGenre)
 {
   CMusicInfoTag tag, tag2;
   const char *genre_nr[] = {"0", "2", "4"};
@@ -171,7 +171,7 @@ TEST_F(TestCTagLoaderTagLib, SetGenre)
 
 }
 
-TEST(TestTagLoaderTagLib, SplitMBID)
+TEST_F(TestTagLoaderTagLib, SplitMBID)
 {
   CTagLoaderTagLib lib;
 

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -20,27 +20,23 @@
 
 #include "TestBasicEnvironment.h"
 #include "TestUtils.h"
-#include "cores/DataCacheCore.h"
 #include "ServiceBroker.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
-#include "powermanagement/PowerManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
-#include "Util.h"
 #include "Application.h"
-#include "PlayListPlayer.h"
-#include "interfaces/AnnouncementManager.h"
-#include "addons/BinaryAddonCache.h"
-#include "interfaces/python/XBPython.h"
-#include "pvr/PVRManager.h"
 #include "AppParamParser.h"
 #include "windowing/WinSystem.h"
 
 #if defined(TARGET_WINDOWS)
 #include "platform/win32/WIN32Util.h"
 #include "platform/win32/CharsetConverter.h"
+#endif
+
+#ifdef TARGET_DARWIN
+#include "Util.h"
 #endif
 
 #include <cstdio>
@@ -51,14 +47,12 @@ void TestBasicEnvironment::SetUp()
 {
   XFILE::CFile *f;
 
-  g_application.m_ServiceManager.reset(new CServiceManager());
-  if (!g_application.m_ServiceManager->InitStageOne())
-    exit(1);
-
   /* NOTE: The below is done to fix memleak warning about uninitialized variable
    * in xbmcutil::GlobalsSingleton<CAdvancedSettings>::getInstance().
    */
   g_advancedSettings.Initialize();
+
+  g_application.m_ServiceManager.reset(new CServiceManager());
 
   if (!CXBMCTestUtils::Instance().SetReferenceFileBasePath())
     SetUpError();
@@ -117,23 +111,19 @@ void TestBasicEnvironment::SetUp()
     TearDown();
     SetUpError();
   }
-  g_powerManager.Initialize();
-  CServiceBroker::GetSettings().Initialize();
 
-  std::unique_ptr<CWinSystemBase> winSystem = CWinSystemBase::CreateWinSystem();
-  g_application.m_ServiceManager->SetWinSystem(std::move(winSystem));
-
-  if (!g_application.m_ServiceManager->InitStageTwo(CAppParamParser()))
+  if (!g_application.m_ServiceManager->InitForTesting())
     exit(1);
+
+  CServiceBroker::GetSettings().Initialize();
 }
 
 void TestBasicEnvironment::TearDown()
 {
-  g_application.m_ServiceManager->DeinitStageTwo();
   std::string xbmcTempPath = CSpecialProtocol::TranslatePath("special://temp/");
   XFILE::CDirectory::Remove(xbmcTempPath);
   CServiceBroker::GetSettings().Uninitialize();
-  g_application.m_ServiceManager->DeinitStageOne();
+  g_application.m_ServiceManager->DeinitTesting();
 }
 
 void TestBasicEnvironment::SetUpError()


### PR DESCRIPTION
This limits the services in the test environment to

- settings and network (used in various spots)
- addon manager - used in a couple of TestAddonFactory tests