### PR TITLE
[wayland] Support xdg_shell stable

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -67,7 +67,6 @@ endif()
 # external FFMPEG
 if(NOT ENABLE_INTERNAL_FFMPEG OR KODI_DEPENDSBUILD)
   if(FFMPEG_PATH)
-    set(ENV{PKG_CONFIG_PATH} "${FFMPEG_PATH}/lib/pkgconfig")
     list(APPEND CMAKE_PREFIX_PATH ${FFMPEG_PATH})
   endif()
 

--- a/cmake/modules/FindWaylandpp.cmake
+++ b/cmake/modules/FindWaylandpp.cmake
@@ -12,9 +12,15 @@
 
 pkg_check_modules(WAYLANDPP wayland-client++ wayland-egl++ wayland-cursor++)
 pkg_check_modules(PC_WAYLANDPP_SCANNER wayland-scanner++)
+if(WAYLANDPP_FOUND)
+  pkg_get_variable(PC_WAYLANDPP_PKGDATADIR wayland-client++ pkgdatadir)
+endif()
 if(PC_WAYLANDPP_SCANNER_FOUND)
   pkg_get_variable(PC_WAYLANDPP_SCANNER wayland-scanner++ wayland_scannerpp)
 endif()
+
+# Promote to cache variables so all code can access it
+set(WAYLANDPP_PROTOCOLS_DIR "${PC_WAYLANDPP_PKGDATADIR}/protocols" CACHE INTERNAL "")
 
 # wayland-scanner++ is from native/host system in case of cross-compilation, so
 # it's ok if we don't find it with pkgconfig

--- a/cmake/platform/linux/wayland.cmake
+++ b/cmake/platform/linux/wayland.cmake
@@ -1,4 +1,4 @@
-set(PLATFORM_REQUIRED_DEPS EGL WaylandProtocols>=1.7 Waylandpp>=0.1.5 LibDRM Xkbcommon>=0.4.1)
+set(PLATFORM_REQUIRED_DEPS EGL WaylandProtocols>=1.7 Waylandpp>=0.2.2 LibDRM Xkbcommon>=0.4.1)
 set(PLATFORM_OPTIONAL_DEPS VAAPI)
 
 set(WAYLAND_RENDER_SYSTEM "" CACHE STRING "Render system to use with Wayland: \"gl\" or \"gles\"")

--- a/cmake/platform/linux/wayland.cmake
+++ b/cmake/platform/linux/wayland.cmake
@@ -1,4 +1,4 @@
-set(PLATFORM_REQUIRED_DEPS EGL WaylandProtocols>=1.7 Waylandpp>=0.2.2 LibDRM Xkbcommon>=0.4.1)
+set(PLATFORM_REQUIRED_DEPS EGL WaylandProtocols>=1.12 Waylandpp>=0.2.2 LibDRM Xkbcommon>=0.4.1)
 set(PLATFORM_OPTIONAL_DEPS VAAPI)
 
 set(WAYLAND_RENDER_SYSTEM "" CACHE STRING "Render system to use with Wayland: \"gl\" or \"gles\"")

--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -17,7 +17,8 @@ endif()
 if(CORE_PLATFORM_NAME_LC STREQUAL "wayland")
   # This cannot go into wayland.cmake since it requires the Wayland dependencies
   # to already be resolved
-  set(PROTOCOL_XMLS "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
+  set(PROTOCOL_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
+                    "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
   add_custom_command(OUTPUT "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.hpp" "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.cpp"
                      COMMAND "${WAYLANDPP_SCANNER}" ${PROTOCOL_XMLS} "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.hpp" "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.cpp"

--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -18,6 +18,7 @@ if(CORE_PLATFORM_NAME_LC STREQUAL "wayland")
   # This cannot go into wayland.cmake since it requires the Wayland dependencies
   # to already be resolved
   set(PROTOCOL_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
+                    "${WAYLAND_PROTOCOLS_DIR}/stable/xdg-shell/xdg-shell.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
   add_custom_command(OUTPUT "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.hpp" "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.cpp"

--- a/tools/depends/native/waylandpp-scanner-native/Makefile
+++ b/tools/depends/native/waylandpp-scanner-native/Makefile
@@ -5,7 +5,7 @@ DEPS=../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=waylandpp
-VERSION=0.1.5
+VERSION=0.2.2
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/depends/target/wayland-protocols/Makefile
+++ b/tools/depends/target/wayland-protocols/Makefile
@@ -3,7 +3,7 @@ DEPS=Makefile
 
 # lib name, version
 LIBNAME=wayland-protocols
-VERSION=1.7
+VERSION=1.12
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
 

--- a/tools/depends/target/waylandpp/Makefile
+++ b/tools/depends/target/waylandpp/Makefile
@@ -3,7 +3,7 @@ DEPS=Makefile
 
 # lib name, version
 LIBNAME=waylandpp
-VERSION=0.1.5
+VERSION=0.2.2
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/windowing/wayland/CMakeLists.txt
+++ b/xbmc/windowing/wayland/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES Connection.cpp
             SeatSelection.cpp
             ShellSurface.cpp
             ShellSurfaceWlShell.cpp
+            ShellSurfaceXdgShell.cpp
             ShellSurfaceXdgShellUnstableV6.cpp
             Util.cpp
             VideoSyncWpPresentation.cpp
@@ -39,6 +40,7 @@ set(HEADERS Connection.h
             SeatSelection.h
             ShellSurface.h
             ShellSurfaceWlShell.h
+            ShellSurfaceXdgShell.h
             ShellSurfaceXdgShellUnstableV6.h
             Signals.h
             VideoSyncWpPresentation.h

--- a/xbmc/windowing/wayland/ShellSurfaceXdgShell.cpp
+++ b/xbmc/windowing/wayland/ShellSurfaceXdgShell.cpp
@@ -1,0 +1,163 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ShellSurfaceXdgShell.h"
+
+#include "messaging/ApplicationMessenger.h"
+#include "Registry.h"
+
+using namespace KODI::WINDOWING::WAYLAND;
+
+namespace
+{
+
+IShellSurface::State ConvertStateFlag(wayland::xdg_toplevel_state flag)
+{
+  switch(flag)
+  {
+    case wayland::xdg_toplevel_state::activated:
+      return IShellSurface::STATE_ACTIVATED;
+    case wayland::xdg_toplevel_state::fullscreen:
+      return IShellSurface::STATE_FULLSCREEN;
+    case wayland::xdg_toplevel_state::maximized:
+      return IShellSurface::STATE_MAXIMIZED;
+    case wayland::xdg_toplevel_state::resizing:
+      return IShellSurface::STATE_RESIZING;
+    default:
+      throw std::runtime_error(std::string("Unknown xdg_toplevel state flag ") + std::to_string(static_cast<std::underlying_type<decltype(flag)>::type> (flag)));
+  }
+}
+
+}
+
+CShellSurfaceXdgShell* CShellSurfaceXdgShell::TryCreate(IShellSurfaceHandler& handler, CConnection& connection, const wayland::surface_t& surface, std::string const& title, std::string const& class_)
+{
+  wayland::xdg_wm_base_t shell;
+  CRegistry registry{connection};
+  registry.RequestSingleton(shell, 1, 1, false);
+  registry.Bind();
+
+  if (shell)
+  {
+    return new CShellSurfaceXdgShell(handler, connection.GetDisplay(), shell, surface, title, class_);
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
+CShellSurfaceXdgShell::CShellSurfaceXdgShell(IShellSurfaceHandler& handler, wayland::display_t& display, const wayland::xdg_wm_base_t& shell, const wayland::surface_t& surface, std::string const& title, std::string const& app_id)
+: m_handler{handler}, m_display{display}, m_shell{shell}, m_surface{surface}, m_xdgSurface{m_shell.get_xdg_surface(m_surface)}, m_xdgToplevel{m_xdgSurface.get_toplevel()}
+{
+  m_shell.on_ping() = [this](std::uint32_t serial)
+  {
+    m_shell.pong(serial);
+  };
+  m_xdgSurface.on_configure() = [this](std::uint32_t serial)
+  {
+    m_handler.OnConfigure(serial, m_configuredSize, m_configuredState);
+  };
+  m_xdgToplevel.on_close() = [this]()
+  {
+    m_handler.OnClose();
+  };
+  m_xdgToplevel.on_configure() = [this](std::int32_t width, std::int32_t height, std::vector<wayland::xdg_toplevel_state> states)
+  {
+    m_configuredSize.Set(width, height);
+    m_configuredState.reset();
+    for (auto state : states)
+    {
+      m_configuredState.set(ConvertStateFlag(state));
+    }
+  };
+  m_xdgToplevel.set_app_id(app_id);
+  m_xdgToplevel.set_title(title);
+  // Set sensible minimum size
+  m_xdgToplevel.set_min_size(300, 200);
+}
+
+void CShellSurfaceXdgShell::Initialize()
+{
+  // Commit surface to confirm role
+  // Don't do it in constructor since SetFullScreen might be called before
+  m_surface.commit();
+  // Make sure we get the initial configure before continuing
+  m_display.roundtrip();
+}
+
+void CShellSurfaceXdgShell::AckConfigure(std::uint32_t serial)
+{
+  m_xdgSurface.ack_configure(serial);
+}
+
+CShellSurfaceXdgShell::~CShellSurfaceXdgShell() noexcept
+{
+  // xdg_shell is picky: must destroy toplevel role before surface
+  m_xdgToplevel.proxy_release();
+  m_xdgSurface.proxy_release();
+}
+
+void CShellSurfaceXdgShell::SetFullScreen(const wayland::output_t& output, float)
+{
+  // xdg_shell does not support refresh rate setting at the moment
+  m_xdgToplevel.set_fullscreen(output);
+}
+
+void CShellSurfaceXdgShell::SetWindowed()
+{
+  m_xdgToplevel.unset_fullscreen();
+}
+
+void CShellSurfaceXdgShell::SetMaximized()
+{
+  m_xdgToplevel.set_maximized();
+}
+
+void CShellSurfaceXdgShell::UnsetMaximized()
+{
+  m_xdgToplevel.unset_maximized();
+}
+
+void CShellSurfaceXdgShell::SetMinimized()
+{
+  m_xdgToplevel.set_minimized();
+}
+
+void CShellSurfaceXdgShell::SetWindowGeometry(CRectInt geometry)
+{
+  m_xdgSurface.set_window_geometry(geometry.x1, geometry.y1, geometry.Width(), geometry.Height());
+}
+
+void CShellSurfaceXdgShell::StartMove(const wayland::seat_t& seat, std::uint32_t serial)
+{
+  m_xdgToplevel.move(seat, serial);
+}
+
+void CShellSurfaceXdgShell::StartResize(const wayland::seat_t& seat, std::uint32_t serial, wayland::shell_surface_resize edge)
+{
+  // wl_shell shell_surface_resize is identical to xdg_shell resize_edge
+  m_xdgToplevel.resize(seat, serial, static_cast<std::uint32_t> (edge));
+}
+
+void CShellSurfaceXdgShell::ShowShellContextMenu(const wayland::seat_t& seat, std::uint32_t serial, CPointInt position)
+{
+  m_xdgToplevel.show_window_menu(seat, serial, position.x, position.y);
+}

--- a/xbmc/windowing/wayland/ShellSurfaceXdgShell.h
+++ b/xbmc/windowing/wayland/ShellSurfaceXdgShell.h
@@ -1,0 +1,84 @@
+/*
+ *      Copyright (C) 2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "Connection.h"
+#include "ShellSurface.h"
+
+#include <wayland-extra-protocols.hpp>
+
+namespace KODI
+{
+namespace WINDOWING
+{
+namespace WAYLAND
+{
+
+/**
+ * Shell surface implementation for stable xdg_shell
+ */
+class CShellSurfaceXdgShell : public IShellSurface
+{
+public:
+  /**
+   * Construct xdg_shell toplevel object for given surface
+   *
+   * \param handler the shell surface handler
+   * \param display the wl_display global (for initial roundtrip)
+   * \param shell the xdg_wm_base global
+   * \param surface surface to make shell surface for
+   * \param title title of the surfae
+   * \param class_ class of the surface, which should match the name of the
+   *               .desktop file of the application
+   */
+  CShellSurfaceXdgShell(IShellSurfaceHandler& handler, wayland::display_t& display, wayland::xdg_wm_base_t const& shell, wayland::surface_t const& surface, std::string const& title, std::string const& class_);
+  virtual ~CShellSurfaceXdgShell() noexcept;
+
+  static CShellSurfaceXdgShell* TryCreate(IShellSurfaceHandler& handler, CConnection& connection, wayland::surface_t const& surface, std::string const& title, std::string const& class_);
+
+  void Initialize() override;
+
+  void SetFullScreen(wayland::output_t const& output, float refreshRate) override;
+  void SetWindowed() override;
+  void SetMaximized() override;
+  void UnsetMaximized() override;
+  void SetMinimized() override;
+  void SetWindowGeometry(CRectInt geometry) override;
+  void AckConfigure(std::uint32_t serial) override;
+
+  void StartMove(const wayland::seat_t& seat, std::uint32_t serial) override;
+  void StartResize(const wayland::seat_t& seat, std::uint32_t serial, wayland::shell_surface_resize edge) override;
+  void ShowShellContextMenu(const wayland::seat_t& seat, std::uint32_t serial, CPointInt position) override;
+
+private:
+  IShellSurfaceHandler& m_handler;
+  wayland::display_t& m_display;
+  wayland::xdg_wm_base_t m_shell;
+  wayland::surface_t m_surface;
+  wayland::xdg_surface_t m_xdgSurface;
+  wayland::xdg_toplevel_t m_xdgToplevel;
+
+  CSizeInt m_configuredSize;
+  StateBitset m_configuredState;
+};
+
+}
+}
+}

--- a/xbmc/windowing/wayland/ShellSurfaceXdgShellUnstableV6.h
+++ b/xbmc/windowing/wayland/ShellSurfaceXdgShellUnstableV6.h
@@ -31,6 +31,13 @@ namespace WINDOWING
 namespace WAYLAND
 {
 
+/**
+ * Shell surface implementation for unstable xdg_shell in version 6
+ *
+ * xdg_shell was accepted as a stable protocol in wayland-protocols, which
+ * means this class is deprecated and can be safely removed once the relevant
+ * compositors have made the switch.
+ */
 class CShellSurfaceXdgShellUnstableV6 : public IShellSurface
 {
 public:

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -511,7 +511,7 @@ std::shared_ptr<COutput> CWinSystemWayland::FindOutputByWaylandOutput(wayland::o
 {
   CSingleLock lock(m_outputsMutex);
   auto outputIt = std::find_if(m_outputs.begin(), m_outputs.end(),
-                               [this, &output](decltype(m_outputs)::value_type const& entry)
+                               [&output](decltype(m_outputs)::value_type const& entry)
                                {
                                  return (output == entry.second->GetWaylandOutput());
                                });

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -44,6 +44,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "ShellSurfaceWlShell.h"
+#include "ShellSurfaceXdgShell.h"
 #include "ShellSurfaceXdgShellUnstableV6.h"
 #include "threads/SingleLock.h"
 #include "Util.h"
@@ -303,10 +304,14 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
   // Try with this resolution if compositor does not say otherwise
   UpdateSizeVariables({res.iWidth, res.iHeight}, m_scale, m_shellSurfaceState, false);
 
-  m_shellSurface.reset(CShellSurfaceXdgShellUnstableV6::TryCreate(*this, *m_connection, m_surface, name, KODI::LINUX::DESKTOP_FILE_NAME));
+  m_shellSurface.reset(CShellSurfaceXdgShell::TryCreate(*this, *m_connection, m_surface, name, KODI::LINUX::DESKTOP_FILE_NAME));
   if (!m_shellSurface)
   {
-    CLog::LogF(LOGWARNING, "Compositor does not support xdg_shell unstable v6 protocol - falling back to wl_shell, not all features might work");
+    m_shellSurface.reset(CShellSurfaceXdgShellUnstableV6::TryCreate(*this, *m_connection, m_surface, name, KODI::LINUX::DESKTOP_FILE_NAME));
+  }
+  if (!m_shellSurface)
+  {
+    CLog::LogF(LOGWARNING, "Compositor does not support xdg_shell protocol (stable or unstable v6) - falling back to wl_shell, not all features might work");
     m_shellSurface.reset(new CShellSurfaceWlShell(*this, *m_connection, m_surface, name, KODI::LINUX::DESKTOP_FILE_NAME));
   }
 

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -29,6 +29,7 @@
 
 #include <wayland-client.hpp>
 #include <wayland-cursor.hpp>
+#include <wayland-extra-protocols.hpp>
 
 #include "Connection.h"
 #include "Output.h"


### PR DESCRIPTION


## Description
Besides wl_shell and zxdg_unstable_v6, also support xdg_wm_base, which is the new recommended desktop shell extension for Wayland

## Motivation and Context
wl_shell is effectively deprecated now and zxdg_unstable_v6 was always unstable, as the name indicates. xdg_shell has been stabilized as xdg_wm_base, so we should use it if possible

## How Has This Been Tested?
Fallback to old behavior verified with mutter. xdg_wm_base itself could not be checked due to missing compositor support at the moment, but as code and behavior are equivalent to xdg_shell unstable v6 there should be no major problems.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
