### PR TITLE
[PVR] Remove unused action ACTION_PLAY, use ACTION_PLAYER_PLAY.

### DIFF
--- a/xbmc/input/ActionIDs.h
+++ b/xbmc/input/ActionIDs.h
@@ -102,7 +102,6 @@
 #define REMOTE_8                      66
 #define REMOTE_9                      67
 
-#define ACTION_PLAY                   68  //!< Unused at the moment
 #define ACTION_PLAYER_PROCESS_INFO    69 //!< show player process info (video decoder, pixel format, pvr signal strength and the like
 #define ACTION_PLAYER_PROGRAM_SELECT  70
 #define ACTION_SMALL_STEP_BACK        76  //!< jumps a few seconds back during playback of movie. Can b used in videoFullScreen.xml window id=2005

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -148,7 +148,7 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
           {
            case ACTION_SELECT_ITEM:
            case ACTION_MOUSE_LEFT_CLICK:
-           case ACTION_PLAY:
+           case ACTION_PLAYER_PLAY:
              CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(m_vecItems->Get(iItem), true);
              break;
            case ACTION_SHOW_INFO:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -350,8 +350,8 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
               CServiceBroker::GetPVRManager().GUIActions()->ShowEPGInfo(pItem);
               bReturn = true;
               break;
-            case ACTION_PLAY:
-              CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(pItem, true);
+            case ACTION_PLAYER_PLAY:
+              CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(pItem, true);
               bReturn = true;
               break;
             case ACTION_RECORD:
@@ -376,7 +376,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
           {
             case ACTION_SELECT_ITEM:
             case ACTION_MOUSE_LEFT_CLICK:
-            case ACTION_PLAY:
+            case ACTION_PLAYER_PLAY:
             {
               // EPG "gap" selected => switch to associated channel.
               CGUIEPGGridContainer *epgGridContainer = GetGridControl();

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -206,7 +206,7 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage &message)
           {
             case ACTION_SELECT_ITEM:
             case ACTION_MOUSE_LEFT_CLICK:
-            case ACTION_PLAY:
+            case ACTION_PLAYER_PLAY:
             {
               const CPVRRecordingsPath path(m_vecItems->GetPath());
               if (path.IsValid() && path.IsRecordingsRoot() && item->IsParentFolder())
@@ -224,7 +224,7 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage &message)
                 break;
               }
 
-              if (message.GetParam1() == ACTION_PLAY)
+              if (message.GetParam1() == ACTION_PLAYER_PLAY)
               {
                 CServiceBroker::GetPVRManager().GUIActions()->PlayRecording(item, true /* check resume */);
                 bReturn = true;


### PR DESCRIPTION
`ACTION_PLAY` was not wired to button translator and thus actually dead code and in fact a duplicate to `ACTION_PLAYER_PLAY`. This PR removes `ACTION_PLAY` (which only occurred in PVR code) and replaces it with `ACTION_PLAYER_PLAY`. Immediate gain is that now the "play" button present on many remotes and keyboards starts playing the selected channel / recording in the respective PVR windows and dialogs.

@da-anda you suggested this change long time ago... ;-)

@xhaggi mind taking a look at the code change. It's straight forward.