### PR TITLE
[bugfix] Stack Regression: synchronize m_itemCurrentFile with player state

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3227,7 +3227,7 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
   // one of the players that allows gapless playback (paplayer, VideoPlayer)
   if (m_appPlayer.HasPlayer())
   {
-    if (m_appPlayer.CanClosePlayerGapless(newPlayer, item))
+    if (m_appPlayer.SupportsGaplessClose(newPlayer, item))
     {
       m_appPlayer.ClosePlayerGapless(newPlayer);
     }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -445,6 +445,8 @@ protected:
   bool m_dpmsIsManual;
 
   CFileItemPtr m_itemCurrentFile;
+  CFileItemPtr m_itemLastFile;
+  XbmcThreads::ConditionVariable m_itemCurrentFileEvent;
 
   std::string m_prevMedia;
   ThreadIdentifier m_threadID;       // application thread ID.  Used in applicationMessenger to know where we are firing a thread with delay from.

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -62,29 +62,31 @@ void CApplicationPlayer::CloseFile(bool reopen)
   }
 }
 
+bool CApplicationPlayer::CanClosePlayerGapless(std::string &playername, CFileItem& item)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (!player)
+    return false;
+
+  bool gaplessSupported = player->m_type == "music" || (player->m_type == "video" && !item.IsDiscImage() && !item.IsDVDFile());
+  gaplessSupported = gaplessSupported && (playername == player->m_name);
+  return gaplessSupported;
+}
+
 void CApplicationPlayer::ClosePlayerGapless(std::string &playername)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (!player)
     return;
 
-  bool gaplessSupported = player->m_type == "music" || player->m_type == "video";
-  gaplessSupported = gaplessSupported && (playername == player->m_name);
-  if (!gaplessSupported)
+  if (player->m_type != "video")
   {
-    ClosePlayer();
-  }
-  else
-  {
-    if (player->m_type != "video")
-    {
-      // XXX: we had to stop the previous playing item, it was done in VideoPlayer::OpenFile.
-      // but in paplayer::OpenFile, it sometimes just fade in without call CloseFile.
-      // but if we do not stop it, we can not distinguish callbacks from previous
-      // item and current item, it will confused us then we can not make correct delay
-      // callback after the starting state.
-      CloseFile(true);
-    }
+    // XXX: we had to stop the previous playing item, it was done in VideoPlayer::OpenFile.
+    // but in paplayer::OpenFile, it sometimes just fade in without call CloseFile.
+    // but if we do not stop it, we can not distinguish callbacks from previous
+    // item and current item, it will confused us then we can not make correct delay
+    // callback after the starting state.
+    CloseFile(true);
   }
 }
 

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -62,7 +62,7 @@ void CApplicationPlayer::CloseFile(bool reopen)
   }
 }
 
-bool CApplicationPlayer::CanClosePlayerGapless(std::string &playername, CFileItem& item)
+bool CApplicationPlayer::SupportsGaplessClose(std::string &playername, CFileItem& item)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (!player)

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -54,7 +54,7 @@ public:
   // player management
   void CloseFile(bool reopen = false);
   void ClosePlayer();
-  bool CanClosePlayerGapless(std::string &playername, CFileItem& item);
+  bool SupportsGaplessClose(std::string &playername, CFileItem& item);
   void ClosePlayerGapless(std::string &playername);
   void CreatePlayer(const std::string &player, IPlayerCallback& callback);
   std::string GetCurrentPlayer();

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -54,6 +54,7 @@ public:
   // player management
   void CloseFile(bool reopen = false);
   void ClosePlayer();
+  bool CanClosePlayerGapless(std::string &playername, CFileItem& item);
   void ClosePlayerGapless(std::string &playername);
   void CreatePlayer(const std::string &player, IPlayerCallback& callback);
   std::string GetCurrentPlayer();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
As reported on the team slack channel, when playing music hitting "next" lost current item information.
Upon deeper investigation, the culprit was with how m_itemCurrentFile is not properly synchronized with player state. This PR addresses that issue.
Additionally two special issues had to be dealt with:
- player doesn't always start gapless, in which case two player threads can be active (the one stopping plus the new one starting). In order to properly set m_itemCurrentFile, one must wait that the first player stopped before starting the new one.
- because m_itemCurrentFile is now reset to null once player is finished, there are a few additional checks on the validity of m_itemCurrentFile before dereferencing...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
see above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
extensive mix of music, video, dvd, stacks, iso stacks.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
