### PR TITLE
VideoPlayer: advanced setting for max tempo

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -20,6 +20,7 @@
 
 #include "ProcessInfo.h"
 #include "cores/DataCacheCore.h"
+#include "settings/AdvancedSettings.h"
 #include "threads/SingleLock.h"
 
 CCriticalSection createSection;
@@ -528,9 +529,20 @@ float CProcessInfo::GetNewTempo()
   return m_newTempo;
 }
 
+float CProcessInfo::MinTempoPlatform()
+{
+  return 0.75f;
+}
+
+float CProcessInfo::MaxTempoPlatform()
+{
+  return 1.55f;
+}
+
 bool CProcessInfo::IsTempoAllowed(float tempo)
 {
-  if (tempo > 0.75 && tempo < 1.55)
+  if (tempo > MinTempoPlatform() &&
+      (tempo < MaxTempoPlatform() || tempo < g_advancedSettings.m_maxTempo))
     return true;
 
   return false;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -98,7 +98,9 @@ public:
   void SetTempo(float tempo);
   void SetNewTempo(float tempo);
   float GetNewTempo();
-  virtual bool IsTempoAllowed(float tempo);
+  bool IsTempoAllowed(float tempo);
+  virtual float MinTempoPlatform();
+  virtual float MaxTempoPlatform();
   void SetLevelVQ(int level);
   int GetLevelVQ();
   void SetGuiRender(bool gui);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -156,6 +156,7 @@ void CAdvancedSettings::Initialize()
   m_DXVAForceProcessorRenderer = true;
   m_DXVAAllowHqScaling = true;
   m_videoFpsDetect = 1;
+  m_maxTempo = 1.55f;
 
   m_mediacodecForceSoftwareRendering = false;
 
@@ -678,6 +679,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "usedisplaycontrolhwstereo", m_useDisplayControlHWStereo);
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
+    XMLUtils::GetFloat(pElement, "maxtempo", m_maxTempo, 1.5, 2.1);
 
     // Store global display latency settings
     TiXmlElement* pVideoLatency = pElement->FirstChildElement("latency");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -191,6 +191,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVAAllowHqScaling;
     int  m_videoFpsDetect;
     bool m_mediacodecForceSoftwareRendering;
+    float m_maxTempo;
 
     std::string m_videoDefaultPlayer;
     float m_videoPlayCountMinimumPercent;


### PR DESCRIPTION
Users demanding max tempo > 1.5 but this won't work in general on all platforms. So far platform devs did not override maxTempo.
The advanced setting gives users the chance to experiment.