### PR TITLE
[win32]Fix env vars out of sync in debug mode regression

### DIFF
--- a/xbmc/platform/win32/Environment.cpp
+++ b/xbmc/platform/win32/Environment.cpp
@@ -63,6 +63,32 @@ int CEnvironment::win_setenv(const std::string &name, const std::string &value /
   else
     EnvString = Wname + L"=" + Wvalue;
 
+  #ifdef _DEBUG
+    // Most dependencies are built in release and use non-debug runtime libs, 
+    // and so we have to sync environment vars for these during debug because 
+    // they don't share environments between themselves
+    typedef int(_cdecl * wputenvPtr) (const wchar_t *envstring);
+    static const wchar_t *modulesList[] =
+    {
+      { L"vcruntime140.dll" },
+      { L"ucrtbase.dll" },
+      { nullptr } // Terminating NULL for list
+    };
+  
+    // Check all modules each function run, because modules can be loaded/unloaded at runtime
+    for (int i = 0; modulesList[i]; i++)
+    {
+      HMODULE hModule;
+      if (!GetModuleHandleExW(0, modulesList[i], &hModule) || hModule == nullptr) // Flag 0 ensures that module will be kept loaded until it'll be freed
+         continue; // Module not loaded
+  
+      wputenvPtr wputenvFunc = (wputenvPtr)GetProcAddress(hModule, "_wputenv");
+      if (wputenvFunc != nullptr && wputenvFunc(EnvString.c_str()) != 0)
+         retValue |= 2; // At lest one external runtime library Environment update failed
+      FreeLibrary(hModule);
+    }
+  #endif
+
   // Update process Environment used for current process and for future new child processes
   if (action == deleteVariable || value.empty())
     retValue += SetEnvironmentVariableW(Wname.c_str(), nullptr) ? 0 : 4; // 4 if failed


### PR DESCRIPTION
Restore a variation of CEnvironment setenv processing, that was removed by https://github.com/xbmc/xbmc/pull/13424/commits/e958b6af1c81028a8f244add07ce8931cf50e302,  for **debug build only**. 

Following CEnvironment cleanup by #13424 running both x86 and x64 debug builds from VS2017 silently terminate after displaying splash screen. **Release builds are uneffected**.

Debug and non-debug runtime libraries do not share environments, and since most dependencies are built in release and use non-debug runtime libs,  we have to sync environment vars when in debug mode. Without this sync during debug  attempting to initiate Python silently terminates the Kodi process because cannot find its library. Kodi is linked to vcruntime140d but dependencies such as Python do not.

@afedchin since you are busy I have raised this PR with the fix you suggested, hope this is OK.
