### PR TITLE
[windows] d3d11: use smart pointers (ComPtr) instead of raw pointers.

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -25,6 +25,8 @@
 
 #if defined(HAS_DX)
 #include "guilib/GUIShaderDX.h"
+#include <DirectXMath.h>
+using namespace DirectX;
 #endif
 
 using namespace KODI;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderBuffer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderBuffer.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 #include "DVDCodecs/Video/DXVA.h"
+#include <wrl/client.h>
 
 class CVideoBuffer;
 struct VideoPicture;
@@ -90,7 +91,7 @@ private:
   unsigned int m_activePlanes;
   D3D11_MAP m_mapType;
   CD3D11_TEXTURE2D_DESC m_sDesc;
-  ID3D11Texture2D* m_staging;
+  Microsoft::WRL::ComPtr<ID3D11Texture2D> m_staging;
 
   D3D11_MAPPED_SUBRESOURCE m_rects[YuvImage::MAX_PLANES];
   CD3DTexture m_textures[YuvImage::MAX_PLANES];

--- a/xbmc/guilib/GUIFontTTFDX.h
+++ b/xbmc/guilib/GUIFontTTFDX.h
@@ -31,6 +31,7 @@
 #include "GUIFontTTF.h"
 #include <list>
 #include <vector>
+#include <wrl/client.h>
 
 #define ELEMENT_ARRAY_MAX_CHAR_INDEX (2000)
 
@@ -65,14 +66,13 @@ private:
   static void AddReference(CGUIFontTTFDX* font, CD3DBuffer* pBuffer);
   static void ClearReference(CGUIFontTTFDX* font, CD3DBuffer* pBuffer);
 
-  CD3DTexture*           m_speedupTexture;  // extra texture to speed up reallocations when the main texture is in d3dpool_default.
-                                            // that's the typical situation of Windows Vista and above.
-  ID3D11Buffer*          m_vertexBuffer;
-  unsigned               m_vertexWidth;
+  unsigned m_vertexWidth;
+  CD3DTexture* m_speedupTexture;  // extra texture to speed up reallocations
+  Microsoft::WRL::ComPtr<ID3D11Buffer> m_vertexBuffer;
   std::list<CD3DBuffer*> m_buffers;
 
-  static bool            m_staticIndexBufferCreated;
-  static ID3D11Buffer*   m_staticIndexBuffer;
+  static bool m_staticIndexBufferCreated;
+  static Microsoft::WRL::ComPtr<ID3D11Buffer> m_staticIndexBuffer;
 };
 
 #endif

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -22,23 +22,23 @@
 #include "utils/Geometry.h"
 #include "Texture.h"
 #include "D3DResource.h"
-#include <DirectXMath.h>
 
-using namespace DirectX;
+#include <DirectXMath.h>
+#include <wrl/client.h>
 
 struct Vertex {
   Vertex() {}
 
-  Vertex(XMFLOAT3 p, XMFLOAT4 c)
+  Vertex(DirectX::XMFLOAT3 p, DirectX::XMFLOAT4 c)
     : pos(p), color(c) {}
 
-  Vertex(XMFLOAT3 p, XMFLOAT4 c, XMFLOAT2 t1, XMFLOAT2 t2)
+  Vertex(DirectX::XMFLOAT3 p, DirectX::XMFLOAT4 c, DirectX::XMFLOAT2 t1, DirectX::XMFLOAT2 t2)
     : pos(p), color(c), texCoord(t1), texCoord2(t2) {}
 
-  XMFLOAT3 pos;
-  XMFLOAT4 color;
-  XMFLOAT2 texCoord;
-  XMFLOAT2 texCoord2;
+  DirectX::XMFLOAT3 pos;
+  DirectX::XMFLOAT4 color;
+  DirectX::XMFLOAT2 texCoord;
+  DirectX::XMFLOAT2 texCoord2;
 };
 
 class ID3DResource;
@@ -58,20 +58,20 @@ public:
   void SetShaderViews(unsigned int numViews, ID3D11ShaderResourceView** views);
   void SetViewPort(D3D11_VIEWPORT viewPort);
 
-  void XM_CALLCONV GetWVP(XMMATRIX &w, XMMATRIX &v, XMMATRIX &p) 
+  void XM_CALLCONV GetWVP(DirectX::XMMATRIX &w, DirectX::XMMATRIX &v, DirectX::XMMATRIX &p)
   { 
     w = m_cbWorldViewProj.world; 
     v = m_cbWorldViewProj.view; 
     p = m_cbWorldViewProj.projection; 
   }
-  XMMATRIX XM_CALLCONV GetWorld()      const { return m_cbWorldViewProj.world; }
-  XMMATRIX XM_CALLCONV GetView()       const { return m_cbWorldViewProj.view; }
-  XMMATRIX XM_CALLCONV GetProjection() const { return m_cbWorldViewProj.projection; }
-  void     XM_CALLCONV SetWVP(const XMMATRIX &w, const XMMATRIX &v, const XMMATRIX &p);
-  void     XM_CALLCONV SetWorld(const XMMATRIX &value);
-  void     XM_CALLCONV SetView(const XMMATRIX &value);
-  void     XM_CALLCONV SetProjection(const XMMATRIX &value);
-  void                 Project(float &x, float &y, float &z);
+  DirectX::XMMATRIX XM_CALLCONV GetWorld() const { return m_cbWorldViewProj.world; }
+  DirectX::XMMATRIX XM_CALLCONV GetView() const { return m_cbWorldViewProj.view; }
+  DirectX::XMMATRIX XM_CALLCONV GetProjection() const { return m_cbWorldViewProj.projection; }
+  void XM_CALLCONV SetWVP(const DirectX::XMMATRIX &w, const DirectX::XMMATRIX &v, const DirectX::XMMATRIX &p);
+  void XM_CALLCONV SetWorld(const DirectX::XMMATRIX &value);
+  void XM_CALLCONV SetView(const DirectX::XMMATRIX &value);
+  void XM_CALLCONV SetProjection(const DirectX::XMMATRIX &value);
+  void Project(float &x, float &y, float &z);
 
   void DrawQuad(Vertex& v1, Vertex& v2, Vertex& v3, Vertex& v4);
   void DrawIndexed(unsigned int indexCount, unsigned int startIndex, unsigned int startVertex);
@@ -100,9 +100,9 @@ public:
 private:
   struct cbWorldViewProj
   {
-    XMMATRIX world;
-    XMMATRIX view;
-    XMMATRIX projection;
+    DirectX::XMMATRIX world;
+    DirectX::XMMATRIX view;
+    DirectX::XMMATRIX projection;
   };
   struct cbViewPort
   {
@@ -113,7 +113,7 @@ private:
   };
   struct cbWorld
   {
-    XMMATRIX wvp;
+    DirectX::XMMATRIX wvp;
     float blackLevel;
     float colorRange;
   };
@@ -125,26 +125,26 @@ private:
   void ClipToScissorParams(void);
 
   // GUI constants
-  cbViewPort          m_cbViewPort;
-  cbWorldViewProj     m_cbWorldViewProj;
+  cbViewPort m_cbViewPort;
+  cbWorldViewProj m_cbWorldViewProj;
 
-  bool                m_bCreated;
-  ID3D11SamplerState* m_pSampLinear;
-  CD3DVertexShader    m_vertexShader;
-  CD3DPixelShader     m_pixelShader[SHADER_METHOD_RENDER_COUNT];
-  size_t              m_currentShader;
+  bool  m_bCreated;
+  size_t m_currentShader;
+  CD3DVertexShader m_vertexShader;
+  CD3DPixelShader m_pixelShader[SHADER_METHOD_RENDER_COUNT];
+  Microsoft::WRL::ComPtr<ID3D11SamplerState> m_pSampLinear;
 
   // GUI buffers
-  ID3D11Buffer*       m_pWVPBuffer;
-  ID3D11Buffer*       m_pVPBuffer;
-  ID3D11Buffer*       m_pVertexBuffer;
-  bool                m_bIsWVPDirty;
-  bool                m_bIsVPDirty;
+  bool m_bIsWVPDirty;
+  bool m_bIsVPDirty;
+  Microsoft::WRL::ComPtr<ID3D11Buffer> m_pWVPBuffer;
+  Microsoft::WRL::ComPtr<ID3D11Buffer> m_pVPBuffer;
+  Microsoft::WRL::ComPtr<ID3D11Buffer> m_pVertexBuffer;
 
   // clip to scissors params
-  bool                m_clipPossible;
-  float               m_clipXFactor;
-  float               m_clipXOffset;
-  float               m_clipYFactor;
-  float               m_clipYOffset;
+  bool m_clipPossible;
+  float m_clipXFactor;
+  float m_clipXOffset;
+  float m_clipYFactor;
+  float m_clipYOffset;
 };

--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -21,8 +21,12 @@
 #include "D3DResource.h"
 #include "GUIShaderDX.h"
 #include "GUITextureD3D.h"
-#include "Texture.h"
 #include "rendering/dx/RenderContext.h"
+#include "Texture.h"
+
+#include <DirectXMath.h>
+
+using namespace DirectX;
 
 CGUITextureD3D::CGUITextureD3D(float posX, float posY, float width, float height, const CTextureInfo &texture)
 : CGUITextureBase(posX, posY, width, height, texture)

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -39,6 +39,8 @@
 #elif defined(TARGET_WINDOWS)
 #include "rendering/dx/DeviceResources.h"
 #include "rendering/dx/RenderContext.h"
+#include <DirectXMath.h>
+using namespace DirectX;
 #endif
 
 #define IMMEDIATE_TRANSITION_TIME          20

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -24,6 +24,7 @@
 #include <string>
 #ifdef HAS_DX
 #include "guilib/GUIShaderDX.h"
+#include <wrl/client.h>
 #endif
 typedef uint32_t color_t;
 
@@ -134,7 +135,7 @@ private:
 
   CCriticalSection m_textureAccess;
 #ifdef HAS_DX
-  ID3D11Buffer*    m_vb;
-  bool             UpdateVertexBuffer(Vertex *vertices);
+  Microsoft::WRL::ComPtr<ID3D11Buffer> m_vb;
+  bool UpdateVertexBuffer(Vertex *vertices);
 #endif
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -54,7 +54,6 @@ bool DX::DeviceResources::CBackBuffer::Acquire(ID3D11Texture2D* pTexture)
   m_usage = desc.Usage;
 
   m_texture = pTexture;
-  m_texture->AddRef();
   return true;
 }
 
@@ -369,8 +368,8 @@ void DX::DeviceResources::ReleaseBackBuffer()
   CLog::LogF(LOGDEBUG, "release buffers.");
 
   // Clear the previous window size specific context.
-  ID3D11RenderTargetView* nullViews[] = { nullptr };
-  m_deferrContext->OMSetRenderTargets(ARRAYSIZE(nullViews), nullViews, nullptr);
+  ID3D11RenderTargetView* nullViews[] = { nullptr, nullptr, nullptr, nullptr };
+  m_deferrContext->OMSetRenderTargets(4, nullViews, nullptr);
   FinishCommandList(false);
 
   m_backBufferTex.Release();

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -162,6 +162,9 @@ namespace DX
     Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_d3dContext;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_deferrContext;
     Microsoft::WRL::ComPtr<IDXGISwapChain1> m_swapChain;
+#ifdef _DEBUG
+    Microsoft::WRL::ComPtr<ID3D11Debug> m_d3dDebug;
+#endif
 
     CBackBuffer m_backBufferTex;
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> m_d3dDepthStencilView;

--- a/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
+++ b/xbmc/rendering/dx/GUIWindowTestPatternDX.cpp
@@ -29,6 +29,7 @@
 
 #ifndef _d3d9TYPES_H_
 #include "DirectXPackedVector.h"
+using namespace DirectX;
 using namespace DirectX::PackedVector;
 
 DWORD D3DCOLOR_COLORVALUE(float r, float g, float b, float a)

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -17,8 +17,7 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#include <DirectXPackedVector.h>
-
+#include "RenderSystemDX.h"
 #include "Application.h"
 #if defined(TARGET_WINDOWS_DESKTOP)
 #include "cores/RetroPlayer/process/windows/RPProcessInfoWin.h"
@@ -42,13 +41,15 @@
 #include "threads/SingleLock.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
-#include "RenderSystemDX.h"
+
+#include <DirectXPackedVector.h>
 
 extern "C" {
 #include "libavutil/pixfmt.h"
 }
 
 using namespace KODI;
+using namespace DirectX;
 using namespace DirectX::PackedVector;
 using namespace Microsoft::WRL;
 

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -23,14 +23,14 @@
 
 #pragma once
 
-#include <vector>
-#include <wrl.h>
-#include <wrl/client.h>
-
 #include "DeviceResources.h"
 #include "threads/Condition.h"
 #include "threads/CriticalSection.h"
 #include "rendering/RenderSystem.h"
+
+#include <vector>
+#include <wrl.h>
+#include <wrl/client.h>
 
 enum PCI_Vendors
 {


### PR DESCRIPTION
see title.

@lrusak this also gets rid of `SAFE_RELEASE` macros for DirectX pointers and `SAFE_DELETE` where I found them. only DX part was changed.