### PR TITLE
[gui] use select dialog instead of context menu for profile lock mode selection

### DIFF
--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -285,12 +285,12 @@ void CGUIDialogLockSettings::InitializeSettings()
     AddToggle(groupDetails, SETTING_LOCK_FILEMANAGER, 20042, SettingLevel::Basic, m_locks.files);
 
     TranslatableIntegerSettingOptions settingsLevelOptions;
-    settingsLevelOptions.push_back(std::make_pair(106,    LOCK_LEVEL::NONE));
-    settingsLevelOptions.push_back(std::make_pair(593,    LOCK_LEVEL::ALL));
-    settingsLevelOptions.push_back(std::make_pair(10037,  LOCK_LEVEL::STANDARD));
-    settingsLevelOptions.push_back(std::make_pair(10038,  LOCK_LEVEL::ADVANCED));
-    settingsLevelOptions.push_back(std::make_pair(10039,  LOCK_LEVEL::EXPERT));
-    AddSpinner(groupDetails, SETTING_LOCK_SETTINGS, 20043, SettingLevel::Basic, static_cast<int>(m_locks.settings), settingsLevelOptions);
+    settingsLevelOptions.push_back(std::make_pair(106, LOCK_LEVEL::NONE));
+    settingsLevelOptions.push_back(std::make_pair(593, LOCK_LEVEL::ALL));
+    settingsLevelOptions.push_back(std::make_pair(10037, LOCK_LEVEL::STANDARD));
+    settingsLevelOptions.push_back(std::make_pair(10038, LOCK_LEVEL::ADVANCED));
+    settingsLevelOptions.push_back(std::make_pair(10039, LOCK_LEVEL::EXPERT));
+    AddList(groupDetails, SETTING_LOCK_SETTINGS, 20043, SettingLevel::Basic, static_cast<int>(m_locks.settings), settingsLevelOptions, 20043);
     
     AddToggle(groupDetails, SETTING_LOCK_ADDONMANAGER, 24090, SettingLevel::Basic, m_locks.addonManager);
   }

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.h
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.h
@@ -49,8 +49,9 @@ protected:
   void InitializeSettings() override;
 
 private:
-  void setDetailSettingsEnabled(bool enabled);
-  void setLockCodeLabel();
+  std::string GetLockModeLabel();
+  void SetDetailSettingsEnabled(bool enabled);
+  void SetSettingLockCodeLabel();
 
   bool m_changed;
 


### PR DESCRIPTION
Some pros:
* we use the select dialog for all multi value settings
* pre-select the selected lock mode
* set custom heading

![screenshot001](https://user-images.githubusercontent.com/1878991/34618837-547334f6-f240-11e7-8dd6-719ebf826239.png)

@ronie any objections?