### PR TITLE
[Music]Fix Container.Art for collaboration albums

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1235,14 +1235,23 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
     }
     if (artfound)
     {
+      std::string dirType = MediaTypeArtist;
+      if (params.GetAlbumId() > 0)
+        dirType = MediaTypeAlbum;
       std::map<std::string, std::string> artmap;
       for (auto artitem : art)
       {
         std::string artname;
-        artname = artitem.artType;
-        if (params.GetAlbumId() > 0 && artitem.mediaType != MediaTypeAlbum)
+        if (dirType == artitem.mediaType)
+          artname = artitem.artType;
+        else if (artitem.prefix.empty())
           artname = artitem.mediaType + "." + artitem.artType;
-        artmap.insert(std::make_pair(artname, artitem.url));
+        else
+        {
+          if (dirType == MediaTypeAlbum)
+            StringUtils::Replace(artitem.prefix, "albumartist", "artist");
+          artname = artitem.prefix + "." + artitem.artType;
+        }
       }
       items.SetArt(artmap);
     }


### PR DESCRIPTION
Minor fix of overwrite of artist art for `Container.Art` on music nav windows when album has multiple album artists.

A short follow up to #13352 Music Artwork Consistently Availlable To GUI. Tested using albums with multiple artists e.g. collaborations like composer, conductor and orchestra, and a modified skin.

@rmrector may be interested, this provides the missing art you spotted. Deciding that we only want art for the selected/filtered artist I'll take as a feature change, if that is the way we want to go subsequnently.

