### PR TITLE
AML: remove check for no longer used amlvideo/omx_pts

### DIFF
--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -129,11 +129,6 @@ bool aml_permissions()
       CLog::Log(LOGERROR, "AML: no rw on /dev/video10");
       permissions_ok = 0;
     }
-    if (!SysfsUtils::HasRW("/sys/module/amvideo/parameters/omx_pts"))
-    {
-      CLog::Log(LOGERROR, "AML: no rw on /sys/module/amvideo/parameters/omx_pts");
-      permissions_ok = 0;
-    }
     if (!SysfsUtils::HasRW("/sys/module/amlvideodri/parameters/freerun_mode"))
     {
       CLog::Log(LOGERROR, "AML: no rw on /sys/module/amlvideodri/parameters/freerun_mode");


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Remove check for existence of omx_pts parameter of amlvideo module, last usage of which was removed in a matter of this commit:
https://github.com/xbmc/xbmc/commit/58acb4e2937367f0b30bcb65df31159fbd4fbaf9#diff-e39867d73d40423a9182df49306f1c6aL128
so it is no longer used anywhere on any kernel.
And being not available on 4.9 kernel stops amlcodec from being properly initialized.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Adopting latest kernel from amlogic (4.9) to be able to run Kodi

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Run on S905X device with kernel 4.9, run on S905 device with kernel 3.14.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed