### PR TITLE
[cmake] move ifdef conditions to cmake

### DIFF
--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -18,10 +18,6 @@
  *
  */
 
-#include "system.h"
-
-#ifdef HAS_CDDA_RIPPER
-
 #include "CDDARipper.h"
 #include "CDDARipJob.h"
 #include "ServiceBroker.h"
@@ -316,5 +312,3 @@ void CCDDARipper::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 
   CancelJobs();
 }
-
-#endif

--- a/xbmc/cdrip/CMakeLists.txt
+++ b/xbmc/cdrip/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(SOURCES CDDARipJob.cpp
-            CDDARipper.cpp
             Encoder.cpp
             EncoderFFmpeg.cpp)
 
 set(HEADERS CDDARipJob.h
-            CDDARipper.h
             Encoder.h
             EncoderFFmpeg.h
             IEncoder.h)
+
+if(ENABLE_OPTICAL)
+  list(APPEND SOURCES CDDARipper.cpp)
+  list(APPEND HEADERS CDDARipper.h)
+endif()
 
 core_add_library(cdrip)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkSNDIO.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkSNDIO.cpp
@@ -18,8 +18,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAS_SNDIO
 #include "AESinkSNDIO.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
@@ -327,5 +325,3 @@ void CAESinkSNDIO::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
     list.push_back(info);
   }
 }
-
-#endif

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -19,8 +19,6 @@
  *
  */
 
-#if defined(HAS_MMAL)
-
 #include "cores/VideoPlayer/DVDStreamInfo.h"
 #include "DVDVideoCodec.h"
 #include "threads/Event.h"
@@ -127,5 +125,3 @@ protected:
 };
 
 };
-// defined(HAS_MMAL)
-#endif

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -18,9 +18,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAS_MMAL
-
 #include <interface/mmal/util/mmal_default_components.h>
 
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
@@ -339,5 +336,3 @@ void CDecoder::Register()
 {
   CDVDFactoryCodec::RegisterHWAccel("mmalffmpeg", CDecoder::Create);
 }
-
-#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.cpp
@@ -20,7 +20,6 @@
 
 #include "RendererAML.h"
 
-#if defined(HAS_LIBAMCODEC)
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h"
 #include "utils/log.h"
@@ -168,5 +167,3 @@ void CRendererAML::RenderUpdate(int index, int index2, bool clear, unsigned int 
   }
   CAMLCodec::PollFrame();
 }
-
-#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -20,10 +20,6 @@
 
 #pragma once
 
-#include "system.h"
-
-#if defined(HAS_LIBAMCODEC)
-
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 
 class CRendererAML : public CBaseRenderer
@@ -70,5 +66,3 @@ private:
   int m_prevVPts;
   bool m_bConfigured;
 };
-
-#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -29,8 +29,6 @@ class CDVDOverlaySpu;
 class CDVDOverlaySSA;
 typedef struct ass_image ASS_Image;
 
-#if defined(HAS_GL) || HAS_GLES >= 2
-
 namespace OVERLAY {
 
   class COverlayTextureGL : public COverlay
@@ -73,6 +71,3 @@ namespace OVERLAY {
   };
 
 }
-
-#endif
-

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -29,7 +29,6 @@
 #include "Util.h"
 #include "utils/StringUtils.h"
 
-#ifdef HAS_MYSQL
 #include "mysqldataset.h"
 #include "mysql/errmsg.h"
 
@@ -1744,5 +1743,3 @@ void MysqlDataset::interrupt() {
 }
 
 }//namespace
-#endif //HAS_MYSQL
-

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -33,8 +33,6 @@ set(SOURCES AddonsDirectory.cpp
             MusicDatabaseFile.cpp
             MusicFileDirectory.cpp
             MusicSearchDirectory.cpp
-            NFSDirectory.cpp
-            NFSFile.cpp
             OverrideDirectory.cpp
             OverrideFile.cpp
             PipeFile.cpp
@@ -46,8 +44,6 @@ set(SOURCES AddonsDirectory.cpp
             ResourceDirectory.cpp
             ResourceFile.cpp
             RSSDirectory.cpp
-            SFTPDirectory.cpp
-            SFTPFile.cpp
             ShoutcastFile.cpp
             SmartPlaylistDirectory.cpp
             SourcesDirectory.cpp
@@ -82,7 +78,6 @@ set(HEADERS AddonsDirectory.h
             DirectoryFactory.h
             DirectoryHistory.h
             DllLibCurl.h
-            DllLibNfs.h
             EventsDirectory.h
             FTPDirectory.h
             FTPParse.h
@@ -107,8 +102,6 @@ set(HEADERS AddonsDirectory.h
             MusicDatabaseFile.h
             MusicFileDirectory.h
             MusicSearchDirectory.h
-            NFSDirectory.h
-            NFSFile.h
             OverrideDirectory.h
             OverrideFile.h
             PVRDirectory.h
@@ -120,8 +113,6 @@ set(HEADERS AddonsDirectory.h
             RSSDirectory.h
             ResourceDirectory.h
             ResourceFile.h
-            SFTPDirectory.h
-            SFTPFile.h
             ShoutcastFile.h
             SmartPlaylistDirectory.h
             SourcesDirectory.h
@@ -172,6 +163,21 @@ if(ENABLE_OPTICAL)
                       CDDAFile.cpp)
   list(APPEND HEADERS CDDADirectory.h
                       CDDAFile.h)
+endif()
+
+if(NFS_FOUND)
+  list(APPEND SOURCES NFSDirectory.cpp
+                      NFSFile.cpp)
+  list(APPEND HEADERS DllLibNfs.h
+                      NFSDirectory.h
+                      NFSFile.h)
+endif()
+
+if(SSH_FOUND)
+  list(APPEND SOURCES SFTPDirectory.cpp
+                      SFTPFile.cpp)
+  list(APPEND SOURCES SFTPDirectory.h
+                      SFTPFile.h)
 endif()
 
 if(ENABLE_UPNP)

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -18,9 +18,6 @@
  *
  */
 
-#include "system.h"
-
-#ifdef HAS_FILESYSTEM_NFS
 #include "DllLibNfs.h"
 
 #ifdef TARGET_WINDOWS
@@ -360,5 +357,3 @@ bool CNFSDirectory::Exists(const CURL& url2)
   }
   return S_ISDIR(info.st_mode) ? true : false;
 }
-
-#endif

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -21,9 +21,7 @@
 // FileNFS.cpp: implementation of the CNFSFile class.
 //
 //////////////////////////////////////////////////////////////////////
-#include "system.h"
 
-#ifdef HAS_FILESYSTEM_NFS
 #include "NFSFile.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
@@ -888,5 +886,3 @@ bool CNFSFile::IsValidFile(const std::string& strFileName)
     return false;
   return true;
 }
-#endif//HAS_FILESYSTEM_NFS
-

--- a/xbmc/filesystem/SFTPDirectory.cpp
+++ b/xbmc/filesystem/SFTPDirectory.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "SFTPDirectory.h"
-#ifdef HAS_FILESYSTEM_SFTP
+
 #include "SFTPFile.h"
 #include "utils/log.h"
 #include "URL.h"
@@ -47,4 +47,3 @@ bool CSFTPDirectory::Exists(const CURL& url)
     return false;
   }
 }
-#endif

--- a/xbmc/filesystem/SFTPDirectory.h
+++ b/xbmc/filesystem/SFTPDirectory.h
@@ -19,8 +19,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAS_FILESYSTEM_SFTP
 #include "IDirectory.h"
 
 class CURL;
@@ -37,4 +35,3 @@ namespace XFILE
     bool Exists(const CURL& url) override;
   };
 }
-#endif

--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -20,7 +20,6 @@
 
 #include "threads/SystemClock.h"
 #include "SFTPFile.h"
-#ifdef HAS_FILESYSTEM_SFTP
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "URL.h"
@@ -729,5 +728,3 @@ int CSFTPFile::IoControl(EIoControl request, void* param)
 
   return -1;
 }
-
-#endif

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -19,8 +19,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAS_FILESYSTEM_SFTP
 #include "IFile.h"
 #include "FileItem.h"
 #include "threads/CriticalSection.h"
@@ -121,4 +119,3 @@ namespace XFILE
     sftp_file m_sftp_handle;
   };
 }
-#endif

--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -4,4 +4,8 @@ set(SOURCES TestDirectory.cpp
             TestZipFile.cpp
             TestZipManager.cpp)
 
+if(NFS_FOUND)
+  list(APPEND SOURCES TestNfsFile.cpp)
+endif()
+
 core_add_test_library(filesystem_test)

--- a/xbmc/filesystem/test/TestNfsFile.cpp
+++ b/xbmc/filesystem/test/TestNfsFile.cpp
@@ -18,8 +18,6 @@
  *
  */
 
-#include "system.h"
-#if defined(HAS_FILESYSTEM_NFS)
 #include "filesystem/NFSFile.h"
 #include "test/TestUtils.h"
 
@@ -96,4 +94,3 @@ TEST_P(TestNfs, splitUrlIntoExportAndPath)
 }
 
 INSTANTIATE_TEST_CASE_P(NfsFile, TestNfs, ValuesIn(g_TestData));
-#endif//HAS_FILESYSTEM_NFS

--- a/xbmc/guilib/MatrixGLES.cpp
+++ b/xbmc/guilib/MatrixGLES.cpp
@@ -19,9 +19,6 @@
  */
 
 
-#include "system.h"
-
-#if defined(HAS_GL) || HAS_GLES >= 2
 #include "system_gl.h"
 
 #include <cmath>
@@ -322,5 +319,3 @@ void CMatrixGLStack::Load()
 {
 
 }
-
-#endif

--- a/xbmc/network/CMakeLists.txt
+++ b/xbmc/network/CMakeLists.txt
@@ -10,7 +10,6 @@ set(SOURCES DNSNameCache.cpp
             TCPServer.cpp
             UdpClient.cpp
             WakeOnAccess.cpp
-            WebServer.cpp
             ZeroconfBrowser.cpp
             Zeroconf.cpp)
 
@@ -26,7 +25,6 @@ set(HEADERS DNSNameCache.h
             TCPServer.h
             UdpClient.h
             WakeOnAccess.h
-            WebServer.h
             Zeroconf.h
             ZeroconfBrowser.h)
 
@@ -45,6 +43,11 @@ if(SHAIRPLAY_FOUND)
   list(APPEND SOURCES AirTunesServer.cpp)
   list(APPEND HEADERS AirTunesServer.h
                       DllLibShairplay.h)
+endif()
+
+if(MICROHTTPD_FOUND)
+  list(APPEND SOURCES WebServer.cpp)
+  list(APPEND HEADERS WebServer.h)
 endif()
 
 core_add_library(network)

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -20,7 +20,6 @@
 
 #include "WebServer.h"
 
-#ifdef HAS_WEB_SERVER
 #include <algorithm>
 #include <memory>
 #include <stdexcept>
@@ -1383,4 +1382,3 @@ int CWebServer::AddHeader(struct MHD_Response *response, const std::string &name
 
   return MHD_add_response_header(response, name.c_str(), value.c_str());
 }
-#endif

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -19,9 +19,6 @@
  *
  */
 
-#include "system.h"
-
-#ifdef HAS_WEB_SERVER
 #include <memory>
 #include <vector>
 
@@ -155,4 +152,3 @@ private:
   CCriticalSection m_critSection;
   std::vector<IHTTPRequestHandler *> m_requestHandlers;
 };
-#endif

--- a/xbmc/network/linux/ZeroconfAvahi.h
+++ b/xbmc/network/linux/ZeroconfAvahi.h
@@ -19,10 +19,6 @@
  *
  */
 
-#include "system.h"
-
-#ifdef HAS_AVAHI
-
 #include <memory>
 #include <map>
 #include <vector>
@@ -92,6 +88,3 @@ private:
   bool m_shutdown;
   pthread_t m_thread_id;
 };
-
-#endif // HAS_AVAHI
-

--- a/xbmc/network/linux/ZeroconfBrowserAvahi.h
+++ b/xbmc/network/linux/ZeroconfBrowserAvahi.h
@@ -19,9 +19,6 @@
  *
  */
 
-#include "system.h"
-#ifdef HAS_AVAHI
-
 #include <memory>
 #include <map>
 #include <vector>
@@ -106,5 +103,3 @@ class CZeroconfBrowserAvahi : public CZeroconfBrowser
     CZeroconfBrowser::ZeroconfService m_resolving_service;
     CEvent m_resolved_event;
 };
-
-#endif //HAS_AVAHI

--- a/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
+++ b/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
@@ -20,9 +20,6 @@
  *
  */
 
-#include "system.h"
-
-#ifdef HAS_GL
 #include "system_gl.h"
 #include "GUIWindowTestPatternGL.h"
 
@@ -198,5 +195,3 @@ void CGUIWindowTestPatternGL::EndRender()
 {
 
 }
-
-#endif

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -35,7 +35,9 @@
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "guilib/LocalizeStrings.h"
+#if defined(HAS_WEB_SERVER)
 #include "network/WebServer.h"
+#endif
 #include "peripherals/Peripherals.h"
 #include "profiles/ProfilesManager.h"
 #include "pvr/PVRGUIActions.h"

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -60,9 +60,6 @@
 #include "dxgi.h"
 #include "d3dcompiler.h"
 #include "directxmath.h"
-#ifdef HAS_SDL
-#include "SDL\SDL.h"
-#endif
 #endif
 
 #if defined(TARGET_POSIX)

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -182,10 +182,13 @@ if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windo
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL android OR AML_FOUND)
-  list(APPEND SOURCES AMLUtils.cpp
-                      ScreenshotAML.cpp)
-  list(APPEND HEADERS AMLUtils.h
-                      ScreenshotAML.h)
+  list(APPEND SOURCES AMLUtils.cpp)
+  list(APPEND HEADERS AMLUtils.h)
+endif()
+
+if(AML_FOUND)
+  list(APPEND HEADERS ScreenshotAML.cpp)
+  list(APPEND HEADERS ScreenshotAML.h)
 endif()
 
 core_add_library(utils)

--- a/xbmc/utils/ScreenshotAML.cpp
+++ b/xbmc/utils/ScreenshotAML.cpp
@@ -18,12 +18,12 @@
  *
  */
 
-#include "system.h"
-#if defined(HAS_LIBAMCODEC)
 #include "utils/ScreenshotAML.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 
 #include <sys/ioctl.h>
 
@@ -95,4 +95,3 @@ void CScreenshotAML::CaptureVideoFrame(unsigned char *buffer, int iWidth, int iH
     delete [] videoBuffer;
   }
 }
-#endif //defined(HAS_LIBAMCODEC)

--- a/xbmc/utils/ScreenshotAML.h
+++ b/xbmc/utils/ScreenshotAML.h
@@ -19,7 +19,6 @@
  *
  */
 
-#if defined(HAS_LIBAMCODEC)
 class CScreenshotAML
 {
   public:
@@ -27,4 +26,3 @@ class CScreenshotAML
     // the passed overlay. The buffer format is BGRA (4 byte)
     static void CaptureVideoFrame(unsigned char *buffer, int iWidth, int iHeight, bool bBlendToBuffer = true);
 };
-#endif//HAS_LIBAMCODEC

--- a/xbmc/windowing/mir/CMakeLists.txt
+++ b/xbmc/windowing/mir/CMakeLists.txt
@@ -1,11 +1,16 @@
 set(SOURCES GLContextEGL.cpp
             WinEventsMir.cpp
-            WinSystemMir.cpp
-            WinSystemMirGLContext.cpp
-            WinSystemMirGLESContext.cpp)
+            WinSystemMir.cpp)
 
-set(HEADERS WinSystemMir.h
-            WinSystemMirGLContext.h
-            WinSystemMirGLESContext.h)
+set(HEADERS WinSystemMir.h)
+
+if(OPENGL_FOUND)
+  list(APPEND SOURCES WinSystemMirGLContext.cpp)
+  list(APPEND HEADERS WinSystemMirGLContext.h)
+endif()
+elseif(OPENGLES_FOUND)
+  list(APPEND SOURCES WinSystemMirGLESContext.cpp)
+  list(APPEND HEADERS WinSystemMirGLESContext.h)
+endif()
 
 core_add_library(windowing_MIR)

--- a/xbmc/windowing/mir/WinSystemMirGLContext.cpp
+++ b/xbmc/windowing/mir/WinSystemMirGLContext.cpp
@@ -21,8 +21,6 @@
 
 #include "WinSystemMirGLContext.h"
 
-#if defined(HAS_GL)
-
 bool CWinSystemMirGLContext::CreateNewWindow(const std::string& name,
                                                bool fullScreen,
                                                RESOLUTION_INFO& res)
@@ -102,5 +100,3 @@ bool CWinSystemMirGLContext::IsExtSupported(const char* extension)
 {
   return false;
 }
-
-#endif

--- a/xbmc/windowing/mir/WinSystemMirGLESContext.cpp
+++ b/xbmc/windowing/mir/WinSystemMirGLESContext.cpp
@@ -21,8 +21,6 @@
 
 #include "WinSystemMirGLESContext.h"
 
-#if defined(HAS_GLES)
-
 bool CWinSystemMirGLESContext::CreateNewWindow(const std::string& name,
                                                bool fullScreen,
                                                RESOLUTION_INFO& res)
@@ -103,5 +101,3 @@ bool CWinSystemMirGLESContext::IsExtSupported(const char* extension)
 {
   return false;
 }
-
-#endif

--- a/xbmc/windowing/osx/WinEventsSDL.h
+++ b/xbmc/windowing/osx/WinEventsSDL.h
@@ -19,9 +19,6 @@
  */
 #pragma once
 
-#include "system.h"
-
-#ifdef HAS_SDL
 #include <SDL/SDL_events.h>
 
 #include "windowing/WinEvents.h"
@@ -32,12 +29,5 @@ public:
   bool MessagePump() override;
 
 private:
-#ifdef TARGET_DARWIN
   static bool ProcessOSXShortcuts(SDL_Event& event);
-#elif defined(TARGET_POSIX)
-  static bool ProcessLinuxShortcuts(SDL_Event& event);
-#endif
 };
-
-#endif
-


### PR DESCRIPTION
## Description
Move condition checking to cmake if the whole `*.cpp` file is enclosed into one `#if ...`.

## How Has This Been Tested?
compiled for windows, osx, ios, android and linux

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
