### PR TITLE
[videoplayer] CVideoPlayer::OpenVideoStream: Pass item's dynpath to R…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3676,7 +3676,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     if (hint.fpsrate > 0 && hint.fpsscale > 0)
     {
       float fFramesPerSecond = (float)m_CurrentVideo.hint.fpsrate / (float)m_CurrentVideo.hint.fpsscale;
-      m_Edl.ReadEditDecisionLists(m_item.GetPath(), fFramesPerSecond, m_CurrentVideo.hint.height);
+      m_Edl.ReadEditDecisionLists(m_item.GetDynPath(), fFramesPerSecond, m_CurrentVideo.hint.height);
     }
 
     if (s.stereo_mode == "mono")


### PR DESCRIPTION
…eadEditDecisionLists, not the static path.

Fixes EDL support for Mediaportal PVR client addon supplied content. Problem was brought up in the forum: https://forum.kodi.tv/showthread.php?tid=324893&pid=2686537#pid2686537

@margro f.y.i.

@FernetMenta good to go?