### PR TITLE
[depends] fix autoconf endian check

### DIFF
--- a/tools/depends/native/autoconf-native/Makefile
+++ b/tools/depends/native/autoconf-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include.in Makefile endian-c++11-narrowing.patch
 
 # lib name, version
 LIBNAME=autoconf
@@ -24,6 +24,7 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../endian-c++11-narrowing.patch
 
 $(LIBDYLIB): $(PLATFORM)
 	cd $(PLATFORM); $(CONFIGURE)

--- a/tools/depends/native/autoconf-native/endian-c++11-narrowing.patch
+++ b/tools/depends/native/autoconf-native/endian-c++11-narrowing.patch
@@ -1,0 +1,23 @@
+--- a/lib/autoconf/c.m4
++++ b/lib/autoconf/c.m4
+@@ -1553,16 +1553,16 @@
+ 	[# Try to guess by grepping values from an object file.
+ 	 AC_COMPILE_IFELSE(
+ 	   [AC_LANG_PROGRAM(
+-	      [[short int ascii_mm[] =
++	      [[unsigned short int ascii_mm[] =
+ 		  { 0x4249, 0x4765, 0x6E44, 0x6961, 0x6E53, 0x7953, 0 };
+-		short int ascii_ii[] =
++		unsigned short int ascii_ii[] =
+ 		  { 0x694C, 0x5454, 0x656C, 0x6E45, 0x6944, 0x6E61, 0 };
+ 		int use_ascii (int i) {
+ 		  return ascii_mm[i] + ascii_ii[i];
+ 		}
+-		short int ebcdic_ii[] =
++		unsigned short int ebcdic_ii[] =
+ 		  { 0x89D3, 0xE3E3, 0x8593, 0x95C5, 0x89C4, 0x9581, 0 };
+-		short int ebcdic_mm[] =
++		unsigned short int ebcdic_mm[] =
+ 		  { 0xC2C9, 0xC785, 0x95C4, 0x8981, 0x95E2, 0xA8E2, 0 };
+ 		int use_ebcdic (int i) {
+ 		  return ebcdic_mm[i] + ebcdic_ii[i];


### PR DESCRIPTION
## Motivation and Context
audiodecoder.modplug doesn't build on android because autoconfs endian check fails with `-Wc++11-narrowing` errors.

## How Has This Been Tested?
build audiodecoder.modplug for android

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
