### PR TITLE
VideoPlayer: do not set stereo mode for monoscopic video, keep it an empty string

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -700,7 +700,7 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
           stereoMode = m_hints.stereo_mode;
           break;
       }
-      if (!stereoMode.empty())
+      if (!stereoMode.empty() && stereoMode != "mono")
       {
         m_picture.stereoMode = stereoMode;
       }

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -162,7 +162,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetNextSupportedStereoMode(const RENDE
 
 std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &needle)
 {
-  std::string stereoMode = "mono";
+  std::string stereoMode;
   std::string searchString(needle);
   CRegExp re(true);
 


### PR DESCRIPTION
Do not set stereo mode for monoscopic video, keep it an empty string.

## Description
Keep stereo mode for monoscopic video in video player as an empty string, stereo mode should be set only for 3D videos.

## Motivation and Context
Kodi sometimes switches to display mode with refresh rate not matching FPS of the video being played, because render manager mistakenly treats "mono" stereo mode as a 3D mode.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
