### PR TITLE
CHG: [droid] Draw GUI on own View

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -62,6 +62,7 @@ set(package_files strings.xml
                   src/XBMCBroadcastReceiver.java
                   src/XBMCInputDeviceListener.java
                   src/XBMCJsonRPC.java
+                  src/XBMCMainView.java
                   src/XBMCMediaSession.java
                   src/XBMCRecommendationBuilder.java
                   src/XBMCSearchableActivity.java

--- a/tools/android/packaging/xbmc/res/layout/activity_main.xml
+++ b/tools/android/packaging/xbmc/res/layout/activity_main.xml
@@ -2,6 +2,7 @@
   android:id="@+id/VideoLayout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="@android:color/black" >
   >
 
 </RelativeLayout>

--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -17,6 +17,7 @@ import android.view.View;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.os.Handler;
+import android.widget.RelativeLayout;
 
 import @APP_PACKAGE@.channels.util.TvUtil;
 
@@ -25,11 +26,13 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   private static final String TAG = "@APP_NAME@";
 
   public static Main MainActivity = null;
+  public XBMCMainView mMainView = null;
 
   private XBMCSettingsContentObserver mSettingsContentObserver;
   private XBMCInputDeviceListener mInputDeviceListener;
   private XBMCJsonRPC mJsonRPC = null;
-  private View thisView = null;
+  private View mDecorView = null;
+  private RelativeLayout mVideoLayout = null;
   private Handler handler = new Handler();
   private Intent mNewIntent = null;
   private int mNewIntentDelay = 0;
@@ -75,8 +78,8 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
 
     try
     {
-      ret.right = thisView.getRootView().getWidth();
-      ret.bottom = thisView.getRootView().getHeight();
+      ret.right = mDecorView.getRootView().getWidth();
+      ret.bottom = mDecorView.getRootView().getHeight();
     }
     catch (Exception e)
     {
@@ -103,7 +106,6 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     System.loadLibrary("@APP_NAME_LC@");
 
     super.onCreate(savedInstanceState);
-    getWindow().setFormat(PixelFormat.TRANSPARENT);
 
     setContentView(R.layout.activity_main);
     setVolumeControlStream(AudioManager.STREAM_MUSIC);
@@ -137,8 +139,18 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     InputManager manager = (InputManager) getSystemService(INPUT_SERVICE);
     manager.registerInputDeviceListener(mInputDeviceListener, handler);
 
-    thisView = getWindow().getDecorView();
-    thisView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener()
+    mDecorView = getWindow().getDecorView();
+    mDecorView.setBackground(null);
+    getWindow().takeSurface(null);
+    setContentView(R.layout.activity_main);
+    mVideoLayout = (RelativeLayout) findViewById(R.id.VideoLayout);
+
+    mMainView = new XBMCMainView(this);
+    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+    mMainView.setElevation(1);  // Always on Top
+    mVideoLayout.addView(mMainView, layoutParams);
+
+    mDecorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener()
     {
       @Override
       public void onSystemUiVisibilityChange(int visibility)
@@ -156,7 +168,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
                 // Constants from API > 17
                 final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
 
-                thisView.setSystemUiVisibility(
+                mDecorView.setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
@@ -184,7 +196,6 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   public void onStart()
   {
     super.onStart();
-    getWindow().setFormat(PixelFormat.TRANSPARENT);
 
     Choreographer.getInstance().removeFrameCallback(this);
     Choreographer.getInstance().postFrameCallback(this);
@@ -202,7 +213,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
       // Constants from API > 17
       final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
 
-      thisView.setSystemUiVisibility(
+      mDecorView.setSystemUiVisibility(
               View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                       | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                       | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN

--- a/tools/android/packaging/xbmc/src/XBMCMainView.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMainView.java.in
@@ -1,0 +1,77 @@
+package @APP_PACKAGE@;
+
+import android.content.Context;
+import android.graphics.PixelFormat;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.SurfaceView;
+import android.view.SurfaceHolder;
+
+/**
+ * Created by cbro on 5/13/17.
+ */
+
+public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
+{
+  native void _attach();
+  native void _surfaceChanged(SurfaceHolder holder, int format, int width, int height);
+  native void _surfaceCreated(SurfaceHolder holder);
+  native void _surfaceDestroyed(SurfaceHolder holder);
+
+  private static final String TAG = "XBMCMainView";
+
+  public boolean mIsCreated = false;
+
+  public XBMCMainView(Context context)
+  {
+    super(context);
+    setZOrderOnTop(true);
+    getHolder().addCallback(this);
+    getHolder().setFormat(PixelFormat.TRANSLUCENT);
+
+    Log.d(TAG, "Created");
+}
+
+  public XBMCMainView(Context context, AttributeSet attrs, int defStyle)
+  {
+    super(context, attrs, defStyle);
+    setZOrderOnTop(true);
+    getHolder().addCallback(this);
+    getHolder().setFormat(PixelFormat.TRANSLUCENT);
+
+    Log.d(TAG, "Created");
+  }
+
+  public XBMCMainView(Context context, AttributeSet attrs)
+  {
+    this(context, attrs, 0);
+  }
+
+  @Override
+  public void surfaceCreated(SurfaceHolder holder)
+  {
+    Log.d(TAG, "Surface Created");
+    mIsCreated = true;
+    _attach();
+    _surfaceCreated(holder);
+  }
+
+  @Override
+  public void surfaceChanged(SurfaceHolder holder, int format, int width,
+                             int height)
+  {
+    if (holder != getHolder())
+      return;
+
+    Log.d(TAG, "Surface Changed, format:" + format + ", width:" + width + ", height:" + height);
+    _surfaceChanged(holder, format, width, height);
+  }
+
+  @Override
+  public void surfaceDestroyed(SurfaceHolder holder)
+  {
+    Log.d(TAG, "Surface Destroyed");
+    mIsCreated = false;
+    _surfaceDestroyed(holder);
+  }
+}

--- a/tools/android/packaging/xbmc/src/XBMCVideoView.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCVideoView.java.in
@@ -57,9 +57,10 @@ public class XBMCVideoView extends SurfaceView implements
   public XBMCVideoView(Context context)
   {
     super(context);
-    getHolder().addCallback(this);
-    getHolder().setFormat(PixelFormat.TRANSPARENT);
     setZOrderMediaOverlay(true);
+    getHolder().addCallback(this);
+    getHolder().setFormat(PixelFormat.TRANSLUCENT);
+
     mVideoLayout = (RelativeLayout) Main.MainActivity.findViewById(R.id.VideoLayout);
   }
 
@@ -72,7 +73,6 @@ public class XBMCVideoView extends SurfaceView implements
       {
         RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
         mVideoLayout.addView(XBMCVideoView.this, layoutParams);
-        setBackgroundColor(Color.TRANSPARENT);
       }
     });
   }

--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=c2faa6fb006070b4965d949c5f7d94094f5cd98b
+VERSION=d5fd1b46484d103f51c93cf4a38784d7cddd8175
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/platform/android/activity/CMakeLists.txt
+++ b/xbmc/platform/android/activity/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES android_main.cpp
             EventLoop.cpp
             GraphicBuffer.cpp
             JNIMainActivity.cpp
+            JNIXBMCMainView.cpp
             JNIXBMCMediaSession.cpp
             JNIXBMCVideoView.cpp
             JNIXBMCAudioManagerOnAudioFocusChangeListener.cpp
@@ -30,6 +31,7 @@ set(HEADERS AndroidExtra.h
             GraphicBuffer.h
             IActivityHandler.h
             JNIMainActivity.h
+            JNIXBMCMainView.h
             JNIXBMCMediaSession.h
             JNIXBMCVideoView.h
             JNIXBMCAudioManagerOnAudioFocusChangeListener.h

--- a/xbmc/platform/android/activity/JNIXBMCMainView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.cpp
@@ -1,0 +1,141 @@
+/*
+ *      Copyright (C) 2017 Christian Browet
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "JNIXBMCMainView.h"
+
+#include <androidjni/jutils-details.hpp>
+#include <androidjni/Context.h>
+
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <list>
+#include <algorithm>
+#include <cassert>
+
+#include "CompileInfo.h"
+
+using namespace jni;
+
+static std::string s_className = std::string(CCompileInfo::GetClass()) + "/XBMCMainView";
+CEvent CJNIXBMCMainView::m_surfaceCreated;
+CJNIXBMCMainView* CJNIXBMCMainView::m_instance = nullptr;
+
+void CJNIXBMCMainView::RegisterNatives(JNIEnv* env)
+{
+  jclass cClass = env->FindClass(s_className.c_str());
+  if(cClass)
+  {
+    JNINativeMethod methods[] =
+    {
+      {"_attach", "()V", (void*)&CJNIXBMCMainView::_attach},
+      {"_surfaceChanged", "(Landroid/view/SurfaceHolder;III)V", (void*)&CJNIXBMCMainView::_surfaceChanged},
+      {"_surfaceCreated", "(Landroid/view/SurfaceHolder;)V", (void*)&CJNIXBMCMainView::_surfaceCreated},
+      {"_surfaceDestroyed", "(Landroid/view/SurfaceHolder;)V", (void*)&CJNIXBMCMainView::_surfaceDestroyed}
+    };
+
+    env->RegisterNatives(cClass, methods, sizeof(methods)/sizeof(methods[0]));
+  }
+}
+
+CJNIXBMCMainView::CJNIXBMCMainView(CJNISurfaceHolderCallback* callback)
+  : m_callback(callback)
+{
+  m_instance = this;
+}
+
+CJNIXBMCMainView::~CJNIXBMCMainView()
+{
+}
+
+void CJNIXBMCMainView::_attach(JNIEnv* env, jobject thiz)
+{
+  (void)env;
+
+  if (m_instance)
+    m_instance->attach(thiz);
+}
+
+void CJNIXBMCMainView::_surfaceChanged(JNIEnv *env, jobject thiz, jobject holder, jint format, jint width, jint height )
+{
+  (void)env;
+
+  if (m_instance)
+    m_instance->surfaceChanged(CJNISurfaceHolder(jhobject(holder)), format, width, height);
+}
+
+void CJNIXBMCMainView::_surfaceCreated(JNIEnv* env, jobject thiz, jobject holder)
+{
+  (void)env;
+
+  if (m_instance)
+    m_instance->surfaceCreated(CJNISurfaceHolder(jhobject(holder)));
+}
+
+void CJNIXBMCMainView::_surfaceDestroyed(JNIEnv* env, jobject thiz, jobject holder)
+{
+  (void)env;
+
+  if (m_instance)
+    m_instance->surfaceDestroyed(CJNISurfaceHolder(jhobject(holder)));
+}
+
+void CJNIXBMCMainView::attach(const jobject& thiz)
+{
+  if (!m_object)
+  {
+    m_object = jhobject(thiz);
+    m_object.setGlobal();
+  }
+}
+
+void CJNIXBMCMainView::surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height)
+{
+  if (m_callback)
+    m_callback->surfaceChanged(holder, format, width, height);
+}
+
+void CJNIXBMCMainView::surfaceCreated(CJNISurfaceHolder holder)
+{
+  if (m_callback)
+    m_callback->surfaceCreated(holder);
+  m_surfaceCreated.Set();
+}
+
+void CJNIXBMCMainView::surfaceDestroyed(CJNISurfaceHolder holder)
+{
+  m_surfaceCreated.Reset();
+  if (m_callback)
+    m_callback->surfaceDestroyed(holder);
+}
+
+bool CJNIXBMCMainView::waitForSurface(unsigned int millis)
+{
+  return m_surfaceCreated.WaitMSec(millis);
+}
+
+bool CJNIXBMCMainView::isCreated() const
+{
+  if (!m_object)
+    return false;
+  return get_field<jboolean>(m_object, "mIsCreated");
+
+}
+

--- a/xbmc/platform/android/activity/JNIXBMCMainView.h
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2016 Christian Browet
+ *      Copyright (C) 2017 Christian Browet
  *      http://xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -22,47 +22,38 @@
 #include <androidjni/JNIBase.h>
 
 #include <androidjni/Context.h>
-#include <androidjni/Rect.h>
 #include <androidjni/Surface.h>
 #include <androidjni/SurfaceHolder.h>
 
 #include "guilib/Geometry.h"
 #include "threads/Event.h"
 
-class CJNIXBMCVideoView : virtual public CJNIBase, public CJNISurfaceHolderCallback, public CJNIInterfaceImplem<CJNIXBMCVideoView>
+class CJNIXBMCMainView : virtual public CJNIBase, public CJNISurfaceHolderCallback, public CJNIInterfaceImplem<CJNIXBMCMainView>
 {
 public:
-  CJNIXBMCVideoView(const jni::jhobject &object);
-  ~CJNIXBMCVideoView();
+  CJNIXBMCMainView(CJNISurfaceHolderCallback* callback);
+  ~CJNIXBMCMainView();
 
   static void RegisterNatives(JNIEnv* env);
-  
-  static CJNIXBMCVideoView* createVideoView(CJNISurfaceHolderCallback* callback);
 
   // CJNISurfaceHolderCallback interface
   void surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height);
   void surfaceCreated(CJNISurfaceHolder holder);
   void surfaceDestroyed(CJNISurfaceHolder holder);
 
-  static void _surfaceChanged(JNIEnv* env, jobject thiz, jobject holder, jint format, jint width, jint height);
-  static void _surfaceCreated(JNIEnv* env, jobject thiz, jobject holder);
-  static void _surfaceDestroyed(JNIEnv* env, jobject thiz, jobject holder);
-
+  void attach(const jobject& thiz);
   bool waitForSurface(unsigned int millis);
   bool isActive() { return m_surfaceCreated.Signaled(); }
   CJNISurface getSurface();
-  const CRect& getSurfaceRect();
-  void setSurfaceRect(const CRect& rect);
-  void add();
-  void release();
-  int ID() const;
   bool isCreated() const;
 
 protected:
+  static CJNIXBMCMainView* m_instance;
   CJNISurfaceHolderCallback* m_callback;
-  CEvent m_surfaceCreated;
-  CRect m_surfaceRect;
+  static CEvent m_surfaceCreated;
 
-private:
-  CJNIXBMCVideoView();
-  };
+  static void _attach(JNIEnv* env, jobject thiz);
+  static void _surfaceChanged(JNIEnv* env, jobject thiz, jobject holder, jint format, jint width, jint height);
+  static void _surfaceCreated(JNIEnv* env, jobject thiz, jobject holder);
+  static void _surfaceDestroyed(JNIEnv* env, jobject thiz, jobject holder);
+};

--- a/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCVideoView.cpp
@@ -54,20 +54,17 @@ void CJNIXBMCVideoView::RegisterNatives(JNIEnv* env)
 
 CJNIXBMCVideoView::CJNIXBMCVideoView()
   : m_callback(nullptr)
-  , m_surfaceCreated(nullptr)
 {
 }
 
 CJNIXBMCVideoView::CJNIXBMCVideoView(const jni::jhobject &object)
   : CJNIBase(object)
   , m_callback(nullptr)
-  , m_surfaceCreated(nullptr)
 {
 }
 
 CJNIXBMCVideoView::~CJNIXBMCVideoView()
 {
-  delete m_surfaceCreated;
 }
 
 CJNIXBMCVideoView* CJNIXBMCVideoView::createVideoView(CJNISurfaceHolderCallback* callback)
@@ -85,9 +82,8 @@ CJNIXBMCVideoView* CJNIXBMCVideoView::createVideoView(CJNISurfaceHolderCallback*
 
   add_instance(pvw->get_raw(), pvw);
   pvw->m_callback = callback;
-  pvw->m_surfaceCreated = new CEvent;
   if (pvw->isCreated())
-    pvw->m_surfaceCreated->Set();
+    pvw->m_surfaceCreated.Set();
   pvw->add();
 
   return pvw;
@@ -128,23 +124,21 @@ void CJNIXBMCVideoView::surfaceChanged(CJNISurfaceHolder holder, int format, int
 
 void CJNIXBMCVideoView::surfaceCreated(CJNISurfaceHolder holder)
 {
-  if (m_surfaceCreated)
-    m_surfaceCreated->Set();
   if (m_callback)
     m_callback->surfaceCreated(holder);
+  m_surfaceCreated.Set();
 }
 
 void CJNIXBMCVideoView::surfaceDestroyed(CJNISurfaceHolder holder)
 {
-  if (m_surfaceCreated)
-    m_surfaceCreated->Reset();
+  m_surfaceCreated.Reset();
   if (m_callback)
     m_callback->surfaceDestroyed(holder);
 }
 
 bool CJNIXBMCVideoView::waitForSurface(unsigned int millis)
 {
-  return m_surfaceCreated->WaitMSec(millis);
+  return m_surfaceCreated.WaitMSec(millis);
 }
 
 void CJNIXBMCVideoView::add()

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -31,6 +31,7 @@
 #include <android/bitmap.h>
 #include <android/log.h>
 #include <android/native_window.h>
+#include <android/native_window_jni.h>
 
 #include <androidjni/ApplicationInfo.h>
 #include <androidjni/BitmapFactory.h>
@@ -119,7 +120,7 @@ void* thread_run(void* obj)
 }
 
 CXBMCApp* CXBMCApp::m_xbmcappinstance = NULL;
-CEvent CXBMCApp::m_windowCreated;
+std::unique_ptr<CJNIXBMCMainView> CXBMCApp::m_mainView;
 ANativeActivity *CXBMCApp::m_activity = NULL;
 CJNIWakeLock *CXBMCApp::m_wakeLock = NULL;
 ANativeWindow* CXBMCApp::m_window = NULL;
@@ -144,14 +145,16 @@ CXBMCApp::CXBMCApp(ANativeActivity* nativeActivity)
 {
   m_xbmcappinstance = this;
   m_activity = nativeActivity;
-  m_firstrun = true;
-  m_exiting=false;
   if (m_activity == NULL)
   {
     android_printf("CXBMCApp: invalid ANativeActivity instance");
     exit(1);
     return;
   }
+  m_mainView.reset(new CJNIXBMCMainView(this));
+  m_firstrun = true;
+  m_exiting = false;
+  android_printf("CXBMCApp: Created");
 }
 
 CXBMCApp::~CXBMCApp()
@@ -312,39 +315,18 @@ void CXBMCApp::onLowMemory()
 void CXBMCApp::onCreateWindow(ANativeWindow* window)
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
-  if (window == NULL)
-  {
-    android_printf(" => invalid ANativeWindow object");
-    return;
-  }
-  m_window = window;
-  m_windowCreated.Set();
-  if(!m_firstrun)
-  {
-    XBMC_SetupDisplay();
-    XBMC_Pause(false);
-  }
 }
 
 void CXBMCApp::onResizeWindow()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
   m_window = NULL;
-  m_windowCreated.Reset();
   // no need to do anything because we are fixed in fullscreen landscape mode
 }
 
 void CXBMCApp::onDestroyWindow()
 {
   android_printf("%s: ", __PRETTY_FUNCTION__);
-
-  // If we have exited XBMC, it no longer exists.
-  if (!m_exiting)
-  {
-    XBMC_DestroyDisplay();
-    m_window = NULL;
-    XBMC_Pause(true);
-  }
 }
 
 void CXBMCApp::onGainFocus()
@@ -458,6 +440,11 @@ void CXBMCApp::run()
 
   SetupEnv();
   XBMC::Context context;
+
+  // Wait for main window
+  ANativeWindow* nativeWindow = CXBMCApp::GetNativeWindow(30000);
+  if (!nativeWindow)
+    return;
 
   m_firstrun=false;
   android_printf(" => running XBMC_Run...");
@@ -1249,7 +1236,9 @@ ANativeWindow* CXBMCApp::GetNativeWindow(int timeout)
   if (m_window)
     return m_window;
 
-  m_windowCreated.WaitMSec(timeout);
+  if (m_mainView)
+    m_mainView->waitForSurface(timeout);
+
   return m_window;
 }
 
@@ -1309,4 +1298,33 @@ bool CXBMCApp::onInputDeviceEvent(const AInputEvent* event)
     return m_inputDeviceEventHandler->OnInputDeviceEvent(event);
 
   return false;
+}
+
+
+void CXBMCApp::surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height)
+{
+}
+
+void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
+{
+  m_window = ANativeWindow_fromSurface(xbmc_jnienv(), holder.getSurface().get_raw());
+  if (m_window == NULL)
+  {
+    android_printf(" => invalid ANativeWindow object");
+    return;
+  }
+  if(!m_firstrun)
+  {
+    XBMC_SetupDisplay();
+  }
+}
+
+void CXBMCApp::surfaceDestroyed(CJNISurfaceHolder holder)
+{
+  // If we have exited XBMC, it no longer exists.
+  if (!m_exiting)
+  {
+    XBMC_DestroyDisplay();
+    m_window = NULL;
+  }
 }

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -33,6 +33,7 @@
 #include <androidjni/Activity.h>
 #include <androidjni/AudioManager.h>
 #include <androidjni/BroadcastReceiver.h>
+#include <androidjni/SurfaceHolder.h>
 #include <androidjni/View.h>
 
 #include "threads/Event.h"
@@ -43,6 +44,7 @@
 #include "IInputHandler.h"
 #include "JNIMainActivity.h"
 #include "JNIXBMCAudioManagerOnAudioFocusChangeListener.h"
+#include "JNIXBMCMainView.h"
 #include "JNIXBMCMediaSession.h"
 #include "platform/xbmc.h"
 
@@ -92,6 +94,7 @@ class CXBMCApp
     , public CJNIMainActivity
     , public CJNIBroadcastReceiver
     , public ANNOUNCEMENT::IAnnouncer
+    , public CJNISurfaceHolderCallback
 {
 public:
   explicit CXBMCApp(ANativeActivity *nativeActivity);
@@ -209,6 +212,7 @@ protected:
 private:
   static CXBMCApp* m_xbmcappinstance;
   CJNIXBMCAudioManagerOnAudioFocusChangeListener m_audioFocusListener;
+  static std::unique_ptr<CJNIXBMCMainView> m_mainView;
   std::unique_ptr<jni::CJNIXBMCMediaSession> m_mediaSession;
   static bool HasLaunchIntent(const std::string &package);
   std::string GetFilenameFromIntent(const CJNIIntent &intent);
@@ -234,7 +238,6 @@ private:
   static std::vector<CActivityResultEvent*> m_activityResultEvents;
 
   static ANativeWindow* m_window;
-  static CEvent m_windowCreated;
 
   static CVideoSyncAndroid* m_syncImpl;
   static CEvent m_vsyncEvent;
@@ -245,4 +248,10 @@ private:
   bool XBMC_SetupDisplay();
 
   static uint32_t m_playback_state;
+
+public:
+  // CJNISurfaceHolderCallback interface
+  void surfaceChanged(CJNISurfaceHolder holder, int format, int width, int height) override;
+  void surfaceCreated(CJNISurfaceHolder holder) override;
+  void surfaceDestroyed(CJNISurfaceHolder holder) override;
 };

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -30,6 +30,7 @@
 #include "CompileInfo.h"
 #include "EventLoop.h"
 #include "platform/android/activity/JNIMainActivity.h"
+#include "platform/android/activity/JNIXBMCMainView.h"
 #include "platform/android/activity/JNIXBMCVideoView.h"
 #include "platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.h"
 #include "platform/android/activity/JNIXBMCSurfaceTextureOnFrameAvailableListener.h"
@@ -152,6 +153,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
 
   CJNIXBMCAudioManagerOnAudioFocusChangeListener::RegisterNatives(env);
   CJNIXBMCSurfaceTextureOnFrameAvailableListener::RegisterNatives(env);
+  CJNIXBMCMainView::RegisterNatives(env);
   CJNIXBMCVideoView::RegisterNatives(env);
   jni::CJNIXBMCNsdManagerDiscoveryListener::RegisterNatives(env);
   jni::CJNIXBMCNsdManagerRegistrationListener::RegisterNatives(env);


### PR DESCRIPTION
This creates a separate Android View for our GUI.
Previously, the GUI was drawn directly on the root view.

This fixes an issue starting with Oreo that the video is not fullscreen when the gui is set to 4K (1080p size upper/left).
The root cause of this issue is unknown, but probably related to the below commit, in relation to `ANativeWindow_setBuffersGeometry`

This workarounds the issue as the buffer geometry is set on the gui view alone

```
$ git show 9b429f41
commit 9b429f41cbd5964f96f9fb746af3b6932e4acc66
Author: Robert Carr <racarr@google.com>
Date:   Mon Apr 17 14:56:57 2017 -0700
    SurfaceFlinger: Inherit non-transform Scaling from parent.
    When a Layer is fixed-size, we may apply additional scaling
    to the buffer not accounted for in the transform. This means
    that if the WindowManager calls setSize we will scale the parent
    surface but not the child surfaces, breaking the contract that
    the WM can treat the child surfaces as pixels in the parent.
    Test: Included test in Transaction_test.
    Bug: 36820947
    Bug: 37344435
    Change-Id: I5478bad176388fe8e5407379bc36cdfd6600ab97
diff --git a/services/surfaceflinger/Layer.cpp b/services/surfaceflinger/Layer.cpp
index 5e5efb7..d044f37 100644
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -2617,6 +2617,21 @@ Transform Layer::getTransform() const {
     const auto& p = getParent();
     if (p != nullptr) {
         t = p->getTransform();
+
+        // If the parent is not using NATIVE_WINDOW_SCALING_MODE_FREEZE (e.g.
+        // it isFixedSize) then there may be additional scaling not accounted
+        // for in the transform. We need to mirror this scaling in child surfaces
+        // or we will break the contract where WM can treat child surfaces as
+        // pixels in the parent surface.
+        if (p->isFixedSize()) {
+            float sx = p->getDrawingState().active.w /
+                    static_cast<float>(p->mActiveBuffer->getWidth());
+            float sy = p->getDrawingState().active.h /
+                    static_cast<float>(p->mActiveBuffer->getHeight());
+            Transform extraParentScaling;
+            extraParentScaling.set(sx, 0, 0, sy);
+            t = t * extraParentScaling;
+        }
     }
     return t * getDrawingState().active.transform;
```