### PR TITLE
fix stereoscopic playback

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3425,6 +3425,7 @@ void CApplication::OnPlayBackSeekChapter(int iChapter)
 
 void CApplication::OnAVChange()
 {
+  CStereoscopicsManager::GetInstance().OnStreamChange();
 }
 
 void CApplication::RequestVideoSettings(const CFileItem &fileItem)

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -392,16 +392,8 @@ void CStereoscopicsManager::OnSettingChanged(std::shared_ptr<const CSetting> set
 
 bool CStereoscopicsManager::OnMessage(CGUIMessage &message)
 {
-  switch (message.GetMessage())
-  {
-  case GUI_MSG_PLAYBACK_STARTED:
-    OnPlaybackStarted();
-    break;
-  case GUI_MSG_PLAYBACK_STOPPED:
-  case GUI_MSG_PLAYLISTPLAYER_STOPPED:
+  if (message.GetMessage() == GUI_MSG_PLAYBACK_STOPPED || message.GetMessage() == GUI_MSG_PLAYLISTPLAYER_STOPPED)
     OnPlaybackStopped();
-    break;
-  }
 
   return false;
 }
@@ -516,7 +508,7 @@ bool CStereoscopicsManager::IsVideoStereoscopic()
   return !mode.empty() && mode != "mono";
 }
 
-void CStereoscopicsManager::OnPlaybackStarted(void)
+void CStereoscopicsManager::OnStreamChange(void)
 {
   STEREOSCOPIC_PLAYBACK_MODE playbackMode = (STEREOSCOPIC_PLAYBACK_MODE) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE);
   RENDER_STEREO_MODE mode = GetStereoMode();

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -87,10 +87,10 @@ public:
    * @return True if action could be handled, false otherwise.
    */
   bool OnAction(const CAction &action);
+  void OnStreamChange(void);
 
 private:
   void ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool notify = true);
-  void OnPlaybackStarted(void);
   void OnPlaybackStopped(void);
   std::string GetVideoStereoMode();
   bool IsVideoStereoscopic();


### PR DESCRIPTION
After [#12799](https://github.com/xbmc/xbmc/pull/12799) Stereoscopic manager is unable set stereoscopic mode. Stereoscopic manager is informed by GUI_MSG_PLAYBACK_STARTED message at opening stream.  Attempt to set 3D mode fails as the Amlogic decoder is open after demuxing first video frame.

## Description
At open amlogic decoder DVDVideoCodecAmlogic send GUI_MSG_PLAYBACK_STARTED to ask Stereoscpic manager for action in right moment. 

## Motivation and Context
It's most likely broken 3D mode for other devices.  This PR fixed 3D mode only for Amlogic HW decoding.

## How Has This Been Tested?
It was tested in Amlogic S905/S912 community builds.
