### PR TITLE
changed: drop XbmcThread::NonCopyable

### DIFF
--- a/xbmc/threads/Condition.h
+++ b/xbmc/threads/Condition.h
@@ -35,12 +35,15 @@ namespace XbmcThreads
    *  to "spurious returns" as it is built on boost which is built on posix
    *  on many of our platforms.
    */
-  class ConditionVariable : public NonCopyable
+  class ConditionVariable
   {
   private:
     std::condition_variable_any cond;
+    ConditionVariable(const ConditionVariable&) = delete;
+    ConditionVariable& operator=(const ConditionVariable&) = delete;
 
   public:
+    ConditionVariable() = default;
 
     inline void wait(CCriticalSection& lock) 
     {

--- a/xbmc/threads/Event.h
+++ b/xbmc/threads/Event.h
@@ -43,7 +43,7 @@ namespace XbmcThreads
  *
  * This class manages 'spurious returns' from the condition variable.
  */
-class CEvent : public XbmcThreads::NonCopyable
+class CEvent
 {
   bool manualReset;
   volatile bool signaled;
@@ -68,6 +68,9 @@ class CEvent : public XbmcThreads::NonCopyable
 
   // helper for the two wait methods
   inline bool prepReturn() { bool ret = signaled; if (!manualReset && numWaits == 0) signaled = false; return ret; }
+
+  CEvent(const CEvent&) = delete;
+  CEvent& operator=(const CEvent&) = delete;
 
 public:
   inline CEvent(bool manual = false, bool signaled_ = false) : 
@@ -110,7 +113,7 @@ namespace XbmcThreads
    * It is equivalent to WaitOnMultipleObject that returns when "any" Event
    * in the group signaled.
    */
-  class CEventGroup : public NonCopyable
+  class CEventGroup
   {
     std::vector<CEvent*> events;
     CEvent* signaled{};
@@ -124,6 +127,9 @@ namespace XbmcThreads
     inline void Set(CEvent* child) { CSingleLock l(mutex); signaled = child; condVar.notifyAll(); }
 
     friend class ::CEvent;
+
+    CEventGroup(const CEventGroup&) = delete;
+    CEventGroup& operator=(const CEventGroup&) = delete;
 
   public:
     /**

--- a/xbmc/threads/Helpers.h
+++ b/xbmc/threads/Helpers.h
@@ -23,17 +23,6 @@
 namespace XbmcThreads
 {
   /**
-   * Any class that inherits from NonCopyable will ... not be copyable (Duh!)
-   */
-  class NonCopyable
-  {
-    inline NonCopyable(const NonCopyable&) = default;
-    inline NonCopyable& operator=(const NonCopyable&) { return *this; }
-  public:
-    inline NonCopyable() = default;
-  };
-
-  /**
    * This will create a new predicate from an old predicate P with 
    *  inverse truth value. This predicate is safe to use in a 
    *  TightConditionVariable<P>

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -46,9 +46,12 @@ namespace XbmcThreads
    *
    * All xbmc code expects Lockables to be recursive.
    */
-  template<class L> class CountingLockable : public NonCopyable
+  template<class L> class CountingLockable
   {
     friend class ConditionVariable;
+
+    CountingLockable(const CountingLockable&) = delete;
+    CountingLockable& operator=(const CountingLockable&) = delete;
   protected:
     L mutex;
     unsigned int count;
@@ -119,8 +122,10 @@ namespace XbmcThreads
    * This template can be used to define the base implementation for any UniqueLock
    * (such as CSingleLock) that uses a Lockable as its mutex/critical section.
    */
-  template<typename L> class UniqueLock : public NonCopyable
+  template<typename L> class UniqueLock
   {
+    UniqueLock(const UniqueLock&) = delete;
+    UniqueLock& operator=(const UniqueLock&) = delete;
   protected:
     L& mutex;
     bool owns;
@@ -154,8 +159,10 @@ namespace XbmcThreads
    * bool try_lock_shared();
    * void unlock_shared();
    */
-  template<typename L> class SharedLock : public NonCopyable
+  template<typename L> class SharedLock
   {
+    SharedLock(const SharedLock&) = delete;
+    SharedLock& operator=(const SharedLock&) = delete;
   protected:
     L& mutex;
     bool owns;


### PR DESCRIPTION
use deleted ctor/operators instead

@jimfcarroll @Paxxi 