### PR TITLE
[depends] gnutls: don't use getentropy on darwin systems

### DIFF
--- a/tools/depends/target/gnutls/02-darwin-getentropy.patch
+++ b/tools/depends/target/gnutls/02-darwin-getentropy.patch
@@ -1,0 +1,18 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -220,6 +220,7 @@
+ 		   rnd_variant=getrandom],
+ 		  [AC_MSG_RESULT(no)])
+ 
++if test "x$have_macosx" != "xyes"; then
+ AC_MSG_CHECKING([for getentropy])
+ AC_LINK_IFELSE([AC_LANG_PROGRAM([
+ 	   #include <unistd.h>
+@@ -233,6 +234,7 @@
+ 		   AC_DEFINE([HAVE_GETENTROPY], 1, [Enable the OpenBSD getentropy function])
+ 		   rnd_variant=getentropy],
+ 		  [AC_MSG_RESULT(no)])
++fi
+ 
+ AM_CONDITIONAL(HAVE_GETENTROPY, test "$rnd_variant" = "getentropy")
+ 

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS= ../../Makefile.include Makefile size-max.patch
+DEPS= ../../Makefile.include Makefile size-max.patch 02-darwin-getentropy.patch
 
 # lib name, version
 LIBNAME=gnutls
@@ -33,10 +33,9 @@ $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p0 < ../size-max.patch
+	cd $(PLATFORM); patch -p1 -i ../02-darwin-getentropy.patch
+	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
-ifeq (darwin, $(findstring darwin, $(HOST)))
-	cd $(PLATFORM); sed -ie "s/HAVE_GETENTROPY/HAVE_GETENTROPY_NOPE/" config.h
-endif
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)


### PR DESCRIPTION
## Motivation and Context
Kodi on iOS crashes, because`getentropy` symbol can't be found.

## How Has This Been Tested?
runtime tested on iOS

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
