### PR TITLE
[Estuary] hide repeat / random in partymode

### DIFF
--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -119,7 +119,7 @@
 				<control type="group" id="699">
 					<width>76</width>
 					<height>76</height>
-					<visible>!MusicPlayer.Content(LiveTV)</visible>
+					<visible>![MusicPlayer.Content(LiveTV) | MusicPartyMode.Enabled]</visible>
 					<control type="button" id="704">
 						<left>0</left>
 						<top>0</top>
@@ -162,7 +162,7 @@
 					<radioposx>1</radioposx>
 					<radioposy>0</radioposy>
 					<selected>Playlist.IsRandom</selected>
-					<visible>!MusicPlayer.Content(LiveTV)</visible>
+					<visible>![MusicPlayer.Content(LiveTV) | MusicPartyMode.Enabled]</visible>
 					<onclick>PlayerControl(Random)</onclick>
 				</control>
 				<control type="radiobutton" id="703">


### PR DESCRIPTION
the repeat and random buttons on the music osd are non-functional during partymode playback.
let's hide them.

@da-anda 