### PR TITLE
[PVR] Add missing parental check to CPVREpgInfoTag::EpisodeName.

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -684,7 +684,7 @@ public:
     m_strDirector(kodiTag->DeTokenize(kodiTag->Directors())),
     m_strWriter(kodiTag->DeTokenize(kodiTag->Writers())),
     m_strIMDBNumber(kodiTag->IMDBNumber()),
-    m_strEpisodeName(kodiTag->EpisodeName()),
+    m_strEpisodeName(kodiTag->EpisodeName(true)),
     m_strIconPath(kodiTag->Icon()),
     m_strSeriesLink(kodiTag->SeriesLink())
   {

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -397,7 +397,7 @@ int CPVREpgDatabase::Persist(const CPVREpgInfoTag &tag, bool bSingleUpdate /* = 
         tag.DeTokenize(tag.Writers()).c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         static_cast<unsigned int>(iFirstAired), tag.ParentalRating(), tag.StarRating(), tag.Notify(),
-        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(), tag.Flags(),
+        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName(true).c_str(), tag.Flags(),
         tag.UniqueBroadcastID());
   }
   else
@@ -413,7 +413,7 @@ int CPVREpgDatabase::Persist(const CPVREpgInfoTag &tag, bool bSingleUpdate /* = 
         tag.DeTokenize(tag.Writers()).c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.Icon().c_str(), tag.GenreType(), tag.GenreSubType(), strGenre.c_str(),
         static_cast<unsigned int>(iFirstAired), tag.ParentalRating(), tag.StarRating(), tag.Notify(),
-        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName().c_str(), tag.Flags(),
+        tag.SeriesNumber(), tag.EpisodeNumber(), tag.EpisodePart(), tag.EpisodeName(true).c_str(), tag.Flags(),
         tag.UniqueBroadcastID(), iBroadcastId);
   }
 

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -534,9 +534,14 @@ int CPVREpgInfoTag::EpisodePart(void) const
   return m_iEpisodePart;
 }
 
-std::string CPVREpgInfoTag::EpisodeName(void) const
+std::string CPVREpgInfoTag::EpisodeName(bool bOverrideParental /* = false */) const
 {
-  return m_strEpisodeName;
+  std::string retVal;
+
+  if (bOverrideParental || !IsParentalLocked())
+    retVal = m_strEpisodeName;
+
+  return retVal;
 }
 
 std::string CPVREpgInfoTag::Icon(void) const

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -189,27 +189,28 @@ namespace PVR
 
     /*!
      * @brief Get the title of this event.
-     * @param bOverrideParental True to override parental control, false check it.
+     * @param bOverrideParental True to override parental control, false to check it.
      * @return The title.
      */
     std::string Title(bool bOverrideParental = false) const;
 
     /*!
      * @brief Get the plot outline of this event.
-     * @param bOverrideParental True to override parental control, false check it.
+     * @param bOverrideParental True to override parental control, false to check it.
      * @return The plot outline.
      */
     std::string PlotOutline(bool bOverrideParental = false) const;
 
     /*!
      * @brief Get the plot of this event.
-     * @param bOverrideParental True to override parental control, false check it.
+     * @param bOverrideParental True to override parental control, false to check it.
      * @return The plot.
      */
     std::string Plot(bool bOverrideParental = false) const;
 
     /*!
      * @brief Get the original title of this event.
+     * @param bOverrideParental True to override parental control, false check it.
      * @return The original title.
      */
     std::string OriginalTitle(bool bOverrideParental = false) const;
@@ -337,9 +338,10 @@ namespace PVR
 
     /*!
      * @brief The episode name of this event.
+     * @param bOverrideParental True to override parental control, false to check it.
      * @return The episode name.
      */
-    std::string EpisodeName(void) const;
+    std::string EpisodeName(bool bOverrideParental = false) const;
 
     /*!
      * @brief Get the path to the icon for this event.


### PR DESCRIPTION
Seems, that parental check was forgotten to add to `CPVREpgInfoTag::EpisodeName`. Now, it is in and done exactly like for the other respective methods.

Before:

![screenshot000](https://user-images.githubusercontent.com/3226626/34919304-d1f1ad4a-f961-11e7-8216-2912515208c8.png)

After:

![screenshot002](https://user-images.githubusercontent.com/3226626/34919306-d7fd65c6-f961-11e7-818c-4093629cc56f.png)

@xhaggi good to go?