### PR TITLE
AE: remove direct dependency from settings to AE

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -579,13 +579,6 @@ bool CApplication::Create(const CAppParamParser &params)
 
   g_powerManager.Initialize();
 
-  // Load the AudioEngine before settings as they need to query the engine
-  if (!m_ServiceManager->CreateAudioEngine())
-  {
-    CLog::Log(LOGFATAL, "CApplication::Create: Failed to load an AudioEngine");
-    return false;
-  }
-
   // Initialize default Settings - don't move
   CLog::Log(LOGNOTICE, "load settings...");
   if (!m_ServiceManager->GetSettings().Initialize())
@@ -622,6 +615,11 @@ bool CApplication::Create(const CAppParamParser &params)
     return false;
   }
 
+  if (!m_ServiceManager->CreateAudioEngine())
+  {
+    CLog::Log(LOGFATAL, "CApplication::Create: Failed to load an AudioEngine");
+    return false;
+  }
   // start the AudioEngine
   if(!m_ServiceManager->StartAudioEngine())
   {

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -260,11 +260,6 @@ PVR::CPVRManager& CServiceManager::GetPVRManager()
   return *m_PVRManager;
 }
 
-bool CServiceManager::HasActiveAE() const
-{
-  return m_ActiveAE != nullptr;
-}
-
 IAE& CServiceManager::GetActiveAE()
 {
   ActiveAE::CActiveAE& ae = *m_ActiveAE;

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -113,7 +113,6 @@ public:
   XBPython& GetXBPython();
 #endif
   PVR::CPVRManager& GetPVRManager();
-  bool HasActiveAE() const;
   IAE& GetActiveAE();
   CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -22,6 +22,7 @@
 
 using namespace AE;
 using namespace ActiveAE;
+#include "ActiveAESettings.h"
 #include "ActiveAESound.h"
 #include "ActiveAEStream.h"
 #include "ServiceBroker.h"
@@ -292,10 +293,14 @@ CActiveAE::CActiveAE() :
   m_aeGUISoundForce = false;
   m_stats.Reset(44100, true);
   m_streamIdGen = 0;
+
+  CActiveAESettings::m_hasAE = true;
 }
 
 CActiveAE::~CActiveAE()
 {
+  CActiveAESettings::m_hasAE = false;
+
   Dispose();
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2625,11 +2625,6 @@ void CActiveAE::EnumerateOutputDevices(AEDeviceList &devices, bool passthrough)
   m_sink.EnumerateOutputDevices(devices, passthrough);
 }
 
-std::string CActiveAE::GetDefaultDevice(bool passthrough)
-{
-  return m_sink.GetDefaultDevice(passthrough);
-}
-
 void CActiveAE::OnSettingsChange(const std::string& setting)
 {
   if (setting == CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE      ||

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -260,7 +260,6 @@ public:
   void GarbageCollect() override {};
 
   void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) override;
-  std::string GetDefaultDevice(bool passthrough) override;
   bool SupportsRaw(AEAudioFormat &format) override;
   bool SupportsSilenceTimeout() override;
   bool HasStereoAudioChannelCount() override;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -32,18 +32,27 @@
 
 namespace ActiveAE
 {
-void CActiveAESettings::SettingOptionsAudioDevicesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+
+std::atomic_bool CActiveAESettings::m_hasAE(false);
+
+void CActiveAESettings::SettingOptionsAudioDevicesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list,
+                                                         std::string &current, void *data)
 {
   SettingOptionsAudioDevicesFillerGeneral(setting, list, current, false);
 }
 
-void CActiveAESettings::SettingOptionsAudioDevicesPassthroughFiller(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+void CActiveAESettings::SettingOptionsAudioDevicesPassthroughFiller(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list,
+                                                                    std::string &current, void *data)
 {
   SettingOptionsAudioDevicesFillerGeneral(setting, list, current, true);
 }
 
-void CActiveAESettings::SettingOptionsAudioQualityLevelsFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+void CActiveAESettings::SettingOptionsAudioQualityLevelsFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list,
+                                                               int &current, void *data)
 {
+  if (!m_hasAE)
+    return;
+
   if(CServiceBroker::GetActiveAE().SupportsQualityLevel(AE_QUALITY_LOW))
     list.push_back(std::make_pair(g_localizeStrings.Get(13506), AE_QUALITY_LOW));
   if(CServiceBroker::GetActiveAE().SupportsQualityLevel(AE_QUALITY_MID))
@@ -56,8 +65,12 @@ void CActiveAESettings::SettingOptionsAudioQualityLevelsFiller(SettingConstPtr s
     list.push_back(std::make_pair(g_localizeStrings.Get(38010), AE_QUALITY_GPU));
 }
 
-void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list,
+                                                               int &current, void *data)
 {
+  if (!m_hasAE)
+    return;
+
   list.push_back(std::make_pair(g_localizeStrings.Get(20422), XbmcThreads::EndTime::InfiniteValue));
   list.push_back(std::make_pair(g_localizeStrings.Get(13551), 0));
 
@@ -76,13 +89,20 @@ bool CActiveAESettings::IsSettingVisible(const std::string & condition, const st
   if (setting == NULL || value.empty())
     return false;
 
+  if (!m_hasAE)
+    return false;
+
   return CServiceBroker::GetActiveAE().IsSettingVisible(value);
 }
 
-void CActiveAESettings::SettingOptionsAudioDevicesFillerGeneral(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, bool passthrough)
+void CActiveAESettings::SettingOptionsAudioDevicesFillerGeneral(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list,
+                                                                std::string &current, bool passthrough)
 {
   current = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
   std::string firstDevice;
+
+  if (!m_hasAE)
+    return;
 
   bool foundValue = false;
   AEDeviceList sinkList;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -79,13 +79,6 @@ bool CActiveAESettings::IsSettingVisible(const std::string & condition, const st
   return CServiceBroker::GetActiveAE().IsSettingVisible(value);
 }
 
-bool CActiveAESettings::SupportsQualitySetting(void)
-{
-    return ((CServiceBroker::GetActiveAE().SupportsQualityLevel(AE_QUALITY_LOW) ? 1 : 0) +
-            (CServiceBroker::GetActiveAE().SupportsQualityLevel(AE_QUALITY_MID) ? 1 : 0) +
-            (CServiceBroker::GetActiveAE().SupportsQualityLevel(AE_QUALITY_HIGH) ? 1 : 0)) >= 2;
-}
-
 void CActiveAESettings::SettingOptionsAudioDevicesFillerGeneral(SettingConstPtr setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, bool passthrough)
 {
   current = std::static_pointer_cast<const CSettingString>(setting)->GetValue();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -39,6 +40,7 @@ public:
   static void SettingOptionsAudioStreamsilenceFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static bool IsSettingVisible(const std::string &condition, const std::string &value, std::shared_ptr<const CSetting> setting, void *data);
 
+  static std::atomic_bool m_hasAE;
 private:
   static void SettingOptionsAudioDevicesFillerGeneral(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, bool passthrough);
 };

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h
@@ -38,7 +38,6 @@ public:
   static void SettingOptionsAudioQualityLevelsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static void SettingOptionsAudioStreamsilenceFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static bool IsSettingVisible(const std::string &condition, const std::string &value, std::shared_ptr<const CSetting> setting, void *data);
-  static bool SupportsQualitySetting(void);
 
 private:
   static void SettingOptionsAudioDevicesFillerGeneral(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, bool passthrough);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -737,26 +737,6 @@ void CActiveAESink::EnumerateOutputDevices(AEDeviceList &devices, bool passthrou
   }
 }
 
-std::string CActiveAESink::GetDefaultDevice(bool passthrough)
-{
-  EnumerateSinkList(false);
-
-  for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
-  {
-    AESinkInfo sinkInfo = *itt;
-    for (AEDeviceInfoList::iterator itt2 = sinkInfo.m_deviceInfoList.begin(); itt2 != sinkInfo.m_deviceInfoList.end(); ++itt2)
-    {
-      CAEDeviceInfo devInfo = *itt2;
-      if (passthrough && devInfo.m_deviceType == AE_DEVTYPE_PCM)
-        continue;
-
-      std::string device = sinkInfo.m_sinkName + ":" + devInfo.m_deviceName;
-      return device;
-    }
-  }
-  return "default";
-}
-
 void CActiveAESink::GetDeviceFriendlyName(std::string &device)
 {
   m_deviceFriendlyName = "Device not found";

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -96,7 +96,6 @@ public:
   explicit CActiveAESink(CEvent *inMsgEvent);
   void EnumerateSinkList(bool force);
   void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough);
-  std::string GetDefaultDevice(bool passthrough);
   void Start();
   void Dispose();
   AEDeviceType GetDeviceType(const std::string &device);

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -192,13 +192,6 @@ public:
   virtual void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough) = 0;
 
   /**
-   * Returns the default audio device
-   * @param passthrough True if the default passthrough device is wanted
-   * @return the default audio device
-   */
-  virtual std::string GetDefaultDevice(bool passthrough) { return "default"; }
-
-  /**
    * Returns true if the AudioEngine supports AE_FMT_RAW streams for use with formats such as IEC61937
    * @see CAEPackIEC61937::CAEPackIEC61937()
    * @returns true if the AudioEngine is capable of RAW output

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -374,8 +374,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilehassettingslocked",      ProfileHasSettingsLocked));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilehasvideoslocked",        ProfileHasVideosLocked));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("profilelockmode",               ProfileLockMode));
-  if (g_application.m_ServiceManager->HasActiveAE())
-    m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("aesettingvisible",              ActiveAE::CActiveAESettings::IsSettingVisible));
+  m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("aesettingvisible",              ActiveAE::CActiveAESettings::IsSettingVisible));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("codecoptionvisible",            CDVDVideoCodec::IsSettingVisible));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("gt",                            GreaterThan));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("gte",                           GreaterThanOrEqual));

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -347,8 +347,7 @@ void CSettingConditions::Initialize()
     m_simpleConditions.insert("isstandalone");
 #endif
 
-  if(g_application.m_ServiceManager->HasActiveAE() && ActiveAE::CActiveAESettings::SupportsQualitySetting())
-    m_simpleConditions.insert("has_ae_quality_levels");
+  m_simpleConditions.insert("has_ae_quality_levels");
 
   // add complex conditions
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("addonhassettings",              AddonHasSettings));

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -664,14 +664,6 @@ void CSettings::InitializeDefaults()
     std::static_pointer_cast<CSettingBool>(GetSettingsManager()->GetSetting(CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN))->SetDefault(false);
 #endif
 
-#if !defined(TARGET_WINDOWS)
-  if (g_application.m_ServiceManager->HasActiveAE())
-  {
-    std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE))->SetDefault(CServiceBroker::GetActiveAE().GetDefaultDevice(false));
-    std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE))->SetDefault(CServiceBroker::GetActiveAE().GetDefaultDevice(true));
-  }
-#endif
-
   if (g_application.IsStandAlone())
     std::static_pointer_cast<CSettingInt>(GetSettingsManager()->GetSetting(CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE))->SetDefault(POWERSTATE_SHUTDOWN);
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -676,13 +676,10 @@ void CSettings::InitializeOptionFillers()
 #ifdef HAS_DVD_DRIVE
   GetSettingsManager()->RegisterSettingOptionsFiller("audiocdactions", MEDIA_DETECT::CAutorun::SettingOptionAudioCdActionsFiller);
 #endif
-  if (g_application.m_ServiceManager->HasActiveAE())
-  {
-    GetSettingsManager()->RegisterSettingOptionsFiller("aequalitylevels", ActiveAE::CActiveAESettings::SettingOptionsAudioQualityLevelsFiller);
-    GetSettingsManager()->RegisterSettingOptionsFiller("audiodevices", ActiveAE::CActiveAESettings::SettingOptionsAudioDevicesFiller);
-    GetSettingsManager()->RegisterSettingOptionsFiller("audiodevicespassthrough", ActiveAE::CActiveAESettings::SettingOptionsAudioDevicesPassthroughFiller);
-    GetSettingsManager()->RegisterSettingOptionsFiller("audiostreamsilence", ActiveAE::CActiveAESettings::SettingOptionsAudioStreamsilenceFiller);
-  }
+  GetSettingsManager()->RegisterSettingOptionsFiller("aequalitylevels", ActiveAE::CActiveAESettings::SettingOptionsAudioQualityLevelsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller("audiodevices", ActiveAE::CActiveAESettings::SettingOptionsAudioDevicesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller("audiodevicespassthrough", ActiveAE::CActiveAESettings::SettingOptionsAudioDevicesPassthroughFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller("audiostreamsilence", ActiveAE::CActiveAESettings::SettingOptionsAudioStreamsilenceFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("charsets", CCharsetConverter::SettingOptionsCharsetsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("languagenames", CLangInfo::SettingOptionsLanguageNamesFiller);


### PR DESCRIPTION
Having a depency from settings to AE is nonsense.

If platforms want operational audio on first start, their sinks have to handle device "default", see Windows