### PR TITLE
Fix uPnP Movies Thumbnails for LG Smart TV

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -235,19 +235,24 @@ NPT_String CUPnPServer::BuildSafeResourceUri(const NPT_HttpUrl &rooturi,
 {
     CURL url(file_path);
     std::string md5;
+    std::string mapped_file_path(file_path);
 
     // determine the filename to provide context to md5'd urls
     std::string filename;
     if (url.IsProtocol("image"))
+    {
       filename = URIUtils::GetFileName(url.GetHostName());
+      // Remove trailing / for Platinum/Neptune to recognize the file extension and use the correct mime type when serving the image
+      URIUtils::RemoveSlashAtEnd(mapped_file_path);
+    }
     else
-      filename = URIUtils::GetFileName(file_path);
+      filename = URIUtils::GetFileName(mapped_file_path);
 
     filename = CURL::Encode(filename);
-    md5 = XBMC::XBMC_MD5::GetMD5(file_path);
+    md5 = XBMC::XBMC_MD5::GetMD5(mapped_file_path);
     md5 += "/" + filename;
     { NPT_AutoLock lock(m_FileMutex);
-      NPT_CHECK(m_FileMap.Put(md5.c_str(), file_path));
+      NPT_CHECK(m_FileMap.Put(md5.c_str(), mapped_file_path.c_str()));
     }
     return PLT_FileMediaServer::BuildSafeResourceUri(rooturi, host, md5.c_str());
 }


### PR DESCRIPTION
There were no thumbnails for movies served by Kodi via uPnP on my LG smart TV.
Wireshark revealed a couple issues with Kodi's responses to thumbnail requests.

## Issues

1. content type "application/octet-stream" instead of "image/jpeg", "image/png", ...
That issue makes a recent LG Smart TV display a generic icon instead of the movie poster.

2. blank filename in the filename header
More cosmetic as it doesn't have an impact on LG TV but looks incorrect and only due to a small bug

Note that something else is wrong with TV Shows / Seasons as the TV doesn't even request the thumbnails. I'll tackle that separately.

## Analysis / Solutions

Issue 1 happens because the file_path given to Platinum by CUPnPServer::ServeFile() has a trailing / after the normal file extension.
for example poster.jpg/
Platinum has a file extension to content type mapping for common extensions but nothing for jpg/ and defaults to "application/octet-stream".
The trailing / comes from earlier in the code when BuildObject() in UPnPInternal.cpp calls CTextureUtils::GetWrappedImageURL().

* Low risk solution (included in this PR): modify BuildObject to remove a trailing / when present
* More risky (but likely better) fix: modify CTextureUtils::GetWrappedImageURL() and/or CURL.Get() that add the trailing / but are used by a lot of other code, that I don't know anything about.


Issue 2 the file path is wrapped as the hostname in an image:// URL but no unwrapping is done before attempting to read the hostname back, so CUPnPServer::ServeFile sets the filename header to blank in the http response.
fix included in this PR: apply the unwrapping and the existing code does the rest.