### PR TITLE
[fix][android] Geometry.h move missed at 7ec2489

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -90,8 +90,8 @@ bool CRendererVAAPI::Configure(const VideoPicture &picture, float fps, unsigned 
 bool CRendererVAAPI::ConfigChanged(const VideoPicture &picture)
 {
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(picture.videoBuffer);
-  if (pic->procPic.videoSurface != VA_INVALID_ID && !m_isVAAPIBuffer ||
-      pic->procPic.videoSurface == VA_INVALID_ID && m_isVAAPIBuffer)
+  if ((pic->procPic.videoSurface != VA_INVALID_ID && !m_isVAAPIBuffer) ||
+      (pic->procPic.videoSurface == VA_INVALID_ID && m_isVAAPIBuffer))
     return true;
 
   return false;

--- a/xbmc/platform/android/activity/JNIXBMCMainView.h
+++ b/xbmc/platform/android/activity/JNIXBMCMainView.h
@@ -25,8 +25,8 @@
 #include <androidjni/Surface.h>
 #include <androidjni/SurfaceHolder.h>
 
-#include "guilib/Geometry.h"
 #include "threads/Event.h"
+#include "utils/Geometry.h"
 
 class CJNIXBMCMainView : virtual public CJNIBase, public CJNISurfaceHolderCallback, public CJNIInterfaceImplem<CJNIXBMCMainView>
 {


### PR DESCRIPTION
## Motivation and Context
Fix jenkins builds for android and linux wayland

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
