### PR TITLE
[PVR] Search window: Fix init of search filter.

### DIFF
--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -34,7 +34,8 @@
 
 using namespace PVR;
 
-CPVREpgSearchFilter::CPVREpgSearchFilter()
+CPVREpgSearchFilter::CPVREpgSearchFilter(bool bRadio)
+: m_bIsRadio(bRadio)
 {
   Reset();
 }
@@ -51,17 +52,22 @@ void CPVREpgSearchFilter::Reset()
 
   m_startDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetFirstEPGDate());
   if (!m_startDateTime.IsValid())
+  {
+    CLog::Log(LOGWARNING, "%s - No valid epg start time. Defaulting search start time to 'now'", __FUNCTION__);
     m_startDateTime.SetFromUTCDateTime(CDateTime::GetUTCDateTime()); // default to 'now'
+  }
 
   m_endDateTime.SetFromUTCDateTime(CServiceBroker::GetPVRManager().EpgContainer().GetLastEPGDate());
   if (!m_endDateTime.IsValid())
+  {
+    CLog::Log(LOGWARNING, "%s - No valid epg end time. Defaulting search end time to search start time plus 10 days", __FUNCTION__);
     m_endDateTime.SetFromUTCDateTime(m_startDateTime + CDateTimeSpan(10, 0, 0, 0)); // default to start + 10 days
+  }
 
   m_bIncludeUnknownGenres    = false;
   m_bRemoveDuplicates        = false;
 
   /* pvr specific filters */
-  m_bIsRadio                 = false;
   m_channelNumber = CPVRChannelNumber();
   m_bFreeToAirOnly           = false;
   m_iChannelGroup            = EPG_SEARCH_UNSET;

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -35,7 +35,13 @@ namespace PVR
   class CPVREpgSearchFilter
   {
   public:
-    CPVREpgSearchFilter();
+    CPVREpgSearchFilter() = delete;
+
+    /*!
+     * @brief ctor.
+     * @param bRadio the type of channels to search - if true, 'radio'. 'tv', otherwise.
+     */
+    CPVREpgSearchFilter(bool bRadio);
 
     /*!
      * @brief Clear this filter.
@@ -55,6 +61,12 @@ namespace PVR
      * @return the number of items in the list after removing duplicates.
      */
     static int RemoveDuplicates(CFileItemList &results);
+
+    /*!
+     * @brief Get the type of channels to search.
+     * @return true, if 'radio'. false, otherwise.
+     */
+    bool IsRadio() const { return m_bIsRadio; }
 
     const std::string &GetSearchTerm() const { return m_strSearchTerm; }
     void SetSearchTerm(const std::string &strSearchTerm) { m_strSearchTerm = strSearchTerm; }
@@ -89,9 +101,6 @@ namespace PVR
 
     bool ShouldRemoveDuplicates() const { return m_bRemoveDuplicates; }
     void SetRemoveDuplicates(bool bRemoveDuplicates) { m_bRemoveDuplicates = bRemoveDuplicates; }
-
-    bool IsRadio() const { return m_bIsRadio; }
-    void SetIsRadio(bool bIsRadio) { m_bIsRadio = bIsRadio; }
 
     const CPVRChannelNumber& GetChannelNumber() const { return m_channelNumber; }
     void SetChannelNumber(const CPVRChannelNumber& channelNumber) { m_channelNumber = channelNumber; }
@@ -135,7 +144,7 @@ namespace PVR
     CDateTime     m_endDateTime;              /*!< The maximum end time for an entry */
     bool          m_bIncludeUnknownGenres;    /*!< Include unknown genres or not */
     bool          m_bRemoveDuplicates;        /*!< True to remove duplicate events, false if not */
-    bool          m_bIsRadio;                 /*!< True to filter radio channels only, false to tv only */
+    const bool    m_bIsRadio;                 /*!< True to filter radio channels only, false to tv only */
 
     /* PVR specific filters */
     CPVRChannelNumber  m_channelNumber;       /*!< The channel number in the selected channel group */

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -19,11 +19,14 @@
  *
  */
 
-#include "pvr/epg/EpgSearchFilter.h"
+#include <memory>
+
 #include "pvr/windows/GUIWindowPVRBase.h"
 
 namespace PVR
 {
+  class CPVREpgSearchFilter;
+
   class CGUIWindowPVRSearchBase : public CGUIWindowPVRBase
   {
   public:
@@ -50,7 +53,7 @@ namespace PVR
     void OpenDialogSearch();
 
     bool m_bSearchConfirmed;
-    CPVREpgSearchFilter m_searchfilter;
+    std::unique_ptr<CPVREpgSearchFilter> m_searchfilter;
   };
 
   class CGUIWindowPVRTVSearch : public CGUIWindowPVRSearchBase


### PR DESCRIPTION
Fixes a bug reported here: https://forum.kodi.tv/showthread.php?tid=327671

The search filter of the search window instances cannot be initialized in windows' ctor as the windows get created long before PVR gets initialized... and the ctor of `CPVREpgSearchFilter` needs some data from the epg container. Thus, init the search filter on demand.

@Jalle19 good to go?