### PR TITLE
fixed: show the actual set poster/fanart for sets

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -231,10 +231,15 @@ std::vector<std::string> CVideoThumbLoader::GetArtTypes(const std::string &type)
     ret.push_back("poster");
     ret.push_back("fanart");
   }
-  else if (type == MediaTypeMovie || type == MediaTypeMusicVideo || type == MediaTypeVideoCollection)
+  else if (type == MediaTypeMovie || type == MediaTypeMusicVideo)
   {
     ret.push_back("poster");
     ret.push_back("fanart");
+  }
+  else if (type == MediaTypeVideoCollection)
+  {
+    ret.push_back("set");
+    ret.push_back("setfanart");
   }
   else if (type.empty()) // unknown - just throw everything in
   {
@@ -500,6 +505,14 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
         if (i != m_seasonArt.end())
           item.AppendArt(i->second, MediaTypeSeason);
       }
+    }
+
+    if (tag.m_type == MediaTypeVideoCollection)
+    {
+      if (item.HasArt("set"))
+        item.SetArt("poster", item.GetArt("set"));
+      if (item.HasArt("setfanart"))
+        item.SetArt("fanart", item.GetArt("setfanart"));
     }
     m_videoDatabase->Close();
   }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -647,12 +647,19 @@ std::string CGUIDialogVideoInfo::ChooseArtType(const CFileItem &videoItem, std::
   for (std::vector<std::string>::const_iterator i = artTypes.begin(); i != artTypes.end(); ++i)
   {
     std::string type = *i;
+    if (videoItem.GetVideoInfoTag()->m_type == MediaTypeVideoCollection &&
+        !StringUtils::StartsWith(type, "set"))
+      continue;
+    else if (videoItem.GetVideoInfoTag()->m_type != MediaTypeVideoCollection &&
+             StringUtils::StartsWith(type, "set"))
+      continue;
+
     CFileItemPtr item(new CFileItem(type, false));
     if (type == "banner")
       item->SetLabel(g_localizeStrings.Get(20020));
-    else if (type == "fanart")
+    else if (type == "fanart" || type == "setfanart")
       item->SetLabel(g_localizeStrings.Get(20445));
-    else if (type == "poster")
+    else if (type == "poster" || type == "set")
       item->SetLabel(g_localizeStrings.Get(20021));
     else if (type == "thumb")
       item->SetLabel(g_localizeStrings.Get(21371));


### PR DESCRIPTION
only show relevant art types in the Choose art dialog. @olympia