### PR TITLE
[xbmc][fixes] Get rid of a bunch of warnings about lossy conversions.

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -337,7 +337,7 @@ std::string CScraper::InternalRun(const std::string& function,
                                  const std::vector<std::string>* extras)
 {
   // walk the list of input URLs and fetch each into parser parameters
-  unsigned int i;
+  size_t i;
   for (i=0;i<scrURL.m_url.size();++i)
   {
     if (!CScraperUrl::Get(scrURL.m_url[i],m_parser.m_param[i],http,ID()) || m_parser.m_param[i].empty())
@@ -346,7 +346,7 @@ std::string CScraper::InternalRun(const std::string& function,
   // put the 'extra' parameterts into the parser parameter list too
   if (extras)
   {
-    for (unsigned int j=0;j<extras->size();++j)
+    for (size_t j=0;j<extras->size();++j)
       m_parser.m_param[j+i] = (*extras)[j];
   }
 
@@ -447,7 +447,7 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
 
   // parse returned XML: either <error> element on error, blank on failure,
   // or <url>...</url> or <url>...</url><id>...</id> on success
-  for (unsigned int i=0; i < vcsOut.size(); ++i)
+  for (size_t i=0; i < vcsOut.size(); ++i)
   {
     CXBMCTinyXML doc;
     doc.Parse(vcsOut[i], TIXML_ENCODING_UTF8);
@@ -523,7 +523,7 @@ CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
 
   // parse returned XML: either <error> element on error, blank on failure,
   // or <url>...</url> or <url>...</url><id>...</id> on success
-  for (unsigned int i=0; i < vcsOut.size(); ++i)
+  for (size_t i=0; i < vcsOut.size(); ++i)
   {
     CXBMCTinyXML doc;
     doc.Parse(vcsOut[i], TIXML_ENCODING_UTF8);
@@ -615,7 +615,7 @@ CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem& item)
 
   info = CMusicAlbumInfo(sTitle, sArtist, sAlbumName, url);
   if (item.HasProperty("relevance"))
-    info.SetRelevance(item.GetProperty("relevance").asDouble());
+    info.SetRelevance(item.GetProperty("relevance").asFloat());
 
   return info;
 }
@@ -655,8 +655,8 @@ PythonFind(const std::string& ID,
 
   if (XFILE::CDirectory::GetDirectory(str.str(), items))
   {
-    for (int i = 0; i < items.Size(); ++i)
-      result.emplace_back(std::move(FromFileItem<T>(*items[i])));
+      for (auto it : items)
+        result.emplace_back(std::move(FromFileItem<T>(*it)));
   }
 
   return result;
@@ -722,7 +722,7 @@ void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
   album.strMusicBrainzAlbumID = FromString(item, "album.musicbrainzid");
   album.strReleaseGroupMBID = FromString(item, "album.releasegroupid");
 
-  int nArtists = item.GetProperty("album.artists").asInteger();
+  int nArtists = item.GetProperty("album.artists").asInteger32();
   album.artistCredits.reserve(nArtists);
   for (int i = 0; i < nArtists; ++i)
   {
@@ -745,12 +745,12 @@ void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
   album.strLabel = FromString(item, "album.label");
   album.strType = FromString(item, "album.type");
   album.SetReleaseType(FromString(item, "album.release_type"));
-  album.iYear = item.GetProperty("album.year").asInteger();
-  album.fRating = item.GetProperty("album.rating").asDouble();
-  album.iUserrating = item.GetProperty("album.user_rating").asInteger();
-  album.iVotes = item.GetProperty("album.votes").asInteger();
+  album.iYear = item.GetProperty("album.year").asInteger32();
+  album.fRating = item.GetProperty("album.rating").asFloat();
+  album.iUserrating = item.GetProperty("album.user_rating").asInteger32();
+  album.iVotes = item.GetProperty("album.votes").asInteger32();
 
-  int nThumbs = item.GetProperty("album.thumbs").asInteger();
+  int nThumbs = item.GetProperty("album.thumbs").asInteger32();
   ParseThumbs(album.thumbURL, item, nThumbs, "album.thumb");
 }
 
@@ -770,7 +770,7 @@ void DetailsFromFileItem<CArtist>(const CFileItem& item, CArtist& artist)
   artist.strDied = FromString(item, "artist.died");
   artist.strDisbanded = FromString(item, "artist.disbanded");
 
-  int nAlbums = item.GetProperty("artist.albums").asInteger();
+  int nAlbums = item.GetProperty("artist.albums").asInteger32();
   artist.discography.reserve(nAlbums);
   for (int i = 0; i < nAlbums; ++i)
   {
@@ -780,10 +780,10 @@ void DetailsFromFileItem<CArtist>(const CFileItem& item, CArtist& artist)
                                                 FromString(item, prefix.str()+".year")));
   }
 
-  int nThumbs = item.GetProperty("artist.thumbs").asInteger();
+  int nThumbs = item.GetProperty("artist.thumbs").asInteger32();
   ParseThumbs(artist.thumbURL, item, nThumbs, "artist.thumb");
 
-  int nFanart = item.GetProperty("artist.fanarts").asInteger();
+  int nFanart = item.GetProperty("artist.fanarts").asInteger32();
   artist.fanart.m_xml = ParseFanart(item, nFanart, "artist.fanart");
   artist.fanart.Unpack();
 }
@@ -795,49 +795,49 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
   tag.SetOriginalTitle(FromString(item, "video.original_title"));
   tag.SetShowTitle(FromString(item, "video.show_title"));
   tag.SetSortTitle(FromString(item, "video.sort_title"));
-  int nRatings = item.GetProperty("video.ratings").asInteger();
+  int nRatings = item.GetProperty("video.ratings").asInteger32();
   for (int i = 0; i < nRatings; ++i)
   {
     std::stringstream str;
     str << "video.rating" << i+1;
-    int votes = item.GetProperty(str.str()+".votes").asInteger();
-    float rating = item.GetProperty(str.str()+".value").asDouble();
+    int votes = item.GetProperty(str.str()+".votes").asInteger32();
+    float rating = item.GetProperty(str.str()+".value").asFloat();
     tag.SetRating(rating, votes, "default");
   }
-  tag.m_iUserRating = item.GetProperty("video.user_rating").asInteger();
-  tag.m_iTop250 = item.GetProperty("video.top250").asInteger();
-  tag.m_iSeason = item.GetProperty("video.season").asInteger();
-  tag.m_iEpisode = item.GetProperty("video.episode").asInteger();
-  tag.m_iTrack = item.GetProperty("video.track").asInteger();
+  tag.m_iUserRating = item.GetProperty("video.user_rating").asInteger32();
+  tag.m_iTop250 = item.GetProperty("video.top250").asInteger32();
+  tag.m_iSeason = item.GetProperty("video.season").asInteger32();
+  tag.m_iEpisode = item.GetProperty("video.episode").asInteger32();
+  tag.m_iTrack = item.GetProperty("video.track").asInteger32();
   tag.SetUniqueIDs({{"IMDB", FromString(item, "video.imdb_id")}});
-  tag.m_iSpecialSortSeason = item.GetProperty("video.display_season").asInteger();
-  tag.m_iSpecialSortEpisode = item.GetProperty("video.display_episode").asInteger();
+  tag.m_iSpecialSortSeason = item.GetProperty("video.display_season").asInteger32();
+  tag.m_iSpecialSortEpisode = item.GetProperty("video.display_episode").asInteger32();
   tag.SetPlotOutline(FromString(item, "video.plot_outline"));
   tag.SetPlot(FromString(item, "video.plot"));
   tag.SetTagLine(FromString(item, "video.tag_line"));
-  tag.m_duration = item.GetProperty("video.duration_minutes").asInteger();
+  tag.m_duration = item.GetProperty("video.duration_minutes").asInteger32();
   tag.SetMPAARating(FromString(item, "video.mpaa"));
-  tag.SetYear(item.GetProperty("video.premiere_year").asInteger());
+  tag.SetYear(item.GetProperty("video.premiere_year").asInteger32());
   tag.SetStatus(FromString(item, "video.status"));
   tag.SetProductionCode(FromString(item, "video.production_code"));
   tag.m_firstAired.SetFromDBDate(FromString(item, "video.first_aired"));
   tag.SetAlbum(FromString(item, "video.album"));
   tag.SetTrailer(FromString(item, "video.trailer"));
-  int nThumbs = item.GetProperty("video.thumbs").asInteger();
+  int nThumbs = item.GetProperty("video.thumbs").asInteger32();
   ParseThumbs(tag.m_strPictureURL, item, nThumbs, "video.thumb");
   tag.SetGenre(FromArray(item, "video.genre", 1));
   tag.SetCountry(FromArray(item, "video.country", 1));
   tag.SetWritingCredits(FromArray(item, "video.writing_credits", 1));
   tag.SetDirector(FromArray(item, "video.director", 1));
   tag.SetShowLink(FromArray(item, "video.tvshow_links", 1));
-  int nSeasons = item.GetProperty("video.seasons").asInteger();
+  int nSeasons = item.GetProperty("video.seasons").asInteger32();
   for (int i = 0; i < nSeasons; ++i)
   {
     std::stringstream str;
     str << "video.season" << i+1;
     tag.m_namedSeasons.insert(std::make_pair(i+1, FromString(item, str.str()+".name")));
   }
-  int nActors = item.GetProperty("video.actors").asInteger();
+  int nActors = item.GetProperty("video.actors").asInteger32();
   for (int i = 0; i< nActors; ++i)
   {
     std::stringstream str;
@@ -845,11 +845,11 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
     SActorInfo actor;
     actor.strName = FromString(item, str.str()+".name");
     actor.strRole = FromString(item, str.str()+".role");
-    actor.order = item.GetProperty(str.str()+".sort_order").asInteger();
+    actor.order = item.GetProperty(str.str()+".sort_order").asInteger32();
     std::string url = FromString(item, str.str()+".thumb");
     if (!url.empty())
     {
-      double aspect = item.GetProperty(str.str()+".thumb_aspect").asDouble();
+      auto aspect = item.GetProperty(str.str()+".thumb_aspect").asInteger32();
       TiXmlElement thumb("thumb");
       thumb.SetAttribute("aspect", aspect);
       TiXmlText text(url);
@@ -865,7 +865,7 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
   tag.SetStudio(FromArray(item, "video.studio", 1));
   tag.SetArtist(FromArray(item, "video.artist", 1));
   tag.m_strEpisodeGuide = "<episodeguide>"+FromString(item, "video.episode_guide_url")+"</episodeguide>";
-  int nFanart = item.GetProperty("video.fanarts").asInteger();
+  int nFanart = item.GetProperty("video.fanarts").asInteger32();
   tag.m_fanart.m_xml = ParseFanart(item, nFanart, "video.fanart");
   tag.m_fanart.Unpack();
   tag.m_firstAired.SetFromDBDate(FromString(item, "video.date_added"));
@@ -1242,9 +1242,9 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
     {
       EPISODE ep;
       ep.strTitle = items[i]->GetLabel();
-      ep.iSeason = items[i]->GetProperty("video.season").asInteger();
-      ep.iEpisode = items[i]->GetProperty("video.episode").asInteger();
-      ep.iSubepisode = items[i]->GetProperty("video.sub_episode").asInteger();
+      ep.iSeason = items[i]->GetProperty("video.season").asInteger32();
+      ep.iEpisode = items[i]->GetProperty("video.episode").asInteger32();
+      ep.iSubepisode = items[i]->GetProperty("video.sub_episode").asInteger32();
       CScraperUrl::SUrlEntry surl;
       surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
       surl.m_url =  FromString(*items[i], "video.url");

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -19,34 +19,34 @@
  */
 
 #include "Scraper.h"
+#include "AddonManager.h"
+#include "FileItem.h"
 #include "ServiceBroker.h"
+#include "URL.h"
+#include "Util.h"
 #include "filesystem/CurlFile.h"
-#include "filesystem/File.h"
 #include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "filesystem/PluginDirectory.h"
 #include "guilib/LocalizeStrings.h"
-#include "AddonManager.h"
-#include "utils/ScraperParser.h"
-#include "utils/ScraperUrl.h"
-#include "utils/CharsetConverter.h"
-#include "utils/log.h"
-#include "music/infoscanner/MusicAlbumInfo.h"
-#include "music/infoscanner/MusicArtistInfo.h"
-#include "utils/fstrcmp.h"
-#include "settings/AdvancedSettings.h"
-#include "FileItem.h"
-#include "utils/URIUtils.h"
-#include "utils/XMLUtils.h"
-#include "utils/StringUtils.h"
-#include "music/MusicDatabase.h"
-#include "video/VideoDatabase.h"
 #include "music/Album.h"
 #include "music/Artist.h"
-#include "Util.h"
-#include "URL.h"
+#include "music/MusicDatabase.h"
+#include "music/infoscanner/MusicAlbumInfo.h"
+#include "music/infoscanner/MusicArtistInfo.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/CharsetConverter.h"
+#include "utils/ScraperParser.h"
+#include "utils/ScraperUrl.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/XMLUtils.h"
+#include "utils/fstrcmp.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
 
-#include <sstream>
 #include <algorithm>
+#include <sstream>
 
 using namespace XFILE;
 using namespace MUSIC_GRABBER;
@@ -57,23 +57,22 @@ namespace ADDON
 
 typedef struct
 {
-  const char*  name;
+  const char *name;
   CONTENT_TYPE type;
-  int          pretty;
+  int pretty;
 } ContentMapping;
 
-static const ContentMapping content[] =
-  {{"unknown",       CONTENT_NONE,          231 },
-   {"albums",        CONTENT_ALBUMS,        132 },
-   {"music",         CONTENT_ALBUMS,        132 },
-   {"artists",       CONTENT_ARTISTS,       133 },
-   {"movies",        CONTENT_MOVIES,      20342 },
-   {"tvshows",       CONTENT_TVSHOWS,     20343 },
-   {"musicvideos",   CONTENT_MUSICVIDEOS, 20389 }};
+static const ContentMapping content[] = {{"unknown", CONTENT_NONE, 231},
+                                         {"albums", CONTENT_ALBUMS, 132},
+                                         {"music", CONTENT_ALBUMS, 132},
+                                         {"artists", CONTENT_ARTISTS, 133},
+                                         {"movies", CONTENT_MOVIES, 20342},
+                                         {"tvshows", CONTENT_TVSHOWS, 20343},
+                                         {"musicvideos", CONTENT_MUSICVIDEOS, 20389}};
 
-std::string TranslateContent(const CONTENT_TYPE &type, bool pretty/*=false*/)
+std::string TranslateContent(const CONTENT_TYPE &type, bool pretty /*=false*/)
 {
-  for (unsigned int index=0; index < ARRAY_SIZE(content); ++index)
+  for (unsigned int index = 0; index < ARRAY_SIZE(content); ++index)
   {
     const ContentMapping &map = content[index];
     if (type == map.type)
@@ -89,7 +88,7 @@ std::string TranslateContent(const CONTENT_TYPE &type, bool pretty/*=false*/)
 
 CONTENT_TYPE TranslateContent(const std::string &string)
 {
-  for (unsigned int index=0; index < ARRAY_SIZE(content); ++index)
+  for (unsigned int index = 0; index < ARRAY_SIZE(content); ++index)
   {
     const ContentMapping &map = content[index];
     if (string == map.name)
@@ -129,55 +128,61 @@ static void CheckScraperError(const TiXmlElement *pxeRoot)
   throw CScraperError(sTitle, sMessage);
 }
 
-std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext)
+std::unique_ptr<CScraper> CScraper::FromExtension(CAddonInfo addonInfo, const cp_extension_t *ext)
 {
-  bool requiressettings = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration,"@requiressettings") == "true";
+  bool requiressettings =
+      CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@requiressettings") == "true";
 
   CDateTimeSpan persistence;
-  std::string tmp = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@cachepersistence");
+  std::string tmp =
+      CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "@cachepersistence");
   if (!tmp.empty())
     persistence.SetFromTimeString(tmp);
 
   CONTENT_TYPE pathContent(CONTENT_NONE);
   switch (addonInfo.MainType())
   {
-    case ADDON_SCRAPER_ALBUMS:
-      pathContent = CONTENT_ALBUMS;
-      break;
-    case ADDON_SCRAPER_ARTISTS:
-      pathContent = CONTENT_ARTISTS;
-      break;
-    case ADDON_SCRAPER_MOVIES:
-      pathContent = CONTENT_MOVIES;
-      break;
-    case ADDON_SCRAPER_MUSICVIDEOS:
-      pathContent = CONTENT_MUSICVIDEOS;
-      break;
-    case ADDON_SCRAPER_TVSHOWS:
-      pathContent = CONTENT_TVSHOWS;
-      break;
-    default:
-      break;
+  case ADDON_SCRAPER_ALBUMS:
+    pathContent = CONTENT_ALBUMS;
+    break;
+  case ADDON_SCRAPER_ARTISTS:
+    pathContent = CONTENT_ARTISTS;
+    break;
+  case ADDON_SCRAPER_MOVIES:
+    pathContent = CONTENT_MOVIES;
+    break;
+  case ADDON_SCRAPER_MUSICVIDEOS:
+    pathContent = CONTENT_MUSICVIDEOS;
+    break;
+  case ADDON_SCRAPER_TVSHOWS:
+    pathContent = CONTENT_TVSHOWS;
+    break;
+  default:
+    break;
   }
 
-  return std::unique_ptr<CScraper>(new CScraper(std::move(addonInfo), requiressettings, persistence, pathContent));
+  return std::unique_ptr<CScraper>(
+      new CScraper(std::move(addonInfo), requiressettings, persistence, pathContent));
 }
 
 CScraper::CScraper(CAddonInfo addonInfo)
-  : CAddon(std::move(addonInfo)),
-    m_fLoaded(false),
-    m_requiressettings(false),
-    m_pathContent(CONTENT_NONE)
+    : CAddon(std::move(addonInfo))
+    , m_fLoaded(false)
+    , m_requiressettings(false)
+    , m_pathContent(CONTENT_NONE)
 {
   m_isPython = URIUtils::GetExtension(LibPath()) == ".py";
 }
 
-CScraper::CScraper(CAddonInfo addonInfo, bool requiressettings, CDateTimeSpan persistence, CONTENT_TYPE pathContent)
-  : CAddon(std::move(addonInfo)),
-    m_fLoaded(false),
-    m_requiressettings(requiressettings),
-    m_persistence(persistence),
-    m_pathContent(pathContent)
+CScraper::CScraper(CAddonInfo addonInfo,
+                   bool requiressettings,
+                   CDateTimeSpan persistence,
+                   CONTENT_TYPE pathContent)
+    : CAddon(std::move(addonInfo))
+    , m_fLoaded(false)
+    , m_requiressettings(requiressettings)
+    , m_persistence(persistence)
+    , m_pathContent(pathContent)
 {
   m_isPython = URIUtils::GetExtension(LibPath()) == ".py";
 }
@@ -187,7 +192,7 @@ bool CScraper::Supports(const CONTENT_TYPE &content) const
   return Type() == ScraperTypeFromContent(content);
 }
 
-bool CScraper::SetPathSettings(CONTENT_TYPE content, const std::string& xml)
+bool CScraper::SetPathSettings(CONTENT_TYPE content, const std::string &xml)
 {
   m_pathContent = content;
   if (!LoadSettings(false, false))
@@ -229,8 +234,8 @@ void CScraper::ClearCache()
   if (CDirectory::Exists(strCachePath))
   {
     CFileItemList items;
-    CDirectory::GetDirectory(strCachePath,items);
-    for (int i=0;i<items.Size();++i)
+    CDirectory::GetDirectory(strCachePath, items);
+    for (int i = 0; i < items.Size(); ++i)
     {
       // wipe cache
       if (items[i]->m_dateTime + m_persistence <= CDateTime::GetCurrentDateTime())
@@ -245,49 +250,49 @@ void CScraper::ClearCache()
 // is XML output by chained functions, possibly recursively
 // the CCurlFile object is passed in so that URL fetches can be canceled from other threads
 // throws CScraperError abort on internal failures (e.g., parse errors)
-std::vector<std::string> CScraper::Run(const std::string& function,
-                                       const CScraperUrl& scrURL,
-                                       CCurlFile& http,
-                                       const std::vector<std::string>* extras)
+std::vector<std::string> CScraper::Run(const std::string &function,
+                                       const CScraperUrl &scrURL,
+                                       CCurlFile &http,
+                                       const std::vector<std::string> *extras)
 {
   if (!Load())
     throw CScraperError();
 
-  std::string strXML = InternalRun(function,scrURL,http,extras);
+  std::string strXML = InternalRun(function, scrURL, http, extras);
   if (strXML.empty())
   {
     if (function != "NfoUrl" && function != "ResolveIDToUrl")
-      CLog::Log(LOGERROR, "%s: Unable to parse web site",__FUNCTION__);
+      CLog::Log(LOGERROR, "%s: Unable to parse web site", __FUNCTION__);
     throw CScraperError();
   }
 
-  CLog::Log(LOGDEBUG,"scraper: %s returned %s",function.c_str(),strXML.c_str());
+  CLog::Log(LOGDEBUG, "scraper: %s returned %s", function.c_str(), strXML.c_str());
 
   CXBMCTinyXML doc;
   /* all data was converted to UTF-8 before being processed by scraper */
   doc.Parse(strXML, TIXML_ENCODING_UTF8);
   if (!doc.RootElement())
   {
-    CLog::Log(LOGERROR, "%s: Unable to parse XML",__FUNCTION__);
+    CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
     throw CScraperError();
   }
 
   std::vector<std::string> result;
   result.push_back(strXML);
-  TiXmlElement* xchain = doc.RootElement()->FirstChildElement();
+  TiXmlElement *xchain = doc.RootElement()->FirstChildElement();
   // skip children of the root element until <url> or <chain>
-  while (xchain && strcmp(xchain->Value(),"url") && strcmp(xchain->Value(),"chain"))
-      xchain = xchain->NextSiblingElement();
+  while (xchain && strcmp(xchain->Value(), "url") && strcmp(xchain->Value(), "chain"))
+    xchain = xchain->NextSiblingElement();
   while (xchain)
   {
     // <chain|url function="...">param</>
-    const char* szFunction = xchain->Attribute("function");
+    const char *szFunction = xchain->Attribute("function");
     if (szFunction)
     {
       CScraperUrl scrURL2;
       std::vector<std::string> extras;
       // for <chain>, pass the contained text as a parameter; for <url>, as URL content
-      if (strcmp(xchain->Value(),"chain")==0)
+      if (strcmp(xchain->Value(), "chain") == 0)
       {
         if (xchain->FirstChild())
           extras.push_back(xchain->FirstChild()->Value());
@@ -300,12 +305,12 @@ std::vector<std::string> CScraper::Run(const std::string& function,
       // url or the parameters to a chain, we can safely clear it here
       // to fix this issue
       m_parser.m_param[0].clear();
-      std::vector<std::string> result2 = RunNoThrow(szFunction,scrURL2,http,&extras);
-      result.insert(result.end(),result2.begin(),result2.end());
+      std::vector<std::string> result2 = RunNoThrow(szFunction, scrURL2, http, &extras);
+      result.insert(result.end(), result2.begin(), result2.end());
     }
     xchain = xchain->NextSiblingElement();
     // continue to skip past non-<url> or <chain> elements
-    while (xchain && strcmp(xchain->Value(),"url") && strcmp(xchain->Value(),"chain"))
+    while (xchain && strcmp(xchain->Value(), "url") && strcmp(xchain->Value(), "chain"))
       xchain = xchain->NextSiblingElement();
   }
 
@@ -314,10 +319,10 @@ std::vector<std::string> CScraper::Run(const std::string& function,
 
 // just like Run, but returns an empty list instead of throwing in case of error
 // don't use in new code; errors should be handled appropriately
-std::vector<std::string> CScraper::RunNoThrow(const std::string& function,
-  const CScraperUrl& url,
-  XFILE::CCurlFile& http,
-  const std::vector<std::string>* extras)
+std::vector<std::string> CScraper::RunNoThrow(const std::string &function,
+                                              const CScraperUrl &url,
+                                              XFILE::CCurlFile &http,
+                                              const std::vector<std::string> *extras)
 {
   std::vector<std::string> vcs;
   try
@@ -326,31 +331,32 @@ std::vector<std::string> CScraper::RunNoThrow(const std::string& function,
   }
   catch (const CScraperError &sce)
   {
-    assert(sce.FAborted());  // the only kind we should get
+    assert(sce.FAborted()); // the only kind we should get
   }
   return vcs;
 }
 
-std::string CScraper::InternalRun(const std::string& function,
-                                 const CScraperUrl& scrURL,
-                                 CCurlFile& http,
-                                 const std::vector<std::string>* extras)
+std::string CScraper::InternalRun(const std::string &function,
+                                  const CScraperUrl &scrURL,
+                                  CCurlFile &http,
+                                  const std::vector<std::string> *extras)
 {
   // walk the list of input URLs and fetch each into parser parameters
   size_t i;
-  for (i=0;i<scrURL.m_url.size();++i)
+  for (i = 0; i < scrURL.m_url.size(); ++i)
   {
-    if (!CScraperUrl::Get(scrURL.m_url[i],m_parser.m_param[i],http,ID()) || m_parser.m_param[i].empty())
+    if (!CScraperUrl::Get(scrURL.m_url[i], m_parser.m_param[i], http, ID()) ||
+        m_parser.m_param[i].empty())
       return "";
   }
   // put the 'extra' parameterts into the parser parameter list too
   if (extras)
   {
-    for (size_t j=0;j<extras->size();++j)
-      m_parser.m_param[j+i] = (*extras)[j];
+    for (size_t j = 0; j < extras->size(); ++j)
+      m_parser.m_param[j + i] = (*extras)[j];
   }
 
-  return m_parser.Parse(function,this);
+  return m_parser.Parse(function, this);
 }
 
 bool CScraper::Load()
@@ -358,7 +364,7 @@ bool CScraper::Load()
   if (m_fLoaded || m_isPython)
     return true;
 
-  bool result=m_parser.Load(LibPath());
+  bool result = m_parser.Load(LibPath());
   if (result)
   {
     //! @todo this routine assumes that deps are a single level, and assumes the dep is installed.
@@ -447,7 +453,7 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
 
   // parse returned XML: either <error> element on error, blank on failure,
   // or <url>...</url> or <url>...</url><id>...</id> on success
-  for (size_t i=0; i < vcsOut.size(); ++i)
+  for (size_t i = 0; i < vcsOut.size(); ++i)
   {
     CXBMCTinyXML doc;
     doc.Parse(vcsOut[i], TIXML_ENCODING_UTF8);
@@ -462,9 +468,9 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
        with start and end-tags we're not able to use it.
        Check for the desired Elements instead.
       */
-      TiXmlElement* pxeUrl=NULL;
-      TiXmlElement* pId=NULL;
-      if (!strcmp(doc.RootElement()->Value(),"details"))
+      TiXmlElement *pxeUrl = NULL;
+      TiXmlElement *pId = NULL;
+      if (!strcmp(doc.RootElement()->Value(), "details"))
       {
         pxeUrl = doc.RootElement()->FirstChildElement("url");
         pId = doc.RootElement()->FirstChildElement("id");
@@ -492,15 +498,14 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
   return scurlRet;
 }
 
-CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
+CScraperUrl CScraper::ResolveIDToUrl(const std::string &externalID)
 {
   CScraperUrl scurlRet;
 
   if (m_isPython)
   {
     std::stringstream str;
-    str << "plugin://" << ID()
-        << "?action=resolveid&key=" << CURL::Encode(externalID);
+    str << "plugin://" << ID() << "?action=resolveid&key=" << CURL::Encode(externalID);
 
     CFileItem item("resolve me", false);
 
@@ -523,7 +528,7 @@ CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
 
   // parse returned XML: either <error> element on error, blank on failure,
   // or <url>...</url> or <url>...</url><id>...</id> on success
-  for (size_t i=0; i < vcsOut.size(); ++i)
+  for (size_t i = 0; i < vcsOut.size(); ++i)
   {
     CXBMCTinyXML doc;
     doc.Parse(vcsOut[i], TIXML_ENCODING_UTF8);
@@ -538,9 +543,9 @@ CScraperUrl CScraper::ResolveIDToUrl(const std::string& externalID)
        with start and end-tags we're not able to use it.
        Check for the desired Elements instead.
        */
-      TiXmlElement* pxeUrl=NULL;
-      TiXmlElement* pId=NULL;
-      if (!strcmp(doc.RootElement()->Value(),"details"))
+      TiXmlElement *pxeUrl = NULL;
+      TiXmlElement *pId = NULL;
+      if (!strcmp(doc.RootElement()->Value(), "details"))
       {
         pxeUrl = doc.RootElement()->FirstChildElement("url");
         pId = doc.RootElement()->FirstChildElement("id");
@@ -574,11 +579,10 @@ static bool RelevanceSortFunction(const CScraperUrl &left, const CScraperUrl &ri
 }
 
 template<class T>
-static T FromFileItem(const CFileItem& item);
-
+static T FromFileItem(const CFileItem &item);
 
 template<>
-CScraperUrl FromFileItem<CScraperUrl>(const CFileItem& item)
+CScraperUrl FromFileItem<CScraperUrl>(const CFileItem &item)
 {
   CScraperUrl url;
 
@@ -587,17 +591,17 @@ CScraperUrl FromFileItem<CScraperUrl>(const CFileItem& item)
     url.relevance = item.GetProperty("relevance").asDouble();
   CScraperUrl::SUrlEntry surl;
   surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
-  surl.m_url =  item.GetPath();
+  surl.m_url = item.GetPath();
   url.m_url.push_back(surl);
 
   return url;
 }
 
 template<>
-CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem& item)
+CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem &item)
 {
   CMusicAlbumInfo info;
-  std::string sTitle  = item.GetLabel();
+  std::string sTitle = item.GetLabel();
   std::string sArtist = item.GetProperty("album.artist").asString();
   std::string sAlbumName;
   if (!sArtist.empty())
@@ -621,10 +625,10 @@ CMusicAlbumInfo FromFileItem<CMusicAlbumInfo>(const CFileItem& item)
 }
 
 template<>
-CMusicArtistInfo FromFileItem<CMusicArtistInfo>(const CFileItem& item)
+CMusicArtistInfo FromFileItem<CMusicArtistInfo>(const CFileItem &item)
 {
   CMusicArtistInfo info;
-  std::string sTitle  = item.GetLabel();
+  std::string sTitle = item.GetLabel();
 
   CScraperUrl url;
   url.m_url.resize(1);
@@ -640,67 +644,63 @@ CMusicArtistInfo FromFileItem<CMusicArtistInfo>(const CFileItem& item)
   return info;
 }
 
-
 template<class T>
-static std::vector<T>
-PythonFind(const std::string& ID,
-           const std::map<std::string, std::string>& additionals)
+static std::vector<T> PythonFind(const std::string &ID,
+                                 const std::map<std::string, std::string> &additionals)
 {
   std::vector<T> result;
   CFileItemList items;
   std::stringstream str;
   str << "plugin://" << ID << "?action=find";
-  for (const auto& it : additionals)
-    str << "&" << it.first<< "=" << CURL::Encode(it.second);
+  for (const auto &it : additionals)
+    str << "&" << it.first << "=" << CURL::Encode(it.second);
 
   if (XFILE::CDirectory::GetDirectory(str.str(), items))
   {
-      for (auto it : items)
-        result.emplace_back(std::move(FromFileItem<T>(*it)));
+    for (auto it : items)
+      result.emplace_back(std::move(FromFileItem<T>(*it)));
   }
 
   return result;
 }
 
-static std::string FromString(const CFileItem& item,
-                              const std::string& key)
+static std::string FromString(const CFileItem &item, const std::string &key)
 {
-    return item.GetProperty(key).asString();
+  return item.GetProperty(key).asString();
 }
 
-static std::vector<std::string> FromArray(const CFileItem& item,
-                                          const std::string& key,
-                                          int sep)
+static std::vector<std::string> FromArray(const CFileItem &item, const std::string &key, int sep)
 {
-    return StringUtils::Split(item.GetProperty(key).asString(),
-                              sep ? g_advancedSettings.m_videoItemSeparator :
-                                    g_advancedSettings.m_musicItemSeparator);
+  return StringUtils::Split(item.GetProperty(key).asString(),
+                            sep ? g_advancedSettings.m_videoItemSeparator
+                                : g_advancedSettings.m_musicItemSeparator);
 }
 
-static void ParseThumbs(CScraperUrl& scurl, const CFileItem& item,
-                        int nThumbs, const std::string& tag)
+static void ParseThumbs(CScraperUrl &scurl,
+                        const CFileItem &item,
+                        int nThumbs,
+                        const std::string &tag)
 {
   for (int i = 0; i < nThumbs; ++i)
   {
     std::stringstream prefix;
-    prefix << tag << i+1;
-    std::string url = FromString(item, prefix.str()+".url");
-    std::string aspect = FromString(item, prefix.str()+".aspect");
+    prefix << tag << i + 1;
+    std::string url = FromString(item, prefix.str() + ".url");
+    std::string aspect = FromString(item, prefix.str() + ".aspect");
     scurl.AddElement(url, aspect);
   }
 }
 
-static std::string ParseFanart(const CFileItem& item,
-                               int nFanart, const std::string& tag)
+static std::string ParseFanart(const CFileItem &item, int nFanart, const std::string &tag)
 {
   std::string result;
   TiXmlElement fanart("fanart");
   for (int i = 0; i < nFanart; ++i)
   {
     std::stringstream prefix;
-    prefix << tag << i+1;
-    std::string url = FromString(item, prefix.str()+".url");
-    std::string preview = FromString(item, prefix.str()+".preview");
+    prefix << tag << i + 1;
+    std::string url = FromString(item, prefix.str() + ".url");
+    std::string preview = FromString(item, prefix.str() + ".preview");
     TiXmlElement thumb("thumb");
     thumb.SetAttribute("preview", preview);
     TiXmlText text(url);
@@ -713,10 +713,10 @@ static std::string ParseFanart(const CFileItem& item,
 }
 
 template<class T>
-static void DetailsFromFileItem(const CFileItem&, T&);
+static void DetailsFromFileItem(const CFileItem &, T &);
 
 template<>
-void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
+void DetailsFromFileItem<CAlbum>(const CFileItem &item, CAlbum &album)
 {
   album.strAlbum = item.GetLabel();
   album.strMusicBrainzAlbumID = FromString(item, "album.musicbrainzid");
@@ -727,10 +727,10 @@ void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
   for (int i = 0; i < nArtists; ++i)
   {
     std::stringstream prefix;
-    prefix << "album.artist" << i+1;
+    prefix << "album.artist" << i + 1;
     CArtistCredit artistCredit;
-    artistCredit.SetArtist(FromString(item, prefix.str()+".name"));
-    artistCredit.SetMusicBrainzArtistID(FromString(item, prefix.str()+".musicbrainzid"));
+    artistCredit.SetArtist(FromString(item, prefix.str() + ".name"));
+    artistCredit.SetMusicBrainzArtistID(FromString(item, prefix.str() + ".musicbrainzid"));
     album.artistCredits.push_back(artistCredit);
   }
 
@@ -755,7 +755,7 @@ void DetailsFromFileItem<CAlbum>(const CFileItem& item, CAlbum& album)
 }
 
 template<>
-void DetailsFromFileItem<CArtist>(const CFileItem& item, CArtist& artist)
+void DetailsFromFileItem<CArtist>(const CFileItem &item, CArtist &artist)
 {
   artist.strArtist = item.GetLabel();
   artist.strMusicBrainzArtistID = FromString(item, "artist.musicbrainzid");
@@ -775,9 +775,9 @@ void DetailsFromFileItem<CArtist>(const CFileItem& item, CArtist& artist)
   for (int i = 0; i < nAlbums; ++i)
   {
     std::stringstream prefix;
-    prefix << "artist.album" << i+1;
-    artist.discography.push_back(std::make_pair(FromString(item, prefix.str()+".title"),
-                                                FromString(item, prefix.str()+".year")));
+    prefix << "artist.album" << i + 1;
+    artist.discography.push_back(std::make_pair(FromString(item, prefix.str() + ".title"),
+                                                FromString(item, prefix.str() + ".year")));
   }
 
   int nThumbs = item.GetProperty("artist.thumbs").asInteger32();
@@ -789,7 +789,7 @@ void DetailsFromFileItem<CArtist>(const CFileItem& item, CArtist& artist)
 }
 
 template<>
-void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& tag)
+void DetailsFromFileItem<CVideoInfoTag>(const CFileItem &item, CVideoInfoTag &tag)
 {
   tag.SetTitle(item.GetLabel());
   tag.SetOriginalTitle(FromString(item, "video.original_title"));
@@ -799,9 +799,9 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
   for (int i = 0; i < nRatings; ++i)
   {
     std::stringstream str;
-    str << "video.rating" << i+1;
-    int votes = item.GetProperty(str.str()+".votes").asInteger32();
-    float rating = item.GetProperty(str.str()+".value").asFloat();
+    str << "video.rating" << i + 1;
+    int votes = item.GetProperty(str.str() + ".votes").asInteger32();
+    float rating = item.GetProperty(str.str() + ".value").asFloat();
     tag.SetRating(rating, votes, "default");
   }
   tag.m_iUserRating = item.GetProperty("video.user_rating").asInteger32();
@@ -834,22 +834,22 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
   for (int i = 0; i < nSeasons; ++i)
   {
     std::stringstream str;
-    str << "video.season" << i+1;
-    tag.m_namedSeasons.insert(std::make_pair(i+1, FromString(item, str.str()+".name")));
+    str << "video.season" << i + 1;
+    tag.m_namedSeasons.insert(std::make_pair(i + 1, FromString(item, str.str() + ".name")));
   }
   int nActors = item.GetProperty("video.actors").asInteger32();
-  for (int i = 0; i< nActors; ++i)
+  for (int i = 0; i < nActors; ++i)
   {
     std::stringstream str;
-    str << "video.actor" << i+1;
+    str << "video.actor" << i + 1;
     SActorInfo actor;
-    actor.strName = FromString(item, str.str()+".name");
-    actor.strRole = FromString(item, str.str()+".role");
-    actor.order = item.GetProperty(str.str()+".sort_order").asInteger32();
-    std::string url = FromString(item, str.str()+".thumb");
+    actor.strName = FromString(item, str.str() + ".name");
+    actor.strRole = FromString(item, str.str() + ".role");
+    actor.order = item.GetProperty(str.str() + ".sort_order").asInteger32();
+    std::string url = FromString(item, str.str() + ".thumb");
     if (!url.empty())
     {
-      auto aspect = item.GetProperty(str.str()+".thumb_aspect").asInteger32();
+      auto aspect = item.GetProperty(str.str() + ".thumb_aspect").asInteger32();
       TiXmlElement thumb("thumb");
       thumb.SetAttribute("aspect", aspect);
       TiXmlText text(url);
@@ -864,7 +864,8 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
   tag.SetTags(FromArray(item, "video.tags", 1));
   tag.SetStudio(FromArray(item, "video.studio", 1));
   tag.SetArtist(FromArray(item, "video.artist", 1));
-  tag.m_strEpisodeGuide = "<episodeguide>"+FromString(item, "video.episode_guide_url")+"</episodeguide>";
+  tag.m_strEpisodeGuide =
+      "<episodeguide>" + FromString(item, "video.episode_guide_url") + "</episodeguide>";
   int nFanart = item.GetProperty("video.fanarts").asInteger32();
   tag.m_fanart.m_xml = ParseFanart(item, nFanart, "video.fanart");
   tag.m_fanart.Unpack();
@@ -872,15 +873,14 @@ void DetailsFromFileItem<CVideoInfoTag>(const CFileItem& item, CVideoInfoTag& ta
 }
 
 template<class T>
-static bool PythonDetails(const std::string& ID,
-                          const std::string& key,
-                          const std::string& url,
-                          const std::string& action,
-                          T& result)
+static bool PythonDetails(const std::string &ID,
+                          const std::string &key,
+                          const std::string &url,
+                          const std::string &action,
+                          T &result)
 {
   std::stringstream str;
-  str << "plugin://" << ID << "?action=" << action
-      << "&" << key << "=" << CURL::Encode(url);
+  str << "plugin://" << ID << "?action=" << action << "&" << key << "=" << CURL::Encode(url);
 
   CFileItem item(url, false);
 
@@ -891,7 +891,6 @@ static bool PythonDetails(const std::string& ID,
   return true;
 }
 
-
 // fetch list of matching movies sorted by relevance (may be empty);
 // throws CScraperError on error; first called with fFirst set, then unset if first try fails
 std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
@@ -900,19 +899,20 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
 {
   // prepare parameters for URL creation
   std::string sTitle, sTitleYear, sYear;
-  CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true/*fRemoveExt*/, fFirst);
+  CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true /*fRemoveExt*/, fFirst);
 
-  CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
-    "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sTitle.c_str(),
-    Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Searching for '%s' using %s scraper "
+            "(path: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, sTitle.c_str(), Name().c_str(), Path().c_str(),
+            ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   std::vector<CScraperUrl> vcscurl;
   if (IsNoop())
     return vcscurl;
 
   if (!fFirst)
-    StringUtils::Replace(sTitle, '-',' ');
+    StringUtils::Replace(sTitle, '-', ' ');
 
   if (m_isPython)
   {
@@ -953,7 +953,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
     if (!doc.RootElement())
     {
       CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
-      continue;  // might have more valid results later
+      continue; // might have more valid results later
     }
 
     CheckScraperError(doc.RootElement());
@@ -962,7 +962,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
     TiXmlHandle xhResults = xhDoc.FirstChild("results");
     if (!xhResults.Element())
       continue;
-    fResults = true;  // even if empty
+    fResults = true; // even if empty
 
     // we need to sort if returned results don't specify 'sorted="yes"'
     if (fSort)
@@ -972,8 +972,8 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
         fSort = !StringUtils::EqualsNoCase(sorted, "yes");
     }
 
-    for (TiXmlElement *pxeMovie = xhResults.FirstChild("entity").Element();
-      pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())
+    for (TiXmlElement *pxeMovie = xhResults.FirstChild("entity").Element(); pxeMovie;
+         pxeMovie = pxeMovie->NextSiblingElement())
     {
       CScraperUrl scurlMovie;
       TiXmlNode *pxnTitle = pxeMovie->FirstChild("title");
@@ -983,7 +983,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
         scurlMovie.strTitle = pxnTitle->FirstChild()->Value();
         XMLUtils::GetString(pxeMovie, "id", scurlMovie.strId);
 
-        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+        for (; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
           scurlMovie.ParseElement(pxeLink);
 
         // calculate the relevance of this hit
@@ -1003,7 +1003,8 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
 
         double yearScore = 0;
         if (!sYear.empty() && !sCompareYear.empty())
-          yearScore = std::max(0.0, 1-0.5*abs(atoi(sYear.c_str())-atoi(sCompareYear.c_str())));
+          yearScore =
+              std::max(0.0, 1 - 0.5 * abs(atoi(sYear.c_str()) - atoi(sCompareYear.c_str())));
 
         scurlMovie.relevance = fstrcmp(sMatchTitle.c_str(), sCompareTitle.c_str(), 0.0) + yearScore;
 
@@ -1023,7 +1024,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
   }
 
   if (!fResults)
-    throw CScraperError();  // scraper aborted
+    throw CScraperError(); // scraper aborted
 
   if (fSort)
     std::stable_sort(vcscurl.begin(), vcscurl.end(), RelevanceSortFunction);
@@ -1037,18 +1038,18 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
                                                  const std::string &sAlbum,
                                                  const std::string &sArtist)
 {
-  CLog::Log(LOGDEBUG, "%s: Searching for '%s - %s' using %s scraper "
-    "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
-    sAlbum.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Searching for '%s - %s' using %s scraper "
+            "(path: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, sArtist.c_str(), sAlbum.c_str(), Name().c_str(), Path().c_str(),
+            ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   std::vector<CMusicAlbumInfo> vcali;
   if (IsNoop())
     return vcali;
 
   if (m_isPython)
-    return PythonFind<CMusicAlbumInfo>(ID(), {{"title", sAlbum},
-                                              {"artist", sArtist}});
+    return PythonFind<CMusicAlbumInfo>(ID(), {{"title", sAlbum}, {"artist", sArtist}});
 
   // scraper function is given the album and artist as parameters and
   // returns an XML <url> element parseable by CScraperUrl
@@ -1087,8 +1088,8 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
     doc.Parse(*i, TIXML_ENCODING_UTF8);
     TiXmlHandle xhDoc(&doc);
 
-    for (TiXmlElement* pxeAlbum = xhDoc.FirstChild("results").FirstChild("entity").Element();
-      pxeAlbum; pxeAlbum = pxeAlbum->NextSiblingElement())
+    for (TiXmlElement *pxeAlbum = xhDoc.FirstChild("results").FirstChild("entity").Element();
+         pxeAlbum; pxeAlbum = pxeAlbum->NextSiblingElement())
     {
       std::string sTitle;
       if (XMLUtils::GetString(pxeAlbum, "title", sTitle) && !sTitle.empty())
@@ -1106,11 +1107,11 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
 
         // if no URL is provided, use the URL we got back from CreateAlbumSearchUrl
         // (e.g., in case we only got one result back and were sent to the detail page)
-        TiXmlElement* pxeLink = pxeAlbum->FirstChildElement("url");
+        TiXmlElement *pxeLink = pxeAlbum->FirstChildElement("url");
         CScraperUrl scurlAlbum;
         if (!pxeLink)
           scurlAlbum.ParseString(scurl.m_xml);
-        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+        for (; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
           scurlAlbum.ParseElement(pxeLink);
 
         if (!scurlAlbum.m_url.size())
@@ -1118,10 +1119,10 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
 
         CMusicAlbumInfo ali(sTitle, sArtist, sAlbumName, scurlAlbum);
 
-        TiXmlElement* pxeRel = pxeAlbum->FirstChildElement("relevance");
+        TiXmlElement *pxeRel = pxeAlbum->FirstChildElement("relevance");
         if (pxeRel && pxeRel->FirstChild())
         {
-          const char* szScale = pxeRel->Attribute("scale");
+          const char *szScale = pxeRel->Attribute("scale");
           float flScale = szScale ? float(atof(szScale)) : 1;
           ali.SetRelevance(float(atof(pxeRel->FirstChild()->Value())) / flScale);
         }
@@ -1135,13 +1136,13 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
 
 // find artist, using fcurl for web fetches
 // returns a list of artists (empty if no match or failure)
-std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
-                                                   const std::string &sArtist)
+std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::string &sArtist)
 {
-  CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
-    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
-    Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Searching for '%s' using %s scraper "
+            "(file: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, sArtist.c_str(), Name().c_str(), Path().c_str(),
+            ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   std::vector<CMusicArtistInfo> vcari;
   if (IsNoop())
@@ -1186,18 +1187,18 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
       return vcari;
     }
     TiXmlHandle xhDoc(&doc);
-    for (TiXmlElement* pxeArtist = xhDoc.FirstChild("results").FirstChild("entity").Element();
-      pxeArtist; pxeArtist = pxeArtist->NextSiblingElement())
+    for (TiXmlElement *pxeArtist = xhDoc.FirstChild("results").FirstChild("entity").Element();
+         pxeArtist; pxeArtist = pxeArtist->NextSiblingElement())
     {
-      TiXmlNode* pxnTitle = pxeArtist->FirstChild("title");
+      TiXmlNode *pxnTitle = pxeArtist->FirstChild("title");
       if (pxnTitle && pxnTitle->FirstChild())
       {
         CScraperUrl scurlArtist;
 
-        TiXmlElement* pxeLink = pxeArtist->FirstChildElement("url");
+        TiXmlElement *pxeLink = pxeArtist->FirstChildElement("url");
         if (!pxeLink)
           scurlArtist.ParseString(scurl.m_xml);
-        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+        for (; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
           scurlArtist.ParseElement(pxeLink);
 
         if (!scurlArtist.m_url.size())
@@ -1207,7 +1208,8 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
         std::string genre;
         XMLUtils::GetString(pxeArtist, "genre", genre);
         if (!genre.empty())
-          ari.GetArtist().genre = StringUtils::Split(genre, g_advancedSettings.m_musicItemSeparator);
+          ari.GetArtist().genre =
+              StringUtils::Split(genre, g_advancedSettings.m_musicItemSeparator);
         XMLUtils::GetString(pxeArtist, "year", ari.GetArtist().strBorn);
 
         vcari.push_back(ari);
@@ -1224,16 +1226,17 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
   if (scurl.m_url.empty())
     return vcep;
 
-  CLog::Log(LOGDEBUG, "%s: Searching '%s' using %s scraper "
-    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
-    scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Searching '%s' using %s scraper "
+            "(file: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
+            ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   if (m_isPython)
   {
     std::stringstream str;
-    str << "plugin://" << ID() << "?action=getepisodelist&url="
-        << CURL::Encode(scurl.m_url.front().m_url);
+    str << "plugin://" << ID()
+        << "?action=getepisodelist&url=" << CURL::Encode(scurl.m_url.front().m_url);
     CFileItemList items;
     if (!XFILE::CDirectory::GetDirectory(str.str(), items))
       return vcep;
@@ -1247,7 +1250,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
       ep.iSubepisode = items[i]->GetProperty("video.sub_episode").asInteger32();
       CScraperUrl::SUrlEntry surl;
       surl.m_type = CScraperUrl::URL_TYPE_GENERAL;
-      surl.m_url =  FromString(*items[i], "video.url");
+      surl.m_url = FromString(*items[i], "video.url");
       ep.cScraperUrl.m_url.push_back(surl);
       ep.cScraperUrl.strId = FromString(*items[i], "video.unique_id");
       vcep.push_back(ep);
@@ -1267,29 +1270,29 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
     doc.Parse(*i);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "%s: Unable to parse XML",__FUNCTION__);
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
       continue;
     }
 
     TiXmlHandle xhDoc(&doc);
-    for (TiXmlElement *pxeMovie = xhDoc.FirstChild("episodeguide").FirstChild("episode").
-      Element(); pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())
+    for (TiXmlElement *pxeMovie = xhDoc.FirstChild("episodeguide").FirstChild("episode").Element();
+         pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())
     {
       EPISODE ep;
       TiXmlElement *pxeLink = pxeMovie->FirstChildElement("url");
       std::string strEpNum;
       if (pxeLink && XMLUtils::GetInt(pxeMovie, "season", ep.iSeason) &&
-        XMLUtils::GetString(pxeMovie, "epnum", strEpNum) && !strEpNum.empty())
+          XMLUtils::GetString(pxeMovie, "epnum", strEpNum) && !strEpNum.empty())
       {
         CScraperUrl &scurlEp(ep.cScraperUrl);
         size_t dot = strEpNum.find(".");
         ep.iEpisode = atoi(strEpNum.c_str());
         ep.iSubepisode = (dot != std::string::npos) ? atoi(strEpNum.substr(dot + 1).c_str()) : 0;
-        if (!XMLUtils::GetString(pxeMovie, "title", scurlEp.strTitle) || scurlEp.strTitle.empty() )
-            scurlEp.strTitle = g_localizeStrings.Get(416);
+        if (!XMLUtils::GetString(pxeMovie, "title", scurlEp.strTitle) || scurlEp.strTitle.empty())
+          scurlEp.strTitle = g_localizeStrings.Get(416);
         XMLUtils::GetString(pxeMovie, "id", scurlEp.strId);
 
-        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+        for (; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
           scurlEp.ParseElement(pxeLink);
 
         // date must be the format of yyyy-mm-dd
@@ -1299,7 +1302,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
         {
           tm tm;
           if (strptime(sDate.c_str(), "%Y-%m-%d", &tm))
-            ep.cDate.SetDate(1900+tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
+            ep.cDate.SetDate(1900 + tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
         }
         vcep.push_back(ep);
       }
@@ -1312,13 +1315,15 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
 // takes URL; returns true and populates video details on success, false otherwise
 bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
                                const CScraperUrl &scurl,
-                               bool fMovie/*else episode*/,
+                               bool fMovie /*else episode*/,
                                CVideoInfoTag &video)
 {
-  CLog::Log(LOGDEBUG, "%s: Reading %s '%s' using %s scraper "
-    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
-    fMovie ? MediaTypeMovie : MediaTypeEpisode, scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Reading %s '%s' using %s scraper "
+            "(file: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, fMovie ? MediaTypeMovie : MediaTypeEpisode, scurl.m_url[0].m_url.c_str(),
+            Name().c_str(), Path().c_str(), ADDON::TranslateContent(Content()).c_str(),
+            Version().asString().c_str());
 
   video.Reset();
 
@@ -1351,8 +1356,8 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
       CLog::Log(LOGERROR, "%s: Invalid XML file (want <details>)", __FUNCTION__);
       continue;
     }
-    video.Load(pxeDetails, true/*fChain*/);
-    fRet = true;  // but don't exit in case of chaining
+    video.Load(pxeDetails, true /*fChain*/);
+    fRet = true; // but don't exit in case of chaining
   }
   return fRet;
 }
@@ -1360,14 +1365,14 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
 // takes a URL; returns true and populates album on success, false otherwise
 bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbum &album)
 {
-  CLog::Log(LOGDEBUG, "%s: Reading '%s' using %s scraper "
-    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
-    scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Reading '%s' using %s scraper "
+            "(file: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
+            ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   if (m_isPython)
-    return PythonDetails(ID(), "url", scurl.m_url.front().m_url,
-                         "getdetails", album);
+    return PythonDetails(ID(), "url", scurl.m_url.front().m_url, "getdetails", album);
 
   std::vector<std::string> vcsOut = RunNoThrow("GetAlbumDetails", scurl, fcurl);
 
@@ -1389,20 +1394,23 @@ bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbu
 
 // takes a URL (one returned from FindArtist), the original search string, and
 // returns true and populates artist on success, false on failure
-bool CScraper::GetArtistDetails(CCurlFile &fcurl, const CScraperUrl &scurl,
-  const std::string &sSearch, CArtist &artist)
+bool CScraper::GetArtistDetails(CCurlFile &fcurl,
+                                const CScraperUrl &scurl,
+                                const std::string &sSearch,
+                                CArtist &artist)
 {
   if (!scurl.m_url.size())
     return false;
 
-  CLog::Log(LOGDEBUG, "%s: Reading '%s' ('%s') using %s scraper "
-    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
-    scurl.m_url[0].m_url.c_str(), sSearch.c_str(), Name().c_str(), Path().c_str(),
-    ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Reading '%s' ('%s') using %s scraper "
+            "(file: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, scurl.m_url[0].m_url.c_str(), sSearch.c_str(), Name().c_str(),
+            Path().c_str(), ADDON::TranslateContent(Content()).c_str(),
+            Version().asString().c_str());
 
   if (m_isPython)
-    return PythonDetails(ID(), "url", scurl.m_url.front().m_url,
-                         "getdetails", artist);
+    return PythonDetails(ID(), "url", scurl.m_url.front().m_url, "getdetails", artist);
 
   // pass in the original search string for chaining to search other sites
   std::vector<std::string> vcIn;
@@ -1433,9 +1441,11 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
   if (!details.HasUniqueID())
     return false;
 
-  CLog::Log(LOGDEBUG, "%s: Reading artwork for '%s' using %s scraper "
-    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, details.GetUniqueID().c_str(),
-    Name().c_str(), Path().c_str(), ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
+  CLog::Log(LOGDEBUG,
+            "%s: Reading artwork for '%s' using %s scraper "
+            "(file: '%s', content: '%s', version: '%s')",
+            __FUNCTION__, details.GetUniqueID().c_str(), Name().c_str(), Path().c_str(),
+            ADDON::TranslateContent(Content()).c_str(), Version().asString().c_str());
 
   if (m_isPython)
     return PythonDetails(ID(), "id", details.GetUniqueID("IMDB"), "getartwork", details);
@@ -1459,5 +1469,4 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
   }
   return fRet;
 }
-
 }

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -414,6 +414,11 @@ int64_t CVariant::asInteger(int64_t fallback) const
   return fallback;
 }
 
+int32_t CVariant::asInteger32(int32_t fallback) const
+{
+  return static_cast<int32_t>(asInteger(fallback));
+}
+
 uint64_t CVariant::asUnsignedInteger(uint64_t fallback) const
 {
   switch (m_type)
@@ -433,6 +438,11 @@ uint64_t CVariant::asUnsignedInteger(uint64_t fallback) const
   }
   
   return fallback;
+}
+
+uint32_t CVariant::asUnsignedInteger32(uint32_t fallback) const
+{
+  return static_cast<uint32_t>(asUnsignedInteger(fallback));
 }
 
 double CVariant::asDouble(double fallback) const

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -93,7 +93,9 @@ public:
   VariantType type() const;
 
   int64_t asInteger(int64_t fallback = 0) const;
+  int32_t asInteger32(int32_t fallback = 0) const;
   uint64_t asUnsignedInteger(uint64_t fallback = 0u) const;
+  uint32_t asUnsignedInteger32(uint32_t fallback = 0u) const;
   bool asBoolean(bool fallback = false) const;
   std::string asString(const std::string &fallback = "") const;
   std::wstring asWideString(const std::wstring &fallback = L"") const;


### PR DESCRIPTION
Added 32-bit versions of asInteger to CVariant to cut down on the amount of casts needed.

Reminder that size_t is a variable size type, it's 64-bit on windows x64 so any return value from .size() will be an uint64_t on windows x64.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
