### PR TITLE
Support for vaExportSurfaceHandle

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -2265,7 +2265,7 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
   // create config
   if (!CheckSuccess(vaCreateConfig(m_config.dpy, VAProfileNone, VAEntrypointVideoProc, NULL, 0, &m_configId)))
   {
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed");
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaCreateConfig");
 
     return false;
   }
@@ -2294,7 +2294,7 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
                                      nb_surfaces,
                                      attribs, 1)))
   {
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed");
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaCreateSurfaces");
 
     return false;
   }
@@ -2314,7 +2314,7 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
                                     &m_contextId)))
   {
     m_contextId = VA_INVALID_ID;
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed");
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaCreateContext");
 
     return false;
   }
@@ -2326,7 +2326,7 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
 
   if (!CheckSuccess(vaQueryVideoProcFilters(m_config.dpy, m_contextId, filters, &numFilters)))
   {
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed");
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaQueryVideoProcFilters");
 
     return false;
   }
@@ -2337,7 +2337,7 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
                                                deinterlacingCaps,
                                                &numDeinterlacingCaps)))
   {
-    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed");
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaQueryVideoProcFilterCaps");
 
     return false;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -64,7 +64,6 @@ CVAAPIContext::CVAAPIContext()
 {
   m_context = 0;
   m_refCount = 0;
-  m_attributes = NULL;
   m_profiles = NULL;
   m_display = NULL;
 }
@@ -200,15 +199,11 @@ bool CVAAPIContext::CreateContext()
   if (!m_profileCount)
     return false;
 
-  if (!m_attributeCount)
-    CLog::Log(LOGWARNING, "VAAPI - driver did not return anything from vlVaQueryDisplayAttributes");
-
   return true;
 }
 
 void CVAAPIContext::DestroyContext()
 {
-  delete[] m_attributes;
   delete[] m_profiles;
   if (m_display)
     CheckSuccess(vaTerminate(m_display));
@@ -216,26 +211,7 @@ void CVAAPIContext::DestroyContext()
 
 void CVAAPIContext::QueryCaps()
 {
-  m_attributeCount = 0;
   m_profileCount = 0;
-
-  int max_attributes = vaMaxNumDisplayAttributes(m_display);
-  m_attributes = new VADisplayAttribute[max_attributes];
-
-  if (!CheckSuccess(vaQueryDisplayAttributes(m_display, m_attributes, &m_attributeCount)))
-    return;
-
-  for(int i = 0; i < m_attributeCount; i++)
-  {
-    VADisplayAttribute * const display_attr = &m_attributes[i];
-    CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI - attrib %d (%s/%s) min %d max %d value 0x%x\n"
-                         , display_attr->type
-                         ,(display_attr->flags & VA_DISPLAY_ATTRIB_GETTABLE) ? "get" : "---"
-                         ,(display_attr->flags & VA_DISPLAY_ATTRIB_SETTABLE) ? "set" : "---"
-                         , display_attr->min_value
-                         , display_attr->max_value
-                         , display_attr->value);
-  }
 
   int max_profiles = vaMaxNumProfiles(m_display);
   m_profiles = new VAProfile[max_profiles];

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -51,6 +51,10 @@ extern "C" {
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#if VA_CHECK_VERSION(1, 0, 0)
+# include <va/va_str.h>
+#endif
+
 using namespace VAAPI;
 #define NUM_RENDER_PICS 7
 
@@ -221,7 +225,11 @@ void CVAAPIContext::QueryCaps()
 
   for(int i = 0; i < m_profileCount; i++)
   {
+#if VA_CHECK_VERSION(1, 0, 0)
+    CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI - profile %s", vaProfileStr(m_profiles[i]));
+#else
     CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI - profile %d", m_profiles[i]);
+#endif
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -461,7 +461,7 @@ bool CVideoSurfaces::HasRefs()
 //-----------------------------------------------------------------------------
 
 bool CDecoder::m_capGeneral = false;
-bool CDecoder::m_capHevc = false;
+bool CDecoder::m_capDeepColor = false;
 IVaapiWinSystem* CDecoder::m_pWinSystem = nullptr;
 
 CDecoder::CDecoder(CProcessInfo& processInfo) :
@@ -563,11 +563,13 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
     }
     case AV_CODEC_ID_HEVC:
     {
-      if (!m_capHevc)
-        return false;
-
       if (avctx->profile == FF_PROFILE_HEVC_MAIN_10)
+      {
+        if (!m_capDeepColor)
+          return false;
+
         profile = VAProfileHEVCMain10;
+      }
       else if (avctx->profile == FF_PROFILE_HEVC_MAIN)
         profile = VAProfileHEVCMain;
       else
@@ -1160,7 +1162,7 @@ IHardwareDecoder* CDecoder::Create(CDVDStreamInfo &hint, CProcessInfo &processIn
   return nullptr;
 }
 
-void CDecoder::Register(IVaapiWinSystem *winSystem, bool hevc)
+void CDecoder::Register(IVaapiWinSystem *winSystem, bool deepColor)
 {
   m_pWinSystem = winSystem;
 
@@ -1169,7 +1171,7 @@ void CDecoder::Register(IVaapiWinSystem *winSystem, bool hevc)
     return;
 
   m_capGeneral = true;
-  m_capHevc = hevc;
+  m_capDeepColor = deepColor;
   CDVDFactoryCodec::RegisterHWAccel("vaapi", CDecoder::Create);
   config.context->Release(nullptr);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -2306,8 +2306,8 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
   // create vaapi decoder context
   if (!CheckSuccess(vaCreateContext(m_config.dpy,
                                     m_configId,
-                                    0,
-                                    0,
+                                    m_config.surfaceWidth,
+                                    m_config.surfaceHeight,
                                     0,
                                     surfaces,
                                     nb_surfaces,

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -565,9 +565,9 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
       break;
     case AV_CODEC_ID_H264:
     {
-      if (avctx->profile == FF_PROFILE_H264_BASELINE)
+      if (avctx->profile == FF_PROFILE_H264_CONSTRAINED_BASELINE)
       {
-        profile = VAProfileH264Baseline;
+        profile = VAProfileH264ConstrainedBaseline;
         if (!m_vaapiConfig.context->SupportsProfile(profile))
           return false;
       }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1054,17 +1054,23 @@ bool CDecoder::ConfigVAAPI()
     return false;
 
   // create surfaces
+  unsigned int format = VA_RT_FORMAT_YUV420;
+  std::int32_t pixelFormat = VA_FOURCC_NV12;
+
+  if (m_vaapiConfig.profile == VAProfileHEVCMain10)
+  {
+    format = VA_RT_FORMAT_YUV420_10BPP;
+    pixelFormat = VA_FOURCC_P010;
+  }
+
   VASurfaceAttrib attribs[1], *attrib;
   attrib = attribs;
   attrib->flags = VA_SURFACE_ATTRIB_SETTABLE;
   attrib->type = VASurfaceAttribPixelFormat;
   attrib->value.type = VAGenericValueTypeInteger;
-  attrib->value.value.i = VA_FOURCC_NV12;
+  attrib->value.value.i = pixelFormat;
 
   VASurfaceID surfaces[32];
-  unsigned int format = VA_RT_FORMAT_YUV420;
-  if (m_vaapiConfig.profile == VAProfileHEVCMain10)
-    format = VA_RT_FORMAT_YUV420_10BPP;
   int nb_surfaces = m_vaapiConfig.maxReferences;
   if (!CheckSuccess(vaCreateSurfaces(m_vaapiConfig.dpy,
                                      format,

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -392,7 +392,7 @@ public:
   static int FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);
 
   static IHardwareDecoder* Create(CDVDStreamInfo &hint, CProcessInfo &processInfo, AVPixelFormat fmt);
-  static void Register(IVaapiWinSystem *winSystem, bool hevc);
+  static void Register(IVaapiWinSystem *winSystem, bool deepColor);
 
   static IVaapiWinSystem* m_pWinSystem;
 
@@ -431,7 +431,7 @@ protected:
   CProcessInfo& m_processInfo;
 
   static bool m_capGeneral;
-  static bool m_capHevc;
+  static bool m_capDeepColor;
 };
 
 //-----------------------------------------------------------------------------

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -118,6 +118,7 @@ struct CVaapiConfig
   VAProfile profile;
   VAConfigAttrib attrib;
   CProcessInfo *processInfo;
+  bool driverIsMesa;
 };
 
 /**

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -344,8 +344,6 @@ private:
   static CCriticalSection m_section;
   VADisplay m_display;
   int m_refCount;
-  int m_attributeCount;
-  VADisplayAttribute *m_attributes;
   int m_profileCount;
   VAProfile *m_profiles;
   std::vector<CDecoder*> m_decoders;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -42,7 +42,19 @@ CBaseRenderer* CRendererVAAPI::Create(CVideoBuffer *buffer)
 
 void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc)
 {
-  CVaapiTexture::TestInterop(vaDpy, eglDisplay, general, hevc);
+  int major_version, minor_version;
+  if (vaInitialize(vaDpy, &major_version, &minor_version) != VA_STATUS_SUCCESS)
+  {
+    vaTerminate(vaDpy);
+    return;
+  }
+
+  general = hevc = false;
+  CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
+  CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+
+  vaTerminate(vaDpy);
+
   if (general)
   {
     VIDEOPLAYER::CRendererFactory::RegisterRenderer("vaapi", CRendererVAAPI::Create);
@@ -77,7 +89,8 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
 
   for (auto &tex : m_vaapiTextures)
   {
-    tex.Init(interop);
+    tex.reset(new VAAPI::CVaapi1Texture);
+    tex->Init(interop);
   }
   for (auto &fence : m_fences)
   {
@@ -185,14 +198,15 @@ bool CRendererVAAPI::UploadTexture(int index)
     return UploadNV12Texture(index);
   }
 
-  m_vaapiTextures[index].Map(pic);
-  m_buffers[index].m_srcTextureBits = m_vaapiTextures[index].GetBits();
+  m_vaapiTextures[index]->Map(pic);
+  m_buffers[index].m_srcTextureBits = m_vaapiTextures[index]->GetBits();
 
   YuvImage &im = buf.image;
   YUVPLANE (&planes)[3] = buf.fields[0];
 
-  planes[0].texwidth  = m_vaapiTextures[index].m_texWidth;
-  planes[0].texheight = m_vaapiTextures[index].m_texHeight;
+  auto size = m_vaapiTextures[index]->GetTextureSize();
+  planes[0].texwidth  = size.Width();
+  planes[0].texheight = size.Height();
 
   planes[1].texwidth  = planes[0].texwidth  >> im.cshift_x;
   planes[1].texheight = planes[0].texheight >> im.cshift_y;
@@ -206,9 +220,9 @@ bool CRendererVAAPI::UploadTexture(int index)
   }
 
   // set textures
-  planes[0].id = m_vaapiTextures[index].m_textureY;
-  planes[1].id = m_vaapiTextures[index].m_textureVU;
-  planes[2].id = m_vaapiTextures[index].m_textureVU;
+  planes[0].id = m_vaapiTextures[index]->GetTextureY();
+  planes[1].id = m_vaapiTextures[index]->GetTextureVU();
+  planes[2].id = m_vaapiTextures[index]->GetTextureVU();
 
   for (int p=0; p<2; p++)
   {
@@ -264,6 +278,6 @@ void CRendererVAAPI::ReleaseBuffer(int idx)
     glDeleteSync(m_fences[idx]);
     m_fences[idx] = GL_NONE;
   }
-  m_vaapiTextures[idx].Unmap();
+  m_vaapiTextures[idx]->Unmap();
   CLinuxRendererGL::ReleaseBuffer(idx);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -50,8 +50,13 @@ void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDi
   }
 
   general = hevc = false;
-  CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
-  CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+  CVaapi2Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
+  CLog::Log(LOGDEBUG, "Vaapi2 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+  if (!general)
+  {
+    CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
+    CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+  }
 
   vaTerminate(vaDpy);
 
@@ -87,9 +92,18 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
   interop.glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
   interop.eglDisplay = CRendererVAAPI::m_pWinSystem->GetEGLDisplay();
 
+  bool useVaapi2 = VAAPI::CVaapi2Texture::TestInteropGeneral(pic->vadsp, CRendererVAAPI::m_pWinSystem->GetEGLDisplay());
+
   for (auto &tex : m_vaapiTextures)
   {
-    tex.reset(new VAAPI::CVaapi1Texture);
+    if (useVaapi2)
+    {
+      tex.reset(new VAAPI::CVaapi2Texture);
+    }
+    else
+    {
+      tex.reset(new VAAPI::CVaapi1Texture);
+    }
     tex->Init(interop);
   }
   for (auto &fence : m_fences)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -40,7 +40,7 @@ CBaseRenderer* CRendererVAAPI::Create(CVideoBuffer *buffer)
   return nullptr;
 }
 
-void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc)
+void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor)
 {
   int major_version, minor_version;
   if (vaInitialize(vaDpy, &major_version, &minor_version) != VA_STATUS_SUCCESS)
@@ -49,13 +49,13 @@ void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDi
     return;
   }
 
-  general = hevc = false;
-  CVaapi2Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
-  CLog::Log(LOGDEBUG, "Vaapi2 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+  general = deepColor = false;
+  CVaapi2Texture::TestInterop(vaDpy, eglDisplay, general, deepColor);
+  CLog::Log(LOGDEBUG, "Vaapi2 EGL interop test results: general %s, deepColor %s", general ? "yes" : "no", deepColor ? "yes" : "no");
   if (!general)
   {
-    CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
-    CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+    CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, deepColor);
+    CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, deepColor %s", general ? "yes" : "no", deepColor ? "yes" : "no");
   }
 
   vaTerminate(vaDpy);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
@@ -37,7 +37,7 @@ public:
   ~CRendererVAAPI() override;
 
   static CBaseRenderer* Create(CVideoBuffer *buffer);
-  static void Register(VAAPI::IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc);
+  static void Register(VAAPI::IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);
 
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "VaapiEGL.h"
 
@@ -61,7 +63,7 @@ protected:
   EShaderFormat GetShaderFormat() override;
 
   bool m_isVAAPIBuffer = true;
-  VAAPI::CVaapiTexture m_vaapiTextures[NUM_BUFFERS];
+  std::unique_ptr<VAAPI::CVaapiTexture> m_vaapiTextures[NUM_BUFFERS];
   GLsync m_fences[NUM_BUFFERS];
   static VAAPI::IVaapiWinSystem *m_pWinSystem;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -40,7 +40,7 @@ CBaseRenderer* CRendererVAAPI::Create(CVideoBuffer *buffer)
   return nullptr;
 }
 
-void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc)
+void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor)
 {
   int major_version, minor_version;
   if (vaInitialize(vaDpy, &major_version, &minor_version) != VA_STATUS_SUCCESS)
@@ -49,13 +49,13 @@ void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDi
     return;
   }
 
-  general = hevc = false;
-  CVaapi2Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
-  CLog::Log(LOGDEBUG, "Vaapi2 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+  general = deepColor = false;
+  CVaapi2Texture::TestInterop(vaDpy, eglDisplay, general, deepColor);
+  CLog::Log(LOGDEBUG, "Vaapi2 EGL interop test results: general %s, deepColor %s", general ? "yes" : "no", deepColor ? "yes" : "no");
   if (!general)
   {
-    CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
-    CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+    CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, deepColor);
+    CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, deepColor %s", general ? "yes" : "no", deepColor ? "yes" : "no");
   }
 
   vaTerminate(vaDpy);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -42,7 +42,19 @@ CBaseRenderer* CRendererVAAPI::Create(CVideoBuffer *buffer)
 
 void CRendererVAAPI::Register(IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc)
 {
-  CVaapiTexture::TestInterop(vaDpy, eglDisplay, general, hevc);
+  int major_version, minor_version;
+  if (vaInitialize(vaDpy, &major_version, &minor_version) != VA_STATUS_SUCCESS)
+  {
+    vaTerminate(vaDpy);
+    return;
+  }
+
+  general = hevc = false;
+  CVaapi1Texture::TestInterop(vaDpy, eglDisplay, general, hevc);
+  CLog::Log(LOGDEBUG, "Vaapi1 EGL interop test results: general %s, hevc %s", general ? "yes" : "no", hevc ? "yes" : "no");
+
+  vaTerminate(vaDpy);
+
   if (general)
   {
     VIDEOPLAYER::CRendererFactory::RegisterRenderer("vaapi", CRendererVAAPI::Create);
@@ -77,7 +89,8 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
 
   for (auto &tex : m_vaapiTextures)
   {
-    tex.Init(interop);
+    tex.reset(new VAAPI::CVaapi1Texture);
+    tex->Init(interop);
   }
   for (auto &fence : m_fences)
   {
@@ -185,13 +198,14 @@ bool CRendererVAAPI::UploadTexture(int index)
     return false;
   }
 
-  m_vaapiTextures[index].Map(pic);
+  m_vaapiTextures[index]->Map(pic);
 
   YuvImage &im = buf.image;
   YUVPLANE (&planes)[3] = buf.fields[0];
 
-  planes[0].texwidth  = m_vaapiTextures[index].m_texWidth;
-  planes[0].texheight = m_vaapiTextures[index].m_texHeight;
+  auto size = m_vaapiTextures[index]->GetTextureSize();
+  planes[0].texwidth  = size.Width();
+  planes[0].texheight = size.Height();
 
   planes[1].texwidth  = planes[0].texwidth  >> im.cshift_x;
   planes[1].texheight = planes[0].texheight >> im.cshift_y;
@@ -205,9 +219,10 @@ bool CRendererVAAPI::UploadTexture(int index)
   }
 
   // set textures
-  planes[0].id = m_vaapiTextures[index].m_textureY;
-  planes[1].id = m_vaapiTextures[index].m_textureVU;
-  planes[2].id = m_vaapiTextures[index].m_textureVU;
+  planes[0].id = m_vaapiTextures[index]->GetTextureY();
+  planes[1].id = m_vaapiTextures[index]->GetTextureVU();
+  planes[2].id = m_vaapiTextures[index]->GetTextureVU();
+
 
   for (int p=0; p<2; p++)
   {
@@ -263,6 +278,6 @@ void CRendererVAAPI::ReleaseBuffer(int idx)
     glDeleteSync(m_fences[idx]);
     m_fences[idx] = GL_NONE;
   }
-  m_vaapiTextures[idx].Unmap();
+  m_vaapiTextures[idx]->Unmap();
   CLinuxRendererGLES::ReleaseBuffer(idx);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -37,7 +37,7 @@ public:
   ~CRendererVAAPI() override;
 
   static CBaseRenderer* Create(CVideoBuffer *buffer);
-  static void Register(VAAPI::IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc);
+  static void Register(VAAPI::IVaapiWinSystem *winSystem, VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);
 
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "VaapiEGL.h"
 
@@ -61,7 +63,7 @@ protected:
   EShaderFormat GetShaderFormat() override;
 
   bool m_isVAAPIBuffer = true;
-  VAAPI::CVaapiTexture m_vaapiTextures[NUM_BUFFERS];
+  std::unique_ptr<VAAPI::CVaapiTexture> m_vaapiTextures[NUM_BUFFERS];
   GLsync m_fences[NUM_BUFFERS];
   static VAAPI::IVaapiWinSystem *m_pWinSystem;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -339,10 +339,10 @@ CSizeInt CVaapi1Texture::GetTextureSize()
   return {m_texWidth, m_texHeight};
 }
 
-void CVaapi1Texture::TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc)
+void CVaapi1Texture::TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor)
 {
   general = false;
-  hevc = false;
+  deepColor = false;
 
   PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC)eglGetProcAddress("eglCreateImageKHR");
   PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC)eglGetProcAddress("eglDestroyImageKHR");
@@ -403,11 +403,11 @@ void CVaapi1Texture::TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &g
 
   if (general)
   {
-    hevc = TestInteropHevc(vaDpy, eglDisplay);
+    deepColor = TestInteropDeepColor(vaDpy, eglDisplay);
   }
 }
 
-bool CVaapi1Texture::TestInteropHevc(VADisplay vaDpy, EGLDisplay eglDisplay)
+bool CVaapi1Texture::TestInteropDeepColor(VADisplay vaDpy, EGLDisplay eglDisplay)
 {
   bool ret = false;
 
@@ -733,15 +733,15 @@ bool CVaapi2Texture::TestEsh(VADisplay vaDpy, EGLDisplay eglDisplay, std::uint32
 #endif
 }
 
-void CVaapi2Texture::TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool& general, bool& hevc)
+void CVaapi2Texture::TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool& general, bool& deepColor)
 {
   general = false;
-  hevc = false;
+  deepColor = false;
 
   general = TestInteropGeneral(vaDpy, eglDisplay);
   if (general)
   {
-    hevc = TestEsh(vaDpy, eglDisplay, VA_RT_FORMAT_YUV420_10BPP, VA_FOURCC_P010);
+    deepColor = TestEsh(vaDpy, eglDisplay, VA_RT_FORMAT_YUV420_10BPP, VA_FOURCC_P010);
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -81,7 +81,7 @@ public:
   GLuint GetTextureVU() override;
   CSizeInt GetTextureSize() override;
 
-  static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc);
+  static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);
 
   GLuint m_texture = 0;
   GLuint m_textureY = 0;
@@ -91,7 +91,7 @@ public:
   int m_bits = 0;
 
 protected:
-  static bool TestInteropHevc(VADisplay vaDpy, EGLDisplay eglDisplay);
+  static bool TestInteropDeepColor(VADisplay vaDpy, EGLDisplay eglDisplay);
 
   InteropInfo m_interop;
   CVaapiRenderPicture *m_vaapiPic = nullptr;
@@ -116,7 +116,7 @@ public:
   GLuint GetTextureVU() override;
   CSizeInt GetTextureSize() override;
 
-  static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc);
+  static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);
   static bool TestInteropGeneral(VADisplay vaDpy, EGLDisplay eglDisplay);
 
 private:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <array>
+
 #if defined(HAS_GL)
 #include <GL/gl.h>
 #elif defined(HAS_GLES)
@@ -33,6 +35,7 @@
 #include <va/va.h>
 
 #include "utils/Geometry.h"
+#include "utils/posix/FileHandle.h"
 
 namespace VAAPI
 {
@@ -99,6 +102,39 @@ protected:
     EGLImageKHR eglImage;
     EGLImageKHR eglImageY, eglImageVU;
   } m_glSurface;
+};
+
+class CVaapi2Texture : public CVaapiTexture
+{
+public:
+  bool Map(CVaapiRenderPicture *pic) override;
+  void Unmap() override;
+  void Init(InteropInfo &interop) override;
+
+  int GetBits() override;
+  GLuint GetTextureY() override;
+  GLuint GetTextureVU() override;
+  CSizeInt GetTextureSize() override;
+
+  static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc);
+  static bool TestInteropGeneral(VADisplay vaDpy, EGLDisplay eglDisplay);
+
+private:
+  static bool TestEsh(VADisplay vaDpy, EGLDisplay eglDisplay, std::uint32_t rtFormat, std::int32_t pixelFormat);
+
+  struct MappedTexture
+  {
+    EGLImageKHR eglImage{EGL_NO_IMAGE_KHR};
+    GLuint glTexture{0};
+  };
+
+  InteropInfo m_interop;
+  CVaapiRenderPicture* m_vaapiPic{};
+  bool m_hasPlaneModifiers{false};
+  std::array<KODI::UTILS::POSIX::CFileHandle, 4> m_drmFDs;
+  int m_bits{0};
+  MappedTexture m_y, m_vu;
+  CSizeInt m_textureSize;
 };
 
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -32,6 +32,8 @@
 #include <EGL/eglext.h>
 #include <va/va.h>
 
+#include "utils/Geometry.h"
+
 namespace VAAPI
 {
 
@@ -49,11 +51,34 @@ struct InteropInfo
 class CVaapiTexture
 {
 public:
-  bool Map(CVaapiRenderPicture *pic);
-  void Unmap();
-  void Init(InteropInfo &interop);
+  CVaapiTexture() = default;
+  virtual ~CVaapiTexture() = default;
+
+  virtual void Init(InteropInfo &interop) = 0;
+  virtual bool Map(CVaapiRenderPicture *pic) = 0;
+  virtual void Unmap() = 0;
+
+  virtual int GetBits() = 0;
+  virtual GLuint GetTextureY() = 0;
+  virtual GLuint GetTextureVU() = 0;
+  virtual CSizeInt GetTextureSize() = 0;
+};
+
+class CVaapi1Texture : public CVaapiTexture
+{
+public:
+  CVaapi1Texture();
+
+  bool Map(CVaapiRenderPicture *pic) override;
+  void Unmap() override;
+  void Init(InteropInfo &interop) override;
+
+  int GetBits() override;
+  GLuint GetTextureY() override;
+  GLuint GetTextureVU() override;
+  CSizeInt GetTextureSize() override;
+
   static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &hevc);
-  int GetBits();
 
   GLuint m_texture = 0;
   GLuint m_textureY = 0;
@@ -69,11 +94,12 @@ protected:
   CVaapiRenderPicture *m_vaapiPic = nullptr;
   struct GLSurface
   {
-    VAImage vaImage;
+    VAImage vaImage{VA_INVALID_ID};
     VABufferInfo vBufInfo;
     EGLImageKHR eglImage;
     EGLImageKHR eglImageY, eglImageVU;
   } m_glSurface;
 };
+
 }
 

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -33,6 +33,24 @@ std::set<std::string> CEGLUtils::GetClientExtensions()
   return result;
 }
 
+std::set<std::string> CEGLUtils::GetExtensions(EGLDisplay eglDisplay)
+{
+  const char* extensions = eglQueryString(eglDisplay, EGL_EXTENSIONS);
+  if (!extensions)
+  {
+    throw std::runtime_error("Could not query EGL for extensions");
+  }
+  std::set<std::string> result;
+  StringUtils::SplitTo(std::inserter(result, result.begin()), extensions, " ");
+  return result;
+}
+
+bool CEGLUtils::HasExtension(EGLDisplay eglDisplay, const std::string& name)
+{
+  auto exts = GetExtensions(eglDisplay);
+  return (exts.find(name) != exts.end());
+}
+
 void CEGLUtils::LogError(const std::string& what)
 {
   CLog::Log(LOGERROR, "%s (EGL error %d)", what.c_str(), eglGetError());

--- a/xbmc/windowing/X11/OptionalsReg.cpp
+++ b/xbmc/windowing/X11/OptionalsReg.cpp
@@ -58,16 +58,16 @@ void X11::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
   proxy->eglDisplay = eglDpy;
 }
 
-void X11::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+void X11::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
-  VAAPI::CDecoder::Register(winSystem, hevc);
+  VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
   EGLDisplay eglDpy = winSystem->eglDisplay;
   VADisplay vaDpy = vaGetDisplay(winSystem->dpy);
-  CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, hevc);
+  CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, deepColor);
 }
 
 #else
@@ -89,11 +89,11 @@ void X11::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
 {
 }
 
-void X11::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+void X11::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
 }
 
-void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+void X11::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
 }
 

--- a/xbmc/windowing/X11/OptionalsReg.h
+++ b/xbmc/windowing/X11/OptionalsReg.h
@@ -33,8 +33,8 @@ namespace X11
 CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy);
-void VAAPIRegister(CVaapiProxy *winSystem, bool hevc);
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc);
+void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
+void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -275,10 +275,10 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
       m_vaapiProxy.reset(X11::VaapiProxyCreate());
       X11::VaapiProxyConfig(m_vaapiProxy.get(), GetDisplay(),
                        static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay);
-      bool general, hevc;
-      X11::VAAPIRegisterRender(m_vaapiProxy.get(), general, hevc);
+      bool general, deepColor;
+      X11::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
       if (general)
-        X11::VAAPIRegister(m_vaapiProxy.get(), hevc);
+        X11::VAAPIRegister(m_vaapiProxy.get(), deepColor);
       return success;
     }
   }

--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -85,14 +85,14 @@ void GBM::VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy)
   proxy->eglDisplay = eglDpy;
 }
 
-void GBM::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+void GBM::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
-  VAAPI::CDecoder::Register(winSystem, hevc);
+  VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void GBM::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+void GBM::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
-  CRendererVAAPI::Register(winSystem, winSystem->vaDpy, winSystem->eglDisplay, general, hevc);
+  CRendererVAAPI::Register(winSystem, winSystem->vaDpy, winSystem->eglDisplay, general, deepColor);
 }
 
 #else
@@ -115,12 +115,12 @@ void GBM::VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy)
 
 }
 
-void GBM::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+void GBM::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
 
 }
 
-void GBM::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+void GBM::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
 
 }

--- a/xbmc/windowing/gbm/OptionalsReg.h
+++ b/xbmc/windowing/gbm/OptionalsReg.h
@@ -32,8 +32,8 @@ namespace GBM
 CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy);
-void VAAPIRegister(CVaapiProxy *winSystem, bool hevc);
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc);
+void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
+void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -57,14 +57,14 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
     return false;
   }
 
-  bool general, hevc;
+  bool general, deepColor;
   m_vaapiProxy.reset(GBM::VaapiProxyCreate());
   GBM::VaapiProxyConfig(m_vaapiProxy.get(), m_pGLContext.m_eglDisplay);
-  GBM::VAAPIRegisterRender(m_vaapiProxy.get(), general, hevc);
+  GBM::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
 
   if (general)
   {
-    GBM::VAAPIRegister(m_vaapiProxy.get(), hevc);
+    GBM::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
 
   CRendererDRMPRIME::Register(this);

--- a/xbmc/windowing/wayland/OptionalsReg.cpp
+++ b/xbmc/windowing/wayland/OptionalsReg.cpp
@@ -56,16 +56,16 @@ void WAYLAND::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
   proxy->eglDisplay = eglDpy;
 }
 
-void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
-  VAAPI::CDecoder::Register(winSystem, hevc);
+  VAAPI::CDecoder::Register(winSystem, deepColor);
 }
 
-void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
   EGLDisplay eglDpy = winSystem->eglDisplay;
   VADisplay vaDpy = vaGetDisplayWl(winSystem->dpy);
-  CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, hevc);
+  CRendererVAAPI::Register(winSystem, vaDpy, eglDpy, general, deepColor);
 }
 
 #else
@@ -88,12 +88,12 @@ void WAYLAND::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
 
 }
 
-void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+void WAYLAND::VAAPIRegister(CVaapiProxy *winSystem, bool deepColor)
 {
 
 }
 
-void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+void WAYLAND::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor)
 {
 
 }

--- a/xbmc/windowing/wayland/OptionalsReg.h
+++ b/xbmc/windowing/wayland/OptionalsReg.h
@@ -32,8 +32,8 @@ namespace WAYLAND
 CVaapiProxy* VaapiProxyCreate();
 void VaapiProxyDelete(CVaapiProxy *proxy);
 void VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy);
-void VAAPIRegister(CVaapiProxy *winSystem, bool hevc);
-void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc);
+void VAAPIRegister(CVaapiProxy *winSystem, bool deepColor);
+void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &deepColor);
 }
 
 

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -46,14 +46,14 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   CLinuxRendererGL::Register();
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
-  bool general, hevc;
+  bool general, deepColor;
   m_vaapiProxy.reset(::WAYLAND::VaapiProxyCreate());
   ::WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(),GetConnection()->GetDisplay(),
                               m_eglContext.GetEGLDisplay());
-  ::WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, hevc);
+  ::WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
   if (general)
   {
-    ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), hevc);
+    ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
 
   return true;

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -47,14 +47,14 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
-  bool general, hevc;
+  bool general, deepColor;
   m_vaapiProxy.reset(::WAYLAND::VaapiProxyCreate());
   ::WAYLAND::VaapiProxyConfig(m_vaapiProxy.get(),GetConnection()->GetDisplay(),
                               m_eglContext.GetEGLDisplay());
-  ::WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, hevc);
+  ::WAYLAND::VAAPIRegisterRender(m_vaapiProxy.get(), general, deepColor);
   if (general)
   {
-    ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), hevc);
+    ::WAYLAND::VAAPIRegister(m_vaapiProxy.get(), deepColor);
   }
 
   return true;


### PR DESCRIPTION

## Description
Reorganize Vaapi EGL interop so we can also render with vaExportSurfaceHandle

This is WIP, but open for discussion.

TODO:
- [x] Check whether this still works on intel, especially HEVC10
- [x] Modify interop check name to deep color instead of hevc (since it doesn't really check anything hevc-related)
- [x] Find out if this works reliably on AMD due to possibly missing vaSyncSurface support
- [x] Check vaapi and ffmpeg postprocessing/deinterlacing

## Motivation and Context
Hardware decoding with AMD GPUs is only supported with this new method

## How Has This Been Tested?
Run-tested with H.264 and HEVC10 on Linux/Wayland/AMD GPU

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
