### PR TITLE
Fix broken ctrl+shift modifiers

### DIFF
--- a/xbmc/games/addons/input/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/input/GameClientKeyboard.cpp
@@ -58,6 +58,8 @@ bool CGameClientKeyboard::OnKeyPress(const CKey& key)
 
   bool bHandled = false;
 
+  CKey::Modifier mod = static_cast<CKey::Modifier>(key.GetModifiers() | key.GetLockingModifiers());
+
   game_input_event event;
 
   event.type            = GAME_INPUT_EVENT_KEY;
@@ -66,7 +68,7 @@ bool CGameClientKeyboard::OnKeyPress(const CKey& key)
   event.feature_name    = ""; //! @todo
   event.key.pressed     = true;
   event.key.character   = static_cast<XBMCVKey>(key.GetButtonCode() & BUTTON_INDEX_MASK);
-  event.key.modifiers   = CGameClientTranslator::GetModifiers(static_cast<CKey::Modifier>(key.GetModifiers()));
+  event.key.modifiers   = CGameClientTranslator::GetModifiers(mod);
 
   if (event.key.character != 0)
   {
@@ -85,6 +87,8 @@ bool CGameClientKeyboard::OnKeyPress(const CKey& key)
 
 void CGameClientKeyboard::OnKeyRelease(const CKey& key)
 {
+  CKey::Modifier mod = static_cast<CKey::Modifier>(key.GetModifiers() | key.GetLockingModifiers());
+
   game_input_event event;
 
   event.type            = GAME_INPUT_EVENT_KEY;
@@ -93,7 +97,7 @@ void CGameClientKeyboard::OnKeyRelease(const CKey& key)
   event.feature_name    = ""; //! @todo
   event.key.pressed     = false;
   event.key.character   = static_cast<XBMCVKey>(key.GetButtonCode() & BUTTON_INDEX_MASK);
-  event.key.modifiers   = CGameClientTranslator::GetModifiers(static_cast<CKey::Modifier>(key.GetModifiers()));
+  event.key.modifiers   = CGameClientTranslator::GetModifiers(mod);
 
   if (event.key.character != 0)
   {

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -276,11 +276,6 @@ unsigned int CButtonTranslator::GetActionCode(int window, const CKey &key, std::
 {
   uint32_t code = key.GetButtonCode();
 
-  // Keymaps don't use locking modifiers
-  code &= ~CKey::MODIFIER_CAPSLOCK;
-  code &= ~CKey::MODIFIER_NUMLOCK;
-  code &= ~CKey::MODIFIER_SCROLLLOCK;
-
   std::map<int, buttonMap>::const_iterator it = m_translatorMap.find(window);
   if (it == m_translatorMap.end())
     return ACTION_NONE;

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -590,7 +590,7 @@ bool CInputManager::HandleKey(const CKey& key)
 
         // If the key pressed is shift-A to shift-Z set usekeyboard to true.
         // This causes the keypress to be used for list navigation.
-        if (control->IsContainer() && (key.GetModifiers() & CKey::MODIFIER_SHIFT) && key.GetVKey() >= XBMCVK_A && key.GetVKey() <= XBMCVK_Z)
+        if (control->IsContainer() && key.GetModifiers() == CKey::MODIFIER_SHIFT && key.GetVKey() >= XBMCVK_A && key.GetVKey() <= XBMCVK_Z)
           useKeyboard = true;
       }
     }
@@ -629,13 +629,13 @@ bool CInputManager::HandleKey(const CKey& key)
           // Check for paste keypress
 #ifdef TARGET_WINDOWS
           // In Windows paste is ctrl-V
-          if (key.GetVKey() == XBMCVK_V && (key.GetModifiers() & CKey::MODIFIER_CTRL))
+          if (key.GetVKey() == XBMCVK_V && key.GetModifiers() == CKey::MODIFIER_CTRL)
 #elif defined(TARGET_LINUX)
           // In Linux paste is ctrl-V
-          if (key.GetVKey() == XBMCVK_V && (key.GetModifiers() & CKey::MODIFIER_CTRL))
+          if (key.GetVKey() == XBMCVK_V && key.GetModifiers() == CKey::MODIFIER_CTRL)
 #elif defined(TARGET_DARWIN_OSX)
           // In OSX paste is cmd-V
-          if (key.GetVKey() == XBMCVK_V && (key.GetModifiers() & CKey::MODIFIER_META))
+          if (key.GetVKey() == XBMCVK_V && key.GetModifiers() == CKey::MODIFIER_META)
 #else
           // Placeholder for other operating systems
           if (false)

--- a/xbmc/input/Key.cpp
+++ b/xbmc/input/Key.cpp
@@ -48,7 +48,7 @@ CKey::CKey(uint32_t buttonCode, unsigned int held)
   m_held = held;
 }
 
-CKey::CKey(uint32_t keycode, uint8_t vkey, wchar_t unicode, char ascii, uint32_t modifiers, unsigned int held)
+CKey::CKey(uint32_t keycode, uint8_t vkey, wchar_t unicode, char ascii, uint32_t modifiers, uint32_t lockingModifiers, unsigned int held)
 {
   Reset();
   if (vkey) // FIXME: This needs cleaning up - should we always use the unicode key where available?
@@ -61,6 +61,7 @@ CKey::CKey(uint32_t keycode, uint8_t vkey, wchar_t unicode, char ascii, uint32_t
   m_unicode = unicode;
   m_ascii = ascii;
   m_modifiers = modifiers;
+  m_lockingModifiers = lockingModifiers;
   m_held = held;
 }
 
@@ -85,6 +86,7 @@ void CKey::Reset()
   m_unicode = 0;
   m_ascii = 0;
   m_modifiers = 0;
+  m_lockingModifiers = 0;
   m_held = 0;
 }
 
@@ -105,6 +107,7 @@ CKey& CKey::operator=(const CKey& key)
   m_unicode     = key.m_unicode;
   m_ascii       = key.m_ascii;
   m_modifiers    = key.m_modifiers;
+  m_lockingModifiers = key.m_lockingModifiers;
   m_held         = key.m_held;
   return *this;
 }

--- a/xbmc/input/Key.h
+++ b/xbmc/input/Key.h
@@ -149,7 +149,7 @@ public:
   CKey(void);
   CKey(uint32_t buttonCode, uint8_t leftTrigger = 0, uint8_t rightTrigger = 0, float leftThumbX = 0.0f, float leftThumbY = 0.0f, float rightThumbX = 0.0f, float rightThumbY = 0.0f, float repeat = 0.0f);
   CKey(uint32_t buttonCode, unsigned int held);
-  CKey(uint32_t keycode, uint8_t vkey, wchar_t unicode, char ascii, uint32_t modifiers, unsigned int held);
+  CKey(uint32_t keycode, uint8_t vkey, wchar_t unicode, char ascii, uint32_t modifiers, uint32_t lockingModifiers, unsigned int held);
   CKey(const CKey& key);
   void Reset();
 
@@ -174,6 +174,7 @@ public:
   inline wchar_t  GetUnicode() const    { return m_unicode; }
   inline char     GetAscii() const      { return m_ascii; }
   inline uint32_t GetModifiers() const  { return m_modifiers; };
+  inline uint32_t GetLockingModifiers() const { return m_lockingModifiers; };
   inline unsigned int GetHeld() const   { return m_held; }
 
   enum Modifier {
@@ -196,6 +197,7 @@ private:
   wchar_t  m_unicode;
   char     m_ascii;
   uint32_t m_modifiers;
+  uint32_t m_lockingModifiers;
   unsigned int m_held;
 
   uint8_t m_leftTrigger;

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -79,6 +79,7 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
   wchar_t unicode;
   char ascii;
   uint32_t modifiers;
+  uint32_t lockingModifiers;
   unsigned int held;
   XBMCKEYTABLE keytable;
 
@@ -93,12 +94,14 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
     modifiers |= CKey::MODIFIER_SUPER;
   if (keysym.mod & XBMCKMOD_META)
     modifiers |= CKey::MODIFIER_META;
+
+  lockingModifiers = 0;
   if (keysym.mod & XBMCKMOD_NUM)
-    modifiers |= CKey::MODIFIER_NUMLOCK;
+    lockingModifiers |= CKey::MODIFIER_NUMLOCK;
   if (keysym.mod & XBMCKMOD_CAPS)
-    modifiers |= CKey::MODIFIER_CAPSLOCK;
+    lockingModifiers |= CKey::MODIFIER_CAPSLOCK;
   if (keysym.mod & XBMCKMOD_MODE)
-    modifiers |= CKey::MODIFIER_SCROLLLOCK;
+    lockingModifiers |= CKey::MODIFIER_SCROLLLOCK;
 
   CLog::Log(LOGDEBUG, "Keyboard: scancode: 0x%02x, sym: 0x%04x, unicode: 0x%04x, modifier: 0x%x", keysym.scancode, keysym.sym, keysym.unicode, keysym.mod);
 
@@ -185,7 +188,7 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
 
   // Create and return a CKey
 
-  CKey key(keycode, vkey, unicode, ascii, modifiers, held);
+  CKey key(keycode, vkey, unicode, ascii, modifiers, lockingModifiers, held);
 
   return key;
 }

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -179,7 +179,7 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
   // The A-Z keys are exempted because shift-A-Z is used for navigation in lists.
   // The function keys are exempted because function keys have no shifted value and
   // the Nyxboard remote uses keys like Shift-F3 for some buttons.
-  if (modifiers & CKey::MODIFIER_SHIFT)
+  if (modifiers == CKey::MODIFIER_SHIFT)
     if ((unicode < 'A' || unicode > 'Z') && (unicode < 'a' || unicode > 'z') && (vkey < XBMCVK_F1 || vkey > XBMCVK_F24))
       modifiers = 0;
 


### PR DESCRIPTION
This fixes a regression introduced in #13354. Apparently somewhere in the code, Kodi makes the assumption that new keyboard modifiers won't be introduced. I couldn't find this assumption after much searching, so I'm reverting the problematic commit from #13354 and simply introducing a second variable to hold these new modifiers.

## Motivation and Context
Reported here: https://forum.kodi.tv/showthread.php?tid=298462&pid=2694915#pid2694915

## How Has This Been Tested?
Tested on Linux.

Before: In Fullscreen Video, pressing CTRL+Shift+O had the same effect as pressing O (PlayerProcess info).

Now: pressing CTRL+Shift+O properly opens debug info.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
