### PR TITLE
Fix for multiGPU setups

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -124,7 +124,7 @@ namespace DX
     bool IsStereoEnabled() const { return m_stereoEnabled; }
     void SetStereoIdx(byte idx) { m_backBufferTex.SetViewIdx(idx); }
 
-    void SetMonitor(HMONITOR monitor) const;
+    void SetMonitor(HMONITOR monitor);
     HMONITOR GetMonitor() const;
 #if defined(TARGET_WINDOWS_DESKTOP)
     void SetWindow(HWND window);

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -84,6 +84,7 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
     // sleep until vblank
     Microsoft::WRL::ComPtr<IDXGIOutput> pOutput;
     DX::DeviceResources::Get()->GetOutput(&pOutput);
+    if (pOutput != nullptr) //*FIXME! During MultiGPU screen switching fall to last working renderer*//
     HRESULT hr = pOutput->WaitForVBlank();
 
     // calculate how many vblanks happened


### PR DESCRIPTION
Fix for multiGPU setups
<!--- Provide a general summary of your change in the Title above -->

## Description
Most setups have multi renderer hardware. This patch fixes the recognition of d3d11 devices. Note that if the screen is switched, in the next video rendendering it will crash, but an application restart permits to use it without problems. Better than nothing. I think initialization requires a big rewrite for including multi gpu support.
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Built with VS2017 15.5.6
Windows SDK 10.0.16299.0
Tested on Windows 10 16299 3GPU system
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
