### PR TITLE
filesystem: set proper check size for smb

### DIFF
--- a/xbmc/filesystem/SMBFile.h
+++ b/xbmc/filesystem/SMBFile.h
@@ -89,7 +89,7 @@ public:
   bool OpenForWrite(const CURL& url, bool bOverWrite = false) override;
   bool Delete(const CURL& url) override;
   bool Rename(const CURL& url, const CURL& urlnew) override;
-  int GetChunkSize() override { return 1; }
+  int GetChunkSize() override { return 2048*1024; }
   int IoControl(EIoControl request, void* param) override;
 
 protected:


### PR DESCRIPTION
fix https://trac.kodi.tv/ticket/17728

reading 4k chunks from smb shares makes no sense. with increasing number of high bitrate files this fix get more important.

Note:
Some Pi users who use modified code for caching report issues when reading bluray iso files from smb shared. Those PI builds have switchs on file caching for LAN, not default, and popcornmix has modified code for caching.

@popcornmix I am not able to reproduce any issues with master branch.