### PR TITLE
[Estuary][PVR] Season/Ep info in PVRGuide

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRInfo.xml
+++ b/addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -119,7 +119,7 @@
 			</control>
 			<include content="InfoDialogTopBarInfo">
 				<param name="main_label" value="$INFO[ListItem.Title]" />
-				<param name="sub_label" value="$VAR[SeasonEpisodeLabel]" />
+				<param name="sub_label" value="[COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white][B],[/B][/COLOR]]" />
 				<param name="posy" value="40" />
 			</include>
 		</control>

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -167,7 +167,7 @@
 				<top>435</top>
 				<width>830</width>
 				<height>70</height>
-				<label>[I]$INFO[ListItem.EpisodeName][/I]</label>
+				<label>[I]$VAR[SeasonEpisodeLabel]$INFO[ListItem.EpisodeName][/I]</label>
 			</control>
 			<control type="textbox">
 				<top>490</top>

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -64,11 +64,18 @@
 						<left>300</left>
 						<right>60</right>
 						<height>30</height>
-						<label>[COLOR button_focus]$INFO[ListItem.StartTime][/COLOR]$INFO[ListItem.EndTime,[COLOR button_focus] - ,[/COLOR]] $INFO[ListItem.EpgEventTitle]$INFO[ListItem.EpisodeName, (,)]$INFO[ListItem.Genre,      [COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
+						<label>[COLOR button_focus]$INFO[ListItem.StartTime][/COLOR]$INFO[ListItem.EndTime,[COLOR button_focus] - ,[/COLOR]] $INFO[ListItem.EpgEventTitle]$INFO[ListItem.Genre,      [COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
+					</control>
+					<control type="label">
+						<top>29</top>
+						<left>300</left>
+						<right>60</right>
+						<height>30</height>
+						<label>[COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white],[/COLOR]]</label>
 					</control>
 					<control type="textbox">
 						<left>300</left>
-						<top>38</top>
+						<top>67</top>
 						<right>60</right>
 						<height>173</height>
 						<label>$INFO[ListItem.Plot]</label>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -409,9 +409,8 @@
 		<value condition="ListItem.HasTimer">icons/pvr/PVR-HasTimer.png</value>
 	</variable>
 	<variable name="SeasonEpisodeLabel">
-		<value condition="String.IsEmpty(ListItem.Season) + String.IsEmpty(ListItem.Episode)">$INFO[ListItem.EpisodeName,[B],[/B]]</value>
-		<value condition="String.IsEmpty(ListItem.EpisodeName)">$INFO[ListItem.Season,[COLOR grey]S,[/COLOR]]$INFO[ListItem.Episode,[COLOR grey]E,[/COLOR]]</value>
-		<value>$INFO[ListItem.Season,[COLOR grey]S,[/COLOR]]$INFO[ListItem.Episode,[COLOR grey]E,[/COLOR]]: [B]$INFO[ListItem.EpisodeName][/B]</value>
+		<value condition="String.IsEmpty(ListItem.EpisodeName)">$INFO[ListItem.Season,S]$INFO[ListItem.Episode,E]</value>
+		<value>$INFO[ListItem.Season,S]$INFO[ListItem.Episode,E,: ]</value>
 	</variable>
 	<variable name="ExpirationDateTimeLabel">
 		<value condition="!String.IsEmpty(ListItem.ExpirationDate)">[COLOR grey]$LOCALIZE[19299]:[/COLOR] $INFO[ListItem.ExpirationDate] $INFO[ListItem.ExpirationTime][CR]</value>


### PR DESCRIPTION
Add Season/Ep info to PVR EPG Guide screen

## Description
Show season and episode on main PVR Guide screen when available. Move Episode Title
to same line with ep/season when available, similar to DialogPVRInfo.xml. Havent reused the existing variable SeasonEpisodeLabel as i thought it may need to be altered for colour/formatting as it doesnt look nice with the grey on the Guide screen.

Would appreciate any feedback on how to make it look prettier. Im not familiar with the skinning side of kodi at all, so not entirely sure how to manage colours. 

## Motivation and Context
Provides further information at a glance regarding series/episode without having to open the EPG entry.

## How Has This Been Tested?
Have runtime tested on Mac OS X running latest tip of Kodi

## Screenshots (if appropriate):
Series + Episode + Episode Title
![screen shot 2018-01-04 at 1 53 59 pm](https://user-images.githubusercontent.com/2861319/34549755-d935b2a8-f156-11e7-891e-0f3324cfbae8.png)

Episode Number + Title
![screen shot 2018-01-04 at 1 54 10 pm](https://user-images.githubusercontent.com/2861319/34549765-ef47a27c-f156-11e7-8b1d-1dae10abab48.png)

Episode Name Only
![screen shot 2018-01-04 at 1 54 06 pm](https://user-images.githubusercontent.com/2861319/34549769-f8bb82ec-f156-11e7-9842-947f28d9e51f.png)

No tag info
![screen shot 2018-01-04 at 1 54 08 pm](https://user-images.githubusercontent.com/2861319/34549773-fb9731fa-f156-11e7-997c-e3defc469bf0.png)


## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

  