### PR TITLE
AESinkPULSE: Align buffer size handling to documentation

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -745,21 +745,18 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
 
   // default buffer construction
   // align with AE's max buffer
-  unsigned int latency = m_BytesPerSecond / 2.5; // 400 ms
-  unsigned int process_time = latency / 4; // 100 ms
+  uint32_t latency = m_BytesPerSecond / 2.5; // 400 ms
   if(sinkStruct.isHWDevice)
   {
     // on hw devices buffers can be further reduced
     // 200ms max latency
-    // 50ms min packet size
     latency = m_BytesPerSecond / 5;
-    process_time = latency / 4;
   }
 
   pa_buffer_attr buffer_attr;
-  buffer_attr.fragsize = latency;
+  buffer_attr.fragsize = (uint32_t) -1;
   buffer_attr.maxlength = (uint32_t) -1;
-  buffer_attr.minreq = process_time;
+  buffer_attr.minreq = (uint32_t) -1;
   buffer_attr.prebuf = (uint32_t) -1;
   buffer_attr.tlength = latency;
   int flags = (PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_ADJUST_LATENCY);


### PR DESCRIPTION
According to: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/Clients/LatencyControl/

we only need to set tlength which simplifies certain things. I looked at the stuff again after receiving a bugreport without a debuglog. 

Normally: If there is nothing broken don't fix it.

Please keep it open until someone other than me also tests the change. In short: it should change absolutely nothing, just align to above documentation.