### PR TITLE
Fix hang on exit. 

### DIFF
--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -164,7 +164,7 @@ void CJobQueue::CancelJobs()
 
 bool CJobQueue::IsProcessing() const
 {
-  return !m_processing.empty() || !m_jobQueue.empty();
+  return CJobManager::GetInstance().m_running && (!m_processing.empty() || !m_jobQueue.empty());
 }
 
 bool CJobQueue::QueueEmpty() const

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -322,6 +322,7 @@ public:
 protected:
   friend class CJobWorker;
   friend class CJob;
+  friend class CJobQueue;
 
   /*!
    \brief Get a new job to process. Blocks until a new job is available, or a timeout has occurred.


### PR DESCRIPTION

<!--- Provide a general summary of your change in the Title above -->
The VideoPlayer has a JobQueue that's not managed directly by the JobManager and so when the JobManager shuts down this queue can't be clearer. 

## Description
<!--- Describe your change in detail -->
This change just makes the CJobQueue::IsProcessing method also check the CJobManager::m_isrunning flag since if it's not running then the JobQueue is also not processing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If you try to exit while playing a video, Kodi hangs.

<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Easily reproduced the problem. Made sure there was a clean exit after the change.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
