### PR TITLE
[PVR] Fix trac#17748.

### DIFF
--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -328,8 +328,9 @@ bool CPVREpg::Load(void)
     return bReturn;
   }
 
-  CSingleLock lock(m_critSection);
   int iEntriesLoaded = database->Get(*this);
+
+  CSingleLock lock(m_critSection);
   if (iEntriesLoaded <= 0)
   {
     CLog::Log(LOGDEBUG, "EPG - %s - no database entries found for table '%s'.", __FUNCTION__, m_strName.c_str());


### PR DESCRIPTION
`CPVREpgDatabase::Get(CPVREpg &epg)` must not be called while holding `epg`s lock.

Fixes https://trac.kodi.tv/ticket/17748

I runtime-tested this change on latest kodi master on macOS.

@Jalle19 mind taking a look?

@vindicatorr maybe you can do a runtime test this?