### PR TITLE
[PVR][Estuary] Guide window: Channel groups selector

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11074,16 +11074,16 @@ msgctxt "#19296"
 msgid "No PVR add-on enabled"
 msgstr ""
 
-#. 'timeline' label used in pvr guide window
+#. 'Viewtype' label for vertical channel layout, used in pvr guide window
 #: addons/skin.estuary/xml/MyPVRGuide.xml
 msgctxt "#19297"
-msgid "Vertical"
+msgid "Vertical channels"
 msgstr ""
 
-#. 'timeline' label used in pvr guide window
+#. 'Viewtype' label for horizontal channel layout, used in pvr guide window
 #: addons/skin.estuary/xml/MyPVRGuide.xml
 msgctxt "#19298"
-msgid "Horizontal"
+msgid "Horizontal channels"
 msgstr ""
 
 #. generic "expiration" label used in different places
@@ -11093,7 +11093,19 @@ msgctxt "#19299"
 msgid "Expires"
 msgstr ""
 
-#empty strings from id 19300 to 19498
+#. 'Viewtype' label for vertical channel layout without channel group selctor, used in pvr guide window
+#: addons/skin.estuary/xml/MyPVRGuide.xml
+msgctxt "#19300"
+msgid "Vertical channels, no group selector"
+msgstr ""
+
+#. 'Viewtype' label for horizontal channel layout without channel group selctor, used in pvr guide window
+#: addons/skin.estuary/xml/MyPVRGuide.xml
+msgctxt "#19301"
+msgid "Horizontal channels, no group selector"
+msgstr ""
+
+#empty strings from id 19302 to 19498
 
 #. label for epg genre value
 #: xbmc/epg/Epg.cpp

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -257,7 +257,7 @@
 		<definition>
 			<control type="epggrid" id="$PARAM[control_id]">
 				<left>0</left>
-				<top>0</top>
+				<top>$PARAM[control_top]</top>
 				<right>20</right>
 				<bottom>340</bottom>
 				<orientation>$PARAM[control_orientation]</orientation>
@@ -267,8 +267,8 @@
 				<rulerunit>6</rulerunit>
 				<onleft>9000</onleft>
 				<onright>60</onright>
-				<onup>50</onup>
-				<ondown>50</ondown>
+				<onup>$PARAM[control_onup_id]</onup>
+				<ondown>$PARAM[control_id]</ondown>
 				<viewtype label="$PARAM[viewtype_label]">list</viewtype>
 				<progresstexture border="$PARAM[progress_texture_border]" colordiffuse="button_focus">$PARAM[progress_texture]</progresstexture>
 				<rulerdatelayout width="1700" height="45" condition="$PARAM[has_rulerdate_layout]">

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -2,7 +2,7 @@
 <window>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<backgroundcolor>background</backgroundcolor>
-	<views>50,51</views>
+	<views>50,51,52,53</views>
 	<menucontrol>9000</menucontrol>
 	<controls>
 		<include>DefaultBackground</include>
@@ -10,7 +10,7 @@
 			<animation effect="fade" start="100" end="0" time="200" tween="sine" condition="$EXP[infodialog_active]">Conditional</animation>
 			<control type="group">
 				<description>Guide Timeline</description>
-				<visible>Control.IsVisible(50) | Control.IsVisible(51)</visible>
+				<visible>Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(52) | Control.IsVisible(53)</visible>
 				<include>OpenClose_Right</include>
 				<include>Visible_Right</include>
 				<control type="group">
@@ -23,30 +23,115 @@
 						<bottom>336</bottom>
 						<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 					</control>
-					<include content="EpgGrid">
-						<param name="control_id" value="50"/>
-						<param name="control_orientation" value="vertical"/>
-						<param name="viewtype_label" value="19297"/>
-						<param name="progress_texture_border" value="0,60,18,14"/>
-						<param name="progress_texture" value="windows/pvr/epg_progress_vertical.png"/>
-						<param name="has_rulerdate_layout" value="false"/>
-						<param name="ruler_width" value="1400"/>
-						<param name="ruler_label_width" value="365"/>
-						<param name="channel_width" value="350"/>
-						<param name="scrollbar_top" value="47"/>
-					</include>
-					<include content="EpgGrid">
-						<param name="control_id" value="51"/>
-						<param name="control_orientation" value="horizontal"/>
-						<param name="viewtype_label" value="19298"/>
-						<param name="progress_texture_border" value="5,10,5,10"/>
-						<param name="progress_texture" value="windows/pvr/epg_progress_horizontal.png"/>
-						<param name="has_rulerdate_layout" value="true"/>
-						<param name="ruler_width" value="150"/>
-						<param name="ruler_label_width" value="150"/>
-						<param name="channel_width" value="310"/>
-						<param name="scrollbar_top" value="105"/>
-					</include>
+					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<width>100%</width>
+						<height>44</height>
+						<texture colordiffuse="60FFFFFF">colors/white50.png</texture>
+					</control>
+					<control type="wraplist" id="11">
+						<top>0</top>
+						<left>0</left>
+						<width>100%</width>
+						<onup>63</onup>
+						<ondown>63</ondown>
+						<orientation>horizontal</orientation>
+						<scrolltime>200</scrolltime>
+						<focusposition>3</focusposition>
+						<visible>Control.IsVisible(50) | Control.IsVisible(51)</visible>
+						<itemlayout height="44" width="300">
+							<control type="label">
+								<left>-140</left>
+								<width>280</width>
+								<align>center</align>
+								<aligny>center</aligny>
+								<label>$INFO[ListItem.Label]</label>
+								<textcolor>grey</textcolor>
+							</control>
+						</itemlayout>
+						<focusedlayout height="44" width="300">
+							<control type="image">
+								<top>2</top>
+								<left>-148</left>
+								<width>296</width>
+								<height>42</height>
+								<texture colordiffuse="button_focus">lists/focus.png</texture>
+								<visible>Control.HasFocus(11)</visible>
+							</control>
+							<control type="image">
+								<left>-150</left>
+								<width>300</width>
+								<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
+							</control>
+							<control type="label">
+								<left>-140</left>
+								<width>280</width>
+								<align>center</align>
+								<aligny>center</aligny>
+								<scroll>true</scroll>
+								<label>$INFO[ListItem.Label]</label>
+							</control>
+						</focusedlayout>
+					</control>
+					<control type="group" id="63">
+						<include content="EpgGrid">
+							<param name="control_id" value="50"/>
+							<param name="control_orientation" value="vertical"/>
+							<param name="control_top" value="55"/>
+							<param name="control_onup_id" value="11"/>
+							<param name="viewtype_label" value="19298"/>
+							<param name="progress_texture_border" value="0,60,18,14"/>
+							<param name="progress_texture" value="windows/pvr/epg_progress_vertical.png"/>
+							<param name="has_rulerdate_layout" value="false"/>
+							<param name="ruler_width" value="1400"/>
+							<param name="ruler_label_width" value="365"/>
+							<param name="channel_width" value="350"/>
+							<param name="scrollbar_top" value="47"/>
+						</include>
+						<include content="EpgGrid">
+							<param name="control_id" value="51"/>
+							<param name="control_orientation" value="horizontal"/>
+							<param name="control_top" value="55"/>
+							<param name="control_onup_id" value="11"/>
+							<param name="viewtype_label" value="19297"/>
+							<param name="progress_texture_border" value="5,10,5,10"/>
+							<param name="progress_texture" value="windows/pvr/epg_progress_horizontal.png"/>
+							<param name="has_rulerdate_layout" value="true"/>
+							<param name="ruler_width" value="150"/>
+							<param name="ruler_label_width" value="150"/>
+							<param name="channel_width" value="310"/>
+							<param name="scrollbar_top" value="105"/>
+						</include>
+						<include content="EpgGrid">
+							<param name="control_id" value="52"/>
+							<param name="control_orientation" value="vertical"/>
+							<param name="control_top" value="0"/>
+							<param name="control_onup_id" value="52"/>
+							<param name="viewtype_label" value="19301"/>
+							<param name="progress_texture_border" value="0,60,18,14"/>
+							<param name="progress_texture" value="windows/pvr/epg_progress_vertical.png"/>
+							<param name="has_rulerdate_layout" value="false"/>
+							<param name="ruler_width" value="1400"/>
+							<param name="ruler_label_width" value="365"/>
+							<param name="channel_width" value="350"/>
+							<param name="scrollbar_top" value="47"/>
+						</include>
+						<include content="EpgGrid">
+							<param name="control_id" value="53"/>
+							<param name="control_orientation" value="horizontal"/>
+							<param name="control_top" value="0"/>
+							<param name="control_onup_id" value="53"/>
+							<param name="viewtype_label" value="19300"/>
+							<param name="progress_texture_border" value="5,10,5,10"/>
+							<param name="progress_texture" value="windows/pvr/epg_progress_horizontal.png"/>
+							<param name="has_rulerdate_layout" value="true"/>
+							<param name="ruler_width" value="150"/>
+							<param name="ruler_label_width" value="150"/>
+							<param name="channel_width" value="310"/>
+							<param name="scrollbar_top" value="105"/>
+						</include>
+					</control>
 				</control>
 				<control type="group">
 					<bottom>0</bottom>

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -407,9 +407,8 @@ void CPVRChannel::UpdatePath(CPVRChannelGroupInternal* group)
 
   std::string strFileNameAndPath;
   CSingleLock lock(m_critSection);
-  strFileNameAndPath = StringUtils::Format("pvr://channels/%s/%s/%s_%d.pvr",
-                                           (m_bIsRadio ? "radio" : "tv"),
-                                           group->GroupName().c_str(),
+  strFileNameAndPath = StringUtils::Format("%s%s_%d.pvr",
+                                           group->GetPath(),
                                            CServiceBroker::GetPVRManager().Clients()->GetClientAddonId(m_iClientId).c_str(),
                                            m_iUniqueId);
   if (m_strFileNameAndPath != strFileNameAndPath)

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -204,6 +204,11 @@ bool CPVRChannelGroup::Update(void)
   return UpdateGroupEntries(PVRChannels_tmp);
 }
 
+std::string CPVRChannelGroup::GetPath() const
+{
+  return StringUtils::Format("pvr://channels/%s/%s/", m_bRadio ? "radio" : "tv", GroupName().c_str());
+}
+
 bool CPVRChannelGroup::SetChannelNumber(const CPVRChannelPtr &channel, const CPVRChannelNumber &channelNumber)
 {
   bool bReturn(false);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -118,6 +118,12 @@ namespace PVR
     virtual bool Update(void);
 
     /*!
+     * @brief Get the path of this group.
+     * @return the path.
+     */
+    std::string GetPath() const;
+
+    /*!
      * @brief Change the channelnumber of a group. Used by CGUIDialogPVRChannelManager. Call SortByChannelNumber() and Renumber() after all changes are done.
      * @param channel The channel to change the channel number for.
      * @param channelNumber The new channel number.

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -19,6 +19,8 @@
  *
  */
 
+#include <vector>
+
 #include "utils/Observer.h"
 #include "windows/GUIMediaWindow.h"
 
@@ -32,6 +34,7 @@
 #define CONTROL_BTNSHOWDELETED            7
 #define CONTROL_BTNHIDEDISABLEDTIMERS     8
 #define CONTROL_BTNSHOWMODE               10
+#define CONTROL_LSTCHANNELGROUPS          11
 
 #define CONTROL_BTNCHANNELGROUPS          28
 #define CONTROL_BTNFILTERCHANNELS         31
@@ -112,6 +115,12 @@ namespace PVR
   private:
     bool OpenChannelGroupSelectionDialog(void);
 
+    bool HasChannelGroupsControl();
+    bool IsChannelGroupsControlFocused();
+    void InitChannelGroupsControl();
+    bool SelectActiveChannelGroup();
+    bool ActivateSelectedChannelGroup();
+
     /*!
      * @brief Show or update the progress dialog.
      * @param strText The current status.
@@ -125,6 +134,7 @@ namespace PVR
     void HideProgressDialog(void);
 
     CPVRChannelGroupPtr m_channelGroup;
+    std::vector<CPVRChannelGroupPtr> m_channelGroups;
     XbmcThreads::EndTime m_refreshTimeout;
     CGUIDialogProgressBarHandle *m_progressHandle; /*!< progress dialog that is displayed while the pvr manager is loading */
   };

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -18,6 +18,8 @@
  *
  */
 
+#include <iterator>
+
 #include "GUIWindowPVRGuide.h"
 
 #include "ContextMenuManager.h"
@@ -29,15 +31,12 @@
 #include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
-#include "utils/log.h"
 #include "view/GUIViewState.h"
 
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
-#include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
-#include "pvr/timers/PVRTimers.h"
 #include "pvr/windows/GUIEPGGridContainer.h"
 
 using namespace PVR;
@@ -63,7 +62,7 @@ CGUIEPGGridContainer* CGUIWindowPVRGuideBase::GetGridControl()
   return dynamic_cast<CGUIEPGGridContainer*>(GetControl(m_viewControl.GetCurrentControl()));
 }
 
-void CGUIWindowPVRGuideBase::Init()
+void CGUIWindowPVRGuideBase::InitEpgGridControl()
 {
   CGUIEPGGridContainer *epgGridContainer = GetGridControl();
   if (epgGridContainer)
@@ -98,7 +97,7 @@ void CGUIWindowPVRGuideBase::OnInitWindow()
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl(), false);
 
   if (InitChannelGroup()) // no channels -> lazy init
-    Init();
+    InitEpgGridControl();
 
   CGUIWindowPVRBase::OnInitWindow();
 }
@@ -184,6 +183,7 @@ void CGUIWindowPVRGuideBase::UpdateSelectedItemPath()
 void CGUIWindowPVRGuideBase::UpdateButtons(void)
 {
   CGUIWindowPVRBase::UpdateButtons();
+
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, GetChannelGroup()->GroupName());
 }
@@ -425,7 +425,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
         CSingleLock lock(m_critSection);
         m_bRefreshTimelineItems = true;
       }
-      Init();
+      InitEpgGridControl();
 
       Refresh(true);
       bReturn = true;
@@ -438,7 +438,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
         {
           // late init
           InitChannelGroup();
-          Init();
+          InitEpgGridControl();
           break;
         }
         case ObservableMessageChannelGroupReset:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -63,11 +63,8 @@ namespace PVR
     void ClearData() override;
 
   private:
-    void Init();
-
     CGUIEPGGridContainer* GetGridControl();
-
-    bool SelectPlayingFile(void);
+    void InitEpgGridControl();
 
     bool OnContextButtonBegin();
     bool OnContextButtonEnd();


### PR DESCRIPTION
Requested many times and for a long time in the forum, here it comes... channel groups selector for the Guide window:

![screenshot001](https://user-images.githubusercontent.com/3226626/34918990-f9279a50-f95c-11e7-9857-c56dc2220860.png)

Channel groups are displayed as a "band" on top of the epg grid. Channel groups are switched live when selecting a group in the "band". Thus, a user can switch very quickly between channel groups.

The channel group selector can be turned off. There are two new view types for the Guide window "horizontal channels, no group selector" and "vertical channels, no group selector", in addition to the two existing viewtypes, which now contain the group selector. The views without the selector look exactly the same as the views we had before this PR. 

Changes are runtime-tested on macOS and Linux, latest kodi master.

@xhaggi mind taking a look at the code changes changes.
@ronie are the skin changes okay?