### PR TITLE
[PVR] Fix crash when enabling a PVR client addon.

### DIFF
--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -202,7 +202,6 @@ void CPVRClients::UpdateAddons(const std::string &changedAddonId /*= ""*/)
         if (m_clientMap.find(addon.second) == m_clientMap.end())
         {
           m_clientMap.insert(std::make_pair(addon.second, addon.first));
-          m_addonNameIds.insert(make_pair(addon.first->ID(), addon.second));
         }
       }
     }
@@ -294,8 +293,15 @@ bool CPVRClients::GetClient(int iClientId, CPVRClientPtr &addon) const
 int CPVRClients::GetClientId(const std::string& strId) const
 {
   CSingleLock lock(m_critSection);
-  const auto& it = m_addonNameIds.find(strId);
-  return it != m_addonNameIds.end() ? it->second : -1;
+  for (const auto &entry : m_clientMap)
+  {
+    if (entry.second->ID() == strId)
+    {
+      return entry.first;
+    }
+  }
+
+  return -1;
 }
 
 int CPVRClients::CreatedClientAmount(void) const

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -716,6 +716,5 @@ namespace PVR
     std::string           m_strPlayingClientName;     /*!< the name client that is currently playing a stream or an empty string if nothing is playing */
     CPVRClientMap         m_clientMap;                /*!< a map of all known clients */
     CCriticalSection      m_critSection;
-    std::map<std::string, int> m_addonNameIds; /*!< map add-on names to IDs */
   };
 }


### PR DESCRIPTION
Crash reported by @MartijnKaijser. 

I introduced this regression with one of the larger refactorings I made during the last months. Sorry for that.

Fix is runtime-tested on macOS, latest Kodi master.

@Jalle19 mind taking a look?  Crash was caused by a nullptr returned by `GetClient` (PVRClients.cpp, line 142). The nullptr was a result of an invalid refactoring of `IsKnownClient`. After my refactoring it did a lookup in the wrong map (`m_addonNameIds` instead of `m_clientMap`). The fix restores the old logic.