### PR TITLE
[coverity] dividing integer expressions and convert to double

### DIFF
--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -204,8 +204,8 @@ void CSeekHandler::SetSeekSize(double seekSize)
 {
   CApplicationPlayer& player = g_application.GetAppPlayer();
   int64_t playTime = player.GetTime();
-  double minSeekSize = (player.GetMinTime() - playTime) / 1000;
-  double maxSeekSize = (player.GetMaxTime() - playTime) / 1000;
+  double minSeekSize = (player.GetMinTime() - playTime) / 1000.0;
+  double maxSeekSize = (player.GetMaxTime() - playTime) / 1000.0;
 
   m_seekSize = seekSize > 0
     ? std::min(seekSize, maxSeekSize)


### PR DESCRIPTION
Fix coverity issue pointed out by @ksooo at https://github.com/xbmc/xbmc/commit/753426555a5a1b82a4f8e694dd0933250c1608a7#commitcomment-26562656