### PR TITLE
[xbmc] start peripherals before login. this also fixes that periphera…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1117,6 +1117,7 @@ bool CApplication::Initialize()
     // check if we should use the login screen
     if (m_ServiceManager->GetProfileManager().UsingLoginScreen())
     {
+      CServiceBroker::GetPeripherals().Initialise();
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_LOGIN_SCREEN);
     }
     else

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -184,6 +184,11 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
                                                     *m_gameControllerManager));
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
+  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager,
+    *m_gameRenderManager,
+    *m_settings,
+    *m_peripherals,
+    *m_profileManager));
 
   m_fileExtensionProvider.reset(new CFileExtensionProvider(*m_addonMgr,
                                                            *m_binaryAddonManager));
@@ -204,12 +209,6 @@ bool CServiceManager::InitStageThree()
   // Peripherals depends on strings being loaded before stage 3
   m_peripherals->Initialise();
 
-  m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager,
-    *m_gameRenderManager,
-    *m_settings,
-    *m_peripherals,
-    *m_profileManager));
-
   m_contextMenuManager->Init();
   m_PVRManager->Init();
 
@@ -227,7 +226,6 @@ void CServiceManager::DeinitStageThree()
   m_playerCoreFactory.reset();
   m_PVRManager->Deinit();
   m_contextMenuManager->Deinit();
-  m_gameServices.reset();
   m_peripherals->Clear();
 }
 
@@ -238,6 +236,7 @@ void CServiceManager::DeinitStageTwo()
   m_weatherManager.reset();
   m_powerManager.reset();
   m_fileExtensionProvider.reset();
+  m_gameServices.reset();
   m_gameRenderManager.reset();
   m_peripherals.reset();
   m_inputManager.reset();

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -43,6 +43,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
+#include "peripherals/Peripherals.h"
 #include "settings/Settings.h"
 #include "settings/lib/SettingsManager.h"
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
@@ -272,6 +273,9 @@ void CProfilesManager::PrepareLoadProfile(unsigned int profileIndex)
 
   // stop PVR related services
   pvrManager.Stop();
+
+  // clear peripherals
+  CServiceBroker::GetPeripherals().Clear();
 
   if (profileIndex != 0 || !IsMasterProfile())
     networkManager.NetworkMessage(CNetwork::SERVICES_DOWN, 1);


### PR DESCRIPTION
…ls doesn't start at all if login screen is enabled.

this allows start peripherals service before login
this also fixes that peripherals doesn't start at all if login screen is enabled.

@garbear please review I'm not sure that this doesn't break game service.