### PR TITLE
[pvr] no delay on switch to previous channel with key 0

### DIFF
--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -57,7 +57,7 @@ public:
    * @brief Appends a channel number character.
    * @param cCharacter The character to append. value must be CPVRChannelNumber::SEPARATOR ('.') or any char in the range from '0' to '9'.
    */
-  void AppendChannelNumberCharacter(char cCharacter);
+  virtual void AppendChannelNumberCharacter(char cCharacter);
 
   /*!
    * @brief Get the currently entered channel number as a formatted string. Format is n digits with leading zeros, where n is the number of digits specified when calling the ctor.

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1843,22 +1843,23 @@ namespace PVR
     }
   }
 
-  void CPVRChannelSwitchingInputHandler::OnInputDone()
+  void CPVRChannelSwitchingInputHandler::AppendChannelNumberCharacter(char cCharacter)
   {
-    CPVRChannelNumber channelNumber;
-    bool bSwitchToPreviousChannel;
-
+    // special case. if only a single zero was typed in, switch to previously played channel.
+    if (GetCurrentDigitCount() == 0 && cCharacter == '0')
     {
-      CSingleLock lock(m_mutex);
-      channelNumber = GetChannelNumber();
-      // special case. if only a single zero was typed in, switch to previously played channel.
-      bSwitchToPreviousChannel = (channelNumber.GetChannelNumber() == 0 && GetCurrentDigitCount() == 1);
+      SwitchToPreviousChannel();
+      return;
     }
 
+    CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(cCharacter);
+  }
+
+  void CPVRChannelSwitchingInputHandler::OnInputDone()
+  {
+    CPVRChannelNumber channelNumber = GetChannelNumber();
     if (channelNumber.GetChannelNumber())
       SwitchToChannel(channelNumber);
-    else if (bSwitchToPreviousChannel)
-      SwitchToPreviousChannel();
   }
 
   void CPVRChannelSwitchingInputHandler::SwitchToChannel(const CPVRChannelNumber& channelNumber)

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -47,6 +47,7 @@ namespace PVR
   {
   public:
     // CPVRChannelNumberInputHandler implementation
+    void AppendChannelNumberCharacter(char cCharacter) override;
     void OnInputDone() override;
 
   private:


### PR DESCRIPTION
This PR removes the annoying delay while switching to the previous channel with key 0. There is no need to wait for more input from the user.
