### PR TITLE
[PVR] Ensure larger objects are heap allocated to avoid stack overflows.

### DIFF
--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -49,8 +49,11 @@ namespace PVR
   class CPVRClientCapabilities
   {
   public:
-    CPVRClientCapabilities();
+    CPVRClientCapabilities() = default;
     virtual ~CPVRClientCapabilities() = default;
+
+    CPVRClientCapabilities(const CPVRClientCapabilities& other);
+    const CPVRClientCapabilities& operator =(const CPVRClientCapabilities& other);
 
     const CPVRClientCapabilities& operator =(const PVR_ADDON_CAPABILITIES& addonCapabilities);
 
@@ -66,37 +69,37 @@ namespace PVR
      * @brief Check whether this add-on supports TV channels.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsTV() const { return m_addonCapabilities.bSupportsTV; }
+    bool SupportsTV() const { return m_addonCapabilities && m_addonCapabilities->bSupportsTV; }
 
     /*!
      * @brief Check whether this add-on supports radio channels.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsRadio() const { return m_addonCapabilities.bSupportsRadio; }
+    bool SupportsRadio() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRadio; }
 
     /*!
      * @brief Check whether this add-on supports channel groups.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsChannelGroups() const { return m_addonCapabilities.bSupportsChannelGroups; }
+    bool SupportsChannelGroups() const { return m_addonCapabilities && m_addonCapabilities->bSupportsChannelGroups; }
 
     /*!
      * @brief Check whether this add-on supports scanning for new channels on the backend.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsChannelScan() const { return m_addonCapabilities.bSupportsChannelScan; }
+    bool SupportsChannelScan() const { return m_addonCapabilities && m_addonCapabilities->bSupportsChannelScan; }
 
     /*!
      * @brief Check whether this add-on supports the following functions: DeleteChannel, RenameChannel, DialogChannelSettings and DialogAddChannel.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsChannelSettings() const { return m_addonCapabilities.bSupportsChannelSettings; }
+    bool SupportsChannelSettings() const { return m_addonCapabilities && m_addonCapabilities->bSupportsChannelSettings; }
 
     /*!
      * @brief Check whether this add-on supports descramble information for playing channels.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsDescrambleInfo() const { return m_addonCapabilities.bSupportsDescrambleInfo; }
+    bool SupportsDescrambleInfo() const { return m_addonCapabilities && m_addonCapabilities->bSupportsDescrambleInfo; }
 
     /////////////////////////////////////////////////////////////////////////////////
     //
@@ -108,7 +111,7 @@ namespace PVR
      * @brief Check whether this add-on provides EPG information.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsEPG() const { return m_addonCapabilities.bSupportsEPG; }
+    bool SupportsEPG() const { return m_addonCapabilities && m_addonCapabilities->bSupportsEPG; }
 
     /////////////////////////////////////////////////////////////////////////////////
     //
@@ -120,7 +123,7 @@ namespace PVR
      * @brief Check whether this add-on supports the creation and editing of timers.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsTimers() const { return m_addonCapabilities.bSupportsTimers; }
+    bool SupportsTimers() const { return m_addonCapabilities && m_addonCapabilities->bSupportsTimers; }
 
     /////////////////////////////////////////////////////////////////////////////////
     //
@@ -132,43 +135,43 @@ namespace PVR
      * @brief Check whether this add-on supports recordings.
      * @return True if recordings are supported, false otherwise.
      */
-    bool SupportsRecordings() const { return m_addonCapabilities.bSupportsRecordings; }
+    bool SupportsRecordings() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings; }
 
     /*!
      * @brief Check whether this add-on supports undelete of deleted recordings.
      * @return True if supported, false otherwise.
      */
-    bool SupportsRecordingsUndelete() const { return m_addonCapabilities.bSupportsRecordings && m_addonCapabilities.bSupportsRecordingsUndelete; }
+    bool SupportsRecordingsUndelete() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings && m_addonCapabilities->bSupportsRecordingsUndelete; }
 
     /*!
      * @brief Check whether this add-on supports play count for recordings.
      * @return True if supported, false otherwise.
      */
-    bool SupportsRecordingsPlayCount() const { return m_addonCapabilities.bSupportsRecordings && m_addonCapabilities.bSupportsRecordingPlayCount; }
+    bool SupportsRecordingsPlayCount() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings && m_addonCapabilities->bSupportsRecordingPlayCount; }
 
     /*!
      * @brief Check whether this add-on supports store/retrieve of last played position for recordings..
      * @return True if supported, false otherwise.
      */
-    bool SupportsRecordingsLastPlayedPosition() const { return m_addonCapabilities.bSupportsRecordings && m_addonCapabilities.bSupportsLastPlayedPosition; }
+    bool SupportsRecordingsLastPlayedPosition() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings && m_addonCapabilities->bSupportsLastPlayedPosition; }
 
     /*!
      * @brief Check whether this add-on supports retrieving an edit decision list for recordings.
      * @return True if supported, false otherwise.
      */
-    bool SupportsRecordingsEdl() const { return m_addonCapabilities.bSupportsRecordings && m_addonCapabilities.bSupportsRecordingEdl; }
+    bool SupportsRecordingsEdl() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings && m_addonCapabilities->bSupportsRecordingEdl; }
 
     /*!
      * @brief Check whether this add-on supports renaming recordings..
      * @return True if supported, false otherwise.
      */
-    bool SupportsRecordingsRename() const { return m_addonCapabilities.bSupportsRecordings && m_addonCapabilities.bSupportsRecordingsRename; }
+    bool SupportsRecordingsRename() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings && m_addonCapabilities->bSupportsRecordingsRename; }
 
     /*!
      * @brief Check whether this add-on supports changing lifetime of recording.
      * @return True if supported, false otherwise.
      */
-    bool SupportsRecordingsLifetimeChange() const { return m_addonCapabilities.bSupportsRecordings && m_addonCapabilities.bSupportsRecordingsLifetimeChange; }
+    bool SupportsRecordingsLifetimeChange() const { return m_addonCapabilities && m_addonCapabilities->bSupportsRecordings && m_addonCapabilities->bSupportsRecordingsLifetimeChange; }
 
     /*!
      * @brief Obtain a list with all possible values for recordings lifetime.
@@ -186,18 +189,18 @@ namespace PVR
      * @brief Check whether this add-on provides an input stream. false if Kodi handles the stream.
      * @return True if supported, false otherwise.
      */
-    bool HandlesInputStream() const { return m_addonCapabilities.bHandlesInputStream; }
+    bool HandlesInputStream() const { return m_addonCapabilities && m_addonCapabilities->bHandlesInputStream; }
 
     /*!
      * @brief Check whether this add-on demultiplexes packets.
      * @return True if supported, false otherwise.
      */
-    bool HandlesDemuxing() const { return m_addonCapabilities.bHandlesDemuxing; }
+    bool HandlesDemuxing() const { return m_addonCapabilities && m_addonCapabilities->bHandlesDemuxing; }
 
   private:
     void InitRecordingsLifetimeValues();
 
-    PVR_ADDON_CAPABILITIES m_addonCapabilities;
+    std::unique_ptr<PVR_ADDON_CAPABILITIES> m_addonCapabilities;
     std::vector<std::pair<std::string, int>> m_recordingsLifetimeValues;
   };
 


### PR DESCRIPTION
Fixes some potential stack overflow issues.

<pre>
Severity    Code    Description    Project    File    Line    Suppression State
Warning    C6262    Function uses '34880' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'class PVR::CPVRClientCapabilities' at line 123.  Consider moving some data to heap.    xbmc    c:\code\kodi\xbmc\pvr\timers\pvrtimerinfotag.cpp    123

Severity    Code    Description    Project    File    Line    Suppression State
Warning    C6262    Function uses '148080' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'struct PVR_TIMER_TYPE' at line 450.  Consider moving some data to heap.    xbmc    c:\code\kodi\xbmc\addons\pvrclient.cpp    450    Active

Severity    Code    Description    Project    File    Line    Suppression State
Warning    C6262    Function uses '41608' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.    xbmc    c:\code\kodi\xbmc\addons\pvrclient.cpp    786    Active
Warning    C6262    Function uses '43104' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.    xbmc    c:\code\kodi\xbmc\addons\pvrclient.cpp    1096    Active
Warning    C6262    Function uses '52336' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.    xbmc    c:\code\kodi\xbmc\addons\pvrclient.cpp    1118    Active</pre>

@Paxxi as discussed, good to go?