### PR TITLE
Mode whitelist

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7689,7 +7689,10 @@ msgctxt "#14084"
 msgid "Queue songs on selection"
 msgstr ""
 
-#empty string with id 14085
+#: system/settings/settings.xml
+msgctxt "#14085"
+msgid "Whitelist"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14086"
@@ -18998,7 +19001,11 @@ msgctxt "#36355"
 msgid "In a multi-screen configuration, the screens not displaying this application are blacked out."
 msgstr ""
 
-#empty string with id 36356
+#. Description of setting with label #14085 "Whitelist"
+#: system/settings/settings.xml
+msgctxt "#36356"
+msgid "Whitelisted modes are allowed to be switched to when changing resolution and refresh rate"
+msgstr ""
 
 #. Description of setting with label #214 "Video calibration..."
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2013,6 +2013,18 @@
           </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
+        <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14085" help="36356">
+          <level>1</level>
+          <constraints>
+            <options>modes</options>
+            <default></default>
+            <delimiter>,</delimiter>
+            <minimumitems>0</minimumitems>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+          </control>
+        </setting>
         <setting id="videoscreen.resolution" type="integer" parent="videoscreen.screen" label="169" help="36352">
           <level>0</level>
           <default>16</default> <!-- RES_DESKTOP -->

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -77,6 +77,7 @@ public:
 
   const RESOLUTION_INFO& GetCurrentResolutionInfo() const { return GetResolutionInfo(m_currentResolution); }
   RESOLUTION_INFO& GetCurrentResolutionInfo() { return GetResolutionInfo(m_currentResolution); }
+  const RESOLUTION GetResFromString(const std::string &strResolution) { return GetResolutionFromString(strResolution); }
 
   void ApplyCalibrations();
   void UpdateCalibrations();
@@ -91,6 +92,7 @@ public:
   bool IsNonLinearStretched() const { return m_nonLinearStretched; }
   void SetNonLinearStretched(bool nonLinearStretch) { m_nonLinearStretched = nonLinearStretch; }
 
+  static void SettingOptionsModesFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsRefreshChangeDelaysFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static void SettingOptionsRefreshRatesFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
   static void SettingOptionsResolutionsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
@@ -102,7 +104,7 @@ public:
   static void SettingOptionsCmsWhitepointsFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static void SettingOptionsCmsPrimariesFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
   static void SettingOptionsCmsGammaModesFiller(std::shared_ptr<const CSetting> setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
-  
+
 
 protected:
   CDisplaySettings();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -342,6 +342,7 @@ const std::string CSettings::SETTING_SMB_MAXPROTOCOL = "smb.maxprotocol";
 const std::string CSettings::SETTING_SMB_LEGACYSECURITY = "smb.legacysecurity";
 const std::string CSettings::SETTING_VIDEOSCREEN_MONITOR = "videoscreen.monitor";
 const std::string CSettings::SETTING_VIDEOSCREEN_SCREEN = "videoscreen.screen";
+const std::string CSettings::SETTING_VIDEOSCREEN_WHITELIST = "videoscreen.whitelist";
 const std::string CSettings::SETTING_VIDEOSCREEN_RESOLUTION = "videoscreen.resolution";
 const std::string CSettings::SETTING_VIDEOSCREEN_SCREENMODE = "videoscreen.screenmode";
 const std::string CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN = "videoscreen.fakefullscreen";
@@ -683,6 +684,7 @@ void CSettings::InitializeOptionFillers()
   GetSettingsManager()->RegisterSettingOptionsFiller("speedunits", CLangInfo::SettingOptionsSpeedUnitsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("temperatureunits", CLangInfo::SettingOptionsTemperatureUnitsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("rendermethods", CBaseRenderer::SettingOptionsRenderMethodsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller("modes", CDisplaySettings::SettingOptionsModesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("resolutions", CDisplaySettings::SettingOptionsResolutionsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("screens", CDisplaySettings::SettingOptionsScreensFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("stereoscopicmodes", CDisplaySettings::SettingOptionsStereoscopicModesFiller);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -296,6 +296,7 @@ public:
   static const std::string SETTING_SMB_LEGACYSECURITY;
   static const std::string SETTING_VIDEOSCREEN_MONITOR;
   static const std::string SETTING_VIDEOSCREEN_SCREEN;
+  static const std::string SETTING_VIDEOSCREEN_WHITELIST;
   static const std::string SETTING_VIDEOSCREEN_RESOLUTION;
   static const std::string SETTING_VIDEOSCREEN_SCREENMODE;
   static const std::string SETTING_VIDEOSCREEN_FAKEFULLSCREEN;

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -20,11 +20,15 @@
 
 #include "Resolution.h"
 #include "guilib/gui3d.h"
-#include "windowing/GraphicContext.h"
+#include "GraphicContext.h"
+#include "utils/Variant.h"
 #include "utils/log.h"
 #include "utils/MathUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
+#include "settings/Settings.h"
+#include "ServiceBroker.h"
+
 #include <cstdlib>
 
 RESOLUTION_INFO::RESOLUTION_INFO(int width, int height, float aspect, const std::string &mode) :
@@ -64,14 +68,103 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, bool is3
 {
   RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
   float weight;
+
   if (!FindResolutionFromOverride(fps, width, is3D, res, weight, false)) //find a refreshrate from overrides
   {
-    if (!FindResolutionFromOverride(fps, width, is3D, res, weight, true))//if that fails find it from a fallback
-      FindResolutionFromFpsMatch(fps, width, is3D, res, weight);//if that fails use automatic refreshrate selection
+    if (!FindResolutionFromOverride(fps, width, is3D, res, weight, true)) //if that fails find it from a fallback
+    {
+      FindResolutionFromWhitelist(fps, width, is3D, res); //find a refreshrate from whitelist
+    }
   }
+
   CLog::Log(LOGNOTICE, "Display resolution ADJUST : %s (%d) (weight: %.3f)",
             CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res).strMode.c_str(), res, weight);
   return res;
+}
+
+void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is3D, RESOLUTION &resolution)
+{
+  RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
+
+  std::vector<CVariant> indexList = CServiceBroker::GetSettings().GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+
+  CLog::Log(LOGDEBUG, "Trying to find exact refresh rate");
+
+  for (const auto &mode : indexList)
+  {
+    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+    // allow resolutions that are exact and have the correct refresh rate
+    if (info.iScreenWidth == width &&
+        info.iScreen == curr.iScreen &&
+        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.005f))
+    {
+      CLog::Log(LOGDEBUG, "Matched exact whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
+      resolution = i;
+      return;
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "No exact whitelisted resolution matched, trying double refresh rate");
+
+  for (const auto &mode : indexList)
+  {
+    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+    // allow resolutions that are exact and have double the refresh rate
+    if (info.iScreenWidth == width &&
+        info.iScreen == curr.iScreen &&
+        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.005f))
+    {
+      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
+      resolution = i;
+      return;
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "No double refresh rate whitelisted resolution matched, trying larger resolutions");
+
+  for (const auto &mode : indexList)
+  {
+    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+    // allow resolutions that are larger than required but have the correct refresh rate
+    if (info.iScreenWidth > width &&
+        info.iScreen == curr.iScreen &&
+        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.005f))
+    {
+      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
+      resolution = i;
+      return;
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "No larger whitelisted resolution matched, trying larger resolutions with double refreshrate");
+
+  for (const auto &mode : indexList)
+  {
+    auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
+    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
+
+    // allow resolutions that are larger than required but have double the refresh rate
+    if (info.iScreenWidth > width &&
+        info.iScreen == curr.iScreen &&
+        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.005f))
+    {
+      CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
+      resolution = i;
+      return;
+    }
+  }
+
+  CLog::Log(LOGDEBUG, "No whitelisted resolution matched");
 }
 
 bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback)
@@ -126,178 +219,6 @@ bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3
   }
 
   return false; //no override found
-}
-
-void CResolutionUtils::FindResolutionFromFpsMatch(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight)
-{
-  const float maxWeight = 0.0021f;
-  RESOLUTION_INFO curr;
-
-  resolution = FindClosestResolution(fps, width, is3D, 1.0, resolution, weight);
-  curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
-
-  if (weight >= maxWeight) //not a very good match, try a 2:3 cadence instead
-  {
-    CLog::Log(LOGDEBUG, "Resolution %s (%d) not a very good match for fps %.3f (weight: %.3f), trying 2:3 cadence",
-        curr.strMode.c_str(), resolution, fps, weight);
-
-    resolution = FindClosestResolution(fps, width, is3D, 2.5, resolution, weight);
-    curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
-
-    if (weight >= maxWeight) //2:3 cadence not a good match
-    {
-      CLog::Log(LOGDEBUG, "Resolution %s (%d) not a very good match for fps %.3f with 2:3 cadence (weight: %.3f), choosing 60 hertz",
-          curr.strMode.c_str(), resolution, fps, weight);
-
-      //get the resolution with the refreshrate closest to 60 hertz
-      for (size_t i = (int)RES_DESKTOP; i < CDisplaySettings::GetInstance().ResolutionInfoSize(); i++)
-      {
-        RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo((RESOLUTION)i);
-
-        if (MathUtils::round_int(info.fRefreshRate) == 60
-         && info.iScreenWidth  == curr.iScreenWidth
-         && info.iScreenHeight == curr.iScreenHeight
-         && (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)
-         && info.iScreen       == curr.iScreen)
-        {
-          if (fabs(info.fRefreshRate - 60.0) < fabs(curr.fRefreshRate - 60.0)) {
-            resolution = (RESOLUTION)i;
-            curr = info;
-          }
-        }
-      }
-
-      //60 hertz not available, get the highest refreshrate
-      if (MathUtils::round_int(curr.fRefreshRate) != 60)
-      {
-        CLog::Log(LOGDEBUG, "60 hertz refreshrate not available, choosing highest");
-        for (size_t i = (int)RES_DESKTOP; i < CDisplaySettings::GetInstance().ResolutionInfoSize(); i++)
-        {
-          RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo((RESOLUTION)i);
-
-          if (info.fRefreshRate  >  curr.fRefreshRate
-           && info.iScreenWidth  == curr.iScreenWidth
-           && info.iScreenHeight == curr.iScreenHeight
-           && (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)
-           && info.iScreen       == curr.iScreen)
-          {
-            resolution = (RESOLUTION)i;
-            curr = info;
-          }
-        }
-      }
-
-      weight = RefreshWeight(curr.fRefreshRate, fps);
-    }
-  }
-}
-
-RESOLUTION CResolutionUtils::FindClosestResolution(float fps, int width, bool is3D, float multiplier, RESOLUTION current, float& weight)
-{
-  RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(current);
-  RESOLUTION orig_res  = CDisplaySettings::GetInstance().GetCurrentResolution();
-
-  if (orig_res <= RES_DESKTOP)
-    orig_res = RES_DESKTOP;
-
-  RESOLUTION_INFO orig = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(orig_res);
-
-  float fRefreshRate = fps;
-
-  float last_diff = fRefreshRate;
-
-  int curr_diff = std::abs(width - curr.iScreenWidth);
-  int loop_diff = 0;
-
-  // Find closest refresh rate
-  for (size_t i = (int)RES_DESKTOP; i < CDisplaySettings::GetInstance().ResolutionInfoSize(); i++)
-  {
-    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo((RESOLUTION)i);
-
-    //discard resolutions that are not the same width and height (and interlaced/3D flags)
-    //or have a too low refreshrate
-    if (info.iScreenWidth != curr.iScreenWidth ||
-        info.iScreenHeight != curr.iScreenHeight ||
-        info.iScreen != curr.iScreen ||
-        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) ||
-        info.fRefreshRate < (fRefreshRate * multiplier / 1.001) - 0.001)
-    {
-      // evaluate all higher modes and evaluate them
-      // concerning dimension and refreshrate weight
-      // skip lower resolutions
-      // don't change resolutions when 3D is wanted
-      if ((width < orig.iScreenWidth) || // orig res large enough
-         (info.iScreenWidth < orig.iScreenWidth) || // new res is smaller
-         (info.iScreenHeight < orig.iScreenHeight) || // new height would be smaller
-         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) || // don't switch to interlaced modes
-         (info.iScreen != curr.iScreen) || // skip not current displays
-         is3D) // skip res changing when doing 3D
-      {
-        continue;
-      }
-    }
-
-    // Allow switching to larger resolution:
-    // e.g. if m_sourceWidth == 3840 and we have a 3840 mode - use this one
-    // if it has a matching fps mode, which is evaluated below
-
-    loop_diff = std::abs(width - info.iScreenWidth);
-    curr_diff = std::abs(width - curr.iScreenWidth);
-
-    // For 3D choose the closest refresh rate
-    if (is3D)
-    {
-      float diff = (info.fRefreshRate - fRefreshRate);
-      if(diff < 0)
-        diff *= -1.0f;
-
-      if(diff < last_diff)
-      {
-        last_diff = diff;
-        current = (RESOLUTION)i;
-        curr = info;
-      }
-    }
-    else
-    {
-      int c_weight = MathUtils::round_int(RefreshWeight(curr.fRefreshRate, fRefreshRate * multiplier) * 10000.0);
-      int i_weight = MathUtils::round_int(RefreshWeight(info.fRefreshRate, fRefreshRate * multiplier) * 10000.0);
-
-      RESOLUTION current_bak = current;
-      RESOLUTION_INFO curr_bak = curr;
-
-      // Closer the better, prefer higher refresh rate if the same
-      if ((i_weight < c_weight) ||
-          (i_weight == c_weight && info.fRefreshRate > curr.fRefreshRate))
-      {
-        current = (RESOLUTION)i;
-        curr = info;
-      }
-      // use case 1080p50 vs 3840x2160@25 for 3840@25 content
-      // prefer the higher resolution of 3840
-      if (i_weight == c_weight && (loop_diff < curr_diff))
-      {
-        current = (RESOLUTION)i;
-        curr = info;
-      }
-      // same as above but iterating with 3840@25 set and overwritten
-      // by e.g. 1080@50 - restore backup in that case
-      // to give priority to the better matching width
-      if (i_weight == c_weight && (loop_diff > curr_diff))
-      {
-        current = current_bak;
-        curr = curr_bak;
-      }
-    }
-  }
-
-  // For 3D overwrite weight
-  if (is3D)
-    weight = 0;
-  else
-    weight = RefreshWeight(curr.fRefreshRate, fRefreshRate * multiplier);
-
-  return current;
 }
 
 //distance of refresh to the closest multiple of fps (multiple is 1 or higher), as a multiplier of fps

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -102,8 +102,7 @@ class CResolutionUtils
 public:
   static RESOLUTION ChooseBestResolution(float fps, int width, bool is3D);
 protected:
+  static void FindResolutionFromWhitelist(float fps, int width, bool is3D, RESOLUTION &resolution);
   static bool FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback);
-  static void FindResolutionFromFpsMatch(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight);
-  static RESOLUTION FindClosestResolution(float fps, int width, bool is3D, float multiplier, RESOLUTION current, float& weight);
   static float RefreshWeight(float refresh, float fps);
 };

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -147,12 +147,6 @@ void CWinSystemGbm::UpdateResolutions()
 {
   CWinSystemBase::UpdateResolutions();
 
-  UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP),
-                          0,
-                          m_DRM->m_mode->hdisplay,
-                          m_DRM->m_mode->vdisplay,
-                          m_DRM->m_mode->vrefresh);
-
   std::vector<RESOLUTION_INFO> resolutions;
 
   if (!m_DRM->GetModes(resolutions) || resolutions.empty())
@@ -165,17 +159,42 @@ void CWinSystemGbm::UpdateResolutions()
 
     for (unsigned int i = 0; i < resolutions.size(); i++)
     {
-      CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
-      CDisplaySettings::GetInstance().AddResolutionInfo(resolutions[i]);
+      if(m_DRM->m_mode->hdisplay == resolutions[i].iWidth &&
+         m_DRM->m_mode->vdisplay == resolutions[i].iHeight &&
+         m_DRM->m_mode->vrefresh == resolutions[i].fRefreshRate &&
+         ((m_DRM->m_mode->flags ^ DRM_MODE_FLAG_INTERLACE) &&
+          (resolutions[i].dwFlags ^ D3DPRESENTFLAG_INTERLACED)))
+      {
+        CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz setting to RES_DESKTOP at %d",
+                  resolutions[i].iWidth,
+                  resolutions[i].iHeight,
+                  resolutions[i].iScreen,
+                  resolutions[i].iScreenWidth,
+                  resolutions[i].iScreenHeight,
+                  resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
+                  resolutions[i].fRefreshRate,
+                  (int)RES_DESKTOP);
 
-      CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz",
-                resolutions[i].iWidth,
-                resolutions[i].iHeight,
-                resolutions[i].iScreen,
-                resolutions[i].iScreenWidth,
-                resolutions[i].iScreenHeight,
-                resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
-                resolutions[i].fRefreshRate);
+        UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP),
+                                0,
+                                m_DRM->m_mode->hdisplay,
+                                m_DRM->m_mode->vdisplay,
+                                m_DRM->m_mode->vrefresh);
+      }
+      else
+      {
+        CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz",
+                  resolutions[i].iWidth,
+                  resolutions[i].iHeight,
+                  resolutions[i].iScreen,
+                  resolutions[i].iScreenWidth,
+                  resolutions[i].iScreenHeight,
+                  resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
+                  resolutions[i].fRefreshRate);
+
+        CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
+        CDisplaySettings::GetInstance().AddResolutionInfo(resolutions[i]);
+      }
     }
   }
 


### PR DESCRIPTION
@FernetMenta wanted me to PR this to get some more visibility. I'll add what I had already posted to the internal boards.

---

Just wanted to start a discussion that won't get lost in slack.

For those that don't know the display and refresh rate switching logic in kodi is rather complex yet it doesn't quite fit everyone's needs. @FernetMenta proposed that we create a set of `whitelisted` resolutions that one can select and create a logic for kodi to switch to only these `whitelisted` modes.

Some reasons to do this is as follows:
 1. Some people want to switch to a lower resolution when watching 720P content however some people do not want this because when watching live TV the refresh rate switching would happen too often.
 2. We can disable modes that have too high of refresh rate ie. 120HZ.
 3. We can use the exact refresh rate (for low bandwidth systems playing 30hz content at 60hz on a 4k display is difficult)

The problem with this come down to adding yet another setting. More settings generally decrease the user experience. So how can we make things simpler not more complex?
 1. Pre define `whitelisted` modes. (add all refresh rates from the desktop resolution automatically)
 2. Revert to the old behaviour if no `whitelisted` modes are defined.
 3. Hide option at the same settings level as the refresh rate switching option

Currently the logic is this:
 1. for all the methods below remember that it will only select from the whitelist!
 2. the order goes from fuzziest match towards exact match
 3. allow resolutions that are larger than required but have double the refresh rate
 4. allow resolutions that are larger than required but have the correct refresh rate
 5. allow resolutions that are exact and have double the refresh rate
 6. allow resolutions that are exact and have the correct refresh rate

Sample GUI
![Imgur](https://i.imgur.com/1LOp0RO.png)

Sample outputs below.
```
10:35:21.752 T:140499105462656   DEBUG: display width: 1920 vs video width: 1920
10:35:21.752 T:140499105462656   DEBUG: display fps: 60.000000 vs video fps: 29.970030
10:35:21.752 T:140499105462656   DEBUG: float equals: false
10:35:21.752 T:140499105462656   DEBUG: display width: 1920 vs video width: 1920
10:35:21.752 T:140499105462656   DEBUG: display fps: 50.000000 vs video fps: 29.970030
10:35:21.752 T:140499105462656   DEBUG: float equals: false
10:35:21.752 T:140499105462656   DEBUG: display width: 1920 vs video width: 1920
10:35:21.752 T:140499105462656   DEBUG: display fps: 59.940201 vs video fps: 29.970030
10:35:21.752 T:140499105462656   DEBUG: float equals: false
10:35:21.752 T:140499105462656   DEBUG: Matched fuzzy whitelisted Resolution DVI-1: 1920x1080 @ 59.94Hz (19)
10:35:21.752 T:140499105462656   DEBUG: display width: 1920 vs video width: 1920
10:35:21.752 T:140499105462656   DEBUG: display fps: 24.000000 vs video fps: 29.970030
10:35:21.752 T:140499105462656   DEBUG: float equals: false
10:35:21.752 T:140499105462656   DEBUG: display width: 1920 vs video width: 1920
10:35:21.752 T:140499105462656   DEBUG: display fps: 23.976080 vs video fps: 29.970030
10:35:21.752 T:140499105462656   DEBUG: float equals: false
10:35:21.752 T:140499105462656   DEBUG: display width: 1280 vs video width: 1920
10:35:21.752 T:140499105462656   DEBUG: display fps: 60.000000 vs video fps: 29.970030
10:35:21.752 T:140499105462656   DEBUG: float equals: false
10:35:21.752 T:140499105462656  NOTICE: Display resolution ADJUST : DVI-1: 1920x1080 @ 59.94Hz (19) (weight: 0.000)
```
---
```
11:00:03.307 T:140082496567680   DEBUG: display width: 1920 vs video width: 1280
11:00:03.307 T:140082496567680   DEBUG: display fps: 60.000000 vs video fps: 60.000000
11:00:03.307 T:140082496567680   DEBUG: float equals: true
11:00:03.307 T:140082496567680   DEBUG: Matched fuzzy whitelisted Resolution DVI-1: 1920x1080 @ 60.00Hz (17)
11:00:03.307 T:140082496567680   DEBUG: display width: 1920 vs video width: 1280
11:00:03.307 T:140082496567680   DEBUG: display fps: 50.000000 vs video fps: 60.000000
11:00:03.307 T:140082496567680   DEBUG: float equals: false
11:00:03.307 T:140082496567680   DEBUG: display width: 1920 vs video width: 1280
11:00:03.307 T:140082496567680   DEBUG: display fps: 59.940201 vs video fps: 60.000000
11:00:03.307 T:140082496567680   DEBUG: float equals: false
11:00:03.307 T:140082496567680   DEBUG: display width: 1920 vs video width: 1280
11:00:03.307 T:140082496567680   DEBUG: display fps: 24.000000 vs video fps: 60.000000
11:00:03.307 T:140082496567680   DEBUG: float equals: false
11:00:03.307 T:140082496567680   DEBUG: display width: 1920 vs video width: 1280
11:00:03.307 T:140082496567680   DEBUG: display fps: 23.976080 vs video fps: 60.000000
11:00:03.307 T:140082496567680   DEBUG: float equals: false
11:00:03.307 T:140082496567680   DEBUG: display width: 1280 vs video width: 1280
11:00:03.307 T:140082496567680   DEBUG: display fps: 60.000000 vs video fps: 60.000000
11:00:03.307 T:140082496567680   DEBUG: float equals: true
11:00:03.307 T:140082496567680   DEBUG: Matched exact whitelisted Resolution DVI-1: 1280x720 @ 60.00Hz (26)
11:00:03.307 T:140082496567680  NOTICE: Display resolution ADJUST : DVI-1: 1280x720 @ 60.00Hz (26) (weight: 0.000)
```

Please comment to explain why you :heart: or :skull: this idea and any further logic or comments about usability below