### PR TITLE
Fix DVD resume issue since PR #13146

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3519,8 +3519,7 @@ void CApplication::OnPlayerCloseFile(const CFileItem &file, const CBookmark &boo
   }
   else if (bookmark.timeInSeconds > g_advancedSettings.m_videoIgnoreSecondsAtStart)
   {
-    resumeBookmark.timeInSeconds = bookmark.timeInSeconds;
-    resumeBookmark.totalTimeInSeconds = bookmark.totalTimeInSeconds;
+    resumeBookmark = bookmark;
   }
   else
   {


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
As per title

## Description
<!--- Describe your change in detail -->
Now we copy the entire CBookmark object instead of just the timestamp attributes. This way other stuff that got tracked before (like the DVD Navigator state which was needed to track progress of DVD playback) gets properly saved to the bookmark database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes DVD resume.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
By using DVD video material.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
