### PR TITLE
[PVR] Fix parental locked channels snafu.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -141,6 +141,7 @@ CPVRManager::CPVRManager(void) :
     m_bFirstStart(true),
     m_bEpgsCreated(false),
     m_managerState(ManagerStateStopped),
+    m_parentalTimer(new CStopWatch),
     m_settings({
       CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
       CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,


### PR DESCRIPTION
Fixes a regression I introduced during recent pvr manager start/stop refactoring. :-/

The issue was reported in the forum: https://forum.kodi.tv/showthread.php?tid=326060

No review needed because this is a no-brainer one liner.