### PR TITLE
[cmake] disable doc, exmaples, tests & gtest for internal libs

### DIFF
--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -40,6 +40,8 @@ if(ENABLE_INTERNAL_FMT)
                       PREFIX ${CORE_BUILD_DIR}/fmt
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                                 -DFMT_DOC=OFF
+                                 -DFMT_TEST=OFF
                                  "${EXTRA_ARGS}"
                       BUILD_BYPRODUCTS ${FMT_LIBRARY})
   set_target_properties(fmt PROPERTIES FOLDER "External Projects")

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -36,6 +36,10 @@ if(ENABLE_INTERNAL_RapidJSON)
                       PREFIX ${CORE_BUILD_DIR}/rapidjson
                       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
                                  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+                                 -DRAPIDJSON_BUILD_DOC=OFF
+                                 -DRAPIDJSON_BUILD_EXAMPLES=OFF
+                                 -DRAPIDJSON_BUILD_TESTS=OFF
+                                 -DRAPIDJSON_BUILD_THIRDPARTY_GTEST=OFF
                                  "${EXTRA_ARGS}"
                       PATCH_COMMAND patch -p1 < ${CORE_SOURCE_DIR}/tools/depends/target/rapidjson/0001-remove_custom_cxx_flags.patch
                       BUILD_BYPRODUCTS ${RapidJSON_LIBRARY})


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Motivation and Context
RapidJSON fails to build without disabled examples, because it treats all warnings as errors and examples contain some warings.
The other components (docs, tests) are already disabled in depends and as they aren't needed I disabled them here too.

## How Has This Been Tested?
compiled on linux with internal fmt and rapidjson

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
