### PR TITLE
[libUPnP][platinum] fix format-security warning

### DIFF
--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp
@@ -631,7 +631,7 @@ args:
     msg = "Invalid args";
 
 failure:
-    NPT_LOG_WARNING(msg);
+    NPT_LOG_WARNING_1("%s", msg);
     action->SetError(err, msg);
     return NPT_FAILURE;
 }

--- a/lib/libUPnP/patches/0046-platinum-fix-format-security-warning.patch
+++ b/lib/libUPnP/patches/0046-platinum-fix-format-security-warning.patch
@@ -1,0 +1,22 @@
+From 75dca8c816de2d65aee5117876b3c7110ad4cd47 Mon Sep 17 00:00:00 2001
+From: Rechi <Rechi@users.noreply.github.com>
+Date: Wed, 3 Jan 2018 10:31:43 +0100
+Subject: [PATCH] [libUPnP][platinum] fix format-security warning
+
+---
+ lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp
+index 0a43dab603..feeb537648 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp
+@@ -631,7 +631,7 @@ args:
+     msg = "Invalid args";
+ 
+ failure:
+-    NPT_LOG_WARNING(msg);
++    NPT_LOG_WARNING_1("%s", msg);
+     action->SetError(err, msg);
+     return NPT_FAILURE;
+ }


### PR DESCRIPTION
## Motivation and Context
Ubuntu PPA builds with `-Werror=format-security`

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
