### PR TITLE
RetroPlayer: GL(ES) don't hardcode pixelformats

### DIFF
--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -55,7 +55,7 @@ CRPProcessInfo::CRPProcessInfo(std::string platformName) :
 {
   for (auto &rendererFactory : m_rendererFactories)
   {
-    RenderBufferPoolVector bufferPools = rendererFactory->CreateBufferPools();
+    RenderBufferPoolVector bufferPools = rendererFactory->CreateBufferPools(*m_renderContext);
     m_renderBufferManager->RegisterPools(rendererFactory.get(), std::move(bufferPools));
   }
 

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -51,7 +51,7 @@ namespace RETRO
 
     virtual std::string RenderSystemName() const = 0;
     virtual CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) = 0;
-    virtual RenderBufferPoolVector CreateBufferPools() = 0;
+    virtual RenderBufferPoolVector CreateBufferPools(CRenderContext &context) = 0;
   };
 
   class CRPProcessInfo

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -70,6 +70,11 @@ void CRenderContext::ApplyStateBlock()
   m_rendering->ApplyStateBlock();
 }
 
+bool CRenderContext::IsExtSupported(const char* extension)
+{
+  return m_rendering->IsExtSupported(extension);
+}
+
 #if defined(HAS_GL) || defined(HAS_GLES)
 namespace
 {

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -61,6 +61,7 @@ namespace RETRO
     void GetViewPort(CRect &viewPort);
     void SetScissors(const CRect &rect);
     void ApplyStateBlock();
+    bool IsExtSupported(const char* extension);
 
     // OpenGL(ES) rendering functions
     void EnableGUIShader(GL_SHADER_METHOD method);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -46,7 +46,7 @@ CRPBaseRenderer *CRendererFactoryGuiTexture::CreateRenderer(const CRenderSetting
   return new CRPRendererGuiTexture(settings, context, std::move(bufferPool));
 }
 
-RenderBufferPoolVector CRendererFactoryGuiTexture::CreateBufferPools()
+RenderBufferPoolVector CRendererFactoryGuiTexture::CreateBufferPools(CRenderContext &context)
 {
   return {
 #if !defined(HAS_DX)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h
@@ -36,7 +36,7 @@ namespace RETRO
     // implementation of IRendererFactory
     std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
-    RenderBufferPoolVector CreateBufferPools() override;
+    RenderBufferPoolVector CreateBufferPools(CRenderContext &context) override;
   };
 
   class CRenderBufferPoolGuiTexture : public CBaseRenderBufferPool

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererMMAL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererMMAL.cpp
@@ -36,7 +36,7 @@ CRPBaseRenderer *CRendererFactoryMMAL::CreateRenderer(const CRenderSettings &set
   return new CRPRendererMMAL(settings, context, std::move(bufferPool));
 }
 
-RenderBufferPoolVector CRendererFactoryMMAL::CreateBufferPools()
+RenderBufferPoolVector CRendererFactoryMMAL::CreateBufferPools(CRenderContext &context)
 {
   return { std::make_shared<CRenderBufferPoolMMAL>() };
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererMMAL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererMMAL.h
@@ -42,7 +42,7 @@ namespace RETRO
     ~CRendererFactoryMMAL() override = default;
 
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
-    RenderBufferPoolVector CreateBufferPools() override;
+    RenderBufferPoolVector CreateBufferPools(CRenderContext &context) override;
   };
 
   class CRPRendererMMAL : public CRPBaseRenderer

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -44,9 +44,39 @@ RenderBufferPoolVector CRendererFactoryOpenGL::CreateBufferPools(CRenderContext 
 
 // --- CRenderBufferOpenGL -----------------------------------------------------
 
-CRenderBufferOpenGL::CRenderBufferOpenGL(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
-  CRenderBufferOpenGLES(context, format, targetFormat, width, height)
+CRenderBufferOpenGL::CRenderBufferOpenGL(CRenderContext &context,
+                                         GLuint pixeltype,
+                                         GLuint internalformat,
+                                         GLuint pixelformat,
+                                         GLuint bpp,
+                                         unsigned int width,
+                                         unsigned int height) :
+  CRenderBufferOpenGLES(context,
+                        pixeltype,
+                        internalformat,
+                        pixelformat,
+                        bpp,
+                        width,
+                        height)
 {
+}
+
+bool CRenderBufferOpenGL::UploadTexture()
+{
+  if (!glIsTexture(m_textureId))
+    CreateTexture();
+
+  glBindTexture(m_textureTarget, m_textureId);
+
+  const int stride = GetFrameSize() / m_height;
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, m_bpp);
+
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, stride / m_bpp);
+  glTexSubImage2D(m_textureTarget, 0, 0, 0, m_width, m_height, m_pixelformat, m_pixeltype, m_data.data());
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+  return true;
 }
 
 // --- CRenderBufferPoolOpenGL -------------------------------------------------
@@ -58,7 +88,49 @@ CRenderBufferPoolOpenGL::CRenderBufferPoolOpenGL(CRenderContext &context)
 
 IRenderBuffer *CRenderBufferPoolOpenGL::CreateRenderBuffer(void *header /* = nullptr */)
 {
-  return new CRenderBufferOpenGL(m_context, m_format, m_targetFormat, m_width, m_height);
+  return new CRenderBufferOpenGL(m_context,
+                                 m_pixeltype,
+                                 m_internalformat,
+                                 m_pixelformat,
+                                 m_bpp,
+                                 m_width,
+                                 m_height);
+}
+
+bool CRenderBufferPoolOpenGL::ConfigureInternal()
+{
+  // Configure CRenderBufferPoolOpenGLES
+  switch (m_format)
+  {
+  case AV_PIX_FMT_0RGB32:
+  {
+    m_pixeltype = GL_UNSIGNED_BYTE;
+    m_internalformat = GL_RGBA;
+    m_pixelformat = GL_BGRA;
+    m_bpp = sizeof(uint32_t);
+    return true;
+  }
+  case AV_PIX_FMT_RGB555:
+  {
+    m_pixeltype = GL_UNSIGNED_SHORT_5_5_5_1;
+    m_internalformat = GL_RGB;
+    m_pixelformat = GL_RGB;
+    m_bpp = sizeof(uint16_t);
+    return true;
+  }
+  case AV_PIX_FMT_RGB565:
+  {
+    m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
+    m_internalformat = GL_RGB;
+    m_pixelformat = GL_RGB;
+    m_bpp = sizeof(uint16_t);
+    return true;
+  }
+  default:
+    break;
+  }
+
+  return false;
 }
 
 // --- CRPRendererOpenGL -------------------------------------------------------

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -37,23 +37,28 @@ CRPBaseRenderer *CRendererFactoryOpenGL::CreateRenderer(const CRenderSettings &s
   return new CRPRendererOpenGL(settings, context, std::move(bufferPool));
 }
 
-RenderBufferPoolVector CRendererFactoryOpenGL::CreateBufferPools()
+RenderBufferPoolVector CRendererFactoryOpenGL::CreateBufferPools(CRenderContext &context)
 {
-  return { std::make_shared<CRenderBufferPoolOpenGL>() };
+  return { std::make_shared<CRenderBufferPoolOpenGL>(context) };
 }
 
 // --- CRenderBufferOpenGL -----------------------------------------------------
 
-CRenderBufferOpenGL::CRenderBufferOpenGL(AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
-  CRenderBufferOpenGLES(format, targetFormat, width, height)
+CRenderBufferOpenGL::CRenderBufferOpenGL(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
+  CRenderBufferOpenGLES(context, format, targetFormat, width, height)
 {
 }
 
 // --- CRenderBufferPoolOpenGL -------------------------------------------------
 
+CRenderBufferPoolOpenGL::CRenderBufferPoolOpenGL(CRenderContext &context)
+  : CRenderBufferPoolOpenGLES(context)
+{
+}
+
 IRenderBuffer *CRenderBufferPoolOpenGL::CreateRenderBuffer(void *header /* = nullptr */)
 {
-  return new CRenderBufferOpenGL(m_format, m_targetFormat, m_width, m_height);
+  return new CRenderBufferOpenGL(m_context, m_format, m_targetFormat, m_width, m_height);
 }
 
 // --- CRPRendererOpenGL -------------------------------------------------------

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -38,20 +38,20 @@ namespace RETRO
     // implementation of IRendererFactory
     std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
-    RenderBufferPoolVector CreateBufferPools() override;
+    RenderBufferPoolVector CreateBufferPools(CRenderContext &context) override;
   };
 
   class CRenderBufferOpenGL : public CRenderBufferOpenGLES
   {
   public:
-    CRenderBufferOpenGL(AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
+    CRenderBufferOpenGL(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
     ~CRenderBufferOpenGL() override = default;
   };
 
   class CRenderBufferPoolOpenGL : public CRenderBufferPoolOpenGLES
   {
   public:
-    CRenderBufferPoolOpenGL() = default;
+    CRenderBufferPoolOpenGL(CRenderContext &context);
     ~CRenderBufferPoolOpenGL() override = default;
 
     // implementation of CBaseRenderBufferPool via CRenderBufferPoolOpenGLES

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -44,8 +44,17 @@ namespace RETRO
   class CRenderBufferOpenGL : public CRenderBufferOpenGLES
   {
   public:
-    CRenderBufferOpenGL(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
+    CRenderBufferOpenGL(CRenderContext &context,
+                        GLuint pixeltype,
+                        GLuint internalformat,
+                        GLuint pixelformat,
+                        GLuint bpp,
+                        unsigned int width,
+                        unsigned int height);
     ~CRenderBufferOpenGL() override = default;
+
+    // implementation of IRenderBuffer via CRenderBufferOpenGLES
+    bool UploadTexture() override;
   };
 
   class CRenderBufferPoolOpenGL : public CRenderBufferPoolOpenGLES
@@ -54,8 +63,10 @@ namespace RETRO
     CRenderBufferPoolOpenGL(CRenderContext &context);
     ~CRenderBufferPoolOpenGL() override = default;
 
+  protected:
     // implementation of CBaseRenderBufferPool via CRenderBufferPoolOpenGLES
     IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
+    bool ConfigureInternal() override;
   };
 
   class CRPRendererOpenGL : public CRPRendererOpenGLES

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -41,14 +41,15 @@ CRPBaseRenderer *CRendererFactoryOpenGLES::CreateRenderer(const CRenderSettings 
   return new CRPRendererOpenGLES(settings, context, std::move(bufferPool));
 }
 
-RenderBufferPoolVector CRendererFactoryOpenGLES::CreateBufferPools()
+RenderBufferPoolVector CRendererFactoryOpenGLES::CreateBufferPools(CRenderContext &context)
 {
-  return { std::make_shared<CRenderBufferPoolOpenGLES>() };
+  return { std::make_shared<CRenderBufferPoolOpenGLES>(context) };
 }
 
 // --- CRenderBufferOpenGLES ---------------------------------------------------
 
-CRenderBufferOpenGLES::CRenderBufferOpenGLES(AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
+CRenderBufferOpenGLES::CRenderBufferOpenGLES(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
+  m_context(context),
   m_format(format),
   m_targetFormat(targetFormat),
   m_width(width),
@@ -101,6 +102,11 @@ void CRenderBufferOpenGLES::DeleteTexture()
 
 // --- CRenderBufferPoolOpenGLES -----------------------------------------------
 
+CRenderBufferPoolOpenGLES::CRenderBufferPoolOpenGLES(CRenderContext &context)
+  : m_context(context)
+{
+}
+
 bool CRenderBufferPoolOpenGLES::IsCompatible(const CRenderVideoSettings &renderSettings) const
 {
   if (!CRPRendererOpenGLES::SupportsScalingMethod(renderSettings.GetScalingMethod()))
@@ -111,7 +117,7 @@ bool CRenderBufferPoolOpenGLES::IsCompatible(const CRenderVideoSettings &renderS
 
 IRenderBuffer *CRenderBufferPoolOpenGLES::CreateRenderBuffer(void *header /* = nullptr */)
 {
-  return new CRenderBufferOpenGLES(m_format, m_targetFormat, m_width, m_height);
+  return new CRenderBufferOpenGLES(m_context, m_format, m_targetFormat, m_width, m_height);
 }
 
 bool CRenderBufferPoolOpenGLES::SetTargetFormat(AVPixelFormat targetFormat)

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -25,6 +25,9 @@
 #include "utils/log.h"
 
 #include <cstring>
+#include <stddef.h>
+
+#define BUFFER_OFFSET(i) ((char *)NULL + (i))
 
 using namespace KODI;
 using namespace RETRO;
@@ -48,10 +51,18 @@ RenderBufferPoolVector CRendererFactoryOpenGLES::CreateBufferPools(CRenderContex
 
 // --- CRenderBufferOpenGLES ---------------------------------------------------
 
-CRenderBufferOpenGLES::CRenderBufferOpenGLES(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
+CRenderBufferOpenGLES::CRenderBufferOpenGLES(CRenderContext &context,
+                                             GLuint pixeltype,
+                                             GLuint internalformat,
+                                             GLuint pixelformat,
+                                             GLuint bpp,
+                                             unsigned int width,
+                                             unsigned int height) :
   m_context(context),
-  m_format(format),
-  m_targetFormat(targetFormat),
+  m_pixeltype(pixeltype),
+  m_internalformat(internalformat),
+  m_pixelformat(pixelformat),
+  m_bpp(bpp),
   m_width(width),
   m_height(height)
 {
@@ -68,7 +79,7 @@ void CRenderBufferOpenGLES::CreateTexture()
 
   glBindTexture(m_textureTarget, m_textureId);
 
-  glTexImage2D(m_textureTarget, 0, GL_RGB, m_width, m_height, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, NULL);
+  glTexImage2D(m_textureTarget, 0, m_internalformat, m_width, m_height, 0, m_pixelformat, m_pixeltype, NULL);
 
   glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -84,10 +95,35 @@ bool CRenderBufferOpenGLES::UploadTexture()
   glBindTexture(m_textureTarget, m_textureId);
 
   const int stride = GetFrameSize() / m_height;
-  const uint8_t* src = m_data.data();
 
-  for (unsigned int y = 0; y < m_height; ++y, src += stride)
-    glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, src);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, m_bpp);
+
+  if (m_bpp == 4 && m_pixelformat == GL_RGBA)
+  {
+    // XOR Swap RGBA -> BGRA
+    // GLES 2.0 doesn't support strided textures (unless GL_UNPACK_ROW_LENGTH_EXT is supported)
+    uint8_t* pixels = const_cast<uint8_t*>(m_data.data());
+    for (unsigned int y = 0; y < m_height; ++y, pixels += stride)
+    {
+      for (int x = 0; x < stride; x += 4)
+        std::swap(pixels[x], pixels[x + 2]);
+      glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelformat, m_pixeltype, pixels);
+    }
+  }
+#ifdef GL_UNPACK_ROW_LENGTH_EXT
+  else if (m_context.IsExtSupported("GL_EXT_unpack_subimage"))
+  {
+    glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / m_bpp);
+    glTexSubImage2D(m_textureTarget, 0, 0, 0, m_width, m_height, m_pixelformat, m_pixeltype, m_data.data());
+    glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);
+  }
+#endif
+  else
+  {
+    uint8_t* pixels = const_cast<uint8_t*>(m_data.data());
+    for (unsigned int y = 0; y < m_height; ++y, pixels += stride)
+      glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelformat, m_pixeltype, pixels);
+  }
 
   return true;
 }
@@ -117,17 +153,64 @@ bool CRenderBufferPoolOpenGLES::IsCompatible(const CRenderVideoSettings &renderS
 
 IRenderBuffer *CRenderBufferPoolOpenGLES::CreateRenderBuffer(void *header /* = nullptr */)
 {
-  return new CRenderBufferOpenGLES(m_context, m_format, m_targetFormat, m_width, m_height);
+  return new CRenderBufferOpenGLES(m_context,
+                                   m_pixeltype,
+                                   m_internalformat,
+                                   m_pixelformat,
+                                   m_bpp,
+                                   m_width,
+                                   m_height);
 }
 
-bool CRenderBufferPoolOpenGLES::SetTargetFormat(AVPixelFormat targetFormat)
+bool CRenderBufferPoolOpenGLES::ConfigureInternal()
 {
-  if (m_targetFormat != AV_PIX_FMT_NONE)
-    return false; // Already configured
+  switch (m_format)
+  {
+  case AV_PIX_FMT_0RGB32:
+  {
+    m_pixeltype = GL_UNSIGNED_BYTE;
+    if (m_context.IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
+        m_context.IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+    {
+      m_internalformat = GL_BGRA_EXT;
+      m_pixelformat = GL_BGRA_EXT;
+    }
+    else if (m_context.IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
+    {
+      // Apple's implementation does not conform to spec. Instead, they require
+      // differing format/internalformat, more like GL.
+      m_internalformat = GL_RGBA;
+      m_pixelformat = GL_BGRA_EXT;
+    }
+    else
+    {
+      m_internalformat = GL_RGBA;
+      m_pixelformat = GL_RGBA;
+    }
+    m_bpp = sizeof(uint32_t);
+    return true;
+  }
+  case AV_PIX_FMT_RGB555:
+  {
+    m_pixeltype = GL_UNSIGNED_SHORT_5_5_5_1;
+    m_internalformat = GL_RGB;
+    m_pixelformat = GL_RGB;
+    m_bpp = sizeof(uint16_t);
+    return true;
+  }
+  case AV_PIX_FMT_RGB565:
+  {
+    m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
+    m_internalformat = GL_RGB;
+    m_pixelformat = GL_RGB;
+    m_bpp = sizeof(uint16_t);
+    return true;
+  }
+  default:
+    break;
+  }
 
-  m_targetFormat = targetFormat;
-
-  return true;
+  return false;
 }
 
 // --- CRPRendererOpenGLES -----------------------------------------------------
@@ -140,15 +223,6 @@ CRPRendererOpenGLES::CRPRendererOpenGLES(const CRenderSettings &renderSettings, 
 CRPRendererOpenGLES::~CRPRendererOpenGLES()
 {
   Deinitialize();
-}
-
-bool CRPRendererOpenGLES::ConfigureInternal()
-{
-  AVPixelFormat targetFormat = AV_PIX_FMT_RGB565LE;
-
-  static_cast<CRenderBufferPoolOpenGLES*>(m_bufferPool.get())->SetTargetFormat(targetFormat);
-
-  return true;
 }
 
 void CRPRendererOpenGLES::RenderInternal(bool clear, uint8_t alpha)
@@ -352,11 +426,6 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   rect.y1 /= m_sourceHeight;
   rect.y2 /= m_sourceHeight;
 
-  float u1 = rect.x1;
-  float u2 = rect.x2;
-  float v1 = rect.y1;
-  float v2 = rect.y2;
-
   const uint32_t color = (alpha << 24) | 0xFFFFFF;
 
   glBindTexture(m_textureTarget, renderBuffer->TextureID());
@@ -372,19 +441,18 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
 
   GLubyte colour[4];
-  GLfloat ver[4][3];
-  GLfloat tex[4][2];
   GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+  GLuint vertexVBO;
+  GLuint indexVBO;
+  struct PackedVertex
+  {
+    float x, y, z;
+    float u1, v1;
+  } vertex[4];
 
-  GLint posLoc = m_context.GUIShaderGetPos();
-  GLint tex0Loc = m_context.GUIShaderGetCoord0();
+  GLint vertLoc = m_context.GUIShaderGetPos();
+  GLint loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
-
-  glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, 0, ver);
-  glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, 0, tex);
-
-  glEnableVertexAttribArray(posLoc);
-  glEnableVertexAttribArray(tex0Loc);
 
   // Setup color values
   colour[0] = static_cast<GLubyte>(GET_R(color));
@@ -395,22 +463,41 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   for (unsigned int i = 0; i < 4; i++)
   {
     // Setup vertex position values
-    ver[i][0] = m_rotatedDestCoords[i].x;
-    ver[i][1] = m_rotatedDestCoords[i].y;
-    ver[i][2] = 0.0f;
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
   }
 
   // Setup texture coordinates
-  tex[0][0] = tex[3][0] = u1;
-  tex[0][1] = tex[1][1] = v1;
-  tex[1][0] = tex[2][0] = u2;
-  tex[2][1] = tex[3][1] = v2;
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex)*4, &vertex[0], GL_STATIC_DRAW);
+
+  glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, x)));
+  glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex), BUFFER_OFFSET(offsetof(PackedVertex, u1)));
+
+  glEnableVertexAttribArray(vertLoc);
+  glEnableVertexAttribArray(loc);
+
+  glGenBuffers(1, &indexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
   glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f), (colour[3] / 255.0f));
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
-  glDisableVertexAttribArray(posLoc);
-  glDisableVertexAttribArray(tex0Loc);
+  glDisableVertexAttribArray(vertLoc);
+  glDisableVertexAttribArray(loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &indexVBO);
 
   m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -42,13 +42,13 @@ namespace RETRO
     // implementation of IRendererFactory
     std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
-    RenderBufferPoolVector CreateBufferPools() override;
+    RenderBufferPoolVector CreateBufferPools(CRenderContext &context) override;
   };
 
   class CRenderBufferOpenGLES : public CRenderBufferSysMem
   {
   public:
-    CRenderBufferOpenGLES(AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
+    CRenderBufferOpenGLES(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
     ~CRenderBufferOpenGLES() override;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
@@ -58,6 +58,7 @@ namespace RETRO
 
   protected:
     // Construction parameters
+    CRenderContext &m_context;
     const AVPixelFormat m_format;
     const AVPixelFormat m_targetFormat;
     const unsigned int m_width;
@@ -74,7 +75,7 @@ namespace RETRO
   class CRenderBufferPoolOpenGLES : public CBaseRenderBufferPool
   {
   public:
-    CRenderBufferPoolOpenGLES() = default;
+    CRenderBufferPoolOpenGLES(CRenderContext &context);
     ~CRenderBufferPoolOpenGLES() override = default;
 
     // implementation of IRenderBufferPool via CRenderBufferPoolSysMem
@@ -87,6 +88,10 @@ namespace RETRO
     bool SetTargetFormat(AVPixelFormat targetFormat);
 
   protected:
+    // Construction parameters
+    CRenderContext &m_context;
+
+    // GLES parameters
     AVPixelFormat m_targetFormat = AV_PIX_FMT_NONE; //! @todo Change type to GLenum
   };
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -48,7 +48,13 @@ namespace RETRO
   class CRenderBufferOpenGLES : public CRenderBufferSysMem
   {
   public:
-    CRenderBufferOpenGLES(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
+    CRenderBufferOpenGLES(CRenderContext &context,
+                          GLuint pixeltype,
+                          GLuint internalformat,
+                          GLuint pixelformat,
+                          GLuint bpp,
+                          unsigned int width,
+                          unsigned int height);
     ~CRenderBufferOpenGLES() override;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
@@ -59,16 +65,19 @@ namespace RETRO
   protected:
     // Construction parameters
     CRenderContext &m_context;
-    const AVPixelFormat m_format;
-    const AVPixelFormat m_targetFormat;
+    const GLuint m_pixeltype;
+    const GLuint m_internalformat;
+    const GLuint m_pixelformat;
+    const GLuint m_bpp;
     const unsigned int m_width;
     const unsigned int m_height;
 
     const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo
     GLuint m_textureId = 0;
 
-  private:
     void CreateTexture();
+
+  private:
     void DeleteTexture();
   };
 
@@ -78,21 +87,22 @@ namespace RETRO
     CRenderBufferPoolOpenGLES(CRenderContext &context);
     ~CRenderBufferPoolOpenGLES() override = default;
 
-    // implementation of IRenderBufferPool via CRenderBufferPoolSysMem
+    // implementation of IRenderBufferPool via CBaseRenderBufferPool
     bool IsCompatible(const CRenderVideoSettings &renderSettings) const override;
 
-    // implementation of CBaseRenderBufferPool via CRenderBufferPoolSysMem
-    IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
-
-    // GLES interface
-    bool SetTargetFormat(AVPixelFormat targetFormat);
-
   protected:
+    // implementation of CBaseRenderBufferPool
+    IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
+    bool ConfigureInternal() override;
+
     // Construction parameters
     CRenderContext &m_context;
 
-    // GLES parameters
-    AVPixelFormat m_targetFormat = AV_PIX_FMT_NONE; //! @todo Change type to GLenum
+    // Configuration parameters
+    GLuint m_pixeltype = 0;
+    GLuint m_internalformat = 0;
+    GLuint m_pixelformat = 0;
+    GLuint m_bpp = 0;
   };
 
   class CRPRendererOpenGLES : public CRPBaseRenderer
@@ -109,7 +119,6 @@ namespace RETRO
 
   protected:
     // implementation of CRPBaseRenderer
-    bool ConfigureInternal() override;
     void RenderInternal(bool clear, uint8_t alpha) override;
     void FlushInternal() override;
 
@@ -128,7 +137,6 @@ namespace RETRO
 
     void Render(uint8_t alpha);
 
-    AVPixelFormat m_targetFormat = AV_PIX_FMT_NONE;
     GLenum m_textureTarget = GL_TEXTURE_2D;
     float m_clearColour = 0.0f;
   };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -49,7 +49,7 @@ CRPBaseRenderer *CWinRendererFactory::CreateRenderer(const CRenderSettings &sett
   return new CRPWinRenderer(settings, context, std::move(bufferPool));
 }
 
-RenderBufferPoolVector CWinRendererFactory::CreateBufferPools()
+RenderBufferPoolVector CWinRendererFactory::CreateBufferPools(CRenderContext &context)
 {
   return { std::make_shared<CWinRenderBufferPool>() };
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -47,7 +47,7 @@ namespace RETRO
     // implementation of IRendererFactory
     std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
-    RenderBufferPoolVector CreateBufferPools() override;
+    RenderBufferPoolVector CreateBufferPools(CRenderContext &context) override;
   };
 
   class CWinRenderBuffer : public CRenderBufferSysMem

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -34,7 +34,7 @@
 #include "VideoSyncDRM.h"
 
 #include "cores/RetroPlayer/process/X11/RPProcessInfoX11.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/Process/X11/ProcessInfoX11.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
@@ -257,7 +257,7 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
 
   VIDEOPLAYER::CProcessInfoX11::Register();
   RETRO::CRPProcessInfoX11::Register();
-  RETRO::CRPProcessInfoX11::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoX11::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
   CDVDFactoryCodec::ClearHWAccels();
   VIDEOPLAYER::CRendererFactory::ClearRenderer();
   CLinuxRendererGL::Register();

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -25,7 +25,7 @@
 
 #include "ServiceBroker.h"
 #include "cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h"
@@ -97,7 +97,7 @@ bool CWinSystemAmlogic::InitWindowSystem()
   CDVDVideoCodecAmlogic::Register();
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfoAmlogic::Register();
-  RETRO::CRPProcessInfoAmlogic::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoAmlogic::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
   CRendererAML::Register();
 
   aml_set_framebuffer_resolution(1920, 1080, m_framebuffer_name);

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -35,7 +35,7 @@
 #include "platform/android/activity/XBMCApp.h"
 
 #include "cores/RetroPlayer/process/android/RPProcessInfoAndroid.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h"
@@ -83,7 +83,7 @@ bool CWinSystemAndroid::InitWindowSystem()
 
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfoAndroid::Register();
-  RETRO::CRPProcessInfoAndroid::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoAndroid::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
   CRendererMediaCodec::Register();
   CRendererMediaCodecSurface::Register();
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -22,7 +22,7 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h"
 
 #include "cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
@@ -43,7 +43,7 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
 {
   CLinuxRendererGLES::Register();
   RETRO::CRPProcessInfoGbm::Register();
-  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   if (!CWinSystemGbm::InitWindowSystem())
   {

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -26,7 +26,7 @@
 #include "WinSystemIOS.h"
 #include "cores/AudioEngine/Sinks/AESinkDARWINIOS.h"
 #include "cores/RetroPlayer/process/ios/RPProcessInfoIOS.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/VTB.h"
 #include "cores/VideoPlayer/Process/ios/ProcessInfoIOS.h"
@@ -137,7 +137,7 @@ bool CWinSystemIOS::CreateNewWindow(const std::string& name, bool fullScreen, RE
   CRendererVTB::Register();
   VIDEOPLAYER::CProcessInfoIOS::Register();
   RETRO::CRPProcessInfoIOS::Register();
-  RETRO::CRPProcessInfoIOS::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoIOS::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   return true;
 }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -29,7 +29,7 @@
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/AESinkDARWINOSX.h"
 #include "cores/RetroPlayer/process/osx/RPProcessInfoOSX.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/VTB.h"
 #include "cores/VideoPlayer/Process/osx/ProcessInfoOSX.h"
@@ -799,7 +799,7 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   CRendererVTB::Register();
   VIDEOPLAYER::CProcessInfoOSX::Register();
   RETRO::CRPProcessInfoOSX::Register();
-  RETRO::CRPProcessInfoOSX::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoOSX::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
   return true;
 }
 

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -25,7 +25,7 @@
 #include "utils/log.h"
 #include "cores/RetroPlayer/process/rbpi/RPProcessInfoPi.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererMMAL.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h"
@@ -57,7 +57,7 @@ bool CWinSystemRpiGLESContext::InitWindowSystem()
   CProcessInfoPi::Register();
   RETRO::CRPProcessInfoPi::Register();
   //RETRO::CRPProcessInfoPi::RegisterRendererFactory(new RETRO::CRendererFactoryMMAL); //! @todo
-  RETRO::CRPProcessInfoPi::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfoPi::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
   CDVDFactoryCodec::ClearHWAccels();
   MMAL::CDecoder::Register();
   CDVDFactoryCodec::ClearHWVideoCodecs();

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -24,7 +24,7 @@
 #include <EGL/egl.h>
 
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "utils/log.h"
 
@@ -44,7 +44,7 @@ bool CWinSystemWaylandEGLContextGL::InitWindowSystem()
   }
 
   CLinuxRendererGL::Register();
-  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);
 
   bool general, hevc;
   m_vaapiProxy.reset(::WAYLAND::VaapiProxyCreate());

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp
@@ -24,7 +24,7 @@
 #include <EGL/egl.h>
 
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
-#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h"
+#include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "utils/log.h"
@@ -45,7 +45,7 @@ bool CWinSystemWaylandEGLContextGLES::InitWindowSystem()
   }
 
   CLinuxRendererGLES::Register();
-  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryGuiTexture);
+  RETRO::CRPProcessInfo::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   bool general, hevc;
   m_vaapiProxy.reset(::WAYLAND::VaapiProxyCreate());


### PR DESCRIPTION
Before we were hardcoding in the pixelformat. Now we can use the pixel format as given by libretro

This PR also activates the `CRPRendererOpenGL` and `CRPRendererOpenGLES` for `X11` and `GBM` respectively. Other platforms can be added after they have been tested.

build and run tested on Linux using `X11` and `GBM` for `GL` and `GLES` respectively.