### PR TITLE
 VideoPlayer: OpenGL - implement tone mapping

### DIFF
--- a/system/shaders/GL/1.2/gl_yuv2rgb_basic.glsl
+++ b/system/shaders/GL/1.2/gl_yuv2rgb_basic.glsl
@@ -122,13 +122,9 @@ vec4 process()
 #endif
 
 #if defined(XBMC_COL_CONVERSION)
-  rgb.r = pow(rgb.r, m_gammaSrc);
-  rgb.g = pow(rgb.g, m_gammaSrc);
-  rgb.b = pow(rgb.b, m_gammaSrc);
+  rgb.rgb = pow(rgb.rgb, vec3(m_gammaSrc));
   rgb.rgb = m_primMat * rgb.rgb;
-  rgb.r = pow(rgb.r, m_gammaDstInv);
-  rgb.g = pow(rgb.g, m_gammaDstInv);
-  rgb.b = pow(rgb.b, m_gammaDstInv);
+  rgb.rgb = pow(rgb.rgb, vec3(m_gammaDstInv));
 #endif
 
   return rgb;

--- a/system/shaders/GL/1.5/gl_tonemap.glsl
+++ b/system/shaders/GL/1.5/gl_tonemap.glsl
@@ -1,0 +1,4 @@
+float tonemap(float val)
+{
+  return val * (1 + val/(m_toneP1*m_toneP1))/(1 + val);
+}

--- a/system/shaders/GL/4.0/gl_yuv2rgb_filter4.glsl
+++ b/system/shaders/GL/4.0/gl_yuv2rgb_filter4.glsl
@@ -16,6 +16,8 @@ uniform sampler1D m_kernelTex;
 uniform mat3 m_primMat;
 uniform float m_gammaDstInv;
 uniform float m_gammaSrc;
+uniform float m_toneP1;
+uniform vec3 m_coefsDst;
 in vec2 m_cordY;
 in vec2 m_cordU;
 in vec2 m_cordV;
@@ -88,33 +90,37 @@ float filter_0(sampler2D sampler, vec2 coord)
 vec4 process()
 {
   vec4 rgb;
+  vec4 yuv;
+
 #if defined(XBMC_YV12)
 
-  vec4 yuv = vec4(filter_0(m_sampY, stretch(m_cordY)),
-                  texture(m_sampU, stretch(m_cordU)).r,
-                  texture(m_sampV, stretch(m_cordV)).r,
-                  1.0);
-
-  rgb = m_yuvmat * yuv;
-  rgb.a = m_alpha;
+  yuv = vec4(filter_0(m_sampY, stretch(m_cordY)),
+             texture(m_sampU, stretch(m_cordU)).r,
+             texture(m_sampV, stretch(m_cordV)).r,
+             1.0);
 
 #elif defined(XBMC_NV12)
 
-  vec4 yuv = vec4(filter_0(m_sampY, stretch(m_cordY)),
-                  texture(m_sampU, stretch(m_cordU)).rg,
-                  1.0);
-  rgb = m_yuvmat * yuv;
-  rgb.a = m_alpha;
+  yuv = vec4(filter_0(m_sampY, stretch(m_cordY)),
+             texture(m_sampU, stretch(m_cordU)).rg,
+             1.0);
+
 #endif
 
+  rgb = m_yuvmat * yuv;
+  rgb.a = m_alpha;
+
 #if defined(XBMC_COL_CONVERSION)
-  rgb.r = pow(rgb.r, m_gammaSrc);
-  rgb.g = pow(rgb.g, m_gammaSrc);
-  rgb.b = pow(rgb.b, m_gammaSrc);
+  rgb.rgb = pow(rgb.rgb, vec3(m_gammaSrc));
   rgb.rgb = m_primMat * rgb.rgb;
-  rgb.r = pow(rgb.r, m_gammaDstInv);
-  rgb.g = pow(rgb.g, m_gammaDstInv);
-  rgb.b = pow(rgb.b, m_gammaDstInv);
+  rgb.rgb = pow(rgb.rgb, vec3(m_gammaDstInv));
+
+#if defined(XBMC_TONE_MAPPING)
+  float luma = dot(rgb.rgb, m_coefsDst);
+  rgb.rgb *= tonemap(luma) / luma;
 #endif
+
+#endif
+
   return rgb;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -129,7 +129,7 @@ bool CRendererVAAPI::CreateTexture(int index)
     return CreateNV12Texture(index);
   }
 
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YuvImage &im = buf.image;
   YUVPLANE (&planes)[YuvImage::MAX_PLANES] = buf.fields[0];
 
@@ -157,7 +157,7 @@ void CRendererVAAPI::DeleteTexture(int index)
     return;
   }
 
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   buf.fields[FIELD_FULL][0].id = 0;
   buf.fields[FIELD_FULL][1].id = 0;
   buf.fields[FIELD_FULL][2].id = 0;
@@ -165,7 +165,7 @@ void CRendererVAAPI::DeleteTexture(int index)
 
 bool CRendererVAAPI::UploadTexture(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(buf.videoBuffer);
 
   if (!pic || !pic->valid)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVDPAU.cpp
@@ -288,7 +288,7 @@ bool CRendererVDPAU::UploadTexture(int index)
 
 bool CRendererVDPAU::CreateVDPAUTexture(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YuvImage &im = buf.image;
   YUVPLANE &plane = buf.fields[FIELD_FULL][0];
 
@@ -311,7 +311,7 @@ bool CRendererVDPAU::CreateVDPAUTexture(int index)
 
 void CRendererVDPAU::DeleteVDPAUTexture(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YUVPLANE &plane = buf.fields[FIELD_FULL][0];
 
   plane.id = 0;
@@ -319,7 +319,7 @@ void CRendererVDPAU::DeleteVDPAUTexture(int index)
 
 bool CRendererVDPAU::UploadVDPAUTexture(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   VDPAU::CVdpauRenderPicture *pic = dynamic_cast<VDPAU::CVdpauRenderPicture*>(buf.videoBuffer);
 
   YUVPLANE &plane = buf.fields[FIELD_FULL][0];
@@ -365,7 +365,7 @@ bool CRendererVDPAU::UploadVDPAUTexture(int index)
 
 bool CRendererVDPAU::CreateVDPAUTexture420(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YuvImage &im = buf.image;
   YUVPLANE (&planes)[YuvImage::MAX_PLANES] = buf.fields[0];
   GLuint *pbo = buf.pbo;
@@ -394,7 +394,7 @@ bool CRendererVDPAU::CreateVDPAUTexture420(int index)
 
 void CRendererVDPAU::DeleteVDPAUTexture420(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
 
   buf.fields[0][0].id = 0;
   buf.fields[1][0].id = 0;
@@ -405,7 +405,7 @@ void CRendererVDPAU::DeleteVDPAUTexture420(int index)
 
 bool CRendererVDPAU::UploadVDPAUTexture420(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YuvImage &im = buf.image;
 
   VDPAU::CVdpauRenderPicture *pic = dynamic_cast<VDPAU::CVdpauRenderPicture*>(buf.videoBuffer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
@@ -61,7 +61,7 @@ CRendererVTB::~CRendererVTB()
 
 void CRendererVTB::ReleaseBuffer(int idx)
 {
-  YUVBUFFER &buf = m_buffers[idx];
+  CPictureBuffer &buf = m_buffers[idx];
   if (buf.videoBuffer)
   {
     VTB::CVideoBufferVTB *vb = dynamic_cast<VTB::CVideoBufferVTB*>(buf.videoBuffer);
@@ -92,7 +92,7 @@ bool CRendererVTB::LoadShadersHook()
 
 bool CRendererVTB::CreateTexture(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YuvImage &im = buf.image;
   YUVPLANE (&planes)[YuvImage::MAX_PLANES] = buf.fields[0];
 
@@ -149,7 +149,7 @@ void CRendererVTB::DeleteTexture(int index)
 
 bool CRendererVTB::UploadTexture(int index)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YUVPLANE (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[0];
 
   VTB::CVideoBufferVTB *vb = dynamic_cast<VTB::CVideoBufferVTB*>(buf.videoBuffer);
@@ -211,7 +211,7 @@ bool CRendererVTB::UploadTexture(int index)
 
 void CRendererVTB::AfterRenderHook(int idx)
 {
-  YUVBUFFER &buf = m_buffers[idx];
+  CPictureBuffer &buf = m_buffers[idx];
   VTB::CVideoBufferVTB *vb = dynamic_cast<VTB::CVideoBufferVTB*>(buf.videoBuffer);
   if (!vb)
   {
@@ -228,7 +228,7 @@ void CRendererVTB::AfterRenderHook(int idx)
 
 bool CRendererVTB::NeedBuffer(int idx)
 {
-  YUVBUFFER &buf = m_buffers[idx];
+  CPictureBuffer &buf = m_buffers[idx];
   VTB::CVideoBufferVTB *vb = dynamic_cast<VTB::CVideoBufferVTB*>(buf.videoBuffer);
   if (!vb)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -101,7 +101,7 @@ static const GLubyte stipple_weave[] = {
   0x00, 0x00, 0x00, 0x00,
 };
 
-CLinuxRendererGL::YUVBUFFER::YUVBUFFER()
+CLinuxRendererGL::CPictureBuffer::CPictureBuffer()
 {
   memset(&fields, 0, sizeof(fields));
   memset(&image , 0, sizeof(image));
@@ -110,7 +110,7 @@ CLinuxRendererGL::YUVBUFFER::YUVBUFFER()
   loaded = false;
 }
 
-CLinuxRendererGL::YUVBUFFER::~YUVBUFFER() = default;
+CLinuxRendererGL::CPictureBuffer::~CPictureBuffer() = default;
 
 CBaseRenderer* CLinuxRendererGL::Create(CVideoBuffer *buffer)
 {
@@ -192,7 +192,7 @@ bool CLinuxRendererGL::ValidateRenderer()
     return false;
 
   int index = m_iYV12RenderBuffer;
-  YUVBUFFER& buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
 
   if (!buf.fields[FIELD_FULL][0].id)
     return false;
@@ -316,7 +316,7 @@ bool CLinuxRendererGL::ConfigChanged(const VideoPicture &picture)
 
 void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index, double currentClock)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
   buf.loaded = false;
@@ -328,7 +328,7 @@ void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index, d
 
 void CLinuxRendererGL::ReleaseBuffer(int idx)
 {
-  YUVBUFFER &buf = m_buffers[idx];
+  CPictureBuffer &buf = m_buffers[idx];
   if (buf.videoBuffer)
   {
     buf.videoBuffer->Release();
@@ -358,7 +358,7 @@ void CLinuxRendererGL::GetPlaneTextureSize(YUVPLANE& plane)
 
 void CLinuxRendererGL::CalculateTextureSourceRects(int source, int num_planes)
 {
-  YUVBUFFER& buf = m_buffers[source];
+  CPictureBuffer& buf = m_buffers[source];
   YuvImage* im  = &buf.image;
 
   // calculate the source rectangle
@@ -1052,7 +1052,7 @@ bool CLinuxRendererGL::Render(DWORD flags, int renderBuffer)
 
 void CLinuxRendererGL::RenderSinglePass(int index, int field)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YUVPLANE (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[field];
 
   AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);
@@ -1204,7 +1204,7 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
 
 void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 {
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YUVPLANE (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[field];
 
   AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);
@@ -1805,7 +1805,7 @@ bool CLinuxRendererGL::CreateYV12Texture(int index)
   /* since we also want the field textures, pitch must be texture aligned */
   unsigned p;
 
-  YUVBUFFER &buf = m_buffers[index];
+  CPictureBuffer &buf = m_buffers[index];
   YuvImage &im = m_buffers[index].image;
   GLuint *pbo = m_buffers[index].pbo;
 
@@ -1949,7 +1949,7 @@ bool CLinuxRendererGL::CreateYV12Texture(int index)
 
 bool CLinuxRendererGL::UploadYV12Texture(int source)
 {
-  YUVBUFFER& buf = m_buffers[source];
+  CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
 
   bool deinterlacing;
@@ -2069,7 +2069,7 @@ void CLinuxRendererGL::DeleteYV12Texture(int index)
 //********************************************************************************************************
 bool CLinuxRendererGL::UploadNV12Texture(int source)
 {
-  YUVBUFFER& buf = m_buffers[source];
+  CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
 
   bool deinterlacing;
@@ -2128,7 +2128,7 @@ bool CLinuxRendererGL::UploadNV12Texture(int source)
 bool CLinuxRendererGL::CreateNV12Texture(int index)
 {
   // since we also want the field textures, pitch must be texture aligned
-  YUVBUFFER& buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
   YuvImage &im = buf.image;
   GLuint *pbo = buf.pbo;
 
@@ -2259,7 +2259,7 @@ bool CLinuxRendererGL::CreateNV12Texture(int index)
 
 void CLinuxRendererGL::DeleteNV12Texture(int index)
 {
-  YUVBUFFER& buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
   YuvImage &im = buf.image;
   GLuint *pbo = buf.pbo;
 
@@ -2310,7 +2310,7 @@ void CLinuxRendererGL::DeleteNV12Texture(int index)
 
 bool CLinuxRendererGL::UploadYUV422PackedTexture(int source)
 {
-  YUVBUFFER& buf = m_buffers[source];
+  CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
 
   bool deinterlacing;
@@ -2351,7 +2351,7 @@ bool CLinuxRendererGL::UploadYUV422PackedTexture(int source)
 
 void CLinuxRendererGL::DeleteYUV422PackedTexture(int index)
 {
-  YUVBUFFER& buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
   YuvImage &im = buf.image;
   GLuint *pbo = buf.pbo;
 
@@ -2398,7 +2398,7 @@ void CLinuxRendererGL::DeleteYUV422PackedTexture(int index)
 bool CLinuxRendererGL::CreateYUV422PackedTexture(int index)
 {
   // since we also want the field textures, pitch must be texture aligned
-  YUVBUFFER& buf = m_buffers[index];
+  CPictureBuffer& buf = m_buffers[index];
   YuvImage &im = buf.image;
   GLuint *pbo = buf.pbo;
 
@@ -2515,7 +2515,7 @@ void CLinuxRendererGL::SetTextureFilter(GLenum method)
 {
   for (int i = 0 ; i<m_NumYV12Buffers ; i++)
   {
-    YUVBUFFER& buf = m_buffers[i];
+    CPictureBuffer& buf = m_buffers[i];
 
     for (int f = FIELD_FULL; f<=FIELD_BOT ; f++)
     {
@@ -2602,7 +2602,7 @@ bool CLinuxRendererGL::Supports(ESCALINGMETHOD method)
   return false;
 }
 
-void CLinuxRendererGL::BindPbo(YUVBUFFER& buff)
+void CLinuxRendererGL::BindPbo(CPictureBuffer& buff)
 {
   bool pbo = false;
   for(int plane = 0; plane < YuvImage::MAX_PLANES; plane++)
@@ -2619,7 +2619,7 @@ void CLinuxRendererGL::BindPbo(YUVBUFFER& buff)
     glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_ARB, 0);
 }
 
-void CLinuxRendererGL::UnBindPbo(YUVBUFFER& buff)
+void CLinuxRendererGL::UnBindPbo(CPictureBuffer& buff)
 {
   bool pbo = false;
   for(int plane = 0; plane < YuvImage::MAX_PLANES; plane++)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -203,10 +203,10 @@ protected:
     unsigned pixpertex_y;
   };
 
-  struct YUVBUFFER
+  struct CPictureBuffer
   {
-    YUVBUFFER();
-   ~YUVBUFFER();
+    CPictureBuffer();
+   ~CPictureBuffer();
 
     YUVPLANE fields[MAX_FIELDS][YuvImage::MAX_PLANES];
     YuvImage image;
@@ -224,7 +224,7 @@ protected:
 
   // YV12 decoder textures
   // field index 0 is full image, 1 is odd scanlines, 2 is even scanlines
-  YUVBUFFER m_buffers[NUM_BUFFERS];
+  CPictureBuffer m_buffers[NUM_BUFFERS];
 
   void LoadPlane(YUVPLANE& plane, int type,
                  unsigned width,  unsigned height,
@@ -244,8 +244,8 @@ protected:
   // clear colour for "black" bars
   float m_clearColour;
 
-  void BindPbo(YUVBUFFER& buff);
-  void UnBindPbo(YUVBUFFER& buff);
+  void BindPbo(CPictureBuffer& buff);
+  void UnBindPbo(CPictureBuffer& buff);
   bool m_pboSupported;
   bool m_pboUsed;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -37,6 +37,10 @@
 #include "threads/Event.h"
 #include "VideoShaders/ShaderFormats.h"
 
+extern "C" {
+#include "libavutil/mastering_display_metadata.h"
+}
+
 class CRenderCapture;
 class CRenderSystemGL;
 
@@ -50,20 +54,6 @@ struct DRAWRECT
   float top;
   float right;
   float bottom;
-};
-
-struct YUVRANGE
-{
-  int y_min, y_max;
-  int u_min, u_max;
-  int v_min, v_max;
-};
-
-struct YUVCOEF
-{
-  float r_up, r_vp;
-  float g_up, g_vp;
-  float b_up, b_vp;
 };
 
 enum RenderMethod
@@ -86,13 +76,6 @@ enum RenderQuality
 #define FIELD_FULL 0
 #define FIELD_TOP 1
 #define FIELD_BOT 2
-
-extern YUVRANGE yuv_range_lim;
-extern YUVRANGE yuv_range_full;
-extern YUVCOEF yuv_coef_bt601;
-extern YUVCOEF yuv_coef_bt709;
-extern YUVCOEF yuv_coef_ebu;
-extern YUVCOEF yuv_coef_smtp240m;
 
 class CLinuxRendererGL : public CBaseRenderer
 {
@@ -220,6 +203,11 @@ protected:
     int m_srcBits = 8;
     int m_srcTextureBits = 8;
     bool m_srcFullRange;
+
+    bool hasDisplayMetadata = false;
+    AVMasteringDisplayMetadata displayMetadata;
+    bool hasLightMetadata = false;
+    AVContentLightMetadata lightMetadata;
   };
 
   // YV12 decoder textures
@@ -240,6 +228,7 @@ protected:
   unsigned int m_ditherDepth;
   bool m_fullRange;
   AVColorPrimaries m_srcPrimaries;
+  bool m_toneMap = false;
 
   // clear colour for "black" bars
   float m_clearColour;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.cpp
@@ -562,3 +562,35 @@ float CConvertMatrix::GetGammaDst()
 {
   return m_gammaDst;
 }
+
+bool CConvertMatrix::GetRGBYuvCoefs(AVColorSpace colspace, float (&coefs)[3])
+{
+  switch (colspace)
+  {
+    case AVCOL_SPC_BT709:
+      coefs[0] = BT709YCbCr.Kr;
+      coefs[1] = 1 - BT709YCbCr.Kr - BT709YCbCr.Kb;
+      coefs[2] = BT709YCbCr.Kb;
+      break;
+    case AVCOL_SPC_BT470BG:
+    case AVCOL_SPC_SMPTE170M:
+      coefs[0] = BT601YCbCr.Kr;
+      coefs[1] = 1 - BT601YCbCr.Kr - BT601YCbCr.Kb;
+      coefs[2] = BT601YCbCr.Kb;
+      break;
+    case AVCOL_SPC_SMPTE240M:
+      coefs[0] = ST240YCbCr.Kr;
+      coefs[1] = 1 - ST240YCbCr.Kr - ST240YCbCr.Kb;
+      coefs[2] = ST240YCbCr.Kb;
+      break;
+    case AVCOL_SPC_BT2020_NCL:
+    case AVCOL_SPC_BT2020_CL:
+      coefs[0] = ST240YCbCr.Kr;
+      coefs[1] = 1 - ST240YCbCr.Kr - ST240YCbCr.Kb;
+      coefs[2] = ST240YCbCr.Kb;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ConversionMatrix.h
@@ -123,6 +123,7 @@ public:
   bool GetPrimMat(float (&mat)[3][3]);
   float GetGammaSrc();
   float GetGammaDst();
+  bool GetRGBYuvCoefs(AVColorSpace colspace, float (&coefs)[3]);
   
 protected:
   void GenMat();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -29,6 +29,7 @@
 
 extern "C" {
 #include "libavutil/pixfmt.h"
+#include "libavutil/mastering_display_metadata.h"
 }
 
 class CConvertMatrix;
@@ -40,6 +41,7 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
 public:
   BaseYUV2RGBGLSLShader(bool rect, EShaderFormat format, bool stretch,
                         AVColorPrimaries dst, AVColorPrimaries src,
+                        bool toneMap,
                         std::shared_ptr<GLSLOutput> output);
   virtual ~BaseYUV2RGBGLSLShader();
 
@@ -51,6 +53,8 @@ public:
   void SetBlack(float black) { m_black = black; }
   void SetContrast(float contrast) { m_contrast = contrast; }
   void SetNonLinStretch(float stretch) { m_stretch = stretch; }
+  void SetDisplayMetadata(bool hasDisplayMetadata, AVMasteringDisplayMetadata displayMetadata,
+                          bool hasLightMetadata, AVContentLightMetadata lightMetadata);
 
   void SetConvertFullColorRange(bool convertFullRange) { m_convertFullRange = convertFullRange; }
 
@@ -74,6 +78,11 @@ protected:
   int m_width;
   int m_height;
   int m_field;
+  bool m_hasDisplayMetadata = false;
+  AVMasteringDisplayMetadata m_displayMetadata;
+  bool m_hasLightMetadata = false;
+  AVContentLightMetadata m_lightMetadata;
+  bool m_toneMapping = false;
 
   float m_black;
   float m_contrast;
@@ -98,6 +107,8 @@ protected:
   GLint m_hGammaSrc = -1;
   GLint m_hGammaDstInv = -1;
   GLint m_hPrimMat = -1;
+  GLint m_hToneP1 = -1;
+  GLint m_hCoefsDst = -1;
 
   // vertex shader attribute handles
   GLint m_hVertex = -1;
@@ -116,6 +127,7 @@ public:
                            EShaderFormat format,
                            bool stretch,
                            AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries,
+                           bool toneMap,
                            std::shared_ptr<GLSLOutput> output);
 };
 
@@ -126,6 +138,7 @@ public:
                        EShaderFormat format,
                        bool stretch,
                        AVColorPrimaries dstPrimaries, AVColorPrimaries srcPrimaries,
+                       bool toneMap,
                        ESCALINGMETHOD method,
                        std::shared_ptr<GLSLOutput> output);
   ~YUV2RGBFilterShader4() override;

--- a/xbmc/guilib/Shader.cpp
+++ b/xbmc/guilib/Shader.cpp
@@ -89,6 +89,36 @@ bool CShader::AppendSource(const std::string& filename)
   return true;
 }
 
+bool CShader::InsertSource(const std::string& filename, const std::string& loc)
+{
+  if(filename.empty())
+    return true;
+
+  CFileStream file;
+  std::string temp;
+
+  std::string path = "special://xbmc/system/shaders/";
+  path += CServiceBroker::GetRenderSystem().GetShaderPath(filename);
+  path += filename;
+  if(!file.Open(path))
+  {
+    CLog::Log(LOGERROR, "CShader::InsertSource - failed to open file %s", filename.c_str());
+    return false;
+  }
+  getline(file, temp, '\0');
+
+  size_t locPos = m_source.find(loc);
+  if (locPos == std::string::npos)
+  {
+    CLog::Log(LOGERROR, "CShader::InsertSource - could not find location %s", loc.c_str());
+    return false;
+  }
+
+  m_source.insert(locPos, temp);
+
+  return true;
+}
+
 //////////////////////////////////////////////////////////////////////
 // CGLSLVertexShader
 //////////////////////////////////////////////////////////////////////

--- a/xbmc/guilib/Shader.h
+++ b/xbmc/guilib/Shader.h
@@ -43,6 +43,7 @@ namespace Shaders {
     virtual void SetSource(const std::string& src) { m_source = src; }
     virtual bool LoadSource(const std::string& filename, const std::string& prefix = "");
     virtual bool AppendSource(const std::string& filename);
+    virtual bool InsertSource(const std::string& filename, const std::string& loc);
     bool OK() const { return m_compiled; }
 
   protected:


### PR DESCRIPTION
Implements tone mapping for OpenGL. More operators can be implemented and some parameters should be exposed to video settings later.