### PR TITLE
[win10] fixes store failures.

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -51,7 +51,15 @@ CServiceManager::CServiceManager()
 {
 }
 
-CServiceManager::~CServiceManager() = default;
+CServiceManager::~CServiceManager()
+{
+  if (init_level > 2)
+    DeinitStageThree();
+  if (init_level > 1)
+    DeinitStageTwo();
+  if (init_level > 0)
+    DeinitStageOne();
+}
 
 bool CServiceManager::InitForTesting()
 {

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -117,7 +117,7 @@ public:
   unsigned int GetMinDXTPitch() const { return m_minDXTPitch; }
   unsigned int GetRenderQuirks() const { return m_renderQuirks; }
 
-  void ShowSplash(const std::string& message);
+  virtual void ShowSplash(const std::string& message);
 
 protected:
   bool                m_bRenderCreated;

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -93,6 +93,15 @@ bool CWinSystemWin10DX::DestroyRenderSystem()
   return true;
 }
 
+void CWinSystemWin10DX::ShowSplash(const std::string & message)
+{
+  CRenderSystemBase::ShowSplash(message);
+
+  // this will prevent killing the app by watchdog timeout during loading
+  if (m_coreWindow.Get())
+    m_coreWindow->Dispatcher->ProcessEvents(Windows::UI::Core::CoreProcessEventsOption::ProcessAllIfPresent);
+}
+
 void CWinSystemWin10DX::UpdateMonitor() const
 {
   //const MONITOR_DETAILS* monitor = GetMonitor(m_nScreen);

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -72,6 +72,8 @@ public:
   void Register(IDispResource *resource) override { CWinSystemWin10::Register(resource); };
   void Unregister(IDispResource *resource) override { CWinSystemWin10::Unregister(resource); };
 
+  void ShowSplash(const std::string& message) override;
+
 protected:
   void UpdateMonitor() const;
   void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;


### PR DESCRIPTION
this PR it a try to fix a couple of crashes reported by Windows Store.

1. A try to prevent the OS forcibly close the app by inactivity reason. (see commit details)
2. Do not post application message in CNetwork destructor