### PR TITLE
Music Artwork Consistently Availlable To GUI

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -73,6 +73,19 @@ typedef std::set<std::string> SETPATHS;
  */
 typedef std::set<std::string>::iterator ISETPATHS;
 
+/*!
+\ingroup music
+\brief A structure used for fetching music art data
+\sa CMusicDatabase::GetArtForItem()
+*/
+
+typedef struct {
+  std::string mediaType;
+  std::string artType;
+  std::string prefix;
+  std::string url;
+} ArtForThumbLoader;
+
 class CGUIDialogProgress;
 class CFileItemList;
 
@@ -479,6 +492,26 @@ public:
    */
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
 
+
+  /*! \brief Fetch all related art for a database item.
+  Fetches multiple pieces of art for a database item including that for related media types
+  Given song id art for the related album, artist(s) and albumartist(s) will also be fetched, looking up the 
+  album and artist when ids are not provided.
+  Given album id (and not song id) art for the related artist(s) will also be fetched, looking up the 
+  artist(s) when id are not provided.
+  \param songId the id in the song table, -1 when song art not being fetched
+  \param albumId the id in the album table, -1 when album art not being fetched
+  \param artistId the id in the artist table, -1 when artist not known
+  \param bPrimaryArtist true if art from only the first song artist or album artist is to be fetched
+  \param art [out] a vector, each element having media type e.g. "artist", "album" or "song", 
+  artType e.g. "thumb", "fanart", etc., prefix of "", "artist" or "albumartist" etc. giving the kind of artist
+  relationship, and the original url of the art.
+  
+  \return true if art is retrieved, false if no art is found.
+  \sa SetArtForItem
+  */
+  bool GetArtForItem(int songId, int albumId, int artistId, bool bPrimaryArtist, std::vector<ArtForThumbLoader> &art);
+
   /*! \brief Fetch art for a database item.
    Fetches multiple pieces of art for a database item.
    \param mediaId the id in the media (song/artist/album) table.
@@ -498,26 +531,6 @@ public:
    \sa SetArtForItem
    */
   std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
-
-  /*! \brief Fetch artist art for a song or album item.
-   Fetches the art associated with the primary artist for the song or album.
-   \param mediaId the id in the media (song/album) table.
-   \param mediaType the type of media, which corresponds to the table the item resides in (song/album).
-   \param art [out] the art map <type, url> of artist art.
-   \return true if artist art is found, false otherwise.
-   \sa GetArtForItem
-   */
-  bool GetArtistArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);
-
-  /*! \brief Fetch artist art for a song or album item.
-   Fetches a single piece of art associated with the primary artist for the song or album.
-   \param mediaId the id in the media (song/album) table.
-   \param mediaType the type of media, which corresponds to the table the item resides in (song/album).
-   \param artType the type of art to retrieve, eg "thumb", "fanart".
-   \return the original URL to the piece of art, if available.
-   \sa GetArtForItem
-   */
-  std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
 
   /*! \brief Remove art for a database item.
   Removes  a single piece of art for a database item.

--- a/xbmc/music/MusicThumbLoader.h
+++ b/xbmc/music/MusicThumbLoader.h
@@ -39,9 +39,17 @@ public:
   bool LoadItemCached(CFileItem* pItem) override;
   bool LoadItemLookup(CFileItem* pItem) override;
 
-  /*! \brief helper function to fill the art for a video library item
-   \param item a video CFileItem
-   \return true if we fill art, false otherwise
+  /*! \brief Helper function to fill all the art for a music library item
+  This fetches the original url for each type of art, and sets fallback thumb and fanart.
+  For songs the art for the related album and artist(s) is also set, and for albums that
+  of the related artist(s). Art type is named according to media type of the item, 
+  for example: 
+  artists may have "thumb", "fanart", "logo", "poster" etc., 
+  albums may have "thumb", "spine" etc. and "artist.thumb", "artist.fanart" etc.,
+  songs may have "thumb", "album.thumb", "artist.thumb", "artist.fanart", "artist.logo",... 
+  "artist1.thumb", "artist1.fanart",... "albumartist.thumb", "albumartist1.thumb" etc.
+   \param item a music CFileItem
+   \return true if we fill art, false if there is no art found
    */
   bool FillLibraryArt(CFileItem &item) override;
   

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -269,8 +269,23 @@ bool CRecentlyAddedJob::UpdateMusic()
     {
       auto& album=albums[j];
       std::string value = StringUtils::Format("%lu", j + 1);
-      std::string strThumb = musicdatabase.GetArtForItem(album.idAlbum, MediaTypeAlbum, "thumb");
-      std::string strFanart = musicdatabase.GetArtistArtForItem(album.idAlbum, MediaTypeAlbum, "fanart");
+      std::string strThumb;
+      std::string strFanart;
+      bool artfound = false;
+      std::vector<ArtForThumbLoader> art;
+      // Get album thumb and fanart for first album artist
+      artfound = musicdatabase.GetArtForItem(-1, album.idAlbum, -1, true, art);
+      if (artfound)
+      {
+        for (auto artitem : art)
+        {
+          if (artitem.mediaType == MediaTypeAlbum && artitem.artType == "thumb")
+            strThumb = artitem.url;
+          else if (artitem.mediaType == MediaTypeArtist && artitem.artType == "fanart")
+            strFanart = artitem.url;
+        }
+      }
+
       std::string strDBpath = StringUtils::Format("musicdb://albums/%li/", album.idAlbum);
       
       home->SetProperty("LatestAlbum." + value + ".Title"   , album.strAlbum);


### PR DESCRIPTION
Continuing the "liberation" of music library art by making the extended artwork consistently availlable to skins.

As long wanted #13101 added parameters to JSON API to get/set _any_ type of artwork for artists, albums and songs, and brought it inline with video library functionality.  However the range of artwork presented by Kodi to the skins and API remained very inconsistent e.g. some places getting art for a song would also get artist thumb too, but not other types of artist art, and only album thumb when the song had none etc. The way the art was queried was also inefficient. 

The main change has been to `CMusicThumbloader::FillLibraryArt` to get _all_ types of art, using one efficient db query per music item. So for example getting song art also gets all related artist and album art. This is then used to make all relevent art available to skins in all places.

Also taken the opportunity to make art for **multiple artists** available where the song has  guest/featured artists or an album is a collaboration e.g. composer, conductor, orchestra. Done in a backwards compatible way, numbering subsequent artists "artist1", "artist2" etc. . Hence using `Listitem.Art(...)` for a song item the possible type parameters include:
"thumb", "album.thumb",... "artist.thumb", "artist.fanart", "artist.logo",... "artist1.thumb",  "artist1.fanart",... "albumartist.thumb", "albumartist.fanart",... "albumartist1.thumb" etc.

For consistency `Listitem.Property(artistthumbs)` and `Listitem.Property(artistthumb)` have been deprecated. They were only availlable on the music info dialogs, I believe little used by skins,  and  superceded by `Listitem.Art(artist.thumb)`

A small fix too for the album/artist info dialog:  `Container.Art()` will return the same art as `Listitem.Art()` - the artist or album art. The control list art for each item is access by `Container(50).Listitem.Art()`

Hence **all** the art for an item is consistently availlable for display on both music library navigation window for every media type, and the music information dialogs. It is up to the skinner if they want to show the secondary artist art, or work inconjunction with an art addon that adds spines, logos or backcovers etc., Kodi  just makes it possible.

Note: In all places I talk about "getting art" what I mean is getting the original location of the art from the music database not the actual art from the texture DB or cache. Fetching more art is just a few more text strings per item (if that type of art exists), not lumping lots of images about. That only happens when a skin requests actually specific images.

@ronie thanks for the help with some of the skin interface stuff.
@rmrector sorted as promised, I will get a test build up
Not sure who else might know about thumbloader, @notspiff perhaps (it is ancient).
