### PR TITLE
xbmcgui - add option to define listitem as folder

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -152,6 +152,16 @@ namespace XBMCAddon
       }
     }
 
+    void ListItem::setIsFolder(bool isFolder)
+    {
+      if (!item)
+        return;
+      {
+        XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+        item->m_bIsFolder = isFolder;
+      }
+    }
+
     void ListItem::setUniqueIDs(const Properties& dictionary, const String& defaultrating /* = "" */)
     {
       if (!item) return;

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -275,6 +275,33 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setIsFolder(isFolder) }
+      ///-----------------------------------------------------------------------
+      /// Sets if this listitem is a folder.
+      ///
+      /// @param isFolder            bool - True=folder / False=not a folder (default).
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      ///
+      /// @python_v18 New function added.
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ...
+      /// # setIsFolder(isFolder)
+      /// listitem.setIsFolder(True)
+      /// ...
+      /// ~~~~~~~~~~~~~
+      ///
+      setIsFolder(...);
+#else
+      void setIsFolder(bool isFolder);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ setUniqueIDs(values, defaultrating) }
       ///-----------------------------------------------------------------------
       /// Sets the listitem's uniqueID


### PR DESCRIPTION
allow python scripts to define a listitem as a folder (python plugins can already do this).

reasoning:
in the globalsearch addon i create a list of tv shows and set content to tv shows.
but due to this code https://github.com/xbmc/xbmc/blob/c8e69045fe7d3e3dd72f011d535c256bfbe29998/xbmc/video/windows/GUIWindowVideoBase.cpp#L322-L330
kodi will try to fetch episode info for those items from the db, unless you define the listitem as a folder.