### PR TITLE
[video] Fix CGUIWindowVideoBase::GetResumeItemOffset after #13288 (on…

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -566,7 +566,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int64_t& st
   {
     if (item->GetCurrentResumeTimeAndPartNumber(startoffset, partNumber))
     {
-      startoffset *= 75;
+      startoffset = CUtil::ConvertSecsToMilliSecs(startoffset);
     }
     else
     {


### PR DESCRIPTION
Fix CGUIWindowVideoBase::GetResumeItemOffset after #13288 (one more 75 missed)

![screenshot000](https://user-images.githubusercontent.com/3226626/35103954-b9a131e4-fc67-11e7-8790-d98c4aa5cd25.png)

I recently stumbled over wrong "Resume from xx:xx:xx" time values in the context menus of in-progress videos / pvr recordings and found another forgotten "75" after #13288 

I have runtime-tested the change on macOS, latest kodi master.

@Voyager1 good to go?