### PR TITLE
FIX: [droid;gradle] override aaptOptions

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -22,6 +22,9 @@ android {
         }
         
     }
+    aaptOptions {
+        ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
+    }
 
     sourceSets {
         main {


### PR DESCRIPTION
Prevent "_*" directories in assets from being ignored.

Default pattern from `aapt`includes `<dir>_*`
```   
   --ignore-assets
       Assets to be ignored. Default pattern is:
       !.svn:!.git:!.ds_store:!*.scc:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~
```