### PR TITLE
StackHelper increase part times precision to msec and bugfix

### DIFF
--- a/xbmc/ApplicationStackHelper.h
+++ b/xbmc/ApplicationStackHelper.h
@@ -89,29 +89,29 @@ public:
   \brief Returns the end time of a FileItem part of a (non-ISO) stack playback
   \param partNumber the requested part number in the stack
   */
-  double GetStackPartEndTime(int partNumber) const { return GetStackPartFileItem(partNumber).m_lEndOffset; }
+  uint64_t GetStackPartEndTimeMs(int partNumber) const { return GetStackPartFileItem(partNumber).m_lEndOffset * 1000 / 75; }
 
   /*!
   \brief Returns the start time of a FileItem part of a (non-ISO) stack playback
   \param partNumber the requested part number in the stack
   */
-  double GetStackPartStartTime(int partNumber) const { return (partNumber > 0) ? GetStackPartEndTime(partNumber - 1) : 0; }
+  uint64_t GetStackPartStartTimeMs(int partNumber) const { return (partNumber > 0) ? GetStackPartEndTimeMs(partNumber - 1) : 0; }
 
   /*!
   \brief Returns the start time of the current FileItem part of a (non-ISO) stack playback
   */
-  double GetCurrentStackPartStartTime() const { return GetStackPartStartTime(m_currentStackPosition); }
+  uint64_t GetCurrentStackPartStartTimeMs() const { return GetStackPartStartTimeMs(m_currentStackPosition); }
 
   /*!
   \brief Returns the total time of a (non-ISO) stack playback
   */
-  double GetStackTotalTime() const { return GetStackPartEndTime(m_currentStack->Size() - 1); }
+  uint64_t GetStackTotalTimeMs() const { return GetStackPartEndTimeMs(m_currentStack->Size() - 1); }
 
   /*!
   \brief Returns the stack part number corresponding to the given timestamp in a (non-ISO) stack playback
-  \param seconds the requested timestamp in the stack (in seconds)
+  \param msecs the requested timestamp in the stack (in milliseconds)
   */
-  int GetStackPartNumberAtTime(double seconds);
+  int GetStackPartNumberAtTimeMs(uint64_t msecs);
 
   // Stack information registration methods
 
@@ -155,27 +155,27 @@ public:
   \brief Returns the start time of the part in the parameter
   \param item the reference to the item that is part of a stack
   */
-  int GetRegisteredStackPartStartTime(const CFileItem& item);
+  uint64_t GetRegisteredStackPartStartTimeMs(const CFileItem& item);
 
   /*!
   \brief Stores the part start time in the item-stack map.
   \param item the reference to the item that is part of a stack
   \param startTime the start time of the part in other parameter
   */
-  void SetRegisteredStackPartStartTime(const CFileItem& item, int startTime);
+  void SetRegisteredStackPartStartTimeMs(const CFileItem& item, uint64_t startTimeMs);
 
   /*!
   \brief Returns the total time of the stack associated to the part in the parameter
   \param item the reference to the item that is part of a stack
   */
-  int GetRegisteredStackTotalTime(const CFileItem& item);
+  uint64_t GetRegisteredStackTotalTimeMs(const CFileItem& item);
 
   /*!
   \brief Stores the stack's total time associated to the part in the item-stack map.
   \param item the reference to the item that is part of a stack
   \param totalTime the total time of the stack
   */
-  void SetRegisteredStackTotalTime(const CFileItem& item, int totalTime);
+  void SetRegisteredStackTotalTimeMs(const CFileItem& item, uint64_t totalTimeMs);
 
   CCriticalSection m_critSection;
 
@@ -187,12 +187,12 @@ protected:
     StackPartInformation()
     {
       m_lStackPartNumber = 0;
-      m_lStackPartStartTime = 0;
-      m_lStackTotalTime = 0;
+      m_lStackPartStartTimeMs = 0;
+      m_lStackTotalTimeMs = 0;
       m_pStack = nullptr;
     };
-    int m_lStackPartStartTime;
-    int m_lStackTotalTime;
+    uint64_t m_lStackPartStartTimeMs;
+    uint64_t m_lStackTotalTimeMs;
     int m_lStackPartNumber;
     CFileItemPtr m_pStack;
   };

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -142,7 +142,7 @@ void CSaveFileState::DoWork(CFileItem& item,
         }
 
         // could be part of an ISO stacks. In this case the bookmark is saved onto the part. In order to properly update the the list, we need to refresh the stack's resume point
-        if (g_application.m_pStackHelper->HasRegisteredStack(item) && g_application.m_pStackHelper->GetRegisteredStackTotalTime(item) == 0)
+        if (g_application.m_pStackHelper->HasRegisteredStack(item) && g_application.m_pStackHelper->GetRegisteredStackTotalTimeMs(item) == 0)
           videodatabase.GetResumePoint(*(g_application.m_pStackHelper->GetRegisteredStack(item)->GetVideoInfoTag()));
 
         videodatabase.Close();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4522,7 +4522,7 @@ bool CVideoDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
 
 /// \brief GetStackTimes() obtains any saved video times for the stacked file
 /// \retval Returns true if the stack times exist, false otherwise.
-bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<int> &times)
+bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<uint64_t> &times)
 {
   try
   {
@@ -4536,13 +4536,14 @@ bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<int>
     m_pDS->query( strSQL );
     if (m_pDS->num_rows() > 0)
     { // get the video settings info
-      int timeTotal = 0;
+      uint64_t timeTotal = 0;
       std::vector<std::string> timeString = StringUtils::Split(m_pDS->fv("times").get_asString(), ",");
       times.clear();
       for (const auto &i : timeString)
       {
-        times.push_back(atoi(i.c_str()));
-        timeTotal += atoi(i.c_str());
+        uint64_t partTime = static_cast<uint64_t>(atof(i.c_str()) * 1000.0f);
+        times.push_back(partTime); // db stores in secs, convert to msecs
+        timeTotal += partTime;
       }
       m_pDS->close();
       return (timeTotal > 0);
@@ -4557,7 +4558,7 @@ bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<int>
 }
 
 /// \brief Sets the stack times for a particular video file
-void CVideoDatabase::SetStackTimes(const std::string& filePath, const std::vector<int> &times)
+void CVideoDatabase::SetStackTimes(const std::string& filePath, const std::vector<uint64_t> &times)
 {
   try
   {
@@ -4571,9 +4572,9 @@ void CVideoDatabase::SetStackTimes(const std::string& filePath, const std::vecto
     m_pDS->exec( PrepareSQL("delete from stacktimes where idFile=%i", idFile) );
 
     // add the items
-    std::string timeString = StringUtils::Format("%i", times[0]);
+    std::string timeString = StringUtils::Format("%.3f", times[0] / 1000.0f);
     for (unsigned int i = 1; i < times.size(); i++)
-      timeString += StringUtils::Format(",%i", times[i]);
+      timeString += StringUtils::Format(",%.3f", times[i] / 1000.0f);
 
     m_pDS->exec( PrepareSQL("insert into stacktimes (idFile,times) values (%i,'%s')\n", idFile, timeString.c_str()) );
   }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -603,8 +603,8 @@ public:
    */
   void EraseVideoSettings(const std::string &path = "");
 
-  bool GetStackTimes(const std::string &filePath, std::vector<int> &times);
-  void SetStackTimes(const std::string &filePath, const std::vector<int> &times);
+  bool GetStackTimes(const std::string &filePath, std::vector<uint64_t> &times);
+  void SetStackTimes(const std::string &filePath, const std::vector<uint64_t> &times);
 
   void GetBookMarksForFile(const std::string& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, bool bAppend=false, long partNumber=0);
   void AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -826,7 +826,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       {
         if (URIUtils::IsStack(path))
         {
-          std::vector<int> times;
+          std::vector<uint64_t> times;
           if (m_database.GetStackTimes(path,times) || CFileItem(CStackDirectory::GetFirstStackedFile(path),false).IsDiscImage())
             buttons.Add(CONTEXT_BUTTON_PLAY_PART, 20324);
         }
@@ -935,9 +935,9 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int iItem)
     {
       if (selectedFile > 0)
       {
-        std::vector<int> times;
+        std::vector<uint64_t> times;
         if (m_database.GetStackTimes(path,times))
-          stack->m_lStartOffset = times[selectedFile - 1] * 75;
+          stack->m_lStartOffset = static_cast<int>( times[selectedFile - 1] * 75 / 1000);
       }
       else
         stack->m_lStartOffset = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
see title
## Description
<!--- Describe your change in detail -->
following PR #13235 some CApplicationStackHelper internals are modified to increase times precision to double (instead of int). Also, CFileItem's startOffset & endOffset are now properly used as seconds multiplied by 75. It was incorrectly used by CApplicationStackHelper in #13235, but not really an issue as long as the startOffset & endOffset were not used by anything else. Now this is in line and shouldn't be an issue with the rest of the code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
