### PR TITLE
Games: Register setting handlers inside CGameSettings

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -139,7 +139,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_inputManager.reset(new CInputManager(params));
   m_inputManager->InitializeInputs();
 
-  m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager));
+  m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager,
+                                                    *m_inputManager));
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -192,6 +192,7 @@ bool CServiceManager::InitStageThree()
 
   m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager,
     *m_gameRenderManager,
+    *m_settings,
     *m_peripherals));
 
   m_contextMenuManager->Init();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -140,7 +140,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_inputManager->InitializeInputs();
 
   m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager,
-                                                    *m_inputManager));
+                                                    *m_inputManager,
+                                                    *m_gameControllerManager));
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
 

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -22,16 +22,18 @@
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/ports/PortManager.h"
-#include "ServiceBroker.h"
+#include "games/GameSettings.h"
 
 using namespace KODI;
 using namespace GAME;
 
 CGameServices::CGameServices(CControllerManager &controllerManager,
                              RETRO:: CGUIGameRenderManager &renderManager,
+                             CSettings &settings,
                              PERIPHERALS::CPeripherals &peripheralManager) :
   m_controllerManager(controllerManager),
   m_gameRenderManager(renderManager),
+  m_gameSettings(new CGameSettings(settings)),
   m_portManager(new CPortManager(peripheralManager))
 {
 }

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <string>
 
+class CSettings;
+
 namespace PERIPHERALS
 {
   class CPeripherals;
@@ -39,6 +41,7 @@ namespace RETRO
 namespace GAME
 {
   class CControllerManager;
+  class CGameSettings;
   class CPortManager;
 
   class CGameServices
@@ -46,6 +49,7 @@ namespace GAME
   public:
     CGameServices(CControllerManager &controllerManager,
                   RETRO::CGUIGameRenderManager &renderManager,
+                  CSettings &settings,
                   PERIPHERALS::CPeripherals &peripheralManager);
     ~CGameServices();
 
@@ -53,6 +57,7 @@ namespace GAME
     ControllerPtr GetDefaultController();
     ControllerVector GetControllers();
 
+    CGameSettings& GameSettings() { return *m_gameSettings; }
     CPortManager& PortManager();
 
     RETRO::CGUIGameRenderManager &GameRenderManager() { return m_gameRenderManager; }
@@ -63,6 +68,7 @@ namespace GAME
     RETRO::CGUIGameRenderManager &m_gameRenderManager;
 
     // Game services
+    std::unique_ptr<CGameSettings> m_gameSettings;
     std::unique_ptr<CPortManager> m_portManager;
   };
 }

--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -34,10 +34,27 @@ using namespace GAME;
 
 #define SETTING_GAMES_KEYBOARD_PLAYERCONFIG_PREFIX  "gameskeyboard.keyboardplayerconfig" //! @todo
 
-CGameSettings& CGameSettings::GetInstance()
+CGameSettings::CGameSettings(CSettings &settings) :
+  m_settings(settings)
 {
-  static CGameSettings gameSettingsInstance;
-  return gameSettingsInstance;
+  m_settings.RegisterCallback(this, {
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERS,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_1,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_2,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_3,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_4,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_5,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_6,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_7,
+    CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_8,
+    CSettings::SETTING_GAMES_ENABLEREWIND,
+    CSettings::SETTING_GAMES_REWINDTIME,
+  });
+}
+
+CGameSettings::~CGameSettings()
+{
+  m_settings.UnregisterCallback(this);
 }
 
 void CGameSettings::OnSettingChanged(std::shared_ptr<const CSetting> setting)

--- a/xbmc/games/GameSettings.h
+++ b/xbmc/games/GameSettings.h
@@ -23,6 +23,7 @@
 #include "utils/Observer.h"
 
 class CSetting;
+class CSettings;
 
 namespace KODI
 {
@@ -33,15 +34,16 @@ class CGameSettings : public ISettingCallback,
                       public Observable
 {
 public:
-  static CGameSettings& GetInstance();
-  virtual ~CGameSettings() = default;
+  CGameSettings(CSettings &settings);
+  ~CGameSettings() override;
 
   // Inherited from ISettingCallback
   virtual void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
   virtual void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
 private:
-  CGameSettings() = default;
+  // Construction parameters
+  CSettings &m_settings;
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
@@ -26,10 +26,12 @@
 #include "games/addons/savestates/Savestate.h"
 #include "games/addons/savestates/SavestateReader.h"
 #include "games/addons/savestates/SavestateWriter.h"
+#include "games/GameServices.h"
 #include "games/GameSettings.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
+#include "ServiceBroker.h"
 
 #include <algorithm>
 
@@ -52,14 +54,14 @@ CGameClientReversiblePlayback::CGameClientReversiblePlayback(CGameClient* gameCl
 {
   UpdateMemoryStream();
 
-  CGameSettings::GetInstance().RegisterObserver(this);
+  CServiceBroker::GetGameServices().GameSettings().RegisterObserver(this);
 
   m_gameLoop.Start();
 }
 
 CGameClientReversiblePlayback::~CGameClientReversiblePlayback()
 {
-  CGameSettings::GetInstance().UnregisterObserver(this);
+  CServiceBroker::GetGameServices().GameSettings().UnregisterObserver(this);
 
   m_gameLoop.Stop();
 }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -78,9 +78,11 @@ using namespace XFILE;
 using namespace KODI::MESSAGING;
 
 CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements,
-                           CInputManager &inputManager) :
+                           CInputManager &inputManager,
+                           GAME::CControllerManager &controllerProfiles) :
   m_announcements(announcements),
   m_inputManager(inputManager),
+  m_controllerProfiles(controllerProfiles),
   m_eventScanner(this)
 {
   // Register settings

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -77,8 +77,10 @@ using namespace PERIPHERALS;
 using namespace XFILE;
 using namespace KODI::MESSAGING;
 
-CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements) :
+CPeripherals::CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements,
+                           CInputManager &inputManager) :
   m_announcements(announcements),
+  m_inputManager(inputManager),
   m_eventScanner(this)
 {
   // Register settings

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -33,6 +33,7 @@
 #include "utils/Observer.h"
 
 class CFileItemList;
+class CInputManager;
 class CSetting;
 class CSettingsCategory;
 class TiXmlElement;
@@ -61,7 +62,8 @@ namespace PERIPHERALS
                         public ANNOUNCEMENT::IAnnouncer
   {
   public:
-    explicit CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements);
+    explicit CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements,
+                          CInputManager &inputManager);
 
     ~CPeripherals() override;
 
@@ -313,6 +315,11 @@ namespace PERIPHERALS
     // implementation of IAnnouncer
     void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data) override;
 
+    /*!
+     * \brief Access the input manager passed to the constructor
+     */
+    CInputManager &GetInputManager() { return m_inputManager; }
+
   private:
     bool LoadMappings();
     bool GetMappingForDevice(const CPeripheralBus &bus, PeripheralScanResult& result) const;
@@ -322,6 +329,7 @@ namespace PERIPHERALS
 
     // Construction parameters
     ANNOUNCEMENT::CAnnouncementManager &m_announcements;
+    CInputManager &m_inputManager;
 
 #if !defined(HAVE_LIBCEC)
     bool                                 m_bMissingLibCecWarningDisplayed = false;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -42,6 +42,11 @@ class CKey;
 
 namespace KODI
 {
+namespace GAME
+{
+  class CControllerManager;
+}
+
 namespace JOYSTICK
 {
   class IButtonMapper;
@@ -63,7 +68,8 @@ namespace PERIPHERALS
   {
   public:
     explicit CPeripherals(ANNOUNCEMENT::CAnnouncementManager &announcements,
-                          CInputManager &inputManager);
+                          CInputManager &inputManager,
+                          KODI::GAME::CControllerManager &controllerProfiles);
 
     ~CPeripherals() override;
 
@@ -320,6 +326,11 @@ namespace PERIPHERALS
      */
     CInputManager &GetInputManager() { return m_inputManager; }
 
+    /*!
+     * \brief Access controller profiles through the construction parameter
+     */
+    KODI::GAME::CControllerManager &GetControllerProfiles() { return m_controllerProfiles; }
+
   private:
     bool LoadMappings();
     bool GetMappingForDevice(const CPeripheralBus &bus, PeripheralScanResult& result) const;
@@ -330,6 +341,7 @@ namespace PERIPHERALS
     // Construction parameters
     ANNOUNCEMENT::CAnnouncementManager &m_announcements;
     CInputManager &m_inputManager;
+    KODI::GAME::CControllerManager &m_controllerProfiles;
 
 #if !defined(HAVE_LIBCEC)
     bool                                 m_bMissingLibCecWarningDisplayed = false;

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -45,6 +45,7 @@ namespace PERIPHERALS
 {
   class CPeripheral;
   class CPeripheralJoystick;
+  class CPeripherals;
 
   typedef std::vector<kodi::addon::DriverPrimitive> PrimitiveVector;
   typedef std::map<KODI::JOYSTICK::FeatureName, kodi::addon::JoystickFeature> FeatureMap;
@@ -52,7 +53,7 @@ namespace PERIPHERALS
   class CPeripheralAddon : public ADDON::IAddonInstanceHandler
   {
   public:
-    explicit CPeripheralAddon(const ADDON::BinaryAddonBasePtr& addonInfo);
+    explicit CPeripheralAddon(const ADDON::BinaryAddonBasePtr& addonInfo, CPeripherals &manager);
     ~CPeripheralAddon(void) override;
 
     /*!
@@ -100,7 +101,6 @@ namespace PERIPHERALS
 
     void RegisterButtonMap(CPeripheral* device, KODI::JOYSTICK::IButtonMap* buttonMap);
     void UnregisterButtonMap(KODI::JOYSTICK::IButtonMap* buttonMap);
-    void RefreshButtonMaps(const std::string& strDeviceName = "");
 
     static inline bool ProvidesJoysticks(const ADDON::BinaryAddonBasePtr& addonInfo)
     {
@@ -114,6 +114,12 @@ namespace PERIPHERALS
 
   private:
     void UnregisterButtonMap(CPeripheral* device);
+
+    // Binary add-on callbacks
+    void TriggerDeviceScan();
+    void RefreshButtonMaps(const std::string& strDeviceName = "");
+    unsigned int FeatureCount(const std::string &controllerId, JOYSTICK_FEATURE_TYPE type) const;
+    JOYSTICK_FEATURE_TYPE FeatureType(const std::string &controllerId, const std::string &featureName) const;
 
     /*!
      * @brief Helper functions
@@ -137,6 +143,9 @@ namespace PERIPHERALS
 
     static std::string GetDeviceName(PeripheralType type);
     static std::string GetProvider(PeripheralType type);
+
+    // Construction parameters
+    CPeripherals &m_manager;
 
     /* @brief Cache for const char* members in PERIPHERAL_PROPERTIES */
     std::string         m_strUserPath;    /*!< @brief translated path to the user profile */

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -417,7 +417,7 @@ void CPeripheralBusAddon::UpdateAddons(void)
     BinaryAddonBaseList::iterator it = std::find_if(newAddons.begin(), newAddons.end(), GetAddon);
     if (it != newAddons.end())
     {
-      PeripheralAddonPtr newAddon = std::make_shared<CPeripheralAddon>(*it);
+      PeripheralAddonPtr newAddon = std::make_shared<CPeripheralAddon>(*it, m_manager);
       if (newAddon)
       {
         bool bCreated;

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -22,7 +22,7 @@
 #include "utils/log.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
-#include "ServiceBroker.h"
+#include "peripherals/Peripherals.h"
 
 using namespace PERIPHERALS;
 
@@ -38,7 +38,7 @@ CPeripheralHID::~CPeripheralHID(void)
   if (!m_strKeymap.empty() && !GetSettingBool("do_not_use_custom_keymap"))
   {
     CLog::Log(LOGDEBUG, "%s - switching active keymapping to: default", __FUNCTION__);
-    CServiceBroker::GetInputManager().RemoveKeymap(m_strKeymap);
+    m_manager.GetInputManager().RemoveKeymap(m_strKeymap);
   }
 }
 
@@ -66,12 +66,12 @@ bool CPeripheralHID::InitialiseFeature(const PeripheralFeature feature)
       if (bKeymapEnabled)
       {
         CLog::Log(LOGDEBUG, "%s - adding keymapping for: %s", __FUNCTION__, m_strKeymap.c_str());
-        CServiceBroker::GetInputManager().AddKeymap(m_strKeymap);
+        m_manager.GetInputManager().AddKeymap(m_strKeymap);
       }
       else if (!bKeymapEnabled)
       {
         CLog::Log(LOGDEBUG, "%s - removing keymapping for: %s", __FUNCTION__, m_strKeymap.c_str());
-        CServiceBroker::GetInputManager().RemoveKeymap(m_strKeymap);
+        m_manager.GetInputManager().RemoveKeymap(m_strKeymap);
       }
     }
 

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -34,7 +34,6 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "Application.h"
-#include "ServiceBroker.h"
 
 #include <algorithm>
 
@@ -93,7 +92,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
         InitializeDeadzoneFiltering();
 
         // Give joystick monitor priority over default controller
-        m_appInput.reset(new CKeymapHandling(this, false, CServiceBroker::GetInputManager().KeymapEnvironment()));
+        m_appInput.reset(new CKeymapHandling(this, false, m_manager.GetInputManager().KeymapEnvironment()));
         m_joystickMonitor.reset(new CJoystickMonitor);
         RegisterInputHandler(m_joystickMonitor.get(), false);
       }

--- a/xbmc/peripherals/devices/PeripheralJoystickEmulation.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystickEmulation.cpp
@@ -21,8 +21,8 @@
 #include "PeripheralJoystickEmulation.h"
 #include "input/keyboard/generic/JoystickEmulation.h"
 #include "input/InputManager.h"
+#include "peripherals/Peripherals.h"
 #include "threads/SingleLock.h"
-#include "ServiceBroker.h"
 
 #include <algorithm>
 #include <sstream>
@@ -38,7 +38,7 @@ CPeripheralJoystickEmulation::CPeripheralJoystickEmulation(CPeripherals& manager
 
 CPeripheralJoystickEmulation::~CPeripheralJoystickEmulation(void)
 {
-  CServiceBroker::GetInputManager().UnregisterKeyboardHandler(this);
+  m_manager.GetInputManager().UnregisterKeyboardHandler(this);
 }
 
 bool CPeripheralJoystickEmulation::InitialiseFeature(const PeripheralFeature feature)
@@ -49,7 +49,7 @@ bool CPeripheralJoystickEmulation::InitialiseFeature(const PeripheralFeature fea
   {
     if (feature == FEATURE_JOYSTICK)
     {
-      CServiceBroker::GetInputManager().RegisterKeyboardHandler(this);
+      m_manager.GetInputManager().RegisterKeyboardHandler(this);
     }
     bSuccess = true;
   }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -31,7 +31,6 @@
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "filesystem/File.h"
-#include "games/GameSettings.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIFontManager.h"
 #include "guilib/StereoscopicsManager.h"
@@ -1003,20 +1002,6 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_POWERMANAGEMENT_WAKEONACCESS);
   GetSettingsManager()->RegisterCallback(&CWakeOnAccess::GetInstance(), settingSet);
 
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERS);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_1);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_2);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_3);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_4);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_5);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_6);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_7);
-  settingSet.insert(CSettings::SETTING_GAMES_KEYBOARD_PLAYERCONFIG_8);
-  settingSet.insert(CSettings::SETTING_GAMES_ENABLEREWIND);
-  settingSet.insert(CSettings::SETTING_GAMES_REWINDTIME);
-  GetSettingsManager()->RegisterCallback(&GAME::CGameSettings::GetInstance(), settingSet);
-
 #ifdef HAVE_LIBBLURAY
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_DISC_PLAYBACK);
@@ -1039,7 +1024,6 @@ void CSettings::UninitializeISettingCallbacks()
   GetSettingsManager()->UnregisterCallback(&CNetworkServices::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_passwordManager);
   GetSettingsManager()->UnregisterCallback(&CRssManager::GetInstance());
-  GetSettingsManager()->UnregisterCallback(&GAME::CGameSettings::GetInstance());
 #if defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)


### PR DESCRIPTION
This hops on the bandwagon by removing the `CGameSettings` global and moving its settings registration into the class.

Also provided are two commits that replace access to services through CServiceBroker by passing references to the peripherals subsystem upon creation. This removes the possibility of circular dependencies.

## How Has This Been Tested?
SNES games still play. Will test changing settings soon.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
