### PR TITLE
WinSystemAmlogic: don't strictly depend on fbdev_window

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -63,7 +63,7 @@ CWinSystemAmlogic::CWinSystemAmlogic()
   }
 
   m_nativeDisplay = EGL_NO_DISPLAY;
-  m_nativeWindow = nullptr;
+  m_nativeWindow = static_cast<EGLNativeWindowType>(NULL);
 
   m_displayWidth = 0;
   m_displayHeight = 0;
@@ -84,7 +84,7 @@ CWinSystemAmlogic::~CWinSystemAmlogic()
 {
   if(m_nativeWindow)
   {
-    m_nativeWindow = nullptr;
+    m_nativeWindow = static_cast<EGLNativeWindowType>(NULL);
   }
 }
 
@@ -149,10 +149,12 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
   m_stereo_mode = stereo_mode;
   m_bFullScreen = fullScreen;
 
+#ifdef _FBDEV_WINDOW_H_
   fbdev_window *nativeWindow = new fbdev_window;
   nativeWindow->width = res.iWidth;
   nativeWindow->height = res.iHeight;
   m_nativeWindow = static_cast<EGLNativeWindowType>(nativeWindow);
+#endif
 
   aml_set_native_resolution(res, m_framebuffer_name, stereo_mode);
 
@@ -171,7 +173,7 @@ bool CWinSystemAmlogic::CreateNewWindow(const std::string& name,
 
 bool CWinSystemAmlogic::DestroyWindow()
 {
-  m_nativeWindow = nullptr;
+  m_nativeWindow = static_cast<EGLNativeWindowType>(NULL);
 
   return true;
 }

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.h
@@ -51,7 +51,7 @@ public:
 protected:
   std::string m_framebuffer_name;
   EGLDisplay m_nativeDisplay;
-  fbdev_window *m_nativeWindow;
+  EGLNativeWindowType m_nativeWindow;
 
   int m_displayWidth;
   int m_displayHeight;


### PR DESCRIPTION
Fixes building for systems that do not have fbdev_window, e.g. working with libhybris.

<!--- Provide a general summary of your change in the Title above -->

## Description
Building Amlogic windowing system will fail if EGL headers don't contain fbdev_window definition, which is not a standard EGL extension. Fix this by changing `m_nativewindow` to `EGLNativeWindowType` and ifdef code that initializes fbdev_window.

## Motivation and Context
Add ability to compile for targets not defining fbdev_window, e.g. using libhybris.

## How Has This Been Tested?
LE master + Kodi master.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
