### PR TITLE
add ftp with implicit SSL support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12436,7 +12436,10 @@ msgctxt "#20173"
 msgid "FTP server"
 msgstr ""
 
-#empty string with id 20174
+#: xbmc/network/GUIDialogNetworkSetup.cpp
+msgctxt "#20174"
+msgid "FTPS server"
+msgstr ""
 
 #: xbmc/network/GUIDialogNetworkSetup.cpp
 msgctxt "#20175"

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -215,6 +215,7 @@ void CGUIDialogNetworkSetup::InitializeSettings()
          { true,  true,  true,  true, false, 443,  "davs", 20254},
          { true,  true,  true,  true, false,  80,   "dav", 20253},
          { true,  true,  true,  true, false,  21,   "ftp", 20173},
+         { true,  true,  true,  true, false, 990,  "ftps", 20174},
          {false, false, false, false,  true,   0,  "upnp", 20175},
          { true,  true,  true,  true, false,  80,   "rss", 20304}};
 
@@ -377,7 +378,7 @@ void CGUIDialogNetworkSetup::UpdateButtons()
     SendMessage(GUI_MSG_SET_TYPE, passControlID, CGUIEditControl::INPUT_TYPE_PASSWORD, 12326);
   }
 
-  // server browse should be disabled if we are in FTP, HTTP, HTTPS, RSS, DAV or DAVS
+  // server browse should be disabled if we are in FTP, FTPS, HTTP, HTTPS, RSS, DAV or DAVS
   BaseSettingControlPtr browseControl = GetSettingControl(SETTING_SERVER_BROWSE);
   if (browseControl != NULL && browseControl->GetControl() != NULL)
   {


### PR DESCRIPTION
Add support for FTP with implicit SSL

## Description
Add a FTP server with implicit SSL using FTP server GUI doesn't work.
The protocol must be ftps:// and not ftp://

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested on Ubuntu 17.10 and personal ftp server

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
