### PR TITLE
[Android] default sdk=android-26 / update doc

### DIFF
--- a/cmake/scripts/android/ArchSetup.cmake
+++ b/cmake/scripts/android/ArchSetup.cmake
@@ -1,7 +1,5 @@
 if(NOT CMAKE_TOOLCHAIN_FILE)
   message(FATAL_ERROR "CMAKE_TOOLCHAIN_FILE required for android. See ${CMAKE_SOURCE_DIR}/cmake/README.md")
-elseif(NOT SDK_PLATFORM)
-  message(FATAL_ERROR "Toolchain did not define SDK_PLATFORM. Possibly outdated depends.")
 endif()
 
 set(ARCH_DEFINES -DTARGET_POSIX -DTARGET_LINUX -D_LINUX -DTARGET_ANDROID)

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -171,7 +171,6 @@ foreach(target apk obb apk-unsigned apk-obb apk-obb-unsigned apk-noobb apk-clean
               DEPENDS_PATH=${DEPENDS_PATH}
               NDKROOT=${NDKROOT}
               SDKROOT=${SDKROOT}
-              SDK_PLATFORM=${SDK_PLATFORM}
               STRIP=${CMAKE_STRIP}
               AAPT=${AAPT_EXECUTABLE}
               DX=${DX_EXECUTABLE}

--- a/docs/README.android
+++ b/docs/README.android
@@ -76,7 +76,6 @@ f. Once you have your hdd image with case sensitive hfs+ file system do all step
    example the hdd image is mounted on /Volumes/android-dev.
     $ ./configure --with-tarballs=/Users/Shared/xbmc-depends/tarballs --host=arm-linux-androideabi \
                   --with-sdk-path=/Volumes/android-dev/android/android-sdk-macosx \
-                  --with-sdk=android-21 \
                   --with-ndk-path=/Volumes/android-dev/android/android-ndk-r16 \
                   --with-toolchain=/Volumes/android-dev/android/android-toolchain-arm/android-21 \
                   --prefix=/Volumes/android-dev/android/xbmc-depends
@@ -152,7 +151,7 @@ Building for arm architecture:
     $ ls platforms
     $ cd build/tools
     $ ./make-standalone-toolchain.sh \
-      --install-dir=<android-toolchain-arm>/android-21 --platform=android-21 \
+      --install-dir=<android-toolchain-arm> --platform=android-21 \
       --toolchain=arm-linux-androideabi-4.9 --stl=libc++
 
 Building for aarch64 architecture:
@@ -161,7 +160,7 @@ Building for aarch64 architecture:
     $ ls platforms
     $ cd build/tools
     $ ./make-standalone-toolchain.sh \
-      --install-dir=<android-toolchain-aarch64>/android-21 --platform=android-21 \
+      --install-dir=<android-toolchain-aarch64> --platform=android-21 \
       --toolchain=aarch64-linux-android-4.9 --stl=libc++
 
 Building for x86 architecture:
@@ -170,7 +169,7 @@ Building for x86 architecture:
     $ ls platforms
     $ cd build/tools
     $ ./make-standalone-toolchain.sh \
-      --install-dir=<android-toolchain-x86>/android-21 --platform=android-21 \
+      --install-dir=<android-toolchain-x86> --platform=android-21 \
       --toolchain=x86-4.9 --arch=x86 --stl=libc++
 
 Make sure to pick a toolchain for your desired architecture. If an error about

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -69,7 +69,7 @@ ifeq ($(JAVA8),yes)
   JAVAC_EXTRA_ARGS = -source 1.7 -target 1.7
 endif
 
-SRCLIBS = $(addprefix $(PREFIX)/lib/,$(OBJS)) $(addprefix $(PREFIX)/lib/$(SDK_PLATFORM)/,$(PLATFORM_OBJS))
+SRCLIBS = $(addprefix $(PREFIX)/lib/,$(OBJS))
 DSTLIBS = $(CPU)/lib/lib@APP_NAME_LC@.so $(addprefix $(CPU)/lib/,$(OBJS)) $(addprefix $(CPU)/lib/,$(PLATFORM_OBJS))
 libs= $(DSTLIBS)
 

--- a/tools/buildsteps/android-arm64-v8a/configure-depends
+++ b/tools/buildsteps/android-arm64-v8a/configure-depends
@@ -14,7 +14,6 @@ then
     --host=aarch64-linux-android \
     --with-sdk-path=$SDK_PATH \
     --with-ndk-path=$NDK_PATH \
-    $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
     $(if [ "$NDK_API" != "Default" ]; then echo --with-ndk-api=$NDK_API;fi) \
     --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT \

--- a/tools/buildsteps/android/configure-depends
+++ b/tools/buildsteps/android/configure-depends
@@ -14,7 +14,6 @@ then
     --host=arm-linux-androideabi \
     --with-sdk-path=$SDK_PATH \
     --with-ndk-path=$NDK_PATH \
-    $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
     $(if [ "$NDK_API" != "Default" ]; then echo --with-ndk-api=$NDK_API;fi) \
     --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT \

--- a/tools/buildsteps/androidx86/configure-depends
+++ b/tools/buildsteps/androidx86/configure-depends
@@ -14,7 +14,6 @@ then
     --host=i686-linux-android \
     --with-sdk-path=$SDK_PATH \
     --with-ndk-path=$NDK_PATH \
-    $(if [ "$SDK_VERSION" != "Default" ]; then echo --with-sdk=android-$SDK_VERSION;fi) \
     $(if [ "$NDK_API" != "Default" ]; then echo --with-ndk-api=$NDK_API;fi) \
     --with-toolchain=$TOOLCHAIN \
     --prefix=$XBMC_DEPENDS_ROOT $DEBUG_SWITCH

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -34,7 +34,6 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   android)
-    DEFAULT_SDK_VERSION="24"
     DEFAULT_NDK_VERSION="16"
     DEFAULT_NDK_API="21"
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends

--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -10,7 +10,6 @@ PLATFORM=@deps_dir@
 HOST=@use_host@
 CPU=@use_cpu@
 NATIVEPLATFORM=@build_cpu@-@build_os@-native
-SDK_PLATFORM=@use_sdk@
 NDK_LEVEL=@use_ndk_api@
 RETRIEVE_TOOL=@CURL@
 ARCHIVE_TOOL=@TAR@

--- a/tools/depends/README
+++ b/tools/depends/README
@@ -25,10 +25,10 @@ TVOS:
 #----------------------------------------------------------------------------
 
   arm:
-    ./configure --with-tarballs=/opt/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=/opt/android-sdk-linux --with-ndk-path=/opt/android-ndk-r16 --with-toolchain=/opt/arm-linux-androideabi-4.8-vanilla/android-21 --prefix=/opt/xbmc-depends
+    ./configure --with-tarballs=/opt/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=/opt/android-sdk-linux --with-ndk-path=/opt/android-ndk-r16 --with-toolchain=/opt/arm-linux-androideabi-4.9-vanilla/android-21 --prefix=/opt/xbmc-depends
 
   x86:
-    ./configure --with-tarballs=/opt/xbmc-tarballs --host=i686-linux-android --with-sdk-path=/opt/android-sdk-linux --with-ndk-path=/opt/android-ndk-r16 --with-toolchain=/opt/x86-linux-4.8-vanilla/android-21 --prefix=/opt/xbmc-depends
+    ./configure --with-tarballs=/opt/xbmc-tarballs --host=i686-linux-android --with-sdk-path=/opt/android-sdk-linux --with-ndk-path=/opt/android-ndk-r16 --with-toolchain=/opt/x86-linux-4.9-vanilla/android-21 --prefix=/opt/xbmc-depends
 
 #- Linux
 #----------------------------------------------------------------------------

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -73,13 +73,14 @@ AC_ARG_WITH([sdk-path],
 
 AC_ARG_WITH([sdk],
   [AS_HELP_STRING([--with-sdk],
-  [specify sdk platform version (optional for android). default is android-24])],
+  [specify sdk platform version.])],
   [use_sdk=$withval])
 
 AC_ARG_WITH([ndk-api],
   [AS_HELP_STRING([--with-ndk-api],
-  [specify ndk level (optional for android). default is 21])],
-  [use_ndk_api=$withval])
+  [specify ndk level (optional for android), default is 21.])],
+  [use_ndk_api=$withval],
+  [use_ndk_api=21])
 
 AC_ARG_ENABLE([gplv3],
   [AS_HELP_STRING([--enable-gplv3],
@@ -202,8 +203,6 @@ case $host in
     fi
     platform_cc=clang
     platform_cxx=clang++
-    use_sdk="${use_sdk:-android-24}"
-    use_ndk_api="${use_ndk_api:-21}"
     deps_dir="$use_host-$use_ndk_api-$build_type"
     platform_cflags="-DANDROID -D__ANDROID_API__=$use_ndk_api -fexceptions -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fPIC -DPIC -D_GLIBCXX_USE_C99_MATH_TR1"
     optimize_flags="-Os"
@@ -223,8 +222,6 @@ case $host in
     fi
     platform_cc=clang
     platform_cxx=clang++
-    use_sdk="${use_sdk:-android-24}"
-    use_ndk_api="${use_ndk_api:-21}"
     deps_dir="$use_host-$use_ndk_api-$build_type"
     platform_cflags="-DANDROID -D__ANDROID_API__=$use_ndk_api -fexceptions -funwind-tables -fstack-protector-strong -no-canonical-prefixes  -fPIC -DPIC -D_GLIBCXX_USE_C99_MATH_TR1"
     optimize_flags="-Os"
@@ -244,8 +241,6 @@ case $host in
     fi
     platform_cc=clang
     platform_cxx=clang++
-    use_sdk="${use_sdk:-android-24}"
-    use_ndk_api="${use_ndk_api:-21}"
     deps_dir="$use_host-$use_ndk_api-$build_type"
     platform_cflags="-DANDROID -D__ANDROID_API__=$use_ndk_api -fexceptions -funwind-tables -fstack-protector-strong -no-canonical-prefixes  -fPIC -DPIC -D_GLIBCXX_USE_C99_MATH_TR1"
     optimize_flags="-Os"
@@ -678,18 +673,6 @@ if [ ! `mkdir -p $use_tarballs` ]; then
   AC_MSG_ERROR(unable to create tarballs dir. verify that the path and permissions are correct.)
 fi
 
-if test "$platform_os" == "android"; then
-  echo
-
-  if [ ! `mkdir -p $prefix/$deps_dir/include/$use_sdk` ]; then
-    AC_MSG_ERROR(unable to create $prefix/$deps_dir/include/$use_sdk. verify that the path and permissions are correct.)
-  fi
-
-  if [ ! `mkdir -p $prefix/$deps_dir/lib/$use_sdk` ]; then
-    AC_MSG_ERROR(unable to create $prefix/$deps_dir/lib/$use_sdk. verify that the path and permissions are correct.)
-  fi
-fi
-
 # remove unwanted optimization flags
 tmp_cflags=$(echo $c11_flags $platform_cflags | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ \{2,\}//g')
 tmp_cxxflags=$(echo $cxx11_flags $platform_cxxflags | sed 's/-O@<:@123@:>@//g;s/-g //g;s/ \{2,\}//g')
@@ -730,7 +713,6 @@ if test "$platform_os" == "android"; then
 echo -e
   AC_SUBST(use_sdk_path)
   AC_SUBST(use_ndk_path)
-  AC_SUBST(use_sdk)
   AC_SUBST(use_ndk_api)
   AC_SUBST(build_tools_path)
 fi
@@ -768,14 +750,6 @@ AC_SUBST(app_rendersystem)
 AC_SUBST(ffmpeg_options)
 
 AC_OUTPUT
-echo -e "ccache:\t $use_ccache"
-echo -e "toolchain:\t $use_toolchain"
-echo -e "cpu:\t\t $use_cpu"
-echo -e "host:\t\t $use_host"
-if test "$platform_os" == "android"; then
-  echo -e "sdk-platform:\t $use_sdk"
-  echo -e "build-tools:\t $build_tools_path"
-fi
 
 if test "$platform_os" == "ios"; then
   if test "$use_platform" = "tvos"; then
@@ -799,6 +773,7 @@ cp -vf native/config.site.native $prefix/$tool_dir/share/config.site
 
 
 echo -e "\n\n#------- configuration -------#"
+echo -e "ccache:\t\t $use_ccache"
 echo -e "build type:\t $build_type"
 echo -e "toolchain:\t $use_toolchain"
 echo -e "cpu:\t\t $use_cpu"
@@ -807,10 +782,10 @@ echo -e "cflags:\t\t $platform_cflags"
 echo -e "cxxflags:\t $platform_cxxflags"
 echo -e "ldflags:\t $platform_ldflags"
 echo -e "ffmpeg options:\t $ffmpeg_options"
-echo -e "prefix:\t\t  $prefix"
+echo -e "prefix:\t\t $prefix"
 echo -e "depends:\t $prefix/$deps_dir"
 if test "$platform_os" == "android"; then
-  echo -e "sdk-platform:\t $use_sdk"
+  echo -e "ndk-api-level:\t $use_ndk_api"
   echo -e "build-tools:\t $build_tools_path"
 fi
 

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -83,7 +83,6 @@ if(CORE_SYSTEM_NAME STREQUAL android)
   set(SDKROOT @use_sdk_path@)
   set(TOOLCHAIN @use_toolchain@)
   set(HOST @use_host@)
-  set(SDK_PLATFORM @use_sdk@)
   string(REPLACE ":" ";" SDK_BUILDTOOLS_PATH "@build_tools_path@")
 endif()
 

--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -75,7 +75,6 @@ endif()
 if(CORE_SYSTEM_NAME STREQUAL android)
   set(NDKROOT @use_ndk_path@)
   set(SDKROOT @use_sdk_path@)
-  set(SDK_PLATFORM @use_sdk@)
   string(REPLACE ":" ";" SDK_BUILDTOOLS_PATH "@build_tools_path@")
 endif()
 


### PR DESCRIPTION
## Description
Bump sdk default version to 26 because gradle builds with 26 and we don't need a different sdk for depends / kpodi.

## Motivation and Context
README.android was not correct regarding the versions used

## How Has This Been Tested?
complete buld arm(32)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
