### PR TITLE
[cmake] fix find_package_handle_standard_args name for Xkbcommon

### DIFF
--- a/cmake/modules/FindXkbcommon.cmake
+++ b/cmake/modules/FindXkbcommon.cmake
@@ -21,7 +21,7 @@ find_library(XKBCOMMON_LIBRARY NAMES xkbcommon
                                PATHS ${PC_XKBCOMMON_LIBRARIES} ${PC_XKBCOMMON_LIBRARY_DIRS})
 
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (XKBCOMMON
+find_package_handle_standard_args (Xkbcommon
   REQUIRED_VARS
   XKBCOMMON_INCLUDE_DIR
   XKBCOMMON_LIBRARY)


### PR DESCRIPTION
## Description
The package name in `find_package_handle_standard_args` must be the exact same as in `find_package` otherwise REQUIRED has no effect.

## Motivation and Context
cmake didn't fail if xkbcommon isn't found
@pkerling FYI

## How Has This Been Tested?
run cmake with and without libxkbcommon-dev installed

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
