### PR TITLE
[uPnP] Content-Disposition Header

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -50,6 +50,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
 #include "utils/FileUtils.h"
+#include "TextureDatabase.h"
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.server")
 
@@ -1198,9 +1199,10 @@ CUPnPServer::ServeFile(const NPT_HttpRequest&              request,
         return NPT_SUCCESS;
     }
 
-    if(URIUtils::IsURL((const char*)file_path))
+    if (URIUtils::IsURL(static_cast<const char*>(file_path)))
     {
-      std::string disp = "inline; filename=\"" + URIUtils::GetFileName((const char*)file_path) + "\"";
+      CURL url(CTextureUtils::UnwrapImageURL(static_cast<const char*>(file_path)));
+      std::string disp = "inline; filename=\"" + URIUtils::GetFileName(url) + "\"";
       response.GetHeaders().SetHeader("Content-Disposition", disp.c_str());
     }
 


### PR DESCRIPTION
Kodi currently sends the following header when serving thumbnails:
Content-Disposition:inline; filename=""

because of a slight problem in the decoding of the wrapped image file name in CUPnPServer::ServeFile().
For information, the same code also adds the header for the actual media files (*.mkv, *.mp3, ...) with a correct value in my testing. The header is not sent for local media (since not wrapped as URL).

This PR contains a modified version of the patch submitted earlier, due to problems found with FTP sources.

However, taking a step back, should the header be sent at all in general situations?

In my opinion it should not sent because it is an optional http header to suggest a filename to the requester, and:
- The filename is already in the clear at the end of the URL, the content disposition is a duplication of the information.
- In the context of uPnP the main intent is display the image or play the video/audio, not to persist it.
- Other popular uPnP servers such as Serviio and Twonky do not send that header.
Only reason I can think of to keep it is if some client requires for compatibility, but that is unlikely due to the previous points.

Is it possible to ask the person who wrote the original code what the intention was?


Alternatively, to keep the header and fix it:
As suggested in a previous PR, I tested with an FTP source and the initial fix created problems for the content (ftp://xxxxxxx) because of the added GetHostName().
There can be double-protocols in image URLs (example image://https%3a%2f%2fimage.tmdb.org%2ft%2fp%2foriginal%2fsIZr3pWcnLTjMkOaTkBrV967lTK.jpg/), so it seemed best not to modify the CURL constructor that parses the string, but instead to reverse the wrapping performed by UPnPInternal::BuildObject() for the thumbnails.
The unwrapping takes care of detecting image:// protocol and lets the other through unchanged.

Tested successfully with local thumbnails and media, FTP thumbnails and media.


Let me know what you think and I'll update the code.