### PR TITLE
Fix crash due to out-of-order resource destruction

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -169,6 +169,7 @@ CGameClient::CGameClient(ADDON::CAddonInfo addonInfo) :
 CGameClient::~CGameClient(void)
 {
   CloseFile();
+  DestroySubsystems(m_subsystems);
 }
 
 GameClientSubsystems CGameClient::CreateSubsystems(CGameClient &gameClient, AddonInstance_Game &gameStruct, CCriticalSection &clientAccess)
@@ -178,6 +179,11 @@ GameClientSubsystems CGameClient::CreateSubsystems(CGameClient &gameClient, Addo
   subsystems.Input.reset(new CGameClientInput(gameClient, gameStruct, clientAccess));
 
   return subsystems;
+}
+
+void CGameClient::DestroySubsystems(GameClientSubsystems &subsystems)
+{
+  subsystems.Input.reset();
 }
 
 std::string CGameClient::LibPath() const

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -136,6 +136,13 @@ private:
    */
   static GameClientSubsystems CreateSubsystems(CGameClient &gameClient, AddonInstance_Game &gameStruct, CCriticalSection &clientAccess);
 
+  /*!
+   * \brief Deallocate subsystems
+   *
+   * \param subsystems The subsystems created by CreateSubsystems()
+   */
+  static void DestroySubsystems(GameClientSubsystems &subsystems);
+
   // Private gameplay functions
   bool InitializeGameplay(const std::string& gamePath, IGameAudioCallback* audio, IGameVideoCallback* video, IGameInputCallback *input);
   bool LoadGameInfo();


### PR DESCRIPTION
This fixes a crash introduced in https://github.com/xbmc/xbmc/pull/13316.

Currently, destroying the input subsystem requires access to the main class (this is legacy code and will change when the Player Manager drops).

Destruction is deterministic, so we just need to ensure that subsystems are destroyed before the resources they access. Placing a call in the destructor is sufficient.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
