### PR TITLE
AMLUtils: turn off 3D mode before switching resolution

### DIFF
--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -639,6 +639,8 @@ bool aml_set_native_resolution(const RESOLUTION_INFO &res, std::string framebuff
 {
   bool result = false;
 
+  aml_handle_display_stereo_mode(RENDER_STEREO_MODE_OFF);
+
   result = aml_set_display_resolution(res, framebuffer_name);
 
   aml_handle_scale(res);


### PR DESCRIPTION
With 3.14 "Nougat" kernel if we switch resolution when 3D is turned on, the kernel would crash. To prevent this, switch 3D mode off before a resolution switch. This does not affect devices using older kernel as 3D mode is turned back on after a resolution switch.

<!--- Provide a general summary of your change in the Title above -->

## How Has This Been Tested?
LibreELEC community builds for Amlogic S905 and S912 with the latest 3.14 kernel from Amlogic.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
