### PR TITLE
[gui] refactor window is topmost methods and add new boolean conditions

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4634,7 +4634,7 @@ bool CApplication::SwitchToFullScreen(bool force /* = false */)
     return false;
 
   // if playing from the video info window, close it first!
-  if (g_windowManager.HasModalDialog() && g_windowManager.GetTopmostModalDialogID() == WINDOW_DIALOG_VIDEO_INFO)
+  if (g_windowManager.HasModalDialog() && g_windowManager.GetTopmostModalDialog() == WINDOW_DIALOG_VIDEO_INFO)
   {
     CGUIDialogVideoInfo* pDialog = g_windowManager.GetWindow<CGUIDialogVideoInfo>(WINDOW_DIALOG_VIDEO_INFO);
     if (pDialog) pDialog->Close(true);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4634,7 +4634,7 @@ bool CApplication::SwitchToFullScreen(bool force /* = false */)
     return false;
 
   // if playing from the video info window, close it first!
-  if (g_windowManager.HasModalDialog() && g_windowManager.GetTopmostModalDialog() == WINDOW_DIALOG_VIDEO_INFO)
+  if (g_windowManager.IsModalDialogTopmost(WINDOW_DIALOG_VIDEO_INFO))
   {
     CGUIDialogVideoInfo* pDialog = g_windowManager.GetWindow<CGUIDialogVideoInfo>(WINDOW_DIALOG_VIDEO_INFO);
     if (pDialog) pDialog->Close(true);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4634,7 +4634,7 @@ bool CApplication::SwitchToFullScreen(bool force /* = false */)
     return false;
 
   // if playing from the video info window, close it first!
-  if (g_windowManager.HasModalDialog() && g_windowManager.GetTopMostModalDialogID() == WINDOW_DIALOG_VIDEO_INFO)
+  if (g_windowManager.HasModalDialog() && g_windowManager.GetTopmostModalDialogID() == WINDOW_DIALOG_VIDEO_INFO)
   {
     CGUIDialogVideoInfo* pDialog = g_windowManager.GetWindow<CGUIDialogVideoInfo>(WINDOW_DIALOG_VIDEO_INFO);
     if (pDialog) pDialog->Close(true);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7693,9 +7693,9 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         break;
       case WINDOW_IS_TOPMOST:
         if (info.GetData1())
-          bReturn = g_windowManager.IsWindowTopMost(info.GetData1());
+          bReturn = g_windowManager.IsDialogTopmost(info.GetData1());
         else
-          bReturn = g_windowManager.IsWindowTopMost(m_stringParameters[info.GetData2()]);
+          bReturn = g_windowManager.IsDialogTopmost(m_stringParameters[info.GetData2()]);
         break;
       case WINDOW_IS_ACTIVE:
         if (info.GetData1())

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4093,8 +4093,8 @@ const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
 ///     Returns true if the window with id or title _window_ is active (excludes
 ///     fade out time on dialogs) \ref modules__General__Window_IDs "See here for a list of windows"
 ///   }
-///   \table_row3{   <b>`Window.IsTopMost(window)`</b>,
-///                  \anchor Window_IsTopMost
+///   \table_row3{   <b>`Window.IsTopmost(window)`</b>,
+///                  \anchor Window_IsTopmost
 ///                  _boolean_,
 ///     Returns true if the window with id or title _window_ is on top of the
 ///     window stack (excludes fade out time on dialogs)
@@ -7673,7 +7673,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
           if (!window)
           {
             // try topmost dialog
-            window = g_windowManager.GetWindow(g_windowManager.GetTopMostModalDialogID());
+            window = g_windowManager.GetWindow(g_windowManager.GetTopmostModalDialogID());
             if (!window)
             {
               // try active window
@@ -10712,7 +10712,7 @@ CGUIWindow *CGUIInfoManager::GetWindowWithCondition(int contextWindow, int condi
     return window;
 
   // try topmost dialog
-  window = g_windowManager.GetWindow(g_windowManager.GetTopMostModalDialogID());
+  window = g_windowManager.GetWindow(g_windowManager.GetTopmostModalDialogID());
   if (CheckWindowCondition(window, condition))
     return window;
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4093,17 +4093,32 @@ const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
 ///     Returns true if the window with id or title _window_ is active (excludes
 ///     fade out time on dialogs) \ref modules__General__Window_IDs "See here for a list of windows"
 ///   }
+///   \table_row3{   <b>`Window.IsVisible(window)`</b>,
+///                  \anchor Window_IsVisible
+///                  _boolean_,
+///     Returns true if the window is visible (includes fade out time on dialogs)
+///   }
 ///   \table_row3{   <b>`Window.IsTopmost(window)`</b>,
 ///                  \anchor Window_IsTopmost
 ///                  _boolean_,
 ///     Returns true if the window with id or title _window_ is on top of the
 ///     window stack (excludes fade out time on dialogs)
 ///     \ref modules__General__Window_IDs "See here for a list of windows"
+///     \deprecated use `Window.IsDialogTopmost(dialog)` instead
 ///   }
-///   \table_row3{   <b>`Window.IsVisible(window)`</b>,
-///                  \anchor Window_IsVisible
+///   \table_row3{   <b>`Window.IsDialogTopmost(dialog)`</b>,
+///                  \anchor Window_IsDialogTopmost
 ///                  _boolean_,
-///     Returns true if the window is visible (includes fade out time on dialogs)
+///     Returns true if the dialog with id or title _dialog_ is on top of the
+///     dialog stack (excludes fade out time on dialogs)
+///     \ref modules__General__Window_IDs "See here for a list of windows"
+///   }
+///   \table_row3{   <b>`Window.IsModalDialogTopmost(dialog)`</b>,
+///                  \anchor Window_IsModalDialogTopmost
+///                  _boolean_,
+///     Returns true if the dialog with id or title _dialog_ is on top of the
+///     modal dialog stack (excludes fade out time on dialogs)
+///     \ref modules__General__Window_IDs "See here for a list of windows"
 ///   }
 ///   \table_row3{   <b>`Window.Previous(window)`</b>,
 ///                  \anchor Window_Previous
@@ -4126,8 +4141,10 @@ const infomap skin_labels[] =    {{ "currenttheme",      SKIN_THEME },
 const infomap window_bools[] =   {{ "ismedia",          WINDOW_IS_MEDIA },
                                   { "is",               WINDOW_IS },
                                   { "isactive",         WINDOW_IS_ACTIVE },
-                                  { "istopmost",        WINDOW_IS_TOPMOST },
                                   { "isvisible",        WINDOW_IS_VISIBLE },
+                                  { "istopmost",        WINDOW_IS_DIALOG_TOPMOST }, // deprecated, remove in v19
+                                  { "isdialogtopmost",  WINDOW_IS_DIALOG_TOPMOST },
+                                  { "ismodaldialogtopmost", WINDOW_IS_MODAL_DIALOG_TOPMOST },
                                   { "previous",         WINDOW_PREVIOUS },
                                   { "next",             WINDOW_NEXT }};
 
@@ -7691,17 +7708,23 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         else
           bReturn = g_windowManager.IsWindowVisible(m_stringParameters[info.GetData2()]);
         break;
-      case WINDOW_IS_TOPMOST:
-        if (info.GetData1())
-          bReturn = g_windowManager.IsDialogTopmost(info.GetData1());
-        else
-          bReturn = g_windowManager.IsDialogTopmost(m_stringParameters[info.GetData2()]);
-        break;
       case WINDOW_IS_ACTIVE:
         if (info.GetData1())
           bReturn = g_windowManager.IsWindowActive(info.GetData1());
         else
           bReturn = g_windowManager.IsWindowActive(m_stringParameters[info.GetData2()]);
+        break;
+      case WINDOW_IS_DIALOG_TOPMOST:
+        if (info.GetData1())
+          bReturn = g_windowManager.IsDialogTopmost(info.GetData1());
+        else
+          bReturn = g_windowManager.IsDialogTopmost(m_stringParameters[info.GetData2()]);
+        break;
+      case WINDOW_IS_MODAL_DIALOG_TOPMOST:
+        if (info.GetData1())
+          bReturn = g_windowManager.IsModalDialogTopmost(info.GetData1());
+        else
+          bReturn = g_windowManager.IsModalDialogTopmost(m_stringParameters[info.GetData2()]);
         break;
       case SYSTEM_HAS_ALARM:
         bReturn = g_alarmClock.HasAlarm(m_stringParameters[info.GetData1()]);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -7673,7 +7673,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
           if (!window)
           {
             // try topmost dialog
-            window = g_windowManager.GetWindow(g_windowManager.GetTopmostModalDialogID());
+            window = g_windowManager.GetWindow(g_windowManager.GetTopmostModalDialog());
             if (!window)
             {
               // try active window
@@ -10712,7 +10712,7 @@ CGUIWindow *CGUIInfoManager::GetWindowWithCondition(int contextWindow, int condi
     return window;
 
   // try topmost dialog
-  window = g_windowManager.GetWindow(g_windowManager.GetTopmostModalDialogID());
+  window = g_windowManager.GetWindow(g_windowManager.GetTopmostModalDialog());
   if (CheckWindowCondition(window, condition))
     return window;
 

--- a/xbmc/addons/interfaces/GUI/General.cpp
+++ b/xbmc/addons/interfaces/GUI/General.cpp
@@ -208,7 +208,7 @@ int Interface_GUIGeneral::get_current_window_dialog_id(void* kodiBase)
   }
 
   CSingleLock gl(g_graphicsContext);
-  return g_windowManager.GetTopmostModalDialogID();
+  return g_windowManager.GetTopmostModalDialog();
 }
 
 int Interface_GUIGeneral::get_current_window_id(void* kodiBase)

--- a/xbmc/addons/interfaces/GUI/General.cpp
+++ b/xbmc/addons/interfaces/GUI/General.cpp
@@ -208,7 +208,7 @@ int Interface_GUIGeneral::get_current_window_dialog_id(void* kodiBase)
   }
 
   CSingleLock gl(g_graphicsContext);
-  return g_windowManager.GetTopMostModalDialogID();
+  return g_windowManager.GetTopmostModalDialogID();
 }
 
 int Interface_GUIGeneral::get_current_window_id(void* kodiBase)

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -108,7 +108,7 @@ void CGUIDialogBusy::Open_Internal(const std::string &param /* = "" */)
 
 void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  bool visible = g_windowManager.GetTopMostModalDialogID() == WINDOW_DIALOG_BUSY;
+  bool visible = g_windowManager.GetTopmostModalDialogID() == WINDOW_DIALOG_BUSY;
   if(!visible && m_bLastVisible)
     dirtyregions.push_back(CDirtyRegion(m_renderRegion));
   m_bLastVisible = visible;

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -108,7 +108,7 @@ void CGUIDialogBusy::Open_Internal(const std::string &param /* = "" */)
 
 void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  bool visible = g_windowManager.GetTopmostModalDialogID() == WINDOW_DIALOG_BUSY;
+  bool visible = g_windowManager.GetTopmostModalDialog() == WINDOW_DIALOG_BUSY;
   if(!visible && m_bLastVisible)
     dirtyregions.push_back(CDirtyRegion(m_renderRegion));
   m_bLastVisible = visible;

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -108,7 +108,7 @@ void CGUIDialogBusy::Open_Internal(const std::string &param /* = "" */)
 
 void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  bool visible = g_windowManager.GetTopmostModalDialog() == WINDOW_DIALOG_BUSY;
+  bool visible = g_windowManager.IsModalDialogTopmost(WINDOW_DIALOG_BUSY);
   if(!visible && m_bLastVisible)
     dirtyregions.push_back(CDirtyRegion(m_renderRegion));
   m_bLastVisible = visible;

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -614,13 +614,14 @@
 #define PLAYER_PROCESS_AUDIOBITSPERSAMPLE (PLAYER_PROCESS + 11)
 
 #define WINDOW_PROPERTY             9993
-#define WINDOW_IS_TOPMOST           9994
 #define WINDOW_IS_VISIBLE           9995
 #define WINDOW_NEXT                 9996
 #define WINDOW_PREVIOUS             9997
 #define WINDOW_IS_MEDIA             9998
 #define WINDOW_IS_ACTIVE            9999
 #define WINDOW_IS                   10000
+#define WINDOW_IS_DIALOG_TOPMOST    10001
+#define WINDOW_IS_MODAL_DIALOG_TOPMOST 10002
 
 #define CONTROL_GET_LABEL           29996
 #define CONTROL_IS_ENABLED          29997

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1671,7 +1671,7 @@ CGUIWindow *CGUIWindowManager::GetTopMostDialog() const
   return *renderList.rbegin();
 }
 
-bool CGUIWindowManager::IsWindowTopMost(int id) const
+bool CGUIWindowManager::IsDialogTopmost(int id) const
 {
   CGUIWindow *topMost = GetTopMostDialog();
   if (topMost && (topMost->GetID() & WINDOW_ID_MASK) == id)
@@ -1679,7 +1679,7 @@ bool CGUIWindowManager::IsWindowTopMost(int id) const
   return false;
 }
 
-bool CGUIWindowManager::IsWindowTopMost(const std::string &xmlFile) const
+bool CGUIWindowManager::IsDialogTopmost(const std::string &xmlFile) const
 {
   CGUIWindow *topMost = GetTopMostDialog();
   if (topMost && StringUtils::EqualsNoCase(URIUtils::GetFileName(topMost->GetProperty("xmlfile").asString()), xmlFile))

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1663,17 +1663,27 @@ void CGUIWindowManager::RemoveFromWindowHistory(int windowID)
   }
 }
 
-bool CGUIWindowManager::IsDialogTopmost(int id) const
+bool CGUIWindowManager::IsModalDialogTopmost(int id) const
 {
-  CGUIWindow *topmost = GetWindow(GetTopmostDialog(false));
+  return IsDialogTopmost(id, true);
+}
+
+bool CGUIWindowManager::IsModalDialogTopmost(const std::string &xmlFile) const
+{
+  return IsDialogTopmost(xmlFile, true);
+}
+
+bool CGUIWindowManager::IsDialogTopmost(int id, bool modal /* = false */) const
+{
+  CGUIWindow *topmost = GetWindow(GetTopmostDialog(modal, false));
   if (topmost && (topmost->GetID() & WINDOW_ID_MASK) == id)
     return true;
   return false;
 }
 
-bool CGUIWindowManager::IsDialogTopmost(const std::string &xmlFile) const
+bool CGUIWindowManager::IsDialogTopmost(const std::string &xmlFile, bool modal /* = false */) const
 {
-  CGUIWindow *topmost = GetWindow(GetTopmostDialog(false));
+  CGUIWindow *topmost = GetWindow(GetTopmostDialog(modal, false));
   if (topmost && StringUtils::EqualsNoCase(URIUtils::GetFileName(topmost->GetProperty("xmlfile").asString()), xmlFile))
     return true;
   return false;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1066,10 +1066,10 @@ bool CGUIWindowManager::OnAction(const CAction &action) const
 bool CGUIWindowManager::HandleAction(CAction const& action) const
 {
   CSingleLock lock(g_graphicsContext);
-  unsigned int topMost = m_activeDialogs.size();
-  while (topMost)
+  unsigned int topmost = m_activeDialogs.size();
+  while (topmost)
   {
-    CGUIWindow *dialog = m_activeDialogs[--topMost];
+    CGUIWindow *dialog = m_activeDialogs[--topmost];
     lock.Leave();
     if (dialog->IsModalDialog())
     { // we have the topmost modal dialog
@@ -1089,8 +1089,8 @@ bool CGUIWindowManager::HandleAction(CAction const& action) const
       return true; // do nothing with the action until the anim is finished
     }
     lock.Enter();
-    if (topMost > m_activeDialogs.size())
-      topMost = m_activeDialogs.size();
+    if (topmost > m_activeDialogs.size())
+      topmost = m_activeDialogs.size();
   }
   lock.Leave();
   CGUIWindow* window = GetWindow(GetActiveWindow());
@@ -1396,7 +1396,7 @@ bool CGUIWindowManager::HasVisibleModalDialog(const std::vector<DialogModalityTy
 
 /// \brief Get the ID of the top most routed window
 /// \return id ID of the window or WINDOW_INVALID if no routed window available
-int CGUIWindowManager::GetTopMostModalDialogID(bool ignoreClosing /*= false*/) const
+int CGUIWindowManager::GetTopmostModalDialogID(bool ignoreClosing /*= false*/) const
 {
   CSingleLock lock(g_graphicsContext);
   for (auto it = m_activeDialogs.rbegin(); it != m_activeDialogs.rend(); ++it)
@@ -1507,7 +1507,7 @@ int CGUIWindowManager::GetActiveWindowID() const
 
   // If there is a dialog active get the dialog id instead
   if (HasModalDialog())
-    iWin = GetTopMostModalDialogID() & WINDOW_ID_MASK;
+    iWin = GetTopmostModalDialogID() & WINDOW_ID_MASK;
 
   // If the window is FullScreenVideo check for special cases
   if (iWin == WINDOW_FULLSCREEN_VIDEO)
@@ -1538,7 +1538,7 @@ int CGUIWindowManager::GetActiveWindowID() const
 // same as GetActiveWindow() except it first grabs dialogs
 int CGUIWindowManager::GetFocusedWindow() const
 {
-  int dialog = GetTopMostModalDialogID(true);
+  int dialog = GetTopmostModalDialogID(true);
   if (dialog != WINDOW_INVALID)
     return dialog;
 
@@ -1657,7 +1657,7 @@ void CGUIWindowManager::RemoveFromWindowHistory(int windowID)
   }
 }
 
-CGUIWindow *CGUIWindowManager::GetTopMostDialog() const
+CGUIWindow *CGUIWindowManager::GetTopmostDialog() const
 {
   CSingleLock lock(g_graphicsContext);
   // find the window with the lowest render order
@@ -1673,16 +1673,16 @@ CGUIWindow *CGUIWindowManager::GetTopMostDialog() const
 
 bool CGUIWindowManager::IsDialogTopmost(int id) const
 {
-  CGUIWindow *topMost = GetTopMostDialog();
-  if (topMost && (topMost->GetID() & WINDOW_ID_MASK) == id)
+  CGUIWindow *topmost = GetTopmostDialog();
+  if (topmost && (topmost->GetID() & WINDOW_ID_MASK) == id)
     return true;
   return false;
 }
 
 bool CGUIWindowManager::IsDialogTopmost(const std::string &xmlFile) const
 {
-  CGUIWindow *topMost = GetTopMostDialog();
-  if (topMost && StringUtils::EqualsNoCase(URIUtils::GetFileName(topMost->GetProperty("xmlfile").asString()), xmlFile))
+  CGUIWindow *topmost = GetTopmostDialog();
+  if (topmost && StringUtils::EqualsNoCase(URIUtils::GetFileName(topmost->GetProperty("xmlfile").asString()), xmlFile))
     return true;
   return false;
 }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1394,11 +1394,6 @@ bool CGUIWindowManager::HasVisibleModalDialog(const std::vector<DialogModalityTy
   return HasModalDialog(types, false);
 }
 
-bool CGUIWindowManager::HasDialogOnScreen() const
-{
-  return (m_activeDialogs.size() > 0);
-}
-
 /// \brief Get the ID of the top most routed window
 /// \return id ID of the window or WINDOW_INVALID if no routed window available
 int CGUIWindowManager::GetTopMostModalDialogID(bool ignoreClosing /*= false*/) const

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -212,8 +212,10 @@ public:
   int GetFocusedWindow() const;
   bool HasModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>(), bool ignoreClosing = true) const;
   bool HasVisibleModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>()) const;
-  bool IsDialogTopmost(int id) const;
-  bool IsDialogTopmost(const std::string &xmlFile) const;
+  bool IsDialogTopmost(int id, bool modal = false) const;
+  bool IsDialogTopmost(const std::string &xmlFile, bool modal = false) const;
+  bool IsModalDialogTopmost(int id) const;
+  bool IsModalDialogTopmost(const std::string &xmlFile) const;
   bool IsWindowActive(int id, bool ignoreClosing = true) const;
   bool IsWindowVisible(int id) const;
   bool IsWindowActive(const std::string &xmlFile, bool ignoreClosing = true) const;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -186,7 +186,7 @@ public:
    */
   void RegisterDialog(CGUIWindow* dialog);
   void RemoveDialog(int id);
-  int GetTopMostModalDialogID(bool ignoreClosing = false) const;
+  int GetTopmostModalDialogID(bool ignoreClosing = false) const;
 
   void SendThreadMessage(CGUIMessage& message, int window = 0);
   void DispatchThreadMessages();
@@ -238,7 +238,7 @@ private:
   void RemoveFromWindowHistory(int windowID);
   void ClearWindowHistory();
   void CloseWindowSync(CGUIWindow *window, int nextWindowID = 0);
-  CGUIWindow *GetTopMostDialog() const;
+  CGUIWindow *GetTopmostDialog() const;
 
   friend class KODI::MESSAGING::CApplicationMessenger;
   

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -199,7 +199,6 @@ public:
   int GetFocusedWindow() const;
   bool HasModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>(), bool ignoreClosing = true) const;
   bool HasVisibleModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>()) const;
-  bool HasDialogOnScreen() const;
   bool IsWindowActive(int id, bool ignoreClosing = true) const;
   bool IsWindowVisible(int id) const;
   bool IsWindowTopMost(int id) const;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -199,12 +199,12 @@ public:
   int GetFocusedWindow() const;
   bool HasModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>(), bool ignoreClosing = true) const;
   bool HasVisibleModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>()) const;
+  bool IsDialogTopmost(int id) const;
+  bool IsDialogTopmost(const std::string &xmlFile) const;
   bool IsWindowActive(int id, bool ignoreClosing = true) const;
   bool IsWindowVisible(int id) const;
-  bool IsWindowTopMost(int id) const;
   bool IsWindowActive(const std::string &xmlFile, bool ignoreClosing = true) const;
   bool IsWindowVisible(const std::string &xmlFile) const;
-  bool IsWindowTopMost(const std::string &xmlFile) const;
   /*! \brief Checks if the given window is an addon window.
    *
    * \return true if the given window is an addon window, otherwise false.

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -186,7 +186,20 @@ public:
    */
   void RegisterDialog(CGUIWindow* dialog);
   void RemoveDialog(int id);
-  int GetTopmostModalDialogID(bool ignoreClosing = false) const;
+
+  /*! \brief Get the ID of the topmost dialog
+   *
+   * \param ignoreClosing ignore dialog is closing
+   * \return the ID of the topmost dialog or WINDOW_INVALID if no dialog is active
+   */
+  int GetTopmostDialog(bool ignoreClosing = false) const;
+
+  /*! \brief Get the ID of the topmost modal dialog
+   *
+   * \param ignoreClosing ignore dialog is closing
+   * \return the ID of the topmost modal dialog or WINDOW_INVALID if no modal dialog is active
+   */
+  int GetTopmostModalDialog(bool ignoreClosing = false) const;
 
   void SendThreadMessage(CGUIMessage& message, int window = 0);
   void DispatchThreadMessages();
@@ -238,7 +251,7 @@ private:
   void RemoveFromWindowHistory(int windowID);
   void ClearWindowHistory();
   void CloseWindowSync(CGUIWindow *window, int nextWindowID = 0);
-  CGUIWindow *GetTopmostDialog() const;
+  int GetTopmostDialog(bool modal, bool ignoreClosing) const;
 
   friend class KODI::MESSAGING::CApplicationMessenger;
   

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -348,7 +348,7 @@ namespace XBMCAddon
       {
         XBMCAddonUtils::GuiLock lock(nullptr, false);
 
-        int id = g_windowManager.GetTopMostModalDialogID();
+        int id = g_windowManager.GetTopmostModalDialogID();
         if (id == WINDOW_INVALID) id = g_windowManager.GetActiveWindow();
         ret = g_infoManager.EvaluateBool(condition,id);
       }

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -348,7 +348,7 @@ namespace XBMCAddon
       {
         XBMCAddonUtils::GuiLock lock(nullptr, false);
 
-        int id = g_windowManager.GetTopmostModalDialogID();
+        int id = g_windowManager.GetTopmostModalDialog();
         if (id == WINDOW_INVALID) id = g_windowManager.GetActiveWindow();
         ret = g_infoManager.EvaluateBool(condition,id);
       }

--- a/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
@@ -42,7 +42,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dg;
       CSingleLock gl(g_graphicsContext);
-      return g_windowManager.GetTopMostModalDialogID();
+      return g_windowManager.GetTopmostModalDialogID();
     }
 
     long getScreenHeight()

--- a/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcgui.cpp
@@ -42,7 +42,7 @@ namespace XBMCAddon
     {
       DelayedCallGuard dg;
       CSingleLock gl(g_graphicsContext);
-      return g_windowManager.GetTopmostModalDialogID();
+      return g_windowManager.GetTopmostModalDialog();
     }
 
     long getScreenHeight()

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -129,7 +129,7 @@ bool CPVRActionListener::OnAction(const CAction &action)
       {
         // do not consume action if a python modal is the top most dialog
         // as a python modal can't return that it consumed the action.
-        if (g_windowManager.IsPythonWindow(g_windowManager.GetTopmostModalDialogID()))
+        if (g_windowManager.IsPythonWindow(g_windowManager.GetTopmostModalDialog()))
           return false;
 
         char cCharacter;

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -129,7 +129,7 @@ bool CPVRActionListener::OnAction(const CAction &action)
       {
         // do not consume action if a python modal is the top most dialog
         // as a python modal can't return that it consumed the action.
-        if (g_windowManager.IsPythonWindow(g_windowManager.GetTopMostModalDialogID()))
+        if (g_windowManager.IsPythonWindow(g_windowManager.GetTopmostModalDialogID()))
           return false;
 
         char cCharacter;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -166,7 +166,7 @@ bool CGUIWindowLoginScreen::OnBack(int actionID)
 
 void CGUIWindowLoginScreen::FrameMove()
 {
-  if (GetFocusedControlID() == CONTROL_BIG_LIST && g_windowManager.GetTopMostModalDialogID() == WINDOW_INVALID)
+  if (GetFocusedControlID() == CONTROL_BIG_LIST && g_windowManager.GetTopmostModalDialogID() == WINDOW_INVALID)
     if (m_viewControl.HasControl(CONTROL_BIG_LIST))
       m_iSelectedItem = m_viewControl.GetSelectedItem();
   std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, CProfilesManager::GetInstance().GetNumberOfProfiles());

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -166,7 +166,7 @@ bool CGUIWindowLoginScreen::OnBack(int actionID)
 
 void CGUIWindowLoginScreen::FrameMove()
 {
-  if (GetFocusedControlID() == CONTROL_BIG_LIST && g_windowManager.GetTopmostModalDialog() == WINDOW_INVALID)
+  if (GetFocusedControlID() == CONTROL_BIG_LIST && !g_windowManager.HasModalDialog())
     if (m_viewControl.HasControl(CONTROL_BIG_LIST))
       m_iSelectedItem = m_viewControl.GetSelectedItem();
   std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, CProfilesManager::GetInstance().GetNumberOfProfiles());

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -166,7 +166,7 @@ bool CGUIWindowLoginScreen::OnBack(int actionID)
 
 void CGUIWindowLoginScreen::FrameMove()
 {
-  if (GetFocusedControlID() == CONTROL_BIG_LIST && g_windowManager.GetTopmostModalDialogID() == WINDOW_INVALID)
+  if (GetFocusedControlID() == CONTROL_BIG_LIST && g_windowManager.GetTopmostModalDialog() == WINDOW_INVALID)
     if (m_viewControl.HasControl(CONTROL_BIG_LIST))
       m_iSelectedItem = m_viewControl.GetSelectedItem();
   std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, CProfilesManager::GetInstance().GetNumberOfProfiles());


### PR DESCRIPTION
Most of the stuff is cleanup/refactoring and explained in the commit message.

There are now two new info bools for skinners. The first replaces `Window.IsTopMost` with `Window.IsDialogTopmost` and the other `Window.IsModalDialogTopmost` is used to check if the given dialog is the topmost modal dialog.

@phil65 @ronie mind taking a look.