### PR TITLE
[fix] move virtual window handling to translators to solve issue with remote mappings

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -197,6 +197,9 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
 {
   std::string strAction;
 
+  // handle virtual windows
+  window = CWindowTranslator::GetVirtualWindow(window);
+
   // try to get the action from the current window
   unsigned int actionID = GetActionCode(window, key, strAction);
 
@@ -225,6 +228,13 @@ CAction CButtonTranslator::GetGlobalAction(const CKey &key)
 
 bool CButtonTranslator::HasLongpressMapping(int window, const CKey &key)
 {
+  // handle virtual windows
+  window = CWindowTranslator::GetVirtualWindow(window);
+  return HasLongpressMapping_Internal(window, key);
+}
+
+bool CButtonTranslator::HasLongpressMapping_Internal(int window, const CKey &key)
+{
   std::map<int, buttonMap>::const_iterator it = m_translatorMap.find(window);
   if (it != m_translatorMap.end())
   {
@@ -252,11 +262,11 @@ bool CButtonTranslator::HasLongpressMapping(int window, const CKey &key)
   {
     // first check if we have a fallback for the window
     int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
-    if (fallbackWindow > -1 && HasLongpressMapping(fallbackWindow, key))
+    if (fallbackWindow > -1 && HasLongpressMapping_Internal(fallbackWindow, key))
       return true;
 
     // fallback to default section
-    return HasLongpressMapping(-1, key);
+    return HasLongpressMapping_Internal(-1, key);
   }
 
   return false;
@@ -271,7 +281,7 @@ unsigned int CButtonTranslator::GetActionCode(int window, const CKey &key, std::
   code &= ~CKey::MODIFIER_NUMLOCK;
   code &= ~CKey::MODIFIER_SCROLLLOCK;
 
-  std::map<int, buttonMap>::const_iterator it = m_translatorMap.find(CWindowTranslator::GetVirtualWindow(window));
+  std::map<int, buttonMap>::const_iterator it = m_translatorMap.find(window);
   if (it == m_translatorMap.end())
     return ACTION_NONE;
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -102,5 +102,7 @@ private:
 
   bool LoadKeymap(const std::string &keymapPath);
 
+  bool HasLongpressMapping_Internal(int window, const CKey &key);
+
   std::map<std::string, IButtonMapper*> m_buttonMappers;
 };

--- a/xbmc/input/CustomControllerTranslator.cpp
+++ b/xbmc/input/CustomControllerTranslator.cpp
@@ -78,6 +78,9 @@ bool CCustomControllerTranslator::TranslateCustomControllerString(int windowId, 
 {
   unsigned int actionId = ACTION_NONE;
 
+  // handle virtual windows
+  windowId = CWindowTranslator::GetVirtualWindow(windowId);
+
   // Try to get the action from the current window
   if (!TranslateString(windowId, controllerName, buttonId, actionId, strAction))
   {

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -363,8 +363,6 @@ bool CInputManager::Process(int windowId, float frameTime)
   m_RemoteControl.Update();
 #endif
 
-  windowId = CWindowTranslator::GetVirtualWindow(windowId);
-
   // process input actions
   ProcessRemote(windowId);
   ProcessEventServer(windowId, frameTime);

--- a/xbmc/input/TouchTranslator.cpp
+++ b/xbmc/input/TouchTranslator.cpp
@@ -103,6 +103,9 @@ bool CTouchTranslator::TranslateTouchAction(int window, int touchAction, int tou
 
   unsigned int actionId = ACTION_NONE;
 
+  // handle virtual windows
+  window = CWindowTranslator::GetVirtualWindow(window);
+
   if (!TranslateAction(window, touchAction, touchPointers, actionId, actionString))
   {
     int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
@@ -128,8 +131,6 @@ bool CTouchTranslator::TranslateAction(int window, unsigned int touchCommand, in
 
 unsigned int CTouchTranslator::GetActionID(WindowID window, TouchActionKey touchActionKey, std::string &actionString)
 {
-  window = CWindowTranslator::GetVirtualWindow(window);
-
   auto windowIt = m_touchMap.find(window);
   if (windowIt == m_touchMap.end())
     return ACTION_NONE;

--- a/xbmc/input/WindowKeymap.cpp
+++ b/xbmc/input/WindowKeymap.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "WindowKeymap.h"
+#include "WindowTranslator.h"
 
 using namespace KODI;
 
@@ -37,6 +38,9 @@ void CWindowKeymap::MapAction(int windowId, const std::string &keyName, JOYSTICK
 
 const JOYSTICK::KeymapActionGroup &CWindowKeymap::GetActions(int windowId, const std::string& keyName) const
 {
+  // handle virtual windows
+  windowId = CWindowTranslator::GetVirtualWindow(windowId);
+
   auto it = m_windowKeymap.find(windowId);
   if (it != m_windowKeymap.end())
   {


### PR DESCRIPTION
@MilhouseVH hope this will fix the reported issue https://github.com/xbmc/xbmc/pull/13433#issuecomment-360883707

Runtime tested with keyboard mappings for virtual windows and works fine.
I can't test remote mappings because I don't have a remote control anymore (using FLIRC).