### PR TITLE
[PVR] Fix OSD player times

### DIFF
--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -284,7 +284,17 @@ void CPVRGUIInfo::UpdateTimeshift(void)
   m_iStartTime = iStartTime;
   m_iTimeshiftStartTime = iStartTime + iMinTime;
   m_iTimeshiftEndTime = iStartTime + iMaxTime;
-  m_iTimeshiftPlayTime = iStartTime + iPlayTime;
+
+  if (m_iTimeshiftEndTime > m_iTimeshiftStartTime)
+  {
+    // getstreamtimes api
+    m_iTimeshiftPlayTime = iStartTime + iPlayTime;
+  }
+  else
+  {
+    // legacy api
+    m_iTimeshiftPlayTime = std::time(nullptr);
+  }
 
   CDateTime tmp;
   tmp.SetFromUTCDateTime(m_iTimeshiftStartTime);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -561,7 +561,7 @@ int CPVRGUIInfo::TranslateIntInfo(DWORD dwInfo) const
   CSingleLock lock(m_critSection);
 
   if (dwInfo == PVR_EPG_EVENT_PROGRESS)
-    iReturn = (int) ((float) GetStartTime() / m_iDuration * 100);
+    iReturn = (int) ((float) GetPlayingTime() / m_iDuration * 100);
   else if (dwInfo == PVR_ACTUAL_STREAM_SIG_PROGR)
     iReturn = (int) ((float) m_qualityInfo.iSignal / 0xFFFF * 100);
   else if (dwInfo == PVR_ACTUAL_STREAM_SNR_PROGR)
@@ -875,18 +875,18 @@ void CPVRGUIInfo::CharInfoTimeshiftPlayTime(std::string &strValue) const
 
 void CPVRGUIInfo::CharInfoEpgEventElapsedTime(std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString(GetStartTime() / 1000, TIME_FORMAT_GUESS).c_str();
+  strValue = StringUtils::SecondsToTimeString(GetPlayingTime() / 1000, TIME_FORMAT_GUESS).c_str();
 }
 
 void CPVRGUIInfo::CharInfoEpgEventRemainingTime(std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString((m_iDuration - GetStartTime()) / 1000, TIME_FORMAT_GUESS).c_str();
+  strValue = StringUtils::SecondsToTimeString((m_iDuration - GetPlayingTime()) / 1000, TIME_FORMAT_GUESS).c_str();
 }
 
 void CPVRGUIInfo::CharInfoEpgEventFinishTime(std::string &strValue) const
 {
   CDateTime finishTime = CDateTime::GetCurrentDateTime();
-  finishTime += CDateTimeSpan(0, 0, 0, (m_iDuration - GetStartTime()) / 1000);
+  finishTime += CDateTimeSpan(0, 0, 0, (m_iDuration - GetPlayingTime()) / 1000);
   strValue = finishTime.GetAsLocalizedTime("", false);
 }
 
@@ -1146,7 +1146,7 @@ int CPVRGUIInfo::GetDuration(void) const
   return m_iDuration;
 }
 
-int CPVRGUIInfo::GetStartTime(void) const
+int CPVRGUIInfo::GetPlayingTime(void) const
 {
   CSingleLock lock(m_critSection);
 

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1135,6 +1135,13 @@ void CPVRGUIInfo::UpdateNextTimer(void)
 
 int CPVRGUIInfo::GetDuration(void) const
 {
+  if (!m_bHasTimeshiftData)
+  {
+    // fetch data
+    const_cast<CPVRGUIInfo*>(this)->UpdateTimeshift();
+    const_cast<CPVRGUIInfo*>(this)->UpdatePlayingTag();
+  }
+
   CSingleLock lock(m_critSection);
   return m_iDuration;
 }
@@ -1142,6 +1149,14 @@ int CPVRGUIInfo::GetDuration(void) const
 int CPVRGUIInfo::GetStartTime(void) const
 {
   CSingleLock lock(m_critSection);
+
+  if (!m_bHasTimeshiftData)
+  {
+    // fetch data
+    const_cast<CPVRGUIInfo*>(this)->UpdateTimeshift();
+    const_cast<CPVRGUIInfo*>(this)->UpdatePlayingTag();
+  }
+
   if (m_playingEpgTag || m_iTimeshiftStartTime)
   {
     /* Calculate here the position we have of the running live TV event.

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -68,7 +68,7 @@ namespace PVR
      * @brief Get the current position in milliseconds since the start of a LiveTV item.
      * @return The position in milliseconds or NULL if no channel is playing.
      */
-    int GetStartTime(void) const;
+    int GetPlayingTime(void) const;
 
     /*!
      * @brief Clear the playing EPG tag.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -809,7 +809,7 @@ int CPVRManager::GetTotalTime(void) const
 
 int CPVRManager::GetStartTime(void) const
 {
-  return IsStarted() && m_guiInfo ? m_guiInfo->GetStartTime() : 0;
+  return IsStarted() && m_guiInfo ? m_guiInfo->GetPlayingTime() : 0;
 }
 
 bool CPVRManager::TranslateBoolInfo(DWORD dwInfo) const


### PR DESCRIPTION
This should fix the problems with Live TV OSD times for content provided by PVR client addons that do not support the new API function `GetStreamTimes`.

The changes are runtime tested on macOS, latest kodi master with both addons supporting the API function and also with addons not supporting it.

@FernetMenta good to go?