### PR TITLE
[Fix]Visualisation none as default for all platforms

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -414,7 +414,7 @@
         </setting>
         <setting id="musicplayer.visualisation" type="addon" label="250" help="36273">
           <level>0</level>
-          <default>visualization.spectrum</default>
+          <default></default>
           <constraints>
             <addontype>xbmc.player.musicviz</addontype>
             <allowempty>true</allowempty>

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -658,7 +658,6 @@ void CSettings::InitializeDefaults()
 #endif // defined(TARGET_POSIX)
 
 #if defined(TARGET_WINDOWS)
-  std::static_pointer_cast<CSettingString>(GetSettingsManager()->GetSetting(CSettings::SETTING_MUSICPLAYER_VISUALISATION))->SetDefault("visualization.milkdrop");
   // We prefer a fake fullscreen mode (window covering the screen rather than dedicated fullscreen)
   // as it works nicer with switching to other applications. However on some systems vsync is broken
   // when we do this (eg non-Aero on ATI in particular) and on others (AppleTV) we can't get XBMC to


### PR DESCRIPTION
~Remove Milkdrop as default visualization for WINDOWS target, make it none.~
Remove default visualization for all platforms, make it none. This is consistent with visualisation addons being optionally installed, and initially disabled when they are.

## Motivation and Context
On a clean Windows install Milkdrop runs during playback, overlaying any fanart, despite the Milkdrop addon being disabled, and the main setting screen Settings>Player>Music>Visualization showing "None". The value of this setting can not be changed as no visualizaton addons are enabled. Discussed here https://forum.kodi.tv/showthread.php?tid=326834 and on Slack

The cause is that in guisettings.xml the default visualization is set to Milkdrop, but that addon is disabled on installation, and the main settings screen can only show a selection list of enabled viz addons. Hence it shows "none", and so does not save "none" has the new value to guisettings.xml because it is not a value change.

## How Has This Been Tested?
Run both win32 and win64 clean installations, no viz by default and settings match. Visualization addons then have to be (installed and) enabled before one can be chosen as the viz from either the main settings menu, or from settings dialog from the player OSD during playback.

@jjd-uk there are test builds on the mirror if you would like to confirm, but as a one line fix I'm not sure it is needed.
@afedchin and @notspiff for interest