### PR TITLE
[CustomCOntrollerTranslator] - fixed mapping of global / fallback section

### DIFF
--- a/xbmc/input/CustomControllerTranslator.cpp
+++ b/xbmc/input/CustomControllerTranslator.cpp
@@ -87,7 +87,7 @@ bool CCustomControllerTranslator::TranslateCustomControllerString(int windowId, 
       TranslateString(fallbackWindow, controllerName, buttonId, actionId, strAction);
 
     // Still no valid action? Use global map
-    if (action == ACTION_NONE)
+    if (actionId == ACTION_NONE)
       TranslateString(-1, controllerName, buttonId, actionId, strAction);
   }
 


### PR DESCRIPTION
This restores the custom controller mapping of the global section of those keymaps. 

FIxes trac https://trac.kodi.tv/ticket/17671

Regression introduced in 7bf60946c44cc869a4d1f8a301eb8e7c154b3d1a

Users complained that apple remote mappings from the global section didn't work anymore (up,down,right,left buttons and so on). This is the cause.