### PR TITLE
[fix] boolean condition window.is does not work properly

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7670,6 +7670,16 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         if (info.GetData1())
         {
           CGUIWindow *window = g_windowManager.GetWindow(contextWindow);
+          if (!window)
+          {
+            // try topmost dialog
+            window = g_windowManager.GetWindow(g_windowManager.GetTopMostModalDialogID());
+            if (!window)
+            {
+              // try active window
+              window = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
+            }
+          }
           bReturn = (window && window->GetID() == static_cast<int>(info.GetData1()));
         }
         else


### PR DESCRIPTION
The boolean condition Window.Is does not work properly because the contextual window is not always set. This will try to fix the issue by introducing a fallback. Now we'll first lookup for the contextual window, than the top most dialog and as a last the top most window.

The same is done in `CGUIInfoManager::GetWindowWithCondition(int contextWindow, int condition)` where pass in the contextual window too.

Runtime tested on MacOS.

Related forum thread https://forum.kodi.tv/showthread.php?tid=307923