### PR TITLE
OpenGL 4.0: Fixups

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -242,7 +242,7 @@ void YUV2RGBFilterShader4::OnCompiledAndLinked()
   glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
   GLvoid* data = (GLvoid*)kernel.GetFloatPixels();
-  glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA16F, kernel.GetSize(), 0, GL_RGBA, GL_FLOAT, data);
+  glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA32F, kernel.GetSize(), 0, GL_RGBA, GL_FLOAT, data);
   glActiveTexture(GL_TEXTURE0);
   VerifyGLState();
 }

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -40,7 +40,7 @@ CGLTexture::CGLTexture(unsigned int width, unsigned int height, unsigned int for
   unsigned int major, minor;
   CServiceBroker::GetRenderSystem().GetRenderVersion(major, minor);
   if (major >= 3)
-    m_profile30 = true;
+    m_isOglVersion3orNewer = true;
 }
 
 CGLTexture::~CGLTexture()
@@ -87,7 +87,7 @@ void CGLTexture::LoadToGPU()
 #ifndef HAS_GLES
     // Lower LOD bias equals more sharpness, but less smooth animation
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.5f);
-    if (!m_profile30)
+    if (!m_isOglVersion3orNewer)
       glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
 #endif
   }
@@ -153,7 +153,7 @@ void CGLTexture::LoadToGPU()
                            GetPitch() * GetRows(), m_pixels);
   }
 
-  if (IsMipmapped() && m_profile30)
+  if (IsMipmapped() && m_isOglVersion3orNewer)
   {
     glGenerateMipmap(GL_TEXTURE_2D);
   }

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -40,6 +40,6 @@ public:
 
 protected:
   GLuint m_texture = 0;
-  bool m_profile30 = false;
+  bool m_isOglVersion3orNewer = false;
 };
 


### PR DESCRIPTION
- Rename variable to state that we use no profile but the version
~~- Reintroduce weighting fixup to care for rounding errors~~
- Compute in 32 bit to match CPU float precission