### PR TITLE
[win10] update dependencies packages and do not add pass-through formats for xaudio HDMI device 

### DIFF
--- a/project/BuildDependencies/scripts/0_package.target-win10-arm.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-arm.list
@@ -22,7 +22,7 @@ libiconv-1.15-win10-ARM-v140.7z
 libmicrohttpd-0.9.55-win10-ARM-v140.7z
 libnfs-1.11.0-win10-ARM-v140.7z
 libplist-1.12-win10-ARM-v140.7z
-libssh-0.7.0-win10-ARM-v140.7z
+libssh-0.7.0-v1-win10-ARM-v140.7z
 libxml2-2.9.4-win10-ARM-v140.7z
 libxslt-1.1.29-win10-ARM-v140.7z
 lzo2-2.09-win10-ARM-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-arm.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-arm.list
@@ -32,7 +32,7 @@ openssl-1.0.2k-win10-ARM-v140.7z
 pcre-8.40-win10-ARM-v140.7z
 pillow-4.2.1-v1-win10-ARM-v140.7z
 pycryptodome-3.4.7-v1-win10-ARM-v140.7z
-python-2.7.13-v3-win10-ARM-v140.7z
+python-2.7.13-v4-win10-ARM-v140.7z
 rapidjson-1.1.0-win32.7z
 shairplay-ce80e00-win10-ARM-v140.7z
 sqlite-3170000-win10-ARM-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-win32.list
@@ -32,7 +32,7 @@ openssl-1.0.2k-win10-Win32-v140.7z
 pcre-8.40-win10-Win32-v140.7z
 pillow-4.2.1-v1-win10-Win32-v140.7z
 pycryptodome-3.4.7-v1-win10-Win32-v140.7z
-python-2.7.13-v3-win10-Win32-v140.7z
+python-2.7.13-v4-win10-Win32-v140.7z
 rapidjson-1.1.0-win32.7z
 shairplay-ce80e00-win10-Win32-v140.7z
 sqlite-3170000-win10-Win32-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-win32.list
@@ -22,7 +22,7 @@ libiconv-1.15-win10-Win32-v140.7z
 libmicrohttpd-0.9.55-win10-Win32-v140.7z
 libnfs-1.11.0-win10-Win32-v140.7z
 libplist-1.12-win10-Win32-v140.7z
-libssh-0.7.0-win10-Win32-v140.7z
+libssh-0.7.0-v1-win10-Win32-v140.7z
 libxml2-2.9.4-win10-Win32-v140.7z
 libxslt-1.1.29-win10-Win32-v140.7z
 lzo2-2.09-win10-Win32-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-x64.list
@@ -32,7 +32,7 @@ openssl-1.0.2k-win10-x64-v140.7z
 pcre-8.40-win10-x64-v140.7z
 pillow-4.2.1-v1-win10-x64-v140.7z
 pycryptodome-3.4.7-v1-win10-x64-v140.7z
-python-2.7.13-v4-win10-x64-v140.7z
+python-2.7.13-v5-win10-x64-v140.7z
 rapidjson-1.1.0-win32.7z
 shairplay-ce80e00-win10-x64-v140.7z
 sqlite-3170000-win10-x64-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-x64.list
@@ -22,7 +22,7 @@ libiconv-1.15-win10-x64-v140.7z
 libmicrohttpd-0.9.55-win10-x64-v140.7z
 libnfs-1.11.0-win10-x64-v140.7z
 libplist-1.12-win10-x64-v140.7z
-libssh-0.7.0-win10-x64-v140.7z
+libssh-0.7.0-v1-win10-x64-v140.7z
 libxml2-2.9.4-win10-x64-v140.7z
 libxslt-1.1.29-win10-x64-v140.7z
 lzo2-2.09-win10-x64-v140.7z

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -352,11 +352,12 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
                                         0, deviceId.c_str(), nullptr, AudioCategory_Media);
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
 
-    if (SUCCEEDED(hr) || details.eDeviceType == AE_DEVTYPE_HDMI)
+    if (FAILED(hr))
     {
-      if (FAILED(hr))
-        CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD), details.strDescription.c_str());
-
+      CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD), details.strDescription.c_str());
+    }
+    else
+    {
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
       add192 = true;
     }
@@ -366,11 +367,12 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_MLP;
 
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-    if (SUCCEEDED(hr) || details.eDeviceType == AE_DEVTYPE_HDMI)
+    if (FAILED(hr))
     {
-      if (FAILED(hr))
-        CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD), details.strDescription.c_str());
-
+      CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD), details.strDescription.c_str());
+    }
+    else 
+    {
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
       add192 = true;
     }
@@ -387,11 +389,12 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
                                         0, deviceId.c_str(), nullptr, AudioCategory_Media);
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
 
-    if (SUCCEEDED(hr) || details.eDeviceType == AE_DEVTYPE_HDMI)
+    if (FAILED(hr))
     {
-      if (FAILED(hr))
-        CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription.c_str());
-
+      CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription.c_str());
+    }
+    else 
+    {
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
       add192 = true;
     }
@@ -408,11 +411,12 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr2 = xaudio2->CreateMasteringVoice(&mMasterVoice, wfxex.Format.nChannels, wfxex.Format.nSamplesPerSec,
                                         0, deviceId.c_str(), nullptr, AudioCategory_Media);
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-    if (SUCCEEDED(hr) || details.eDeviceType == AE_DEVTYPE_HDMI)
+    if (FAILED(hr))
     {
-      if (FAILED(hr))
-        CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", "STREAM_TYPE_DTS", details.strDescription.c_str());
-
+      CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", "STREAM_TYPE_DTS", details.strDescription.c_str());
+    }
+    else
+    {
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
@@ -424,11 +428,12 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL;
 
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-    if (SUCCEEDED(hr) || details.eDeviceType == AE_DEVTYPE_HDMI)
+    if (FAILED(hr))
     {
-      if (FAILED(hr))
-        CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription.c_str());
-
+      CLog::Log(LOGNOTICE, __FUNCTION__": stream type \"%s\" on device \"%s\" seems to be not supported.", CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription.c_str());
+    }
+    else
+    {
       deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
     }
 


### PR DESCRIPTION
see commit messages

fixes:
- [x] sftp does not work
- [x] python error `Undefined attribute tzname`
- [x] xaudio: avoid trying of pass-through.