### PR TITLE
Resume last played media after sleep - DVD and stacks update

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -473,7 +473,7 @@ protected:
 
   void VolumeChanged();
 
-  bool PlayStack(const CFileItem& item, bool bRestart);
+  bool PlayStack(CFileItem& item, bool bRestart);
 
   float NavigationIdleTime();
   bool InitDirectoriesLinux();

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -322,6 +322,13 @@ void CPowerManager::StorePlayerState()
     m_lastPlayedFileItem.reset(new CFileItem(g_application.CurrentFileItem()));
     // set the actual offset instead of store and load it from database
     m_lastPlayedFileItem->m_lStartOffset = appPlayer.GetTime();
+    // in case of regular stack, correct the start offset by adding current part start time
+    if (g_application.GetAppStackHelper().IsPlayingRegularStack())
+      m_lastPlayedFileItem->m_lStartOffset += g_application.GetAppStackHelper().GetCurrentStackPartStartTimeMs();
+    // in case of iso stack, keep track of part number
+    m_lastPlayedFileItem->m_lStartPartNumber = g_application.GetAppStackHelper().IsPlayingISOStack() ? g_application.GetAppStackHelper().GetCurrentPartNumber() + 1 : 1;
+    // for iso and iso stacks, keep track of playerstate
+    m_lastPlayedFileItem->SetProperty("savedplayerstate", appPlayer.GetPlayerState());
     CLog::Log(LOGDEBUG, "CPowerManager::StorePlayerState - store last played item (startOffset: %i ms)", m_lastPlayedFileItem->m_lStartOffset);
   }
   else


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
This is a followup to #13390 to cover for DVD requiring the player state to be saved/restored, as well as to deal with stacks.

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
