### PR TITLE
FIX: [droid] "Attempt to remove non-JNI local" messages

### DIFF
--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=8b3d0f09c3bb32c38878813b3a122d7a510b7510
+VERSION=c2faa6fb006070b4965d949c5f7d94094f5cd98b
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/platform/android/activity/JNIMainActivity.cpp
+++ b/xbmc/platform/android/activity/JNIMainActivity.cpp
@@ -44,7 +44,7 @@ void CJNIMainActivity::_onNewIntent(JNIEnv *env, jobject context, jobject intent
   (void)env;
   (void)context;
   if (m_appInstance)
-    m_appInstance->onNewIntent(CJNIIntent(jhobject(intent)));
+    m_appInstance->onNewIntent(CJNIIntent(jhobject::fromJNI(intent)));
 }
 
 void CJNIMainActivity::_onActivityResult(JNIEnv *env, jobject context, jint requestCode, jint resultCode, jobject resultData)
@@ -52,7 +52,7 @@ void CJNIMainActivity::_onActivityResult(JNIEnv *env, jobject context, jint requ
   (void)env;
   (void)context;
   if (m_appInstance)
-    m_appInstance->onActivityResult(requestCode, resultCode, CJNIIntent(jhobject(resultData)));
+    m_appInstance->onActivityResult(requestCode, resultCode, CJNIIntent(jhobject::fromJNI(resultData)));
 }
 
 void CJNIMainActivity::_callNative(JNIEnv *env, jobject context, jlong funcAddr, jlong variantAddr)

--- a/xbmc/platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.cpp
@@ -67,7 +67,7 @@ void CJNIXBMCAudioManagerOnAudioFocusChangeListener::_onAudioFocusChange(JNIEnv 
 {
   (void)env;
 
-  CJNIXBMCAudioManagerOnAudioFocusChangeListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCAudioManagerOnAudioFocusChangeListener *inst = find_instance(thiz);
   if (inst)
     inst->onAudioFocusChange(focusChange);
 }

--- a/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMediaSession.cpp
@@ -177,7 +177,7 @@ void CJNIXBMCMediaSession::_onPlayRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnPlayRequested();
 }
@@ -186,7 +186,7 @@ void CJNIXBMCMediaSession::_onPauseRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnPauseRequested();
 }
@@ -195,7 +195,7 @@ void CJNIXBMCMediaSession::_onNextRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnNextRequested();
 }
@@ -204,7 +204,7 @@ void CJNIXBMCMediaSession::_onPreviousRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnPreviousRequested();
 }
@@ -213,7 +213,7 @@ void CJNIXBMCMediaSession::_onForwardRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnForwardRequested();
 }
@@ -222,7 +222,7 @@ void CJNIXBMCMediaSession::_onRewindRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnRewindRequested();
 }
@@ -231,7 +231,7 @@ void CJNIXBMCMediaSession::_onStopRequested(JNIEnv* env, jobject thiz)
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnStopRequested();
 }
@@ -240,7 +240,7 @@ void CJNIXBMCMediaSession::_onSeekRequested(JNIEnv* env, jobject thiz, jlong pos
 {
   (void)env;
 
-  CJNIXBMCMediaSession *inst = find_instance(jhobject(thiz));
+  CJNIXBMCMediaSession *inst = find_instance(thiz);
   if (inst)
     inst->OnSeekRequested(pos);
 }

--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.cpp
@@ -91,23 +91,23 @@ void CJNIXBMCNsdManagerDiscoveryListener::_onDiscoveryStopped(JNIEnv* env, jobje
 
 void CJNIXBMCNsdManagerDiscoveryListener::_onServiceFound(JNIEnv* env, jobject thiz, jobject serviceInfo)
 {
-  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(thiz);
   if (inst)
-    inst->onServiceFound(CJNINsdServiceInfo(jhobject(serviceInfo)));
+    inst->onServiceFound(CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo)));
 }
 
 void CJNIXBMCNsdManagerDiscoveryListener::_onServiceLost(JNIEnv* env, jobject thiz, jobject serviceInfo)
 {
-  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(thiz);
   if (inst)
-    inst->onServiceLost(CJNINsdServiceInfo(jhobject(serviceInfo)));
+    inst->onServiceLost(CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo)));
 }
 
 void CJNIXBMCNsdManagerDiscoveryListener::_onStartDiscoveryFailed(JNIEnv* env, jobject thiz, jstring serviceType, jint errorCode)
 {
   (void)env;
 
-  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(thiz);
   if (inst)
     inst->onStartDiscoveryFailed(jcast<std::string>(jhstring(serviceType)), errorCode);
 }
@@ -116,7 +116,7 @@ void CJNIXBMCNsdManagerDiscoveryListener::_onStopDiscoveryFailed(JNIEnv* env, jo
 {
   (void)env;
 
-  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCNsdManagerDiscoveryListener *inst = find_instance(thiz);
   if (inst)
     inst->onStopDiscoveryFailed(jcast<std::string>(jhstring(serviceType)), errorCode);
 }

--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerRegistrationListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerRegistrationListener.cpp
@@ -71,25 +71,25 @@ void CJNIXBMCNsdManagerRegistrationListener::RegisterNatives(JNIEnv* env)
 
 void CJNIXBMCNsdManagerRegistrationListener::_onRegistrationFailed(JNIEnv* env, jobject thiz, jobject serviceInfo, jint errorCode)
 {
-  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject(serviceInfo));
+  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo));
   CLog::Log(LOGERROR, "ZeroconfAndroid: %s.%s registration failed: %d", si.getServiceName().c_str(), si.getServiceType().c_str(), errorCode);
 }
 
 void CJNIXBMCNsdManagerRegistrationListener::_onServiceRegistered(JNIEnv* env, jobject thiz, jobject serviceInfo)
 {
-  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject(serviceInfo));
+  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo));
   CLog::Log(LOGINFO, "ZeroconfAndroid: %s.%s now registered and active", si.getServiceName().c_str(), si.getServiceType().c_str());
 }
 
 void CJNIXBMCNsdManagerRegistrationListener::_onServiceUnregistered(JNIEnv* env, jobject thiz, jobject serviceInfo)
 {
-  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject(serviceInfo));
+  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo));
   CLog::Log(LOGINFO, "ZeroconfAndroid: %s.%s registration removed", si.getServiceName().c_str(), si.getServiceType().c_str());
 }
 
 void CJNIXBMCNsdManagerRegistrationListener::_onUnregistrationFailed(JNIEnv* env, jobject thiz, jobject serviceInfo, jint errorCode)
 {
-  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject(serviceInfo));
+  CJNINsdServiceInfo si = CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo));
   CLog::Log(LOGERROR, "ZeroconfAndroid: %s.%s unregistration failed: %d", si.getServiceName().c_str(), si.getServiceType().c_str(), errorCode);
 }
 

--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerResolveListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerResolveListener.cpp
@@ -68,14 +68,14 @@ void CJNIXBMCNsdManagerResolveListener::RegisterNatives(JNIEnv* env)
 
 void CJNIXBMCNsdManagerResolveListener::_onResolveFailed(JNIEnv* env, jobject thiz, jobject serviceInfo, jint errorCode)
 {
-  CJNIXBMCNsdManagerResolveListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCNsdManagerResolveListener *inst = find_instance(thiz);
   if (inst)
-    inst->onResolveFailed(CJNINsdServiceInfo(jhobject(serviceInfo)), errorCode);
+    inst->onResolveFailed(CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo)), errorCode);
 }
 
 void CJNIXBMCNsdManagerResolveListener::_onServiceResolved(JNIEnv* env, jobject thiz, jobject serviceInfo)
 {
-  CJNIXBMCNsdManagerResolveListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCNsdManagerResolveListener *inst = find_instance(thiz);
   if (inst)
-    inst->onServiceResolved(CJNINsdServiceInfo(jhobject(serviceInfo)));
+    inst->onServiceResolved(CJNINsdServiceInfo(jhobject::fromJNI(serviceInfo)));
 }

--- a/xbmc/platform/android/activity/JNIXBMCSurfaceTextureOnFrameAvailableListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCSurfaceTextureOnFrameAvailableListener.cpp
@@ -66,7 +66,7 @@ void CJNIXBMCSurfaceTextureOnFrameAvailableListener::_onFrameAvailable(JNIEnv* e
 {
   (void)env;
 
-  CJNIXBMCSurfaceTextureOnFrameAvailableListener *inst = find_instance(jhobject(thiz));
+  CJNIXBMCSurfaceTextureOnFrameAvailableListener *inst = find_instance(thiz);
   if (inst)
-    inst->onFrameAvailable(CJNISurfaceTexture(jhobject(surface)));
+    inst->onFrameAvailable(CJNISurfaceTexture(jhobject::fromJNI(surface)));
 }

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -97,27 +97,27 @@ void CJNIXBMCVideoView::_surfaceChanged(JNIEnv *env, jobject thiz, jobject holde
 {
   (void)env;
 
-  CJNIXBMCVideoView *inst = find_instance(jhobject(thiz));
+  CJNIXBMCVideoView *inst = find_instance(thiz);
   if (inst)
-    inst->surfaceChanged(CJNISurfaceHolder(jhobject(holder)), format, width, height);
+    inst->surfaceChanged(CJNISurfaceHolder(jhobject::fromJNI(holder)), format, width, height);
 }
 
 void CJNIXBMCVideoView::_surfaceCreated(JNIEnv* env, jobject thiz, jobject holder)
 {
   (void)env;
 
-  CJNIXBMCVideoView *inst = find_instance(jhobject(thiz));
+  CJNIXBMCVideoView *inst = find_instance(thiz);
   if (inst)
-    inst->surfaceCreated(CJNISurfaceHolder(jhobject(holder)));
+    inst->surfaceCreated(CJNISurfaceHolder(jhobject::fromJNI(holder)));
 }
 
 void CJNIXBMCVideoView::_surfaceDestroyed(JNIEnv* env, jobject thiz, jobject holder)
 {
   (void)env;
 
-  CJNIXBMCVideoView *inst = find_instance(jhobject(thiz));
+  CJNIXBMCVideoView *inst = find_instance(thiz);
   if (inst)
-    inst->surfaceDestroyed(CJNISurfaceHolder(jhobject(holder)));
+    inst->surfaceDestroyed(CJNISurfaceHolder(jhobject::fromJNI(holder)));
 }
 
 void CJNIXBMCVideoView::surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height)


### PR DESCRIPTION
When we receive jni refs from Java, we should never delete them