### PR TITLE
AMLCodec: update pts overflow for every frame

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -1765,7 +1765,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
 
   CLog::Log(LOGNOTICE, "CAMLCodec::OpenDecoder - using V4L2 pts format: %s", m_ptsIs64us ? "64Bit":"32Bit");
 
-  m_ptsOverflow = (sizeof(long) == 8) ? 0 : INT64_0;
+  m_ptsOverflow = 0;
 
   m_opened = true;
   // vcodec is open, update speed if it was
@@ -1895,7 +1895,7 @@ void CAMLCodec::Reset()
 
   // reset some interal vars
   m_cur_pts = INT64_0;
-  m_ptsOverflow = (sizeof(long) == 8) ? 0 : INT64_0;
+  m_ptsOverflow = 0;
   m_state = 0;
   m_frameSizes.clear();
   m_frameSizeSum = 0;
@@ -1943,17 +1943,19 @@ bool CAMLCodec::AddData(uint8_t *pData, size_t iSize, double dts, double pts)
       am_private->am_pkt.avpts = am_private->am_pkt.avdts;
   }
 
-  //Handle PTS overflow
+  //Handle PTS overflow for arm
   if (sizeof(long) < 8)
   {
     if (am_private->am_pkt.avpts != INT64_0)
     {
-      if (m_ptsOverflow == INT64_0)
-        m_ptsOverflow = am_private->am_pkt.avpts & 0xFFFF80000000ULL;
+      m_ptsOverflow = am_private->am_pkt.avpts & 0xFFFF80000000ULL;
       am_private->am_pkt.avpts &= 0x7FFFFFFF;
     }
     if (am_private->am_pkt.avdts != INT64_0)
+    {
+      m_ptsOverflow = am_private->am_pkt.avdts & 0xFFFF80000000ULL;
       am_private->am_pkt.avdts &= 0x7FFFFFFF;
+    }
   }
 
   // We use this to determine the fill state if no PTS is given
@@ -2130,16 +2132,7 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
     if (m_last_pts <= 0)
       pVideoPicture->iDuration = (double)(am_private->video_rate * DVD_TIME_BASE) / UNIT_FREQ;
     else
-    {
-      // Check for int overflow
-      if (m_cur_pts + 0xFFFFFFF < m_last_pts)
-      {
-        m_last_pts -= 0x7FFFFFFF;
-        m_ptsOverflow += 0x80000000;
-        CLog::Log(LOGDEBUG, "CAMLCodec::GetPicture, PTS overflow incremented(%llX)", m_ptsOverflow);
-      }
-      pVideoPicture->iDuration = (double)((m_cur_pts - m_last_pts) * DVD_TIME_BASE) / PTS_FREQ;
-    }
+      pVideoPicture->iDuration = (double)((0x7FFFFFFF & (m_cur_pts - m_last_pts)) * DVD_TIME_BASE) / PTS_FREQ;
 
     pVideoPicture->dts = DVD_NOPTS_VALUE;
     pVideoPicture->pts = (double)(m_cur_pts + m_ptsOverflow) / PTS_FREQ * DVD_TIME_BASE;


### PR DESCRIPTION
Amlogic video codec supports for pts/dts only 31 bit counters. In current version  of AMLCodec is used m_ptsoverflow to count number of codec counter overflows. The value is updated only at overflow detection. This detection can be sheeted with frames containing wrong pts values. To avoid wrong detection pts overflow is updating for every frame.


## Motivation and Context
Wrong  detection is causing lost of a/v sync. Playback is slowdown or stuttering.

## How Has This Been Tested?
I tested in @adamg88 Amlogic/S905 build.  I tested with continuous playback for more than 6 hour 37 min (interval for pts overflow).
