### PR TITLE
[PVR] Fix crashes on pvr client addon install/uninstall/update.

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -75,7 +75,7 @@ void CPVRClient::StopRunningInstance()
   const ADDON::AddonPtr addon(GetRunningInstance());
   if (addon)
   {
-    // stop the pvr manager and stop and unload the running pvr addon
+    // stop the pvr manager and stop and unload the running pvr addon. pvr manager will be restarted on demand.
     CServiceBroker::GetPVRManager().Stop();
     CServiceBroker::GetPVRManager().Clients()->StopClient(addon, false);
   }
@@ -88,23 +88,10 @@ void CPVRClient::OnPreInstall()
   CAddon::OnPreInstall();
 }
 
-void CPVRClient::OnPostInstall(bool update, bool modal)
-{
-  CAddon::OnPostInstall(update, modal);
-  CServiceBroker::GetPVRManager().Clients()->UpdateAddons();
-}
-
 void CPVRClient::OnPreUnInstall()
 {
   StopRunningInstance();
   CAddon::OnPreUnInstall();
-}
-
-void CPVRClient::OnPostUnInstall()
-{
-  CAddon::OnPostUnInstall();
-  CServiceBroker::GetPVRManager().Clients()->UpdateAddons();
-  CServiceBroker::GetPVRManager().GetTVDatabase()->Delete(*this);
 }
 
 ADDON::AddonPtr CPVRClient::GetRunningInstance() const

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -213,9 +213,7 @@ namespace PVR
     ~CPVRClient(void) override;
 
     void OnPreInstall() override;
-    void OnPostInstall(bool update, bool modal) override;
     void OnPreUnInstall() override;
-    void OnPostUnInstall() override;
     ADDON::AddonPtr GetRunningInstance() const override;
 
     /** @name PVR add-on methods */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -247,8 +247,10 @@ bool CPVRClients::StopClient(const AddonPtr &addon, bool bRestart)
 
 void CPVRClients::OnAddonEvent(const AddonEvent& event)
 {
-  if (typeid(event) == typeid(AddonEvents::Enabled) ||
-      typeid(event) == typeid(AddonEvents::Disabled))
+  if (typeid(event) == typeid(AddonEvents::Enabled) ||  // also called on install,
+      typeid(event) == typeid(AddonEvents::Disabled) || // not called on uninstall
+      typeid(event) == typeid(AddonEvents::UnInstalled) ||
+      typeid(event) == typeid(AddonEvents::ReInstalled))
   {
     // update addons
     CJobManager::GetInstance().AddJob(new CPVRUpdateAddonsJob(event.id), nullptr);


### PR DESCRIPTION
When I was changing pvr client addon install/uninstall/enable/disable from reacting on synchronous methods to addon events I overlooked some important pieces, which led to all kind of weird behavior.  For instance on install, both the addon event `Enabled` will be fired and a synchronous `OnPostInstall` will be called, and PVR reacted on both. 

This was leading to an attempt to create the same addon instance twice, which often ended in a crash. This PR fixes this by eliminating the `CPVRClient::OnPostInstall` and `CPVRClient::OnPostUninstall` implementations and now uses events whenever possible.



The changes are runtime tested on macOS and Linux, latest Kodi master plus pvr.hts and other pvr client addons in several scenarios.

@Jalle19 do you want to take a look at the code changes? 