### PR TITLE
windowing/gbm: use first overlay plane and fix vga refresh rate

### DIFF
--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -277,8 +277,8 @@ bool CDRMUtils::GetPreferredMode()
 bool CDRMUtils::GetPlanes()
 {
   drmModePlaneResPtr plane_resources;
-  uint32_t primary_plane_id = -1;
-  uint32_t overlay_plane_id = -1;
+  uint32_t primary_plane_id = 0;
+  uint32_t overlay_plane_id = 0;
   uint32_t fourcc = 0;
 
   plane_resources = drmModeGetPlaneResources(m_fd);
@@ -306,14 +306,14 @@ bool CDRMUtils::GetPlanes()
       {
         drmModePropertyPtr p = drmModeGetProperty(m_fd, props->props[j]);
 
-        if ((strcmp(p->name, "type") == 0) && (props->prop_values[j] == DRM_PLANE_TYPE_PRIMARY))
+        if ((strcmp(p->name, "type") == 0) && (props->prop_values[j] == DRM_PLANE_TYPE_PRIMARY) && (primary_plane_id == 0))
         {
-          CLog::Log(LOGDEBUG, "CDRMUtils::%s - found primary plane: %d", __FUNCTION__, id);
+          CLog::Log(LOGDEBUG, "CDRMUtils::%s - found primary plane: %u", __FUNCTION__, id);
           primary_plane_id = id;
         }
-        else if ((strcmp(p->name, "type") == 0) && (props->prop_values[j] == DRM_PLANE_TYPE_OVERLAY))
+        else if ((strcmp(p->name, "type") == 0) && (props->prop_values[j] == DRM_PLANE_TYPE_OVERLAY) && (overlay_plane_id == 0))
         {
-          CLog::Log(LOGDEBUG, "CDRMUtils::%s - found overlay plane: %d", __FUNCTION__, id);
+          CLog::Log(LOGDEBUG, "CDRMUtils::%s - found overlay plane: %u", __FUNCTION__, id);
           overlay_plane_id = id;
         }
 
@@ -332,7 +332,7 @@ bool CDRMUtils::GetPlanes()
   m_primary_plane->plane = drmModeGetPlane(m_fd, primary_plane_id);
   if (!m_primary_plane->plane)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::%s - could not get primary plane %i: %s", __FUNCTION__, primary_plane_id, strerror(errno));
+    CLog::Log(LOGERROR, "CDRMUtils::%s - could not get primary plane %u: %s", __FUNCTION__, primary_plane_id, strerror(errno));
     return false;
   }
 
@@ -377,7 +377,7 @@ bool CDRMUtils::GetPlanes()
   m_overlay_plane->plane = drmModeGetPlane(m_fd, overlay_plane_id);
   if (!m_overlay_plane->plane)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::%s - could not get overlay plane %i: %s", __FUNCTION__, overlay_plane_id, strerror(errno));
+    CLog::Log(LOGERROR, "CDRMUtils::%s - could not get overlay plane %u: %s", __FUNCTION__, overlay_plane_id, strerror(errno));
     return false;
   }
 

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -623,7 +623,7 @@ bool CDRMUtils::GetModes(std::vector<RESOLUTION_INFO> &resolutions)
     res.iHeight = m_connector->connector->modes[i].vdisplay;
     res.iScreenWidth = m_connector->connector->modes[i].hdisplay;
     res.iScreenHeight = m_connector->connector->modes[i].vdisplay;
-    if (m_connector->connector->modes[i].clock % 10 != 0)
+    if (m_connector->connector->modes[i].clock % 5 != 0)
       res.fRefreshRate = (float)m_connector->connector->modes[i].vrefresh * (1000.0f/1001.0f);
     else
       res.fRefreshRate = m_connector->connector->modes[i].vrefresh;


### PR DESCRIPTION
## Description
This PR fixes two issues seen on Rockchip platform.

## Motivation and Context
There are multiple overlay planes on Tinker Board, without this change to use the first overlay plane the last overlay plane is used. In general on Rockchip only the primary and first overlay plane features NV12 and color conversion features.

The first commit changes to prefer using the first detected primary/overlay plane (and signed/unsigned fixes).
The second commit fixes 640x480 @ 60 Hz being detected as 640x480 @ 59.94 Hz.

## How Has This Been Tested?
Tested on ROCK64 and Tinker Board using LibreELEC

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
