### PR TITLE
fix segfault on palyback failed

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -131,8 +131,9 @@ class CSetCurrentItemJob : public CJob
   CFileItemPtr m_itemCurrentFile;
 public:
   explicit CSetCurrentItemJob(const CFileItem& item) : m_itemCurrentFile(std::make_shared<CFileItem>(item)) { }
-
   ~CSetCurrentItemJob(void) override = default;
+  const char *GetType() const override { return "CSetCurrentItemJob"; }
+  bool operator==(const CJob* job) const override { return this->GetType() == job->GetType(); }
 
   bool DoWork(void) override
   {
@@ -143,6 +144,22 @@ public:
   }
 };
 
+class CResetCurrentItemJob : public CJob
+{
+public:
+  explicit CResetCurrentItemJob() { }
+  ~CResetCurrentItemJob(void) override = default;
+  const char *GetType() const override { return "CResetCurrentItemJob"; }
+  bool operator==(const CJob* job) const override { return this->GetType() == job->GetType(); }
+  
+  bool DoWork(void) override
+  {
+    g_infoManager.ResetCurrentItemJob();
+    return true;
+  }
+};
+
+
 bool InfoBoolComparator(const InfoPtr &right, const InfoPtr &left)
 {
   return *right < *left;
@@ -151,6 +168,7 @@ bool InfoBoolComparator(const InfoPtr &right, const InfoPtr &left)
 
 CGUIInfoManager::CGUIInfoManager(void) :
     Observable(),
+    CJobQueue(false, 1, CJob::PRIORITY_NORMAL),
     m_bools(&InfoBoolComparator)
 {
   m_lastSysHeatInfoTime = -SYSHEATUPDATEINTERVAL;  // make sure we grab CPU temp on the first pass
@@ -9059,6 +9077,12 @@ std::string CGUIInfoManager::GetCurrentPlayTimeRemaining(TIME_FORMAT format) con
 
 void CGUIInfoManager::ResetCurrentItem()
 {
+  CResetCurrentItemJob *job = new CResetCurrentItemJob();
+  AddJob(job);
+}
+
+void CGUIInfoManager::ResetCurrentItemJob()
+{
   m_currentFile->Reset();
   m_currentMovieThumb = "";
   m_currentMovieDuration = "";
@@ -9067,12 +9091,12 @@ void CGUIInfoManager::ResetCurrentItem()
 void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 {
   CSetCurrentItemJob *job = new CSetCurrentItemJob(item);
-  CJobManager::GetInstance().AddJob(job, NULL);
+  AddJob(job);
 }
 
 void CGUIInfoManager::SetCurrentItemJob(const CFileItemPtr item)
 {
-  ResetCurrentItem();
+  ResetCurrentItemJob();
 
   if (item->IsAudio())
     SetCurrentSong(*item);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -39,6 +39,7 @@
 #include "cores/IPlayer.h"
 #include "FileItem.h"
 #include "pvr/PVRTypes.h"
+#include "utils/JobManager.h"
 
 #include <atomic>
 #include <map>
@@ -95,7 +96,8 @@ class CSetCurrentItemJob;
  \brief
  */
 class CGUIInfoManager : public IMsgTargetCallback, public Observable,
-                        public KODI::MESSAGING::IMessageTarget
+                        public KODI::MESSAGING::IMessageTarget,
+                        public CJobQueue
 {
 friend CSetCurrentItemJob;
 
@@ -153,6 +155,7 @@ public:
    */
   void SetCurrentItem(const CFileItem &item);
   void ResetCurrentItem();
+  void ResetCurrentItemJob();
   // Current song stuff
   /// \brief Retrieves tag info (if necessary) and fills in our current song path.
   void SetCurrentSong(CFileItem &item);


### PR DESCRIPTION
As discussed in slack with @FernetMenta and @notspiff .

> A quick explanation on the issue:
> 
> In CApplication, on the GUI_MSG_PLAYBACK_STARTED Message 
> https://github.com/xbmc/xbmc/blob/master/xbmc/Application.cpp#L3879
> There is the call to  g_infoManager.SetCurrentItem(*m_itemCurrentFile) which then in turn runs the CSetCurrentItemJob.
> 
> Now, this job is accessing the member CGUIInfoManager::m_currentFile directly in that thread.
> When in CApplication a GUI_MSG_PLAYBACK_STOPPED is happening (in case the playback fails) this is in turn calling g_infoManager.ResetCurrentItem() which 
> is then resetting the m_currentFile that is used by the CSetCurrentItemJob. 
> 
> So if there are any delays in the CSetCurrentItemJob, due to database access or anything else, we end up in a segfault within CGUIInfoManager::SetCurrentMovie.
> I assume this also applies to CGUIInfoManager::SetCurrentSong and CGUIInfoManager::SetCurrentGame as they do it in more or less the same way.


This was fixed now by inheriting CJobQueue in CGUIInfoManager so there is a dedicated job queue with one worker for this. ResetCurrentItem() was also moved into a job to prevent it from running at the same time with SetCurrentItemJob(). A type was added to the jobs so that we only have one of the jobs in the queue at any time. 