### PR TITLE
[pm] resume last played media after sleep

### DIFF
--- a/xbmc/powermanagement/PowerManager.h
+++ b/xbmc/powermanagement/PowerManager.h
@@ -27,6 +27,7 @@
 
 #include "IPowerSyscall.h"
 
+class CFileItem;
 class CSetting;
 
 enum PowerState
@@ -91,8 +92,11 @@ public:
 private:
   void OnSleep() override;
   void OnWake() override;
-
   void OnLowBattery() override;
+  void RestorePlayerState();
+  void StorePlayerState();
 
   IPowerSyscall *m_instance;
+  std::unique_ptr<CFileItem> m_lastPlayedFileItem;
+  std::string m_lastUsedPlayer;
 };

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -511,9 +511,6 @@ void CPVRManager::OnWake()
   /* start job to search for missing channel icons */
   TriggerSearchMissingChannelIcons();
 
-  /* try to play channel on startup */
-  TriggerPlayChannelOnStartup();
-
   /* trigger PVR data updates */
   TriggerChannelGroupsUpdate();
   TriggerChannelsUpdate();


### PR DESCRIPTION
Follow-up of #13138. I just want to push things forward and @Falcosc didn't find time to adjust his PR.

> Auto resume the media which was used during enter sleep mode and resumes it on wake with forced play (playerstate handling is already implemented as part of resume point but I don't know why the player state is allways empty, this issue does force play on my PR)
But this is only the first step, a very basic solution which could be improved step by step.
