### PR TITLE
[wayland] Use xdg-shell.xml from waylandpp 

### DIFF
--- a/cmake/platform/linux/wayland.cmake
+++ b/cmake/platform/linux/wayland.cmake
@@ -1,4 +1,4 @@
-set(PLATFORM_REQUIRED_DEPS EGL WaylandProtocols>=1.12 Waylandpp>=0.2.2 LibDRM Xkbcommon>=0.4.1)
+set(PLATFORM_REQUIRED_DEPS EGL WaylandProtocols>=1.7 Waylandpp>=0.2.2 LibDRM Xkbcommon>=0.4.1)
 set(PLATFORM_OPTIONAL_DEPS VAAPI)
 
 set(WAYLAND_RENDER_SYSTEM "" CACHE STRING "Render system to use with Wayland: \"gl\" or \"gles\"")

--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -18,7 +18,7 @@ if(CORE_PLATFORM_NAME_LC STREQUAL "wayland")
   # This cannot go into wayland.cmake since it requires the Wayland dependencies
   # to already be resolved
   set(PROTOCOL_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
-                    "${WAYLAND_PROTOCOLS_DIR}/stable/xdg-shell/xdg-shell.xml"
+                    "${WAYLANDPP_PROTOCOLS_DIR}/xdg-shell.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
   add_custom_command(OUTPUT "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.hpp" "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.cpp"


### PR DESCRIPTION

## Description
Change CMake scripts to use xdg-shell.xml from waylandpp instead of wayland-protocols

## Motivation and Context
Ubuntu 17.10 does not have recent enough wayland-protocols for building
with xdg-shell stable. To avoid having to package it or adding ifdefs
to support building with older wayland-protocols, use xdg-shell.xml
from waylandpp.

@NilsBrause you will love this :-) Seems I found a strong reason to use xdg-shell.xml from waylandpp...

## How Has This Been Tested?
Build on Linux

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
