### PR TITLE
[depends] improve rebuilding detection

### DIFF
--- a/tools/depends/.gitignore
+++ b/tools/depends/.gitignore
@@ -10,7 +10,6 @@
 /native/*/x86_64-darwin*.*.*-native/
 /native/*/armeabi-v7a-native/*
 
-/target/*/.patched-*
 /target/*/.installed-*
 /target/*/native/*
 /target/*/x86/*
@@ -42,6 +41,7 @@ config.site.native
 /native/*/*native/
 /JsonSchemaBuilder/bin/
 /TexturePacker/bin/
+/target/ffmpeg/.build-*
 /target/ffmpeg/.ffmpeg-installed
 /target/ffmpeg/ffmpeg-*-*.tar.gz
 /target/ffmpeg/ffmpeg-*-*/

--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -33,7 +33,6 @@ NEED_LIBICONV=@need_libiconv@
 LINK_ICONV=@link_iconv@
 ENABLE_GPLV3=@use_gplv3@
 ENABLE_WAYLAND=@enable_wayland@
-HAS_LIBCRYSTAX=@has_libcrystax@
 
 BASE_URL=http://mirrors.kodi.tv/build-deps/sources
 ifneq ($(KODI_MIRROR),)

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -406,8 +406,8 @@ case $host in
 
           found_sdk_version=[`$use_xcodebuild -showsdks | grep $target_platform | sort | tail -n 1 | awk '{ print $2}'`]
           use_sdk="${use_sdk:-$found_sdk_version}"
-	  platform_cflags+=" -fembed-bitcode"
-	  platform_cxxflags+=" -fembed-bitcode"
+          platform_cflags+=" -fembed-bitcode"
+          platform_cxxflags+=" -fembed-bitcode"
           sdk_name=$target_platform$use_sdk
           platform_min_version="$target_platform-version-min=9.0"
         else
@@ -423,7 +423,7 @@ case $host in
           sdk_name=$target_platform$use_sdk
           platform_min_version="$target_platform-version-min=6.0"
         fi
-	case $use_sdk in
+        case $use_sdk in
           4.*);;
           5.*);;
           6.*);;

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -560,7 +560,6 @@ AC_PATH_PROG([CXX_FOR_BUILD],[g++ llvm-g++ $platform_cxx], g++, $PATH_FOR_BUILD)
 
 AC_SEARCH_LIBS([iconv_open],iconv, link_iconv=$ac_cv_search_iconv_open, link_iconv=-liconv; AC_MSG_WARN("No iconv support in toolchain. Will build libiconv."); need_libiconv=1)
 AC_TRY_LINK([#include <locale.h>],[struct lconv* test=localeconv();], has_localeconv=yes, AC_MSG_WARN("No localeconv support in toolchain. Using replacement."); has_localeconv=no)
-AC_CHECK_LIB([crystax],   [main], has_libcrystax=1, has_libcrystax=0)
 
 if test "$link_iconv" = "none required"; then
   link_iconv=
@@ -762,7 +761,6 @@ AC_SUBST(link_iconv)
 AC_SUBST(need_libiconv)
 AC_SUBST(use_gplv3)
 AC_SUBST(enable_wayland)
-AC_SUBST(has_libcrystax)
 AC_SUBST(use_xcode)
 AC_SUBST(use_ccache)
 AC_SUBST(native_platform_min_version)

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -476,7 +476,6 @@ esac
 case $use_platform in
   raspberry-pi)
      target_platform=raspberry-pi
-     use_neon=no
      use_cpu=arm1176jzf-s
      ffmpeg_options_default="--cpu=arm1176jzf-s"
      platform_cflags="-mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfloat-abi=hard -mfpu=vfp"
@@ -486,7 +485,6 @@ case $use_platform in
      ;;
   raspberry-pi2)
      target_platform=raspberry-pi
-     use_neon=yes
      use_cpu=cortex-a7
      ffmpeg_options_default="--cpu=cortex-a7"
      platform_cflags="-fPIC -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4"

--- a/tools/depends/native/JsonSchemaBuilder/Makefile
+++ b/tools/depends/native/JsonSchemaBuilder/Makefile
@@ -1,5 +1,6 @@
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ../../Makefile.include
+DEPS=Makefile
 
 ifeq ($(NATIVEPREFIX),)
   PREFIX = $(ROOT_DIR)
@@ -11,6 +12,7 @@ ifeq ($(NATIVEPLATFORM),)
   PLATFORM = native
 else
   PLATFORM = $(NATIVEPLATFORM)
+  DEPS += ../../Makefile.include
 endif
 
 SOURCE=$(ROOT_DIR)/src
@@ -21,7 +23,7 @@ APPBIN=$(PREFIX)/bin/JsonSchemaBuilder
 
 all: .installed-$(PLATFORM)
 
-$(PLATFORM):
+$(PLATFORM): $(DEPS)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); cp -a $(SOURCE)/* .
 	cd $(PLATFORM); ./autogen.sh

--- a/tools/depends/native/JsonSchemaBuilder/Makefile
+++ b/tools/depends/native/JsonSchemaBuilder/Makefile
@@ -18,7 +18,7 @@ endif
 SOURCE=$(ROOT_DIR)/src
 
 CONFIGURE=./configure --prefix=$(PREFIX)
-APP=$(SOURCE)/JsonSchemaBuilder
+APP=$(PLATFORM)/JsonSchemaBuilder
 APPBIN=$(PREFIX)/bin/JsonSchemaBuilder
 
 all: .installed-$(PLATFORM)

--- a/tools/depends/native/TexturePacker/Makefile
+++ b/tools/depends/native/TexturePacker/Makefile
@@ -1,5 +1,6 @@
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ../../Makefile.include
+DEPS=Makefile
 
 ifeq ($(NATIVEPREFIX),)
   PREFIX = $(ROOT_DIR)
@@ -12,6 +13,7 @@ ifeq ($(NATIVEPLATFORM),)
   EXTRA_CONFIGURE = --enable-static
 else
   PLATFORM = $(NATIVEPLATFORM)
+  DEPS += ../../Makefile.include
 endif
 
 ifeq ($(NATIVE_OS), linux)
@@ -32,7 +34,7 @@ APPBIN=$(PREFIX)/bin/TexturePacker
 
 all: .installed-$(PLATFORM)
 
-$(PLATFORM):
+$(PLATFORM): $(DEPS)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); cp -a $(SOURCE)/* .
 	cd $(PLATFORM); ./autogen.sh

--- a/tools/depends/native/autoconf-native/Makefile
+++ b/tools/depends/native/autoconf-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile endian-c++11-narrowing.patch
+DEPS= ../../Makefile.include Makefile endian-c++11-narrowing.patch
 
 # lib name, version
 LIBNAME=autoconf

--- a/tools/depends/native/automake-native/Makefile
+++ b/tools/depends/native/automake-native/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.include
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=automake

--- a/tools/depends/native/automake-native/Makefile
+++ b/tools/depends/native/automake-native/Makefile
@@ -11,7 +11,7 @@ ARCHIVE=$(SOURCE).tar.gz
 # configuration settings
 CONFIGURE=./configure --prefix=$(NATIVEPREFIX)
 
-LIBDYLIB=$(PLATFORM)/automake
+LIBDYLIB=$(PLATFORM)/bin/automake
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 

--- a/tools/depends/native/distribute-native/Makefile
+++ b/tools/depends/native/distribute-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=distribute

--- a/tools/depends/native/distutilscross-native/Makefile
+++ b/tools/depends/native/distutilscross-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=distutilscross

--- a/tools/depends/native/fakeroot-native/Makefile
+++ b/tools/depends/native/fakeroot-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 APPNAME=fakeroot
 VERSION=macosx-v3.3

--- a/tools/depends/native/fakeroot-native/Makefile
+++ b/tools/depends/native/fakeroot-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-darwin14-openat.patch
 
 APPNAME=fakeroot
 VERSION=macosx-v3.3

--- a/tools/depends/native/gettext-native/Makefile
+++ b/tools/depends/native/gettext-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-gettext-tools-stpncpy.patch
 
 # lib name, version
 LIBNAME=gettext

--- a/tools/depends/native/gettext-native/Makefile
+++ b/tools/depends/native/gettext-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=gettext

--- a/tools/depends/native/libjpeg-turbo-native/Makefile
+++ b/tools/depends/native/libjpeg-turbo-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libjpeg-turbo

--- a/tools/depends/native/libjpeg-turbo-native/Makefile
+++ b/tools/depends/native/libjpeg-turbo-native/Makefile
@@ -18,7 +18,7 @@ LIBDYLIB=$(PLATFORM)/.libs/libjpeg.a
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 
-jpegtest: .installed-$(PLATFORM)
+all: .installed-$(PLATFORM)
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
@@ -30,6 +30,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -j 1 -C $(PLATFORM)
+	touch $@
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install

--- a/tools/depends/native/liblzo2-native/Makefile
+++ b/tools/depends/native/liblzo2-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=lzo

--- a/tools/depends/native/libpng-native/Makefile
+++ b/tools/depends/native/libpng-native/Makefile
@@ -13,7 +13,7 @@ ARCHIVE=$(SOURCE).tar.gz
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX)
 
-LIBDYLIB=$(PLATFORM)/.libs/$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/.libs/$(LIBNAME)16.a
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 

--- a/tools/depends/native/libpng-native/Makefile
+++ b/tools/depends/native/libpng-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libpng

--- a/tools/depends/native/libpng-native/Makefile
+++ b/tools/depends/native/libpng-native/Makefile
@@ -29,6 +29,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
+	touch $@
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install

--- a/tools/depends/native/libtool-native/Makefile
+++ b/tools/depends/native/libtool-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libtool

--- a/tools/depends/native/libtool-native/Makefile
+++ b/tools/depends/native/libtool-native/Makefile
@@ -29,6 +29,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
+	touch $@
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install

--- a/tools/depends/native/m4-native/Makefile
+++ b/tools/depends/native/m4-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile osx_snprintf.patch
+DEPS= ../../Makefile.include Makefile osx_snprintf.patch
 
 # lib name, version
 LIBNAME=m4

--- a/tools/depends/native/pcre-native/Makefile
+++ b/tools/depends/native/pcre-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=pcre

--- a/tools/depends/native/pkg-config-native/Makefile
+++ b/tools/depends/native/pkg-config-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 # lib name, version

--- a/tools/depends/native/python27-native/Makefile
+++ b/tools/depends/native/python27-native/Makefile
@@ -34,6 +34,7 @@ $(LIBDYLIB): $(PLATFORM)
 .installed-$(PLATFORM): $(LIBDYLIB)
 	cd $(PLATFORM); $(MAKE) install
 	install $(PLATFORM)/Parser/pgen $(NATIVEPREFIX)/bin
+	touch $(LIBDYLIB)
 	touch $@
 
 clean:

--- a/tools/depends/native/python27-native/Makefile
+++ b/tools/depends/native/python27-native/Makefile
@@ -13,6 +13,9 @@ HOSTPYTHONDIR=$(CWD)/$(PLATFORM)/hostpython
 CONFIGURE=./configure --prefix=$(NATIVEPREFIX) --disable-shared --disable-toolbox-glue --disable-framework
 
 LIBDYLIB=$(PLATFORM)/python
+ifeq ($(NATIVE_OS), osx)
+	LIBDYLIB=$(PLATFORM)/python.exe
+endif
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/native/python27-native/Makefile
+++ b/tools/depends/native/python27-native/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.include
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=Python

--- a/tools/depends/native/swig-native/Makefile
+++ b/tools/depends/native/swig-native/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
 
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=swig

--- a/tools/depends/native/tar-native/Makefile
+++ b/tools/depends/native/tar-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # app name, version
 APPNAME=tar

--- a/tools/depends/native/tar-native/Makefile
+++ b/tools/depends/native/tar-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile fix_xattrs_configure.patch
 
 # app name, version
 APPNAME=tar

--- a/tools/depends/native/tar-native/Makefile
+++ b/tools/depends/native/tar-native/Makefile
@@ -21,7 +21,7 @@ CONFIGURE=./configure --prefix=$(PREFIX) \
   --disable-dependency-tracking ac_cv_func_fdopendir=no \
   $(PLATFORM_CONFIGURE)
 
-APP=$(SOURCE)/src/tar
+APP=$(PLATFORM)/src/tar
 APPBIN=$(PREFIX)/bin/tar
 
 all: .installed-$(PLATFORM)

--- a/tools/depends/native/xz-native/Makefile
+++ b/tools/depends/native/xz-native/Makefile
@@ -13,7 +13,7 @@ export LIBTOOL=builds/unix/libtool
 export PATH:=$(PREFIX)/bin:$(PATH)
 CONFIGURE=./configure --prefix=$(PREFIX)
 
-APP=$(SOURCE)/src/xz/xz
+APP=$(PLATFORM)/src/xz/xz
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/native/xz-native/Makefile
+++ b/tools/depends/native/xz-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 # app name, version
 APPNAME=xz

--- a/tools/depends/native/yasm-native/Makefile
+++ b/tools/depends/native/yasm-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include.in Makefile
+DEPS= ../../Makefile.include Makefile
 
 APPNAME=yasm
 VERSION=1.1.0

--- a/tools/depends/native/zlib-native/Makefile
+++ b/tools/depends/native/zlib-native/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile visibility.patch
 
 # lib name, version
 LIBNAME=zlib

--- a/tools/depends/target/boblight/Makefile
+++ b/tools/depends/target/boblight/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-fix_fpermissive.patch 02-fixandroid.patch 03-fixtvos.patch
 
 #hint for building a fat lib - "lipo -arch i386 libboblight-i386.dylib -arch x86_64 libboblight-x86_64.dylib -output libboblight-fat.dylib"
 

--- a/tools/depends/target/crossguid/Makefile
+++ b/tools/depends/target/crossguid/Makefile
@@ -35,11 +35,9 @@ endif
 
 LIBDYLIB=$(PLATFORM)/lib$(LIBNAME).a
 
-.PHONY: .installed-$(PLATFORM)
+.PHONY: .installed-native
 
-all: .installed-$(PLATFORM) $(PREFIX)/lib/lib$(LIBNAME).a
-$(PREFIX)/lib/lib$(LIBNAME).a:
-	@make .installed-$(PLATFORM)
+all: .installed-$(PLATFORM)
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)

--- a/tools/depends/target/dbus/Makefile
+++ b/tools/depends/target/dbus/Makefile
@@ -11,7 +11,7 @@ ARCHIVE=$(SOURCE).tar.gz
 CONFIGURE=./configure --prefix=$(PREFIX) \
   --without-x --disable-xml-docs --disable-doxygen-docs
 
-LIBDYLIB=$(PLATFORM)/$(LIBNAME)/.libs/$(LIBNAME).so
+LIBDYLIB=$(PLATFORM)/$(LIBNAME)/.libs/lib$(LIBNAME)-1.so
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 

--- a/tools/depends/target/expat/Makefile
+++ b/tools/depends/target/expat/Makefile
@@ -10,7 +10,7 @@ ARCHIVE=$(SOURCE).tar.bz2
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) ./conftools; ./configure --prefix=$(PREFIX) --disable-shared
 
-LIBDYLIB=$(PLATFORM)/.libs/lib$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -85,10 +85,11 @@ ifeq ($(OS), ios)
 	cd $(PLATFORM); sed -i -- 's/HAVE_CLOCK_GETTIME 1/HAVE_CLOCK_GETTIME 0/g' config.h
 endif
 
-build: $(PLATFORM)
+.build-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
+	touch $@
 
-.installed-$(PLATFORM): build
+.installed-$(PLATFORM): .build-$(PLATFORM)
 	$(MAKE) -C $(PLATFORM) install
 	touch $@
 

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile size-max.patch
 
 # lib name, version
 LIBNAME=gnutls

--- a/tools/depends/target/libbluray/Makefile
+++ b/tools/depends/target/libbluray/Makefile
@@ -12,7 +12,7 @@ CONFIGURE=./configure --prefix=$(PREFIX) --exec-prefix=$(PREFIX) \
   --disable-examples --disable-doxygen-doc \
   --disable-bdjava-jar --without-libxml2 --without-freetype
 
-LIBDYLIB=$(PLATFORM)/src/.libs/libbluray.la
+LIBDYLIB=$(PLATFORM)/.libs/libbluray.la
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/libbluray/Makefile
+++ b/tools/depends/target/libbluray/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile tvos.patch
 
 # lib name, version
 LIBNAME=libbluray

--- a/tools/depends/target/libcdio-gplv3/Makefile
+++ b/tools/depends/target/libcdio-gplv3/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile osx.patch
+DEPS= ../../Makefile.include Makefile osx.patch osx2.patch
 
 # lib name, version
 LIBNAME=libcdio

--- a/tools/depends/target/libcdio/Makefile
+++ b/tools/depends/target/libcdio/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include configure.patch Makefile
+DEPS= ../../Makefile.include Makefile configure.patch cross.patch
 
 # lib name, version
 LIBNAME=libcdio

--- a/tools/depends/target/libcec/Makefile
+++ b/tools/depends/target/libcec/Makefile
@@ -11,7 +11,10 @@ VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
-LIBDYLIB=$(PLATFORM)/build/src/$(LIBNAME).la
+LIBDYLIB=$(PLATFORM)/build/src/$(LIBNAME)/$(LIBNAME).so
+ifeq (darwin, $(findstring darwin, $(HOST)))
+	LIBDYLIB=$(PLATFORM)/build/src/$(LIBNAME)/$(LIBNAME).dylib
+endif
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/libfmt/Makefile
+++ b/tools/depends/target/libfmt/Makefile
@@ -30,11 +30,9 @@ endif
 
 LIBDYLIB=$(PLATFORM)/build/$(LIBNAME)/libfmt.a
 
-.PHONY: .installed-$(PLATFORM)
+.PHONY: .installed-native
 
 all: .installed-$(PLATFORM)
-$(PREFIX)/lib/lib$(LIBNAME).a:
-	@make .installed-$(PLATFORM)
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	cd $(TARBALLS_LOCATION); $(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)

--- a/tools/depends/target/libgcrypt/Makefile
+++ b/tools/depends/target/libgcrypt/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include 01-gcrypt-android-select.patch 02-fix-armv7-neon.patch 03-remove-cipher-gcm-armv8.patch 04-fix-o-flag-munging.patch Makefile
+DEPS= ../../Makefile.include Makefile 01-gcrypt-android-select.patch 02-fix-armv7-neon.patch 03-remove-cipher-gcm-armv8.patch 04-fix-o-flag-munging.patch
 
 # lib name, version
 LIBNAME=libgcrypt

--- a/tools/depends/target/libmicrohttpd/Makefile
+++ b/tools/depends/target/libmicrohttpd/Makefile
@@ -13,13 +13,6 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
             --disable-doc --disable-examples --disable-curl \
             --disable-spdy
 
-# internal memmem sym collides with internal gnutils memmem
-# when built on 10.6.8, strip it.
-ifeq ($(OS), osx)
-STRIP_MEMMEM=-$(AR) d $(PLATFORM)/src/daemon/.libs/libmicrohttpd.a memmem.o
-endif
-
-
 LIBDYLIB=$(PLATFORM)/src/daemon/.libs/$(LIBNAME).a
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
@@ -37,7 +30,6 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)/src/microhttpd
 	$(MAKE) -C $(PLATFORM)/src/include install
-	$(STRIP_MEMMEM)
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	rm -f $(PREFIX)/lib/libmicrohttpd.so $(PREFIX)/lib/libmicrohttpd.so.5 $(PREFIX)/lib/libmicrohttpd.so.5.2.1

--- a/tools/depends/target/libmicrohttpd/Makefile
+++ b/tools/depends/target/libmicrohttpd/Makefile
@@ -13,7 +13,7 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
             --disable-doc --disable-examples --disable-curl \
             --disable-spdy
 
-LIBDYLIB=$(PLATFORM)/src/daemon/.libs/$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/src/microhttpd/.libs/$(LIBNAME).a
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 

--- a/tools/depends/target/libnfs/Makefile
+++ b/tools/depends/target/libnfs/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile vfstat_redefine.patch
 
 # lib name, version
 LIBNAME=libnfs

--- a/tools/depends/target/libpng/Makefile
+++ b/tools/depends/target/libpng/Makefile
@@ -11,7 +11,7 @@ ARCHIVE=$(SOURCE).tar.gz
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-shared
 
-LIBDYLIB=$(PLATFORM)/.libs/$(LIBNAME)15.a
+LIBDYLIB=$(PLATFORM)/.libs/$(LIBNAME)16.a
 
 CLEAN_FILES=$(ARCHIVE) $(PLATFORM)
 

--- a/tools/depends/target/libsdl/Makefile
+++ b/tools/depends/target/libsdl/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include 01-SDL_SetWidthHeight.patch 02-OSX_interpretKeyEvents.patch 03-mavericks-compile.patch 05-x11-xdata32.patch Makefile
+DEPS= ../../Makefile.include Makefile 01-SDL_SetWidthHeight.patch 02-OSX_interpretKeyEvents.patch 03-mavericks-compile.patch 04-fix_external_screen_crash.patch 05-x11-xdata32.patch
 
 # lib name, version
 LIBNAME=SDL

--- a/tools/depends/target/libshairplay/Makefile
+++ b/tools/depends/target/libshairplay/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include 
+DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=shairplay

--- a/tools/depends/target/libssh/Makefile
+++ b/tools/depends/target/libssh/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile removelegacy.patch android.patch ntohl.patch md5.patch pkg-config.patch
+DEPS= ../../Makefile.include Makefile removelegacy.patch android.patch darwin.patch darwin-no-fork.patch fix-gcc-5-compile.patch ntohl.patch md5.patch pkg-config.patch
 
 # lib name, version
 LIBNAME=libssh

--- a/tools/depends/target/libusb/Makefile
+++ b/tools/depends/target/libusb/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile no-Werror.patch
 
 # lib name, version
 LIBNAME=libusb

--- a/tools/depends/target/libxslt/Makefile
+++ b/tools/depends/target/libxslt/Makefile
@@ -30,6 +30,7 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
+	touch $@
 
 .installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install

--- a/tools/depends/target/mysql/Makefile
+++ b/tools/depends/target/mysql/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include 01-mysqlclient-cross-compile.patch 02-mysqlclient-ios.patch 03-mysqlclient-android.patch 04-strnlen.patch 05-mysqlclient-ios64.patch Makefile
+DEPS= ../../Makefile.include Makefile 01-mysqlclient-cross-compile.patch 02-mysqlclient-ios.patch 03-mysqlclient-android.patch 04-strnlen.patch 05-mysqlclient-ios64.patch 06-fixsslcheck.patch 07-no-endpwent.patch
 
 # lib name, version
 LIBNAME=mysql

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile 01-disable_testsuite.patch
 
 # lib name, version
 LIBNAME=nettle

--- a/tools/depends/target/p8-platform/Makefile
+++ b/tools/depends/target/p8-platform/Makefile
@@ -7,7 +7,7 @@ VERSION=2.1.0.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
-LIBDYLIB=$(PLATFORM)/build/src/$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/build/lib$(LIBNAME).a
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/pcre/Makefile
+++ b/tools/depends/target/pcre/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile tvos-bitcode-fix.patch
+DEPS= ../../Makefile.include Makefile tvos-bitcode-fix.patch jit_aarch64.patch
 
 # lib name, version
 LIBNAME=pcre

--- a/tools/depends/target/platform/Makefile
+++ b/tools/depends/target/platform/Makefile
@@ -7,7 +7,7 @@ VERSION=1.0.10
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 
-LIBDYLIB=$(PLATFORM)/build/src/$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/build/lib$(LIBNAME).a
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -25,9 +25,11 @@ LDSHARED:=$(CC) -bundle -undefined dynamic_lookup $(LDFLAGS)
 CROSSFLAGS=PYTHONXCPREFIX="$(PREFIX)" CC="$(CC) $(CFLAGS)" CCSHARED="$(CC) $(CFLAGS) $(PYTHON_O)" LDFLAGS="$(LDFLAGS)" PYTHONPATH="$(PREFIX)/lib/python2.7/site-packages/" LDSHARED="$(LDSHARED)"
 endif
 
-LIBDYLIB=$(PLATFORM)/dist/PIL-$(VERSION)-py2.7-$(OS)-$(CPU).egg
+LIBDYLIB=$(PLATFORM)/dist/Pillow-$(VERSION)-py2.7-$(OS)-$(CPU).egg
 ifeq ($(OS),android)
 LIBDYLIB=$(PREFIX)/share/$(APP_NAME)/addons/script.module.pil/lib/PIL/_imaging.so
+else ifeq (darwin, $(findstring darwin, $(HOST)))
+LIBDYLIB=$(PLATFORM)/dist/Pillow-$(VERSION)-py2.7-macosx-10.4-x86_64.egg
 endif
 
 all: .installed-$(PLATFORM)

--- a/tools/depends/target/pythonmodule-pycryptodome/Makefile
+++ b/tools/depends/target/pythonmodule-pycryptodome/Makefile
@@ -24,7 +24,10 @@ LDSHARED:=$(CC) -bundle -undefined dynamic_lookup $(LDFLAGS)
 CROSSFLAGS=PYTHONXCPREFIX="$(PREFIX)" CC="$(CC) $(CFLAGS)" CCSHARED="$(CC) $(CFLAGS) $(PYTHON_O)" LDFLAGS="$(LDFLAGS)" PYTHONPATH="$(PREFIX)/lib/python2.7/site-packages/" LDSHARED="$(LDSHARED)"
 endif
 
-LIBDYLIB=$(PLATFORM)/dist/$(LIBNAME)-$(VERSION)-py2.7.egg
+LIBDYLIB=$(PLATFORM)/build/lib.$(OS)-$(CPU)-2.7/Cryptodome
+ifeq ($(NATIVE_OS), osx)
+	LIBDYLIB=$(PLATFORM)/build/lib.macosx-10.4-x86_64-2.7/Cryptodome
+endif
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/pythonmodule-pycryptodome/Makefile
+++ b/tools/depends/target/pythonmodule-pycryptodome/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile #pillow-crosscompile.patch
+DEPS= ../../Makefile.include Makefile 01-nosetuptool.patch 02-android-dlopen.patch 03-obey-crosscompileflags.patch
 
 VERSION.TXT := $(CMAKE_SOURCE_DIR)/version.txt
 APP_NAME=$(shell awk '/APP_NAME/ {print tolower($$2)}' $(VERSION.TXT))

--- a/tools/depends/target/pythonmodule-setuptools/Makefile
+++ b/tools/depends/target/pythonmodule-setuptools/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile #pillow-crosscompile.patch
+DEPS= ../../Makefile.include Makefile
 
 VERSION.TXT := $(CMAKE_SOURCE_DIR)/version.txt
 APP_NAME=$(shell awk '/APP_NAME/ {print tolower($$2)}' $(VERSION.TXT))

--- a/tools/depends/target/sqlite3/Makefile
+++ b/tools/depends/target/sqlite3/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile
+DEPS= ../../Makefile.include Makefile fix-32bits-on-64bits.patch sqlite3.c.patch
 
 # lib name, version
 LIBNAME=sqlite

--- a/tools/depends/target/taglib/Makefile
+++ b/tools/depends/target/taglib/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile ID3v2Lookup.patch
+DEPS= ../../Makefile.include Makefile ID3v2Lookup.patch remove-boost.patch
 
 LIBNAME=taglib
 VERSION=1.11.1


### PR DESCRIPTION
## Description
- remove unused settings
- if native config changes (e.g. prefix) native packages also have to rebuild
- fix rebuilding detection for some packages

## Motivation and Context
running make in tools/depends a second time shouldn't do anything

## How Has This Been Tested?
build depends for osx and linux

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed