### PR TITLE
Application: Set volume after opening file

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3203,9 +3203,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       CLog::LogF(LOGDEBUG,"Ignored %d playback thread messages", dMsgCount);
   }
 
+  m_appPlayer.OpenFile(item, options, player, *this);
   m_appPlayer.SetVolume(m_volumeLevel);
   m_appPlayer.SetMute(m_muted);
-  m_appPlayer.OpenFile(item, options, player, *this);
 
 #if !defined(TARGET_POSIX)
   g_audioManager.Enable(false);


### PR DESCRIPTION
Initial volume was broken in omxplayer after #13301

<!--- Provide a general summary of your change in the Title above -->

## Description
Set volume/mute after player is opened.

## Motivation and Context
See: https://forum.kodi.tv/showthread.php?tid=298461&pid=2690445#pid2690445

## How Has This Been Tested?
Positive reports in Milhouse nightly builds

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
