### PR TITLE
X11, Wayland: request OpenGL profile 3.2

### DIFF
--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -28,9 +28,9 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glext.h>
-
 #include "GLContextEGL.h"
 #include "utils/log.h"
+#include <EGL/eglext.h>
 
 #define EGL_NO_CONFIG (EGLConfig)0
 
@@ -177,7 +177,9 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
 
     EGLint contextAttributes[] =
     {
-      EGL_CONTEXT_CLIENT_VERSION, 2,
+      EGL_CONTEXT_MAJOR_VERSION_KHR, 3,
+      EGL_CONTEXT_MINOR_VERSION_KHR, 2,
+      EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
       EGL_NONE
     };
     m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig, EGL_NO_CONTEXT, contextAttributes);

--- a/xbmc/windowing/wayland/GLContextEGL.cpp
+++ b/xbmc/windowing/wayland/GLContextEGL.cpp
@@ -124,7 +124,9 @@ bool CGLContextEGL::CreateSurface(wayland::surface_t const& surface, CSizeInt si
   }
 
   const EGLint context_atrribs[] = {
-    EGL_CONTEXT_CLIENT_VERSION, 2,
+    EGL_CONTEXT_MAJOR_VERSION_KHR, 3,
+    EGL_CONTEXT_MINOR_VERSION_KHR, 2,
+    EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
     EGL_NONE
   };
 


### PR DESCRIPTION
Request OpenGL core profile 3.2 if available

Users can use MESA_GL_VERSION_OVERRIDE to force legacy mode