### PR TITLE
[PVR] Fix: Do not auto close OSD if it was opened manually by the user.

### DIFF
--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -148,13 +148,16 @@ namespace PVR
     {
       g_infoManager.SetShowInfo(true);
 
-      if (iTimeout > 0)
+      CSingleLock lock(m_critSection);
+
+      if (m_iChannelInfoJobId >= 0)
       {
-        CSingleLock lock(m_critSection);
+        CJobManager::GetInstance().CancelJob(m_iChannelInfoJobId);
+        m_iChannelInfoJobId = -1;
+      }
 
-        if (m_iChannelInfoJobId >= 0)
-          CJobManager::GetInstance().CancelJob(m_iChannelInfoJobId);
-
+      if (!bForce && iTimeout > 0)
+      {
         CPVRChannelInfoTimeoutJob *job = new CPVRChannelInfoTimeoutJob(iTimeout * 1000);
         m_iChannelInfoJobId = CJobManager::GetInstance().AddJob(job, dynamic_cast<IJobCallback*>(job));
       }


### PR DESCRIPTION
Fixes a regression I introduced some time ago. Problem reported here: https://forum.kodi.tv/showthread.php?tid=327124

@Jalle19 mind taking a look. Hint: `bForce` is only true if the user manually opened the OSD - usually by pressing 'i' on the keyboard.