### PR TITLE
Change label name to get multiple ratings

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5905,7 +5905,7 @@ int CGUIInfoManager::TranslateListItem(const Property &info)
     }
     if (info.name == "art")
       return AddListItemProp(info.param(), LISTITEM_ART_OFFSET);
-    if (info.name == "ratings")
+    if (info.name == "rating")
       return AddListItemProp(info.param(), LISTITEM_RATING_OFFSET);
     if (info.name == "votes")
       return AddListItemProp(info.param(), LISTITEM_VOTES_OFFSET);


### PR DESCRIPTION
Change Listitem.Ratings() to ListItem.Rating(). 
Votes and RatingAndVotes use the same name with the default and generic info (for example Listitem.Votes for default and ListItem.Votes(name) for specific). Ratings (probably by mistake use ListItem.Rating and ListItem.Ratings(name)
With updated scrapers now people starting to use the feature and noticed this problem.

## How Has This Been Tested?
I tested it with modded estuary

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
