### PR TITLE
Expose controller models to the Game API

### DIFF
--- a/cmake/addons/bootstrap/repositories/binary-addons.txt
+++ b/cmake/addons/bootstrap/repositories/binary-addons.txt
@@ -1,1 +1,1 @@
-binary-addons https://github.com/xbmc/repo-binary-addons.git master
+binary-addons https://github.com/kodi-game/repo-binary-addons.git model

--- a/cmake/treedata/common/games.txt
+++ b/cmake/treedata/common/games.txt
@@ -1,5 +1,6 @@
 xbmc/games                         games
 xbmc/games/addons                  games/addons
+xbmc/games/addons/input            games/addons/input
 xbmc/games/addons/playback         games/addons/playback
 xbmc/games/addons/savestates       games/addons/savestates
 xbmc/games/controllers             games/controllers

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -73,9 +73,9 @@ namespace ADDON
 
     AddonPtr GetRunningInstance() const override;
 
-  protected:
-    bool Initialized() { return m_initialized; }
+    bool Initialized() const { return m_initialized; }
 
+  protected:
     static std::string GetDllPath(const std::string &strFileName);
 
     CAddonInterfaces* m_pHelpers;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -203,9 +203,9 @@ typedef enum GAME_REGION
 } GAME_REGION;
 
 /*!
-* Special game types passed into game_load_game_special(). Only used when
-* multiple ROMs are required.
-*/
+ * Special game types passed into game_load_game_special(). Only used when
+ * multiple ROMs are required.
+ */
 typedef enum SPECIAL_GAME_TYPE
 {
   SPECIAL_GAME_TYPE_BSX,

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -280,6 +280,7 @@ typedef enum GAME_ROTATION
 typedef struct game_controller
 {
   const char*  controller_id;
+  const char*  model;
   unsigned int digital_button_count;
   unsigned int analog_button_count;
   unsigned int analog_stick_count;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -91,8 +91,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_XML_ID    "kodi.binary.instance.audioencoder"
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "1.0.33"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "1.0.33"
+#define ADDON_INSTANCE_VERSION_GAME                   "1.0.34"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "1.0.34"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "kodi_game_dll.h" \
                                                       "kodi_game_types.h" \

--- a/xbmc/games/addons/CMakeLists.txt
+++ b/xbmc/games/addons/CMakeLists.txt
@@ -1,21 +1,15 @@
 set(SOURCES GameClient.cpp
-            GameClientHardware.cpp
             GameClientInGameSaves.cpp
-            GameClientJoystick.cpp
-            GameClientKeyboard.cpp
-            GameClientMouse.cpp
             GameClientProperties.cpp
+            GameClientSubsystem.cpp
             GameClientTiming.cpp
             GameClientTranslator.cpp)
 
 set(HEADERS GameClient.h
             GameClientCallbacks.h
-            GameClientHardware.h
             GameClientInGameSaves.h
-            GameClientJoystick.h
-            GameClientKeyboard.h
-            GameClientMouse.h
             GameClientProperties.h
+            GameClientSubsystem.h
             GameClientTiming.h
             GameClientTranslator.h)
 

--- a/xbmc/games/addons/GameClientSubsystem.cpp
+++ b/xbmc/games/addons/GameClientSubsystem.cpp
@@ -17,38 +17,20 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
-#include "input/hardware/IHardwareInput.h"
+#include "GameClientSubsystem.h"
+#include "GameClient.h"
 
-namespace KODI
+using namespace KODI;
+using namespace GAME;
+
+CGameClientSubsystem::CGameClientSubsystem(CGameClient &gameClient,
+                                           AddonInstance_Game &addonStruct,
+                                           CCriticalSection &clientAccess) :
+  m_gameClient(gameClient),
+  m_struct(addonStruct),
+  m_clientAccess(clientAccess)
 {
-namespace GAME
-{
-  class CGameClient;
-
-  /*!
-   * \ingroup games
-   * \brief Handles events for hardware such as reset buttons
-   */
-  class CGameClientHardware : public HARDWARE::IHardwareInput
-  {
-  public:
-    /*!
-     * \brief Constructor
-     *
-     * \param gameClient The game client implementation
-     */
-    explicit CGameClientHardware(CGameClient* gameClient);
-
-    virtual ~CGameClientHardware() = default;
-
-    // Implementation of IHardwareInput
-    virtual void OnResetButton(unsigned int port) override;
-
-  private:
-    // Construction parameter
-    CGameClient* const m_gameClient;
-  };
 }
-}
+
+CGameClientInput &CGameClientSubsystem::Input() const { return m_gameClient.Input(); }

--- a/xbmc/games/addons/GameClientSubsystem.h
+++ b/xbmc/games/addons/GameClientSubsystem.h
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+struct AddonInstance_Game;
+class CCriticalSection;
+
+namespace KODI
+{
+namespace GAME
+{
+  class CGameClient;
+  class CGameClientInput;
+
+  /*!
+   * \brief Base class for game client subsystems
+   */
+  class CGameClientSubsystem
+  {
+  protected:
+    CGameClientSubsystem(CGameClient &gameClient,
+                         AddonInstance_Game &addonStruct,
+                         CCriticalSection &clientAccess);
+
+    virtual ~CGameClientSubsystem() = default;
+
+    CGameClientInput &Input() const;
+    
+  protected:
+    CGameClient &m_gameClient;
+    AddonInstance_Game &m_struct;
+    CCriticalSection &m_clientAccess;
+  };
+
+}
+}

--- a/xbmc/games/addons/input/CMakeLists.txt
+++ b/xbmc/games/addons/input/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(SOURCES GameClientHardware.cpp
+            GameClientInput.cpp
+            GameClientJoystick.cpp
+            GameClientKeyboard.cpp
+            GameClientMouse.cpp
+)
+
+set(HEADERS GameClientHardware.h
+            GameClientInput.h
+            GameClientJoystick.h
+            GameClientKeyboard.h
+            GameClientMouse.h
+)
+
+core_add_library(gameinput)

--- a/xbmc/games/addons/input/GameClientHardware.cpp
+++ b/xbmc/games/addons/input/GameClientHardware.cpp
@@ -19,22 +19,19 @@
  */
 
 #include "GameClientHardware.h"
-#include "GameClient.h"
+#include "games/addons/GameClient.h"
 #include "utils/log.h"
-
-#include <assert.h>
 
 using namespace KODI;
 using namespace GAME;
 
-CGameClientHardware::CGameClientHardware(CGameClient* gameClient) :
+CGameClientHardware::CGameClientHardware(CGameClient &gameClient) :
   m_gameClient(gameClient)
 {
-  assert(m_gameClient != nullptr);
 }
 
 void CGameClientHardware::OnResetButton(unsigned int port)
 {
-  CLog::Log(LOGDEBUG, "%s: Port %d sending hardware reset", m_gameClient->ID().c_str(), port);
-  m_gameClient->Reset(port);
+  CLog::Log(LOGDEBUG, "%s: Port %d sending hardware reset", m_gameClient.ID().c_str(), port);
+  m_gameClient.Reset(port);
 }

--- a/xbmc/games/addons/input/GameClientHardware.h
+++ b/xbmc/games/addons/input/GameClientHardware.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/hardware/IHardwareInput.h"
+
+namespace KODI
+{
+namespace GAME
+{
+  class CGameClient;
+
+  /*!
+   * \ingroup games
+   * \brief Handles events for hardware such as reset buttons
+   */
+  class CGameClientHardware : public HARDWARE::IHardwareInput
+  {
+  public:
+    /*!
+     * \brief Constructor
+     *
+     * \param gameClient The game client implementation
+     */
+    explicit CGameClientHardware(CGameClient &gameClient);
+
+    virtual ~CGameClientHardware() = default;
+
+    // Implementation of IHardwareInput
+    virtual void OnResetButton(unsigned int port) override;
+
+  private:
+    // Construction parameter
+    CGameClient &m_gameClient;
+  };
+}
+}

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -93,6 +93,7 @@ bool CGameClientInput::OpenPort(unsigned int port)
   {
     //! @todo Choose controller
     ControllerPtr& controller = controllers[0];
+    std::string model = ""; //! @todo
 
     m_joysticks[port].reset(new CGameClientJoystick(m_gameClient, port, controller, m_struct.toAddon));
 
@@ -103,7 +104,7 @@ bool CGameClientInput::OpenPort(unsigned int port)
 
     CServiceBroker::GetGameServices().PortManager().OpenPort(m_joysticks[port].get(), m_hardware.get(), &m_gameClient, port, device);
 
-    UpdatePort(port, controller);
+    UpdatePort(port, controller, model);
 
     return true;
   }
@@ -121,7 +122,7 @@ void CGameClientInput::ClosePort(unsigned int port)
 
   m_joysticks.erase(port);
 
-  UpdatePort(port, CController::EmptyPtr);
+  UpdatePort(port, CController::EmptyPtr, "");
 }
 
 bool CGameClientInput::ReceiveInputEvent(const game_input_event& event)
@@ -141,7 +142,7 @@ bool CGameClientInput::ReceiveInputEvent(const game_input_event& event)
   return bHandled;
 }
 
-void CGameClientInput::UpdatePort(unsigned int port, const ControllerPtr& controller)
+void CGameClientInput::UpdatePort(unsigned int port, const ControllerPtr& controller, const std::string &model)
 {
   using namespace JOYSTICK;
 
@@ -156,6 +157,7 @@ void CGameClientInput::UpdatePort(unsigned int port, const ControllerPtr& contro
       game_controller controllerStruct;
 
       controllerStruct.controller_id        = strId.c_str();
+      controllerStruct.model                = model.c_str();
       controllerStruct.digital_button_count = controller->FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::DIGITAL);
       controllerStruct.analog_button_count  = controller->FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::ANALOG);
       controllerStruct.analog_stick_count   = controller->FeatureCount(FEATURE_TYPE::ANALOG_STICK);

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -1,0 +1,256 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameClientInput.h"
+#include "GameClientHardware.h"
+#include "GameClientJoystick.h"
+#include "GameClientKeyboard.h"
+#include "GameClientMouse.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "games/addons/GameClient.h"
+#include "games/controllers/Controller.h"
+#include "games/ports/PortManager.h"
+#include "games/GameServices.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/WindowIDs.h"
+#include "input/joysticks/JoystickTypes.h"
+#include "input/InputManager.h"
+#include "peripherals/Peripherals.h"
+//#include "threads/SingleLock.h"
+#include "utils/log.h"
+#include "ServiceBroker.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CGameClientInput::CGameClientInput(CGameClient &gameClient,
+                                   AddonInstance_Game &addonStruct,
+                                   CCriticalSection &clientAccess) :
+  CGameClientSubsystem(gameClient, addonStruct, clientAccess)
+{
+}
+
+CGameClientInput::~CGameClientInput()
+{
+  Deinitialize();
+}
+
+void CGameClientInput::Initialize()
+{
+  if (m_gameClient.SupportsKeyboard())
+    OpenKeyboard();
+
+  if (m_gameClient.SupportsMouse())
+    OpenMouse();
+}
+
+void CGameClientInput::Deinitialize()
+{
+  while (!m_joysticks.empty())
+    ClosePort(m_joysticks.begin()->first);
+
+  m_hardware.reset();
+
+  CloseKeyboard();
+
+  CloseMouse();
+}
+
+bool CGameClientInput::AcceptsInput() const
+{
+  return g_windowManager.GetActiveWindowID() == WINDOW_FULLSCREEN_GAME;
+}
+
+bool CGameClientInput::OpenPort(unsigned int port)
+{
+  // Fail if port is already open
+  if (m_joysticks.find(port) != m_joysticks.end())
+    return false;
+
+  // Ensure hardware is open to receive events from the port
+  if (!m_hardware)
+    m_hardware.reset(new CGameClientHardware(m_gameClient));
+
+  ControllerVector controllers = GetControllers(m_gameClient);
+  if (!controllers.empty())
+  {
+    //! @todo Choose controller
+    ControllerPtr& controller = controllers[0];
+
+    m_joysticks[port].reset(new CGameClientJoystick(m_gameClient, port, controller, m_struct.toAddon));
+
+    // If keyboard input is being captured by this add-on, force the port type to PERIPHERAL_JOYSTICK
+    PERIPHERALS::PeripheralType device = PERIPHERALS::PERIPHERAL_UNKNOWN;
+    if (m_gameClient.SupportsKeyboard())
+      device = PERIPHERALS::PERIPHERAL_JOYSTICK;
+
+    CServiceBroker::GetGameServices().PortManager().OpenPort(m_joysticks[port].get(), m_hardware.get(), &m_gameClient, port, device);
+
+    UpdatePort(port, controller);
+
+    return true;
+  }
+
+  return false;
+}
+
+void CGameClientInput::ClosePort(unsigned int port)
+{
+  // Can't close port if it doesn't exist
+  if (m_joysticks.find(port) == m_joysticks.end())
+    return;
+
+  CServiceBroker::GetGameServices().PortManager().ClosePort(m_joysticks[port].get());
+
+  m_joysticks.erase(port);
+
+  UpdatePort(port, CController::EmptyPtr);
+}
+
+bool CGameClientInput::ReceiveInputEvent(const game_input_event& event)
+{
+  bool bHandled = false;
+
+  switch (event.type)
+  {
+    case GAME_INPUT_EVENT_MOTOR:
+      if (event.feature_name)
+        bHandled = SetRumble(event.port, event.feature_name, event.motor.magnitude);
+      break;
+    default:
+      break;
+  }
+
+  return bHandled;
+}
+
+void CGameClientInput::UpdatePort(unsigned int port, const ControllerPtr& controller)
+{
+  using namespace JOYSTICK;
+
+  CSingleLock lock(m_clientAccess);
+
+  if (m_gameClient.Initialized())
+  {
+    if (controller != CController::EmptyPtr)
+    {
+      std::string strId = controller->ID();
+
+      game_controller controllerStruct;
+
+      controllerStruct.controller_id        = strId.c_str();
+      controllerStruct.digital_button_count = controller->FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::DIGITAL);
+      controllerStruct.analog_button_count  = controller->FeatureCount(FEATURE_TYPE::SCALAR, INPUT_TYPE::ANALOG);
+      controllerStruct.analog_stick_count   = controller->FeatureCount(FEATURE_TYPE::ANALOG_STICK);
+      controllerStruct.accelerometer_count  = controller->FeatureCount(FEATURE_TYPE::ACCELEROMETER);
+      controllerStruct.key_count            = 0; //! @todo
+      controllerStruct.rel_pointer_count    = controller->FeatureCount(FEATURE_TYPE::RELPOINTER);
+      controllerStruct.abs_pointer_count    = controller->FeatureCount(FEATURE_TYPE::ABSPOINTER);
+      controllerStruct.motor_count          = controller->FeatureCount(FEATURE_TYPE::MOTOR);
+
+      try { m_struct.toAddon.UpdatePort(port, true, &controllerStruct); }
+      catch (...) { m_gameClient.LogException("UpdatePort()"); }
+    }
+    else
+    {
+      try { m_struct.toAddon.UpdatePort(port, false, nullptr); }
+      catch (...) { m_gameClient.LogException("UpdatePort()"); }
+    }
+  }
+}
+
+void CGameClientInput::OpenKeyboard()
+{
+  m_keyboard.reset(new CGameClientKeyboard(m_gameClient, m_struct.toAddon, &CServiceBroker::GetInputManager()));
+}
+
+void CGameClientInput::CloseKeyboard()
+{
+  m_keyboard.reset();
+}
+
+void CGameClientInput::OpenMouse()
+{
+  m_mouse.reset(new CGameClientMouse(m_gameClient, m_struct.toAddon, &CServiceBroker::GetInputManager()));
+
+  CSingleLock lock(m_clientAccess);
+
+  if (m_gameClient.Initialized())
+  {
+    std::string strId = m_mouse->ControllerID();
+
+    game_controller controllerStruct = { strId.c_str() };
+
+    try { m_struct.toAddon.UpdatePort(GAME_INPUT_PORT_MOUSE, true, &controllerStruct); }
+    catch (...) { m_gameClient.LogException("UpdatePort()"); }
+  }
+}
+
+void CGameClientInput::CloseMouse()
+{
+  {
+    CSingleLock lock(m_clientAccess);
+
+    if (m_gameClient.Initialized())
+    {
+      try { m_struct.toAddon.UpdatePort(GAME_INPUT_PORT_MOUSE, false, nullptr); }
+      catch (...) { m_gameClient.LogException("UpdatePort()"); }
+    }
+  }
+
+  m_mouse.reset();
+}
+
+bool CGameClientInput::SetRumble(unsigned int port, const std::string& feature, float magnitude)
+{
+  bool bHandled = false;
+
+  if (m_joysticks.find(port) != m_joysticks.end())
+    bHandled = m_joysticks[port]->SetRumble(feature, magnitude);
+
+  return bHandled;
+}
+
+ControllerVector CGameClientInput::GetControllers(const CGameClient &gameClient)
+{
+  using namespace ADDON;
+
+  ControllerVector controllers;
+
+  CGameServices& gameServices = CServiceBroker::GetGameServices();
+
+  const ADDONDEPS& dependencies = gameClient.GetDeps();
+  for (ADDONDEPS::const_iterator it = dependencies.begin(); it != dependencies.end(); ++it)
+  {
+    ControllerPtr controller = gameServices.GetController(it->first);
+    if (controller)
+      controllers.push_back(controller);
+  }
+
+  if (controllers.empty())
+  {
+    // Use the default controller
+    ControllerPtr controller = gameServices.GetDefaultController();
+    if (controller)
+      controllers.push_back(controller);
+  }
+
+  return controllers;
+}

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -1,0 +1,82 @@
+/*
+ *      Copyright (C) 2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "games/addons/GameClientSubsystem.h"
+#include "games/controllers/ControllerTypes.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+class CCriticalSection;
+struct game_input_event;
+
+namespace KODI
+{
+namespace GAME
+{
+  class CGameClient;
+  class CGameClientHardware;
+  class CGameClientJoystick;
+  class CGameClientKeyboard;
+  class CGameClientMouse;
+
+  class CGameClientInput : protected CGameClientSubsystem
+  {
+  public:
+    CGameClientInput(CGameClient &gameClient,
+                     AddonInstance_Game &addonStruct,
+                     CCriticalSection &clientAccess);
+    ~CGameClientInput() override;
+
+    void Initialize();
+    void Deinitialize();
+
+    // Input functions
+    bool AcceptsInput() const;
+
+    // Input callbacks
+    bool OpenPort(unsigned int port);
+    void ClosePort(unsigned int port);
+    bool ReceiveInputEvent(const game_input_event& eventStruct);
+
+  private:
+    // Private input helpers
+    void UpdatePort(unsigned int port, const ControllerPtr& controller);
+    void OpenKeyboard();
+    void CloseKeyboard();
+    void OpenMouse();
+    void CloseMouse();
+
+    // Private callback helpers
+    bool SetRumble(unsigned int port, const std::string& feature, float magnitude);
+
+    // Helper functions
+    static ControllerVector GetControllers(const CGameClient &gameClient);
+
+    // Input properties
+    std::map<int, std::unique_ptr<CGameClientJoystick>> m_joysticks;
+    std::unique_ptr<CGameClientKeyboard> m_keyboard;
+    std::unique_ptr<CGameClientMouse> m_mouse;
+    std::unique_ptr<CGameClientHardware> m_hardware;
+  };
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -60,7 +60,7 @@ namespace GAME
 
   private:
     // Private input helpers
-    void UpdatePort(unsigned int port, const ControllerPtr& controller);
+    void UpdatePort(unsigned int port, const ControllerPtr& controller, const std::string &model);
     void OpenKeyboard();
     void CloseKeyboard();
     void OpenMouse();

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -19,24 +19,26 @@
  */
 
 #include "GameClientJoystick.h"
-#include "GameClient.h"
+#include "GameClientInput.h"
+#include "games/addons/GameClient.h"
 #include "games/controllers/Controller.h"
 #include "input/joysticks/IInputReceiver.h"
 #include "utils/log.h"
 
-#include <algorithm>
 #include <assert.h>
 
 using namespace KODI;
 using namespace GAME;
 
-CGameClientJoystick::CGameClientJoystick(CGameClient* gameClient, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game *dllStruct) :
+CGameClientJoystick::CGameClientJoystick(const CGameClient &gameClient,
+                                         int port,
+                                         const ControllerPtr& controller,
+                                         const KodiToAddonFuncTable_Game &dllStruct) :
   m_gameClient(gameClient),
   m_port(port),
   m_controller(controller),
   m_dllStruct(dllStruct)
 {
-  assert(m_gameClient != NULL);
   assert(m_controller.get() != NULL);
 }
 
@@ -49,11 +51,11 @@ bool CGameClientJoystick::HasFeature(const std::string& feature) const
 {
   try
   {
-    return m_dllStruct->HasFeature(m_controller->ID().c_str(), feature.c_str());
+    return m_dllStruct.HasFeature(m_controller->ID().c_str(), feature.c_str());
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in HasFeature()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in HasFeature()", m_gameClient.ID().c_str());
   }
 
   return false;
@@ -61,7 +63,7 @@ bool CGameClientJoystick::HasFeature(const std::string& feature) const
 
 bool CGameClientJoystick::AcceptsInput(const std::string &feature) const
 {
-  return m_gameClient->AcceptsInput();
+  return m_gameClient.Input().AcceptsInput();
 }
 
 bool CGameClientJoystick::OnButtonPress(const std::string& feature, bool bPressed)
@@ -80,11 +82,11 @@ bool CGameClientJoystick::OnButtonPress(const std::string& feature, bool bPresse
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 
   return bHandled;
@@ -106,11 +108,11 @@ bool CGameClientJoystick::OnButtonMotion(const std::string& feature, float magni
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 
   return bHandled;
@@ -133,11 +135,11 @@ bool CGameClientJoystick::OnAnalogStickMotion(const std::string& feature, float 
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 
   return bHandled;
@@ -161,11 +163,11 @@ bool CGameClientJoystick::OnAccelerometerMotion(const std::string& feature, floa
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 
   return bHandled;
@@ -187,12 +189,12 @@ bool CGameClientJoystick::OnWheelMotion(const std::string& feature, float positi
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "GAME: %s: exception caught while handling wheel \"%s\"",
-              m_gameClient->ID().c_str(), feature.c_str());
+              m_gameClient.ID().c_str(), feature.c_str());
   }
 
   return bHandled;
@@ -214,12 +216,12 @@ bool CGameClientJoystick::OnThrottleMotion(const std::string& feature, float pos
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "GAME: %s: exception caught while handling throttle \"%s\"",
-              m_gameClient->ID().c_str(), feature.c_str());
+              m_gameClient.ID().c_str(), feature.c_str());
   }
 
   return bHandled;

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -46,7 +46,10 @@ namespace GAME
      * \param controller The game controller which is used (for controller mapping).
      * \param dllStruct The emulator or game to which the events are sent.
      */
-    CGameClientJoystick(CGameClient* addon, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game* dllStruct);
+    CGameClientJoystick(const CGameClient &addon,
+                        int port,
+                        const ControllerPtr& controller,
+                        const KodiToAddonFuncTable_Game &dllStruct);
 
     virtual ~CGameClientJoystick() = default;
 
@@ -65,10 +68,10 @@ namespace GAME
     bool SetRumble(const std::string& feature, float magnitude);
 
   private:
-    const CGameClient* const  m_gameClient;
+    const CGameClient &m_gameClient;
     const int                 m_port;
     const ControllerPtr       m_controller;
-    const KodiToAddonFuncTable_Game* const m_dllStruct;
+    const KodiToAddonFuncTable_Game &m_dllStruct;
   };
 }
 }

--- a/xbmc/games/addons/input/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/input/GameClientKeyboard.cpp
@@ -19,9 +19,10 @@
  */
 
 #include "GameClientKeyboard.h"
-#include "GameClient.h"
-#include "GameClientTranslator.h"
+#include "GameClientInput.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "games/addons/GameClient.h"
+#include "games/addons/GameClientTranslator.h"
 #include "input/keyboard/IKeyboardInputProvider.h"
 #include "input/Key.h"
 #include "utils/log.h"
@@ -31,7 +32,9 @@ using namespace GAME;
 
 #define BUTTON_INDEX_MASK  0x01ff
 
-CGameClientKeyboard::CGameClientKeyboard(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct, KEYBOARD::IKeyboardInputProvider *inputProvider) :
+CGameClientKeyboard::CGameClientKeyboard(const CGameClient &gameClient,
+                                         const KodiToAddonFuncTable_Game &dllStruct,
+                                         KEYBOARD::IKeyboardInputProvider *inputProvider) :
   m_gameClient(gameClient),
   m_dllStruct(dllStruct),
   m_inputProvider(inputProvider)
@@ -47,7 +50,7 @@ CGameClientKeyboard::~CGameClientKeyboard()
 bool CGameClientKeyboard::OnKeyPress(const CKey& key)
 {
   // Only allow activated input in fullscreen game
-  if (!m_gameClient->AcceptsInput())
+  if (!m_gameClient.Input().AcceptsInput())
   {
     CLog::Log(LOGDEBUG, "GAME: key press ignored, not in fullscreen game");
     return false;
@@ -69,11 +72,11 @@ bool CGameClientKeyboard::OnKeyPress(const CKey& key)
   {
     try
     {
-      bHandled = m_dllStruct->InputEvent(&event);
+      bHandled = m_dllStruct.InputEvent(&event);
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+      CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
     }
   }
 
@@ -96,11 +99,11 @@ void CGameClientKeyboard::OnKeyRelease(const CKey& key)
   {
     try
     {
-      m_dllStruct->InputEvent(&event);
+      m_dllStruct.InputEvent(&event);
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+      CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
     }
   }
 }

--- a/xbmc/games/addons/input/GameClientKeyboard.h
+++ b/xbmc/games/addons/input/GameClientKeyboard.h
@@ -49,7 +49,9 @@ namespace GAME
      * \param dllStruct The emulator or game to which the events are sent.
      * \param inputProvider The interface providing us with keyboard input.
      */
-    CGameClientKeyboard(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct, KEYBOARD::IKeyboardInputProvider *inputProvider);
+    CGameClientKeyboard(const CGameClient &gameClient,
+                        const KodiToAddonFuncTable_Game &dllStruct,
+                        KEYBOARD::IKeyboardInputProvider *inputProvider);
 
     /*!
      * \brief Destructor unregisters from keyboard events from CInputManager.
@@ -62,8 +64,8 @@ namespace GAME
 
   private:
     // Construction parameters
-    const CGameClient* const m_gameClient;
-    const KodiToAddonFuncTable_Game* const m_dllStruct;
+    const CGameClient &m_gameClient;
+    const KodiToAddonFuncTable_Game &m_dllStruct;
     KEYBOARD::IKeyboardInputProvider *const m_inputProvider;
   };
 }

--- a/xbmc/games/addons/input/GameClientMouse.cpp
+++ b/xbmc/games/addons/input/GameClientMouse.cpp
@@ -19,9 +19,9 @@
  */
 
 #include "GameClientMouse.h"
-#include "GameClient.h"
-#include "GameClientTranslator.h"
+#include "GameClientInput.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "games/addons/GameClient.h"
 #include "input/mouse/IMouseInputProvider.h"
 #include "input/Key.h"
 #include "utils/log.h"
@@ -29,7 +29,9 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameClientMouse::CGameClientMouse(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct, MOUSE::IMouseInputProvider *inputProvider) :
+CGameClientMouse::CGameClientMouse(const CGameClient &gameClient,
+                                   const KodiToAddonFuncTable_Game &dllStruct,
+                                   MOUSE::IMouseInputProvider *inputProvider) :
   m_gameClient(gameClient),
   m_dllStruct(dllStruct),
   m_inputProvider(inputProvider),
@@ -50,7 +52,7 @@ std::string CGameClientMouse::ControllerID(void) const
 bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
 {
   // Only allow activated input in fullscreen game
-  if (!m_gameClient->AcceptsInput())
+  if (!m_gameClient.Input().AcceptsInput())
   {
     return false;
   }
@@ -68,11 +70,11 @@ bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 
   return bHandled;
@@ -81,7 +83,7 @@ bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
 bool CGameClientMouse::OnButtonPress(const std::string& button)
 {
   // Only allow activated input in fullscreen game
-  if (!m_gameClient->AcceptsInput())
+  if (!m_gameClient.Input().AcceptsInput())
   {
     return false;
   }
@@ -98,11 +100,11 @@ bool CGameClientMouse::OnButtonPress(const std::string& button)
 
   try
   {
-    bHandled = m_dllStruct->InputEvent(&event);
+    bHandled = m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 
   return bHandled;
@@ -120,10 +122,10 @@ void CGameClientMouse::OnButtonRelease(const std::string& button)
 
   try
   {
-    m_dllStruct->InputEvent(&event);
+    m_dllStruct.InputEvent(&event);
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient.ID().c_str());
   }
 }

--- a/xbmc/games/addons/input/GameClientMouse.h
+++ b/xbmc/games/addons/input/GameClientMouse.h
@@ -49,7 +49,9 @@ namespace GAME
      * \param dllStruct The emulator or game to which the events are sent.
      * \param inputProvider The interface providing us with mouse input.
      */
-    CGameClientMouse(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct, MOUSE::IMouseInputProvider *inputProvider);
+    CGameClientMouse(const CGameClient &gameClient,
+                     const KodiToAddonFuncTable_Game &dllStruct,
+                     MOUSE::IMouseInputProvider *inputProvider);
 
     /*!
      * \brief Destructor unregisters from mouse events from CInputManager.
@@ -64,8 +66,8 @@ namespace GAME
 
   private:
     // Construction parameters
-    const CGameClient* const m_gameClient;
-    const KodiToAddonFuncTable_Game* const m_dllStruct;
+    const CGameClient &m_gameClient;
+    const KodiToAddonFuncTable_Game &m_dllStruct;
     MOUSE::IMouseInputProvider *const m_inputProvider;
     const std::string m_controllerId;
   };

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -41,7 +41,7 @@ public:
   int LabelID(void) const { return m_labelId; }
   const std::string& Icon(void) const { return m_icon; }
   const std::string& Image(void) const   { return m_strImage; }
-  const std::string Models() const { return m_models; }
+  const std::string& Models() const { return m_models; }
 
   /*!
    * \brief Ensures the layout was deserialized correctly, and optionally logs if not

--- a/xbmc/games/ports/InputSink.cpp
+++ b/xbmc/games/ports/InputSink.cpp
@@ -20,6 +20,7 @@
 
 #include "InputSink.h"
 #include "games/addons/GameClient.h"
+#include "games/addons/input/GameClientInput.h"
 #include "input/joysticks/JoystickIDs.h"
 
 using namespace KODI;
@@ -37,7 +38,7 @@ std::string CInputSink::ControllerID(void) const
 
 bool CInputSink::AcceptsInput(const std::string& feature) const
 {
-  return m_gameClient.AcceptsInput();
+  return m_gameClient.Input().AcceptsInput();
 }
 
 bool CInputSink::OnButtonPress(const std::string& feature, bool bPressed)

--- a/xbmc/games/ports/Port.cpp
+++ b/xbmc/games/ports/Port.cpp
@@ -21,6 +21,7 @@
 #include "Port.h"
 #include "InputSink.h"
 #include "games/addons/GameClient.h"
+#include "games/addons/input/GameClientInput.h"
 #include "guilib/WindowIDs.h"
 #include "input/joysticks/keymaps/KeymapHandling.h"
 #include "peripherals/devices/Peripheral.h"
@@ -65,12 +66,12 @@ std::string CPort::ControllerID() const
 
 bool CPort::AcceptsInput(const std::string& feature) const
 {
-  return m_gameClient.AcceptsInput();
+  return m_gameClient.Input().AcceptsInput();
 }
 
 bool CPort::OnButtonPress(const std::string& feature, bool bPressed)
 {
-  if (bPressed && !m_gameClient.AcceptsInput())
+  if (bPressed && !m_gameClient.Input().AcceptsInput())
     return false;
 
   return m_gameInput->OnButtonPress(feature, bPressed);
@@ -83,7 +84,7 @@ void CPort::OnButtonHold(const std::string& feature, unsigned int holdTimeMs)
 
 bool CPort::OnButtonMotion(const std::string& feature, float magnitude, unsigned int motionTimeMs)
 {
-  if (magnitude > 0.0f && !m_gameClient.AcceptsInput())
+  if (magnitude > 0.0f && !m_gameClient.Input().AcceptsInput())
     return false;
 
   return m_gameInput->OnButtonMotion(feature, magnitude, motionTimeMs);
@@ -91,7 +92,7 @@ bool CPort::OnButtonMotion(const std::string& feature, float magnitude, unsigned
 
 bool CPort::OnAnalogStickMotion(const std::string& feature, float x, float y, unsigned int motionTimeMs)
 {
-  if ((x != 0.0f || y != 0.0f) && !m_gameClient.AcceptsInput())
+  if ((x != 0.0f || y != 0.0f) && !m_gameClient.Input().AcceptsInput())
     return false;
 
   return m_gameInput->OnAnalogStickMotion(feature, x, y, motionTimeMs);
@@ -99,7 +100,7 @@ bool CPort::OnAnalogStickMotion(const std::string& feature, float x, float y, un
 
 bool CPort::OnAccelerometerMotion(const std::string& feature, float x, float y, float z)
 {
-  if (!m_gameClient.AcceptsInput())
+  if (!m_gameClient.Input().AcceptsInput())
     return false;
 
   return m_gameInput->OnAccelerometerMotion(feature, x, y, z);
@@ -107,7 +108,7 @@ bool CPort::OnAccelerometerMotion(const std::string& feature, float x, float y, 
 
 bool CPort::OnWheelMotion(const std::string& feature, float position, unsigned int motionTimeMs)
 {
-  if ((position != 0.0f) && !m_gameClient.AcceptsInput())
+  if ((position != 0.0f) && !m_gameClient.Input().AcceptsInput())
     return false;
 
   return m_gameInput->OnWheelMotion(feature, position, motionTimeMs);
@@ -115,7 +116,7 @@ bool CPort::OnWheelMotion(const std::string& feature, float position, unsigned i
 
 bool CPort::OnThrottleMotion(const std::string& feature, float position, unsigned int motionTimeMs)
 {
-  if ((position != 0.0f) && !m_gameClient.AcceptsInput())
+  if ((position != 0.0f) && !m_gameClient.Input().AcceptsInput())
     return false;
 
   return m_gameInput->OnThrottleMotion(feature, position, motionTimeMs);


### PR DESCRIPTION
This PR:

* Refactors the game add-on input code to a new subdirectory
* Exposes the models added in https://github.com/xbmc/xbmc/pull/12608 to the Game API

Models are used in the upcoming Player Manager, so for now we pass an empty model name. The main commit, "[Game API] v1.0.34: Add controller model support", is therefore relatively small. The bulk of the PR is moving code around.

See https://github.com/kodi-game/game.libretro/pull/25 for emulator buttonmap documentation.

Requires https://github.com/kodi-game/game.libretro/pull/25.

## Motivation and Context
Item from my list of Player Manager tasks: https://github.com/garbear/xbmc/issues/87

## How Has This Been Tested?
Saturn is untested, but it doesn't break input on other platforms.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)