### PR TITLE
[Filesystem] Add EfectiveUrl translation in addon interface

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -533,6 +533,9 @@ char** Interface_Filesystem::get_property_values(void* kodiBase, void* file, int
   case ADDON_FILE_PROPERTY_MIME_TYPE:
     internalType = XFILE::FILE_PROPERTY_MIME_TYPE;
     break;
+  case ADDON_FILE_PROPERTY_EFFECTIVE_URL:
+    internalType = XFILE::FILE_PROPERTY_EFFECTIVE_URL;
+    break;
   default:
     CLog::Log(LOGERROR, "Interface_Filesystem::%s - invalid data (addon='%p', file='%p')", __FUNCTION__, addon, file);
     return nullptr;


### PR DESCRIPTION
## Description
Add missing translation from Addon -> Kodi constant for retrieving EffectiveURL from libCURL.

## Motivation and Context
FileSystem::get_property_value(EFFECTIVE_URL) s currently not working

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
