### PR TITLE
[listproviders] Fix certain home screen widgets not refreshing on sta…

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -248,7 +248,8 @@ void CDirectoryProvider::Announce(AnnouncementFlag flag, const char *sender, con
       if (strcmp(message, "OnPlay") == 0 ||
           strcmp(message, "OnStop") == 0)
       {
-        if (m_currentSort.sortBy == SortByLastPlayed ||
+        if (m_currentSort.sortBy == SortByNone || // not nice, but many directories that need to be refreshed on start/stop have no special sort order (e.g. in progress movies)
+            m_currentSort.sortBy == SortByLastPlayed ||
             m_currentSort.sortBy == SortByPlaycount ||
             m_currentSort.sortBy == SortByLastUsed)
           m_updateState = INVALIDATED;


### PR DESCRIPTION
…rt/stop playback (like in progress movies). 

Noticed by myself and reported in the forum. For example after starting to watch a movie, then stop watching it before movie's end,  the movie was not added immediately to home screen's "in progress movies" widget. Under certain circumstances it appeared only after Kodi restart. Other home screen items are affected by this bug as well.

Runtime-tested on macOS, latest Kodi master.

@tamland mind taking a look.