### PR TITLE
Wayland: Fix VAAPIRegisterRender implementation when vaapi disabled

### DIFF
--- a/xbmc/windowing/wayland/OptionalsReg.cpp
+++ b/xbmc/windowing/wayland/OptionalsReg.cpp
@@ -93,8 +93,7 @@ void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
 
 }
 
-void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, void* dpy,
-                         void* eglDisplay, bool &general, bool &hevc)
+void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
 {
 
 }


### PR DESCRIPTION
Obvious c/p failure. I think no one for now tested the path with vaapi off