### PR TITLE
RetroPlayer: Input fixes

### DIFF
--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -153,7 +153,6 @@
 						<item id="102">
 							<description>Reset button</description>
 							<label>$LOCALIZE[13007]</label>
-							<label2>Select + B</label2>
 							<icon>osd/fullscreen/buttons/reset.png</icon>
 							<onclick>PlayerControl(Reset)</onclick>
 						</item>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -148,7 +148,8 @@
       -->
       <!-- Merged -->
       <a hotkey="back">Screenshot</a>
-      <b hotkey="back">PlayerControl(Reset)</b>
+      <!-- Reset is disabled until player can undo a reset -->
+      <!--<b hotkey="back">PlayerControl(Reset)</b> -->
       <x hotkey="back">OSD</x>
       <y hotkey="back">FullScreen</y>
       <start hotkey="back">Stop</start>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -147,7 +147,9 @@
       <leftstick direction="right" hotkey="back">SaveSlotIncrease</leftstick>
       -->
       <!-- Merged -->
-      <a hotkey="back">Screenshot</a>
+      <!-- Screenshot is disabled until it has been further automated
+           (currently pops up multiple annoying confusing dialogs) -->
+      <!-- <a hotkey="back">Screenshot</a> -->
       <!-- Reset is disabled until player can undo a reset -->
       <!--<b hotkey="back">PlayerControl(Reset)</b> -->
       <x hotkey="back">OSD</x>

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -454,7 +454,8 @@ void CRetroPlayer::FrameMove()
 
   if (m_gameClient)
   {
-    const bool bFullscreen = g_windowManager.IsWindowActive(WINDOW_FULLSCREEN_GAME);
+    const int activeId = g_windowManager.GetActiveWindowOrDialog();
+    const bool bFullscreen = (activeId == WINDOW_FULLSCREEN_GAME);
 
     switch (m_state)
     {


### PR DESCRIPTION
This PR contains ~~two~~ three fixes:

* Fix pause/play inside Game OSD after #13433
* Remove reset hotkey from FullscreenGame window
* Remove screenshot hotkey from FullscreenGame window

## Description
Pause/play was broken because RP was checking active window (always itself) instead of active window or dialog (which ignored the Game OSD dialog).

During gameplay, when shit gets real and buttons get mashed, players can press Select+B causing an unexpected reset. Disable this hotkey until/if resets are easily undoable. Functionality is still available through the Game OSD.

Similarly, the screenshot hotkey is somewhat broken and opens up multiple annoying confusing dialogs. Disable this until it has been further automated.

## How Has This Been Tested?
Tested on OSX.

## Screenshots (if appropriate):
Game OSD without the reset hotkey:

![screen shot 2018-02-11 at 4 23 20 pm](https://user-images.githubusercontent.com/531482/36080668-f5358a00-0f47-11e8-82ea-59deb8d538a5.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
