### PR TITLE
CWinSystemRpi: ensure that we register the ALSA sink as well as PiSink is needed for external DACs

### DIFF
--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -22,6 +22,9 @@
 #include "utils/log.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/AESinkPi.h"
+#ifdef HAS_ALSA
+  #include "cores/AudioEngine/Sinks/AESinkALSA.h"
+#endif // HAS_ALSA
 #include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 
 #include <EGL/egl.h>
@@ -43,6 +46,9 @@ CWinSystemRpi::CWinSystemRpi() :
 
   AE::CAESinkFactory::ClearSinks();
   CAESinkPi::Register();
+  #ifdef HAS_ALSA
+    CAESinkALSA::Register();
+  #endif // HAS_ALSA
   CLinuxPowerSyscall::Register();
   m_lirc.reset(OPTIONALS::LircRegister());
   m_libinput->Start();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description

It seems that after c0064a99d4cb13fbb77f6f411cba48a12ef50669, the AESink is tied to the windowing system. The ALSA sink does not seem to be registered elsewhere on RBP, which means that external DACs (USB and I2S) are not enumerated. 

The patch was necessary to re-register ALSA sinks on RBP.

## How Has This Been Tested?

Tested in OSMC v18 nightlies for Raspberry Pi with positive reports: https://discourse.osmc.tv/t/testing-kodi-18-leia-builds-for-raspberry-pi/20631/632

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
