### PR TITLE
depends: Fix guid build

### DIFF
--- a/tools/depends/target/crossguid/Makefile
+++ b/tools/depends/target/crossguid/Makefile
@@ -10,6 +10,7 @@ ARCHIVE=$(SOURCE).tar.gz
 
 ifeq ($(CROSS_COMPILING), yes)
   DEPS += ../../Makefile.include
+  CXXFLAGS += -std=c++11
 else
   CXXFLAGS += -std=c++11
   ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Specify -std=c++11 to avoid compile error
<!--- Describe your change in detail -->

## Motivation and Context
Avoids error with gcc4.9:
guid.cpp:112:25: error: range-based 'for' loops are not allowed in C++98 mode

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [Z] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
