### PR TITLE
Replace "Play programme" with "Play program"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -10446,7 +10446,7 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
 #: xbmc/pvr/PVRContextMenus.cpp
 msgctxt "#19190"
-msgid "Play programme"
+msgid "Play program"
 msgstr ""
 
 #: addons/skin.estuary/xml/SettingsSystemInfo.xml

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -567,7 +567,7 @@ namespace PVR
   {
     m_items =
     {
-      std::make_shared<CONTEXTMENUITEM::PlayEpgTag>(19190), /* Play programme */
+      std::make_shared<CONTEXTMENUITEM::PlayEpgTag>(19190), /* Play program */
       std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
       std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
       std::make_shared<CONTEXTMENUITEM::ShowChannelGuide>(19686), /* Channel guide */


### PR DESCRIPTION
I first thought "Play programme" is a typo until I realized that its British English :)
Still, "Play programme" looks ugly to me. I would prefer "Play program". Or what about "Play show"?

And yes, this somehow really disturbs me... not the British English, only this "programme"... enough to create this PR :)