### PR TITLE
[Estuary][PVR] PVRInfoPanel: move channel logo to the right, remove default logo.

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -105,17 +105,17 @@
 		<control type="group">
 			<visible>!ListItem.IsFolder</visible>
 			<control type="image">
-				<left>0</left>
-				<top>120</top>
+				<top>135</top>
+				<left>630</left>
 				<width>200</width>
 				<height>200</height>
-				<aspectratio align="right">keep</aspectratio>
-				<texture fallback="DefaultTVShows.png">$INFO[Listitem.Icon]</texture>
+				<aspectratio align="center" aligny="top">keep</aspectratio>
+				<texture>$INFO[Listitem.Icon]</texture>
 				<fadetime>200</fadetime>
 			</control>
 			<control type="group">
 				<top>120</top>
-				<left>240</left>
+				<left>0</left>
 				<width>590</width>
 				<control type="label">
 					<height>262</height>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -185,6 +185,10 @@ CFileItem::CFileItem(const CPVRChannelPtr& channel)
 
   if (!channel->IconPath().empty())
     SetIconImage(channel->IconPath());
+  else if (channel->IsRadio())
+    SetIconImage("DefaultAudio.png");
+  else
+    SetIconImage("DefaultTVShows.png");
 
   SetProperty("channelid", channel->ChannelID());
   SetProperty("path", channel->Path());
@@ -1300,12 +1304,12 @@ void CFileItem::FillInDefaultIcon()
         if (GetPVRChannelInfoTag()->IsRadio())
           SetIconImage("DefaultAudio.png");
         else
-          SetIconImage("DefaultVideo.png");
+          SetIconImage("DefaultTVShows.png");
       }
       else if ( IsLiveTV() )
       {
         // Live TV Channel
-        SetIconImage("DefaultVideo.png");
+        SetIconImage("DefaultTVShows.png");
       }
       else if ( URIUtils::IsArchive(m_strPath) )
       { // archive


### PR DESCRIPTION
@da-anda @MartijnKaijser I changed my mind. :-) Quadratic channel logos imo actually look better when right to the textual event description. And as most people will have square logos lets change the look.

I also removed the default channel logo. 

![screenshot000](https://user-images.githubusercontent.com/3226626/34454594-d95e86ce-ed6e-11e7-990e-770b5b0170bd.png)
![screenshot001](https://user-images.githubusercontent.com/3226626/34454595-d9775d5c-ed6e-11e7-8349-a0d9ed5baebe.png)
![screenshot002](https://user-images.githubusercontent.com/3226626/34454596-d99002ee-ed6e-11e7-9433-ca86a7eeba9f.png)
![screenshot003](https://user-images.githubusercontent.com/3226626/34454597-d9b72ba8-ed6e-11e7-8034-54108d390ed5.png)
 