### PR TITLE
[fix] register settings callback for weather manager is called before it is ready

### DIFF
--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -1017,11 +1017,6 @@ void CSettings::InitializeISettingCallbacks()
   GetSettingsManager()->RegisterCallback(&g_timezone, settingSet);
 #endif
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_WEATHER_ADDON);
-  settingSet.insert(CSettings::SETTING_WEATHER_ADDONSETTINGS);
-  GetSettingsManager()->RegisterCallback(&CServiceBroker::GetWeatherManager(), settingSet);
-
 #if defined(TARGET_DARWIN_OSX)
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEMODE);
@@ -1079,7 +1074,6 @@ void CSettings::UninitializeISettingCallbacks()
 #if defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)
-  GetSettingsManager()->UnregisterCallback(&CServiceBroker::GetWeatherManager());
 #if defined(TARGET_DARWIN_OSX)
   GetSettingsManager()->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -27,6 +27,7 @@
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "settings/lib/Setting.h"
+#include "settings/lib/SettingsManager.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -38,10 +39,18 @@ using namespace ADDON;
 
 CWeatherManager::CWeatherManager(void) : CInfoLoader(30 * 60 * 1000) // 30 minutes
 {
+  CServiceBroker::GetSettings().GetSettingsManager()->RegisterCallback(this, {
+    CSettings::SETTING_WEATHER_ADDON,
+    CSettings::SETTING_WEATHER_ADDONSETTINGS
+  });
+
   Reset();
 }
 
-CWeatherManager::~CWeatherManager(void) = default;
+CWeatherManager::~CWeatherManager(void)
+{
+  CServiceBroker::GetSettings().GetSettingsManager()->UnregisterCallback(this);
+}
 
 std::string CWeatherManager::BusyInfo(int info) const
 {


### PR DESCRIPTION
As @FernetMenta pointed out, the weather manager is not ready when we want to register the settings callbacks. Now the registration/deregistration is moved to our service manager.

@MartijnKaijser ping you too.