### PR TITLE
AMLCodec: fix ioctl for devices using 3.10 kernel, fix typo

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -346,18 +346,26 @@ typedef struct vframe_states
   int buf_avail_num;
 } vframe_states_t;
 
-static int aml_ioctl_get(CODEC_HANDLE h, int subcmd, unsigned long paramter)
+static int aml_ioctl_get(CODEC_HANDLE h, int subcmd, unsigned long parameter)
 {
+#ifdef AMSTREAM_IOC_GET
   struct am_ioctl_parm parm;
   memset(&parm, 0, sizeof(parm));
   parm.cmd = subcmd;
-  parm.data_32 = *(unsigned int *)paramter;
+  parm.data_32 = *(unsigned int *)parameter;
   if (ioctl(h, AMSTREAM_IOC_GET, (unsigned long)&parm) < 0)
   {
     CLog::Log(LOGERROR, "aml_ioctl_get failed: subcmd=%x, errno=%d", subcmd, errno);
     return -1;
   }
   *(unsigned int *)paramter = parm.data_32;
+#else
+  if (ioctl(h, subcmd, &parameter) < 0)
+  {
+    CLog::Log(LOGERROR, "aml_ioctl_get failed: subcmd=%x, errno=%d", subcmd, errno);
+    return -1;
+  }
+#endif
   return 0;
 }
 


### PR DESCRIPTION
## Description
Fixes building Kodi for Amlogic devices using 3.10 kernel and older amcodec with a bit different IOCTLs.

## How Has This Been Tested?
LE master + S805 device.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Ping @peak3d and @codesnake 