### PR TITLE
fix: settings: check if webserver is compiled in before enabling ssl

### DIFF
--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -347,8 +347,10 @@ void CSettingConditions::Initialize()
 
   m_simpleConditions.insert("has_ae_quality_levels");
 
+#ifdef HAS_WEB_SERVER
   if(CWebServer::WebServerSupportsSSL())
     m_simpleConditions.insert("webserver_has_ssl");
+#endif
 
   // add complex conditions
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("addonhassettings",              AddonHasSettings));


### PR DESCRIPTION
fixes a build error with webserver disabled after #13165