### PR TITLE
sql-client: add support for mariadb-client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,6 @@ set(optional_deps Alsa
                   LCMS2
                   MDNS
                   MicroHttpd
-                  MySqlClient
                   PulseAudio
                   Python
                   SmbClient
@@ -178,6 +177,17 @@ core_require_dep(${required_deps})
 core_optional_dep(${optional_deps})
 core_require_dyload_dep(${required_dyload})
 core_optional_dyload_dep(${dyload_optional})
+
+if(ENABLE_MARIADBCLIENT AND NOT ENABLE_MARIADBCLIENT STREQUAL AUTO AND ENABLE_MYSQLCLIENT AND NOT ENABLE_MYSQLCLIENT STREQUAL AUTO)
+  MESSAGE(FATAL_ERROR "You can not use MySql and MariaDB at the same time. Disable one by adding -DENABLE_MYSQLCLIENT=OFF or -DENABLE_MARIADBCLIENT=OFF.")
+elseif(ENABLE_MYSQLCLIENT AND NOT ENABLE_MYSQLCLIENT STREQUAL AUTO)
+  set(ENABLE_MARIADBCLIENT OFF CACHE BOOL "")
+endif()
+
+core_optional_dep(MariaDBClient)
+if(NOT MARIADBCLIENT_FOUND)
+  core_optional_dep(MySqlClient)
+endif()
 
 if(NOT UDEV_FOUND)
   core_optional_dep(LibUSB)

--- a/cmake/modules/FindMariaDBClient.cmake
+++ b/cmake/modules/FindMariaDBClient.cmake
@@ -1,0 +1,69 @@
+#.rst:
+# FindMariaDBClient
+# ---------------
+# Finds the MariaDBClient library
+#
+# This will will define the following variables::
+#
+# MARIADBCLIENT_FOUND - system has MariaDBClient
+# MARIADBCLIENT_INCLUDE_DIRS - the MariaDBClient include directory
+# MARIADBCLIENT_LIBRARIES - the MariaDBClient libraries
+# MARIADBCLIENT_DEFINITIONS - the MariaDBClient compile definitions
+#
+# and the following imported targets::
+#
+#   MariaDBClient::MariaDBClient   - The MariaDBClient library
+
+# Don't find system wide installed version on Windows
+if(WIN32)
+  set(EXTRA_FIND_ARGS NO_SYSTEM_ENVIRONMENT_PATH)
+else()
+  set(EXTRA_FIND_ARGS)
+endif()
+
+find_path(MARIADBCLIENT_INCLUDE_DIR NAMES mariadb/mysql.h mariadb/server/mysql.h)
+find_library(MARIADBCLIENT_LIBRARY_RELEASE NAMES mariadbclient libmariadb
+                                           PATH_SUFFIXES mariadb
+                                           ${EXTRA_FIND_ARGS})
+find_library(MARIADBCLIENT_LIBRARY_DEBUG NAMES mariadbclient libmariadb
+                                         PATH_SUFFIXES mariadb
+                                         ${EXTRA_FIND_ARGS})
+
+if(MARIADBCLIENT_INCLUDE_DIR AND EXISTS "${MARIADBCLIENT_INCLUDE_DIR}/mariadb/mariadb_version.h")
+  file(STRINGS "${MARIADBCLIENT_INCLUDE_DIR}/mariadb/mariadb_version.h" mariadb_version_str REGEX "^#define[\t ]+MARIADB_CLIENT_VERSION_STR[\t ]+\".*\".*")
+  string(REGEX REPLACE "^#define[\t ]+MARIADB_CLIENT_VERSION_STR[\t ]+\"([^\"]+)\".*" "\\1" MARIADBCLIENT_VERSION_STRING "${mariadb_version_str}")
+  unset(mariadb_version_str)
+endif()
+
+include(SelectLibraryConfigurations)
+select_library_configurations(MARIADBCLIENT)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MariaDBClient
+                                  REQUIRED_VARS MARIADBCLIENT_LIBRARY MARIADBCLIENT_INCLUDE_DIR
+                                  VERSION_VAR MARIADBCLIENT_VERSION_STRING)
+
+if(MARIADBCLIENT_FOUND)
+  set(MARIADBCLIENT_LIBRARIES ${MARIADBCLIENT_LIBRARY})
+  set(MARIADBCLIENT_INCLUDE_DIRS ${MARIADBCLIENT_INCLUDE_DIR})
+  set(MARIADBCLIENT_DEFINITIONS -DHAS_MARIADB=1)
+
+  if(NOT TARGET MariaDBClient::MariaDBClient)
+    add_library(MariaDBClient::MariaDBClient UNKNOWN IMPORTED)
+    if(MARIADBCLIENT_LIBRARY_RELEASE)
+      set_target_properties(MariaDBClient::MariaDBClient PROPERTIES
+                                                         IMPORTED_CONFIGURATIONS RELEASE
+                                                         IMPORTED_LOCATION "${MARIADBCLIENT_LIBRARY_RELEASE}")
+    endif()
+    if(MARIADBCLIENT_LIBRARY_DEBUG)
+      set_target_properties(MariaDBClient::MariaDBClient PROPERTIES
+                                                         IMPORTED_CONFIGURATIONS DEBUG
+                                                         IMPORTED_LOCATION "${MARIADBCLIENT_LIBRARY_DEBUG}")
+    endif()
+    set_target_properties(MariaDBClient::MariaDBClient PROPERTIES
+                                                       INTERFACE_INCLUDE_DIRECTORIES "${MARIADBCLIENT_INCLUDE_DIR}"
+                                                       INTERFACE_COMPILE_DEFINITIONS HAS_MARIADB=1)
+  endif()
+endif()
+
+mark_as_advanced(MARIADBCLIENT_INCLUDE_DIR MARIADBCLIENT_LIBRARY)

--- a/xbmc/dbwrappers/CMakeLists.txt
+++ b/xbmc/dbwrappers/CMakeLists.txt
@@ -10,7 +10,7 @@ set(HEADERS Database.h
             qry_dat.h
             sqlitedataset.h)
 
-if(MYSQLCLIENT_FOUND)
+if(MYSQLCLIENT_FOUND OR MARIADBCLIENT_FOUND)
   list(APPEND SOURCES mysqldataset.cpp)
   list(APPEND HEADERS mysqldataset.h)
 endif()

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -30,7 +30,7 @@
 #include "DatabaseManager.h"
 #include "DbUrl.h"
 
-#ifdef HAS_MYSQL
+#if defined(HAS_MYSQL) || defined(HAS_MARIADB) 
 #include "mysqldataset.h"
 #endif
 
@@ -378,7 +378,7 @@ void CDatabase::InitSettings(DatabaseSettings &dbSettings)
 {
   m_sqlite = true;
 
-#ifdef HAS_MYSQL
+#if defined(HAS_MYSQL) || defined(HAS_MARIADB)
   if (dbSettings.type == "mysql")
   {
     // check we have all information before we cancel the fallback
@@ -421,7 +421,7 @@ bool CDatabase::Connect(const std::string &dbName, const DatabaseSettings &dbSet
   {
     m_pDB.reset( new SqliteDatabase() ) ;
   }
-#ifdef HAS_MYSQL
+#if defined(HAS_MYSQL) || defined(HAS_MARIADB)
   else if (dbSettings.type == "mysql")
   {
     m_pDB.reset( new MysqlDatabase() ) ;

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -30,7 +30,11 @@
 #include "utils/StringUtils.h"
 
 #include "mysqldataset.h"
+#ifdef HAS_MYSQL
 #include "mysql/errmsg.h"
+#elif defined(HAS_MARIADB)
+#include <mariadb/errmsg.h>
+#endif
 
 #ifdef TARGET_POSIX
 #include "platform/linux/ConvUtils.h"

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -22,7 +22,11 @@
 
 #include <stdio.h>
 #include "dataset.h"
+#ifdef HAS_MYSQL
 #include "mysql/mysql.h"
+#elif defined(HAS_MARIADB)
+#include <mariadb/mysql.h>
+#endif
 
 namespace dbiplus {
 /***************** Class MysqlDatabase definition ******************


### PR DESCRIPTION
make it possible to link against mariadb-client instead of mysql

## Description
Search explicit for libmariadb and mysql-header under include/mariadb/.
Additional added a test, to protect against using of mysql & mariadb at the same time 

## Motivation and Context
most distributions switch to mariadb, this follows up.

## How Has This Been Tested?
tested on top of LibreELEC master with MariaDB 10.2 and MySQL 5.7 as sql-server.
test-cases: 
 - database migration from Video108 -> Video109
 - database migration from Music66 -> Music69
 - list movies
 - mark movie as seen
 - builds against mysql-client and mariadb-client and against both (as negative test)

reallife test on top of KRYTON (LE 8.2.2), is started.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

  