### PR TITLE
Remove ServiceBroker usage from FileExtensionProvider

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -72,14 +72,22 @@ bool CServiceManager::InitForTesting()
 
   m_databaseManager.reset(new CDatabaseManager);
 
-  m_fileExtensionProvider.reset(new CFileExtensionProvider());
-
+  m_binaryAddonManager.reset(new ADDON::CBinaryAddonManager());
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
     CLog::Log(LOGFATAL, "CServiceManager::%s: Unable to start CAddonMgr", __FUNCTION__);
     return false;
   }
+
+  if (!m_binaryAddonManager->Init())
+  {
+    CLog::Log(LOGFATAL, "CServiceManager::%s: Unable to initialize CBinaryAddonManager", __FUNCTION__);
+    return false;
+  }
+
+  m_fileExtensionProvider.reset(new CFileExtensionProvider(*m_addonMgr,
+                                                           *m_binaryAddonManager));
 
   init_level = 1;
   return true;
@@ -88,8 +96,9 @@ bool CServiceManager::InitForTesting()
 void CServiceManager::DeinitTesting()
 {
   init_level = 0;
-  m_addonMgr.reset();
   m_fileExtensionProvider.reset();
+  m_binaryAddonManager.reset();
+  m_addonMgr.reset();
   m_databaseManager.reset();
   m_profileManager.reset();
   m_network.reset();
@@ -175,7 +184,8 @@ bool CServiceManager::InitStageTwo(const CAppParamParser &params)
 
   m_gameRenderManager.reset(new RETRO::CGUIGameRenderManager);
 
-  m_fileExtensionProvider.reset(new CFileExtensionProvider());
+  m_fileExtensionProvider.reset(new CFileExtensionProvider(*m_addonMgr,
+                                                           *m_binaryAddonManager));
 
   m_powerManager.reset(new CPowerManager());
   m_powerManager->Initialize();

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -23,10 +23,17 @@
 #include "addons/AddonEvents.h"
 #include "settings/AdvancedSettings.h"
 
+namespace ADDON
+{
+  class CAddonMgr;
+  class CBinaryAddonManager;
+}
+
 class CFileExtensionProvider
 {
 public:
-  CFileExtensionProvider();
+  CFileExtensionProvider(ADDON::CAddonMgr &addonManager,
+                         ADDON::CBinaryAddonManager &binaryAddonManager);
   ~CFileExtensionProvider();
 
   /*!
@@ -67,6 +74,11 @@ private:
 
   void OnAddonEvent(const ADDON::AddonEvent& event);
 
+  // Construction properties
+  ADDON::CAddonMgr &m_addonManager;
+  ADDON::CBinaryAddonManager &m_binaryAddonManager;
+
+  // File extension properties
   std::map<ADDON::TYPE, std::string> m_addonExtensions;
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   std::map<ADDON::TYPE, std::string> m_addonFileFolderExtensions;


### PR DESCRIPTION
This supersedes #13470. It contains the fix posted lower in the thread.

## How Has This Been Tested?
Compiles successfully. Unit tests don't segfault.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
