### PR TITLE
VideoPlayer: RenderManager: treat mono as non-3d mode when updating display resolution

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -870,7 +870,7 @@ void CRenderManager::UpdateResolution()
     {
       if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
-        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, !m_stereomode.empty());
+        RESOLUTION res = CResolutionUtils::ChooseBestResolution(m_fps, m_width, !m_stereomode.empty() && m_stereomode != "mono");
         g_graphicsContext.SetVideoResolution(res, false);
         UpdateLatencyTweak();
       }


### PR DESCRIPTION
Treat "mono" as non-3D mode when updating display resolution.

## Description
CVideoPlayer::OpenVideo() may pass "mono" as stereo mode to CRenderManager::TriggerUpdateResolution(), but CRenderManager::UpdateResolution() mistakenly treats this as a 3D mode, leading to selection of wrong display mode.

## Motivation and Context
Kodi sometimes switches to display mode with refresh rate not matching FPS of the video being played.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
