### PR TITLE
Add history table

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5260,7 +5260,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
   }
   if (iVersion < 110)
   {
-    m_pDS->exec("CREATE TABLE history(id INTEGER PRIMARY KEY AUTOINCREMENT, dateWatched TEXT NOT NULL, idFile INTEGER NOT NULL)");
+    m_pDS->exec("CREATE TABLE history(id INTEGER PRIMARY KEY, dateWatched TEXT NOT NULL, idFile INTEGER NOT NULL)");
 
     m_pDS->exec("INSERT INTO history(dateWatched, idFile) SELECT lastPlayed, idFile FROM files AS f WHERE f.playCount is not NULL");
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -353,7 +353,7 @@ void CVideoDatabase::CreateViews()
                                       "  files.strFileName AS strFileName,"
                                       "  path.strPath AS strPath,"
                                       "  (SELECT COUNT(history.idFile) FROM history WHERE history.idFile = files.idFile) AS playCount,"
-                                      "  files.lastPlayed AS lastPlayed,"
+                                      "  (SELECT MAX(history.dateWatched) FROM history WHERE history.idFile = files.idFile) AS lastPlayed,"
                                       "  files.dateAdded AS dateAdded,"
                                       "  tvshow.c%02d AS strTitle,"
                                       "  tvshow.c%02d AS genre,"
@@ -5276,6 +5276,12 @@ void CVideoDatabase::UpdateTables(int iVersion)
         m_pDS->exec(PrepareSQL("INSERT INTO history(dateWatched, idFile) SELECT '', idFile FROM files AS f WHERE f.playCount = %i;", playCountIterator));
       }
     }
+
+    // Remove old columns
+    m_pDS->exec("CREATE TABLE filesnew(idFile INTEGER PRIMARY KEY, idPath INTEGER, strFilename TEXT, dateAdded TEXT)");
+    m_pDS->exec("INSERT INTO filesnew SELECT idFile, idPath, strFilename, dateAdded FROM files");
+    m_pDS->exec("DROP TABLE files");
+    m_pDS->exec("ALTER TABLE filesnew RENAME TO files");
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
This is heavily work in progress and while it works at the moment it probably has some cases that re broken.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This replaces the old files `playCount` and `lastPlayed` columns with a `history` table. It has `dateWatched` and a reference to a file. For every time watched, we add a new row. 
So this is much richer than the old fields, as we can have multiple lastPlayed/dateWatched entries for the same file. We're basically emulating the old fields while adding the new table to use in the future.

This first implementation however will focus on only having this internal and handling it correctly in core. We will need to expose it to the outer world in a later PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Very little. It seems to work fine on migration and leanback. And it also seems to safe fine on `Set as watched`.
It also sets playCount to 0 instead of `null` at the moment, not sure if this causes regressions.

- MySQL is completely untested as of now (might be broken due to me using subqueries, can't remember if those were bad for MySQL)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

  
  