### PR TITLE
[cmake] remove force disabling vaapi for gbm

### DIFF
--- a/cmake/scripts/linux/ArchSetup.cmake
+++ b/cmake/scripts/linux/ArchSetup.cmake
@@ -101,7 +101,6 @@ endif()
 
 if(ENABLE_GBM)
   set(ENABLE_VDPAU OFF CACHE BOOL "Disabling VDPAU" FORCE)
-  set(ENABLE_VAAPI OFF CACHE BOOL "Disabling VAAPI" FORCE)
 endif()
 
 if(ENABLE_VDPAU)


### PR DESCRIPTION
@fritsch @a1rwulf I found the issue with vaapi being disabled after running cmake again :D