### PR TITLE
addonsettings - don't lowercase condition value

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -1462,7 +1462,6 @@ bool CAddonSettings::ParseOldCondition(std::shared_ptr<const CSetting> setting, 
 
 bool CAddonSettings::ParseOldConditionExpression(std::string str, ConditionExpression& expression)
 {
-  StringUtils::ToLower(str);
   StringUtils::Trim(str);
 
   size_t posOpen = str.find('(');


### PR DESCRIPTION
the addon settings migration (PR #12125) broke a few things, one of them being enable/visible conditions for addon setting.

this fixes the bug reported here: https://forum.kodi.tv/showthread.php?tid=321370