### PR TITLE
ITime and INPUTSTREAM_INFO::m_name implementation for inputstream

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -133,7 +133,7 @@ extern "C" {
     };
     uint32_t m_flags;
 
-    char m_name[256] = {0};              /*!< @brief (optinal) name of the stream, \0 for default handling */
+    char m_name[256];                    /*!< @brief (optinal) name of the stream, \0 for default handling */
     char m_codecName[32];                /*!< @brief (required) name of codec according to ffmpeg */
     char m_codecInternalName[32];        /*!< @brief (optional) internal name of codec (selectionstream info) */
     STREAMCODEC_PROFILE m_codecProfile;  /*!< @brief (optional) the profile of the codec */
@@ -214,7 +214,7 @@ extern "C" {
     int (__cdecl* get_time)(const AddonInstance_InputStream* instance);
 
     // ITime
-    bool(__cdecl* get_times)(const AddonInstance_InputStream* instance, INPUTSTREAM_TIMES &times);
+    bool(__cdecl* get_times)(const AddonInstance_InputStream* instance, INPUTSTREAM_TIMES *times);
 
     // IPosTime
     bool (__cdecl* pos_time)(const AddonInstance_InputStream* instance, int ms);
@@ -604,9 +604,9 @@ namespace addon
     }
 
     // ITime
-    inline static bool ADDON_GetTimes(const AddonInstance_InputStream* instance, INPUTSTREAM_TIMES &times)
+    inline static bool ADDON_GetTimes(const AddonInstance_InputStream* instance, INPUTSTREAM_TIMES *times)
     {
-      return instance->toAddon.addonInstance->GetTimes(times);
+      return instance->toAddon.addonInstance->GetTimes(*times);
     }
 
     // IPosTime

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -41,7 +41,7 @@ extern "C" {
   /*!
    * @brief InputStream add-on capabilities. All capabilities are set to "false" as default.
    */
-  typedef struct INPUTSTREAM_CAPABILITIES
+  struct INPUTSTREAM_CAPABILITIES
   {
     enum MASKTYPE: uint32_t
     {
@@ -66,12 +66,12 @@ extern "C" {
 
     /// set of supported capabilities
     uint32_t m_mask;
-  } INPUTSTREAM_CAPABILITIES;
+  };
 
   /*!
    * @brief structure of key/value pairs passed to addon on Open()
    */
-  typedef struct INPUTSTREAM
+  struct INPUTSTREAM
   {
     static const unsigned int MAX_INFO_COUNT = 8;
 
@@ -86,22 +86,22 @@ extern "C" {
 
     const char *m_libFolder;
     const char *m_profileFolder;
-  } INPUTSTREAM;
+  };
 
   /*!
    * @brief Array of stream IDs
    */
-  typedef struct INPUTSTREAM_IDS
+  struct INPUTSTREAM_IDS
   {
     static const unsigned int MAX_STREAM_COUNT = 32;
     unsigned int m_streamCount;
     unsigned int m_streamIds[MAX_STREAM_COUNT];
-  } INPUTSTREAM_IDS;
+  };
 
   /*!
    * @brief stream properties
    */
-  typedef struct INPUTSTREAM_INFO
+  struct INPUTSTREAM_INFO
   {
     enum STREAM_TYPE
     {
@@ -133,7 +133,7 @@ extern "C" {
     };
     uint32_t m_flags;
 
-    char m_name[256];                    /*!< @brief (optinal) name of the stream, \0 for default handling */
+    char m_name[256] = {0};              /*!< @brief (optinal) name of the stream, \0 for default handling */
     char m_codecName[32];                /*!< @brief (required) name of codec according to ffmpeg */
     char m_codecInternalName[32];        /*!< @brief (optional) internal name of codec (selectionstream info) */
     STREAMCODEC_PROFILE m_codecProfile;  /*!< @brief (optional) the profile of the codec */
@@ -157,15 +157,15 @@ extern "C" {
     unsigned int m_BlockAlign;
 
     CRYPTO_INFO m_cryptoInfo;
-  } INPUTSTREAM_INFO;
+  };
 
-  typedef struct INPUTSTREAM_TIMES
+  struct INPUTSTREAM_TIMES
   {
     time_t startTime;
     double ptsStart;
     double ptsBegin;
     double ptsEnd;
-  }INPUTSTREAM_TIMES;
+  };
 
   /*!
    * @brief Structure to transfer the methods from xbmc_inputstream_dll.h to XBMC

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -58,7 +58,10 @@ extern "C" {
       SUPPORTS_SEEK = (1 << 3),
 
       /// supports pause
-      SUPPORTS_PAUSE = (1 << 4)
+      SUPPORTS_PAUSE = (1 << 4),
+
+      /// supports interface ITime
+      SUPPORTS_ITIME = (1 << 5)
     };
 
     /// set of supported capabilities
@@ -155,6 +158,14 @@ extern "C" {
     CRYPTO_INFO m_cryptoInfo;
   } INPUTSTREAM_INFO;
 
+  typedef struct INPUTSTREAM_TIMES
+  {
+    time_t startTime;
+    double ptsStart;
+    double ptsBegin;
+    double ptsEnd;
+  }INPUTSTREAM_TIMES;
+
   /*!
    * @brief Structure to transfer the methods from xbmc_inputstream_dll.h to XBMC
    */
@@ -200,6 +211,9 @@ extern "C" {
     // IDisplayTime
     int (__cdecl* get_total_time)(const AddonInstance_InputStream* instance);
     int (__cdecl* get_time)(const AddonInstance_InputStream* instance);
+
+    // ITime
+    bool(__cdecl* get_times)(const AddonInstance_InputStream* instance, INPUTSTREAM_TIMES &times);
 
     // IPosTime
     bool (__cdecl* pos_time)(const AddonInstance_InputStream* instance, int ms);
@@ -364,6 +378,12 @@ namespace addon
     virtual int GetTime() { return -1; }
 
     /*!
+    * Get current timing values in PTS scale
+    * @remarks
+    */
+    virtual bool GetTimes(INPUTSTREAM_TIMES &times) { return false; }
+
+    /*!
      * Positions inputstream to playing time given in ms
      * @remarks
      */
@@ -483,6 +503,8 @@ namespace addon
       m_instanceData->toAddon.get_total_time = ADDON_GetTotalTime;
       m_instanceData->toAddon.get_time = ADDON_GetTime;
 
+      m_instanceData->toAddon.get_times = ADDON_GetTimes;
+
       m_instanceData->toAddon.pos_time = ADDON_PosTime;
 
       m_instanceData->toAddon.can_pause_stream = ADDON_CanPauseStream;
@@ -580,6 +602,11 @@ namespace addon
       return instance->toAddon.addonInstance->GetTime();
     }
 
+    // ITime
+    inline static bool ADDON_GetTimes(const AddonInstance_InputStream* instance, INPUTSTREAM_TIMES &times)
+    {
+      return instance->toAddon.addonInstance->GetTimes(times);
+    }
 
     // IPosTime
     inline static bool ADDON_PosTime(const AddonInstance_InputStream* instance, int ms)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -133,6 +133,7 @@ extern "C" {
     };
     uint32_t m_flags;
 
+    char m_name[256];                    /*!< @brief (optinal) name of the stream, \0 for default handling */
     char m_codecName[32];                /*!< @brief (required) name of codec according to ffmpeg */
     char m_codecInternalName[32];        /*!< @brief (optional) internal name of codec (selectionstream info) */
     STREAMCODEC_PROFILE m_codecProfile;  /*!< @brief (optional) the profile of the codec */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -103,8 +103,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.5"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.5"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.6"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.6"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -72,5 +72,5 @@ int CDVDDemux::GetNrOfSubtitleStreams()
 
 std::string CDemuxStream::GetStreamName()
 {
-  return "";
+  return name;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -126,6 +126,7 @@ public:
   char language[4]; // ISO 639 3-letter language code (empty string if undefined)
   bool disabled; // set when stream is disabled. (when no decoder exists)
 
+  std::string name;
   std::string codecName;
 
   int  changes; // increment on change which player may need to know about

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -255,6 +255,33 @@ int CInputStreamAddon::GetTime()
   return m_struct.toAddon.get_time(&m_struct);
 }
 
+// ITime
+CDVDInputStream::ITimes* CInputStreamAddon::GetITimes()
+{
+  if ((m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTS_ITIME) == 0)
+    return nullptr;
+
+  return this;
+}
+
+bool CInputStreamAddon::GetTimes(Times &times)
+{
+  if (!m_struct.toAddon.get_times)
+    return false;
+
+  INPUTSTREAM_TIMES i_times;
+
+  if (m_struct.toAddon.get_times(&m_struct, i_times))
+  {
+    times.ptsBegin = i_times.ptsBegin;
+    times.ptsEnd = i_times.ptsEnd;
+    times.ptsStart = i_times.ptsStart;
+    times.startTime = i_times.startTime;
+    return true;
+  }
+  return false;
+}
+
 // IPosTime
 CDVDInputStream::IPosTime* CInputStreamAddon::GetIPosTime()
 {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -386,6 +386,7 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   else
     return nullptr;
 
+  demuxStream->name = stream.m_name;
   demuxStream->codec = codec->id;
   demuxStream->codecName = stream.m_codecInternalName;
   demuxStream->uniqueId = streamId;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -271,7 +271,7 @@ bool CInputStreamAddon::GetTimes(Times &times)
 
   INPUTSTREAM_TIMES i_times;
 
-  if (m_struct.toAddon.get_times(&m_struct, i_times))
+  if (m_struct.toAddon.get_times(&m_struct, &i_times))
   {
     times.ptsBegin = i_times.ptsBegin;
     times.ptsEnd = i_times.ptsEnd;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -47,6 +47,7 @@ class CInputStreamAddon
   : public ADDON::IAddonInstanceHandler,
     public CDVDInputStream,
     public CDVDInputStream::IDisplayTime,
+    public CDVDInputStream::ITimes,
     public CDVDInputStream::IPosTime,
     public CDVDInputStream::IDemux
 {
@@ -71,6 +72,10 @@ public:
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override;
   int GetTotalTime() override;
   int GetTime() override;
+
+  // ITime
+  CDVDInputStream::ITimes* GetITimes() override;
+  bool GetTimes(Times &times) override;
 
   // IPosTime
   CDVDInputStream::IPosTime* GetIPosTime() override;


### PR DESCRIPTION
## Description
This PR extends the inputstream binary interface by ITime and stream::name
Please note that Inputstream API version was bumped and Inputstream addon devs have at least to initialize the new m_name member of INPUTSREAM_INFO with \0.

## Motivation and Context
- ITime Interface is necessary for proper display of timeshift window.
- INPUTSTREAM_INFO::m_name will be used in a later step in inputstream.adaptive to get rid of manual / auto stream selection. Instead of this there will be an Item labeled "Auto" in stream selection box beside all the other provided stream reolutions / qualities.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
