### PR TITLE
[PVR][Estuary] Guide window teaks for more consistency and readability.

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -234,7 +234,7 @@
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</itemlayout>
-					<content sortby="date" sortorder=$PARAM[folder_sortorder]>$INFO[ListItem.FilenameAndPath]</content>
+					<content sortby="date" sortorder="$PARAM[folder_sortorder]">$INFO[ListItem.FilenameAndPath]</content>
 				</control>
 			</control>
 		</control>
@@ -307,7 +307,7 @@
 						<left>68</left>
 						<top>-2</top>
 						<height>60</height>
-						<font>font12</font>
+						<font>font13</font>
 						<label>$INFO[ListItem.ChannelName]</label>
 						<aligny>center</aligny>
 						<textoffsetx>10</textoffsetx>
@@ -329,7 +329,7 @@
 						<left>68</left>
 						<top>-2</top>
 						<height>60</height>
-						<font>font12</font>
+						<font>font13</font>
 						<label>$INFO[ListItem.ChannelName]</label>
 						<textcolor>button_focus</textcolor>
 						<aligny>center</aligny>
@@ -347,7 +347,7 @@
 						<top>0</top>
 						<height>36</height>
 						<aligny>center</aligny>
-						<font>font12</font>
+						<font>font13</font>
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="image">
@@ -384,7 +384,7 @@
 						<top>0</top>
 						<height>36</height>
 						<aligny>center</aligny>
-						<font>font12</font>
+						<font>font13</font>
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="image">

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -169,35 +169,54 @@
 					</control>
 				</control>
 				<control type="group">
-					<bottom>0</bottom>
+					<bottom>30</bottom>
 					<height>300</height>
 					<control type="image">
-						<left>10</left>
-						<width>240</width>
-						<height>200</height>
-						<aspectratio align="right">keep</aspectratio>
+						<top>10</top>
+						<left>30</left>
+						<width>290</width>
+						<height>250</height>
+						<aspectratio align="center" aligny="center">keep</aspectratio>
 						<fadetime>400</fadetime>
 						<texture>$INFO[ListItem.Icon]</texture>
 					</control>
-					<control type="label">
-						<top>-9</top>
-						<left>300</left>
-						<right>60</right>
-						<height>30</height>
-						<label>[COLOR button_focus]$INFO[ListItem.StartTime][/COLOR]$INFO[ListItem.EndTime,[COLOR button_focus] - ,[/COLOR]] $INFO[ListItem.EpgEventTitle]$INFO[ListItem.Genre,      [COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
-					</control>
-					<control type="label">
-						<top>29</top>
-						<left>300</left>
-						<right>60</right>
-						<height>30</height>
-						<label>[COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white],[/COLOR]]</label>
+					<control type="group">
+						<top>0</top>
+						<left>350</left>
+						<control type="label">
+							<width>70%</width>
+							<height>30</height>
+							<label>[B]$INFO[ListItem.EpgEventTitle][/B]</label>
+						</control>
+						<control type="label">
+							<top>0</top>
+							<right>30</right>
+							<width>30%</width>
+							<height>30</height>
+							<align>right</align>
+							<label>[COLOR button_focus]$INFO[ListItem.StartTime,[COLOR grey]$LOCALIZE[555]:[/COLOR] ][/COLOR]$INFO[ListItem.EndTime,[COLOR button_focus] - ,[/COLOR]]</label>
+						</control>
+						<control type="label">
+							<top>35</top>
+							<width>60%</width>
+							<height>30</height>
+							<label>[I][COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white],[/COLOR]][/I]</label>
+						</control>
+						<control type="label">
+							<top>35</top>
+							<right>30</right>
+							<width>40%</width>
+							<height>30</height>
+							<align>right</align>
+							<label>$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
+						</control>
 					</control>
 					<control type="textbox">
-						<left>300</left>
-						<top>67</top>
-						<right>60</right>
-						<height>173</height>
+						<left>350</left>
+						<top>85</top>
+						<right>30</right>
+						<height>170</height>
+						<align>justify</align>
 						<label>$INFO[ListItem.Plot]</label>
 						<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
 					</control>


### PR DESCRIPTION
* Font for epg items, channel names and ruler slightly increased (requested many time sin teh forum)
* start time/duration/genre + plot now in a common (on demand scrolling) textbox, like in pvr info dialog
* moderate repositioning of some controls

before:
![screenshot000](https://user-images.githubusercontent.com/3226626/35185719-fa091948-fe08-11e7-92cb-294793a70fb8.png)

after:
![screenshot001](https://user-images.githubusercontent.com/3226626/35185720-006f1c6a-fe09-11e7-98d5-075090992993.png)

@ronie: okay, xml-wise?
