### PR TITLE
[Windows][DX]Fix interlaced modes on fullscreen

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -556,7 +556,7 @@ void DX::DeviceResources::ResizeBuffers()
     swapChainDesc.SampleDesc.Quality = 0;
 
     DXGI_SWAP_CHAIN_FULLSCREEN_DESC scFSDesc = { 0 }; // unused for uwp
-    scFSDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_PROGRESSIVE;
+    scFSDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
     scFSDesc.Windowed = windowed;
 
     ComPtr<IDXGISwapChain1> swapChain;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
A little fix for interlaced modes on fullscreen.
## Description
<!--- Describe your change in detail -->
Continuation of  #13476
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During set monitor to true fullscreen and the display mode is interlaced will ever fall to progressive
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested in all possible configurations, in progressive an interlaced, seems that works fine.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

