### PR TITLE
Kill CProfilesManager singleton

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1034,7 +1034,7 @@ bool CApplication::Initialize()
   if (!LoadLanguage(false))
     return false;
 
-  CEventLog::GetInstance().Add(EventPtr(new CNotificationEvent(
+  m_ServiceManager->GetEventLog().Add(EventPtr(new CNotificationEvent(
     StringUtils::Format(g_localizeStrings.Get(177).c_str(), g_sysinfo.GetAppName().c_str()),
     StringUtils::Format(g_localizeStrings.Get(178).c_str(), g_sysinfo.GetAppName().c_str()),
     "special://xbmc/media/icon256x256.png", EventLevel::Basic)));

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2215,12 +2215,14 @@ bool CApplication::OnAction(const CAction &action)
 
   if (action.GetID() == ACTION_SWITCH_PLAYER)
   {
+    const CPlayerCoreFactory &playerCoreFactory = m_ServiceManager->GetPlayerCoreFactory();
+
     if(m_appPlayer.IsPlaying())
     {
       std::vector<std::string> players;
       CFileItem item(*m_itemCurrentFile.get());
-      CPlayerCoreFactory::GetInstance().GetPlayers(item, players);
-      std::string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+      playerCoreFactory.GetPlayers(item, players);
+      std::string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
       {
         item.m_lStartOffset = CUtil::ConvertSecsToMilliSecs(GetTime());
@@ -2230,8 +2232,8 @@ bool CApplication::OnAction(const CAction &action)
     else
     {
       std::vector<std::string> players;
-      CPlayerCoreFactory::GetInstance().GetRemotePlayers(players);
-      std::string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+      playerCoreFactory.GetRemotePlayers(players);
+      std::string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
       {
         PlayFile(CFileItem(), player, false);
@@ -3209,7 +3211,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       CLog::LogF(LOGDEBUG,"Ignored %d playback thread messages", dMsgCount);
   }
 
-  m_appPlayer.OpenFile(item, options, player, *this);
+  m_appPlayer.OpenFile(item, options, m_ServiceManager->GetPlayerCoreFactory(), player, *this);
   m_appPlayer.SetVolume(m_volumeLevel);
   m_appPlayer.SetMute(m_muted);
 
@@ -4001,7 +4003,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       if (!m_appPlayer.IsPlaying())
       {
         g_audioManager.Enable(true);
-        m_appPlayer.OpenNext();
+        m_appPlayer.OpenNext(m_ServiceManager->GetPlayerCoreFactory());
       }
 
       if (!m_appPlayer.IsPlayingVideo())

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -62,13 +62,13 @@ void CApplicationPlayer::CloseFile(bool reopen)
   }
 }
 
-void CApplicationPlayer::CreatePlayer(const std::string &player, IPlayerCallback& callback)
+void CApplicationPlayer::CreatePlayer(const CPlayerCoreFactory &factory, const std::string &player, IPlayerCallback& callback)
 {
   CSingleLock lock(m_playerLock);
   if (!m_pPlayer)
   {
     CDataCacheCore::GetInstance().Reset();
-    m_pPlayer.reset(CPlayerCoreFactory::GetInstance().CreatePlayer(player, callback));
+    m_pPlayer.reset(factory.CreatePlayer(player, callback));
   }
 }
 
@@ -83,14 +83,15 @@ std::string CApplicationPlayer::GetCurrentPlayer()
 }
 
 bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& options,
-                                         const std::string &playerName, IPlayerCallback& callback)
+                                  const CPlayerCoreFactory &factory,
+                                  const std::string &playerName, IPlayerCallback& callback)
 {
   // get player type
   std::string newPlayer;
   if (!playerName.empty())
     newPlayer = playerName;
   else
-    newPlayer = CPlayerCoreFactory::GetInstance().GetDefaultPlayer(item);
+    newPlayer = factory.GetDefaultPlayer(item);
 
   // check if we need to close current player
   // VideoPlayer can open a new file while playing
@@ -127,7 +128,7 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
 
   if (!player)
   {
-    CreatePlayer(newPlayer, callback);
+    CreatePlayer(factory, newPlayer, callback);
     player = GetInternal();
     if (!player)
       return false;
@@ -145,11 +146,12 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
   return ret;
 }
 
-void CApplicationPlayer::OpenNext()
+void CApplicationPlayer::OpenNext(const CPlayerCoreFactory &factory)
 {
   if (m_nextItem.pItem)
   {
     OpenFile(*m_nextItem.pItem, m_nextItem.options,
+             factory,
              m_nextItem.playerName, *m_nextItem.callback);
     m_nextItem.pItem.reset();
   }

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -31,6 +31,7 @@
 #include "SeekHandler.h"
 
 class CAction;
+class CPlayerCoreFactory;
 class CPlayerOptions;
 class CStreamDetails;
 
@@ -51,8 +52,9 @@ public:
   float GetPlayTempo();
   bool HasPlayer() const;
   bool OpenFile(const CFileItem& item, const CPlayerOptions& options,
+                const CPlayerCoreFactory &factory,
                 const std::string &playerName, IPlayerCallback& callback);
-  void OpenNext();
+  void OpenNext(const CPlayerCoreFactory &factory);
   void SetPlaySpeed(float speed);
   void SetTempo(float tempo);
   void FrameAdvance(int frames);
@@ -158,9 +160,9 @@ public:
 
   CSeekHandler& GetSeekHandler();
 
-protected:
+private:
   std::shared_ptr<IPlayer> GetInternal() const;
-  void CreatePlayer(const std::string &player, IPlayerCallback& callback);
+  void CreatePlayer(const CPlayerCoreFactory &factory, const std::string &player, IPlayerCallback& callback);
   void CloseFile(bool reopen = false);
 
   std::shared_ptr<IPlayer> m_pPlayer;

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -304,7 +304,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
             item.m_lStartOffset = STARTOFFSET_RESUME;
 
             // get playername
-            std::string hdVideoPlayer = CPlayerCoreFactory::GetInstance().GetDefaultPlayer(item);
+            std::string hdVideoPlayer = CServiceBroker::GetPlayerCoreFactory().GetDefaultPlayer(item);
             
             // Single *.xpl or *.ifo files require an external player to handle playback.
             // If no matching rule was found, VideoPlayer will be default player.

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -78,14 +78,18 @@ void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool
 
   g_application.ResetScreenSaver();
   g_application.WakeUpScreenSaverAndDPMS();  // turn off the screensaver if it's active
+
 #ifdef HAS_CDDA_RIPPER
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) == AUTOCD_RIP && 
-      pInfo->IsAudio(1) && !CProfilesManager::GetInstance().GetCurrentProfile().musicLocked())
+      pInfo->IsAudio(1) && !profileManager.GetCurrentProfile().musicLocked())
   {
     CCDDARipper::GetInstance().RipCD();
   }
   else
 #endif
+
   PlayDisc(path, bypassSettings, startFromBeginning);
 }
 
@@ -153,9 +157,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
   bool bAllowMusic = true;
   if (!g_passwordManager.IsMasterLockUnlocked(false))
   {
-    bAllowVideo = !CProfilesManager::GetInstance().GetCurrentProfile().videoLocked();
-//    bAllowPictures = !CProfilesManager::GetInstance().GetCurrentProfile().picturesLocked();
-    bAllowMusic = !CProfilesManager::GetInstance().GetCurrentProfile().musicLocked();
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+    bAllowVideo = !profileManager.GetCurrentProfile().videoLocked();
+//    bAllowPictures = !profileManager.GetCurrentProfile().picturesLocked();
+    bAllowMusic = !profileManager.GetCurrentProfile().musicLocked();
   }
 
   // is this a root folder we have to check the content to determine a disc type

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -39,20 +39,15 @@ class DatabaseSettings;
 class CDatabaseManager
 {
 public:
-  /*!
-   \brief The only way through which the global instance of the CDatabaseManager should be accessed.
-   \return the global instance.
-   */
-  static CDatabaseManager &GetInstance();
+  CDatabaseManager();
+  CDatabaseManager(const CDatabaseManager&) = delete;
+  CDatabaseManager const& operator=(CDatabaseManager const&) = delete;
+  ~CDatabaseManager();
 
   /*! \brief Initialize the database manager
    Checks that all databases are up to date, otherwise updates them.
    */
-  void Initialize(bool addonsOnly = false);
-
-  /*! \brief Deinitialize the database manager
-   */
-  void Deinitialize();
+  void Initialize();
 
   /*! \brief Check whether we can open a database.
 
@@ -64,14 +59,11 @@ public:
    \return true if the database can be opened, false otherwise.
    */ 
   bool CanOpen(const std::string &name);
-  std::atomic<bool> m_bIsUpgrading;
+
+  bool IsUpgrading() const { return m_bIsUpgrading; }
 
 private:
-  // private construction, and no assignments; use the provided singleton methods
-  CDatabaseManager();
-  CDatabaseManager(const CDatabaseManager&) = delete;
-  CDatabaseManager const& operator=(CDatabaseManager const&) = delete;
-  virtual ~CDatabaseManager();
+  std::atomic<bool> m_bIsUpgrading;
 
   enum DB_STATUS { DB_CLOSED, DB_UPDATING, DB_READY, DB_FAILED };
   void UpdateStatus(const std::string &name, DB_STATUS status);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5987,6 +5987,8 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     return strLabel;
   }
 
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   switch (info)
   {
   case PVR_NEXT_RECORDING_CHANNEL:
@@ -6615,15 +6617,15 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
     }
     break;
   case SYSTEM_PROFILENAME:
-    strLabel = CProfilesManager::GetInstance().GetCurrentProfile().getName();
+    strLabel = profileManager.GetCurrentProfile().getName();
     break;
   case SYSTEM_PROFILECOUNT:
-    strLabel = StringUtils::Format("{0}", CProfilesManager::GetInstance().GetNumberOfProfiles());
+    strLabel = StringUtils::Format("{0}", profileManager.GetNumberOfProfiles());
     break;
   case SYSTEM_PROFILEAUTOLOGIN:
     {
-      int profileId = CProfilesManager::GetInstance().GetAutoLoginProfileId();
-      if ((profileId < 0) || (!CProfilesManager::GetInstance().GetProfileName(profileId, strLabel)))
+      int profileId = profileManager.GetAutoLoginProfileId();
+      if ((profileId < 0) || (!profileManager.GetProfileName(profileId, strLabel)))
         strLabel = g_localizeStrings.Get(37014); // Last used profile
     }
     break;
@@ -6954,7 +6956,10 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
       }
     }
   }
-  else {
+  else
+  {
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
     switch (condition)
     {
       // Ethernet Link state checking
@@ -7072,7 +7077,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
         bReturn = IsPlayerChannelPreviewActive();
         break;
       case SYSTEM_HASLOCKS:
-        bReturn = CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE;
+        bReturn = profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE;
         break;
       case SYSTEM_HAS_PVR:
         bReturn = true;
@@ -7096,7 +7101,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
 #endif
         break;
       case SYSTEM_ISMASTER:
-        bReturn = CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
+        bReturn = profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
         break;
       case SYSTEM_ISFULLSCREEN:
         bReturn = CServiceBroker::GetWinSystem().IsFullScreen();
@@ -7117,7 +7122,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
         bReturn = g_advancedSettings.m_showExitButton;
         break;
       case SYSTEM_HAS_LOGINSCREEN:
-        bReturn = CProfilesManager::GetInstance().UsingLoginScreen();
+        bReturn = profileManager.UsingLoginScreen();
         break;
       case SYSTEM_HAS_ACTIVE_MODAL_DIALOG:
         bReturn = g_windowManager.HasModalDialog();
@@ -8252,7 +8257,9 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *
     return CServiceBroker::GetWeatherManager().GetInfo(WEATHER_IMAGE_CURRENT_ICON);
   else if (info == SYSTEM_PROFILETHUMB)
   {
-    std::string thumb = CProfilesManager::GetInstance().GetCurrentProfile().getThumb();
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+    std::string thumb = profileManager.GetCurrentProfile().getThumb();
     if (thumb.empty())
       thumb = "DefaultUser.png";
     return thumb;

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -52,11 +52,13 @@ CGUIPassword::~CGUIPassword(void) = default;
 
 bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string &strType)
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   // \brief Tests if the user is allowed to access the share folder
   // \param pItem The share folder item to access
   // \param strType The type of share being accessed, e.g. "music", "video", etc. See CSettings::UpdateSources()
   // \return If access is granted, returns \e true
-  if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   while (pItem->m_iHasLock > 1)
@@ -128,18 +130,26 @@ bool CGUIPassword::CheckStartUpLock()
 {
   // prompt user for mastercode if the mastercode was set b4 or by xml
   int iVerifyPasswordResult = -1;
+
   std::string strHeader = g_localizeStrings.Get(20075);
+
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
-  if (g_passwordManager.iMasterLockRetriesLeft == 0) g_passwordManager.iMasterLockRetriesLeft = 1;
-  std::string strPassword = CProfilesManager::GetInstance().GetMasterProfile().getLockCode();
-  if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == 0)
+
+  if (g_passwordManager.iMasterLockRetriesLeft == 0)
+    g_passwordManager.iMasterLockRetriesLeft = 1;
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  std::string strPassword = profileManager.GetMasterProfile().getLockCode();
+
+  if (profileManager.GetMasterProfile().getLockMode() == 0)
     iVerifyPasswordResult = 0;
   else
   {
     for (int i=1; i <= g_passwordManager.iMasterLockRetriesLeft; i++)
     {
-      iVerifyPasswordResult = VerifyPassword(CProfilesManager::GetInstance().GetMasterProfile().getLockMode(), strPassword, strHeader);
+      iVerifyPasswordResult = VerifyPassword(profileManager.GetMasterProfile().getLockMode(), strPassword, strHeader);
       if (iVerifyPasswordResult != 0 )
       {
         std::string strLabel1;
@@ -169,7 +179,9 @@ bool CGUIPassword::CheckStartUpLock()
 
 bool CGUIPassword::SetMasterLockMode(bool bDetails)
 {
-  CProfile* profile = CProfilesManager::GetInstance().GetProfile(0);
+  CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  CProfile* profile = profileManager.GetProfile(0);
   if (profile)
   {
     CProfile::CLock locks = profile->GetLocks();
@@ -192,14 +204,18 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
 {
   if (g_passwordManager.bMasterUser)
     return true;
-  int iProfileToCheck=iProfile;
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  int iProfileToCheck = iProfile;
   if (iProfile == -1)
-    iProfileToCheck = CProfilesManager::GetInstance().GetCurrentProfileIndex();
+    iProfileToCheck = profileManager.GetCurrentProfileIndex();
+
   if (iProfileToCheck == 0)
     return IsMasterLockUnlocked(prompt,bCanceled);
   else
   {
-    CProfile *profile = CProfilesManager::GetInstance().GetProfile(iProfileToCheck);
+    const CProfile *profile = profileManager.GetProfile(iProfileToCheck);
     if (!profile)
       return false;
 
@@ -207,7 +223,7 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
       return (profile->getLockMode() == LOCK_MODE_EVERYONE);
 
     if (profile->getDate().empty() &&
-       (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+       (profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
         profile->getLockMode() == LOCK_MODE_EVERYONE))
     {
       // user hasn't set a password and this is the first time they've used this account
@@ -216,8 +232,10 @@ bool CGUIPassword::IsProfileLockUnlocked(int iProfile, bool& bCanceled, bool pro
         return true;
     }
     else
-       if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+    {
+      if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         return CheckLock(profile->getLockMode(),profile->getLockCode(),20095,bCanceled);
+    }
   }
 
   return true;
@@ -232,13 +250,19 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser)
 bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
 {
   bCanceled = false;
+
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
-  if ((LOCK_MODE_EVERYONE < CProfilesManager::GetInstance().GetMasterProfile().getLockMode() && !bMasterUser) && !bPromptUser)
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if ((LOCK_MODE_EVERYONE < profileManager.GetMasterProfile().getLockMode() && !bMasterUser) && !bPromptUser)
+  {
     // not unlocked, but calling code doesn't want to prompt user
     return false;
+  }
 
-  if (g_passwordManager.bMasterUser || CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  if (g_passwordManager.bMasterUser || profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   if (iMasterLockRetriesLeft == 0)
@@ -249,8 +273,9 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
 
   // no, unlock since we are allowed to prompt
   std::string strHeading = g_localizeStrings.Get(20075);
-  std::string strPassword = CProfilesManager::GetInstance().GetMasterProfile().getLockCode();
-  int iVerifyPasswordResult = VerifyPassword(CProfilesManager::GetInstance().GetMasterProfile().getLockMode(), strPassword, strHeading);
+  std::string strPassword = profileManager.GetMasterProfile().getLockCode();
+
+  int iVerifyPasswordResult = VerifyPassword(profileManager.GetMasterProfile().getLockMode(), strPassword, strHeading);
   if (1 == iVerifyPasswordResult)
     UpdateMasterLockRetryCount(false);
 
@@ -309,9 +334,16 @@ bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, i
 bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, int iHeading, bool& bCanceled)
 {
   bCanceled = false;
-  if (btnType == LOCK_MODE_EVERYONE || strPassword == "-"        ||
-      CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE || g_passwordManager.bMasterUser)
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (btnType == LOCK_MODE_EVERYONE ||
+      strPassword == "-" ||
+      profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      g_passwordManager.bMasterUser)
+  {
     return true;
+  }
 
   std::string strHeading = g_localizeStrings.Get(iHeading);
   int iVerifyPasswordResult = VerifyPassword(btnType, strPassword, strHeading);
@@ -324,7 +356,9 @@ bool CGUIPassword::CheckLock(LockType btnType, const std::string& strPassword, i
 
 bool CGUIPassword::CheckSettingLevelLock(const SettingLevel& level, bool enforce /*=false*/)
 {
-  LOCK_LEVEL::SETTINGS_LOCK lockLevel = CProfilesManager::GetInstance().GetCurrentProfile().settingsLockLevel();
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  LOCK_LEVEL::SETTINGS_LOCK lockLevel = profileManager.GetCurrentProfile().settingsLockLevel();
   
   if (lockLevel == LOCK_LEVEL::NONE)
     return true;
@@ -362,7 +396,7 @@ bool IsSettingsWindow(int iWindowID)
 
 bool CGUIPassword::CheckMenuLock(int iWindowID)
 {
-  bool bCheckPW         = false;
+  bool bCheckPW = false;
   int iSwitch = iWindowID;
 
   // check if a settings subcategory was called from other than settings window
@@ -374,12 +408,18 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
   }
 
   if (iWindowID == WINDOW_MUSIC_NAV)
+  {
     if (g_windowManager.GetActiveWindow() == WINDOW_HOME)
       iSwitch = WINDOW_MUSIC_NAV;
+  }
 
   if (iWindowID == WINDOW_VIDEO_NAV)
+  {
     if (g_windowManager.GetActiveWindow() == WINDOW_HOME)
       iSwitch = WINDOW_VIDEO_NAV;
+  }
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
 
   switch (iSwitch)
   {
@@ -387,25 +427,25 @@ bool CGUIPassword::CheckMenuLock(int iWindowID)
       return CheckSettingLevelLock(CViewStateSettings::GetInstance().GetSettingLevel());
       break;
     case WINDOW_ADDON_BROWSER:  // Addons
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().addonmanagerLocked();
+      bCheckPW = profileManager.GetCurrentProfile().addonmanagerLocked();
       break;
     case WINDOW_FILES:          // Files
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().filesLocked();
+      bCheckPW = profileManager.GetCurrentProfile().filesLocked();
       break;
     case WINDOW_PROGRAMS:       // Programs
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().programsLocked();
+      bCheckPW = profileManager.GetCurrentProfile().programsLocked();
       break;
     case WINDOW_MUSIC_NAV:      // Music
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().musicLocked();
+      bCheckPW = profileManager.GetCurrentProfile().musicLocked();
       break;
     case WINDOW_VIDEO_NAV:      // Video
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().videoLocked();
+      bCheckPW = profileManager.GetCurrentProfile().videoLocked();
       break;
     case WINDOW_PICTURES:       // Pictures
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().picturesLocked();
+      bCheckPW = profileManager.GetCurrentProfile().picturesLocked();
       break;
     case WINDOW_GAMES:          // Games
-      bCheckPW = CProfilesManager::GetInstance().GetCurrentProfile().gamesLocked();
+      bCheckPW = profileManager.GetCurrentProfile().gamesLocked();
       break;
     case WINDOW_SETTINGS_PROFILES:
       bCheckPW = true;
@@ -479,7 +519,9 @@ void CGUIPassword::RemoveSourceLocks()
 
 bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES& vecSources)
 {
-  if (g_passwordManager.bMasterUser || CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (g_passwordManager.bMasterUser || profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
 
   // try to find the best matching source

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -40,6 +40,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
+#include "ServiceBroker.h"
 
 using namespace KODI::MESSAGING;
 using namespace PLAYLIST;
@@ -65,12 +66,15 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
   bool playlistLoaded;
 
   m_bIsVideo = context == PARTYMODECONTEXT_VIDEO;
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   if (!strXspPath.empty()) //if a path to a smartplaylist is supplied use it
     partyModePath = strXspPath;
   else if (m_bIsVideo)
-    partyModePath = CProfilesManager::GetInstance().GetUserDataItem("PartyMode-Video.xsp");
+    partyModePath = profileManager.GetUserDataItem("PartyMode-Video.xsp");
   else
-    partyModePath = CProfilesManager::GetInstance().GetUserDataItem("PartyMode.xsp");
+    partyModePath = profileManager.GetUserDataItem("PartyMode.xsp");
 
   playlistLoaded=playlist.Load(partyModePath);
 

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -26,6 +26,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "filesystem/File.h"
+#include "ServiceBroker.h"
 
 CPasswordManager &CPasswordManager::GetInstance()
 {
@@ -114,7 +115,10 @@ void CPasswordManager::Clear()
 void CPasswordManager::Load()
 {
   Clear();
-  std::string passwordsFile = CProfilesManager::GetInstance().GetUserDataItem("passwords.xml");
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  std::string passwordsFile = profileManager.GetUserDataItem("passwords.xml");
   if (XFILE::CFile::Exists(passwordsFile))
   {
     CXBMCTinyXML doc;
@@ -163,7 +167,9 @@ void CPasswordManager::Save() const
     XMLUtils::SetPath(path, "to", i->second);
   }
 
-  doc.SaveFile(CProfilesManager::GetInstance().GetUserDataItem("passwords.xml"));
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  doc.SaveFile(profileManager.GetUserDataItem("passwords.xml"));
 }
 
 std::string CPasswordManager::GetLookupPath(const CURL &url) const

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -172,3 +172,8 @@ CPlayerCoreFactory& CServiceBroker::GetPlayerCoreFactory()
 {
   return g_application.m_ServiceManager->GetPlayerCoreFactory();
 }
+
+CDatabaseManager& CServiceBroker::GetDatabaseManager()
+{
+  return g_application.m_ServiceManager->GetDatabaseManager();
+}

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -167,3 +167,8 @@ CWeatherManager& CServiceBroker::GetWeatherManager()
 {
   return g_application.m_ServiceManager->GetWeatherManager();
 }
+
+CPlayerCoreFactory& CServiceBroker::GetPlayerCoreFactory()
+{
+  return g_application.m_ServiceManager->GetPlayerCoreFactory();
+}

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -177,3 +177,8 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
 {
   return g_application.m_ServiceManager->GetDatabaseManager();
 }
+
+CEventLog& CServiceBroker::GetEventLog()
+{
+  return g_application.m_ServiceManager->GetEventLog();
+}

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -178,6 +178,11 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
   return g_application.m_ServiceManager->GetDatabaseManager();
 }
 
+CProfilesManager& CServiceBroker::GetProfileManager()
+{
+  return g_application.m_ServiceManager->GetProfileManager();
+}
+
 CEventLog& CServiceBroker::GetEventLog()
 {
   return g_application.m_ServiceManager->GetEventLog();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -61,6 +61,7 @@ class CWinSystemBase;
 class CRenderSystemBase;
 class CPowerManager;
 class CWeatherManager;
+class CPlayerCoreFactory;
 
 namespace KODI
 {
@@ -112,4 +113,5 @@ public:
   static CRenderSystemBase& GetRenderSystem();
   static CPowerManager& GetPowerManager();
   static CWeatherManager& GetWeatherManager();
+  static CPlayerCoreFactory &GetPlayerCoreFactory();
 };

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -63,6 +63,7 @@ class CPowerManager;
 class CWeatherManager;
 class CPlayerCoreFactory;
 class CDatabaseManager;
+class CProfilesManager;
 class CEventLog;
 
 namespace KODI
@@ -117,5 +118,6 @@ public:
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();
   static CDatabaseManager &GetDatabaseManager();
+  static CProfilesManager &GetProfileManager();
   static CEventLog &GetEventLog();
 };

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -63,6 +63,7 @@ class CPowerManager;
 class CWeatherManager;
 class CPlayerCoreFactory;
 class CDatabaseManager;
+class CEventLog;
 
 namespace KODI
 {
@@ -116,4 +117,5 @@ public:
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();
   static CDatabaseManager &GetDatabaseManager();
+  static CEventLog &GetEventLog();
 };

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -62,6 +62,7 @@ class CRenderSystemBase;
 class CPowerManager;
 class CWeatherManager;
 class CPlayerCoreFactory;
+class CDatabaseManager;
 
 namespace KODI
 {
@@ -114,4 +115,5 @@ public:
   static CPowerManager& GetPowerManager();
   static CWeatherManager& GetWeatherManager();
   static CPlayerCoreFactory &GetPlayerCoreFactory();
+  static CDatabaseManager &GetDatabaseManager();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -25,6 +25,7 @@
 #include "ContextMenuManager.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
 #include "cores/DataCacheCore.h"
+#include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "cores/RetroPlayer/rendering/GUIGameRenderManager.h"
 #include "favourites/FavouritesService.h"
 #include "games/controllers/ControllerManager.h"
@@ -208,6 +209,9 @@ bool CServiceManager::InitStageThree()
   m_contextMenuManager->Init();
   m_PVRManager->Init();
 
+  m_playerCoreFactory.reset(new CPlayerCoreFactory(*m_settings,
+                                                   CProfilesManager::GetInstance()));
+
   init_level = 3;
   return true;
 }
@@ -216,6 +220,7 @@ void CServiceManager::DeinitStageThree()
 {
   init_level = 2;
 
+  m_playerCoreFactory.reset();
   m_PVRManager->Deinit();
   m_contextMenuManager->Deinit();
   m_gameServices.reset();
@@ -434,3 +439,7 @@ CWeatherManager& CServiceManager::GetWeatherManager()
   return *m_weatherManager;
 }
 
+CPlayerCoreFactory &CServiceManager::GetPlayerCoreFactory()
+{
+  return *m_playerCoreFactory;
+}

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -68,6 +68,8 @@ bool CServiceManager::InitForTesting()
   m_settings.reset(new CSettings());
   m_network.reset(SetupNetwork());
 
+  m_profileManager.reset(new CProfilesManager(*m_settings));
+
   m_databaseManager.reset(new CDatabaseManager);
 
   m_fileExtensionProvider.reset(new CFileExtensionProvider());
@@ -89,6 +91,7 @@ void CServiceManager::DeinitTesting()
   m_addonMgr.reset();
   m_fileExtensionProvider.reset();
   m_databaseManager.reset();
+  m_profileManager.reset();
   m_network.reset();
   m_settings.reset();
 }
@@ -109,6 +112,15 @@ bool CServiceManager::InitStageOne()
   m_network.reset(SetupNetwork());
 
   init_level = 1;
+  return true;
+}
+
+bool CServiceManager::InitStageOnePointFive()
+{
+  m_profileManager.reset(new CProfilesManager(*m_settings));
+  if (!m_profileManager->Load())
+    return false;
+
   return true;
 }
 
@@ -146,14 +158,15 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
   m_binaryAddonCache.reset( new ADDON::CBinaryAddonCache());
   m_binaryAddonCache->Init();
 
-  m_favouritesService.reset(new CFavouritesService(CProfilesManager::GetInstance().GetProfileUserDataFolder()));
+  m_favouritesService.reset(new CFavouritesService(m_profileManager->GetProfileUserDataFolder()));
 
   m_serviceAddons.reset(new ADDON::CServiceAddonManager(*m_addonMgr));
 
   m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr.get()));
 
   m_gameControllerManager.reset(new GAME::CControllerManager);
-  m_inputManager.reset(new CInputManager(params));
+  m_inputManager.reset(new CInputManager(params,
+                                         *m_profileManager));
   m_inputManager->InitializeInputs();
 
   m_peripherals.reset(new PERIPHERALS::CPeripherals(*m_announcementManager,
@@ -212,13 +225,14 @@ bool CServiceManager::InitStageThree()
   m_gameServices.reset(new GAME::CGameServices(*m_gameControllerManager,
     *m_gameRenderManager,
     *m_settings,
-    *m_peripherals));
+    *m_peripherals,
+    *m_profileManager));
 
   m_contextMenuManager->Init();
   m_PVRManager->Init();
 
   m_playerCoreFactory.reset(new CPlayerCoreFactory(*m_settings,
-                                                   CProfilesManager::GetInstance()));
+                                                   *m_profileManager));
 
   init_level = 3;
   return true;
@@ -258,6 +272,11 @@ void CServiceManager::DeinitStageTwo()
   m_addonMgr.reset();
   m_Platform.reset();
   m_databaseManager.reset();
+}
+
+void CServiceManager::DeinitStageOnePointFive()
+{
+  m_profileManager.reset();
 }
 
 void CServiceManager::DeinitStageOne()
@@ -458,7 +477,12 @@ CDatabaseManager &CServiceManager::GetDatabaseManager()
   return *m_databaseManager;
 }
 
+CProfilesManager &CServiceManager::GetProfileManager()
+{
+  return *m_profileManager;
+}
+
 CEventLog &CServiceManager::GetEventLog()
 {
-  return CProfilesManager::GetInstance().GetEventLog();
+  return m_profileManager->GetEventLog();
 }

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -457,3 +457,8 @@ CDatabaseManager &CServiceManager::GetDatabaseManager()
 {
   return *m_databaseManager;
 }
+
+CEventLog &CServiceManager::GetEventLog()
+{
+  return CProfilesManager::GetInstance().GetEventLog();
+}

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -45,6 +45,7 @@
 #include "windowing/WinSystem.h"
 #include "powermanagement/PowerManager.h"
 #include "weather/WeatherManager.h"
+#include "DatabaseManager.h"
 
 using namespace KODI;
 
@@ -66,6 +67,9 @@ bool CServiceManager::InitForTesting()
 {
   m_settings.reset(new CSettings());
   m_network.reset(SetupNetwork());
+
+  m_databaseManager.reset(new CDatabaseManager);
+
   m_fileExtensionProvider.reset(new CFileExtensionProvider());
 
   m_addonMgr.reset(new ADDON::CAddonMgr());
@@ -84,6 +88,7 @@ void CServiceManager::DeinitTesting()
   init_level = 0;
   m_addonMgr.reset();
   m_fileExtensionProvider.reset();
+  m_databaseManager.reset();
   m_network.reset();
   m_settings.reset();
 }
@@ -109,6 +114,9 @@ bool CServiceManager::InitStageOne()
 
 bool CServiceManager::InitStageTwo(const CAppParamParser &params)
 {
+  // Initialize the addon database (must be before the addon manager is init'd)
+  m_databaseManager.reset(new CDatabaseManager);
+
   m_Platform.reset(CPlatform::CreateInstance());
   m_Platform->Init();
 
@@ -249,6 +257,7 @@ void CServiceManager::DeinitStageTwo()
   m_binaryAddonManager.reset();
   m_addonMgr.reset();
   m_Platform.reset();
+  m_databaseManager.reset();
 }
 
 void CServiceManager::DeinitStageOne()
@@ -442,4 +451,9 @@ CWeatherManager& CServiceManager::GetWeatherManager()
 CPlayerCoreFactory &CServiceManager::GetPlayerCoreFactory()
 {
   return *m_playerCoreFactory;
+}
+
+CDatabaseManager &CServiceManager::GetDatabaseManager()
+{
+  return *m_databaseManager;
 }

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -88,6 +88,7 @@ namespace PERIPHERALS
 class CInputManager;
 class CFileExtensionProvider;
 class CPlayerCoreFactory;
+class CDatabaseManager;
 
 class CServiceManager
 {
@@ -146,6 +147,8 @@ public:
 
   CPlayerCoreFactory &GetPlayerCoreFactory();
 
+  CDatabaseManager &GetDatabaseManager();
+
 protected:
   struct delete_dataCacheCore
   {
@@ -199,4 +202,5 @@ protected:
   std::unique_ptr<CPowerManager> m_powerManager;
   std::unique_ptr<CWeatherManager> m_weatherManager;
   std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;
+  std::unique_ptr<CDatabaseManager> m_databaseManager;
 };

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -89,6 +89,7 @@ class CInputManager;
 class CFileExtensionProvider;
 class CPlayerCoreFactory;
 class CDatabaseManager;
+class CEventLog;
 
 class CServiceManager
 {
@@ -148,6 +149,9 @@ public:
   CPlayerCoreFactory &GetPlayerCoreFactory();
 
   CDatabaseManager &GetDatabaseManager();
+
+
+  CEventLog &GetEventLog();
 
 protected:
   struct delete_dataCacheCore

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -89,6 +89,7 @@ class CInputManager;
 class CFileExtensionProvider;
 class CPlayerCoreFactory;
 class CDatabaseManager;
+class CProfilesManager;
 class CEventLog;
 
 class CServiceManager
@@ -99,6 +100,7 @@ public:
 
   bool InitForTesting();
   bool InitStageOne();
+  bool InitStageOnePointFive(); // Services that need our DllLoaders emu env
   bool InitStageTwo(const CAppParamParser &params);
   bool CreateAudioEngine();
   bool DestroyAudioEngine();
@@ -107,6 +109,7 @@ public:
   void DeinitTesting();
   void DeinitStageThree();
   void DeinitStageTwo();
+  void DeinitStageOnePointFive();
   void DeinitStageOne();
   ADDON::CAddonMgr& GetAddonMgr();
   ADDON::CBinaryAddonManager& GetBinaryAddonManager();
@@ -150,6 +153,7 @@ public:
 
   CDatabaseManager &GetDatabaseManager();
 
+  CProfilesManager &GetProfileManager();
 
   CEventLog &GetEventLog();
 
@@ -207,4 +211,5 @@ protected:
   std::unique_ptr<CWeatherManager> m_weatherManager;
   std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;
   std::unique_ptr<CDatabaseManager> m_databaseManager;
+  std::unique_ptr<CProfilesManager> m_profileManager;
 };

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -87,6 +87,7 @@ namespace PERIPHERALS
 
 class CInputManager;
 class CFileExtensionProvider;
+class CPlayerCoreFactory;
 
 class CServiceManager
 {
@@ -143,6 +144,8 @@ public:
 
   CWeatherManager &GetWeatherManager();
 
+  CPlayerCoreFactory &GetPlayerCoreFactory();
+
 protected:
   struct delete_dataCacheCore
   {
@@ -195,4 +198,5 @@ protected:
   std::unique_ptr<CWinSystemBase> m_winSystem;
   std::unique_ptr<CPowerManager> m_powerManager;
   std::unique_ptr<CWeatherManager> m_weatherManager;
+  std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;
 };

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -29,6 +29,7 @@
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "URL.h"
+#include "ServiceBroker.h"
 
 using namespace XFILE;
 
@@ -62,14 +63,19 @@ bool CTextureCache::IsCachedImage(const std::string &url) const
 {
   if (url.empty())
     return false;
+
   if (!CURL::IsFullPath(url))
     return true;
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   if (URIUtils::PathHasParent(url, "special://skin", true) ||
       URIUtils::PathHasParent(url, "special://temp", true) ||
       URIUtils::PathHasParent(url, "resource://", true) ||
       URIUtils::PathHasParent(url, "androidapp://", true)   ||
-      URIUtils::PathHasParent(url, CProfilesManager::GetInstance().GetThumbnailsFolder(), true))
+      URIUtils::PathHasParent(url, profileManager.GetThumbnailsFolder(), true))
     return true;
+
   return false;
 }
 
@@ -261,7 +267,9 @@ std::string CTextureCache::GetCacheFile(const std::string &url)
 
 std::string CTextureCache::GetCachedPath(const std::string &file)
 {
-  return URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetThumbnailsFolder(), file);
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  return URIUtils::AddFileToFolder(profileManager.GetThumbnailsFolder(), file);
 }
 
 void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -668,7 +668,9 @@ void CUtil::GetDVDDriveIcon(const std::string& strPath, std::string& strIcon)
 
 void CUtil::RemoveTempFiles()
 {
-  std::string searchPath = CProfilesManager::GetInstance().GetDatabaseFolder();
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  std::string searchPath = profileManager.GetDatabaseFolder();
   CFileItemList items;
   if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".tmp", DIR_FLAG_NO_FILE_DIRS))
     return;

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -280,7 +280,7 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   CURL zipDir = URIUtils::CreateArchivePath("zip", pathToUrl, "");
   if (!CDirectory::GetDirectory(zipDir, items) || items.Size() != 1 || !items[0]->m_bIsFolder)
   {
-    CEventLog::GetInstance().AddWithNotification(EventPtr(new CNotificationEvent(24045,
+    CServiceBroker::GetEventLog().AddWithNotification(EventPtr(new CNotificationEvent(24045,
         StringUtils::Format(g_localizeStrings.Get(24143).c_str(), path.c_str()),
         "special://xbmc/media/icon256x256.png", EventLevel::Error)));
     return false;
@@ -290,7 +290,7 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   if (CServiceBroker::GetAddonMgr().LoadAddonDescription(items[0]->GetPath(), addon))
     return DoInstall(addon, RepositoryPtr());
 
-  CEventLog::GetInstance().AddWithNotification(EventPtr(new CNotificationEvent(24045,
+  CServiceBroker::GetEventLog().AddWithNotification(EventPtr(new CNotificationEvent(24045,
       StringUtils::Format(g_localizeStrings.Get(24143).c_str(), path.c_str()),
       "special://xbmc/media/icon256x256.png", EventLevel::Error)));
   return false;
@@ -637,14 +637,14 @@ bool CAddonInstallJob::DoWork()
 
   bool notify = (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_ADDONS_NOTIFICATIONS)
         || !m_isAutoUpdate) && !IsModal();
-  CEventLog::GetInstance().Add(
+  CServiceBroker::GetEventLog().Add(
       EventPtr(new CAddonManagementEvent(m_addon, m_isUpdate ? 24065 : 24084)), notify, false);
 
   if (m_isAutoUpdate && !m_addon->Broken().empty())
   {
     CLog::Log(LOGDEBUG, "CAddonInstallJob[%s]: auto-disabling due to being marked as broken", m_addon->ID().c_str());
     CServiceBroker::GetAddonMgr().DisableAddon(m_addon->ID());
-    CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(m_addon, 24094)), true, false);
+    CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(m_addon, 24094)), true, false);
   }
 
   // and we're done!
@@ -829,7 +829,7 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
       HELPERS::ShowOKDialogText(CVariant{fileName}, CVariant{msg});
   }
 
-  CEventLog::GetInstance().Add(activity, !IsModal(), false);
+  CServiceBroker::GetEventLog().Add(activity, !IsModal(), false);
 }
 
 CAddonUnInstallJob::CAddonUnInstallJob(const AddonPtr &addon, bool removeData)
@@ -865,7 +865,7 @@ bool CAddonUnInstallJob::DoWork()
   // if that doesn't work fall back to the local one
   if (!database.Open() || !database.GetAddon(m_addon->ID(), addon) || addon == NULL)
     addon = m_addon;
-  CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24144)));
+  CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(addon, 24144)));
 
   CServiceBroker::GetAddonMgr().OnPostUnInstall(m_addon->ID());
   database.OnPostUnInstall(m_addon->ID());

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -836,7 +836,7 @@ bool CAddonMgr::DisableAddon(const std::string& id)
   AddonPtr addon;
   if (GetAddon(id, addon, ADDON_UNKNOWN, false) && addon != NULL)
   {
-    CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24141)));
+    CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(addon, 24141)));
   }
 
   m_events.Publish(AddonEvents::Disabled(id));
@@ -857,7 +857,7 @@ bool CAddonMgr::EnableSingle(const std::string& id)
   if (!IsCompatible(*addon))
   {
     CLog::Log(LOGERROR, "Add-on '%s' is not compatible with Kodi", addon->ID().c_str());
-    CEventLog::GetInstance().AddWithNotification(EventPtr(new CNotificationEvent(addon->Name(), 24152, EventLevel::Error)));
+    CServiceBroker::GetEventLog().AddWithNotification(EventPtr(new CNotificationEvent(addon->Name(), 24152, EventLevel::Error)));
     return false;
   }
 
@@ -865,7 +865,7 @@ bool CAddonMgr::EnableSingle(const std::string& id)
     return false;
   m_disabled.erase(id);
 
-  CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24064)));
+  CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(addon, 24064)));
 
   CLog::Log(LOGDEBUG, "CAddonMgr: enabled %s", addon->ID().c_str());
   m_events.Publish(AddonEvents::Enabled(id));

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -1578,7 +1578,7 @@ void CPVRClient::cb_recording(void *kodiInstance, const char *strName, const cha
 
   /* display a notification for 5 seconds */
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, strLine1, strLine2, 5000, false);
-  CEventLog::GetInstance().Add(EventPtr(new CNotificationEvent(client->Name(), strLine1, client->Icon(), strLine2)));
+  CServiceBroker::GetEventLog().Add(EventPtr(new CNotificationEvent(client->Name(), strLine1, client->Icon(), strLine2)));
 
   CLog::Log(LOGDEBUG, "PVR - %s - recording %s on client '%s'. name='%s' filename='%s'",
       __FUNCTION__, bOnOff ? "started" : "finished", client->Name().c_str(), strName, strFileName);

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -100,7 +100,7 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
               TOAST_DISPLAY_TIME, false, TOAST_DISPLAY_TIME);
 
         for (const auto &addon : updates)
-          CEventLog::GetInstance().Add(EventPtr(new CAddonManagementEvent(addon, 24068)));
+          CServiceBroker::GetEventLog().Add(EventPtr(new CAddonManagementEvent(addon, 24068)));
       }
     }
 

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -37,6 +37,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "ServiceBroker.h"
 #include "Util.h"
 
 // Global addon callback handle classes
@@ -458,7 +459,8 @@ bool CAddonDll::CheckAPIVersion(int type)
                             kodiMinVersion.asString().c_str(),
                             addonVersion.asString().c_str());
 
-    CEventLog::GetInstance().AddWithNotification(EventPtr(new CNotificationEvent(Name(), 24152, EventLevel::Error)));
+    CEventLog &eventLog = CServiceBroker::GetEventLog();
+    eventLog.AddWithNotification(EventPtr(new CNotificationEvent(Name(), 24152, EventLevel::Error)));
 
     return false;
   }

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "system.h"
-#include "cores/IPlayerCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 #include "threads/CriticalSection.h"
 #include <string>
@@ -34,12 +33,19 @@ class TiXmlElement;
 class CFileItem;
 class CPlayerCoreConfig;
 class CPlayerSelectionRule;
+class CProfilesManager;
+class CSettings;
 class IPlayer;
+class IPlayerCallback;
 
 class CPlayerCoreFactory : public ISettingsHandler
 {
 public:
-  static CPlayerCoreFactory& GetInstance();
+  CPlayerCoreFactory(CSettings &settings,
+                     const CProfilesManager &profileManager);
+  CPlayerCoreFactory(const CPlayerCoreFactory&) = delete;
+  CPlayerCoreFactory& operator=(CPlayerCoreFactory const&) = delete;
+  ~CPlayerCoreFactory() override;
 
   void OnSettingsLoaded() override;
 
@@ -59,11 +65,11 @@ public:
   void OnPlayerDiscovered(const std::string& id, const std::string& name);
   void OnPlayerRemoved(const std::string& id);
 
-protected:
-  CPlayerCoreFactory();
-  CPlayerCoreFactory(const CPlayerCoreFactory&) = delete;
-  CPlayerCoreFactory& operator=(CPlayerCoreFactory const&) = delete;
-  ~CPlayerCoreFactory() override;
+private:
+  // Construction parameters
+  CSettings &m_settings;
+  const CProfilesManager &m_profileManager;
+
   int GetPlayerIndex(const std::string& strCoreName) const;
   std::string GetPlayerName(size_t idx) const;
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -29,6 +29,7 @@
 #include "sqlitedataset.h"
 #include "DatabaseManager.h"
 #include "DbUrl.h"
+#include "ServiceBroker.h"
 
 #ifdef HAS_MYSQL
 #include "mysqldataset.h"
@@ -363,7 +364,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   }
 
   // check our database manager to see if this database can be opened
-  if (!CDatabaseManager::GetInstance().CanOpen(GetBaseDBName()))
+  if (!CServiceBroker::GetDatabaseManager().CanOpen(GetBaseDBName()))
     return false;
 
   DatabaseSettings dbSettings = settings;

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -150,7 +150,8 @@ bool CDatabase::ExistsSubQuery::BuildSQL(std::string & strSQL)
   return true;
 }
 
-CDatabase::CDatabase(void)
+CDatabase::CDatabase() :
+  m_profileManager(CServiceBroker::GetProfileManager())
 {
   m_openCount = 0;
   m_sqlite = true;
@@ -397,7 +398,7 @@ void CDatabase::InitSettings(DatabaseSettings &dbSettings)
   {
     dbSettings.type = "sqlite3";
     if (dbSettings.host.empty())
-      dbSettings.host = CSpecialProtocol::TranslatePath(CProfilesManager::GetInstance().GetDatabaseFolder());
+      dbSettings.host = CSpecialProtocol::TranslatePath(m_profileManager.GetDatabaseFolder());
   }
 
   // use separate, versioned database

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -31,6 +31,7 @@ namespace dbiplus {
 
 class DatabaseSettings; // forward
 class CDbUrl;
+class CProfilesManager;
 struct SortDescription;
 
 class CDatabase
@@ -73,7 +74,7 @@ public:
   };
 
 
-  CDatabase(void);
+  CDatabase();
   virtual ~CDatabase(void);
   bool IsOpen();
   virtual void Close();
@@ -221,6 +222,10 @@ protected:
   std::unique_ptr<dbiplus::Database> m_pDB;
   std::unique_ptr<dbiplus::Dataset> m_pDS;
   std::unique_ptr<dbiplus::Dataset> m_pDS2;
+
+protected:
+  // Construction parameters
+  const CProfilesManager &m_profileManager;
 
 private:
   void InitSettings(DatabaseSettings &dbSettings);

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -222,7 +222,7 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
   // Next, Add buttons to the ContextMenu that should ONLY be visible for sources and not autosourced items
   CMediaSource *share = GetShare(type, item.get());
 
-  if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
+  if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
   {
     if (share)
     {
@@ -244,9 +244,9 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
     if (!GetDefaultShareNameByType(type).empty())
       buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // Clear Default
   }
-  if (share && LOCK_MODE_EVERYONE != CProfilesManager::GetInstance().GetMasterProfile().getLockMode())
+  if (share && LOCK_MODE_EVERYONE != CServiceBroker::GetProfileManager().GetMasterProfile().getLockMode())
   {
-    if (share->m_iHasLock == 0 && (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
+    if (share->m_iHasLock == 0 && (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser))
       buttons.Add(CONTEXT_BUTTON_ADD_LOCK, 12332);
     else if (share->m_iHasLock == 1)
       buttons.Add(CONTEXT_BUTTON_REMOVE_LOCK, 12335);
@@ -279,7 +279,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
   switch (button)
   {
   case CONTEXT_BUTTON_EDIT_SOURCE:
-    if (CProfilesManager::GetInstance().IsMasterProfile())
+    if (CServiceBroker::GetProfileManager().IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
@@ -291,16 +291,16 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
   case CONTEXT_BUTTON_REMOVE_SOURCE:
   {
-    if (CProfilesManager::GetInstance().IsMasterProfile())
+    if (CServiceBroker::GetProfileManager().IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
     }
     else
     {
-      if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsMasterLockUnlocked(false))
+      if (!CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsMasterLockUnlocked(false))
         return false;
-      if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+      if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
         return false;
     }
     // prompt user if they want to really delete the source
@@ -318,7 +318,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
     return true;
   }
   case CONTEXT_BUTTON_SET_DEFAULT:
-    if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
     else if (!g_passwordManager.IsMasterLockUnlocked(true))
       return false;
@@ -328,7 +328,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
     return true;
 
   case CONTEXT_BUTTON_CLEAR_DEFAULT:
-    if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
     else if (!g_passwordManager.IsMasterLockUnlocked(true))
       return false;
@@ -338,7 +338,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
 
   case CONTEXT_BUTTON_SET_THUMB:
     {
-      if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+      if (CServiceBroker::GetProfileManager().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
         return false;
       else if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -429,8 +429,8 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
   OnSort();
 
   if (m_Directory->GetPath().empty() && m_addNetworkShareEnabled &&
-     (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-      CProfilesManager::GetInstance().IsMasterProfile() || g_passwordManager.bMasterUser))
+     (CServiceBroker::GetProfileManager().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      CServiceBroker::GetProfileManager().IsMasterProfile() || g_passwordManager.bMasterUser))
   { // we are in the virtual directory - add the "Add Network Location" item
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1032)));
     pItem->SetPath("net://");

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -156,9 +156,9 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       if (!startupList.empty())
       {
         int party = 0;
-        if (URIUtils::PathEquals(startupList, CProfilesManager::GetInstance().GetUserDataItem("PartyMode.xsp")))
+        if (URIUtils::PathEquals(startupList, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode.xsp")))
           party = 1;
-        else if (URIUtils::PathEquals(startupList, CProfilesManager::GetInstance().GetUserDataItem("PartyMode-Video.xsp")))
+        else if (URIUtils::PathEquals(startupList, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode-Video.xsp")))
           party = 2;
 
         if ((party && !XFILE::CFile::Exists(startupList)) ||
@@ -626,9 +626,9 @@ bool CGUIDialogSmartPlaylistEditor::EditPlaylist(const std::string &path, const 
   if (!editor) return false;
 
   editor->m_mode = type;
-  if (URIUtils::PathEquals(path, CProfilesManager::GetInstance().GetUserDataItem("PartyMode.xsp")))
+  if (URIUtils::PathEquals(path, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode.xsp")))
     editor->m_mode = "partymusic";
-  if (URIUtils::PathEquals(path, CProfilesManager::GetInstance().GetUserDataItem("PartyMode-Video.xsp")))
+  if (URIUtils::PathEquals(path, CServiceBroker::GetProfileManager().GetUserDataItem("PartyMode-Video.xsp")))
     editor->m_mode = "partyvideo";
 
   CSmartPlaylist playlist;

--- a/xbmc/events/CMakeLists.txt
+++ b/xbmc/events/CMakeLists.txt
@@ -2,12 +2,14 @@ set(SOURCES AddonEvent.cpp
             AddonManagementEvent.cpp
             BaseEvent.cpp
             EventLog.cpp
+            EventLogManager.cpp
             MediaLibraryEvent.cpp)
 
 set(HEADERS AddonEvent.h
             AddonManagementEvent.h
             BaseEvent.h
             EventLog.h
+            EventLogManager.h
             IEvent.h
             MediaLibraryEvent.h
             NotificationEvent.h

--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -32,9 +32,6 @@
 
 #include <utility>
 
-std::map<int, std::unique_ptr<CEventLog> > CEventLog::s_eventLogs;
-CCriticalSection CEventLog::s_critical;
-
 std::string CEventLog::EventLevelToString(EventLevel level)
 {
   switch (level)
@@ -66,21 +63,6 @@ EventLevel CEventLog::EventLevelFromString(const std::string& level)
     return EventLevel::Error;
 
   return EventLevel::Information;
-}
-
-CEventLog& CEventLog::GetInstance()
-{
-  int currentProfileId = CProfilesManager::GetInstance().GetCurrentProfileId();
-
-  CSingleLock lock(s_critical);
-  auto eventLog = s_eventLogs.find(currentProfileId);
-  if (eventLog == s_eventLogs.end())
-  {
-    s_eventLogs.insert(std::make_pair(currentProfileId, std::unique_ptr<CEventLog>(new CEventLog())));
-    eventLog = s_eventLogs.find(currentProfileId);
-  }
-
-  return *eventLog->second;
 }
 
 Events CEventLog::Get() const
@@ -247,16 +229,6 @@ void CEventLog::ShowFullEventLog(EventLevel level /* = EventLevel::Basic */, boo
   params.push_back(path);
   params.push_back("return");
   g_windowManager.ActivateWindow(WINDOW_EVENT_LOG, params);
-}
-
-void CEventLog::OnSettingAction(std::shared_ptr<const CSetting> setting)
-{
-  if (setting == nullptr)
-    return;
-
-  const std::string& settingId = setting->GetId();
-  if (settingId == CSettings::SETTING_EVENTLOG_SHOW)
-    ShowFullEventLog();
 }
 
 void CEventLog::SendMessage(const EventPtr& eventPtr, int message)

--- a/xbmc/events/EventLog.h
+++ b/xbmc/events/EventLog.h
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "events/IEvent.h"
-#include "settings/lib/ISettingCallback.h"
 #include "threads/CriticalSection.h"
 
 #define NOTIFICATION_DISPLAY_TIME 5000
@@ -32,12 +31,13 @@
 
 typedef std::vector<EventPtr> Events;
 
-class CEventLog : public ISettingCallback
+class CEventLog
 {
 public:
-  ~CEventLog() override = default;
-
-  static CEventLog& GetInstance();
+  CEventLog() = default;
+  CEventLog(const CEventLog&) = delete;
+  CEventLog& operator=(CEventLog const&) = delete;
+  ~CEventLog() = default;
 
   Events Get() const;
   Events Get(EventLevel level, bool includeHigherLevels = false) const;
@@ -57,18 +57,10 @@ public:
 
   bool Execute(const std::string& eventIdentifier);
 
-  std::string EventLevelToString(EventLevel level);
-  EventLevel EventLevelFromString(const std::string& level);
+  static std::string EventLevelToString(EventLevel level);
+  static EventLevel EventLevelFromString(const std::string& level);
 
   void ShowFullEventLog(EventLevel level = EventLevel::Basic, bool includeHigherLevels = true);
-
-protected:
-  CEventLog() = default;
-  CEventLog(const CEventLog&) = delete;
-  CEventLog& operator=(CEventLog const&) = delete;
-
-  // implementation of ISettingCallback
-  void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
 private:
   void SendMessage(const EventPtr& event, int message);
@@ -78,7 +70,4 @@ private:
   EventsList m_events;
   EventsMap m_eventsMap;
   CCriticalSection m_critical;
-
-  static std::map<int, std::unique_ptr<CEventLog> > s_eventLogs;
-  static CCriticalSection s_critical;
 };

--- a/xbmc/events/EventLogManager.cpp
+++ b/xbmc/events/EventLogManager.cpp
@@ -1,0 +1,39 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "EventLogManager.h"
+#include "EventLog.h"
+#include "threads/SingleLock.h"
+
+#include <utility>
+
+CEventLog& CEventLogManager::GetEventLog(unsigned int profileId)
+{
+  CSingleLock lock(m_eventMutex);
+
+  auto eventLog = m_eventLogs.find(profileId);
+  if (eventLog == m_eventLogs.end())
+  {
+    m_eventLogs.insert(std::make_pair(profileId, std::unique_ptr<CEventLog>(new CEventLog)));
+    eventLog = m_eventLogs.find(profileId);
+  }
+
+  return *eventLog->second;
+}

--- a/xbmc/events/EventLogManager.h
+++ b/xbmc/events/EventLogManager.h
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "threads/CriticalSection.h"
+
+#include <map>
+#include <memory>
+
+class CEventLog;
+
+class CEventLogManager
+{
+public:
+  CEventLog &GetEventLog(unsigned int profileId);
+
+private:
+  std::map<unsigned int, std::unique_ptr<CEventLog>> m_eventLogs;
+  CCriticalSection m_eventMutex;
+};

--- a/xbmc/events/windows/GUIWindowEventLog.cpp
+++ b/xbmc/events/windows/GUIWindowEventLog.cpp
@@ -55,7 +55,7 @@ bool CGUIWindowEventLog::OnMessage(CGUIMessage& message)
     // check if we should clear all items
     if (iControl == CONTROL_BUTTON_CLEAR)
     {
-      CEventLog::GetInstance().Clear(CViewStateSettings::GetInstance().GetEventLevel(), CViewStateSettings::GetInstance().ShowHigherEventLevels());
+      CServiceBroker::GetEventLog().Clear(CViewStateSettings::GetInstance().GetEventLevel(), CViewStateSettings::GetInstance().ShowHigherEventLevels());
 
       // refresh the list
       Refresh(true);
@@ -153,7 +153,7 @@ void CGUIWindowEventLog::GetContextButtons(int itemNumber, CContextButtons &butt
   if (eventIdentifier.empty())
     return;
 
-  EventPtr eventPtr = CEventLog::GetInstance().Get(eventIdentifier);
+  EventPtr eventPtr = CServiceBroker::GetEventLog().Get(eventIdentifier);
   if (eventPtr == nullptr)
     return;
 
@@ -218,7 +218,7 @@ bool CGUIWindowEventLog::GetDirectory(const std::string &strDirectory, CFileItem
     if (!item->HasProperty(PROPERTY_EVENT_LEVEL))
       continue;
 
-    EventLevel level = CEventLog::GetInstance().EventLevelFromString(item->GetProperty(PROPERTY_EVENT_LEVEL).asString());
+    EventLevel level = CEventLog::EventLevelFromString(item->GetProperty(PROPERTY_EVENT_LEVEL).asString());
     if (level == currentLevel ||
       (level > currentLevel && showHigherLevels))
       filteredItems.Add(item);
@@ -248,7 +248,7 @@ bool CGUIWindowEventLog::OnDelete(CFileItemPtr item)
   if (eventIdentifier.empty())
     return false;
 
-  CEventLog::GetInstance().Remove(eventIdentifier);
+  CServiceBroker::GetEventLog().Remove(eventIdentifier);
   return true;
 }
 
@@ -261,7 +261,7 @@ bool CGUIWindowEventLog::OnExecute(CFileItemPtr item)
   if (eventIdentifier.empty())
     return false;
 
-  const EventPtr eventPtr = CEventLog::GetInstance().Get(eventIdentifier);
+  const EventPtr eventPtr = CServiceBroker::GetEventLog().Get(eventIdentifier);
   if (eventPtr == nullptr)
     return false;
 

--- a/xbmc/filesystem/EventsDirectory.cpp
+++ b/xbmc/filesystem/EventsDirectory.cpp
@@ -23,6 +23,7 @@
 #include "URL.h"
 #include "events/EventLog.h"
 #include "utils/StringUtils.h"
+#include "ServiceBroker.h"
 
 using namespace XFILE;
 
@@ -31,7 +32,7 @@ bool CEventsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   items.ClearProperties();
   items.SetContent("events");
 
-  CEventLog& log = CEventLog::GetInstance();
+  CEventLog& log = CServiceBroker::GetEventLog();
   Events events;
 
   std::string hostname = url.GetHostName();
@@ -50,7 +51,7 @@ bool CEventsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       hostname = hostname.substr(0, hostname.size() - 1);
     }
 
-    EventLevel level = CEventLog::GetInstance().EventLevelFromString(hostname);
+    EventLevel level = CEventLog::EventLevelFromString(hostname);
 
     // get the events of the specified level(s)
     events = log.Get(level, includeHigherLevels);
@@ -70,7 +71,7 @@ CFileItemPtr CEventsDirectory::EventToFileItem(const EventPtr& eventItem)
   CFileItemPtr item(new CFileItem(eventItem));
 
   item->SetProperty(PROPERTY_EVENT_IDENTIFIER, eventItem->GetIdentifier());
-  item->SetProperty(PROPERTY_EVENT_LEVEL, CEventLog::GetInstance().EventLevelToString(eventItem->GetLevel()));
+  item->SetProperty(PROPERTY_EVENT_LEVEL, CEventLog::EventLevelToString(eventItem->GetLevel()));
   item->SetProperty(PROPERTY_EVENT_DESCRIPTION, eventItem->GetDescription());
 
   return item;

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -41,9 +41,15 @@ bool CFavouritesDirectory::Exists(const CURL& url)
 {
   if (url.IsProtocol("favourites"))
   {
-    return XFILE::CFile::Exists("special://xbmc/system/favourites.xml")
-        || XFILE::CFile::Exists(URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetProfileUserDataFolder(), "favourites.xml"));
+    if (XFILE::CFile::Exists("special://xbmc/system/favourites.xml"))
+      return true;
+
+    std::string favouritesXml = URIUtils::AddFileToFolder(m_profileManager.GetProfileUserDataFolder(),
+        "favourites.xml");
+
+    return XFILE::CFile::Exists(favouritesXml);
   }
+
   return XFILE::CDirectory::Exists(url);
 }
 } // namespace XFILE

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -25,11 +25,13 @@
 #include "PasswordManager.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
+#include "ServiceBroker.h"
 
 using namespace KODI::MESSAGING;
 using namespace XFILE;
 
-IDirectory::IDirectory(void)
+IDirectory::IDirectory() :
+  m_profileManager(CServiceBroker::GetProfileManager())
 {
   m_flags = DIR_FLAG_DEFAULTS;
 }

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -23,6 +23,7 @@
 #include "utils/Variant.h"
 
 class CFileItemList;
+class CProfilesManager;
 class CURL;
 
 namespace XFILE
@@ -59,7 +60,7 @@ namespace XFILE
 class IDirectory
 {
 public:
-  IDirectory(void);
+  IDirectory();
   virtual ~IDirectory(void);
   /*!
    \brief Get the \e items of the directory \e strPath.
@@ -169,6 +170,9 @@ protected:
    \sa ProcessRequirements
    */
   void RequireAuthentication(const CURL& url);
+
+  // Construction parameters
+  const CProfilesManager &m_profileManager;
 
   std::string m_strFileMask;  ///< Holds the file mask specified by SetMask()
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -165,7 +165,7 @@ bool CLibraryDirectory::Exists(const CURL& url)
 
 std::string CLibraryDirectory::GetNode(const CURL& url)
 {
-  std::string libDir = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetLibraryFolder(), url.GetHostName() + "/");
+  std::string libDir = URIUtils::AddFileToFolder(m_profileManager.GetLibraryFolder(), url.GetHostName() + "/");
   if (!CDirectory::Exists(libDir))
     libDir = URIUtils::AddFileToFolder("special://xbmc/system/library/", url.GetHostName() + "/");
 

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -96,7 +96,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       strIcon = "DefaultHardDisk.png";
     
     pItem->SetIconImage(strIcon);
-    if (share.m_iHasLock == 2 && CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+    if (share.m_iHasLock == 2 && m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_LOCKED);
     else
       pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_NONE);

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -35,6 +35,18 @@
 #include "utils/StringUtils.h"
 #endif
 
+const CProfilesManager *CSpecialProtocol::m_profileManager = nullptr;
+
+void CSpecialProtocol::RegisterProfileManager(const CProfilesManager &profileManager)
+{
+  m_profileManager = &profileManager;
+}
+
+void CSpecialProtocol::UnregisterProfileManager()
+{
+  m_profileManager = nullptr;
+}
+
 void CSpecialProtocol::SetProfilePath(const std::string &dir)
 {
   SetPath("profile", dir);
@@ -149,12 +161,12 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
 
   if (RootDir == "subtitles")
     translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH), FileName);
-  else if (RootDir == "userdata")
-    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetUserDataFolder(), FileName);
-  else if (RootDir == "database")
-    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetDatabaseFolder(), FileName);
-  else if (RootDir == "thumbnails")
-    translatedPath = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetThumbnailsFolder(), FileName);
+  else if (RootDir == "userdata" && m_profileManager)
+    translatedPath = URIUtils::AddFileToFolder(m_profileManager->GetUserDataFolder(), FileName);
+  else if (RootDir == "database" && m_profileManager)
+    translatedPath = URIUtils::AddFileToFolder(m_profileManager->GetDatabaseFolder(), FileName);
+  else if (RootDir == "thumbnails" && m_profileManager)
+    translatedPath = URIUtils::AddFileToFolder(m_profileManager->GetThumbnailsFolder(), FileName);
   else if (RootDir == "recordings" || RootDir == "cdrips")
     translatedPath = URIUtils::AddFileToFolder(CServiceBroker::GetSettings().GetString(CSettings::SETTING_AUDIOCDS_RECORDINGPATH), FileName);
   else if (RootDir == "screenshots")

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <string>
 
+class CProfilesManager;
+
 // static class for path translation from our special:// URLs.
 
 /* paths are as follows:
@@ -53,6 +55,9 @@ class CURL;
 class CSpecialProtocol
 {
 public:
+  static void RegisterProfileManager(const CProfilesManager &profileManager);
+  static void UnregisterProfileManager();
+
   static void SetProfilePath(const std::string &path);
   static void SetXBMCPath(const std::string &path);
   static void SetXBMCBinPath(const std::string &path);
@@ -74,6 +79,8 @@ public:
   static std::string TranslatePathConvertCase(const std::string& path);
 
 private:
+  static const CProfilesManager *m_profileManager;
+
   static void SetPath(const std::string &key, const std::string &path);
   static std::string GetPath(const std::string &key);
 

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -23,6 +23,7 @@
 #include "controllers/ControllerManager.h"
 #include "games/ports/PortManager.h"
 #include "games/GameSettings.h"
+#include "profiles/ProfilesManager.h"
 
 using namespace KODI;
 using namespace GAME;
@@ -30,9 +31,11 @@ using namespace GAME;
 CGameServices::CGameServices(CControllerManager &controllerManager,
                              RETRO:: CGUIGameRenderManager &renderManager,
                              CSettings &settings,
-                             PERIPHERALS::CPeripherals &peripheralManager) :
+                             PERIPHERALS::CPeripherals &peripheralManager,
+                             const CProfilesManager &profileManager) :
   m_controllerManager(controllerManager),
   m_gameRenderManager(renderManager),
+  m_profileManager(profileManager),
   m_gameSettings(new CGameSettings(settings)),
   m_portManager(new CPortManager(peripheralManager))
 {
@@ -53,6 +56,11 @@ ControllerPtr CGameServices::GetDefaultController()
 ControllerVector CGameServices::GetControllers()
 {
   return m_controllerManager.GetControllers();
+}
+
+std::string CGameServices::GetSavestatesFolder() const
+{
+  return m_profileManager.GetSavestatesFolder();
 }
 
 CPortManager& CGameServices::PortManager()

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 
+class CProfilesManager;
 class CSettings;
 
 namespace PERIPHERALS
@@ -50,12 +51,15 @@ namespace GAME
     CGameServices(CControllerManager &controllerManager,
                   RETRO::CGUIGameRenderManager &renderManager,
                   CSettings &settings,
-                  PERIPHERALS::CPeripherals &peripheralManager);
+                  PERIPHERALS::CPeripherals &peripheralManager,
+                  const CProfilesManager &profileManager);
     ~CGameServices();
 
     ControllerPtr GetController(const std::string& controllerId);
     ControllerPtr GetDefaultController();
     ControllerVector GetControllers();
+
+    std::string GetSavestatesFolder() const;
 
     CGameSettings& GameSettings() { return *m_gameSettings; }
     CPortManager& PortManager();
@@ -66,6 +70,7 @@ namespace GAME
     // Construction parameters
     CControllerManager &m_controllerManager;
     RETRO::CGUIGameRenderManager &m_gameRenderManager;
+    const CProfilesManager &m_profileManager;
 
     // Game services
     std::unique_ptr<CGameSettings> m_gameSettings;

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -39,7 +39,6 @@
 #include "guilib/WindowIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
@@ -228,7 +227,8 @@ bool CGameClient::Initialize(void)
     CDirectory::Create(Profile());
 
   // Ensure directory exists for savestates
-  std::string savestatesDir = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetSavestatesFolder(), ID());
+  const CGameServices &gameServices = CServiceBroker::GetGameServices();
+  std::string savestatesDir = URIUtils::AddFileToFolder(gameServices.GetSavestatesFolder(), ID());
   if (!CDirectory::Exists(savestatesDir))
     CDirectory::Create(savestatesDir);
 

--- a/xbmc/games/addons/GameClientInGameSaves.cpp
+++ b/xbmc/games/addons/GameClientInGameSaves.cpp
@@ -24,9 +24,10 @@
 #include "GameClientTranslator.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
-#include "profiles/ProfilesManager.h"
+#include "games/GameServices.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "ServiceBroker.h"
 
 #include <assert.h>
 
@@ -59,7 +60,8 @@ void CGameClientInGameSaves::Save()
 
 std::string CGameClientInGameSaves::GetPath(GAME_MEMORY memoryType)
 {
-  std::string path = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetSavestatesFolder(), INGAME_SAVES_DIRECTORY);
+  const CGameServices &gameServices = CServiceBroker::GetGameServices();
+  std::string path = URIUtils::AddFileToFolder(gameServices.GetSavestatesFolder(), INGAME_SAVES_DIRECTORY);
   if (!XFILE::CDirectory::Exists(path))
     XFILE::CDirectory::Create(path);
 

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -36,9 +36,20 @@ CIRTranslator::CIRTranslator(const CProfilesManager &profileManager) :
 {
 }
 
-void CIRTranslator::Load()
+bool CIRTranslator::HasIR()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+  return true;
+#else
+  return false;
+#endif
+}
+
+void CIRTranslator::Load()
+{
+  if (!HasIR())
+    return;
+
   Clear();
 
   std::string irMapName;
@@ -64,7 +75,6 @@ void CIRTranslator::Load()
 
   if (!success)
     CLog::Log(LOGERROR, "CIRTranslator::Load - unable to load remote map %s", irMapName.c_str());
-#endif
 }
 
 bool CIRTranslator::LoadIRMap(const std::string &irMapPath)

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -31,6 +31,11 @@
 #include <stdlib.h>
 #include <vector>
 
+CIRTranslator::CIRTranslator(const CProfilesManager &profileManager) :
+  m_profileManager(profileManager)
+{
+}
+
 void CIRTranslator::Load()
 {
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
@@ -51,7 +56,7 @@ void CIRTranslator::Load()
   else
     CLog::Log(LOGDEBUG, "CIRTranslator::Load - no system %s found, skipping", irMapName.c_str());
 
-  irMapPath = CProfilesManager::GetInstance().GetUserDataItem(irMapName);
+  irMapPath = m_profileManager.GetUserDataItem(irMapName);
   if (XFILE::CFile::Exists(irMapPath))
     success |= LoadIRMap(irMapPath);
   else

--- a/xbmc/input/IRTranslator.h
+++ b/xbmc/input/IRTranslator.h
@@ -50,6 +50,8 @@ private:
   bool LoadIRMap(const std::string &irMapPath);
   void MapRemote(TiXmlNode *pRemote, const std::string &szDevice);
 
+  static bool HasIR();
+
   // Construction parameters
   const CProfilesManager &m_profileManager;
 

--- a/xbmc/input/IRTranslator.h
+++ b/xbmc/input/IRTranslator.h
@@ -23,12 +23,13 @@
 #include <memory>
 #include <string>
 
+class CProfilesManager;
 class TiXmlNode;
 
 class CIRTranslator
 {
 public:
-  CIRTranslator() = default;
+  CIRTranslator(const CProfilesManager &profileManager);
 
   /*!
    * \brief Loads Lircmap.xml/IRSSmap.xml
@@ -48,6 +49,9 @@ public:
 private:
   bool LoadIRMap(const std::string &irMapPath);
   void MapRemote(TiXmlNode *pRemote, const std::string &szDevice);
+
+  // Construction parameters
+  const CProfilesManager &m_profileManager;
 
   using IRButtonMap = std::map<std::string, std::string>;
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -70,10 +70,11 @@ using EVENTSERVER::CEventServer;
 using namespace KODI;
 using namespace MESSAGING;
 
-CInputManager::CInputManager(const CAppParamParser &params) :
+CInputManager::CInputManager(const CAppParamParser &params,
+                             const CProfilesManager &profileManager) :
   m_keymapEnvironment(new CKeymapEnvironment),
   m_buttonTranslator(new CButtonTranslator),
-  m_irTranslator(new CIRTranslator),
+  m_irTranslator(new CIRTranslator(profileManager)),
   m_customControllerTranslator(new CCustomControllerTranslator),
   m_touchTranslator(new CTouchTranslator),
   m_joystickTranslator(new CJoystickMapper),

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -48,6 +48,7 @@ class CCustomControllerTranslator;
 class CIRTranslator;
 class CJoystickMapper;
 class CKey;
+class CProfilesManager;
 class CTouchTranslator;
 class IKeymapEnvironment;
 class IWindowKeymap;
@@ -87,7 +88,8 @@ class CInputManager : public ISettingCallback,
                       public Observable
 {
 public:
-  explicit CInputManager(const CAppParamParser &params);
+  explicit CInputManager(const CAppParamParser &params,
+                         const CProfilesManager &profileManager);
   CInputManager(const CInputManager&) = delete;
   CInputManager const& operator=(CInputManager const&) = delete;
   ~CInputManager() override;

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -45,11 +45,13 @@ using namespace KODI::MESSAGING;
  */
 static int LoadProfile(const std::vector<std::string>& params)
 {
-  int index = CProfilesManager::GetInstance().GetProfileIndex(params[0]);
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  int index = profileManager.GetProfileIndex(params[0]);
   bool prompt = (params.size() == 2 && StringUtils::EqualsNoCase(params[1], "prompt"));
   bool bCanceled;
   if (index >= 0
-      && (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
+      && (profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
         || g_passwordManager.IsProfileLockUnlocked(index,bCanceled,prompt)))
   {
     CApplicationMessenger::GetInstance().PostMsg(TMSG_LOADPROFILE, index);
@@ -77,7 +79,11 @@ static int LogOff(const std::vector<std::string>& params)
     CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
   CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
-  CProfilesManager::GetInstance().LoadMasterProfileForLogin();
+
+
+  CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  profileManager.LoadMasterProfileForLogin();
+
   g_passwordManager.bMasterUser = false;
 
   g_application.WakeUpScreenSaverAndDPMS();

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -82,20 +82,22 @@ JSONRPC_STATUS CPlayerOperations::GetActivePlayers(const std::string &method, IT
 
 JSONRPC_STATUS CPlayerOperations::GetPlayers(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
+  const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
   std::string media = parameterObject["media"].asString();
   result = CVariant(CVariant::VariantTypeArray);
   std::vector<std::string> players;
 
   if (media == "all")
   {
-    CPlayerCoreFactory::GetInstance().GetPlayers(players);
+    playerCoreFactory.GetPlayers(players);
   }
   else
   {
     bool video = false;
     if (media == "video")
       video = true;
-    CPlayerCoreFactory::GetInstance().GetPlayers(players, true, video);
+    playerCoreFactory.GetPlayers(players, true, video);
   }
 
   for (auto playername: players)
@@ -103,9 +105,9 @@ JSONRPC_STATUS CPlayerOperations::GetPlayers(const std::string &method, ITranspo
     CVariant player(CVariant::VariantTypeObject);
     player["name"] = playername;
 
-    player["playsvideo"] = CPlayerCoreFactory::GetInstance().PlaysVideo(playername);
-    player["playsaudio"] = CPlayerCoreFactory::GetInstance().PlaysAudio(playername);
-    player["type"] = CPlayerCoreFactory::GetInstance().GetPlayerType(playername);
+    player["playsvideo"] = playerCoreFactory.PlaysVideo(playername);
+    player["playsaudio"] = playerCoreFactory.PlaysAudio(playername);
+    player["type"] = playerCoreFactory.GetPlayerType(playername);
 
     result.push_back(player);
   }
@@ -643,13 +645,16 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
 
             if (playername != "default")
             {
+              const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
               // check if the there's actually a player with the given name
-              if (CPlayerCoreFactory::GetInstance().GetPlayerType(playername).empty())
+              if (playerCoreFactory.GetPlayerType(playername).empty())
                 return InvalidParams;
 
               // check if the player can handle at least the first item in the list
               std::vector<std::string> possiblePlayers;
-              CPlayerCoreFactory::GetInstance().GetPlayers(*list.Get(0).get(), possiblePlayers);
+              playerCoreFactory.GetPlayers(*list.Get(0).get(), possiblePlayers);
+
               bool match = false;
               for (auto entry : possiblePlayers)
               {

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3387,12 +3387,12 @@ bool CMusicDatabase::LookupCDDBInfo(bool bRequery/*=false*/)
   if (bRequery)
   {
     std::string strFile = StringUtils::Format("%x.cddb", pCdInfo->GetCddbDiscId());
-    CFile::Delete(URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetCDDBFolder(), strFile));
+    CFile::Delete(URIUtils::AddFileToFolder(m_profileManager.GetCDDBFolder(), strFile));
   }
 
   // Prepare cddb
   Xcddb cddb;
-  cddb.setCacheDir(CProfilesManager::GetInstance().GetCDDBFolder());
+  cddb.setCacheDir(m_profileManager.GetCDDBFolder());
 
   // Do we have to look for cddb information
   if (pCdInfo->HasCDDBInfo() && !cddb.isCDCached(pCdInfo))
@@ -3478,7 +3478,7 @@ void CMusicDatabase::DeleteCDDBInfo()
 {
 #ifdef HAS_DVD_DRIVE
   CFileItemList items;
-  if (!CDirectory::GetDirectory(CProfilesManager::GetInstance().GetCDDBFolder(), items, ".cddb", DIR_FLAG_NO_FILE_DIRS))
+  if (!CDirectory::GetDirectory(m_profileManager.GetCDDBFolder(), items, ".cddb", DIR_FLAG_NO_FILE_DIRS))
   {
     HELPERS::ShowOKDialogText(CVariant{313}, CVariant{426});
     return ;
@@ -3500,7 +3500,7 @@ void CMusicDatabase::DeleteCDDBInfo()
       strFile.erase(strFile.size() - 5, 5);
       ULONG lDiscId = strtoul(strFile.c_str(), NULL, 16);
       Xcddb cddb;
-      cddb.setCacheDir(CProfilesManager::GetInstance().GetCDDBFolder());
+      cddb.setCacheDir(m_profileManager.GetCDDBFolder());
 
       if (!cddb.queryCache(lDiscId))
         continue;
@@ -3536,7 +3536,7 @@ void CMusicDatabase::DeleteCDDBInfo()
       if (i.second == strSelectedAlbum)
       {
         std::string strFile = StringUtils::Format("%x.cddb", (unsigned int) i.first);
-        CFile::Delete(URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetCDDBFolder(), strFile));
+        CFile::Delete(URIUtils::AddFileToFolder(m_profileManager.GetCDDBFolder(), strFile));
         break;
       }
     }

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -39,6 +39,7 @@
 #include "music/MusicThumbLoader.h"
 #include "music/windows/GUIWindowMusicNav.h"
 #include "filesystem/Directory.h"
+#include "ServiceBroker.h"
 
 using namespace XFILE;
 
@@ -292,8 +293,10 @@ void CGUIDialogMusicInfo::Update()
 
   }
 
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   // disable the GetThumb button if the user isn't allowed it
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
 }
 
 void CGUIDialogMusicInfo::SetLabel(int iControl, const std::string& strLabel)

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1221,7 +1221,7 @@ loop:
     }
     else
     {
-      CEventLog::GetInstance().Add(EventPtr(new CMediaLibraryEvent(
+      CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
         MediaTypeAlbum, album.strPath, 24146,
         StringUtils::Format(g_localizeStrings.Get(24147).c_str(), MediaTypeAlbum, album.strAlbum.c_str()),
         CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb()), CURL::GetRedacted(album.strPath), EventLevel::Warning)));
@@ -1263,7 +1263,7 @@ loop:
     }
     else
     {
-      CEventLog::GetInstance().Add(EventPtr(new CMediaLibraryEvent(
+      CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
         MediaTypeArtist, artist.strPath, 24146,
         StringUtils::Format(g_localizeStrings.Get(24147).c_str(), MediaTypeArtist, artist.strArtist.c_str()),
         CScraperUrl::GetThumbURL(artist.thumbURL.GetFirstThumb()), CURL::GetRedacted(artist.strPath), EventLevel::Warning)));

--- a/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
@@ -25,6 +25,7 @@
 #include "profiles/ProfilesManager.h"
 #include "storage/MediaManager.h"
 #include "utils/log.h"
+#include "ServiceBroker.h"
 
 using namespace MUSIC_INFO;
 
@@ -56,9 +57,11 @@ bool CMusicInfoTagLoaderCDDA::Load(const std::string& strFileName, CMusicInfoTag
     if (pCdInfo == NULL)
       return bResult;
 
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
     // Prepare cddb
     Xcddb cddb;
-    cddb.setCacheDir(CProfilesManager::GetInstance().GetCDDBFolder());
+    cddb.setCacheDir(profileManager.GetCDDBFolder());
 
     int iTrack = atoi(strFileName.substr(13, strFileName.size() - 13 - 5).c_str());
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -379,7 +379,9 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CFileItem *pItem, bool bShowInfo 
     // Check if the entry should be refreshed (Only happens if a user pressed refresh)
     if (refresh)
     {
-      if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+      const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+      if (!profileManager.GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
         break; // should display a dialog saying no permissions
 
       if (g_application.IsMusicScanning())
@@ -451,7 +453,9 @@ bool CGUIWindowMusicBase::ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo /
     // Check if the entry should be refreshed (Only happens if a user pressed refresh)
     if (refresh)
     {
-      if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+      const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+      if (!profileManager.GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
       {
         //! @todo should display a dialog saying no permissions
         if (m_dlgProgress)
@@ -750,6 +754,8 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
   if (item)
   {
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
     if (item && !item->IsParentFolder())
     {
       if (item->CanQueue() && !item->IsAddonsPath() && !item->IsScript())
@@ -793,7 +799,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
           !item->IsPlugin() && !item->IsMusicDb()         &&
           !item->IsLibraryFolder() &&
           !StringUtils::StartsWithNoCase(item->GetPath(), "addons://")              &&
-          (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+          (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
@@ -811,7 +817,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
     // enable CDDB lookup if the current dir is CDDA
     if (g_mediaManager.IsDiscInDrive() && m_vecItems->IsCDDA() &&
-       (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+       (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       buttons.Add(CONTEXT_BUTTON_CDDB, 16002);
     }
@@ -1090,10 +1096,12 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
 
 void CGUIWindowMusicBase::UpdateThumb(const CAlbum &album, const std::string &path)
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   // check user permissions
   bool saveDb = album.idAlbum != -1;
   bool saveDirThumb = true;
-  if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+  if (!profileManager.GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
   {
     saveDb = false;
     saveDirThumb = false;
@@ -1242,7 +1250,9 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
     // add in the "New Playlist" item if we're in the playlists folder
     if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))
     {
-      CFileItemPtr newPlaylist(new CFileItem(CProfilesManager::GetInstance().GetUserDataItem("PartyMode.xsp"),false));
+      const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+      CFileItemPtr newPlaylist(new CFileItem(profileManager.GetUserDataItem("PartyMode.xsp"),false));
       newPlaylist->SetLabel(g_localizeStrings.Get(16035));
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetIconImage("DefaultPartyMode.png");

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -763,9 +763,12 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
           buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208); // Play
         }
         else
-        { // check what players we have, if we have multiple display play with option
+        {
+          const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
+          // check what players we have, if we have multiple display play with option
           std::vector<std::string> players;
-          CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
+          playerCoreFactory.GetPlayers(*item, players);
           if (players.size() >= 1)
             buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...
         }
@@ -868,9 +871,11 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_PLAY_WITH:
     {
+      const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
       std::vector<std::string> players;
-      CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
-      std::string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+      playerCoreFactory.GetPlayers(*item, players);
+      std::string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
         OnClick(itemNumber, player);
       return true;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -578,6 +578,8 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
     item = m_vecItems->Get(itemNumber);
   if (item)
   {
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
     // are we in the playlists location?
     bool inPlaylists = m_vecItems->IsPath(CUtil::MusicPlaylistsLocation()) ||
       m_vecItems->IsPath("special://musicplaylists/");
@@ -605,7 +607,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         !item->IsPath("add") && !item->IsParentFolder() &&
         !item->IsPlugin() &&
         !StringUtils::StartsWithNoCase(item->GetPath(), "addons://") &&
-        (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+        (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
@@ -668,7 +670,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
         if (item->HasVideoInfoTag() && !item->m_bIsFolder)
         {
-          if ((CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
+          if ((profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !item->IsPlugin())
           {
             buttons.Add(CONTEXT_BUTTON_RENAME, 16105);
             buttons.Add(CONTEXT_BUTTON_DELETE, 646);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -603,7 +603,9 @@ bool CGUIWindowMusicPlayList::OnContextButton(int itemNumber, CONTEXT_BUTTON but
 
   case CONTEXT_BUTTON_EDIT_PARTYMODE:
   {
-    std::string playlist = CProfilesManager::GetInstance().GetUserDataItem("PartyMode.xsp");
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+    std::string playlist = profileManager.GetUserDataItem("PartyMode.xsp");
     if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist))
     {
       // apply new rules

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -512,10 +512,13 @@ void CGUIWindowMusicPlayList::GetContextButtons(int itemNumber, CContextButtons 
       buttons.Add(CONTEXT_BUTTON_CANCEL_MOVE, 13253);
     }
     else
-    { // aren't in a move
+    {
+      const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
+      // aren't in a move
       // check what players we have, if we have multiple display play with option
       std::vector<std::string> players;
-      CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
+      playerCoreFactory.GetPlayers(*item, players);
       if (players.size() > 1)
         buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...
 
@@ -553,9 +556,11 @@ bool CGUIWindowMusicPlayList::OnContextButton(int itemNumber, CONTEXT_BUTTON but
       if (!item)
         break;
 
+      const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
       std::vector<std::string> players;
-      CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
-      std::string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+      playerCoreFactory.GetPlayers(*item, players);
+      std::string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
         OnClick(itemNumber, player);
       return true;

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -662,8 +662,10 @@ CUPnP::StartServer()
 {
     if (!m_ServerHolder->m_Device.IsNull()) return false;
 
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
     // load upnpserver.xml
-    std::string filename = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetUserDataFolder(), "upnpserver.xml");
+    std::string filename = URIUtils::AddFileToFolder(profileManager.GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::GetInstance().Load(filename);
 
     // create the server with a XBox compatible friendlyname and UUID from upnpserver.xml if found
@@ -742,7 +744,9 @@ bool CUPnP::StartRenderer()
 {
     if (!m_RendererHolder->m_Device.IsNull()) return false;
 
-    std::string filename = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetUserDataFolder(), "upnpserver.xml");
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+    std::string filename = URIUtils::AddFileToFolder(profileManager.GetUserDataFolder(), "upnpserver.xml");
     CUPnPSettings::GetInstance().Load(filename);
 
     m_RendererHolder->m_Device = CreateRenderer(CUPnPSettings::GetInstance().GetRendererPort());

--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -383,7 +383,9 @@ public:
     if (device->GetUUID().IsEmpty() || device->GetUUID().GetChars() == NULL)
       return false;
 
-    CPlayerCoreFactory::GetInstance().OnPlayerDiscovered((const char*)device->GetUUID()
+    CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
+    playerCoreFactory.OnPlayerDiscovered((const char*)device->GetUUID()
                                           ,(const char*)device->GetFriendlyName());
     
     m_registeredRenderers.insert(std::string(device->GetUUID().GetChars()));
@@ -403,7 +405,9 @@ public:
 private:
   void unregisterRenderer(const std::string &deviceUUID)
   {
-    CPlayerCoreFactory::GetInstance().OnPlayerRemoved(deviceUUID);
+    CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
+    playerCoreFactory.OnPlayerRemoved(deviceUUID);
   }
 
   std::set<std::string> m_registeredRenderers;

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -33,6 +33,8 @@
 #include "Util.h"
 #include "addons/Skin.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "events/EventLog.h"
+#include "events/EventLogManager.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/File.h"
@@ -75,10 +77,14 @@ CProfilesManager::CProfilesManager()
     m_autoLoginProfile(-1),
     m_lastUsedProfile(0),
     m_currentProfile(0),
-    m_nextProfileId(0)
-{ }
+    m_nextProfileId(0),
+    m_eventLogs(new CEventLogManager)
+{
+}
 
-CProfilesManager::~CProfilesManager() = default;
+CProfilesManager::~CProfilesManager()
+{
+}
 
 CProfilesManager& CProfilesManager::GetInstance()
 {
@@ -533,6 +539,21 @@ std::string CProfilesManager::GetUserDataItem(const std::string& strFile) const
     path = "special://masterprofile/" + strFile;
 
   return path;
+}
+
+CEventLog& CProfilesManager::GetEventLog()
+{
+  return m_eventLogs->GetEventLog(GetCurrentProfileId());
+}
+
+void CProfilesManager::OnSettingAction(std::shared_ptr<const CSetting> setting)
+{
+  if (setting == nullptr)
+    return;
+
+  const std::string& settingId = setting->GetId();
+  if (settingId == CSettings::SETTING_EVENTLOG_SHOW)
+    GetEventLog().ShowFullEventLog();
 }
 
 void CProfilesManager::SetCurrentProfileId(size_t profileId)

--- a/xbmc/profiles/ProfilesManager.cpp
+++ b/xbmc/profiles/ProfilesManager.cpp
@@ -262,7 +262,7 @@ bool CProfilesManager::LoadProfile(size_t index)
 
   CreateProfileFolders();
 
-  CDatabaseManager::GetInstance().Initialize();
+  CServiceBroker::GetDatabaseManager().Initialize();
   CServiceBroker::GetInputManager().LoadKeymaps();
 
   CServiceBroker::GetInputManager().SetMouseEnabled(CServiceBroker::GetSettings().GetBool(CSettings::SETTING_INPUT_ENABLEMOUSE));

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -30,13 +30,17 @@
 
 class CEventLog;
 class CEventLogManager;
+class CSettings;
 class TiXmlNode;
 
-class CProfilesManager : public ISettingsHandler,
-                         public ISettingCallback
+class CProfilesManager : protected ISettingsHandler,
+                         protected ISettingCallback
 {
 public:
-  static CProfilesManager& GetInstance();
+  CProfilesManager(CSettings &settings);
+  CProfilesManager(const CProfilesManager&) = delete;
+  CProfilesManager& operator=(CProfilesManager const&) = delete;
+  ~CProfilesManager() override;
 
   void OnSettingsLoaded() override;
   void OnSettingsSaved() const override;
@@ -186,11 +190,6 @@ public:
   CEventLog &GetEventLog();
 
 protected:
-  CProfilesManager();
-  CProfilesManager(const CProfilesManager&) = delete;
-  CProfilesManager& operator=(CProfilesManager const&) = delete;
-  ~CProfilesManager() override;
-
   // implementation of ISettingCallback
   void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
@@ -199,6 +198,9 @@ private:
     \param profileId profile index
     */
   void SetCurrentProfileId(size_t profileId);
+
+  // Construction parameters
+  CSettings &m_settings;
 
   std::vector<CProfile> m_profiles;
   bool m_usingLoginScreen;

--- a/xbmc/profiles/ProfilesManager.h
+++ b/xbmc/profiles/ProfilesManager.h
@@ -19,16 +19,21 @@
  *
  */
 
+#include <memory>
 #include <stdint.h>
 #include <vector>
 
 #include "profiles/Profile.h"
+#include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 #include "threads/CriticalSection.h"
 
+class CEventLog;
+class CEventLogManager;
 class TiXmlNode;
 
-class CProfilesManager : public ISettingsHandler
+class CProfilesManager : public ISettingsHandler,
+                         public ISettingCallback
 {
 public:
   static CProfilesManager& GetInstance();
@@ -177,11 +182,17 @@ public:
   // uses HasSlashAtEnd to determine if a directory or file was meant
   std::string GetUserDataItem(const std::string& strFile) const;
 
+  // Event log access
+  CEventLog &GetEventLog();
+
 protected:
   CProfilesManager();
   CProfilesManager(const CProfilesManager&) = delete;
   CProfilesManager& operator=(CProfilesManager const&) = delete;
   ~CProfilesManager() override;
+
+  // implementation of ISettingCallback
+  void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
 
 private:
   /*! \brief Set the current profile id and update the special://profile path
@@ -197,4 +208,7 @@ private:
   uint32_t m_currentProfile; // do not modify directly, use SetCurrentProfileId() function instead
   int m_nextProfileId; // for tracking the next available id to give to a new profile to ensure id's are not re-used
   CCriticalSection m_critical;
+
+  // Event properties
+  std::unique_ptr<CEventLogManager> m_eventLogs;
 };

--- a/xbmc/pvr/PVRJobs.cpp
+++ b/xbmc/pvr/PVRJobs.cpp
@@ -102,7 +102,7 @@ bool CPVREventlogJob::DoWork()
         event.m_bError ? CGUIDialogKaiToast::Error : CGUIDialogKaiToast::Info, event.m_label.c_str(), event.m_msg, 5000, true);
 
     // Write event log entry.
-    CEventLog::GetInstance().Add(
+    CServiceBroker::GetEventLog().Add(
       EventPtr(new CNotificationEvent(event.m_label, event.m_msg, event.m_icon, event.m_bError ? EventLevel::Error : EventLevel::Information)));
   }
   return true;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -337,7 +337,10 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo(CGUIMessage &message)
   CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
   if (!pItem)
     return false;
-  if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profileManager.GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
     return false;
 
   // setup our thumb list

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -60,8 +60,10 @@ CAdvancedSettings::CAdvancedSettings()
 
 void CAdvancedSettings::OnSettingsLoaded()
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   // load advanced settings
-  Load();
+  Load(profileManager);
 
   // default players?
   CLog::Log(LOGNOTICE, "Default Video Player: %s", m_videoDefaultPlayer.c_str());
@@ -405,7 +407,7 @@ void CAdvancedSettings::Initialize()
   m_initialized = true;
 }
 
-bool CAdvancedSettings::Load()
+bool CAdvancedSettings::Load(const CProfilesManager &profileManager)
 {
   // NOTE: This routine should NOT set the default of any of these parameters
   //       it should instead use the versions of GetString/Integer/Float that
@@ -414,7 +416,8 @@ bool CAdvancedSettings::Load()
   ParseSettingsFile("special://xbmc/system/advancedsettings.xml");
   for (unsigned int i = 0; i < m_settingsFiles.size(); i++)
     ParseSettingsFile(m_settingsFiles[i]);
-  ParseSettingsFile(CProfilesManager::GetInstance().GetUserDataItem("advancedsettings.xml"));
+
+  ParseSettingsFile(profileManager.GetUserDataItem("advancedsettings.xml"));
 
   // Add the list of disc stub extensions (if any) to the list of video extensions
   if (!m_discStubExtensions.empty())

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -35,6 +35,7 @@
 #define CACHE_BUFFER_MODE_NONE          3
 #define CACHE_BUFFER_MODE_REMOTE        4
 
+class CProfilesManager;
 class CVariant;
 
 class TiXmlElement;
@@ -116,8 +117,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
   public:
     CAdvancedSettings();
 
-    static CAdvancedSettings* getInstance();
-
     void OnSettingsLoaded() override;
     void OnSettingsUnloaded() override;
 
@@ -126,7 +125,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void Initialize();
     bool Initialized() { return m_initialized; };
     void AddSettingsFile(const std::string &filename);
-    bool Load();
+    bool Load(const CProfilesManager &profileManager);
     void Clear();
 
     static void GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_TVSHOWLIST& settings);

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -32,6 +32,7 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 #include "network/WakeOnAccess.h"
+#include "ServiceBroker.h"
 
 #define SOURCES_FILE  "sources.xml"
 #define XML_SOURCES   "sources"
@@ -54,11 +55,13 @@ CMediaSourceSettings& CMediaSourceSettings::GetInstance()
 
 std::string CMediaSourceSettings::GetSourcesFile()
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   std::string file;
-  if (CProfilesManager::GetInstance().GetCurrentProfile().hasSources())
-    file = CProfilesManager::GetInstance().GetProfileUserDataFolder();
+  if (profileManager.GetCurrentProfile().hasSources())
+    file = profileManager.GetProfileUserDataFolder();
   else
-    file = CProfilesManager::GetInstance().GetUserDataFolder();
+    file = profileManager.GetUserDataFolder();
 
   return URIUtils::AddFileToFolder(file, SOURCES_FILE);
 }

--- a/xbmc/settings/MediaSourceSettings.h
+++ b/xbmc/settings/MediaSourceSettings.h
@@ -24,6 +24,7 @@
 #include "MediaSource.h"
 #include "settings/lib/ISettingsHandler.h"
 
+class CProfilesManager;
 class TiXmlNode;
 
 class CMediaSourceSettings : public ISettingsHandler

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -125,52 +125,52 @@ bool IsUsingTTFSubtitles(const std::string &condition, const std::string &value,
 
 bool ProfileCanWriteDatabase(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases();
+  return CSettingConditions::GetCurrentProfile().canWriteDatabases();
 }
 
 bool ProfileCanWriteSources(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources();
+  return CSettingConditions::GetCurrentProfile().canWriteSources();
 }
 
 bool ProfileHasAddons(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().hasAddons();
+  return CSettingConditions::GetCurrentProfile().hasAddons();
 }
 
 bool ProfileHasDatabase(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().hasDatabases();
+  return CSettingConditions::GetCurrentProfile().hasDatabases();
 }
 
 bool ProfileHasSources(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().hasSources();
+  return CSettingConditions::GetCurrentProfile().hasSources();
 }
 
 bool ProfileHasAddonManagerLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().addonmanagerLocked();
+  return CSettingConditions::GetCurrentProfile().addonmanagerLocked();
 }
 
 bool ProfileHasFilesLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().filesLocked();
+  return CSettingConditions::GetCurrentProfile().filesLocked();
 }
 
 bool ProfileHasMusicLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().musicLocked();
+  return CSettingConditions::GetCurrentProfile().musicLocked();
 }
 
 bool ProfileHasPicturesLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().picturesLocked();
+  return CSettingConditions::GetCurrentProfile().picturesLocked();
 }
 
 bool ProfileHasProgramsLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().programsLocked();
+  return CSettingConditions::GetCurrentProfile().programsLocked();
 }
 
 bool ProfileHasSettingsLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
@@ -184,12 +184,12 @@ bool ProfileHasSettingsLocked(const std::string &condition, const std::string &v
     slValue = LOCK_LEVEL::ADVANCED;
   else if (StringUtils::EqualsNoCase(value, "expert"))
     slValue = LOCK_LEVEL::EXPERT;
-  return slValue <= CProfilesManager::GetInstance().GetCurrentProfile().settingsLockLevel();
+  return slValue <= CSettingConditions::GetCurrentProfile().settingsLockLevel();
 }
 
 bool ProfileHasVideosLocked(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CProfilesManager::GetInstance().GetCurrentProfile().videoLocked();
+  return CSettingConditions::GetCurrentProfile().videoLocked();
 }
 
 bool ProfileLockMode(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
@@ -199,7 +199,7 @@ bool ProfileLockMode(const std::string &condition, const std::string &value, Set
   if (tmp != NULL && *tmp != '\0')
     return false;
 
-  return CProfilesManager::GetInstance().GetCurrentProfile().getLockMode() == lock;
+  return CSettingConditions::GetCurrentProfile().getLockMode() == lock;
 }
 
 bool GreaterThan(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
@@ -270,13 +270,16 @@ bool LessThanOrEqual(const std::string &condition, const std::string &value, Set
   return lhs <= rhs;
 }
 
+const CProfilesManager *CSettingConditions::m_profileManager = nullptr;
 std::set<std::string> CSettingConditions::m_simpleConditions;
 std::map<std::string, SettingConditionCheck> CSettingConditions::m_complexConditions;
 
-void CSettingConditions::Initialize()
+void CSettingConditions::Initialize(const CProfilesManager &profileManager)
 {
   if (!m_simpleConditions.empty())
     return;
+
+  m_profileManager = &profileManager;
 
   // add simple conditions
   m_simpleConditions.insert("true");
@@ -386,6 +389,20 @@ void CSettingConditions::Initialize()
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("lt",                            LessThan));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("lte",                           LessThanOrEqual));
   m_complexConditions.insert(std::pair<std::string, SettingConditionCheck>("pvrsettingvisible",             PVR::CPVRSettings::IsSettingVisible));
+}
+
+void CSettingConditions::Deinitialize()
+{
+  m_profileManager = nullptr;
+}
+
+const CProfile& CSettingConditions::GetCurrentProfile()
+{
+  if (m_profileManager)
+    return m_profileManager->GetCurrentProfile();
+
+  static CProfile emptyProfile;
+  return emptyProfile;
 }
 
 bool CSettingConditions::Check(const std::string &condition, const std::string &value /* = "" */, SettingConstPtr setting /* = NULL */)

--- a/xbmc/settings/SettingConditions.h
+++ b/xbmc/settings/SettingConditions.h
@@ -24,10 +24,16 @@
 
 #include "settings/lib/SettingConditions.h"
 
+class CProfile;
+class CProfilesManager;
+
 class CSettingConditions
 {
 public:
-  static void Initialize();
+  static void Initialize(const CProfilesManager &profileManager);
+  static void Deinitialize();
+
+  static const CProfile& GetCurrentProfile();
 
   static const std::set<std::string>& GetSimpleConditions() { return m_simpleConditions; }
   static const std::map<std::string, SettingConditionCheck>& GetComplexConditions() { return m_complexConditions; }
@@ -35,6 +41,9 @@ public:
   static bool Check(const std::string &condition, const std::string &value = "", std::shared_ptr<const CSetting> setting = NULL);
 
 private:
+  // Initialization parameters
+  static const CProfilesManager *m_profileManager;
+
   static std::set<std::string> m_simpleConditions;
   static std::map<std::string, SettingConditionCheck> m_complexConditions;
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -25,7 +25,6 @@
 #include "Autorun.h"
 #include "LangInfo.h"
 #include "Util.h"
-#include "events/EventLog.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/Skin.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
@@ -799,7 +798,7 @@ void CSettings::InitializeISettingsHandlers()
 void CSettings::UninitializeISettingsHandlers()
 {
   // unregister ISettingCallback implementations
-  GetSettingsManager()->UnregisterCallback(&CEventLog::GetInstance());
+  GetSettingsManager()->UnregisterCallback(&CProfilesManager::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_advancedSettings);
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
@@ -848,7 +847,7 @@ void CSettings::InitializeISettingCallbacks()
   // register any ISettingCallback implementations
   std::set<std::string> settingSet;
   settingSet.insert(CSettings::SETTING_EVENTLOG_SHOW);
-  GetSettingsManager()->RegisterCallback(&CEventLog::GetInstance(), settingSet);
+  GetSettingsManager()->RegisterCallback(&CProfilesManager::GetInstance(), settingSet);
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_DEBUG_SHOWLOGINFO);
@@ -1009,7 +1008,7 @@ void CSettings::InitializeISettingCallbacks()
 
 void CSettings::UninitializeISettingCallbacks()
 {
-  GetSettingsManager()->UnregisterCallback(&CEventLog::GetInstance());
+  GetSettingsManager()->UnregisterCallback(&CProfilesManager::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_advancedSettings);
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -478,7 +478,9 @@ bool CSettings::Initialize()
 
 bool CSettings::Load()
 {
-  return Load(CProfilesManager::GetInstance().GetSettingsFile());
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  return Load(profileManager.GetSettingsFile());
 }
 
 bool CSettings::Load(const std::string &file)
@@ -504,7 +506,9 @@ bool CSettings::Load(const std::string &file)
 
 bool CSettings::Save()
 {
-  return Save(CProfilesManager::GetInstance().GetSettingsFile());
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  return Save(profileManager.GetSettingsFile());
 }
 
 bool CSettings::Save(const std::string &file)
@@ -762,7 +766,9 @@ void CSettings::UninitializeOptionFillers()
 
 void CSettings::InitializeConditions()
 {
-  CSettingConditions::Initialize();
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  CSettingConditions::Initialize(profileManager);
 
   // add basic conditions
   const std::set<std::string> &simpleConditions = CSettingConditions::GetSimpleConditions();
@@ -775,13 +781,17 @@ void CSettings::InitializeConditions()
     GetSettingsManager()->AddCondition(itCondition->first, itCondition->second);
 }
 
+void CSettings::UninitializeConditions()
+{
+  CSettingConditions::Deinitialize();
+}
+
 void CSettings::InitializeISettingsHandlers()
 {
   // register ISettingsHandler implementations
   // The order of these matters! Handlers are processed in the order they were registered.
   GetSettingsManager()->RegisterSettingsHandler(&g_advancedSettings);
   GetSettingsManager()->RegisterSettingsHandler(&CMediaSourceSettings::GetInstance());
-  GetSettingsManager()->RegisterSettingsHandler(&CProfilesManager::GetInstance());
 #ifdef HAS_UPNP
   GetSettingsManager()->RegisterSettingsHandler(&CUPnPSettings::GetInstance());
 #endif
@@ -798,7 +808,6 @@ void CSettings::InitializeISettingsHandlers()
 void CSettings::UninitializeISettingsHandlers()
 {
   // unregister ISettingCallback implementations
-  GetSettingsManager()->UnregisterCallback(&CProfilesManager::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_advancedSettings);
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
@@ -846,10 +855,6 @@ void CSettings::InitializeISettingCallbacks()
 {
   // register any ISettingCallback implementations
   std::set<std::string> settingSet;
-  settingSet.insert(CSettings::SETTING_EVENTLOG_SHOW);
-  GetSettingsManager()->RegisterCallback(&CProfilesManager::GetInstance(), settingSet);
-
-  settingSet.clear();
   settingSet.insert(CSettings::SETTING_DEBUG_SHOWLOGINFO);
   settingSet.insert(CSettings::SETTING_DEBUG_EXTRALOGGING);
   settingSet.insert(CSettings::SETTING_DEBUG_SETEXTRALOGLEVEL);
@@ -1008,7 +1013,6 @@ void CSettings::InitializeISettingCallbacks()
 
 void CSettings::UninitializeISettingCallbacks()
 {
-  GetSettingsManager()->UnregisterCallback(&CProfilesManager::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_advancedSettings);
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
@@ -1035,7 +1039,10 @@ void CSettings::UninitializeISettingCallbacks()
 
 bool CSettings::Reset()
 {
-  std::string settingsFile = CProfilesManager::GetInstance().GetSettingsFile();
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  std::string settingsFile = profileManager.GetSettingsFile();
+
   // try to delete the settings file
   if (XFILE::CFile::Exists(settingsFile, false) && !XFILE::CFile::Delete(settingsFile))
     CLog::Log(LOGWARNING, "Unable to delete old settings file at %s", settingsFile.c_str());

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -782,7 +782,6 @@ void CSettings::InitializeISettingsHandlers()
   // The order of these matters! Handlers are processed in the order they were registered.
   GetSettingsManager()->RegisterSettingsHandler(&g_advancedSettings);
   GetSettingsManager()->RegisterSettingsHandler(&CMediaSourceSettings::GetInstance());
-  GetSettingsManager()->RegisterSettingsHandler(&CPlayerCoreFactory::GetInstance());
   GetSettingsManager()->RegisterSettingsHandler(&CProfilesManager::GetInstance());
 #ifdef HAS_UPNP
   GetSettingsManager()->RegisterSettingsHandler(&CUPnPSettings::GetInstance());

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -466,6 +466,7 @@ protected:
   void InitializeOptionFillers() override;
   void UninitializeOptionFillers() override;
   void InitializeConditions() override;
+  void UninitializeConditions() override;
   void InitializeVisibility() override;
   void InitializeDefaults() override;
   void InitializeISettingsHandlers() override;

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -64,7 +64,7 @@ bool CSettingsBase::Initialize()
 
   m_settingsManager->SetInitialized();
 
-  InitializeISettingsHandlers();  
+  InitializeISettingsHandlers();
   InitializeISubSettings();
   InitializeISettingCallbacks();
 
@@ -147,6 +147,10 @@ void CSettingsBase::Uninitialize()
 
   // unregister setting option fillers
   UninitializeOptionFillers();
+
+  // unregister setting conditions
+  UninitializeConditions();
+
   // unregister ISettingCallback implementations
   UninitializeISettingCallbacks();
 

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -235,6 +235,7 @@ protected:
   virtual void InitializeOptionFillers() { }
   virtual void UninitializeOptionFillers() { }
   virtual void InitializeConditions() { }
+  virtual void UninitializeConditions() { }
   virtual bool InitializeDefinitions() = 0;
   virtual void InitializeVisibility() { }
   virtual void InitializeDefaults() { }

--- a/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogAudioDSPSettings.cpp
@@ -373,8 +373,10 @@ void CGUIDialogAudioDSPSettings::OnSettingAction(std::shared_ptr<const CSetting>
 
 void CGUIDialogAudioDSPSettings::Save()
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
-      CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
   // prompt user if they are sure

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -30,6 +30,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
+#include "ServiceBroker.h"
 
 using namespace KODI::MESSAGING;
 
@@ -72,9 +73,9 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
   EventPtr alarmClockActivity(new CNotificationEvent(labelAlarmClock,
     StringUtils::Format(g_localizeStrings.Get(labelStarted).c_str(), static_cast<int>(event.m_fSecs) / 60, static_cast<int>(event.m_fSecs) % 60)));
   if (bSilent)
-    CEventLog::GetInstance().Add(alarmClockActivity);
+    CServiceBroker::GetEventLog().Add(alarmClockActivity);
   else
-    CEventLog::GetInstance().AddWithNotification(alarmClockActivity);
+    CServiceBroker::GetEventLog().AddWithNotification(alarmClockActivity);
 
   event.watch.StartZero();
   CSingleLock lock(m_events);
@@ -117,9 +118,9 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
   {
     EventPtr alarmClockActivity(new CNotificationEvent(labelAlarmClock, strMessage));
     if (bSilent)
-      CEventLog::GetInstance().Add(alarmClockActivity);
+      CServiceBroker::GetEventLog().Add(alarmClockActivity);
     else
-      CEventLog::GetInstance().AddWithNotification(alarmClockActivity);
+      CServiceBroker::GetEventLog().AddWithNotification(alarmClockActivity);
   }
   else
   {

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -106,8 +106,11 @@ void CRssManager::Stop()
 
 bool CRssManager::Load()
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   CSingleLock lock(m_critical);
-  std::string rssXML = CProfilesManager::GetInstance().GetUserDataItem("RssFeeds.xml");
+
+  std::string rssXML = profileManager.GetUserDataItem("RssFeeds.xml");
   if (!CFile::Exists(rssXML))
     return false;
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5597,7 +5597,7 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir, CFileItemList& 
 
     std::string strSQL;
     Filter extFilter = filter;
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       std::string view, view_id, media_type, extraField, extraJoin;
       if (idContent == VIDEODB_CONTENT_MOVIES)
@@ -5699,7 +5699,7 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir, CFileItemList& 
       return true;
     }
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       std::map<int, std::pair<std::string,int> > mapItems;
       while (!m_pDS->eof())
@@ -5845,7 +5845,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
     extFilter.fields = PrepareSQL("musicvideo_view.c%02d, musicvideo_view.idMVideo, actor.name", VIDEODB_ID_MUSICVIDEO_ALBUM);
     extFilter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo'"));
     extFilter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id = actor_link.actor_id"));
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       extFilter.fields += ", path.strPath";
       extFilter.AppendJoin("join files on files.idFile = musicvideo_view.idFile join path on path.idPath = files.idPath");
@@ -5881,7 +5881,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
       return true;
     }
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       std::map<int, std::pair<std::string,std::string> > mapAlbums;
       while (!m_pDS->eof())
@@ -6003,7 +6003,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir, CFileItemList& 
     // get primary genres for movies
     std::string strSQL;
     Filter extFilter = filter;
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       std::string view, view_id, media_type, extraField, group;
       if (idContent == VIDEODB_CONTENT_MOVIES)
@@ -6127,7 +6127,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir, CFileItemList& 
       return true;
     }
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       std::map<int, CActor> mapActors;
 
@@ -6235,7 +6235,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
 
     std::string strSQL;
     Filter extFilter = filter;
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       if (idContent == VIDEODB_CONTENT_MOVIES)
       {
@@ -6287,7 +6287,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir, CFileItemList& i
     if (iRowsFound <= 0)
       return iRowsFound == 0;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
     {
       std::map<int, std::pair<std::string,int> > mapYears;
       while (!m_pDS->eof())
@@ -6473,7 +6473,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
       std::string path = m_pDS->fv(VIDEODB_ID_SEASON_TVSHOW_PATH).get_asString();
 
       if (mapSeasons.find(std::make_pair(showId, iSeason)) == mapSeasons.end() &&
-         (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE || g_passwordManager.bMasterUser ||
+         (m_profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE || g_passwordManager.bMasterUser ||
           g_passwordManager.IsDatabasePathUnlocked(path, *CMediaSourceSettings::GetInstance().GetSources("video"))))
       {
         mapSeasons.insert(std::make_pair(showId, iSeason));
@@ -6768,7 +6768,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
       const dbiplus::sql_record* const record = data.at(targetRow);
 
       CVideoInfoTag movie = GetDetailsForMovie(record, getDetails);
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      if (m_profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
           g_passwordManager.bMasterUser                                   ||
           g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, *CMediaSourceSettings::GetInstance().GetSources("video")))
       {
@@ -6876,7 +6876,7 @@ bool CVideoDatabase::GetTvShowsByWhere(const std::string& strBaseDir, const Filt
       
       CFileItemPtr pItem(new CFileItem());
       CVideoInfoTag movie = GetDetailsForTvShow(record, getDetails, pItem.get());
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      if (m_profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
            g_passwordManager.bMasterUser                                     ||
            g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, *CMediaSourceSettings::GetInstance().GetSources("video")))
       {
@@ -7003,7 +7003,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
       const dbiplus::sql_record* const record = data.at(targetRow);
 
       CVideoInfoTag movie = GetDetailsForEpisode(record, getDetails);
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+      if (m_profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
           g_passwordManager.bMasterUser                                     ||
           g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, *CMediaSourceSettings::GetInstance().GetSources("video")))
       {
@@ -7425,7 +7425,7 @@ void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileIte
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id = genre.genre_id INNER JOIN movie ON (genre_link.media_type='movie' = genre_link.media_id=movie.idMovie) INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE genre.name LIKE '%%%s%%'",strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT genre.genre_id, genre.name FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id WHERE genre_link.media_type='movie' AND name LIKE '%%%s%%'", strSearch.c_str());
@@ -7433,7 +7433,7 @@ void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileIte
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),
                                                       *CMediaSourceSettings::GetInstance().GetSources("video")))
         {
@@ -7465,7 +7465,7 @@ void CVideoDatabase::GetMovieCountriesByName(const std::string& strSearch, CFile
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT country.country_id, country.name, path.strPath FROM country INNER JOIN country_link ON country_link.country_id=country.country_id INNER JOIN movie ON country_link.media_id=movie.idMovie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE country_link.media_type='movie' AND country.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT country.country_id, country.name FROM country INNER JOIN country_link ON country_link.country_id=country.country_id WHERE country_link.media_type='movie' AND name like '%%%s%%'", strSearch.c_str());
@@ -7473,7 +7473,7 @@ void CVideoDatabase::GetMovieCountriesByName(const std::string& strSearch, CFile
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),
                                                       *CMediaSourceSettings::GetInstance().GetSources("video")))
         {
@@ -7505,7 +7505,7 @@ void CVideoDatabase::GetTvShowGenresByName(const std::string& strSearch, CFileIt
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id INNER JOIN tvshow ON genre_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE genre_link.media_type='tvshow' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT genre.genre_id, genre.name FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id WHERE genre_link.media_type='tvshow' AND name LIKE '%%%s%%'", strSearch.c_str());
@@ -7513,7 +7513,7 @@ void CVideoDatabase::GetTvShowGenresByName(const std::string& strSearch, CFileIt
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7544,7 +7544,7 @@ void CVideoDatabase::GetMovieActorsByName(const std::string& strSearch, CFileIte
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN movie ON actor_link.media_id=movie.idMovie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='movie' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, actor.name FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN movie ON actor_link.media_id=movie.idMovie WHERE actor_link.media_type='movie' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -7552,7 +7552,7 @@ void CVideoDatabase::GetMovieActorsByName(const std::string& strSearch, CFileIte
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7583,7 +7583,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const std::string& strSearch, CFileI
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN tvshow ON actor_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idPath=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE actor_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, actor.name FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN tvshow ON actor_link.media_id=tvshow.idShow WHERE actor_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'",strSearch.c_str());
@@ -7591,7 +7591,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const std::string& strSearch, CFileI
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7625,7 +7625,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const std::string& strSearch, CF
     std::string strLike;
     if (!strSearch.empty())
       strLike = "and actor.name like '%%%s%%'";
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT actor.actor_id, actor.name, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='musicvideo' "+strLike, strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, actor.name from actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id WHERE actor_link.media_type='musicvideo' "+strLike,strSearch.c_str());
@@ -7633,7 +7633,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const std::string& strSearch, CF
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7664,7 +7664,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const std::string& strSearch, CFi
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL=PrepareSQL("SELECT genre.genre_id, genre.name, path.strPath FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id INNER JOIN musicvideo ON genre_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE genre_link.media_type='musicvideo' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL=PrepareSQL("SELECT DISTINCT genre.genre_id, genre.name FROM genre INNER JOIN genre_link ON genre_link.genre_id=genre.genre_id WHERE genre_link.media_type='musicvideo' AND genre.name LIKE '%%%s%%'", strSearch.c_str());
@@ -7672,7 +7672,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const std::string& strSearch, CFi
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7726,7 +7726,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
         continue;
       }
 
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv(2).get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7757,7 +7757,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const std::string& strSearch, CFileIt
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT musicvideo.idMVideo, musicvideo.c%02d,musicvideo.c%02d, path.strPath FROM musicvideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE musicvideo.c%02d LIKE '%%%s%%'", VIDEODB_ID_MUSICVIDEO_ALBUM, VIDEODB_ID_MUSICVIDEO_TITLE, VIDEODB_ID_MUSICVIDEO_ALBUM, strSearch.c_str());
     else
       strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d,musicvideo.c%02d from musicvideo where musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_ALBUM,VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_ALBUM,strSearch.c_str());
@@ -7765,7 +7765,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const std::string& strSearch, CFileIt
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -7843,7 +7843,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
       const dbiplus::sql_record* const record = data.at(targetRow);
       
       CVideoInfoTag musicvideo = GetDetailsForMusicVideo(record, getDetails);
-      if (!checkLocks || CProfilesManager::GetInstance().GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE || g_passwordManager.bMasterUser ||
+      if (!checkLocks || m_profileManager.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE || g_passwordManager.bMasterUser ||
           g_passwordManager.IsDatabasePathUnlocked(musicvideo.m_strPath, *CMediaSourceSettings::GetInstance().GetSources("video")))
       {
         CFileItemPtr item(new CFileItem(musicvideo));
@@ -7951,14 +7951,14 @@ int CVideoDatabase::GetMatchingMusicVideo(const std::string& strArtist, const st
     std::string strSQL;
     if (strAlbum.empty() && strTitle.empty())
     { // we want to return matching artists only
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='musicvideo' AND actor.name like '%s'", strArtist.c_str());
       else
         strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id WHERE actor_link.media_type='musicvideo' AND actor.name LIKE '%s'", strArtist.c_str());
     }
     else
     { // we want to return the matching musicvideo
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         strSQL = PrepareSQL("SELECT musicvideo.idMVideo FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='musicvideo' AND musicvideo.c%02d LIKE '%s' AND musicvideo.c%02d LIKE '%s' AND actor.name LIKE '%s'", VIDEODB_ID_MUSICVIDEO_ALBUM, strAlbum.c_str(), VIDEODB_ID_MUSICVIDEO_TITLE, strTitle.c_str(), strArtist.c_str());
       else
         strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo join actor_link on actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actor.name like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
@@ -7968,7 +7968,7 @@ int CVideoDatabase::GetMatchingMusicVideo(const std::string& strArtist, const st
     if (m_pDS->eof())
       return -1;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
       {
         m_pDS->close();
@@ -7995,7 +7995,7 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT movie.idMovie, movie.c%02d, path.strPath, movie.idSet FROM movie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE movie.c%02d LIKE '%%%s%%'", VIDEODB_ID_TITLE, VIDEODB_ID_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("select movie.idMovie,movie.c%02d, movie.idSet from movie where movie.c%02d like '%%%s%%'",VIDEODB_ID_TITLE,VIDEODB_ID_TITLE,strSearch.c_str());
@@ -8003,7 +8003,7 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8040,7 +8040,7 @@ void CVideoDatabase::GetTvShowsByName(const std::string& strSearch, CFileItemLis
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT tvshow.idShow, tvshow.c%02d, path.strPath FROM tvshow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE tvshow.c%02d LIKE '%%%s%%'", VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("select tvshow.idShow,tvshow.c%02d from tvshow where tvshow.c%02d like '%%%s%%'",VIDEODB_ID_TV_TITLE,VIDEODB_ID_TV_TITLE,strSearch.c_str());
@@ -8048,7 +8048,7 @@ void CVideoDatabase::GetTvShowsByName(const std::string& strSearch, CFileItemLis
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8081,7 +8081,7 @@ void CVideoDatabase::GetEpisodesByName(const std::string& strSearch, CFileItemLi
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d, path.strPath FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow INNER JOIN files ON files.idFile=episode.idFile INNER JOIN path ON path.idPath=files.idPath WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow WHERE episode.c%02d like '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_TITLE, strSearch.c_str());
@@ -8089,7 +8089,7 @@ void CVideoDatabase::GetEpisodesByName(const std::string& strSearch, CFileItemLi
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8124,7 +8124,7 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT musicvideo.idMVideo, musicvideo.c%02d, path.strPath FROM musicvideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE musicvideo.c%02d LIKE '%%%s%%'", VIDEODB_ID_MUSICVIDEO_TITLE, VIDEODB_ID_MUSICVIDEO_TITLE, strSearch.c_str());
     else
       strSQL = PrepareSQL("select musicvideo.idMVideo,musicvideo.c%02d from musicvideo where musicvideo.c%02d like '%%%s%%'",VIDEODB_ID_MUSICVIDEO_TITLE,VIDEODB_ID_MUSICVIDEO_TITLE,strSearch.c_str());
@@ -8132,7 +8132,7 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8171,7 +8171,7 @@ void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemLi
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d, path.strPath FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow INNER JOIN files ON files.idFile=episode.idFile INNER JOIN path ON path.idPath=files.idPath WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_PLOT, strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT episode.idEpisode, episode.c%02d, episode.c%02d, episode.idShow, tvshow.c%02d FROM episode INNER JOIN tvshow ON tvshow.idShow=episode.idShow WHERE episode.c%02d LIKE '%%%s%%'", VIDEODB_ID_EPISODE_TITLE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_EPISODE_PLOT, strSearch.c_str());
@@ -8179,7 +8179,7 @@ void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemLi
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8210,7 +8210,7 @@ void CVideoDatabase::GetMoviesByPlot(const std::string& strSearch, CFileItemList
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("select movie.idMovie, movie.c%02d, path.strPath FROM movie INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%'", VIDEODB_ID_TITLE,VIDEODB_ID_PLOT, strSearch.c_str(), VIDEODB_ID_PLOTOUTLINE, strSearch.c_str(), VIDEODB_ID_TAGLINE,strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT movie.idMovie, movie.c%02d FROM movie WHERE (movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%' OR movie.c%02d LIKE '%%%s%%')", VIDEODB_ID_TITLE, VIDEODB_ID_PLOT, strSearch.c_str(), VIDEODB_ID_PLOTOUTLINE, strSearch.c_str(), VIDEODB_ID_TAGLINE, strSearch.c_str());
@@ -8219,7 +8219,7 @@ void CVideoDatabase::GetMoviesByPlot(const std::string& strSearch, CFileItemList
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv(2).get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8252,7 +8252,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const std::string& strSearch, CFile
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name, path.strPath FROM movie INNER JOIN director_link ON (director_link.media_id=movie.idMovie AND director_link.media_type='movie') INNER JOIN actor ON actor.actor_id=director_link.actor_id INNER JOIN files ON files.idFile=movie.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN movie ON director_link.media_id=movie.idMovie WHERE director_link.media_type='movie' AND actor.name like '%%%s%%'", strSearch.c_str());
@@ -8261,7 +8261,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const std::string& strSearch, CFile
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8293,7 +8293,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const std::string& strSearch, CFi
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name, path.strPath FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN tvshow ON director_link.media_id=tvshow.idShow INNER JOIN tvshowlinkpath ON tvshowlinkpath.idShow=tvshow.idShow INNER JOIN path ON path.idPath=tvshowlinkpath.idPath WHERE director_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN tvshow ON director_link.media_id=tvshow.idShow WHERE director_link.media_type='tvshow' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8302,7 +8302,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const std::string& strSearch, CFi
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();
@@ -8334,7 +8334,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
     if (NULL == m_pDB.get()) return;
     if (NULL == m_pDS.get()) return;
 
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+    if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name, path.strPath FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN musicvideo ON director_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE director_link.media_type='musicvideo' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
     else
       strSQL = PrepareSQL("SELECT DISTINCT director_link.actor_id, actor.name FROM actor INNER JOIN director_link ON director_link.actor_id=actor.actor_id INNER JOIN musicvideo ON director_link.media_id=musicvideo.idMVideo WHERE director_link.media_type='musicvideo' AND actor.name LIKE '%%%s%%'", strSearch.c_str());
@@ -8343,7 +8343,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
 
     while (!m_pDS->eof())
     {
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
+      if (m_profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && !g_passwordManager.bMasterUser)
         if (!g_passwordManager.IsDatabasePathUnlocked(std::string(m_pDS->fv("path.strPath").get_asString()),*CMediaSourceSettings::GetInstance().GetSources("video")))
         {
           m_pDS->next();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -465,7 +465,7 @@ namespace VIDEO
           mediaType = MediaTypeTvShow;
         else if (info2->Content() == CONTENT_MUSICVIDEOS)
           mediaType = MediaTypeMusicVideo;
-        CEventLog::GetInstance().Add(EventPtr(new CMediaLibraryEvent(
+        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
           mediaType, pItem->GetPath(), 24145,
           StringUtils::Format(g_localizeStrings.Get(24147).c_str(), mediaType.c_str(), URIUtils::GetFileName(pItem->GetPath()).c_str()),
           pItem->GetArt("thumb"), CURL::GetRedacted(pItem->GetPath()), EventLevel::Warning)));

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -236,8 +236,10 @@ void CGUIDialogAudioSubtitleSettings::OnSettingAction(std::shared_ptr<const CSet
 
 void CGUIDialogAudioSubtitleSettings::Save()
 {
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   if (!g_passwordManager.CheckSettingLevelLock(SettingLevel::Expert) &&
-      CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
     return;
 
   // prompt user if they are sure

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -430,11 +430,11 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
 
   if (hasImage)
   {
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
 
     auto crc = Crc32::ComputeFromLowerCase(g_application.CurrentFile());
     bookmark.thumbNailImage = StringUtils::Format("%08x_%i.jpg", crc, (int)bookmark.timeInSeconds);
-    bookmark.thumbNailImage = URIUtils::AddFileToFolder(CProfilesManager::GetInstance().GetBookmarksThumbFolder(), bookmark.thumbNailImage);
-
+    bookmark.thumbNailImage = URIUtils::AddFileToFolder(profileManager.GetBookmarksThumbFolder(), bookmark.thumbNailImage);
 
     if (!CPicture::CreateThumbnailFromSurface(pixels, width, height, width * 4,
                                                          bookmark.thumbNailImage))

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -250,14 +250,16 @@ void CGUIDialogVideoInfo::OnInitWindow()
   m_hasUpdatedUserrating = false;
   m_bViewReview = true;
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "xx"));
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   // Disable video user rating button for plugins as they don't have tables to save this
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin());
 
   VIDEODB_CONTENT_TYPE type = static_cast<VIDEODB_CONTENT_TYPE>(m_movieItem->GetVideoContentType());
   if (type == VIDEODB_CONTENT_TVSHOWS || type == VIDEODB_CONTENT_MOVIES)
-    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART, (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
+    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART, (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) && !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str() + 2, "plugin"));
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
 
@@ -1396,10 +1398,12 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
   if (!DeleteVideoItemFromDatabase(item, unavailable))
     return false;
 
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   // check if the user is allowed to delete the actual file as well
   if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION) &&
-      (CProfilesManager::GetInstance().GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-       !CProfilesManager::GetInstance().GetCurrentProfile().filesLocked() ||
+      (profileManager.GetCurrentProfile().getLockMode() == LOCK_MODE_EVERYONE ||
+       !profileManager.GetCurrentProfile().filesLocked() ||
        g_passwordManager.IsMasterLockUnlocked(true)))
   {
     std::string strDeletePath = item->GetVideoInfoTag()->GetPath();

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -201,8 +201,10 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
   const std::string &settingId = setting->GetId();
   if (settingId == SETTING_VIDEO_CALIBRATION)
   {
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
     // launch calibration window
-    if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
+    if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE  &&
         g_passwordManager.CheckSettingLevelLock(CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION)->GetLevel()))
       return;
     g_windowManager.ForceActivateWindow(WINDOW_SCREEN_CALIBRATION);
@@ -214,7 +216,9 @@ void CGUIDialogVideoSettings::OnSettingAction(std::shared_ptr<const CSetting> se
 
 void CGUIDialogVideoSettings::Save()
 {
-  if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
       !g_passwordManager.CheckSettingLevelLock(::SettingLevel::Expert))
     return;
 

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -55,7 +55,9 @@ bool CVideoLibraryMarkWatchedJob::operator==(const CJob* job) const
 
 bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
 {
-  if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases())
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (!profileManager.GetCurrentProfile().canWriteDatabases())
     return false;
 
   CFileItemList items;

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -54,7 +54,9 @@ bool CVideoLibraryResetResumePointJob::operator==(const CJob* job) const
 
 bool CVideoLibraryResetResumePointJob::Work(CVideoDatabase &db)
 {
-  if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases())
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (!profileManager.GetCurrentProfile().canWriteDatabases())
     return false;
 
   CFileItemList items;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -172,8 +172,10 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         }
         else if (iAction == ACTION_DELETE_ITEM)
         {
+          const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
           // is delete allowed?
-          if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases())
+          if (profileManager.GetCurrentProfile().canWriteDatabases())
           {
             // must be at the title window
             if (GetID() == WINDOW_VIDEO_NAV)
@@ -383,8 +385,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
     }
   }
 
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   // quietly return if Internet lookups are disabled
-  if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
+  if (!profileManager.GetCurrentProfile().canWriteDatabases() && !g_passwordManager.bMasterUser)
     return false;
 
   if (!info)
@@ -1144,8 +1148,11 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
   // HACK: stacked files need to be treated as folders in order to be deleted
   if (item->IsStack())
     item->m_bIsFolder = true;
-  if (CProfilesManager::GetInstance().GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-      CProfilesManager::GetInstance().GetCurrentProfile().filesLocked())
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profileManager.GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+      profileManager.GetCurrentProfile().filesLocked())
   {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
@@ -1249,7 +1256,9 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
   // add in the "New Playlist" item if we're in the playlists folder
   if ((items.GetPath() == "special://videoplaylists/") && !items.Contains("newplaylist://"))
   {
-    CFileItemPtr newPlaylist(new CFileItem(CProfilesManager::GetInstance().GetUserDataItem("PartyMode-Video.xsp"),false));
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+    CFileItemPtr newPlaylist(new CFileItem(profileManager.GetUserDataItem("PartyMode-Video.xsp"),false));
     newPlaylist->SetLabel(g_localizeStrings.Get(16035));
     newPlaylist->SetLabelPreformatted(true);
     newPlaylist->SetIconImage("DefaultPartyMode.png");

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -848,15 +848,19 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
 
       if (!item->m_bIsFolder && !(item->IsPlayList() && !g_advancedSettings.m_playlistAsFolders))
-      { // get players
+      {
+        const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
+        // get players
         std::vector<std::string> players;
         if (item->IsVideoDb())
         {
           CFileItem item2(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
-          CPlayerCoreFactory::GetInstance().GetPlayers(item2, players);
+          playerCoreFactory.GetPlayers(item2, players);
         }
         else
-          CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
+          playerCoreFactory.GetPlayers(*item, players);
+
         if (players.size() > 1)
           buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213);
       }
@@ -984,15 +988,18 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_PLAY_WITH:
     {
+      const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
       std::vector<std::string> players;
       if (item->IsVideoDb())
       {
         CFileItem item2(*item->GetVideoInfoTag());
-        CPlayerCoreFactory::GetInstance().GetPlayers(item2, players);
+        playerCoreFactory.GetPlayers(item2, players);
       }
       else
-        CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
-      std:: string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+        playerCoreFactory.GetPlayers(*item, players);
+
+      std:: string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
       {
         // any other select actions but play or resume, resume, play or playpart

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -900,6 +900,8 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
   CVideoDatabaseDirectory dir;
   NODE_TYPE node = dir.GetDirectoryChildType(m_vecItems->GetPath());
 
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   if (!item)
   {
     // nothing to do here
@@ -909,7 +911,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     // get the usual shares
     CGUIDialogContextMenu::GetContextButtons("video", item, buttons);
     if (!item->IsDVD() && item->GetPath() != "add" && !item->IsParentFolder() &&
-        (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+        (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       CVideoDatabase database;
       database.Open();
@@ -967,7 +969,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       GetScraperForItem(item.get(), info, settings);
 
       // can we update the database?
-      if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
+      if (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
       {
         if (!g_application.IsVideoScanning() && item->IsVideoDb() && item->HasVideoInfoTag() &&
            (item->GetVideoInfoTag()->m_type == MediaTypeMovie ||          // movies
@@ -1128,7 +1130,10 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
   if (!item->m_bIsFolder && item->IsVideoDb() && !item->Exists())
   {
     CLog::Log(LOGDEBUG, "%s called on '%s' but file doesn't exist", __FUNCTION__, item->GetPath().c_str());
-    if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
+
+    const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+    if (profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
     {
       if (!CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(item, true))
         return true;

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -405,15 +405,19 @@ void CGUIWindowVideoPlaylist::GetContextButtons(int itemNumber, CContextButtons 
     if (itemNumber > -1)
     {
       CFileItemPtr item = m_vecItems->Get(itemNumber);
+
+      const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
       // check what players we have, if we have multiple display play with option
       std::vector<std::string> players;
       if (item->IsVideoDb())
       {
         CFileItem item2(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
-        CPlayerCoreFactory::GetInstance().GetPlayers(item2, players);
+        playerCoreFactory.GetPlayers(item2, players);
       }
       else
-        CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
+        playerCoreFactory.GetPlayers(*item, players);
+
       if (players.size() > 1)
         buttons.Add(CONTEXT_BUTTON_PLAY_WITH, 15213); // Play With...
 
@@ -451,15 +455,18 @@ bool CGUIWindowVideoPlaylist::OnContextButton(int itemNumber, CONTEXT_BUTTON but
       if (!item)
         break;
 
+      const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
       std::vector<std::string> players;
       if (item->IsVideoDb())
       {
         CFileItem item2(*item->GetVideoInfoTag());
-        CPlayerCoreFactory::GetInstance().GetPlayers(item2, players);
+        playerCoreFactory.GetPlayers(item2, players);
       }
       else
-        CPlayerCoreFactory::GetInstance().GetPlayers(*item, players);
-      std::string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+        playerCoreFactory.GetPlayers(*item, players);
+
+      std::string player = playerCoreFactory.SelectPlayerDialog(players);
       if (!player.empty())
         OnClick(itemNumber, player);
       return true;

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -393,7 +393,9 @@ bool CGUIViewState::HideParentDirItems()
 
 bool CGUIViewState::DisableAddSourceButtons()
 {
-  if (CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profileManager.GetCurrentProfile().canWriteSources() || g_passwordManager.bMasterUser)
     return !CServiceBroker::GetSettings().GetBool(CSettings::SETTING_FILELISTS_SHOWADDSOURCEBUTTONS);
 
   return true;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -940,7 +940,11 @@ void CGUIMediaWindow::OnCacheFileItems(CFileItemList &items)
  */
 bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
 {
-  if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return true;
+  if (iItem < 0 || iItem >= (int)m_vecItems->Size())
+    return true;
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
   CFileItemPtr pItem = m_vecItems->Get(iItem);
 
   if (pItem->IsParentFolder())
@@ -948,14 +952,15 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     GoParentFolder();
     return true;
   }
+
   if (pItem->GetPath() == "add" || pItem->GetPath() == "sources://add/") // 'add source button' in empty root
   {
-    if (CProfilesManager::GetInstance().IsMasterProfile())
+    if (profileManager.IsMasterProfile())
     {
       if (!g_passwordManager.IsMasterLockUnlocked(true))
         return false;
     }
-    else if (!CProfilesManager::GetInstance().GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
+    else if (!profileManager.GetCurrentProfile().canWriteSources() && !g_passwordManager.IsProfileLockUnlocked())
       return false;
 
     if (OnAddMediaSource())
@@ -996,7 +1001,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     if ( pItem->m_bIsShareOrDrive )
     {
       const std::string& strLockType=m_guiState->GetLockType();
-      if (CProfilesManager::GetInstance().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
+      if (profileManager.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
         if (!strLockType.empty() && !g_passwordManager.IsItemUnlocked(pItem.get(), strLockType))
             return true;
 
@@ -1005,8 +1010,8 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
     }
 
     // check for the partymode playlist items - they may not exist yet
-    if ((pItem->GetPath() == CProfilesManager::GetInstance().GetUserDataItem("PartyMode.xsp")) ||
-        (pItem->GetPath() == CProfilesManager::GetInstance().GetUserDataItem("PartyMode-Video.xsp")))
+    if ((pItem->GetPath() == profileManager.GetUserDataItem("PartyMode.xsp")) ||
+        (pItem->GetPath() == profileManager.GetUserDataItem("PartyMode-Video.xsp")))
     {
       // party mode playlist item - if it doesn't exist, prompt for user to define it
       if (!XFILE::CFile::Exists(pItem->GetPath()))
@@ -1540,26 +1545,37 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
   if (item->IsPlayList())
     item->m_bIsFolder = false;
 
-  if (CProfilesManager::GetInstance().GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && CProfilesManager::GetInstance().GetCurrentProfile().filesLocked())
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profileManager.GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profileManager.GetCurrentProfile().filesLocked())
+  {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
+  }
 
   if (!CFileUtils::DeleteItem(item))
     return;
+
   Refresh(true);
   m_viewControl.SetSelectedItem(iItem);
 }
 
 void CGUIMediaWindow::OnRenameItem(int iItem)
 {
-  if ( iItem < 0 || iItem >= m_vecItems->Size()) return;
+  if (iItem < 0 || iItem >= m_vecItems->Size())
+    return;
 
-  if (CProfilesManager::GetInstance().GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && CProfilesManager::GetInstance().GetCurrentProfile().filesLocked())
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profileManager.GetCurrentProfile().getLockMode() != LOCK_MODE_EVERYONE && profileManager.GetCurrentProfile().filesLocked())
+  {
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
+  }
 
   if (!CFileUtils::RenameFile(m_vecItems->Get(iItem)->GetPath()))
     return;
+
   Refresh(true);
   m_viewControl.SetSelectedItem(iItem);
 }

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -1000,6 +1000,9 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
     pItem->Select(false);
     return ;
   }
+
+  const CPlayerCoreFactory &playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();
+
   // popup the context menu
 
   bool showEntry = false;
@@ -1009,7 +1012,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
 
   // determine available players
   std::vector<std::string>players;
-  CPlayerCoreFactory::GetInstance().GetPlayers(*pItem, players);
+  playerCoreFactory.GetPlayers(*pItem, players);
 
   // add the needed buttons
   CContextButtons choices;
@@ -1057,8 +1060,8 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
   if (btnid == CONTROL_BTNPLAYWITH)
   {
     std::vector<std::string>players;
-    CPlayerCoreFactory::GetInstance().GetPlayers(*pItem, players);
-    std::string player = CPlayerCoreFactory::GetInstance().SelectPlayerDialog(players);
+    playerCoreFactory.GetPlayers(*pItem, players);
+    std::string player = playerCoreFactory.SelectPlayerDialog(players);
     if (!player.empty())
       OnStart(pItem.get(), player);
   }

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -167,16 +167,24 @@ bool CGUIWindowLoginScreen::OnBack(int actionID)
 void CGUIWindowLoginScreen::FrameMove()
 {
   if (GetFocusedControlID() == CONTROL_BIG_LIST && !g_windowManager.HasModalDialog())
+  {
     if (m_viewControl.HasControl(CONTROL_BIG_LIST))
       m_iSelectedItem = m_viewControl.GetSelectedItem();
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, CProfilesManager::GetInstance().GetNumberOfProfiles());
+  }
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114).c_str(), m_iSelectedItem+1, profileManager.GetNumberOfProfiles());
   SET_CONTROL_LABEL(CONTROL_LABEL_SELECTED_PROFILE,strLabel);
   CGUIWindow::FrameMove();
 }
 
 void CGUIWindowLoginScreen::OnInitWindow()
 {
-  m_iSelectedItem = (int)CProfilesManager::GetInstance().GetLastUsedProfileIndex();
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  m_iSelectedItem = static_cast<int>(profileManager.GetLastUsedProfileIndex());
+
   // Update list/thumb control
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
   Update();
@@ -204,20 +212,27 @@ void CGUIWindowLoginScreen::OnWindowUnload()
 void CGUIWindowLoginScreen::Update()
 {
   m_vecItems->Clear();
-  for (unsigned int i=0;i<CProfilesManager::GetInstance().GetNumberOfProfiles(); ++i)
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  for (unsigned int i = 0; i < profileManager.GetNumberOfProfiles(); ++i)
   {
-    const CProfile *profile = CProfilesManager::GetInstance().GetProfile(i);
+    const CProfile *profile = profileManager.GetProfile(i);
+
     CFileItemPtr item(new CFileItem(profile->getName()));
+
     std::string strLabel;
     if (profile->getDate().empty())
       strLabel = g_localizeStrings.Get(20113);
     else
       strLabel = StringUtils::Format(g_localizeStrings.Get(20112).c_str(), profile->getDate().c_str());
+
     item->SetLabel2(strLabel);
     item->SetArt("thumb", profile->getThumb());
     if (profile->getThumb().empty())
       item->SetArt("thumb", "DefaultUser.png");
     item->SetLabelPreformatted(true);
+
     m_vecItems->Add(item);
   }
   m_viewControl.SetItems(*m_vecItems);
@@ -226,10 +241,14 @@ void CGUIWindowLoginScreen::Update()
 
 bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
 {
-  if ( iItem < 0 || iItem >= m_vecItems->Size() ) return false;
+  if (iItem < 0 || iItem >= m_vecItems->Size())
+    return false;
+
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
 
   CFileItemPtr pItem = m_vecItems->Get(iItem);
   bool bSelect = pItem->IsSelected();
+
   // mark the item
   pItem->Select(true);
 
@@ -242,7 +261,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
   int choice = CGUIDialogContextMenu::ShowAndGetChoice(choices);
   if (choice == 2)
   {
-    if (g_passwordManager.CheckLock(CProfilesManager::GetInstance().GetMasterProfile().getLockMode(),CProfilesManager::GetInstance().GetMasterProfile().getLockCode(),20075))
+    if (g_passwordManager.CheckLock(profileManager.GetMasterProfile().getLockMode(), profileManager.GetMasterProfile().getLockCode(), 20075))
       g_passwordManager.iMasterLockRetriesLeft = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
     else // be inconvenient
       CApplicationMessenger::GetInstance().PostMsg(TMSG_SHUTDOWN);
@@ -255,7 +274,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
     CGUIDialogProfileSettings::ShowForProfile(m_viewControl.GetSelectedItem());
 
   //NOTE: this can potentially (de)select the wrong item if the filelisting has changed because of an action above.
-  if (iItem < (int)CProfilesManager::GetInstance().GetNumberOfProfiles())
+  if (iItem < static_cast<int>(profileManager.GetNumberOfProfiles()))
     m_vecItems->Get(iItem)->Select(bSelect);
 
   return false;
@@ -280,10 +299,12 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // stop PVR related services
   CServiceBroker::GetPVRManager().Stop();
 
-  if (profile != 0 || !CProfilesManager::GetInstance().IsMasterProfile())
+  CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+
+  if (profile != 0 || !profileManager.IsMasterProfile())
   {
     CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN, 1);
-    CProfilesManager::GetInstance().LoadProfile(profile);
+    profileManager.LoadProfile(profile);
   }
   else
   {
@@ -293,10 +314,10 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   }
   CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_UP, 1);
 
-  CProfilesManager::GetInstance().UpdateCurrentProfileDate();
-  CProfilesManager::GetInstance().Save();
+  profileManager.UpdateCurrentProfileDate();
+  profileManager.Save();
 
-  if (CProfilesManager::GetInstance().GetLastUsedProfileIndex() != profile)
+  if (profileManager.GetLastUsedProfileIndex() != profile)
   {
     CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_VIDEO);
     CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST_MUSIC);
@@ -311,7 +332,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   if (!g_application.LoadLanguage(true))
   {
-    CLog::Log(LOGFATAL, "CGUIWindowLoginScreen: unable to load language for profile \"%s\"", CProfilesManager::GetInstance().GetCurrentProfile().getName().c_str());
+    CLog::Log(LOGFATAL, "CGUIWindowLoginScreen: unable to load language for profile \"%s\"", profileManager.GetCurrentProfile().getName().c_str());
     return;
   }
 
@@ -325,7 +346,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   // restart PVR services
   CServiceBroker::GetPVRManager().Init();
 
-  CServiceBroker::GetFavouritesService().ReInit(CProfilesManager::GetInstance().GetProfileUserDataFolder());
+  CServiceBroker::GetFavouritesService().ReInit(profileManager.GetProfileUserDataFolder());
 
   CServiceBroker::GetServiceAddons().Start();
 


### PR DESCRIPTION
This kills the CProfilesManager singleton by moving it to ServiceManager. Of course, everything depends on CProfilesManager, including a multitude of other globals/singletons, so I started moving some of these to ServiceManager as well.

## Motivation and Context
Make solving the bug tackled by #13412 more tractable.

## How Has This Been Tested?
CPlayerCoreFactory - tested playing a video
CDatabaseManager - tested starting with an existing userdata and a clean userdata
CEventLog - tested by viewing Event Log
CProfilesManager - tested by creating and using several profiles

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
