### PR TITLE
[darwin] Add support for apfs to storage provider.

### DIFF
--- a/xbmc/storage/osx/DarwinStorageProvider.cpp
+++ b/xbmc/storage/osx/DarwinStorageProvider.cpp
@@ -181,9 +181,9 @@ std::vector<std::string> CDarwinStorageProvider::GetDiskUsage()
   char line[1024];
 
 #ifdef TARGET_DARWIN_IOS
-  FILE* pipe = popen("df -ht hfs", "r");
+  FILE* pipe = popen("df -ht hfs,apfs", "r");
 #else
-  FILE* pipe = popen("df -hT ufs,cd9660,hfs,udf", "r");
+  FILE* pipe = popen("df -HT ufs,cd9660,hfs,apfs,udf", "r");
 #endif
 
   if (pipe)


### PR DESCRIPTION
before:
![screenshot000](https://user-images.githubusercontent.com/3226626/35776989-6973dd60-09a6-11e8-81d4-ab507bc4c3b8.png)

after:
![screenshot003](https://user-images.githubusercontent.com/3226626/35776993-72844dd6-09a6-11e8-8775-45978c069fe8.png)

@Memphiz good to go? 

And no, I don't feel responsible to fix the "..." UI glitsch in the system info window. 

Darwin "df" does not seem to provide a way to remove the "inode" information, without altering other row values non-human-readable. According to the man page, adding "-P" parameter will remove the inode information and it does. But "df -HPT ufs,cd9660,hfs,apfs,udf" produces this

<pre>
Filesystem   512-blocks      Used Available Capacity  Mounted on
/dev/disk1s1  975221032 495381088 472195496    52%    /
/dev/disk1s4  975221032   6291496 472195496     2%    /private/var/vm
</pre>

which is of no use for end users.
