### PR TITLE
Scan video title

### DIFF
--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -52,7 +52,8 @@ public:
     URL_NFO      = 2, //!< A URL to grab info from was found
     OVERRIDE_NFO = 3, //!< Override info was found
     COMBINED_NFO = 4, //!< A URL to grab info from + override info was found
-    ERROR_NFO    = 5  //!< Error processing info
+    ERROR_NFO    = 5, //!< Error processing info
+    TITLE_NFO    = 6  //!< At least Title was read (and optionally the Year)
   };
 
   //! \brief Empty destructor.

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -898,8 +898,17 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
                                              bool fFirst)
 {
   // prepare parameters for URL creation
-  std::string sTitle, sTitleYear, sYear;
-  CUtil::CleanString(movieTitle, sTitle, sTitleYear, sYear, true /*fRemoveExt*/, fFirst);
+  std::string sTitle, sYear;
+  if (movieYear < 0)
+  {
+    std::string sTitleYear;
+    CUtil::CleanString(movieTitle, sTitle, sTitleYear, sYear, true /*fRemoveExt*/, fFirst);
+  }
+  else
+  {
+    sTitle = movieTitle;
+    sYear = std::to_string( movieYear );
+  }
 
   CLog::Log(LOGDEBUG,
             "%s: Searching for '%s' using %s scraper "

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -894,12 +894,12 @@ static bool PythonDetails(const std::string &ID,
 // fetch list of matching movies sorted by relevance (may be empty);
 // throws CScraperError on error; first called with fFirst set, then unset if first try fails
 std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
-                                             const std::string &sMovie,
+                                             const std::string &movieTitle, int movieYear,
                                              bool fFirst)
 {
   // prepare parameters for URL creation
   std::string sTitle, sTitleYear, sYear;
-  CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true /*fRemoveExt*/, fFirst);
+  CUtil::CleanString(movieTitle, sTitle, sTitleYear, sYear, true /*fRemoveExt*/, fFirst);
 
   CLog::Log(LOGDEBUG,
             "%s: Searching for '%s' using %s scraper "

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -139,7 +139,7 @@ public:
   CScraperUrl ResolveIDToUrl(const std::string &externalID);
 
   std::vector<CScraperUrl> FindMovie(XFILE::CCurlFile &fcurl,
-    const std::string &sMovie, bool fFirst);
+    const std::string &movieTitle, int movieYear, bool fFirst);
   std::vector<MUSIC_GRABBER::CMusicAlbumInfo> FindAlbum(XFILE::CCurlFile &fcurl,
     const std::string &sAlbum, const std::string &sArtist = "");
   std::vector<MUSIC_GRABBER::CMusicArtistInfo> FindArtist(

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -48,12 +48,13 @@ public:
   // threaded lookup functions
 
   /*! \brief Do a search for matching media items (possibly asynchronously) with our scraper
-   \param strMovie name of the media item to look for
+   \param movieTitle title of the media item to look for
+   \param movieYear year of the media item to look for (-1 if not known)
    \param movielist [out] list of results to fill. May be empty on success.
    \param pProgress progress bar to update as we go. If NULL we run on thread, if non-NULL we run off thread.
    \return 1 on success, -1 on a scraper-specific error, 0 on some other error
    */
-  int FindMovie(const std::string& strMovie, MOVIELIST& movielist, CGUIDialogProgress *pProgress = NULL);
+  int FindMovie(const std::string& movieTitle, int movieYear, MOVIELIST& movielist, CGUIDialogProgress *pProgress = NULL);
 
   /*! \brief Fetch art URLs for an item with our scraper
    \param details the video info tag structure to fill with art.
@@ -75,7 +76,8 @@ protected:
                       GET_EPISODE_DETAILS = 4 };
 
   XFILE::CCurlFile*   m_http;
-  std::string          m_strMovie;
+  std::string         m_movieTitle;
+  int                 m_movieYear;
   MOVIELIST           m_movieList;
   CVideoInfoTag       m_movieDetails;
   CScraperUrl         m_url;
@@ -88,6 +90,6 @@ protected:
   void Process() override;
   void CloseThread();
 
-  int InternalFindMovie(const std::string& strMovie, MOVIELIST& movielist, bool cleanChars = true);
+  int InternalFindMovie(const std::string& movieTitle, int movieYear, MOVIELIST& movielist, bool cleanChars = true);
 };
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -565,7 +565,7 @@ namespace VIDEO
     int retVal = 0;
     if (pURL && !pURL->m_url.empty())
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress)) <= 0)
+    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), -1, info2, url, pDlgProgress)) <= 0)
       return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
 
     CLog::Log(LOGDEBUG,
@@ -641,7 +641,7 @@ namespace VIDEO
     int retVal = 0;
     if (pURL && !pURL->m_url.empty())
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress)) <= 0)
+    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), -1, info2, url, pDlgProgress)) <= 0)
       return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
 
     CLog::Log(LOGDEBUG,
@@ -711,7 +711,7 @@ namespace VIDEO
     int retVal = 0;
     if (pURL && !pURL->m_url.empty())
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress)) <= 0)
+    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), -1, info2, url, pDlgProgress)) <= 0)
       return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
 
     CLog::Log(LOGDEBUG,
@@ -1973,11 +1973,11 @@ namespace VIDEO
     return m_bStop;
   }
 
-  int CVideoInfoScanner::FindVideo(const std::string &videoName, const ScraperPtr &scraper, CScraperUrl &url, CGUIDialogProgress *progress)
+  int CVideoInfoScanner::FindVideo(const std::string &title, int year, const ScraperPtr &scraper, CScraperUrl &url, CGUIDialogProgress *progress)
   {
     MOVIELIST movielist;
     CVideoInfoDownloader imdb(scraper);
-    int returncode = imdb.FindMovie(videoName, movielist, progress);
+    int returncode = imdb.FindMovie(title, year, movielist, progress);
     if (returncode < 0 || (returncode == 0 && (m_bStop || !DownloadFailed(progress))))
     { // scraper reported an error, or we had an error and user wants to cancel the scan
       m_bStop = true;
@@ -1990,4 +1990,5 @@ namespace VIDEO
     }
     return 0;    // didn't find anything
   }
+
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -563,9 +563,17 @@ namespace VIDEO
 
     CScraperUrl url;
     int retVal = 0;
+    std::string movieTitle = pItem->GetMovieName(bDirNames);
+    int movieYear = -1; // hint that movie title was not found
+    if (result == CInfoScanner::TITLE_NFO)
+    {
+      CVideoInfoTag* tag = pItem->GetVideoInfoTag();
+      movieTitle = tag->GetTitle();
+      movieYear = tag->GetYear(); // movieYear is expected to be >= 0
+    }
     if (pURL && !pURL->m_url.empty())
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), -1, info2, url, pDlgProgress)) <= 0)
+    else if ((retVal = FindVideo(movieTitle, movieYear, info2, url, pDlgProgress)) <= 0)
       return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
 
     CLog::Log(LOGDEBUG,
@@ -639,9 +647,17 @@ namespace VIDEO
 
     CScraperUrl url;
     int retVal = 0;
+    std::string movieTitle = pItem->GetMovieName(bDirNames);
+    int movieYear = -1; // hint that movie title was not found
+    if (result == CInfoScanner::TITLE_NFO)
+    {
+      CVideoInfoTag* tag = pItem->GetVideoInfoTag();
+      movieTitle = tag->GetTitle();
+      movieYear = tag->GetYear(); // movieYear is expected to be >= 0
+    }
     if (pURL && !pURL->m_url.empty())
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), -1, info2, url, pDlgProgress)) <= 0)
+    else if ((retVal = FindVideo(movieTitle, movieYear, info2, url, pDlgProgress)) <= 0)
       return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
 
     CLog::Log(LOGDEBUG,
@@ -709,9 +725,17 @@ namespace VIDEO
 
     CScraperUrl url;
     int retVal = 0;
+    std::string movieTitle = pItem->GetMovieName(bDirNames);
+    int movieYear = -1; // hint that movie title was not found
+    if (result == CInfoScanner::TITLE_NFO)
+    {
+      CVideoInfoTag* tag = pItem->GetVideoInfoTag();
+      movieTitle = tag->GetTitle();
+      movieYear = tag->GetYear(); // movieYear is expected to be >= 0
+    }
     if (pURL && !pURL->m_url.empty())
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), -1, info2, url, pDlgProgress)) <= 0)
+    else if ((retVal = FindVideo(movieTitle, movieYear, info2, url, pDlgProgress)) <= 0)
       return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
 
     CLog::Log(LOGDEBUG,

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -131,13 +131,23 @@ namespace VIDEO
     bool ProgressCancelled(CGUIDialogProgress* progress, int heading, const std::string &line1);
 
     /*! \brief Find a url for the given video using the given scraper
-     \param videoName name of the video to lookup
+     \param title title of the video to lookup
+     \param year year of the video to lookup
      \param scraper scraper to use for the lookup
      \param url [out] returned url from the scraper
      \param progress CGUIDialogProgress bar
      \return >0 on success, <0 on failure (cancellation), and 0 on no info found
      */
-    int FindVideo(const std::string &videoName, const ADDON::ScraperPtr &scraper, CScraperUrl &url, CGUIDialogProgress *progress);
+    int FindVideo(const std::string &title, int year, const ADDON::ScraperPtr &scraper, CScraperUrl &url, CGUIDialogProgress *progress);
+
+    /*! \brief Find a url for the given video using the given scraper
+     \param item the video to lookup
+     \param scraper scraper to use for the lookup
+     \param url [out] returned url from the scraper
+     \param progress CGUIDialogProgress bar
+     \return >0 on success, <0 on failure (cancellation), and 0 on no info found
+     */
+    int FindVideoUsingTag(CFileItem& item, const ADDON::ScraperPtr &scraper, CScraperUrl &url, CGUIDialogProgress *progress);
 
     /*! \brief Retrieve detailed information for an item from an online source, optionally supplemented with local data
      @todo sort out some better return codes.

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1314,6 +1314,11 @@ void CVideoInfoTag::SetTitle(std::string title)
   m_strTitle = Trim(std::move(title));
 }
 
+std::string const &CVideoInfoTag::GetTitle()
+{
+  return m_strTitle;
+}
+
 void CVideoInfoTag::SetSortTitle(std::string sortTitle)
 {
   m_strSortTitle = Trim(std::move(sortTitle));

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -136,6 +136,7 @@ public:
   void SetPlotOutline(std::string plotOutline);
   void SetTrailer(std::string trailer);
   void SetPlot(std::string plot);
+  std::string const &GetTitle();
   void SetTitle(std::string title);
   void SetSortTitle(std::string sortTitle);
   void SetPictureURL(CScraperUrl &pictureURL);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -155,7 +155,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
       // try to find a matching item
       MOVIELIST itemResultList;
-      int result = infoDownloader.FindMovie(itemTitle, itemResultList, GetProgressDialog());
+      int result = infoDownloader.FindMovie(itemTitle, -1, itemResultList, GetProgressDialog());
 
       // close the progress dialog
       MarkFinished();

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -201,7 +201,7 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
     hastag = true;
   }
 
-  return hastag ? CInfoScanner::FULL_NFO : CInfoScanner::NO_NFO;
+  return hastag ? CInfoScanner::TITLE_NFO : CInfoScanner::NO_NFO;
 }
 
 CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMP4(CVideoInfoTag& tag,
@@ -244,5 +244,5 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMP4(CVideoInfoTag& tag,
       tag.m_coverArt.emplace_back(EmbeddedArtInfo(size, "image/png", type));
   }
 
-  return CInfoScanner::FULL_NFO;
+  return CInfoScanner::TITLE_NFO;
 }


### PR DESCRIPTION
Extend the current mechanism to retrieve Movie information from IMDB, using:

1. Title as stored in the movie (mp4, mkv)
2. Using the existing codepath (filename as found on disk)

## Description
<!--- Describe your change in detail -->

## Motivation and Context
I'd like to preserve my existing filename. Typical naming convention if 'Year Movie Title in French (Movie Title in English).mp4'. This allow members of my family easy navigation, and file exchange.
Since this convention is highly unusual, it breaks the contracts for the existing FindVideo implementation.

I believe using title within the tags itself is more robust, since filename convention can be very changing from one user to another. As an alternate example I picked a random file, where filename convention does breaks assumptions, but does work with the new patch:

```
$ wget http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4
$ ffprobe -i BigBuckBunny_320x180.mp4 2>&1| grep title
    title           : Big Buck Bunny
```

For reference:
https://trac.kodi.tv/ticket/17755

## How Has This Been Tested?
System is Debian/9.3. xbmc was forked from commit c4eaf9281676568e55f2122471a7d6a39a8b6e09.

## Types of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
