### PR TITLE
[WIP]: websocket does not handle frames > 1024 bytes

### DIFF
--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -60,7 +60,7 @@ static const bdaddr_t bt_bdaddr_local = {{0, 0, 0, 0xff, 0xff, 0xff}};
 using namespace JSONRPC;
 using namespace ANNOUNCEMENT;
 
-#define RECEIVEBUFFER 1024
+#define RECEIVEBUFFER 16384
 
 CTCPServer *CTCPServer::ServerInstance = NULL;
 

--- a/xbmc/network/websocket/WebSocket.cpp
+++ b/xbmc/network/websocket/WebSocket.cpp
@@ -83,7 +83,7 @@ CWebSocketFrame::CWebSocketFrame(const char* data, uint64_t length)
       (m_length == 126 && m_lengthFrame < LENGTH_MIN + 2) ||
       (m_length == 127 && m_lengthFrame < LENGTH_MIN + 8))
   {
-    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received");
+    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received: %lld / %lld", m_length, m_lengthFrame);
     reset();
     return;
   }
@@ -109,7 +109,8 @@ CWebSocketFrame::CWebSocketFrame(const char* data, uint64_t length)
 
   if (m_lengthFrame < LENGTH_MIN + offset + m_length)
   {
-    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received");
+    // TODO: Handle split frames
+    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received: %lld / %lld", m_length, m_lengthFrame);
     reset();
     return;
   }
@@ -311,6 +312,7 @@ const CWebSocketMessage* CWebSocket::Handle(const char* &buffer, size_t &length,
         CWebSocketFrame *frame = GetFrame(buffer, length);
         if (!frame->IsValid())
         {
+          // TODO: Handle split frames
           CLog::Log(LOGINFO, "WebSocket: Invalid frame received");
           delete frame;
           return NULL;


### PR DESCRIPTION
@Montellese @topfs2 There is a bug in our websocket implementation that it assumes that a whole websocket frame will hold in a socket buffer (currently 1024B)

If not mistaken, the RFC does not set a max value, so ideally, we should buffer on the websocket side until we get a full frame.
Would one of you have time to properly fix this?

For my use case (a batch of 20 media details retrieval request, leading to a request of ~4KB), I just increased the tcp buffer, which is just a quick hack, ofc.

Thanks