### PR TITLE
Fix for DVDs not playing under Linux when using UDisks.

### DIFF
--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -606,7 +606,7 @@ std::string CMediaManager::GetDiscPath()
   m_platformStorage->GetRemovableDrives(drives);
   for(unsigned i = 0; i < drives.size(); ++i)
   {
-    if(drives[i].m_iDriveType == CMediaSource::SOURCE_TYPE_DVD)
+    if(drives[i].m_iDriveType == CMediaSource::SOURCE_TYPE_DVD && !drives[i].strPath.empty())
       return drives[i].strPath;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
## Description
I've changed the GetDiscPath code to not return strPath if it is empty if it is called on an unmounted removable drive.  Instead, it runs GetDVDPath to find the DVD path.

<!--- Describe your change in detail -->

## Motivation and Context
For a long time, I haven't been able to play DVDs on Kodi - throughout 17.x, and possibly beforehand.  I eventually tracked this down to my DVD drive being detected as removable, but the path remaining empty.  Making this change meant DVDs have started playing again.
It seems to only be an issue when using UDisks.  The fix is fairly simple - if the strPath is empty (i.e. no path found), then run the normal GetDVDPath code.  This is what happens when the drive is not removable, so it doesn't seem too bad to do it when the drive is removable.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
I've compiled and run this change on my own gentoo system running 17.6, it now plays DVDs correctly when it wouldn't before.  Other people claim to have also had success, see this thread:
https://forum.kodi.tv/showthread.php?tid=321334&page=2
I haven't run any formal tests - I don't know how to.
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
