### PR TITLE
[Windows] fix adapters enumeration for multiple GPU

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -825,7 +825,7 @@ void DX::DeviceResources::SetMonitor(HMONITOR monitor) const
   int index = 0;
   while (true)
   {
-    hr = dxgiFactory->EnumAdapters1(index, &adapter);
+    hr = dxgiFactory->EnumAdapters1(index++, &adapter);
     if (hr == DXGI_ERROR_NOT_FOUND)
       break;
 


### PR DESCRIPTION
This patch fixes the infinite loop for PCs with multiple graphics cards when the screen selected for Kodi is not on the first card enumerated by Windows.

I have 2 cards and Kodi got stuck first time I tried v18 with 100% CPU usage.

To test the patch I set Kodi fullscreen on a screen of card #2, moved Kodi from screen to screen. Worked fine, no more infinite loop.

The fix: the "index" variable needs to increase in order to enumerate multiple graphics cards and find what SetMonitor() is looking for. Or exit in error at worst.

Note: the function DX::DeviceResources::ValidateDevice() also has an issue and hardcodes adapter number 0 for EnumAdapters1() but it doesn't seem to be called by anything.