### PR TITLE
fixed: return actual position for seek in file cache

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -534,7 +534,7 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
   else
     m_readPos = iTarget;
 
-  return m_nSeekResult;
+  return iTarget;
 }
 
 void CFileCache::Close()


### PR DESCRIPTION
I eventually tracked old-style rar's being broken in libarchive when read from sftp down to this beauty.