### PR TITLE
[gui] confirm keyboard dialog with enter while on edit control

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -198,7 +198,8 @@ bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
   bool handled = true;
   if (actionId == (KEY_VKEY | XBMCVK_BACK))
     Backspace();
-  else if (actionId == ACTION_ENTER || (m_isKeyboardNavigationMode && actionId == ACTION_SELECT_ITEM))
+  else if (actionId == ACTION_ENTER ||
+           (actionId == ACTION_SELECT_ITEM && (m_isKeyboardNavigationMode || GetFocusedControlID() == CTL_EDIT)))
     OnOK();
   else if (actionId == ACTION_SHIFT)
     OnShift();

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -194,22 +194,23 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
 
 bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
 {
+  int actionId = action.GetID();
   bool handled = true;
-  if (action.GetID() == (KEY_VKEY | XBMCVK_BACK))
+  if (actionId == (KEY_VKEY | XBMCVK_BACK))
     Backspace();
-  else if (action.GetID() == ACTION_ENTER || (m_isKeyboardNavigationMode && action.GetID() == ACTION_SELECT_ITEM))
+  else if (actionId == ACTION_ENTER || (m_isKeyboardNavigationMode && actionId == ACTION_SELECT_ITEM))
     OnOK();
-  else if (action.GetID() == ACTION_SHIFT)
+  else if (actionId == ACTION_SHIFT)
     OnShift();
-  else if (action.GetID() == ACTION_SYMBOLS)
+  else if (actionId == ACTION_SYMBOLS)
     OnSymbols();
   // don't handle move left/right and select in the edit control
   else if (!m_isKeyboardNavigationMode &&
-           (action.GetID() == ACTION_MOVE_LEFT ||
-           action.GetID() == ACTION_MOVE_RIGHT ||
-           action.GetID() == ACTION_SELECT_ITEM))
+           (actionId == ACTION_MOVE_LEFT ||
+           actionId == ACTION_MOVE_RIGHT ||
+           actionId == ACTION_SELECT_ITEM))
     handled = false;
-  else if (action.GetID() == ACTION_VOICE_RECOGNIZE)
+  else if (actionId == ACTION_VOICE_RECOGNIZE)
     OnVoiceRecognition();
   else
   {
@@ -224,9 +225,9 @@ bool CGUIDialogKeyboardGeneric::OnAction(const CAction &action)
       CGUIControl *edit = GetControl(CTL_EDIT);
       if (edit)
         handled = edit->OnAction(action);
-      if (!handled && action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
+      if (!handled && actionId >= KEY_VKEY && actionId < KEY_ASCII)
       {
-        BYTE b = action.GetID() & 0xFF;
+        BYTE b = actionId & 0xFF;
         if (b == XBMCVK_TAB)
         {
           // Toggle left/right key mode


### PR DESCRIPTION
I was a bit annoyed by the fact that I could not confirm the keyboard dialog by pressing enter while stay on the edit control. You have to navigate to the confirm button. By default we map `enter` to `select` in our [keyboard.xml](https://github.com/xbmc/xbmc/blob/master/system/keymaps/keyboard.xml#L45)

This PR will address the issue.