### PR TITLE
[fix] MusicDatabase Songs set real path to avoid passing MusicDB URLs to player/demuxer

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2074,6 +2074,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
     std::string path = StringUtils::Format("%i%s", record->at(song_idSong).get_asInt(), strExt.c_str());
     itemUrl.AppendPath(path);
     item->SetPath(itemUrl.ToString());
+    item->SetDynPath(strRealPath);
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Some music (flacs) could not be played back when started from the music library nodes, but did work properly when starting from the "files" or "all songs" node.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When playing music from music library nodes, the paths have a different format, which does NOT include the file extension at the very end of the string. Because of this, the demuxer doesn't know the content type and it tries to probe the file to determine the right codec. Some flacs (probably broken, examples provided by @DaveTBlake) are then incorrectly 'recognized' as mp3 therefore playback fails immediately after start.
When playing these same examples from the "files" node, they work fine, as there the file extension is at the end and the right codec is correctly selected. 

The root cause is indeed that the file extension cannot be determined by the demuxer.
To solve this, all that needed to be done was to set the REAL path in m_strDynPath, when reading the item from the music database.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
