### PR TITLE
Refactor ServiceManager/ServiceBroker

### DIFF
--- a/cmake/treedata/android/subdirs.txt
+++ b/cmake/treedata/android/subdirs.txt
@@ -6,7 +6,6 @@ xbmc/platform/posix                     platform/posix
 xbmc/platform/posix/filesystem          platform/posix/filesystem
 xbmc/platform/posix/utils               platform/posix/utils
 xbmc/platform/linux                     platform/linux
-xbmc/platform/linux/network             platform/linux/network
 xbmc/platform/linux/peripherals         platform/linux/peripherals
 xbmc/platform/android/activity          platform/android/activity
 xbmc/platform/android/bionic_supplement platform/android/bionicsupplement

--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -38,6 +38,7 @@ xbmc/playlists                                  playlists
 xbmc/powermanagement                            powermanagement
 xbmc/programs                                   programs
 xbmc/rendering                                  rendering
+xbmc/services                                   services
 xbmc/storage                                    storage
 xbmc/threads                                    threads
 xbmc/utils                                      utils

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -391,6 +391,9 @@ bool CApplication::Create(const CAppParamParser &params)
   m_ServiceManager.reset(new CServiceManager());
 
   SERVICES::CServiceManager::GetInstance().RegisterService(std::make_shared<CAnnouncementManager>(), 0);
+#ifdef HAS_PYTHON
+  SERVICES::CServiceManager::GetInstance().RegisterService(std::make_shared<XBPython>(), 0);
+#endif
 
   if (!m_ServiceManager->InitStageOne())
   {
@@ -3394,7 +3397,9 @@ void CApplication::OnQueueNextItem()
   // informs python script currently running that we are requesting the next track
   // (does nothing if python is not loaded)
 #ifdef HAS_PYTHON
-  g_pythonParser.OnQueueNextItem(); // currently unimplemented
+  auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnQueueNextItem(); // currently unimplemented
 #endif
 
   CGUIMessage msg(GUI_MSG_QUEUE_NEXT_ITEM, 0, 0);
@@ -3433,7 +3438,9 @@ void CApplication::OnPlayBackError()
 void CApplication::OnPlayBackPaused()
 {
 #ifdef HAS_PYTHON
-  g_pythonParser.OnPlayBackPaused();
+  auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnPlayBackPaused();
 #endif
 #if defined(TARGET_DARWIN_IOS)
   CDarwinUtils::EnableOSScreenSaver(true);
@@ -3450,7 +3457,9 @@ void CApplication::OnPlayBackPaused()
 void CApplication::OnPlayBackResumed()
 {
 #ifdef HAS_PYTHON
-  g_pythonParser.OnPlayBackResumed();
+  auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnPlayBackResumed();
 #endif
 #if defined(TARGET_DARWIN_IOS)
   if (m_appPlayer.IsPlayingVideo())
@@ -3468,7 +3477,9 @@ void CApplication::OnPlayBackResumed()
 void CApplication::OnPlayBackSpeedChanged(int iSpeed)
 {
 #ifdef HAS_PYTHON
-  g_pythonParser.OnPlayBackSpeedChanged(iSpeed);
+  auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnPlayBackSpeedChanged(iSpeed);
 #endif
 
   CVariant param;
@@ -3482,7 +3493,9 @@ void CApplication::OnPlayBackSpeedChanged(int iSpeed)
 void CApplication::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
 {
 #ifdef HAS_PYTHON
-  g_pythonParser.OnPlayBackSeek(static_cast<int>(iTime), static_cast<int>(seekOffset));
+  auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnPlayBackSeek(static_cast<int>(iTime), static_cast<int>(seekOffset));
 #endif
 
   CVariant param;
@@ -3499,7 +3512,9 @@ void CApplication::OnPlayBackSeek(int64_t iTime, int64_t seekOffset)
 void CApplication::OnPlayBackSeekChapter(int iChapter)
 {
 #ifdef HAS_PYTHON
-  g_pythonParser.OnPlayBackSeekChapter(iChapter);
+  auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnPlayBackSeekChapter(iChapter);
 #endif
 }
 
@@ -4049,7 +4064,11 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #ifdef HAS_PYTHON
       // informs python script currently running playback has started
       // (does nothing if python is not loaded)
-      g_pythonParser.OnPlayBackStarted(*m_itemCurrentFile);
+      {
+        auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+        if (xbp)
+          xbp->OnPlayBackStarted(*m_itemCurrentFile);
+      }
 #endif
 
       CVariant param;
@@ -4136,7 +4155,11 @@ bool CApplication::OnMessage(CGUIMessage& message)
     CServiceBroker::GetGUI()->GetInfoManager().ResetCurrentItem();
     PlaybackCleanup();
 #ifdef HAS_PYTHON
-    g_pythonParser.OnPlayBackStopped();
+    {
+      auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->OnPlayBackStopped();
+    }
 #endif
      return true;
 
@@ -4155,7 +4178,11 @@ bool CApplication::OnMessage(CGUIMessage& message)
     PlaybackCleanup();
 
 #ifdef HAS_PYTHON
-      g_pythonParser.OnPlayBackEnded();
+    {
+      auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->OnPlayBackEnded();
+    }
 #endif
     return true;
 
@@ -4170,7 +4197,11 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #ifdef HAS_PYTHON
     // informs python script currently running playback has started
     // (does nothing if python is not loaded)
-    g_pythonParser.OnAVStarted(*m_itemCurrentFile);
+    {
+      auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->OnAVStarted(*m_itemCurrentFile);
+    }
 #endif
     return true;
 
@@ -4178,7 +4209,11 @@ bool CApplication::OnMessage(CGUIMessage& message)
 #ifdef HAS_PYTHON
     // informs python script currently running playback has started
     // (does nothing if python is not loaded)
-    g_pythonParser.OnAVChange();
+  {
+    auto xbp = SERVICES::CServiceManager::GetInstance().GetService<XBPython>();
+    if (xbp)
+      xbp->OnAVChange();
+  }
 #endif
       return true;
 

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -29,10 +29,11 @@
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"
 #include "interfaces/python/XBPython.h"
+#include "services/ServiceManager.h"
+using namespace SERVICES;
 #endif
 #include "ServiceBroker.h"
 #include "utils/StringUtils.h"
-
 
 bool CContextMenuItem::IsVisible(const CFileItem& item) const
 {
@@ -64,8 +65,14 @@ bool CContextMenuItem::Execute(const CFileItemPtr& item) const
     return false;
 
 #ifdef HAS_PYTHON
-  LanguageInvokerPtr invoker(new CContextItemAddonInvoker(&g_pythonParser, item));
-  return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon) != -1);
+  auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+  {
+    LanguageInvokerPtr invoker(new CContextItemAddonInvoker(xbp.get(), item));
+    return (CScriptInvocationManager::GetInstance().ExecuteAsync(m_library, invoker, addon) != -1);
+  }
+  else
+    return false;
 #else
   return false;
 #endif

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -40,6 +40,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/info/InfoExpression.h"
 #include "messaging/ApplicationMessenger.h"
+#include "services/ServiceManager.h"
 #include "settings/SkinSettings.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
@@ -6661,7 +6662,9 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
   SetChanged();
   NotifyObservers(ObservableMessageCurrentItem);
   // todo this should be handled by one of the observers above and forwarded
-  g_application.m_ServiceManager->GetAnnouncementManager().Announce(ANNOUNCEMENT::Info, "xbmc", "OnChanged");
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Info, "xbmc", "OnChanged");
 }
 
 void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -50,6 +50,8 @@
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
 using namespace INFO;
+using namespace PLAYLIST;
+
 
 bool InfoBoolComparator(const InfoPtr &right, const InfoPtr &left)
 {

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -35,6 +35,7 @@
 #include "playlists/PlayList.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfilesManager.h"
+#include "services/ServiceManager.h"
 #include "threads/SystemClock.h"
 #include "utils/log.h"
 #include "utils/Random.h"
@@ -722,6 +723,8 @@ void CPartyModeManager::Announce()
     
     data["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
     data["property"]["partymode"] = m_bEnabled;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
   }
 }

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -35,6 +35,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "input/Key.h"
 #include "URL.h"
 #include "messaging/ApplicationMessenger.h"
@@ -747,7 +748,10 @@ void CPlayListPlayer::AnnouncePropertyChanged(int iPlaylist, const std::string &
   CVariant data;
   data["player"]["playerid"] = iPlaylist;
   data["property"][strProperty] = value;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
+
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
 }
 
 int PLAYLIST::CPlayListPlayer::GetMessageMask()

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -612,14 +612,14 @@ void CPlayListPlayer::ReShuffle(int iPlaylist, int iPosition)
       (g_application.GetAppPlayer().IsPlayingVideo() && iPlaylist == PLAYLIST_VIDEO)
       )
     {
-      CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
+      GetPlaylist(iPlaylist).Shuffle(m_iCurrentSong + 2);
     }
   }
   // otherwise, shuffle from the passed position
   // which is the position of the first new item added
   else
   {
-    CServiceBroker::GetPlaylistPlayer().GetPlaylist(iPlaylist).Shuffle(iPosition);
+    GetPlaylist(iPlaylist).Shuffle(iPosition);
   }
 }
 

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -21,6 +21,7 @@
 
 #include "guilib/IMsgTargetCallback.h"
 #include "messaging/IMessageTarget.h"
+#include "services/IService.h"
 #include "ServiceBroker.h"
 #include <memory>
 
@@ -46,7 +47,8 @@ enum REPEAT_STATE { REPEAT_NONE = 0, REPEAT_ONE, REPEAT_ALL };
 class CPlayList;
 
 class CPlayListPlayer : public IMsgTargetCallback,
-                        public KODI::MESSAGING::IMessageTarget
+                        public KODI::MESSAGING::IMessageTarget,
+                        public SERVICES::IService
 {
 
 public:

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -109,7 +109,7 @@ CFileExtensionProvider& CServiceBroker::GetFileExtensionProvider()
   return g_application.m_ServiceManager->GetFileExtensionProvider();
 }
 
-CNetwork& CServiceBroker::GetNetwork()
+CNetworkBase& CServiceBroker::GetNetwork()
 {
   return g_application.m_ServiceManager->GetNetwork();
 }

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -44,13 +44,6 @@ ADDON::CVFSAddonCache &CServiceBroker::GetVFSAddonCache()
   return g_application.m_ServiceManager->GetVFSAddonCache();
 }
 
-#ifdef HAS_PYTHON
-XBPython& CServiceBroker::GetXBPython()
-{
-  return g_application.m_ServiceManager->GetXBPython();
-}
-#endif
-
 PVR::CPVRManager &CServiceBroker::GetPVRManager()
 {
   return g_application.m_ServiceManager->GetPVRManager();

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -44,11 +44,6 @@ ADDON::CVFSAddonCache &CServiceBroker::GetVFSAddonCache()
   return g_application.m_ServiceManager->GetVFSAddonCache();
 }
 
-ANNOUNCEMENT::CAnnouncementManager &CServiceBroker::GetAnnouncementManager()
-{
-  return g_application.m_ServiceManager->GetAnnouncementManager();
-}
-
 #ifdef HAS_PYTHON
 XBPython& CServiceBroker::GetXBPython()
 {

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -109,11 +109,6 @@ CFileExtensionProvider& CServiceBroker::GetFileExtensionProvider()
   return g_application.m_ServiceManager->GetFileExtensionProvider();
 }
 
-CNetworkBase& CServiceBroker::GetNetwork()
-{
-  return g_application.m_ServiceManager->GetNetwork();
-}
-
 bool CServiceBroker::IsBinaryAddonCacheUp()
 {
   return g_application.m_ServiceManager->init_level > 1;

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -59,11 +59,6 @@ CDataCacheCore &CServiceBroker::GetDataCacheCore()
   return g_application.m_ServiceManager->GetDataCacheCore();
 }
 
-PLAYLIST::CPlayListPlayer &CServiceBroker::GetPlaylistPlayer()
-{
-  return g_application.m_ServiceManager->GetPlaylistPlayer();
-}
-
 CSettings& CServiceBroker::GetSettings()
 {
   return g_application.m_ServiceManager->GetSettings();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -40,7 +40,6 @@ namespace PLAYLIST
 }
 
 class CContextMenuManager;
-class XBPython;
 class CDataCacheCore;
 class CSettings;
 class IAE;
@@ -84,7 +83,6 @@ public:
   static ADDON::CBinaryAddonManager &GetBinaryAddonManager();
   static ADDON::CBinaryAddonCache &GetBinaryAddonCache();
   static ADDON::CVFSAddonCache &GetVFSAddonCache();
-  static XBPython &GetXBPython();
   static PVR::CPVRManager &GetPVRManager();
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -29,11 +29,6 @@ class CServiceAddonManager;
 class CRepositoryUpdater;
 }
 
-namespace ANNOUNCEMENT
-{
-  class CAnnouncementManager;
-}
-
 namespace PVR
 {
   class CPVRManager;
@@ -89,7 +84,6 @@ public:
   static ADDON::CBinaryAddonManager &GetBinaryAddonManager();
   static ADDON::CBinaryAddonCache &GetBinaryAddonCache();
   static ADDON::CVFSAddonCache &GetVFSAddonCache();
-  static ANNOUNCEMENT::CAnnouncementManager &GetAnnouncementManager();
   static XBPython &GetXBPython();
   static PVR::CPVRManager &GetPVRManager();
   static CContextMenuManager& GetContextMenuManager();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -34,11 +34,6 @@ namespace PVR
   class CPVRManager;
 }
 
-namespace PLAYLIST
-{
-  class CPlayListPlayer;
-}
-
 class CContextMenuManager;
 class CDataCacheCore;
 class CSettings;
@@ -86,7 +81,6 @@ public:
   static PVR::CPVRManager &GetPVRManager();
   static CContextMenuManager& GetContextMenuManager();
   static CDataCacheCore& GetDataCacheCore();
-  static PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
   static CSettings& GetSettings();
   static KODI::GAME::CControllerManager& GetGameControllerManager();
   static KODI::GAME::CGameServices& GetGameServices();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -41,7 +41,6 @@ class IAE;
 class CFavouritesService;
 class CInputManager;
 class CFileExtensionProvider;
-class CNetworkBase;
 class CWinSystemBase;
 class CRenderSystemBase;
 class CPowerManager;
@@ -93,7 +92,6 @@ public:
   static CFileExtensionProvider &GetFileExtensionProvider();
   static bool IsBinaryAddonCacheUp();
   static bool IsServiceManagerUp();
-  static CNetworkBase& GetNetwork();
   static CPowerManager& GetPowerManager();
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -41,7 +41,7 @@ class IAE;
 class CFavouritesService;
 class CInputManager;
 class CFileExtensionProvider;
-class CNetwork;
+class CNetworkBase;
 class CWinSystemBase;
 class CRenderSystemBase;
 class CPowerManager;
@@ -93,7 +93,7 @@ public:
   static CFileExtensionProvider &GetFileExtensionProvider();
   static bool IsBinaryAddonCacheUp();
   static bool IsServiceManagerUp();
-  static CNetwork& GetNetwork();
+  static CNetworkBase& GetNetwork();
   static CPowerManager& GetPowerManager();
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -106,8 +106,6 @@ void CServiceManager::DeinitTesting()
 
 bool CServiceManager::InitStageOne()
 {
-  m_playlistPlayer.reset(new PLAYLIST::CPlayListPlayer());
-
   m_settings.reset(new CSettings());
   m_network.reset(SetupNetwork());
 
@@ -255,7 +253,6 @@ void CServiceManager::DeinitStageOne()
 
   m_network.reset();
   m_settings.reset();
-  m_playlistPlayer.reset();
 }
 
 ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
@@ -306,11 +303,6 @@ CDataCacheCore& CServiceManager::GetDataCacheCore()
 CPlatform& CServiceManager::GetPlatform()
 {
   return *m_Platform;
-}
-
-PLAYLIST::CPlayListPlayer& CServiceManager::GetPlaylistPlayer()
-{
-  return *m_playlistPlayer;
 }
 
 CSettings& CServiceManager::GetSettings()

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -45,6 +45,7 @@
 #include "powermanagement/PowerManager.h"
 #include "weather/WeatherManager.h"
 #include "DatabaseManager.h"
+#include "services/ServiceManager.h"
 
 using namespace KODI;
 
@@ -106,9 +107,6 @@ void CServiceManager::DeinitTesting()
 
 bool CServiceManager::InitStageOne()
 {
-  m_announcementManager.reset(new ANNOUNCEMENT::CAnnouncementManager());
-  m_announcementManager->Start();
-
 #ifdef HAS_PYTHON
   m_XBPython.reset(new XBPython());
   CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(), ".py");
@@ -176,9 +174,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_inputManager.reset(new CInputManager(params));
   m_inputManager->InitializeInputs();
 
-  m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager,
-                                                    *m_inputManager,
-                                                    *m_gameControllerManager));
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  m_peripherals.reset(new PERIPHERALS::CPeripherals(*man, *m_inputManager, *m_gameControllerManager));
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
 
@@ -269,7 +266,6 @@ void CServiceManager::DeinitStageOne()
   CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
   m_XBPython.reset();
 #endif
-  m_announcementManager.reset();
 }
 
 ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
@@ -300,11 +296,6 @@ ADDON::CServiceAddonManager &CServiceManager::GetServiceAddons()
 ADDON::CRepositoryUpdater &CServiceManager::GetRepositoryUpdater()
 {
   return *m_repositoryUpdater;
-}
-
-ANNOUNCEMENT::CAnnouncementManager& CServiceManager::GetAnnouncementManager()
-{
-  return *m_announcementManager;
 }
 
 #ifdef HAS_PYTHON

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -37,7 +37,6 @@
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "pvr/PVRManager.h"
-#include "network/Network.h"
 #include "settings/Settings.h"
 #include "utils/FileExtensionProvider.h"
 #include "windowing/WinSystem.h"
@@ -65,7 +64,6 @@ CServiceManager::~CServiceManager()
 bool CServiceManager::InitForTesting()
 {
   m_settings.reset(new CSettings());
-  m_network.reset(SetupNetwork());
 
   m_profileManager.reset(new CProfilesManager(*m_settings));
 
@@ -100,14 +98,12 @@ void CServiceManager::DeinitTesting()
   m_addonMgr.reset();
   m_databaseManager.reset();
   m_profileManager.reset();
-  m_network.reset();
   m_settings.reset();
 }
 
 bool CServiceManager::InitStageOne()
 {
   m_settings.reset(new CSettings());
-  m_network.reset(SetupNetwork());
 
   init_level = 1;
   return true;
@@ -251,7 +247,6 @@ void CServiceManager::DeinitStageOne()
 {
   init_level = 0;
 
-  m_network.reset();
   m_settings.reset();
 }
 
@@ -364,26 +359,6 @@ void CServiceManager::delete_contextMenuManager::operator()(CContextMenuManager 
 void CServiceManager::delete_favouritesService::operator()(CFavouritesService *p) const
 {
   delete p;
-}
-
-CNetworkBase* CServiceManager::SetupNetwork() const
-{
-#if defined(TARGET_ANDROID)
-  return new CNetworkAndroid();
-#elif defined(HAS_LINUX_NETWORK)
-  return new CNetworkLinux();
-#elif defined(HAS_WIN32_NETWORK)
-  return new CNetworkWin32();
-#elif defined(HAS_WIN10_NETWORK)
-  return new CNetworkWin10();
-#else
-  return new CNetwork();
-#endif
-}
-
-CNetworkBase& CServiceManager::GetNetwork()
-{
-  return *m_network;
 }
 
 CWeatherManager& CServiceManager::GetWeatherManager()

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -366,7 +366,7 @@ void CServiceManager::delete_favouritesService::operator()(CFavouritesService *p
   delete p;
 }
 
-CNetwork* CServiceManager::SetupNetwork() const
+CNetworkBase* CServiceManager::SetupNetwork() const
 {
 #if defined(TARGET_ANDROID)
   return new CNetworkAndroid();
@@ -381,7 +381,7 @@ CNetwork* CServiceManager::SetupNetwork() const
 #endif
 }
 
-CNetwork& CServiceManager::GetNetwork()
+CNetworkBase& CServiceManager::GetNetwork()
 {
   return *m_network;
 }

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -36,7 +36,6 @@
 #include "input/InputManager.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
-#include "interfaces/python/XBPython.h"
 #include "pvr/PVRManager.h"
 #include "network/Network.h"
 #include "settings/Settings.h"
@@ -107,11 +106,6 @@ void CServiceManager::DeinitTesting()
 
 bool CServiceManager::InitStageOne()
 {
-#ifdef HAS_PYTHON
-  m_XBPython.reset(new XBPython());
-  CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(m_XBPython.get(), ".py");
-#endif
-
   m_playlistPlayer.reset(new PLAYLIST::CPlayListPlayer());
 
   m_settings.reset(new CSettings());
@@ -262,10 +256,6 @@ void CServiceManager::DeinitStageOne()
   m_network.reset();
   m_settings.reset();
   m_playlistPlayer.reset();
-#ifdef HAS_PYTHON
-  CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
-  m_XBPython.reset();
-#endif
 }
 
 ADDON::CAddonMgr &CServiceManager::GetAddonMgr()
@@ -297,13 +287,6 @@ ADDON::CRepositoryUpdater &CServiceManager::GetRepositoryUpdater()
 {
   return *m_repositoryUpdater;
 }
-
-#ifdef HAS_PYTHON
-XBPython& CServiceManager::GetXBPython()
-{
-  return *m_XBPython;
-}
-#endif
 
 PVR::CPVRManager& CServiceManager::GetPVRManager()
 {

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -45,9 +45,6 @@ namespace PLAYLIST
 }
 
 class CContextMenuManager;
-#ifdef HAS_PYTHON
-class XBPython;
-#endif
 class CDataCacheCore;
 class CSettings;
 class CFavouritesService;
@@ -105,9 +102,6 @@ public:
   ADDON::CServiceAddonManager& GetServiceAddons();
   ADDON::CRepositoryUpdater& GetRepositoryUpdater();
   CNetwork& GetNetwork();
-#ifdef HAS_PYTHON
-  XBPython& GetXBPython();
-#endif
   PVR::CPVRManager& GetPVRManager();
   CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();
@@ -164,9 +158,6 @@ protected:
   std::unique_ptr<ADDON::CVFSAddonCache> m_vfsAddonCache;
   std::unique_ptr<ADDON::CServiceAddonManager> m_serviceAddons;
   std::unique_ptr<ADDON::CRepositoryUpdater> m_repositoryUpdater;
-#ifdef HAS_PYTHON
-  std::unique_ptr<XBPython> m_XBPython;
-#endif
   std::unique_ptr<PVR::CPVRManager> m_PVRManager;
   std::unique_ptr<CContextMenuManager, delete_contextMenuManager> m_contextMenuManager;
   std::unique_ptr<CDataCacheCore, delete_dataCacheCore> m_dataCacheCore;

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -43,7 +43,6 @@ class CContextMenuManager;
 class CDataCacheCore;
 class CSettings;
 class CFavouritesService;
-class CNetworkBase;
 class CWinSystemBase;
 class CPowerManager;
 class CWeatherManager;
@@ -96,7 +95,6 @@ public:
   ADDON::CVFSAddonCache& GetVFSAddonCache();
   ADDON::CServiceAddonManager& GetServiceAddons();
   ADDON::CRepositoryUpdater& GetRepositoryUpdater();
-  CNetworkBase& GetNetwork();
   PVR::CPVRManager& GetPVRManager();
   CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();
@@ -143,9 +141,6 @@ protected:
     void operator()(CFavouritesService *p) const;
   };
 
-  //! \brief Initialize appropriate networking instance.
-  CNetworkBase* SetupNetwork() const;
-
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
   std::unique_ptr<ADDON::CBinaryAddonManager> m_binaryAddonManager;
   std::unique_ptr<ADDON::CBinaryAddonCache> m_binaryAddonCache;
@@ -164,7 +159,6 @@ protected:
   std::unique_ptr<CFavouritesService, delete_favouritesService> m_favouritesService;
   std::unique_ptr<CInputManager> m_inputManager;
   std::unique_ptr<CFileExtensionProvider> m_fileExtensionProvider;
-  std::unique_ptr<CNetworkBase> m_network;
   std::unique_ptr<CPowerManager> m_powerManager;
   std::unique_ptr<CWeatherManager> m_weatherManager;
   std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -39,11 +39,6 @@ namespace PVR
 class CPVRManager;
 }
 
-namespace PLAYLIST
-{
-  class CPlayListPlayer;
-}
-
 class CContextMenuManager;
 class CDataCacheCore;
 class CSettings;
@@ -113,7 +108,6 @@ public:
   KODI::RETRO::CGUIGameRenderManager& GetGameRenderManager();
   PERIPHERALS::CPeripherals& GetPeripherals();
 
-  PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
   int init_level = 0;
 
   CSettings& GetSettings();
@@ -162,7 +156,6 @@ protected:
   std::unique_ptr<CContextMenuManager, delete_contextMenuManager> m_contextMenuManager;
   std::unique_ptr<CDataCacheCore, delete_dataCacheCore> m_dataCacheCore;
   std::unique_ptr<CPlatform> m_Platform;
-  std::unique_ptr<PLAYLIST::CPlayListPlayer> m_playlistPlayer;
   std::unique_ptr<CSettings> m_settings;
   std::unique_ptr<KODI::GAME::CControllerManager> m_gameControllerManager;
   std::unique_ptr<KODI::GAME::CGameServices> m_gameServices;

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -34,11 +34,6 @@ class CServiceAddonManager;
 class CRepositoryUpdater;
 }
 
-namespace ANNOUNCEMENT
-{
-class CAnnouncementManager;
-}
-
 namespace PVR
 {
 class CPVRManager;
@@ -109,7 +104,6 @@ public:
   ADDON::CVFSAddonCache& GetVFSAddonCache();
   ADDON::CServiceAddonManager& GetServiceAddons();
   ADDON::CRepositoryUpdater& GetRepositoryUpdater();
-  ANNOUNCEMENT::CAnnouncementManager& GetAnnouncementManager();
   CNetwork& GetNetwork();
 #ifdef HAS_PYTHON
   XBPython& GetXBPython();
@@ -170,7 +164,6 @@ protected:
   std::unique_ptr<ADDON::CVFSAddonCache> m_vfsAddonCache;
   std::unique_ptr<ADDON::CServiceAddonManager> m_serviceAddons;
   std::unique_ptr<ADDON::CRepositoryUpdater> m_repositoryUpdater;
-  std::unique_ptr<ANNOUNCEMENT::CAnnouncementManager> m_announcementManager;
 #ifdef HAS_PYTHON
   std::unique_ptr<XBPython> m_XBPython;
 #endif

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -43,7 +43,7 @@ class CContextMenuManager;
 class CDataCacheCore;
 class CSettings;
 class CFavouritesService;
-class CNetwork;
+class CNetworkBase;
 class CWinSystemBase;
 class CPowerManager;
 class CWeatherManager;
@@ -96,7 +96,7 @@ public:
   ADDON::CVFSAddonCache& GetVFSAddonCache();
   ADDON::CServiceAddonManager& GetServiceAddons();
   ADDON::CRepositoryUpdater& GetRepositoryUpdater();
-  CNetwork& GetNetwork();
+  CNetworkBase& GetNetwork();
   PVR::CPVRManager& GetPVRManager();
   CContextMenuManager& GetContextMenuManager();
   CDataCacheCore& GetDataCacheCore();
@@ -144,7 +144,7 @@ protected:
   };
 
   //! \brief Initialize appropriate networking instance.
-  CNetwork* SetupNetwork() const;
+  CNetworkBase* SetupNetwork() const;
 
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
   std::unique_ptr<ADDON::CBinaryAddonManager> m_binaryAddonManager;
@@ -164,7 +164,7 @@ protected:
   std::unique_ptr<CFavouritesService, delete_favouritesService> m_favouritesService;
   std::unique_ptr<CInputManager> m_inputManager;
   std::unique_ptr<CFileExtensionProvider> m_fileExtensionProvider;
-  std::unique_ptr<CNetwork> m_network;
+  std::unique_ptr<CNetworkBase> m_network;
   std::unique_ptr<CPowerManager> m_powerManager;
   std::unique_ptr<CWeatherManager> m_weatherManager;
   std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -27,7 +27,7 @@
 #include "FileItem.h"
 #include "filesystem/StackDirectory.h"
 #include "network/Network.h"
-#include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #ifndef TARGET_POSIX
 #include <sys\stat.h>
 #endif
@@ -36,6 +36,7 @@
 #include <vector>
 
 using namespace ADDON;
+using namespace SERVICES;
 
 CURL::~CURL() = default;
 
@@ -638,7 +639,8 @@ bool CURL::IsLocal() const
 
 bool CURL::IsLocalHost() const
 {
-  return CServiceBroker::GetNetwork().IsLocalHost(m_strHostName);
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  return net ? net->IsLocalHost(m_strHostName) : true;
 }
 
 bool CURL::IsFileOnly(const std::string &url)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -103,7 +103,6 @@ using namespace MEDIA_DETECT;
 #endif
 
 using namespace XFILE;
-using namespace PLAYLIST;
 using KODI::UTILITY::CDigest;
 
 #if !defined(TARGET_WINDOWS)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -48,6 +48,7 @@
 
 #include "addons/VFSEntry.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "Util.h"
 #include "filesystem/PVRDirectory.h"
 #include "filesystem/Directory.h"
@@ -102,6 +103,7 @@
 using namespace MEDIA_DETECT;
 #endif
 
+using namespace SERVICES;
 using namespace XFILE;
 using KODI::UTILITY::CDigest;
 
@@ -2016,7 +2018,8 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
 
   if (!CMediaSettings::GetInstance().GetAdditionalSubtitleDirectoryChecked() && !CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH).empty()) // to avoid checking non-existent directories (network) every time..
   {
-    if (!CServiceBroker::GetNetwork().IsAvailable() && !URIUtils::IsHD(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH)))
+    auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+    if ((!net || !net->IsAvailable()) && !URIUtils::IsHD(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH)))
     {
       CLog::Log(LOGINFO, "CUtil::CacheSubtitles: disabling alternate subtitle directory for this session, it's inaccessible");
       CMediaSettings::GetInstance().SetAdditionalSubtitleDirectoryChecked(-1); // disabled

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -18,10 +18,11 @@
  *
  */
 
+#include "XBApplicationEx.h"
 #include "FileItem.h"
 #include "messaging/ApplicationMessenger.h"
 #include "PlayListPlayer.h"
-#include "XBApplicationEx.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "threads/SystemClock.h"
 #include "commons/Exception.h"
@@ -34,6 +35,9 @@
 #ifndef _DEBUG
 #define XBMC_TRACK_EXCEPTIONS
 #endif
+
+using namespace SERVICES;
+using namespace PLAYLIST;
 
 CXBApplicationEx::CXBApplicationEx()
 {
@@ -65,8 +69,12 @@ int CXBApplicationEx::Run(const CAppParamParser &params)
 
   if (params.Playlist().Size() > 0)
   {
-    CServiceBroker::GetPlaylistPlayer().Add(0, params.Playlist());
-    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(0);
+    auto pl = SERVICES::CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+    if (pl)
+    {
+      pl->Add(0, params.Playlist());
+      pl->SetCurrentPlaylist(0);
+    }
     KODI::MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
 

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -45,6 +45,8 @@
 
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
+#include "services/ServiceManager.h"
+using namespace SERVICES;
 #endif
 
 using XFILE::CDirectory;
@@ -198,7 +200,9 @@ void CAddon::SaveSettings(void)
   //push the settings changes to the running addon instance
   CServiceBroker::GetAddonMgr().ReloadSettings(ID());
 #ifdef HAS_PYTHON
-  g_pythonParser.OnSettingsChanged(ID());
+  auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+  if (xbp)
+    xbp->OnSettingsChanged(ID());
 #endif
 }
 

--- a/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/interfaces/Addon/AddonCallbacksAddon.cpp
@@ -31,7 +31,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "FileItem.h"
 #include "network/Network.h"
-#include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
@@ -182,7 +182,8 @@ void CAddonCallbacksAddon::QueueNotification(void *addonData, const queue_msg_t 
 
 bool CAddonCallbacksAddon::WakeOnLan(const char *mac)
 {
-  return CServiceBroker::GetNetwork().WakeOnLan(mac);
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  return net ? net->WakeOnLan(mac) : false;
 }
 
 bool CAddonCallbacksAddon::GetAddonSetting(void *addonData, const char *strSettingName, void *settingValue)

--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -27,10 +27,11 @@
 #include "addons/binary-addons/AddonDll.h"
 #include "network/DNSNameCache.h"
 #include "network/Network.h"
-#include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 
 using namespace kodi; // addon-dev-kit namespace
+using namespace SERVICES;
 
 namespace ADDON
 {
@@ -64,7 +65,8 @@ bool Interface_Network::wake_on_lan(void* kodiBase, const char* mac)
     return false;
   }
 
-  return CServiceBroker::GetNetwork().WakeOnLan(mac);
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  return net ? net->WakeOnLan(mac) : false;
 }
 
 char* Interface_Network::get_ip_address(void* kodiBase)
@@ -77,7 +79,8 @@ char* Interface_Network::get_ip_address(void* kodiBase)
   }
 
   std::string titleIP;
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
   if (iface)
     titleIP = iface->GetCurrentIPAddress();
   else

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -58,6 +58,7 @@
 #include "pictures/Picture.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/CharsetConverter.h"
@@ -953,7 +954,9 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
 
     CVariant data(CVariant::VariantTypeObject);
     data["on"] = true;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTA", data);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTA", data);
   }
 
   if (!traffic_announcement && m_TA_TP_TrafficAdvisory && CServiceBroker::GetSettings().GetBool("pvrplayback.trafficadvisory"))
@@ -963,7 +966,9 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(uint8_t *msgElement)
 
     CVariant data(CVariant::VariantTypeObject);
     data["on"] = false;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTA", data);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTA", data);
   }
 
   return 4;
@@ -1186,7 +1191,9 @@ unsigned int CDVDRadioRDSData::DecodeRTC(uint8_t *msgElement)
 
   CVariant data(CVariant::VariantTypeObject);
   data["dateTime"] = (m_RTC_DateTime.IsValid()) ? m_RTC_DateTime.GetAsRFC1123DateTime() : "";
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioRTC", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioRTC", data);
 
   return 8;
 }
@@ -1745,6 +1752,8 @@ void CDVDRadioRDSData::SendTMCSignal(unsigned int flags, uint8_t *data)
     msg["y"]       = (unsigned int)(m_TMC_LastData[1]<<8 | m_TMC_LastData[2]);
     msg["z"]       = (unsigned int)(m_TMC_LastData[3]<<8 | m_TMC_LastData[4]);
 
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTMC", msg);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::PVR, "xbmc", "RDSRadioTMC", msg);
   }
 }

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -47,10 +47,12 @@
 #include "URL.h"
 #include "utils/Variant.h"
 #include "utils/FileExtensionProvider.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "messaging/helpers/DialogOKHelper.h"
 
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 using namespace XFILE;
 
 #define CONTROL_LIST          450
@@ -578,7 +580,8 @@ bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
   else if ( iDriveType == CMediaSource::SOURCE_TYPE_REMOTE )
   {
     //! @todo Handle not connected to a remote share
-    if ( !CServiceBroker::GetNetwork().IsConnected() )
+    auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+    if (!net || !net->IsConnected())
     {
       HELPERS::ShowOKDialogText(CVariant{220}, CVariant{221});
       return false;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "GUIDialogKeyboardGeneric.h"
 #include "interfaces/AnnouncementManager.h"
 #include "input/XBMC_vkeys.h"
 #include "input/InputCodingTable.h"
@@ -30,8 +31,8 @@
 #include "guilib/LocalizeStrings.h"
 #include "GUIUserMessages.h"
 #include "GUIDialogNumeric.h"
-#include "GUIDialogKeyboardGeneric.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "utils/RegExp.h"
 #include "utils/Variant.h"
@@ -52,6 +53,7 @@
 #endif
 
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 
 #define BUTTON_ID_OFFSET      100
 #define BUTTONS_PER_ROW        20
@@ -190,7 +192,10 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   data["title"] = m_strHeading;
   data["type"] = !m_hiddenInput ? "keyboard" : "password";
   data["value"] = GetText();
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
+
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
 }
 
 bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
@@ -523,7 +528,9 @@ void CGUIDialogKeyboardGeneric::OnDeinitWindow(int nextWindowID)
   // reset the heading (we don't always have this)
   m_strHeading = "";
 
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputFinished");
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputFinished");
 }
 
 void CGUIDialogKeyboardGeneric::MoveCursor(int iAmount)

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -33,6 +33,7 @@
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
 
 #define CONTROL_HEADING_LABEL  1
@@ -46,6 +47,7 @@
 
 using namespace KODI::MESSAGING;
 using KODI::UTILITY::CDigest;
+using namespace SERVICES;
 
 CGUIDialogNumeric::CGUIDialogNumeric(void)
   : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml")
@@ -97,7 +99,9 @@ void CGUIDialogNumeric::OnInitWindow()
     data["title"] = control->GetDescription();
 
   data["value"] = GetOutputString();
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputRequested", data);
 }
 
 void CGUIDialogNumeric::OnDeinitWindow(int nextWindowID)
@@ -105,7 +109,9 @@ void CGUIDialogNumeric::OnDeinitWindow(int nextWindowID)
   // call base class
   CGUIDialog::OnDeinitWindow(nextWindowID);
 
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputFinished");
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Input, "xbmc", "OnInputFinished");
 }
 
 bool CGUIDialogNumeric::OnAction(const CAction &action)

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -40,6 +40,7 @@
 #include "UDFDirectory.h"
 #include "utils/log.h"
 #include "network/WakeOnAccess.h"
+#include "services/ServiceManager.h"
 
 #ifdef TARGET_POSIX
 #include "platform/posix/filesystem/PosixDirectory.h"
@@ -91,7 +92,7 @@
 #include "addons/VFSEntry.h"
 
 using namespace ADDON;
-
+using namespace SERVICES;
 using namespace XFILE;
 
 /*!
@@ -152,7 +153,8 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
   if (CWinLibraryDirectory::IsValid(url)) return new CWinLibraryDirectory();
 #endif
 
-  bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  bool networkAvailable = net && net->IsAvailable();
   if (networkAvailable)
   {
     if (url.IsProtocol("ftp") || url.IsProtocol("ftps")) return new CFTPDirectory();

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -72,10 +72,12 @@
 #include "utils/log.h"
 #include "network/WakeOnAccess.h"
 #include "utils/StringUtils.h"
+#include "services/ServiceManager.h"
 #include "ServiceBroker.h"
 #include "addons/VFSEntry.h"
 
 using namespace ADDON;
+using namespace SERVICES;
 using namespace XFILE;
 
 CFileFactory::CFileFactory() = default;
@@ -144,7 +146,8 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   else if (CWinLibraryFile::IsValid(url)) return new CWinLibraryFile();
 #endif
 
-  bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  bool networkAvailable = net && net->IsAvailable();
   if (networkAvailable)
   {
     if (url.IsProtocol("ftp")

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -22,8 +22,10 @@
 #include "PlayListPlayer.h"
 #include "URL.h"
 #include "playlists/PlayList.h"
+#include "services/ServiceManager.h"
 
 using namespace PLAYLIST;
+using namespace SERVICES;
 using namespace XFILE;
 
 CPlaylistDirectory::CPlaylistDirectory() = default;
@@ -41,7 +43,11 @@ bool CPlaylistDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (playlistTyp==PLAYLIST_NONE)
     return false;
 
-  CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistTyp);
+  auto pl = CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+  if (!pl)
+    return false;
+
+  CPlayList& playlist = pl->GetPlaylist(playlistTyp);
   items.Reserve(playlist.size());
 
   for (int i = 0; i < playlist.size(); ++i)

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -29,6 +29,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
 #include "Application.h"
@@ -86,12 +87,16 @@ void CDialogGameVolume::OnInitWindow()
   if (dialogVolumeBar != nullptr)
     dialogVolumeBar->RegisterCallback(this);
 
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(this);
 }
 
 void CDialogGameVolume::OnDeinitWindow(int nextWindowID)
 {
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
 
   CGUIDialogVolumeBar *dialogVolumeBar = dynamic_cast<CGUIDialogVolumeBar*>(CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_DIALOG_VOLUME_BAR));
   if (dialogVolumeBar != nullptr)

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -27,6 +27,7 @@
 #include "guilib/IGUIContainer.h"
 #include "guilib/LocalizeStrings.h"
 #include "playlists/PlayList.h"
+#include "services/ServiceManager.h"
 #include "utils/StringUtils.h"
 #include "windows/GUIMediaWindow.h"
 
@@ -48,32 +49,34 @@ std::string GetPlaylistLabel(int item, int playlistid /* = PLAYLIST_NONE */)
   if (playlistid < PLAYLIST_NONE)
     return std::string();
 
-  PLAYLIST::CPlayListPlayer& player = CServiceBroker::GetPlaylistPlayer();
+  auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+  if (!pl)
+    return "";
 
-  int iPlaylist = playlistid == PLAYLIST_NONE ? player.GetCurrentPlaylist() : playlistid;
+  int iPlaylist = playlistid == PLAYLIST_NONE ? pl->GetCurrentPlaylist() : playlistid;
   switch (item)
   {
     case PLAYLIST_LENGTH:
     {
-      return StringUtils::Format("%i", player.GetPlaylist(iPlaylist).size());
+      return StringUtils::Format("%i", pl->GetPlaylist(iPlaylist).size());
     }
     case PLAYLIST_POSITION:
     {
-      int currentSong = player.GetCurrentSong();
+      int currentSong = pl->GetCurrentSong();
       if (currentSong > -1)
         return StringUtils::Format("%i", currentSong + 1);
       break;
     }
     case PLAYLIST_RANDOM:
     {
-      if (player.IsShuffled(iPlaylist))
+      if (pl->IsShuffled(iPlaylist))
         return g_localizeStrings.Get(16041); // 16041: On
       else
         return g_localizeStrings.Get(591); // 591: Off
     }
     case PLAYLIST_REPEAT:
     {
-      PLAYLIST::REPEAT_STATE state = player.GetRepeat(iPlaylist);
+      PLAYLIST::REPEAT_STATE state = pl->GetRepeat(iPlaylist);
       if (state == PLAYLIST::REPEAT_ONE)
         return g_localizeStrings.Get(592); // 592: One
       else if (state == PLAYLIST::REPEAT_ALL)

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIDialog.h"
 #include "guilib/GUIWindowManager.h"
+#include "services/ServiceManager.h"
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/URIUtils.h"
@@ -532,32 +533,38 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case PLAYLIST_ISRANDOM:
     {
-      PLAYLIST::CPlayListPlayer& player = CServiceBroker::GetPlaylistPlayer();
+      auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
       int playlistid = info.GetData1();
-      if (info.GetData2() > 0 && playlistid > PLAYLIST_NONE)
-        value = player.IsShuffled(playlistid);
+      if (pl && info.GetData2() > 0 && playlistid > PLAYLIST_NONE)
+        value = pl->IsShuffled(playlistid);
+      else if (pl)
+        value = pl->IsShuffled(pl->GetCurrentPlaylist());
       else
-        value = player.IsShuffled(player.GetCurrentPlaylist());
+        value = false;
       return true;
     }
     case PLAYLIST_ISREPEAT:
     {
-      PLAYLIST::CPlayListPlayer& player = CServiceBroker::GetPlaylistPlayer();
+      auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
       int playlistid = info.GetData1();
-      if (info.GetData2() > 0 && playlistid > PLAYLIST_NONE)
-        value = (player.GetRepeat(playlistid) == PLAYLIST::REPEAT_ALL);
+      if (pl && info.GetData2() > 0 && playlistid > PLAYLIST_NONE)
+        value = pl->GetRepeat(playlistid) == PLAYLIST::REPEAT_ALL;
+      else if (pl)
+        value = pl->GetRepeat(pl->GetCurrentPlaylist()) == PLAYLIST::REPEAT_ALL;
       else
-        value = player.GetRepeat(player.GetCurrentPlaylist()) == PLAYLIST::REPEAT_ALL;
+        value = false;
       return true;
     }
     case PLAYLIST_ISREPEATONE:
     {
-      PLAYLIST::CPlayListPlayer& player = CServiceBroker::GetPlaylistPlayer();
+      auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
       int playlistid = info.GetData1();
-      if (info.GetData2() > 0 && playlistid > PLAYLIST_NONE)
-        value = (player.GetRepeat(playlistid) == PLAYLIST::REPEAT_ONE);
+      if (pl && info.GetData2() > 0 && playlistid > PLAYLIST_NONE)
+        value = pl->GetRepeat(playlistid) == PLAYLIST::REPEAT_ONE;
+      else if (pl)
+        value = pl->GetRepeat(pl->GetCurrentPlaylist()) == PLAYLIST::REPEAT_ONE;
       else
-        value = player.GetRepeat(player.GetCurrentPlaylist()) == PLAYLIST::REPEAT_ONE;
+        value = false;
       return true;
     }
 
@@ -577,8 +584,9 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       {
         if (item->HasProperty("playlistposition"))
         {
-          value = static_cast<int>(item->GetProperty("playlisttype").asInteger()) == CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() &&
-                  static_cast<int>(item->GetProperty("playlistposition").asInteger()) == CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
+          auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+          value = pl ? static_cast<int>(item->GetProperty("playlisttype").asInteger()) ==  pl->GetCurrentPlaylist() &&
+                  static_cast<int>(item->GetProperty("playlistposition").asInteger()) == pl->GetCurrentSong() : false;
           return true;
         }
         else if (m_currentItem && !m_currentItem->GetPath().empty())

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -36,6 +36,7 @@
 #endif
 #include "powermanagement/PowerManager.h"
 #include "profiles/ProfilesManager.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -317,7 +318,8 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case NETWORK_IP_ADDRESS:
     {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
       if (iface)
       {
         value = iface->GetCurrentIPAddress();
@@ -327,7 +329,8 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     }
     case NETWORK_SUBNET_MASK:
     {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
       if (iface)
       {
         value = iface->GetCurrentNetmask();
@@ -337,7 +340,8 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     }
     case NETWORK_GATEWAY_ADDRESS:
     {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
       if (iface)
       {
         value = iface->GetCurrentDefaultGateway();
@@ -347,7 +351,10 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     }
     case NETWORK_DNS1_ADDRESS:
     {
-      const std::vector<std::string> nss = CServiceBroker::GetNetwork().GetNameServers();
+      std::vector<std::string> nss;
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      if (net)
+        nss = net->GetNameServers();
       if (nss.size() >= 1)
       {
         value = nss[0];
@@ -357,7 +364,10 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     }
     case NETWORK_DNS2_ADDRESS:
     {
-      const std::vector<std::string> nss = CServiceBroker::GetNetwork().GetNameServers();
+      std::vector<std::string> nss;
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      if (net)
+        nss = net->GetNameServers();
       if (nss.size() >= 2)
       {
         value = nss[1];
@@ -376,7 +386,8 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     {
       std::string linkStatus = g_localizeStrings.Get(151);
       linkStatus += " ";
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
       if (iface && iface->IsConnected())
         linkStatus += g_localizeStrings.Get(15207);
       else

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -34,6 +34,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "guilib/WindowIDs.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
@@ -497,17 +498,23 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     // VIDEOPLAYER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case VIDEOPLAYER_PLAYLISTLEN:
-      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO)
       {
-        value = GUIINFO::GetPlaylistLabel(PLAYLIST_LENGTH);
-        return true;
+        auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+        if (pl && pl->GetCurrentPlaylist() == PLAYLIST_VIDEO)
+        {
+          value = GUIINFO::GetPlaylistLabel(PLAYLIST_LENGTH);
+          return true;
+        }
       }
       break;
     case VIDEOPLAYER_PLAYLISTPOS:
-      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == PLAYLIST_VIDEO)
       {
-        value = GUIINFO::GetPlaylistLabel(PLAYLIST_POSITION);
-        return true;
+        auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+        if (pl && pl->GetCurrentPlaylist() == PLAYLIST_VIDEO)
+        {
+          value = GUIINFO::GetPlaylistLabel(PLAYLIST_POSITION);
+          return true;
+        }
       }
       break;
     case VIDEOPLAYER_VIDEO_ASPECT:

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -45,11 +45,6 @@ CAnnouncementManager::~CAnnouncementManager()
   Deinitialize();
 }
 
-CAnnouncementManager& CAnnouncementManager::GetInstance()
-{
-  return CServiceBroker::GetAnnouncementManager();
-}
-
 void CAnnouncementManager::Start()
 {
   Create();

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "IAnnouncer.h"
+#include "services/IService.h"
 #include "FileItem.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
@@ -31,13 +32,11 @@ class CVariant;
 
 namespace ANNOUNCEMENT
 {
-  class CAnnouncementManager : public CThread
+  class CAnnouncementManager : public CThread, public SERVICES::IService
   {
   public:
     CAnnouncementManager();
     ~CAnnouncementManager() override;
-
-    static CAnnouncementManager& GetInstance();
 
     void Start();
     void Deinitialize();
@@ -51,6 +50,12 @@ namespace ANNOUNCEMENT
         const std::shared_ptr<const CFileItem>& item);
     void Announce(AnnouncementFlag flag, const char *sender, const char *message,
         const std::shared_ptr<const CFileItem>& item, const CVariant &data);
+
+    bool StartService() override
+    {
+      Start();
+      return true;
+    }
 
   protected:
     void Process() override;

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -26,6 +26,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "input/Key.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "network/Network.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -92,7 +93,9 @@ static int NotifyAll(const std::vector<std::string>& params)
     }
   }
 
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Other, params[0].c_str(), params[1].c_str(), data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Other, params[0].c_str(), params[1].c_str(), data);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -150,7 +150,9 @@ static int ToggleDPMS(const std::vector<std::string>& params)
  */
 static int WakeOnLAN(const std::vector<std::string>& params)
 {
-  CServiceBroker::GetNetwork().WakeOnLan(params[0].c_str());
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  if (net)
+    net->WakeOnLan(params[0].c_str());
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -33,6 +33,7 @@
 #include "network/NetworkServices.h"
 #include "profiles/ProfilesManager.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
 #include "video/VideoLibraryQueue.h"
@@ -79,7 +80,9 @@ static int LogOff(const std::vector<std::string>& params)
   if (CVideoLibraryQueue::GetInstance().IsRunning())
     CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
-  CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  if (net)
+    net->NetworkMessage(CNetwork::SERVICES_DOWN,1);
 
 
   CProfilesManager &profileManager = CServiceBroker::GetProfileManager();

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -28,6 +28,7 @@
 #include "input/ActionTranslator.h"
 #include "input/WindowTranslator.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "playlists/SmartPlayList.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
@@ -37,6 +38,7 @@
 
 using namespace ANNOUNCEMENT;
 using namespace JSONRPC;
+using namespace SERVICES;
 
 bool CJSONRPC::m_initialized = false;
 
@@ -221,14 +223,20 @@ JSONRPC_STATUS CJSONRPC::SetConfiguration(const std::string &method, ITransportL
 
 JSONRPC_STATUS CJSONRPC::NotifyAll(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant& parameterObject, CVariant &result)
 {
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (!man)
+    return ACK;
+
   if (parameterObject["data"].isNull())
-    CAnnouncementManager::GetInstance().Announce(Other, parameterObject["sender"].asString().c_str(),  
-      parameterObject["message"].asString().c_str());
+  {
+    man->Announce(Other, parameterObject["sender"].asString().c_str(),
+                         parameterObject["message"].asString().c_str());
+  }
   else
   {
     CVariant data = parameterObject["data"];
-    CAnnouncementManager::GetInstance().Announce(Other, parameterObject["sender"].asString().c_str(),  
-      parameterObject["message"].asString().c_str(), data);
+    man->Announce(Other, parameterObject["sender"].asString().c_str(),
+                         parameterObject["message"].asString().c_str(), data);
   }
 
   return ACK;

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -26,11 +26,13 @@
 #include "messaging/ApplicationMessenger.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
+#include "services/ServiceManager.h"
 #include "utils/Variant.h"
 
 using namespace JSONRPC;
 using namespace PLAYLIST;
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 
 JSONRPC_STATUS CPlaylistOperations::GetPlaylists(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -180,7 +182,8 @@ JSONRPC_STATUS CPlaylistOperations::Remove(const std::string &method, ITransport
     return FailedToExecute;
   
   int position = (int)parameterObject["position"].asInteger();
-  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlist && CServiceBroker::GetPlaylistPlayer().GetCurrentSong() == position)
+  auto pl = CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+  if (!pl || (pl->GetCurrentPlaylist() == playlist && pl->GetCurrentSong() == position))
     return InvalidParams;
 
   CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_REMOVE, playlist, position);

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -47,6 +47,7 @@
 #include "guilib/TextureManager.h"
 #include "Util.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
+#include "services/ServiceManager.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/LangCodeExpander.h"
@@ -228,7 +229,8 @@ namespace XBMCAddon
       XBMC_TRACE;
       char cTitleIP[32];
       sprintf(cTitleIP, "127.0.0.1");
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
       if (iface)
         return iface->GetCurrentIPAddress();
 

--- a/xbmc/interfaces/legacy/PlayList.cpp
+++ b/xbmc/interfaces/legacy/PlayList.cpp
@@ -20,11 +20,12 @@
 
 #include "PlayList.h"
 #include "PlayListPlayer.h"
-#include "Application.h"
 #include "playlists/PlayListFactory.h"
+#include "services/ServiceManager.h"
 #include "utils/URIUtils.h"
 
 using namespace PLAYLIST;
+using namespace SERVICES;
 
 namespace XBMCAddon
 {
@@ -36,11 +37,11 @@ namespace XBMCAddon
       iPlayList(playList), pPlayList(NULL)
     {
       // we do not create our own playlist, just using the ones from playlistplayer
-      if (iPlayList != PLAYLIST_MUSIC &&
-          iPlayList != PLAYLIST_VIDEO)
+      auto pl = CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+      if (!pl || (iPlayList != PLAYLIST_MUSIC && iPlayList != PLAYLIST_VIDEO))
         throw PlayListException("PlayList does not exist");
 
-      pPlayList = &CServiceBroker::GetPlaylistPlayer().GetPlaylist(playList);
+      pPlayList = &pl->GetPlaylist(playList);
       iPlayList = playList;
     }
 
@@ -89,7 +90,9 @@ namespace XBMCAddon
             return false;
 
           // clear current playlist
-          CServiceBroker::GetPlaylistPlayer().ClearPlaylist(this->iPlayList);
+          auto pl = CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+          if (pl)
+            pl->ClearPlaylist(this->iPlayList);
 
           // add each item of the playlist to the playlistplayer
           for (int i=0; i < (int)pPlayList->size(); ++i)
@@ -136,7 +139,8 @@ namespace XBMCAddon
 
     int PlayList::getposition()
     {
-      return CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
+      auto pl = CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+      return pl ? pl->GetCurrentSong() : -1;
     }
 
     XBMCAddon::xbmcgui::ListItem* PlayList::operator [](long i)

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "AddonUtils.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "cores/IPlayer.h"
 
@@ -119,9 +120,10 @@ namespace XBMCAddon
       CMediaSettings::GetInstance().SetVideoStartWindowed(windowed);
 
       // play current file in playlist
-      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != iPlayList)
-        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
-      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, CServiceBroker::GetPlaylistPlayer().GetCurrentSong());
+      auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+      if (pl && pl->GetCurrentPlaylist() != iPlayList)
+        pl->SetCurrentPlaylist(iPlayList);
+      CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, pl ? pl->GetCurrentSong() : 0);
     }
 
     void Player::playPlaylist(const PlayList* playlist, bool windowed, int startpos)
@@ -135,9 +137,11 @@ namespace XBMCAddon
 
         // play a python playlist (a playlist from playlistplayer.cpp)
         iPlayList = playlist->getPlayListId();
-        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
-        if (startpos > -1)
-          CServiceBroker::GetPlaylistPlayer().SetCurrentSong(startpos);
+        auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+        if (pl)
+          pl->SetCurrentPlaylist(iPlayList);
+        if (startpos > -1 && pl)
+          pl->SetCurrentSong(startpos);
         CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, startpos);
       }
       else
@@ -177,11 +181,13 @@ namespace XBMCAddon
       XBMC_TRACE;
       DelayedCallGuard dc(languageHook);
 
-      if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() != iPlayList)
+      auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+      if (pl && pl->GetCurrentPlaylist() != iPlayList)
       {
-        CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(iPlayList);
+        pl->SetCurrentPlaylist(iPlayList);
       }
-      CServiceBroker::GetPlaylistPlayer().SetCurrentSong(selected);
+      if (pl)
+        pl->SetCurrentSong(selected);
 
       CApplicationMessenger::GetInstance().SendMsg(TMSG_PLAYLISTPLAYER_PLAY, selected);
       //CServiceBroker::GetPlaylistPlayer().Play(selected);

--- a/xbmc/interfaces/python/LanguageHook.cpp
+++ b/xbmc/interfaces/python/LanguageHook.cpp
@@ -22,9 +22,12 @@
 #include "LanguageHook.h"
 #include "CallbackHandler.h"
 #include "XBPython.h"
+#include "services/ServiceManager.h"
 
 #include "interfaces/legacy/AddonUtils.h"
 #include "PyContext.h"
+
+using namespace SERVICES;
 
 namespace XBMCAddon
 {
@@ -173,15 +176,46 @@ namespace XBMCAddon
     }
 
 
-    void PythonLanguageHook::RegisterPlayerCallback(IPlayerCallback* player) { XBMC_TRACE; g_pythonParser.RegisterPythonPlayerCallBack(player); }
-    void PythonLanguageHook::UnregisterPlayerCallback(IPlayerCallback* player) { XBMC_TRACE; g_pythonParser.UnregisterPythonPlayerCallBack(player); }
-    void PythonLanguageHook::RegisterMonitorCallback(XBMCAddon::xbmc::Monitor* monitor) { XBMC_TRACE; g_pythonParser.RegisterPythonMonitorCallBack(monitor); }
-    void PythonLanguageHook::UnregisterMonitorCallback(XBMCAddon::xbmc::Monitor* monitor) { XBMC_TRACE; g_pythonParser.UnregisterPythonMonitorCallBack(monitor); }
+    void PythonLanguageHook::RegisterPlayerCallback(IPlayerCallback* player)
+    {
+      XBMC_TRACE;
+      auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->RegisterPythonPlayerCallBack(player);
+    }
+
+    void PythonLanguageHook::UnregisterPlayerCallback(IPlayerCallback* player)
+    {
+      XBMC_TRACE;
+      auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->UnregisterPythonPlayerCallBack(player);
+    }
+
+    void PythonLanguageHook::RegisterMonitorCallback(XBMCAddon::xbmc::Monitor* monitor)
+    {
+      XBMC_TRACE;
+      auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->RegisterPythonMonitorCallBack(monitor);
+    }
+
+    void PythonLanguageHook::UnregisterMonitorCallback(XBMCAddon::xbmc::Monitor* monitor)
+    {
+      XBMC_TRACE;
+      auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        xbp->UnregisterPythonMonitorCallBack(monitor);
+    }
 
     bool PythonLanguageHook::WaitForEvent(CEvent& hEvent, unsigned int milliseconds)
-    { 
+    {
       XBMC_TRACE;
-      return g_pythonParser.WaitForEvent(hEvent,milliseconds);
+      auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+      if (xbp)
+        return xbp->WaitForEvent(hEvent,milliseconds);
+
+      return false;
     }
 
     void PythonLanguageHook::RegisterAddonClassInstance(AddonClass* obj)

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -46,6 +46,7 @@
 #include "interfaces/legacy/AddonUtils.h"
 #include "interfaces/python/AddonPythonInvoker.h"
 #include "interfaces/python/PythonInvoker.h"
+#include "interfaces/generic/ScriptInvocationManager.h"
 
 using namespace ANNOUNCEMENT;
 using namespace SERVICES;
@@ -749,4 +750,16 @@ bool XBPython::WaitForEvent(CEvent& hEvent, unsigned int milliseconds)
   if (ret)
     m_globalEvent.Reset();
   return ret != NULL;
+}
+
+bool XBPython::StartService()
+{
+  CScriptInvocationManager::GetInstance().RegisterLanguageInvocationHandler(this, ".py");
+  return true;
+}
+
+bool XBPython::StopService()
+{
+  CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(this);
+  return true;
 }

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -40,6 +40,7 @@
 
 #include "threads/SystemClock.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 
 #include "interfaces/legacy/Monitor.h"
 #include "interfaces/legacy/AddonUtils.h"
@@ -47,6 +48,7 @@
 #include "interfaces/python/PythonInvoker.h"
 
 using namespace ANNOUNCEMENT;
+using namespace SERVICES;
 
 XBPython::XBPython()
 {
@@ -59,13 +61,17 @@ XBPython::XBPython()
   m_vecPlayerCallbackList.clear();
   m_vecMonitorCallbackList.clear();
 
-  CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(this);
 }
 
 XBPython::~XBPython()
 {
   XBMC_TRACE;
-  CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
 }
 
 #define LOCK_AND_COPY(type, dest, src) \
@@ -524,7 +530,9 @@ void XBPython::Uninitialize()
   // don't handle any more announcements as most scripts are probably already
   // stopped and executing a callback on one of their already destroyed classes
   // would lead to a crash
-  CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
 
   LOCK_AND_COPY(std::vector<PyElem>,tmpvec,m_vecPyList);
   m_vecPyList.clear();

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -26,12 +26,11 @@
 #include "threads/Thread.h"
 #include "interfaces/IAnnouncer.h"
 #include "interfaces/generic/ILanguageInvocationHandler.h"
+#include "services/IService.h"
 #include "ServiceBroker.h"
 
 #include <memory>
 #include <vector>
-
-#define g_pythonParser CServiceBroker::GetXBPython()
 
 class CPythonInvoker;
 class CVariant;
@@ -63,7 +62,8 @@ typedef std::vector<LibraryLoader*> PythonExtensionLibraries;
 class XBPython :
   public IPlayerCallback,
   public ANNOUNCEMENT::IAnnouncer,
-  public ILanguageInvocationHandler
+  public ILanguageInvocationHandler,
+  public SERVICES::IService
 {
 public:
   XBPython();
@@ -112,6 +112,9 @@ public:
   void RegisterExtensionLib(LibraryLoader *pLib);
   void UnregisterExtensionLib(LibraryLoader *pLib);
   void UnloadExtensionLibs();
+
+  bool StartService() override;
+  bool StopService() override;
 
 private:
   void Finalize();

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -38,6 +38,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/dialogs/GUIDialogPVRGuideInfo.h"
 #include "pvr/dialogs/GUIDialogPVRRecordingInfo.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/JobManager.h"
@@ -53,6 +54,7 @@
 using namespace XFILE;
 using namespace ANNOUNCEMENT;
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 using namespace PVR;
 
 class CDirectoryJob : public CJob
@@ -338,7 +340,9 @@ void CDirectoryProvider::Reset()
   if (m_isAnnounced)
   {
     m_isAnnounced = false;
-    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+      man->RemoveAnnouncer(this);
     CServiceBroker::GetFavouritesService().Events().Unsubscribe(this);
     CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
     CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
@@ -451,7 +455,9 @@ bool CDirectoryProvider::UpdateURL()
   if (!m_isAnnounced)
   {
     m_isAnnounced = true;
-    CAnnouncementManager::GetInstance().AddAnnouncer(this);
+    auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+      man->AddAnnouncer(this);
     CServiceBroker::GetAddonMgr().Events().Subscribe(this, &CDirectoryProvider::OnAddonEvent);
     CServiceBroker::GetPVRManager().Events().Subscribe(this, &CDirectoryProvider::OnPVRManagerEvent);
     CServiceBroker::GetFavouritesService().Events().Subscribe(this, &CDirectoryProvider::OnFavouritesEvent);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3448,7 +3448,8 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
     return false;
 
   // check network connectivity
-  if (!CServiceBroker::GetNetwork().IsAvailable())
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  if (!net || !net->IsAvailable())
     return false;
 
   // Get information for the inserted disc

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -43,6 +43,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/tags/MusicInfoTag.h"
@@ -89,7 +90,9 @@ static void AnnounceRemove(const std::string& content, int id)
   data["id"] = id;
   if (g_application.IsMusicScanning())
     data["transaction"] = true;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnRemove", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnRemove", data);
 }
 
 static void AnnounceUpdate(const std::string& content, int id, bool added = false)
@@ -101,7 +104,9 @@ static void AnnounceUpdate(const std::string& content, int id, bool added = fals
     data["transaction"] = true;
   if (added)
     data["added"] = true;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
 }
 
 CMusicDatabase::CMusicDatabase(void)
@@ -3299,7 +3304,9 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   int ret = ERROR_OK;
   unsigned int time = XbmcThreads::SystemClockMillis();
   CLog::Log(LOGNOTICE, "%s: Starting musicdatabase cleanup ..", __FUNCTION__);
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanStarted");
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanStarted");
 
   // first cleanup any songs with invalid paths
   if (progressDialog)
@@ -3418,7 +3425,8 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   }
   time = XbmcThreads::SystemClockMillis() - time;
   CLog::Log(LOGNOTICE, "%s: Cleaning musicdatabase done. Operation took %s", __FUNCTION__, StringUtils::SecondsToTimeString(time / 1000).c_str());
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanFinished");
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanFinished");
 
   if (!Compress(false))
   {
@@ -3428,7 +3436,8 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
 
 error:
   RollbackTransaction();
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanFinished");
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnCleanFinished");
   return ret;
 }
 
@@ -6982,7 +6991,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,  CGUIDialog
         if (iFailCount > 0)
           data["failcount"] = iFailCount;
       }
-      ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnExport", data);
+      auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+      if (man)
+        man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnExport", data);
     }
   }
   catch (...)

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -31,6 +31,7 @@
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "Util.h"
 #include "utils/JobManager.h"
 
@@ -117,7 +118,11 @@ namespace MUSIC_UTILS
       loaded when the playlist is shown.
       */      
       bool clearcache(false);
-      CPlayList& playlist = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST_MUSIC);
+      auto pl = SERVICES::CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+      if (!pl)
+        return false;
+
+      CPlayList& playlist = pl->GetPlaylist(PLAYLIST_MUSIC);
       for (int i = 0; i < playlist.size(); ++i)
       {
         CFileItemPtr songitem = playlist[i];

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -52,6 +52,7 @@
 #include "MusicAlbumInfo.h"
 #include "MusicInfoScraper.h"
 #include "NfoFile.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "TextureCache.h"
@@ -70,6 +71,7 @@ using namespace MUSICDATABASEDIRECTORY;
 using namespace MUSIC_GRABBER;
 using namespace ADDON;
 using KODI::UTILITY::CDigest;
+using namespace SERVICES;
 
 CMusicInfoScanner::CMusicInfoScanner()
 : m_needsCleanup(false),
@@ -87,7 +89,9 @@ CMusicInfoScanner::~CMusicInfoScanner() = default;
 void CMusicInfoScanner::Process()
 {
   m_bStop = false;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanStarted");
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanStarted");
   try
   {
     if (m_showDialog && !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE))
@@ -272,7 +276,8 @@ void CMusicInfoScanner::Process()
   CLog::Log(LOGDEBUG, "%s - Finished scan", __FUNCTION__);
   
   m_bRunning = false;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanFinished");
+  if (man)
+    man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnScanFinished");
   
   // we need to clear the musicdb cache and update any active lists
   CUtil::DeleteMusicDatabaseDirectoryCache();

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -1166,7 +1166,8 @@ int CAirPlayServer::CTCPClient::ProcessRequest( std::string& responseHeader,
   else if (uri == "/server-info")
   {
     CLog::Log(LOGDEBUG, "AIRPLAY: got request %s", uri.c_str());
-    responseBody = StringUtils::Format(SERVER_INFO, CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetMacAddress().c_str());
+    auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+    responseBody = StringUtils::Format(SERVER_INFO, net ? net->GetFirstConnectedInterface()->GetMacAddress().c_str() : "");
     responseHeader = "Content-Type: text/x-apple-plist+xml\r\n";
   }
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -44,6 +44,7 @@
 #include "URL.h"
 #include "cores/IPlayer.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #ifdef HAS_ZEROCONF
 #include "network/Zeroconf.h"
 #endif // HAS_ZEROCONF
@@ -314,12 +315,16 @@ CAirPlayServer::CAirPlayServer(int port, bool nonlocal) : CThread("AirPlayServer
   m_ServerSocket = INVALID_SOCKET;
   m_usePassword = false;
   m_origVolume = -1;
-  CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(this);
 }
 
 CAirPlayServer::~CAirPlayServer()
 {
-  CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
 }
 
 void handleZeroconfAnnouncement()

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -550,7 +550,8 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
 {
   bool success = false;
   std::string pw = password;
-  CNetworkInterface *net = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  auto cnet = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  CNetworkInterface *net = cnet ? cnet->GetFirstConnectedInterface() : nullptr;
   StopServer(true);
 
   if (net)
@@ -712,7 +713,8 @@ bool CAirTunesServer::Initialize(const std::string &password)
 
       m_pLibShairplay->raop_set_log_callback(m_pRaop, shairplay_log, NULL);
 
-      CNetworkInterface *net = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+      auto cnet = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      CNetworkInterface *net = cnet ? cnet->GetFirstConnectedInterface() : nullptr;
 
       if (net)
       {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -44,6 +44,7 @@
 #include "network/Network.h"
 #include "network/Zeroconf.h"
 #include "network/ZeroconfBrowser.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "URL.h"
@@ -659,13 +660,17 @@ void CAirTunesServer::RegisterActionListener(bool doRegister)
 {
   if (doRegister)
   {
-    CAnnouncementManager::GetInstance().AddAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+      man->AddAnnouncer(this);
     g_application.RegisterActionListener(this);
     ServerInstance->Create();
   }
   else
   {
-    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+      man->RemoveAnnouncer(this);
     g_application.UnregisterActionListener(this);
     ServerInstance->StopThread(true);
   }

--- a/xbmc/network/GUIDialogAccessPoints.cpp
+++ b/xbmc/network/GUIDialogAccessPoints.cpp
@@ -25,13 +25,15 @@
 #elif defined(TARGET_POSIX)
 #include "platform/linux/network/NetworkLinux.h"
 #endif
-#include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "FileItem.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/Variant.h"
 
 #define CONTROL_ACCESS_POINTS 3
+
+using namespace SERVICES;
 
 CGUIDialogAccessPoints::CGUIDialogAccessPoints(void)
     : CGUIDialog(WINDOW_DIALOG_ACCESS_POINTS, "DialogAccessPoints.xml")
@@ -88,7 +90,8 @@ void CGUIDialogAccessPoints::OnInitWindow()
   m_accessPoints->Clear();
 
   std::string ifaceName(m_interfaceName);
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetInterfaceByName(ifaceName);
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  CNetworkInterface* iface = net ? net->GetInterfaceByName(ifaceName) : nullptr;
   m_aps = iface->GetAccessPoints();
 
   for (int i = 0; i < (int) m_aps.size(); i++)

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -137,17 +137,17 @@ int NetworkAccessPoint::FreqToChannel(float frequency)
 }
 
 
-CNetwork::CNetwork()
+CNetworkBase::CNetworkBase()
 {
   CApplicationMessenger::GetInstance().PostMsg(TMSG_NETWORKMESSAGE, SERVICES_UP, 0);
 }
 
-CNetwork::~CNetwork()
+CNetworkBase::~CNetworkBase()
 {
   CApplicationMessenger::GetInstance().PostMsg(TMSG_NETWORKMESSAGE, SERVICES_DOWN, 0);
 }
 
-int CNetwork::ParseHex(char *str, unsigned char *addr)
+int CNetworkBase::ParseHex(char *str, unsigned char *addr)
 {
    int len = 0;
 
@@ -166,7 +166,7 @@ int CNetwork::ParseHex(char *str, unsigned char *addr)
    return len;
 }
 
-bool CNetwork::GetHostName(std::string& hostname)
+bool CNetworkBase::GetHostName(std::string& hostname)
 {
   char hostName[128];
   if (gethostname(hostName, sizeof(hostName)))
@@ -182,7 +182,7 @@ bool CNetwork::GetHostName(std::string& hostname)
   return true;
 }
 
-bool CNetwork::IsLocalHost(const std::string& hostname)
+bool CNetworkBase::IsLocalHost(const std::string& hostname)
 {
   if (hostname.empty())
     return false;
@@ -211,7 +211,7 @@ bool CNetwork::IsLocalHost(const std::string& hostname)
   return false;
 }
 
-CNetworkInterface* CNetwork::GetFirstConnectedInterface()
+CNetworkInterface* CNetworkBase::GetFirstConnectedInterface()
 {
    std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
    std::vector<CNetworkInterface*>::const_iterator iter = ifaces.begin();
@@ -226,7 +226,7 @@ CNetworkInterface* CNetwork::GetFirstConnectedInterface()
    return NULL;
 }
 
-bool CNetwork::HasInterfaceForIP(unsigned long address)
+bool CNetworkBase::HasInterfaceForIP(unsigned long address)
 {
    unsigned long subnet;
    unsigned long local;
@@ -248,18 +248,18 @@ bool CNetwork::HasInterfaceForIP(unsigned long address)
    return false;
 }
 
-bool CNetwork::IsAvailable(void)
+bool CNetworkBase::IsAvailable(void)
 {
   std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
   return (ifaces.size() != 0);
 }
 
-bool CNetwork::IsConnected()
+bool CNetworkBase::IsConnected()
 {
    return GetFirstConnectedInterface() != NULL;
 }
 
-CNetworkInterface* CNetwork::GetInterfaceByName(const std::string& name)
+CNetworkInterface* CNetworkBase::GetInterfaceByName(const std::string& name)
 {
    std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
    std::vector<CNetworkInterface*>::const_iterator iter = ifaces.begin();
@@ -274,7 +274,7 @@ CNetworkInterface* CNetwork::GetInterfaceByName(const std::string& name)
    return NULL;
 }
 
-void CNetwork::NetworkMessage(EMESSAGE message, int param)
+void CNetworkBase::NetworkMessage(EMESSAGE message, int param)
 {
   switch( message )
   {
@@ -292,7 +292,7 @@ void CNetwork::NetworkMessage(EMESSAGE message, int param)
   }
 }
 
-bool CNetwork::WakeOnLan(const char* mac)
+bool CNetworkBase::WakeOnLan(const char* mac)
 {
   int i, j, packet;
   unsigned char ethaddr[8];
@@ -427,7 +427,7 @@ static const char* ConnectHostPort(SOCKET soc, const struct sockaddr_in& addr, s
   return 0; // success
 }
 
-bool CNetwork::PingHost(unsigned long ipaddr, unsigned short port, unsigned int timeOutMs, bool readability_check)
+bool CNetworkBase::PingHost(unsigned long ipaddr, unsigned short port, unsigned int timeOutMs, bool readability_check)
 {
   if (port == 0) // use icmp ping
     return PingHost (ipaddr, timeOutMs);
@@ -554,7 +554,7 @@ int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlo
   return sock;
 }
 
-void CNetwork::WaitForNet()
+void CNetworkBase::WaitForNet()
 {
   const int timeout = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_POWERMANAGEMENT_WAITFORNETWORK);
   if (timeout <= 0)

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "settings/lib/ISettingCallback.h"
+#include "services/IService.h"
 
 enum EncMode { ENC_NONE = 0, ENC_WEP = 1, ENC_WPA = 2, ENC_WPA2 = 3 };
 enum NetworkAssignment { NETWORK_DASH = 0, NETWORK_DHCP = 1, NETWORK_STATIC = 2, NETWORK_DISABLED = 3 };
@@ -95,7 +96,7 @@ public:
    virtual void SetSettings(NetworkAssignment& assignment, std::string& ipAddress, std::string& networkMask, std::string& defaultGateway, std::string& essId, std::string& key, EncMode& encryptionMode) = 0;
 };
 
-class CNetworkBase
+class CNetworkBase : public SERVICES::IService
 {
 public:
   enum EMESSAGE

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -95,7 +95,7 @@ public:
    virtual void SetSettings(NetworkAssignment& assignment, std::string& ipAddress, std::string& networkMask, std::string& defaultGateway, std::string& essId, std::string& key, EncMode& encryptionMode) = 0;
 };
 
-class CNetwork
+class CNetworkBase
 {
 public:
   enum EMESSAGE
@@ -104,8 +104,8 @@ public:
     SERVICES_DOWN
   };
 
-   CNetwork();
-   virtual ~CNetwork();
+   CNetworkBase();
+   virtual ~CNetworkBase();
 
    // Return our hostname
    virtual bool GetHostName(std::string& hostname);
@@ -160,6 +160,8 @@ public:
 #include "platform/win32/network/NetworkWin32.h"
 #elif defined(HAS_WIN10_NETWORK)
 #include "platform/win10/network/NetworkWin10.h"
+#else
+using CNetwork = CNetworkBase;
 #endif
 
 //creates, binds and listens a tcp socket on the desired port. Set bindLocal to

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -32,6 +32,7 @@
 #include "network/EventServer.h"
 #include "network/Network.h"
 #include "network/TCPServer.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
@@ -79,6 +80,7 @@
 #endif
 
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 using namespace JSONRPC;
 using namespace EVENTSERVER;
 #ifdef HAS_UPNP
@@ -501,7 +503,8 @@ void CNetworkServices::Stop(bool bWait)
 bool CNetworkServices::StartWebserver()
 {
 #ifdef HAS_WEB_SERVER
-  if (!CServiceBroker::GetNetwork().IsAvailable())
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  if (!net || !net->IsAvailable())
     return false;
 
   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_WEBSERVER))
@@ -571,8 +574,9 @@ bool CNetworkServices::StartAirPlayServer()
   if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_AIRPLAYVIDEOSUPPORT))
     return true;
 
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
 #ifdef HAS_AIRPLAY
-  if (!CServiceBroker::GetNetwork().IsAvailable() || !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_AIRPLAY))
+  if (!net || !net->IsAvailable() || !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_AIRPLAY))
     return false;
 
   if (IsAirPlayServerRunning())
@@ -587,7 +591,7 @@ bool CNetworkServices::StartAirPlayServer()
   
 #ifdef HAS_ZEROCONF
   std::vector<std::pair<std::string, std::string> > txt;
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
   txt.push_back(std::make_pair("deviceid", iface != NULL ? iface->GetMacAddress() : "FF:FF:FF:FF:FF:F2"));
   txt.push_back(std::make_pair("model", "Xbmc,1"));
   txt.push_back(std::make_pair("srcvers", AIRPLAY_SERVER_VERSION_STR));
@@ -634,7 +638,8 @@ bool CNetworkServices::StopAirPlayServer(bool bWait)
 bool CNetworkServices::StartAirTunesServer()
 {
 #ifdef HAS_AIRTUNES
-  if (!CServiceBroker::GetNetwork().IsAvailable() || !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_AIRPLAY))
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  if (!net || !net->IsAvailable() || !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_SERVICES_AIRPLAY))
     return false;
 
   if (IsAirTunesServerRunning())

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -28,6 +28,7 @@
 #include "settings/AdvancedSettings.h"
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
 #include "threads/SingleLock.h"
@@ -59,6 +60,7 @@ static const bdaddr_t bt_bdaddr_local = {{0, 0, 0, 0xff, 0xff, 0xff}};
 
 using namespace JSONRPC;
 using namespace ANNOUNCEMENT;
+using namespace SERVICES;
 
 #define RECEIVEBUFFER 1024
 
@@ -273,7 +275,9 @@ bool CTCPServer::Initialize()
 
   if (started)
   {
-    CAnnouncementManager::GetInstance().AddAnnouncer(this);
+    auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+      man->AddAnnouncer(this);
     CLog::Log(LOGINFO, "JSONRPC Server: Successfully initialized");
     return true;
   }
@@ -506,7 +510,9 @@ void CTCPServer::Deinitialize()
   m_sdpd = NULL;
 #endif
 
-  CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
 }
 
 CTCPServer::CTCPClient::CTCPClient()

--- a/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPPythonHandler.cpp
@@ -29,9 +29,12 @@
 #include "network/httprequesthandler/HTTPWebinterfaceHandler.h"
 #include "network/httprequesthandler/python/HTTPPythonInvoker.h"
 #include "network/httprequesthandler/python/HTTPPythonWsgiInvoker.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+
+using namespace SERVICES;
 
 #define MAX_STRING_POST_SIZE 20000
 
@@ -159,7 +162,8 @@ int CHTTPPythonHandler::HandleRequest()
       pythonRequest->port = port;
     }
 
-    CHTTPPythonInvoker* pythonInvoker = new CHTTPPythonWsgiInvoker(&g_pythonParser, pythonRequest);
+    auto xbp = CServiceManager::GetInstance().GetService<XBPython>();
+    CHTTPPythonInvoker* pythonInvoker = new CHTTPPythonWsgiInvoker(xbp.get(), pythonRequest);
     LanguageInvokerPtr languageInvokerPtr(pythonInvoker);
     int result = CScriptInvocationManager::GetInstance().ExecuteSync(m_scriptPath, languageInvokerPtr, m_addon, args, 30000, false);
 

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -39,6 +39,7 @@
 #include "URL.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "profiles/ProfilesManager.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "GUIUserMessages.h"
 #include "FileItem.h"
@@ -50,6 +51,7 @@
 #include "Util.h"
 #include "utils/SystemInfo.h"
 
+using namespace SERVICES;
 using namespace UPNP;
 using namespace KODI::MESSAGING;
 
@@ -433,8 +435,9 @@ CUPnP::CUPnP() :
     m_UPnP = new PLT_UPnP();
 
     // keep main IP around
-    if (CServiceBroker::GetNetwork().GetFirstConnectedInterface()) {
-        m_IP = CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetCurrentIPAddress().c_str();
+    auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+    if (net && net->GetFirstConnectedInterface()) {
+        m_IP = net->GetFirstConnectedInterface()->GetCurrentIPAddress().c_str();
     }
     NPT_List<NPT_IpAddress> list;
     if (NPT_SUCCEEDED(PLT_UPnPMessageHelper::GetIPAddresses(list)) && list.GetItemCount()) {

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -41,6 +41,7 @@
 #include "TextureDatabase.h"
 #include "ThumbLoader.h"
 #include "URL.h"
+#include "services/ServiceManager.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
@@ -588,11 +589,15 @@ CUPnPRenderer::OnSetNextAVTransportURI(PLT_ActionReference& action)
           playlist = PLAYLIST_VIDEO;
 
         {   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-            CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlist);
-            CServiceBroker::GetPlaylistPlayer().Add(playlist, item);
 
-            CServiceBroker::GetPlaylistPlayer().SetCurrentSong(-1);
-            CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlist);
+            auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+            if (pl) {
+                pl->ClearPlaylist(playlist);
+                pl->Add(playlist, item);
+
+                pl->SetCurrentSong(-1);
+                pl->SetCurrentPlaylist(playlist);
+            }
         }
 
         CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -35,6 +35,7 @@
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "PlayListPlayer.h"
 #include "TextureDatabase.h"
@@ -62,7 +63,9 @@ CUPnPRenderer::CUPnPRenderer(const char* friendly_name, bool show_ip /*= false*/
                              const char* uuid /*= NULL*/, unsigned int port /*= 0*/)
     : PLT_MediaRenderer(friendly_name, show_ip, uuid, port)
 {
-    CAnnouncementManager::GetInstance().AddAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+        man->AddAnnouncer(this);
 }
 
 /*----------------------------------------------------------------------
@@ -70,7 +73,9 @@ CUPnPRenderer::CUPnPRenderer(const char* friendly_name, bool show_ip /*= false*/
 +---------------------------------------------------------------------*/
 CUPnPRenderer::~CUPnPRenderer()
 {
-    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+        man->RemoveAnnouncer(this);
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -427,8 +427,9 @@ CUPnPRenderer::GetMetadata(NPT_String& meta)
         thumb = CTextureUtils::GetWrappedImageURL(thumb);
 
         NPT_String ip;
-        if (CServiceBroker::GetNetwork().GetFirstConnectedInterface()) {
-            ip = CServiceBroker::GetNetwork().GetFirstConnectedInterface()->GetCurrentIPAddress().c_str();
+        auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+        if (net && net->GetFirstConnectedInterface()) {
+            ip = net->GetFirstConnectedInterface()->GetCurrentIPAddress().c_str();
         }
         // build url, use the internal device http server to serv the image
         NPT_HttpUrlQuery query;

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -36,6 +36,7 @@
 #include "guilib/WindowIDs.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/tags/MusicInfoTag.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/Digest.h"
@@ -83,7 +84,9 @@ CUPnPServer::CUPnPServer(const char* friendly_name, const char* uuid /*= NULL*/,
 
 CUPnPServer::~CUPnPServer()
 {
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+        man->RemoveAnnouncer(this);
 }
 
 /*----------------------------------------------------------------------
@@ -120,7 +123,9 @@ CUPnPServer::SetupServices()
     OnScanCompleted(VideoLibrary);
 
     // now safe to start passing on new notifications
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().AddAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+        man->AddAnnouncer(this);
 
     return result;
 }
@@ -1088,7 +1093,9 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
               CVariant data;
               data["id"] = updated.GetVideoInfoTag()->m_iDbId;
               data["type"] = updated.GetVideoInfoTag()->m_type;
-              ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+              auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+              if (man)
+                man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
             }
             updatelisting = true;
         }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -32,6 +32,7 @@
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
 #include "pictures/GUIWindowSlideShow.h"
+#include "services/ServiceManager.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
@@ -103,7 +104,9 @@ CPeripheralCecAdapter::~CPeripheralCecAdapter(void)
 {
   {
     CSingleLock lock(m_critSection);
-    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->RemoveAnnouncer(this);
     m_bStop = true;
   }
 
@@ -162,7 +165,9 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
   {
     CSingleLock lock(m_critSection);
     m_iExitCode = static_cast<int>(data["exitcode"].asInteger(EXITCODE_QUIT));
-    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->RemoveAnnouncer(this);
     StopThread(false);
   }
   else if (flag == GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverDeactivated") && m_bIsReady)
@@ -380,7 +385,9 @@ void CPeripheralCecAdapter::Process(void)
     m_bActiveSourceBeforeStandby = false;
   }
 
-  CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(this);
 
   m_queryThread = new CPeripheralCecAdapterUpdateThread(this, &m_configuration);
   m_queryThread->Create(false);
@@ -1728,7 +1735,9 @@ bool CPeripheralCecAdapter::ReopenConnection(bool bAsync /* = false */)
   {
     CSingleLock lock(m_critSection);
     m_iExitCode = EXITCODE_RESTARTAPP;
-    CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->RemoveAnnouncer(this);
     StopThread(false);
   }
   StopThread();

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -45,6 +45,7 @@
 #include "utils/Variant.h"
 #include "Autorun.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "utils/SortUtils.h"
 #include "utils/StringUtils.h"
 #include "GUIWindowSlideShow.h"
@@ -355,7 +356,9 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
     CVariant param;
     param["player"]["speed"] = 1;
     param["player"]["playerid"] = PLAYLIST_PICTURE;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", pSlideShow->GetCurrentSlide(), param);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", pSlideShow->GetCurrentSlide(), param);
   }
 
   m_slideShowStarted = true;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -45,6 +45,7 @@
 #include "utils/log.h"
 #include "utils/Variant.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "pictures/GUIViewStatePictures.h"
 #include "pictures/PictureThumbLoader.h"
 #include "PlayListPlayer.h"
@@ -161,7 +162,9 @@ void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)
   CVariant param;
   param["player"]["speed"] = m_bSlideShow && !m_bPause ? 1 : 0;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", item, param);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", item, param);
 }
 
 void CGUIWindowSlideShow::AnnouncePlayerPause(const CFileItemPtr& item)
@@ -169,7 +172,9 @@ void CGUIWindowSlideShow::AnnouncePlayerPause(const CFileItemPtr& item)
   CVariant param;
   param["player"]["speed"] = 0;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPause", item, param);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPause", item, param);
 }
 
 void CGUIWindowSlideShow::AnnouncePlayerStop(const CFileItemPtr& item)
@@ -177,14 +182,18 @@ void CGUIWindowSlideShow::AnnouncePlayerStop(const CFileItemPtr& item)
   CVariant param;
   param["player"]["playerid"] = PLAYLIST_PICTURE;
   param["end"] = true;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnStop", item, param);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnStop", item, param);
 }
 
 void CGUIWindowSlideShow::AnnouncePlaylistClear()
 {
   CVariant data;
   data["playlistid"] = PLAYLIST_PICTURE;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
 }
 
 void CGUIWindowSlideShow::AnnouncePlaylistAdd(const CFileItemPtr& item, int pos)
@@ -192,7 +201,9 @@ void CGUIWindowSlideShow::AnnouncePlaylistAdd(const CFileItemPtr& item, int pos)
   CVariant data;
   data["playlistid"] = PLAYLIST_PICTURE;
   data["position"] = pos;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
 }
 
 void CGUIWindowSlideShow::AnnouncePropertyChanged(const std::string &strProperty, const CVariant &value)
@@ -203,7 +214,9 @@ void CGUIWindowSlideShow::AnnouncePropertyChanged(const std::string &strProperty
   CVariant data;
   data["player"]["playerid"] = PLAYLIST_PICTURE;
   data["property"][strProperty] = value;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPropertyChanged", data);
 }
 
 bool CGUIWindowSlideShow::IsPlaying() const
@@ -1236,7 +1249,9 @@ void CGUIWindowSlideShow::RunSlideShow(const std::string &strPath,
     CVariant param;
     param["player"]["speed"] = 0;
     param["player"]["playerid"] = PLAYLIST_PICTURE;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", GetCurrentSlide(), param);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", GetCurrentSlide(), param);
   }
 
   CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -78,6 +78,7 @@
 #include "cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h"
 
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "GUIInfoManager.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "guilib/GUIComponent.h"
@@ -348,7 +349,9 @@ void CXBMCApp::onLostFocus()
 
 void CXBMCApp::Initialize()
 {
-  g_application.m_ServiceManager->GetAnnouncementManager().AddAnnouncer(CXBMCApp::get());  
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(CXBMCApp::get());
 }
 
 void CXBMCApp::Deinitialize()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1025,9 +1025,9 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   {
     if (g_application.IsInitialized())
     {
-      CNetworkBase& net = CServiceBroker::GetNetwork();
-      CNetworkAndroid* netdroid = static_cast<CNetwork*>(&net);
-      netdroid->RetrieveInterfaces();
+      auto netdroid = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      if (netdroid)
+        netdroid->RetrieveInterfaces();
     }
   }
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1025,8 +1025,8 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   {
     if (g_application.IsInitialized())
     {
-      CNetwork& net = CServiceBroker::GetNetwork();
-      CNetworkAndroid* netdroid = static_cast<CNetworkAndroid*>(&net);
+      CNetworkBase& net = CServiceBroker::GetNetwork();
+      CNetworkAndroid* netdroid = static_cast<CNetwork*>(&net);
       netdroid->RetrieveInterfaces();
     }
   }

--- a/xbmc/platform/android/network/NetworkAndroid.h
+++ b/xbmc/platform/android/network/NetworkAndroid.h
@@ -63,7 +63,7 @@ protected:
 };
 
 
-class CNetworkAndroid : public CNetwork
+class CNetworkAndroid : public CNetworkBase
 {
   friend class CXBMCApp;
 
@@ -80,6 +80,7 @@ public:
   virtual void SetNameServers(const std::vector<std::string>& nameServers) override;
 
   // Ping remote host
+  using CNetworkBase::PingHost;
   virtual bool PingHost(unsigned long remote_ip, unsigned int timeout_ms = 2000) override;
 
 protected:
@@ -89,3 +90,4 @@ protected:
   CCriticalSection m_refreshMutex;
 };
 
+using CNetwork = CNetworkAndroid;

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -156,11 +156,12 @@ void AnnounceBridge(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, con
     if (duration > 0)
       [item setValue:[NSNumber numberWithDouble:duration] forKey:@"duration"];
     [item setValue:[NSNumber numberWithDouble:g_application.GetTime()] forKey:@"elapsed"];
-    int current = CServiceBroker::GetPlaylistPlayer().GetCurrentSong();
+    auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+    int current = pl ? pl->GetCurrentSong() : -1;
     if (current >= 0)
     {
       [item setValue:[NSNumber numberWithInt:current] forKey:@"current"];
-      [item setValue:[NSNumber numberWithInt:CServiceBroker::GetPlaylistPlayer().GetPlaylist(CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()).size()] forKey:@"total"];
+      [item setValue:[NSNumber numberWithInt:pl->GetPlaylist(pl->GetCurrentPlaylist()).size()] forKey:@"total"];
     }
     if (g_application.CurrentFileItem().HasMusicInfoTag())
     {

--- a/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
+++ b/xbmc/platform/darwin/ios-common/AnnounceReceiver.mm
@@ -37,6 +37,7 @@
 #endif
 #import "utils/Variant.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 
 id objectFromVariant(const CVariant &data);
 
@@ -202,12 +203,16 @@ CAnnounceReceiver *CAnnounceReceiver::GetInstance()
 
 void CAnnounceReceiver::Initialize()
 {
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().AddAnnouncer(GetInstance());
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(GetInstance());
 }
 
 void CAnnounceReceiver::DeInitialize()
 {
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().RemoveAnnouncer(GetInstance());
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(GetInstance());
 }
 
 void CAnnounceReceiver::Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)

--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -287,7 +287,7 @@ std::string CNetworkInterfaceLinux::GetCurrentDefaultGateway(void)
           strcmp(gateway, "00000000") != 0)
       {
          unsigned char gatewayAddr[4];
-         int len = CNetwork::ParseHex(gateway, gatewayAddr);
+         int len = CNetworkBase::ParseHex(gateway, gatewayAddr);
          if (len == 4)
          {
             struct in_addr in;
@@ -337,7 +337,7 @@ std::vector<CNetworkInterface*>& CNetworkLinux::GetInterfaceList(void)
 //! and the interface comes up during runtime
 CNetworkInterface* CNetworkLinux::GetFirstConnectedInterface(void)
 {
-    CNetworkInterface *pNetIf=CNetwork::GetFirstConnectedInterface();
+    CNetworkInterface *pNetIf=CNetworkBase::GetFirstConnectedInterface();
     
     // no connected Interfaces found? - requeryInterfaceList
     if (!pNetIf)
@@ -345,7 +345,7 @@ CNetworkInterface* CNetworkLinux::GetFirstConnectedInterface(void)
         CLog::Log(LOGDEBUG,"%s no connected interface found - requery list",__FUNCTION__);        
         queryInterfaceList();        
         //retry finding a connected if
-        pNetIf = CNetwork::GetFirstConnectedInterface();
+        pNetIf = CNetworkBase::GetFirstConnectedInterface();
     }
     
     return pNetIf;

--- a/xbmc/platform/linux/network/NetworkLinux.h
+++ b/xbmc/platform/linux/network/NetworkLinux.h
@@ -75,6 +75,7 @@ public:
    CNetworkInterface* GetFirstConnectedInterface(void) override;        
     
    // Ping remote host
+  using CNetworkBase::PingHost;
    bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;
 
    // Get/set the nameserver(s)

--- a/xbmc/platform/linux/network/NetworkLinux.h
+++ b/xbmc/platform/linux/network/NetworkLinux.h
@@ -64,7 +64,7 @@ private:
    CNetworkLinux* m_network;
 };
 
-class CNetworkLinux : public CNetwork
+class CNetworkLinux : public CNetworkBase
 {
 public:
    CNetworkLinux(void);
@@ -90,6 +90,8 @@ private:
    std::vector<CNetworkInterface*> m_interfaces;
    int m_sock;
 };
+
+using CNetwork = CNetworkLinux;
 
 #endif
 

--- a/xbmc/platform/win10/network/NetworkWin10.h
+++ b/xbmc/platform/win10/network/NetworkWin10.h
@@ -66,7 +66,7 @@ private:
 };
 
 
-class CNetworkWin10 : public CNetwork
+class CNetworkWin10 : public CNetworkBase
 {
 public:
     CNetworkWin10(void);
@@ -76,6 +76,7 @@ public:
     virtual std::vector<CNetworkInterface*>& GetInterfaceList(void);
 
     // Ping remote host
+    using CNetworkBase::PingHost;
     virtual bool PingHost(unsigned long host, unsigned int timeout_ms = 2000);
 
     // Get/set the nameserver(s)
@@ -93,4 +94,6 @@ private:
     CStopWatch m_netrefreshTimer;
     CCriticalSection m_critSection;
 };
+
+using CNetwork = CNetworkWin10;
 #endif

--- a/xbmc/platform/win32/network/NetworkWin32.h
+++ b/xbmc/platform/win32/network/NetworkWin32.h
@@ -64,7 +64,7 @@ private:
    std::string m_adaptername;
 };
 
-class CNetworkWin32 : public CNetwork
+class CNetworkWin32 : public CNetworkBase
 {
 public:
    CNetworkWin32(void);
@@ -74,6 +74,7 @@ public:
    virtual std::vector<CNetworkInterface*>& GetInterfaceList(void);
 
    // Ping remote host
+   using CNetworkBase::PingHost;
    virtual bool PingHost(unsigned long host, unsigned int timeout_ms = 2000);
 
    // Get/set the nameserver(s)
@@ -102,5 +103,7 @@ private:
    CStopWatch m_netrefreshTimer;
    CCriticalSection m_critSection;
 };
+
+using CNetwork = CNetworkWin32;
 
 #endif

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -23,6 +23,7 @@
 #include "video/VideoInfoTag.h"
 #include "music/tags/MusicInfoTag.h"
 #include "filesystem/File.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "utils/Random.h"
 #include "utils/URIUtils.h"
@@ -42,6 +43,7 @@
 using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace PLAYLIST;
+using namespace SERVICES;
 
 CPlayList::CPlayList(int id)
   : m_id(id)
@@ -60,7 +62,9 @@ void CPlayList::AnnounceRemove(int pos)
   CVariant data;
   data["playlistid"] = m_id;
   data["position"] = pos;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnRemove", data);
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnRemove", data);
 }
 
 void CPlayList::AnnounceClear()
@@ -70,7 +74,9 @@ void CPlayList::AnnounceClear()
 
   CVariant data;
   data["playlistid"] = m_id;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
 }
 
 void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
@@ -81,7 +87,9 @@ void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
   CVariant data;
   data["playlistid"] = m_id;
   data["position"] = pos;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
+  auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
 }
 
 void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -32,6 +32,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "interfaces/builtins/Builtins.h"
 #include "network/Network.h"
 #include "pvr/PVRManager.h"
@@ -131,7 +132,9 @@ bool CPowerManager::Reboot()
 
   if (success)
   {
-    CAnnouncementManager::GetInstance().Announce(System, "xbmc", "OnRestart");
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+    if (man)
+      man->Announce(System, "xbmc", "OnRestart");
 
     CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
     if (dialog)
@@ -176,7 +179,9 @@ void CPowerManager::ProcessEvents()
 
 void CPowerManager::OnSleep()
 {
-  CAnnouncementManager::GetInstance().Announce(System, "xbmc", "OnSleep");
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->Announce(System, "xbmc", "OnSleep");
 
   CGUIDialogBusy* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
   if (dialog)
@@ -223,7 +228,9 @@ void CPowerManager::OnWake()
   CServiceBroker::GetPVRManager().OnWake();
   RestorePlayerState();
 
-  CAnnouncementManager::GetInstance().Announce(System, "xbmc", "OnWake");
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->Announce(System, "xbmc", "OnWake");
 }
 
 void CPowerManager::OnLowBattery()
@@ -232,7 +239,9 @@ void CPowerManager::OnLowBattery()
 
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13050), "");
 
-  CAnnouncementManager::GetInstance().Announce(System, "xbmc", "OnLowBattery");
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->Announce(System, "xbmc", "OnLowBattery");
 }
 
 void CPowerManager::StorePlayerState()

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -202,7 +202,9 @@ void CPowerManager::OnWake()
 {
   CLog::Log(LOGNOTICE, "%s: Running resume jobs", __FUNCTION__);
 
-  CServiceBroker::GetNetwork().WaitForNet();
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  if (net)
+    net->WaitForNet();
 
   // reset out timers
   g_application.ResetShutdownTimers();

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -37,6 +37,7 @@
 #include "ServiceBroker.h"
 #include "input/Key.h"
 #include "guilib/LocalizeStrings.h"
+#include "services/ServiceManager.h"
 #include "utils/Variant.h"
 
 using namespace XFILE;
@@ -85,7 +86,9 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
     g_application.StopPlaying();
     CGUIMessage msg2(GUI_MSG_ITEM_SELECTED, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), iCtrlID);
     CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg2);
-    CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
+    auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+    if (net)
+      net->NetworkMessage(CNetwork::SERVICES_DOWN, 1);
     profileManager.LoadMasterProfileForLogin();
     CGUIWindowLoginScreen::LoadProfile(iItem);
     return;

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -37,6 +37,7 @@
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
+#include "services/ServiceManager.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "threads/Thread.h"
@@ -1776,7 +1777,8 @@ namespace PVR
     {
       const CPVRTimerInfoTagPtr tag(item->GetPVRTimerInfoTag());
       std::string hostname(CServiceBroker::GetPVRManager().Clients()->GetBackendHostnameByClientId(tag->m_iClientId));
-      if (!hostname.empty() && CServiceBroker::GetNetwork().IsLocalHost(hostname))
+      auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+      if (!hostname.empty() && net && net->IsLocalHost(hostname))
         return true;
     }
     return false;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -26,6 +26,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "threads/SystemClock.h"
 #include "utils/JobManager.h"
@@ -50,6 +51,7 @@
 using namespace PVR;
 using namespace ANNOUNCEMENT;
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 
 CPVRManagerJobQueue::CPVRManagerJobQueue()
 : m_triggerEvent(false),
@@ -149,12 +151,16 @@ CPVRManager::CPVRManager(void) :
       CSettings::SETTING_PVRPARENTAL_DURATION
     })
 {
-  CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(this);
 }
 
 CPVRManager::~CPVRManager(void)
 {
-  CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
   CLog::Log(LOGDEBUG,"PVRManager - destroyed");
 }
 

--- a/xbmc/services/CMakeLists.txt
+++ b/xbmc/services/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SOURCES ServiceManager.cpp)
+
+set(HEADERS IService.h
+            ServiceManager.h)
+
+core_add_library(services)

--- a/xbmc/services/IService.h
+++ b/xbmc/services/IService.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace SERVICES
+{
+
+//! \brief Base class for services.
+class IService
+{
+public:
+  virtual bool StartService() { return true; }
+  virtual bool StopService() { return true; }
+};
+
+}

--- a/xbmc/services/ServiceManager.cpp
+++ b/xbmc/services/ServiceManager.cpp
@@ -1,0 +1,49 @@
+#include "ServiceManager.h"
+
+namespace SERVICES
+{
+
+CServiceManager& CServiceManager::GetInstance()
+{
+  static CServiceManager manager;
+  return manager;
+}
+
+bool CServiceManager::RegisterService(std::shared_ptr<IService> service, size_t level)
+{
+  if (!service->StartService())
+    return false;
+
+  CSingleLock lock(*this);
+  if (m_services.size() < level+1)
+    m_services.resize(level+1);
+  m_services[level].emplace_back(std::move(service));
+
+  return true;
+}
+
+bool CServiceManager::TearDown(size_t level)
+{
+  if (level >= m_services.size())
+    return false;
+
+  CSingleLock lock(*this);
+  size_t ok = 0;
+  for (auto it = m_services[level].rbegin(); it != m_services[level].rend(); ++it, ++ok)
+  {
+    if (!(*it)->StopService())
+      break;
+    it->reset();
+  }
+
+  if (ok == m_services[level].size())
+  {
+    m_services[level].clear();
+    return true;
+  }
+
+  m_services.erase(m_services.begin()+m_services.size()-ok, m_services.end());
+  return false;
+}
+
+}

--- a/xbmc/services/ServiceManager.h
+++ b/xbmc/services/ServiceManager.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "IService.h"
+#include "threads/SingleLock.h"
+
+#include <memory>
+#include <vector>
+
+namespace SERVICES
+{
+
+/*!
+ \brief Singleton class for managing global services.
+ \details Services are grouped in levels. The assumption is that
+          the services are a LIFO stack, both for levels and within
+          a given level.
+ */
+class CServiceManager : public CCriticalSection
+{
+public:
+  static CServiceManager& GetInstance(); //!< Singleton accessor
+  //! \brief Register a service.
+  //! \param service The service to register
+  //! \param level Level to register service at
+  bool RegisterService(std::shared_ptr<IService> service, size_t level = 0);
+
+  //! \brief Obtain a registered service
+  //! \param level Hint for level of service (optional)
+  template<class T>
+  std::shared_ptr<T> GetService(int level = -1)
+  {
+    CSingleLock lock(*this);
+    for (size_t i = (level > -1 ? level : 0); i < m_services.size(); ++i)
+    {
+      for (auto& it : m_services[i])
+        if (typeid(*it) == typeid(T))
+          return std::static_pointer_cast<T>(it);
+    }
+
+    return nullptr;
+  }
+
+  //! \brief Tear down all services at a given level.
+  bool TearDown(size_t level);
+
+protected:
+  std::vector<std::vector<std::shared_ptr<IService>>> m_services; //!< Registered services
+};
+
+}

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -35,6 +35,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
+#include "services/ServiceManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
@@ -184,10 +185,14 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
 
 void CMediaSettings::OnSettingsLoaded()
 {
-  CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_MUSIC, m_musicPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_MUSIC, m_musicPlaylistShuffle);
-  CServiceBroker::GetPlaylistPlayer().SetRepeat(PLAYLIST_VIDEO, m_videoPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
-  CServiceBroker::GetPlaylistPlayer().SetShuffle(PLAYLIST_VIDEO, m_videoPlaylistShuffle);
+  auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+  if (pl)
+  {
+    pl->SetRepeat(PLAYLIST_MUSIC, m_musicPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+    pl->SetShuffle(PLAYLIST_MUSIC, m_musicPlaylistShuffle);
+    pl->SetRepeat(PLAYLIST_VIDEO, m_videoPlaylistRepeat ? PLAYLIST::REPEAT_ALL : PLAYLIST::REPEAT_NONE);
+    pl->SetShuffle(PLAYLIST_VIDEO, m_videoPlaylistShuffle);
+  }
 }
 
 bool CMediaSettings::Save(TiXmlNode *settings) const

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -21,7 +21,7 @@
 #include "network/Network.h"
 #include "threads/SystemClock.h"
 #include "RssReader.h"
-#include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "utils/HTMLUtil.h"
 #include "CharsetConverter.h"
 #include "URL.h"
@@ -43,6 +43,7 @@
 #define RSS_COLOR_HEADLINE  1
 #define RSS_COLOR_CHANNEL   2
 
+using namespace SERVICES;
 using namespace XFILE;
 
 //////////////////////////////////////////////////////////////////////
@@ -145,8 +146,9 @@ void CRssReader::Process()
     std::string fileCharset;
 
     // we wait for the network to come up
+    auto net = CServiceManager::GetInstance().GetService<CNetwork>();
     if ((url.IsProtocol("http") || url.IsProtocol("https")) &&
-        !CServiceBroker::GetNetwork().IsAvailable())
+        (!net || !net->IsAvailable()))
     {
       CLog::Log(LOGWARNING, "RSS: No network connection");
       strXML = "<rss><item><title>"+g_localizeStrings.Get(15301)+"</title></item></rss>";

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -28,6 +28,7 @@
 #include "log.h"
 #include "video/VideoDatabase.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "Util.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
@@ -37,6 +38,8 @@
 #include "xbmc/music/tags/MusicInfoTag.h"
 #include "Application.h"
 #include "ServiceBroker.h"
+
+using namespace SERVICES;
 
 void CSaveFileState::DoWork(CFileItem& item,
                             CBookmark& bookmark,
@@ -112,7 +115,9 @@ void CSaveFileState::DoWork(CFileItem& item,
                 CVariant data;
                 data["id"] = item.GetVideoInfoTag()->m_iDbId;
                 data["type"] = item.GetVideoInfoTag()->m_type;
-                ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+                auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+                if (man)
+                  man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
               }
             }
           }
@@ -136,7 +141,9 @@ void CSaveFileState::DoWork(CFileItem& item,
               CVariant data;
               data["id"] = item.GetVideoInfoTag()->m_iDbId;
               data["type"] = item.GetVideoInfoTag()->m_type;
-              ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+              auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+              if (man)
+                man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
             }
 
             updateListing = true;
@@ -203,7 +210,9 @@ void CSaveFileState::DoWork(CFileItem& item,
             CVariant data;
             data["id"] = item.GetMusicInfoTag()->GetDatabaseId();
             data["type"] = item.GetMusicInfoTag()->GetType();
-            ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
+            auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+            if (man)
+              man->Announce(ANNOUNCEMENT::AudioLibrary, "xbmc", "OnUpdate", data);
           }
         }
       }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -32,6 +32,7 @@
 #include "filesystem/File.h"
 #include "network/Network.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "rendering/RenderSystem.h"
 #include "guilib/LocalizeStrings.h"
 #include "CPUInfo.h"
@@ -89,6 +90,7 @@ using namespace Windows::System::Profile;
 #define STR_MACRO(x) #x
 #define XSTR_MACRO(x) STR_MACRO(x)
 
+using namespace SERVICES;
 using namespace XFILE;
 
 #ifdef TARGET_WINDOWS_DESKTOP
@@ -292,7 +294,8 @@ CSysData::INTERNET_STATE CSysInfoJob::GetInternetState()
 std::string CSysInfoJob::GetMACAddress()
 {
 #if defined(HAS_LINUX_NETWORK) || defined(HAS_WIN32_NETWORK) || defined(HAS_WIN10_NETWORK)
-  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  CNetworkInterface* iface = net ? net->GetFirstConnectedInterface() : nullptr;
   if (iface)
     return iface->GetMacAddress();
 #endif
@@ -1202,7 +1205,9 @@ std::string CSysInfo::GetDeviceName()
   if (StringUtils::EqualsNoCase(friendlyName, CCompileInfo::GetAppName()))
   {
     std::string hostname("[unknown]");
-    CServiceBroker::GetNetwork().GetHostName(hostname);
+    auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+    if (net)
+      net->GetHostName(hostname);
     return StringUtils::Format("%s (%s)", friendlyName.c_str(), hostname.c_str());
   }
   

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -29,6 +29,7 @@
 #include "URL.h"
 #include "utils/FileExtensionProvider.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "StringUtils.h"
 #include "utils/log.h"
 
@@ -41,6 +42,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+using namespace SERVICES;
 using namespace XFILE;
 
 /* returns filename extension including period of filename */
@@ -690,10 +692,11 @@ bool URIUtils::IsHostOnLAN(const std::string& host, bool offLineCheck)
         return true;
     }
     // check if we are on the local subnet
-    if (!CServiceBroker::GetNetwork().GetFirstConnectedInterface())
+    auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+    if (!net || !net->GetFirstConnectedInterface())
       return false;
 
-    if (CServiceBroker::GetNetwork().HasInterfaceForIP(address))
+    if (net->HasInterfaceForIP(address))
       return true;
   }
 

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -22,6 +22,7 @@
 #include "Application.h"
 #include "Autorun.h"
 #include "Util.h"
+#include "services/ServiceManager.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/windows/GUIWindowVideoBase.h"
 
@@ -142,7 +143,11 @@ static void SetPathAndPlay(CFileItem& item)
   if (item.IsLiveTV()) // pvr tv or pvr radio?
     g_application.PlayMedia(item, "", PLAYLIST_NONE);
   else
-    CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
+  {
+    auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+    if (pl)
+      pl->Play(std::make_shared<CFileItem>(item), "");
+  }
 }
 
 bool CResume::Execute(const CFileItemPtr& itemIn) const

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -50,6 +50,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfilesManager.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -5488,7 +5489,9 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
       // Only provide the "playcount" value if it has actually changed
       if (item.GetVideoInfoTag()->GetPlayCount() != count)
         data["playcount"] = count;
-      ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", CFileItemPtr(new CFileItem(item)), data);
+      auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+      if (man)
+        man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", CFileItemPtr(new CFileItem(item)), data);
     }
   }
   catch (...)
@@ -8409,7 +8412,9 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
 
     unsigned int time = XbmcThreads::SystemClockMillis();
     CLog::Log(LOGNOTICE, "%s: Starting videodatabase cleanup ..", __FUNCTION__);
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanStarted");
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanStarted");
 
     BeginTransaction();
 
@@ -8486,7 +8491,9 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
         {
           progress->Close();
           m_pDS->close();
-          ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+          auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+          if (man)
+            man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
           return;
         }
       }
@@ -8699,7 +8706,9 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle, const st
   if (progress)
     progress->Close();
 
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnCleanFinished");
 }
 
 std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, const std::string &cleanableFileIDs,
@@ -9359,7 +9368,9 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       if (iFailCount > 0)
         data["failcount"] = iFailCount;
     }
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnExport", data);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnExport", data);
   }
   catch (...)
   {
@@ -9748,7 +9759,9 @@ void CVideoDatabase::AnnounceRemove(std::string content, int id, bool scanning /
   data["id"] = id;
   if (scanning)
     data["transaction"] = true;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnRemove", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnRemove", data);
 }
 
 void CVideoDatabase::AnnounceUpdate(std::string content, int id)
@@ -9756,7 +9769,9 @@ void CVideoDatabase::AnnounceUpdate(std::string content, int id)
   CVariant data;
   data["type"] = content;
   data["id"] = id;
-  ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+  if (man)
+    man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", data);
 }
 
 bool CVideoDatabase::GetItemsForPath(const std::string &content, const std::string &strPath, CFileItemList &items)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -42,6 +42,7 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "NfoFile.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "TextureCache.h"
@@ -63,6 +64,7 @@
 using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
+using namespace SERVICES;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using KODI::UTILITY::CDigest;
@@ -115,7 +117,9 @@ namespace VIDEO
       m_bCanInterrupt = true;
 
       CLog::Log(LOGNOTICE, "VideoInfoScanner: Starting scan ..");
-      ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanStarted");
+      auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+      if (man)
+        man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanStarted");
 
       // Database operations should not be canceled
       // using Interrupt() while scanning as it could
@@ -174,7 +178,9 @@ namespace VIDEO
     }
     
     m_bRunning = false;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanFinished");
+    auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnScanFinished");
     
     if (m_handle)
       m_handle->MarkFinished();
@@ -1393,7 +1399,9 @@ namespace VIDEO
     data["added"] = true;
     if (m_bRunning)
       data["transaction"] = true;
-    ANNOUNCEMENT::CAnnouncementManager::GetInstance().Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", itemCopy, data);
+    auto man = CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->Announce(ANNOUNCEMENT::VideoLibrary, "xbmc", "OnUpdate", itemCopy, data);
     return lResult;
   }
 

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -43,6 +43,7 @@
 #include "addons/AddonManager.h"
 #include "addons/PluginSource.h"
 #include "view/ViewState.h"
+#include "services/ServiceManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -53,8 +54,10 @@
 #define PROPERTY_SORT_ORDER         "sort.order"
 #define PROPERTY_SORT_ASCENDING     "sort.ascending"
 
-using namespace KODI;
 using namespace ADDON;
+using namespace KODI;
+using namespace PLAYLIST;
+using namespace SERVICES;
 using namespace PVR;
 
 std::string CGUIViewState::m_strPlaylistDirectory;
@@ -420,7 +423,8 @@ void CGUIViewState::SetPlaylistDirectory(const std::string& strDirectory)
 
 bool CGUIViewState::IsCurrentPlaylistDirectory(const std::string& strDirectory)
 {
-  if (CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist()!=GetPlaylist())
+  auto pl = SERVICES::CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+  if (!pl || pl->GetCurrentPlaylist() != GetPlaylist())
     return false;
 
   std::string strDir = strDirectory;

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -31,6 +31,7 @@
 #include "platform/linux/XTimeUtils.h"
 #endif
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "settings/lib/Setting.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -49,6 +50,7 @@
 #define LOCALIZED_TOKEN_LASTID4     97
 
 using namespace ADDON;
+using namespace SERVICES;
 
 CWeatherJob::CWeatherJob(int location)
 {
@@ -58,7 +60,8 @@ CWeatherJob::CWeatherJob(int location)
 bool CWeatherJob::DoWork()
 {
   // wait for the network
-  if (!CServiceBroker::GetNetwork().IsAvailable())
+  auto net = CServiceManager::GetInstance().GetService<CNetwork>();
+  if (!net || !net->IsAvailable())
     return false;
 
   AddonPtr addon;

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -34,6 +34,7 @@
 #include "rendering/dx/DeviceResources.h"
 #include "rendering/dx/RenderContext.h"
 #include "ServiceBroker.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "utils/SystemInfo.h"
 #include "utils/Variant.h"
@@ -183,7 +184,9 @@ void CWinEventsWin10::InitEventHandlers(CoreWindow^ window)
                                (CWinEventsWin10::OnSystemMediaButtonPressed);
     }
     m_smtc->IsEnabled = true;
-    CAnnouncementManager::GetInstance().AddAnnouncer(this);
+    auto man = SERVICES::CServiceManager::GetInstance().GetService<ANNOUNCEMENT::CAnnouncementManager>();
+    if (man)
+      man->AddAnnouncer(this);
   }
   if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Xbox)
   {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1134,7 +1134,8 @@ bool CGUIMediaWindow::HaveDiscOrConnection(const std::string& strPath, int iDriv
   else if (iDriveType==CMediaSource::SOURCE_TYPE_REMOTE)
   {
     //! @todo Handle not connected to a remote share
-    if (!CServiceBroker::GetNetwork().IsConnected())
+    auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+    if (!net || !net->IsConnected())
     {
       HELPERS::ShowOKDialogText(CVariant{220}, CVariant{221});
       return false;
@@ -1794,7 +1795,11 @@ const CFileItemList& CGUIMediaWindow::CurrentDirectory() const
 
 bool CGUIMediaWindow::WaitForNetwork() const
 {
-  if (CServiceBroker::GetNetwork().IsAvailable())
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+  if (!net)
+    return false;
+
+  if (net->IsAvailable())
     return true;
 
   CGUIDialogProgress *progress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
@@ -1806,7 +1811,7 @@ bool CGUIMediaWindow::WaitForNetwork() const
   progress->SetLine(1, CVariant{url.GetWithoutUserDetails()});
   progress->ShowProgressBar(false);
   progress->Open();
-  while (!CServiceBroker::GetNetwork().IsAvailable())
+  while (!net->IsAvailable())
   {
     progress->Progress();
     if (progress->IsCanceled())

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -680,7 +680,8 @@ bool CGUIWindowFileManager::HaveDiscOrConnection( std::string& strPath, int iDri
   else if ( iDriveType == CMediaSource::SOURCE_TYPE_REMOTE )
   {
     //! @todo Handle not connected to a remote share
-    if (!CServiceBroker::GetNetwork().IsConnected())
+    auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
+    if (!net || !net->IsConnected())
     {
       HELPERS::ShowOKDialogText(CVariant{220}, CVariant{221});
       return false;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -45,6 +45,7 @@
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
+#include "services/ServiceManager.h"
 #include "storage/MediaManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -626,7 +627,9 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
   }
   if (pItem->IsAudio() || pItem->IsVideo())
   {
-    CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*pItem), player);
+    auto pl = SERVICES::CServiceManager::GetInstance().GetService<CPlayListPlayer>();
+    if (pl)
+      pl->Play(std::make_shared<CFileItem>(*pItem), player);
     return;
   }
   if (pItem->IsGame())

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -24,6 +24,7 @@
 #include "utils/JobManager.h"
 #include "utils/RecentlyAddedJob.h"
 #include "interfaces/AnnouncementManager.h"
+#include "services/ServiceManager.h"
 #include "utils/log.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Variant.h"
@@ -42,12 +43,16 @@ CGUIWindowHome::CGUIWindowHome(void) : CGUIWindow(WINDOW_HOME, "Home.xml"),
   m_updateRA = (Audio | Video | Totals);
   m_loadType = KEEP_IN_MEMORY;
   
-  CAnnouncementManager::GetInstance().AddAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->AddAnnouncer(this);
 }
 
 CGUIWindowHome::~CGUIWindowHome(void)
 {
-  CAnnouncementManager::GetInstance().RemoveAnnouncer(this);
+  auto man = SERVICES::CServiceManager::GetInstance().GetService<CAnnouncementManager>();
+  if (man)
+    man->RemoveAnnouncer(this);
 }
 
 bool CGUIWindowHome::OnAction(const CAction &action)

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -46,6 +46,7 @@
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
+#include "services/ServiceManager.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -317,9 +318,13 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   if (profileManager.GetLastUsedProfileIndex() != profile)
   {
-    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
-    CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_MUSIC);
-    CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST_NONE);
+    auto pl = SERVICES::CServiceManager::GetInstance().GetService<PLAYLIST::CPlayListPlayer>();
+    if (pl)
+    {
+      pl->ClearPlaylist(PLAYLIST_VIDEO);
+      pl->ClearPlaylist(PLAYLIST_MUSIC);
+      pl->SetCurrentPlaylist(PLAYLIST_NONE);
+    }
   }
 
   // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -298,11 +298,13 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // stop PVR related services
   CServiceBroker::GetPVRManager().Stop();
 
+  auto net = SERVICES::CServiceManager::GetInstance().GetService<CNetwork>();
   CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
 
   if (profile != 0 || !profileManager.IsMasterProfile())
   {
-    CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN, 1);
+    if (net)
+      net->NetworkMessage(CNetwork::SERVICES_DOWN, 1);
     profileManager.LoadProfile(profile);
   }
   else
@@ -311,7 +313,8 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
     if (pWindow)
       pWindow->ResetControlStates();
   }
-  CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_UP, 1);
+  if (net)
+    net->NetworkMessage(CNetwork::SERVICES_UP, 1);
 
   profileManager.UpdateCurrentProfileDate();
   profileManager.Save();


### PR DESCRIPTION
This is the start of my service container refactor. see first commit for why I believe this approach is an improvement.

It's early, feel free to review but some things you can skip
- yes, i'm initing services directly in Application right now. I wil change this in the end, but I want to see how things work out first. Ultimately, I hope to make this a map of types registered in one spot, and then have a separate call to bring services up. Bu to do this we need to change constructors to not do stuff before StartService is called so right now I do not try to factor it nicely into a function.