### PR TITLE
FIX: [droid] fix oreo video view shrinkage

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCVideoView.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCVideoView.java.in
@@ -67,10 +67,8 @@ public class XBMCVideoView extends SurfaceView implements
       @Override
       public void run()
       {
-        mVideoLayout.addView(XBMCVideoView.this);
-
         RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
-        setLayoutParams(layoutParams);
+        mVideoLayout.addView(XBMCVideoView.this, layoutParams);
         setBackgroundColor(Color.TRANSPARENT);
       }
     });

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -207,47 +207,44 @@ bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO *res) const
   if (!nativeWindow)
     return false;
 
-  if (!nativeWindow)
-    return false;
+  if (!m_width || !m_height)
+  {
+    ANativeWindow_acquire(nativeWindow);
+    m_width = ANativeWindow_getWidth(nativeWindow);
+    m_height= ANativeWindow_getHeight(nativeWindow);
+    ANativeWindow_release(nativeWindow);
+    CLog::Log(LOGNOTICE,"CAndroidUtils: window resolution: %dx%d", m_width, m_height);
+  }
 
   if (s_hasModeApi)
   {
     *res = s_res_cur_displayMode;
-    return true;
-  }
-
-  if (!m_width || !m_height)
-  {
-    ANativeWindow_acquire(nativeWindow);
-    res->iWidth = ANativeWindow_getWidth(nativeWindow);
-    res->iHeight= ANativeWindow_getHeight(nativeWindow);
-    ANativeWindow_release(nativeWindow);
-  }
-  else
-  {
     res->iWidth = m_width;
     res->iHeight = m_height;
   }
-
-  res->strId = "-1";
-  res->fRefreshRate = currentRefreshRate();
-  res->dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
-  res->iScreen       = 0;
-  res->bFullScreen   = true;
+  else
+  {
+    res->strId = "-1";
+    res->fRefreshRate = currentRefreshRate();
+    res->dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
+    res->iScreen       = 0;
+    res->bFullScreen   = true;
+    res->iWidth = m_width;
+    res->iHeight = m_height;
+    res->fPixelRatio   = 1.0f;
+    res->iScreenWidth  = res->iWidth;
+    res->iScreenHeight = res->iHeight;
+  }
   res->iSubtitles    = (int)(0.965 * res->iHeight);
-  res->fPixelRatio   = 1.0f;
-  res->iScreenWidth  = res->iWidth;
-  res->iScreenHeight = res->iHeight;
   res->strMode       = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
                                            res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
-  CLog::Log(LOGNOTICE,"CAndroidUtils: Current resolution: %s\n",res->strMode.c_str());
+  CLog::Log(LOGNOTICE,"CAndroidUtils: Current resolution: %dx%d %s\n", res->iWidth, res->iHeight, res->strMode.c_str());
   return true;
 }
 
 bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
 {
-  CLog::Log(LOGDEBUG, "CAndroidUtils: SetNativeResolution: %s: %dx%d@%f", res.strId.c_str(), res.iWidth, res.iHeight, res.fRefreshRate);
-
+  CLog::Log(LOGDEBUG, "CAndroidUtils: SetNativeResolution: %s: %dx%d %dx%d@%f", res.strId.c_str(), res.iWidth, res.iHeight, res.iScreenWidth, res.iScreenHeight, res.fRefreshRate);
 
   if (s_hasModeApi)
   {
@@ -263,16 +260,26 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO &res)
 
 bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
 {
+  RESOLUTION_INFO cur_res;
+  bool ret = GetNativeResolution(&cur_res);
+
+  CLog::Log(LOGDEBUG, "CAndroidUtils: ProbeResolutions: %dx%d", m_width, m_height);
+
   if (s_hasModeApi)
   {
-    resolutions.insert(resolutions.end(), s_res_displayModes.begin(), s_res_displayModes.end());
+    for(RESOLUTION_INFO res : s_res_displayModes)
+    {
+      if (m_width && m_height)
+      {
+        res.iWidth = std::min(res.iWidth, m_width);
+        res.iHeight = std::min(res.iHeight, m_height);
+      }
+      resolutions.push_back(res);
+    }
     return true;
   }
 
-  RESOLUTION_INFO res;
-  bool ret = GetNativeResolution(&res);
-
-  if (ret && res.iWidth > 1 && res.iHeight > 1)
+  if (ret && cur_res.iWidth > 1 && cur_res.iHeight > 1)
   {
     std::vector<float> refreshRates;
     CJNIWindow window = CXBMCApp::getWindow();
@@ -294,17 +301,17 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
         {
           if (refreshRates[i] < 20.0 || refreshRates[i] > 70.0)
             continue;
-          res.fRefreshRate = refreshRates[i];
-          res.strMode      = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", res.iScreenWidth, res.iScreenHeight, res.fRefreshRate,
-                                                 res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
-          resolutions.push_back(res);
+          cur_res.fRefreshRate = refreshRates[i];
+          cur_res.strMode      = StringUtils::Format("%dx%d @ %.6f%s - Full Screen", cur_res.iScreenWidth, cur_res.iScreenHeight, cur_res.fRefreshRate,
+                                                 cur_res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+          resolutions.push_back(cur_res);
         }
       }
     }
     if (resolutions.empty())
     {
       /* No valid refresh rates available, just provide the current one */
-      resolutions.push_back(res);
+      resolutions.push_back(cur_res);
     }
     return true;
   }

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -37,6 +37,6 @@ public:
   virtual bool  ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions);
 
 protected:
-  int m_width;
-  int m_height;
+  mutable int m_width;
+  mutable int m_height;
 };


### PR DESCRIPTION
~~@MartijnKaijser This fixes the issue reported by Nvidia that all videos are shrinked when running in 4K on Oreo.~~