### PR TITLE
[PVR] Fix CPVREpgContainer::CreateChannelEpg not to change channel's …

### DIFF
--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -557,7 +557,9 @@ CPVREpgPtr CPVREpgContainer::CreateChannelEpg(const CPVRChannelPtr &channel)
 
   if (!epg)
   {
-    channel->SetEpgID(NextEpgId());
+    if (channel->EpgID() <= 0)
+      channel->SetEpgID(NextEpgId());
+
     epg.reset(new CPVREpg(channel, false));
 
     CSingleLock lock(m_critSection);


### PR DESCRIPTION
…epg id, if provided. This can lead to totally scrambled epg data in multi pvr client configs due to one epg id used for multiple channels.

I spotted this mess after switching profile in a certain scenario with multiple pvr clients enabled, for instance you can see German show title "Mord im Orient Express" mixed into English channel "BBC EARTH" events. Even channel sort order gets mixed up:

![screenshot000](https://user-images.githubusercontent.com/3226626/34130541-8515ccd2-e448-11e7-8ee3-a2c17e168d63.png)

This has to look like this:

![screenshot001](https://user-images.githubusercontent.com/3226626/34130739-3e4080bc-e449-11e7-8599-457aa510ff0d.png)

The change is runtime tested on macOS, latest kodi master.

@Jalle19 it's barely impossible for me to describe the problem. It's so complex that I even have problems to explain it in my mother tongue. ;-) Please, just trust me, okay?