### PR TITLE
windowing: amlogic: set framebuffer to maximum size before initializing EGL

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -98,6 +98,8 @@ bool CWinSystemAmlogic::InitWindowSystem()
   RETRO::CRPProcessInfoAmlogic::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
   CRendererAML::Register();
 
+  aml_set_framebuffer_resolution(1920, 1080, m_framebuffer_name);
+
   return CWinSystemBase::InitWindowSystem();
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Set framebuffer to maximum size before initializing EGL on Amlogic-based devices.

## Description
<!--- Describe your change in detail -->
If framebuffer size is less than 1920x1080 (for example 1280x720) before
initialization of EGL, an attempt to set resolution in Kodi to 1080p or
higher will result in EGL_BAD_ALLOC error during a call to eglCreateContext().
This PR fixes the issue by setting framebuffer to maximum possible size
before initializing EGL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes Kodi crash if display resolution is set to 1080p or higher in settings, but set to less than 1080p by system before Kodi starts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested on WeTek Play 2 (Amlogic S905) with LibreELEC by setting default resolution to 720p in uboot.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
