### PR TITLE
fixed: use visible, not hidden

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2615,7 +2615,7 @@
           <control type="toggle" />
         </setting>
         <setting id="audiooutput.dspaddonsenabled" type="boolean">
-          <hidden>true</hidden>
+          <visible>false</visible>
           <default>false</default>
           <control type="toggle"/>
         </setting>


### PR DESCRIPTION
i used the wrong syntax in https://github.com/xbmc/xbmc/commit/67f6e6427392aa11197921c8c774387007e13e60 thanks to @stefansaraev @Montellese for pointing out my error
  