### PR TITLE
ActiveAESink: We can only do PT if at least one PT format is supported

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -108,7 +108,7 @@ bool CActiveAESink::HasPassthroughDevice()
     for (AEDeviceInfoList::iterator itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
     {
       CAEDeviceInfo& info = *itt2;
-      if (info.m_deviceType != AE_DEVTYPE_PCM)
+      if (info.m_deviceType != AE_DEVTYPE_PCM && !info.m_streamTypes.empty())
         return true;
     }
   }


### PR DESCRIPTION
This is one step to properly sync GUI settings to available formats. In the past we assumed that when device type is SPDIF or device type is HDMI then it would do passthrough.

Though - we cannot tell the sinks to announce themselves as PCM devices to reflect that it is not a PT device. Especially SPDIF is a problem here. It can only open 2 PCM channels and needs special care.

Therefore: Only make PT available if we have a HDMI or SPDIF device and at least one supported RAW format.

Let's see if this is enough for UWP to not falsely display PT devices if no PT is available.

If ones a device appears that can do e.g. DTS but not AC3 the settings needs to be revisited again.
  