### PR TITLE
[Estuary] fix mastermode label in button menu

### DIFF
--- a/addons/skin.estuary/xml/DialogButtonMenu.xml
+++ b/addons/skin.estuary/xml/DialogButtonMenu.xml
@@ -61,9 +61,7 @@
 						<visible>System.Loggedon</visible>
 					</item>
 					<item>
-						<label>$LOCALIZE[20046]</label>
-						<altlabel>$LOCALIZE[20045]</altlabel>
-						<usealttexture>!System.IsMaster</usealttexture>
+						<label>$VAR[MasterModeLabel]</label>
 						<onclick>mastermode</onclick>
 						<visible>System.HasLocks</visible>
 					</item>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -430,4 +430,8 @@
 		<value condition="String.IsEqual(Skin.String(background_overlay),0)">$LOCALIZE[231]</value>
 		<value>$INFO[Skin.String(background_overlay),$LOCALIZE[467] ]</value>
 	</variable>
+	<variable name="MasterModeLabel">
+		<value condition="!System.IsMaster">$LOCALIZE[20045]</value>
+		<value>$LOCALIZE[20046]</value>
+	</variable>
 </includes>


### PR DESCRIPTION
label controls do not support altlabel, use a var instead.


@phil65 