### PR TITLE
ActivateWindow return reset history if different starting path

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -516,7 +516,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         // ensure our directory is valid
         dir = GetStartFolder(dir);
         bool resetHistory = false;
-        if (!returning || !m_history.IsInHistory(dir))
+        if (!returning || !URIUtils::PathEquals(dir, m_startDirectory, true))
         { // we're not returning to the same path, so set our directory to the requested path
           m_vecItems->SetPath(dir);
           resetHistory = true;


### PR DESCRIPTION
## Description
When opening a media window with the "return" option, reset history if the path is different than the previous starting path, rather than anywhere in the previous history.

## Motivation and Context
Different buttons should only keep the previous history if they point to the same starting window. Navigating to a deep path (like all episodes of one TV show) with return, then returning and opening a shallower path that is a parent of the previous path (like videodb://tvshows/titles/), kept the deeper path navigated when the new path is expected.
Button on Home with action `ActivateWindow(videos, videodb://tvshows/titles/124/-2/, return)`, then press back and another button with action `ActivateWindow(videos, videodb://tvshows/titles/, return)` should show the list of all TV shows but instead goes to the previous episode list.

**Example 1:** This can be reproduced in Estuary by opening a TV show from the "Unwatched TV Shows" widget, then backing out of the video library and then opening "TV shows" from the main list. The "In progress TV Shows" widget does not exhibit the same issue as it works with a different path.

**Example 2:** Another can happen in Estuary with the add-on browser. Open Kodi settings, navigate to "System", "Add-ons", then select "Manage dependencies", then back out to the main settings window and open "Add-ons" from here, and the add-on browser open to the "Manage dependencies" list. The same thing happens with "Running" add-ons from "System" "Add-ons".

## How Has This Been Tested?

Manually. The above scenario doesn't happen, and opening a shallow path (like "videodb://tvshows/" and "musicdb://artists") and navigating to a deeper path then closing and reopening the window with the same shallow path keeps the previous history and starts at the path it was left at, as it was. ActivateWindow calls without "return" are not affected.
The desired behavior from two previous changes to this bit still work as expected: [this bug fix](https://trac.kodi.tv/ticket/15015) and the previous c84dd977473.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
