### PR TITLE
[PVR] fix episode special labeling for PVR Guide, Timer, Channels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9872,30 +9872,25 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
       if (item->HasPVRChannelInfoTag())
       {
         CPVREpgInfoTagPtr tag(item->GetPVRChannelInfoTag()->GetEPGNow());
-        if (tag)
+        if (tag && tag->EpisodeNumber() > 0)
         {
-          if (tag->SeriesNumber() > 0)
-            iSeason = tag->SeriesNumber();
-          if (tag->EpisodeNumber() > 0)
-            iEpisode = tag->EpisodeNumber();
+          iEpisode = tag->EpisodeNumber();
+          iSeason = tag->SeriesNumber();
         }
       }
-      else if (item->HasEPGInfoTag())
+      else if (item->HasEPGInfoTag() &&
+               item->GetEPGInfoTag()->EpisodeNumber() > 0)
       {
-        if (item->GetEPGInfoTag()->SeriesNumber() > 0)
-          iSeason = item->GetEPGInfoTag()->SeriesNumber();
-        if (item->GetEPGInfoTag()->EpisodeNumber() > 0)
-          iEpisode = item->GetEPGInfoTag()->EpisodeNumber();
+        iSeason = item->GetEPGInfoTag()->SeriesNumber();
+        iEpisode = item->GetEPGInfoTag()->EpisodeNumber();
       }
       else if (item->HasPVRTimerInfoTag())
       {
         const CPVREpgInfoTagPtr tag(item->GetPVRTimerInfoTag()->GetEpgInfoTag());
-        if (tag)
+        if (tag && tag->EpisodeNumber() > 0)
         {
-          if (tag->SeriesNumber() > 0)
-            iSeason = tag->SeriesNumber();
-          if (tag->EpisodeNumber() > 0)
-            iEpisode = tag->EpisodeNumber();
+          iSeason = tag->SeriesNumber();
+          iEpisode = tag->EpisodeNumber();
         }
       }
       else if (item->HasVideoInfoTag() &&


### PR DESCRIPTION
Corrects behaviour for season/episode label for PVR Guide, Timer, Channel infotag

## Description
PVR Guide, Timer, Channel codepaths in LISTITEM_EPISODE of CGUIInfoManager::GetItemLabel
to properly return a label as SXX if there is iSeasonNumber == 0, but an episode number is
given in their relevant info tags.
Discussion https://github.com/kodi-pvr/pvr.demo/issues/59

## Motivation and Context
Uniformity for expected behaviour across PVR Channel, Guide, Timer, Recording labels for Season/Episode numbering

## How Has This Been Tested?
Mac OS X running latest kodi master

## Screenshots (if appropriate):

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
