### PR TITLE
[pvr][guiinfo] Fix PVR.EpgEventProgress.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6865,7 +6865,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
     case PVR_ACTUAL_STREAM_SNR_PROGR:
     case PVR_BACKEND_DISKSPACE_PROGR:
     case PVR_TIMESHIFT_PROGRESS:
-      value = CServiceBroker::GetPVRManager().TranslateIntInfo(info);
+      value = CServiceBroker::GetPVRManager().TranslateIntInfo(*m_currentFile, info);
       return true;
     case SYSTEM_BATTERY_LEVEL:
       value = CServiceBroker::GetPowerManager().BatteryLevel();

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -20,6 +20,7 @@
 
 #include "PVRGUIInfo.h"
 
+#include <cmath>
 #include <ctime>
 
 #include "Application.h"
@@ -555,13 +556,17 @@ bool CPVRGUIInfo::TranslateBoolInfo(DWORD dwInfo) const
   return bReturn;
 }
 
-int CPVRGUIInfo::TranslateIntInfo(DWORD dwInfo) const
+int CPVRGUIInfo::TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const
 {
   int iReturn(0);
   CSingleLock lock(m_critSection);
 
   if (dwInfo == PVR_EPG_EVENT_PROGRESS)
-    iReturn = (int) ((float) GetPlayingTime() / m_iDuration * 100);
+  {
+    const CPVREpgInfoTagPtr epgTag = item.GetEPGInfoTag();
+    if (epgTag)
+      iReturn = std::lrintf(epgTag->ProgressPercentage());
+  }
   else if (dwInfo == PVR_ACTUAL_STREAM_SIG_PROGR)
     iReturn = (int) ((float) m_qualityInfo.iSignal / 0xFFFF * 100);
   else if (dwInfo == PVR_ACTUAL_STREAM_SNR_PROGR)
@@ -575,8 +580,8 @@ int CPVRGUIInfo::TranslateIntInfo(DWORD dwInfo) const
   }
   else if (dwInfo == PVR_TIMESHIFT_PROGRESS)
   {
-    iReturn = static_cast<int>(static_cast<float>(m_iTimeshiftPlayTime - m_iTimeshiftStartTime) /
-                               (m_iTimeshiftEndTime - m_iTimeshiftStartTime) * 100);
+    iReturn = std::lrintf(static_cast<float>(m_iTimeshiftPlayTime - m_iTimeshiftStartTime) /
+                          (m_iTimeshiftEndTime - m_iTimeshiftStartTime) * 100);
   }
 
   return iReturn;

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -47,7 +47,7 @@ namespace PVR
 
     bool TranslateBoolInfo(DWORD dwInfo) const;
     bool TranslateCharInfo(DWORD dwInfo, std::string &strValue) const;
-    int TranslateIntInfo(DWORD dwInfo) const;
+    int TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const;
 
     /*!
      * @brief Get a GUIInfoManager video label.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -822,9 +822,9 @@ bool CPVRManager::TranslateCharInfo(DWORD dwInfo, std::string &strValue) const
   return IsStarted() && m_guiInfo ? m_guiInfo->TranslateCharInfo(dwInfo, strValue) : false;
 }
 
-int CPVRManager::TranslateIntInfo(DWORD dwInfo) const
+int CPVRManager::TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const
 {
-  return IsStarted() && m_guiInfo ? m_guiInfo->TranslateIntInfo(dwInfo) : 0;
+  return IsStarted() && m_guiInfo ? m_guiInfo->TranslateIntInfo(item, dwInfo) : 0;
 }
 
 bool CPVRManager::GetVideoLabel(const CFileItem &item, int iLabel, std::string &strValue) const

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -170,10 +170,11 @@ namespace PVR
 
     /*!
      * @brief Get a GUIInfoManager integer.
+     * @param item The item to get the value for.
      * @param dwInfo The integer to get.
      * @return The requested integer or 0 if it wasn't found.
      */
-    int TranslateIntInfo(DWORD dwInfo) const;
+    int TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const;
 
     /*!
      * @brief Get a GUIInfoManager boolean.


### PR DESCRIPTION
Fix PVR.EpgEventProgress to return the percentage of the currently active epg event in gui manager, and not always the percentage of the currently playing event. Otherwise, when in channel preview mode, the progress for the playing event would be displayed for the previewed channel.

@xhaggi mind taking a look. This is a regression I introduced lately. Now it works like before. :-/