### PR TITLE
[Music]Refactor Song Information Dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2589,6 +2589,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
@@ -3955,7 +3956,6 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogFavourites.cpp
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 msgctxt "#1030"
 msgid "Browse for image"
 msgstr ""
@@ -7171,11 +7171,13 @@ msgctxt "#13510"
 msgid "Sync playback to display"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#13511"
 msgid "Choose art"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#13512"
 msgid "Current art"
@@ -7191,14 +7193,17 @@ msgctxt "#13514"
 msgid "Local art"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#13515"
 msgid "No art"
 msgstr ""
 
+#. Button to add a new type of art e.g. "thumb", "poster", "fanart" etc. 
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#13516"
-msgid "Add art"
+msgid "Add art type"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -7221,7 +7226,13 @@ msgctxt "#13520"
 msgid "Embedded fanart"
 msgstr ""
 
-#empty strings from id 13521 to 13549
+#. Heading for selection of a type of art e.g. "thumb", "poster", "fanart" etc. 
+#: xbmc/music/MusicUtils.cpp
+msgctxt "#13521"
+msgid "Choose art type"
+msgstr ""
+
+#empty strings from id 13522 to 13549
 
 #: system/settings/settings.xml
 msgctxt "#13550"
@@ -11804,7 +11815,6 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogContextMenu.cpp
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 msgctxt "#20016"
 msgid "Current thumb"
 msgstr ""
@@ -11818,7 +11828,6 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogContextMenu.cpp
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
-#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 msgctxt "#20018"
 msgid "No thumb"
 msgstr ""
@@ -11830,6 +11839,7 @@ msgid "Choose thumbnail"
 msgstr ""
 
 #. Name of an artwork type
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: addons/skin.estuary/xml/View_501_Banner.xml
 msgctxt "#20020"
@@ -11837,6 +11847,7 @@ msgid "Banner"
 msgstr ""
 
 #. Name of an artwork type
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: addons/skin.estuary/xml/View_51_Poster.xml
 msgctxt "#20021"
@@ -13397,6 +13408,8 @@ msgctxt "#20444"
 msgid "Add to library"
 msgstr ""
 
+#. Name of an artwork type
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
 #: addons/skin.estuary/xml/View_502_FanArt.xml
 msgctxt "#20445"
@@ -13669,6 +13682,11 @@ msgctxt "#21370"
 msgid "Play GUI sounds during media playback"
 msgstr ""
 
+#. Name of an artwork type
+#: xbmc/music/MusicUtils.cpp
+#: xbmc/music/dialogs/GUIDialogSongInfo.cpp
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+#: xbmc/dialogs/GUIDialogFileBrowser.h
 msgctxt "#21371"
 msgid "Thumbnail"
 msgstr ""
@@ -20849,12 +20867,16 @@ msgstr ""
 
 #empty strings from id 38019 to 38021
 
-#. Used for the viewstate selection
+#. Used for the rating selection
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#38022"
 msgid "No rating"
 msgstr ""
 
+#. Used for the rating selection
+#: xbmc/music/MusicUtils.cpp
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#38023"
 msgid "Set my rating"
 msgstr ""

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1600,8 +1600,8 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     SetLabel(item.GetLabel());
   if (replaceLabels && !item.GetLabel2().empty())
     SetLabel2(item.GetLabel2());
-  if (!item.GetArt("thumb").empty())
-    SetArt("thumb", item.GetArt("thumb"));
+  if (!item.GetArt().empty())
+    SetArt(item.GetArt());
   if (!item.GetIconImage().empty())
     SetIconImage(item.GetIconImage());
   AppendProperties(item);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -179,18 +179,6 @@ CGUIInfoManager::~CGUIInfoManager(void)
 
 bool CGUIInfoManager::OnMessage(CGUIMessage &message)
 {
-  if (message.GetMessage() == GUI_MSG_NOTIFY_ALL)
-  {
-    if (message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
-    {
-      CFileItemPtr item = std::static_pointer_cast<CFileItem>(message.GetItem());
-      if (m_currentFile->IsSamePath(item.get()))
-      {
-        m_currentFile->UpdateInfo(*item);
-        return true;
-      }
-    }
-  }
   return false;
 }
 

--- a/xbmc/music/CMakeLists.txt
+++ b/xbmc/music/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES Album.cpp
             MusicInfoLoader.cpp
             MusicLibraryQueue.cpp
             MusicThumbLoader.cpp
+            MusicUtils.cpp
             Song.cpp)
 
 set(HEADERS Album.h
@@ -18,6 +19,7 @@ set(HEADERS Album.h
             MusicInfoLoader.h
             MusicLibraryQueue.h
             MusicThumbLoader.h
+            MusicUtils.h
             Song.h)
 
 core_add_library(music)

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -208,6 +208,7 @@ public:
   bool Search(const std::string& search, CFileItemList &items);
   bool RemoveSongsFromPath(const std::string &path, MAPSONGS& songs, bool exact=true);
   bool SetSongUserrating(const std::string &filePath, int userrating);
+  bool SetSongUserrating(int idSong, int userrating);
   bool SetSongVotes(const std::string &filePath, int votes);
   int  GetSongByArtistAndAlbumAndTitle(const std::string& strArtist, const std::string& strAlbum, const std::string& strTitle);
 
@@ -321,6 +322,7 @@ public:
   std::string GetArtistById(int id);
   int GetArtistByName(const std::string& strArtist);
   int GetArtistByMatch(const CArtist& artist);
+  bool GetArtistFromSong(int idSong, CArtist &artist);
   std::string GetRoleById(int id);
 
   /*! \brief Propagate artist sort name into the concatenated artist sort name strings
@@ -551,6 +553,13 @@ public:
   \sa RemoveArtForItem
   */
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
+
+  /*! \brief Fetch the distinct types of art held in the database for a type of media.
+  \param mediaType the type of media, which corresponds to the table the item resides in (song/artist/album).
+  \param artTypes [out] the types of art e.g. "thumb", "fanart", etc. 
+  \return true if art is found, false if no art is found.
+  */
+  bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 
   /////////////////////////////////////////////////
   // Tag Scan Version

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -1,0 +1,240 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MusicUtils.h"
+#include "dialogs/GUIDialogSelect.h"
+#include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "input/Key.h"
+#include "music/MusicDatabase.h"
+#include "music/tags/MusicInfoTag.h"
+#include "Util.h"
+#include "utils/JobManager.h"
+
+using namespace MUSIC_INFO;
+using namespace XFILE;
+
+namespace MUSIC_UTILS
+{
+  class CSetArtJob : public CJob
+  {
+    CFileItemPtr pItem;
+    std::string m_artType;
+    std::string m_newArt;
+  public:
+    CSetArtJob(const CFileItemPtr item, const std::string& type, const std::string& newArt) :
+      pItem(item),
+      m_artType(type),
+      m_newArt(newArt)
+    { }
+
+    ~CSetArtJob(void) override = default;
+
+    // Asynchronously update song, album or artist art in library
+    bool DoWork(void) override
+    {
+      CMusicInfoTag& tag = *pItem->GetMusicInfoTag();
+      CMusicDatabase db;
+      if (db.Open())
+      {
+        if (!m_newArt.empty())
+          db.SetArtForItem(tag.GetDatabaseId(), tag.GetType(), m_artType, m_newArt);
+        else
+          db.RemoveArtForItem(tag.GetDatabaseId(), tag.GetType(), m_artType);
+        db.Close();
+      }
+      return true;
+    }
+  };
+
+  class CSetSongRatingJob : public CJob
+  {
+    std::string strPath;
+    int idSong;
+    int iUserrating;
+  public:
+    CSetSongRatingJob(const std::string& filePath, int userrating) :
+      strPath(filePath),
+      idSong(-1),
+      iUserrating(userrating)
+    { }
+
+    CSetSongRatingJob(int songId, int userrating) :
+      strPath(),
+      idSong(songId),
+      iUserrating(userrating)
+    { }
+
+    ~CSetSongRatingJob(void) override = default;
+
+    bool DoWork(void) override
+    {
+      // Asynchronously update song userrating in library
+      CMusicDatabase db;
+      if (db.Open())
+      {
+        if (idSong > 0)
+          db.SetSongUserrating(idSong, iUserrating);
+        else
+          db.SetSongUserrating(strPath, iUserrating);
+        db.Close();
+      }
+
+      return true;
+    }
+  };
+
+  void UpdateArtJob(const CFileItemPtr pItem, const std::string& strType, const std::string& strArt)
+  {
+    // Asynchronously update that type of art in the database
+    CSetArtJob *job = new CSetArtJob(pItem, strType, strArt);
+    CJobManager::GetInstance().AddJob(job, NULL);
+  }
+
+  bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist)
+  {
+    CMusicInfoTag &tag = *musicitem.GetMusicInfoTag();
+    if (tag.GetDatabaseId() < 1 || tag.GetType().empty())
+      return false;
+    if (tag.GetType() != MediaTypeArtist && tag.GetType() != MediaTypeAlbum && tag.GetType() != MediaTypeSong)
+      return false;
+
+    artlist.Clear();
+    // Songs, albums and artists all  have thumbs by default
+    std::vector<std::string> artTypes = { "thumb" };
+    if (tag.GetType() == MediaTypeArtist)
+    {
+      artTypes.emplace_back("fanart");
+    }
+
+    CMusicDatabase db;
+    db.Open();
+
+    // Add in any stored art for this item that is non-empty.
+    std::map<std::string, std::string> currentArt;
+    db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
+    for (const auto art : currentArt)
+    {
+      if (!art.second.empty() && find(artTypes.begin(), artTypes.end(), art.first) == artTypes.end())
+        artTypes.push_back(art.first);
+    }
+
+    // Add any art types that exist for other media items of the same type
+    std::vector<std::string> dbArtTypes;
+    db.GetArtTypes(tag.GetType(), dbArtTypes);
+    for (const auto it : dbArtTypes)
+    {
+      if (find(artTypes.begin(), artTypes.end(), it) == artTypes.end())
+        artTypes.push_back(it);
+    }
+    db.Close();
+
+    for (const auto type : artTypes)
+    {
+      CFileItemPtr artitem(new CFileItem(type, false));
+      // Localise the names of common types of art
+      if (type == "banner")
+        artitem->SetLabel(g_localizeStrings.Get(20020));
+      else if (type == "fanart")
+        artitem->SetLabel(g_localizeStrings.Get(20445));
+      else if (type == "poster")
+        artitem->SetLabel(g_localizeStrings.Get(20021));
+      else if (type == "thumb")
+        artitem->SetLabel(g_localizeStrings.Get(21371));
+      else
+        artitem->SetLabel(type);
+      // Set art type as art item property
+      artitem->SetProperty("arttype", type);
+      // Set current art as art item thumb
+      if (musicitem.HasArt(type))
+        artitem->SetArt("thumb", musicitem.GetArt(type));
+      artlist.Add(artitem);
+    }
+
+    return !artlist.IsEmpty();
+  }
+
+  std::string ShowSelectArtTypeDialog(CFileItemList& artitems)
+  {
+    // Prompt for choice
+    CGUIDialogSelect *dialog = g_windowManager.GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+    if (!dialog)
+      return "";
+
+    dialog->SetHeading(CVariant{ 13521 });
+    dialog->Reset();
+    dialog->SetUseDetails(true);
+    dialog->EnableButton(true, 13516);
+
+    dialog->SetItems(artitems);
+    dialog->Open();
+
+    if (dialog->IsButtonPressed())
+    {
+      // Get the new art type name
+      std::string strArtTypeName;
+      if (!CGUIKeyboardFactory::ShowAndGetInput(strArtTypeName, CVariant{ g_localizeStrings.Get(13516) }, false))
+        return "";
+      // Add new type to the list of art types
+      CFileItemPtr artitem(new CFileItem(strArtTypeName, false));
+      artitem->SetLabel(strArtTypeName);
+      artitem->SetProperty("arttype", strArtTypeName);
+      artitems.Add(artitem);
+
+      return strArtTypeName;
+    }
+
+    return dialog->GetSelectedFileItem()->GetProperty("arttype").asString();
+  }
+
+  int ShowSelectRatingDialog(int iSelected)
+  {
+    CGUIDialogSelect *dialog = g_windowManager.GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
+    if (dialog)
+    {
+      dialog->SetHeading(CVariant{ 38023 });
+      dialog->Add(g_localizeStrings.Get(38022));
+      for (int i = 1; i <= 10; i++)
+        dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
+      dialog->SetSelected(iSelected);
+      dialog->Open();
+
+      int userrating = dialog->GetSelectedItem();
+      userrating = std::max(userrating, -1);
+      userrating = std::min(userrating, 10);
+      return userrating;
+    }
+    return -1;
+  }
+
+  void UpdateSongRatingJob(const CFileItemPtr pItem, int userrating)
+  {
+    // Asynchronously update the song user rating in music library
+    const CMusicInfoTag *tag = pItem->GetMusicInfoTag();
+    CSetSongRatingJob *job;
+    if (tag && tag->GetType() == MediaTypeSong && tag->GetDatabaseId() > 0)
+      // Use song ID when known
+      job = new CSetSongRatingJob(tag->GetDatabaseId(), userrating);
+    else 
+      job = new CSetSongRatingJob(pItem->GetPath(), userrating);
+    CJobManager::GetInstance().AddJob(job, NULL);
+  }
+}

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -1,0 +1,69 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileItem.h"
+
+namespace MUSIC_UTILS
+{
+  /*! \brief Show a dialog to allow the selection of type of art from a list.
+  Input is a fileitem list, with each item having an "arttype" property 
+  e.g. "thumb", current art URL (if art exists), and label. One of these art types
+  can be selected, or a new art type added. The new art type is added as a new item
+  in the list, as well as retuned as the selected art type.
+  \param artitems [in/out] a fileitem list to display
+  \return the selected art type e.g. "fanart" or empty string when cancelled.
+  \sa FillArtTypesList
+  */
+  std::string ShowSelectArtTypeDialog(CFileItemList& artitems);
+
+  /*! \brief Helper function to build a list of art types for a music library item.
+  This fetches the possible types of art for a song, album or artist, and the 
+  current art URL (if the item has art of that type), for display on a dialog.
+  \param musicitem a music CFileItem (song, album or artist)
+  \param artitems [out] a fileitem list,  each item having "arttype" property 
+  e.g. "thumb", current art URL (if art exists), and localized label (for common arttypes)
+  \return true if art types are retrieved, false if none is found.
+  \sa ShowSelectArtTypeDialog
+  */
+  bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist);
+
+  /*! \brief Helper function to asynchronously update art in the music database
+  For the song, album or artist this adds a job to the queue to update the art table
+  modifying, adding or deleting that type of art,
+  \param item a shared pointer to a music CFileItem (song, album or artist)
+  \param strType the type of art e.g. "fanart" or "thumb" etc.
+  \param strArt art URL, when empty the entry for that type of art is deleted. 
+  */
+  void UpdateArtJob(const CFileItemPtr pItem, const std::string& strType, const std::string& strArt);
+
+  /*! \brief Show a dialog to allow the selection of user rating.
+  \param iSelected the rating to show initially
+  \return the selected rating, 0 (no rating), 1 to 10 or -1 no rating selected
+  */
+  int ShowSelectRatingDialog(int iSelected);
+
+/*! \brief Helper function to asynchronously update the user rating of a song
+\param pItem pointer to song item being rated
+\param userrating the userrating 0 = no rating, 1 to 10
+*/
+  void UpdateSongRatingJob(const CFileItemPtr pItem, int userrating);
+}

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2018 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,19 +19,12 @@
  */
 
 #include "GUIDialogMusicOSD.h"
-#include "ServiceBroker.h"
+#include "addons/GUIWindowAddonBrowser.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "GUIUserMessages.h"
 #include "input/Key.h"
 #include "input/InputManager.h"
-#include "GUIUserMessages.h"
 #include "settings/Settings.h"
-#include "addons/GUIWindowAddonBrowser.h"
-#include "xbmc/dialogs/GUIDialogSelect.h"
-#include "xbmc/Application.h"
-#include "xbmc/FileItem.h"
-#include "xbmc/music/tags/MusicInfoTag.h"
-#include "xbmc/music/MusicDatabase.h"
 #include "ServiceBroker.h"
 
 #define CONTROL_VIS_BUTTON       500
@@ -81,45 +74,6 @@ bool CGUIDialogMusicOSD::OnAction(const CAction &action)
     case ACTION_SHOW_OSD:
       Close();
       return true;
-  
-    case ACTION_SET_RATING:
-    {
-      CGUIDialogSelect *dialog = g_windowManager.GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
-      if (dialog)
-      {
-        dialog->SetHeading(CVariant{ 38023 });
-        dialog->Add(g_localizeStrings.Get(38022));
-        for (int i = 1; i <= 10; i++)
-          dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
-
-        auto track = g_application.CurrentFileItemPtr();
-        dialog->SetSelected(track->GetMusicInfoTag()->GetUserrating());
-
-        dialog->Open();
-
-        int userrating = dialog->GetSelectedItem();
-
-        if (userrating < 0) userrating = 0;
-        if (userrating > 10) userrating = 10;
-        if (userrating != track->GetMusicInfoTag()->GetUserrating())
-        {
-          track->GetMusicInfoTag()->SetUserrating(userrating);
-          // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
-          CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, track);
-          g_windowManager.SendMessage(msg);
-
-          CMusicDatabase db;
-          if (db.Open())
-          {
-            db.SetSongUserrating(track->GetMusicInfoTag()->GetURL(), userrating);
-            db.Close();
-          }
-        }
-
-      }
-      return true;
-    }
-
     default:
       break;
   }

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2018 Team XBMC
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,8 +21,8 @@
  */
 
 #include "guilib/GUIDialog.h"
-
-class CFileItem;
+#include "FileItem.h"
+#include "threads/Event.h"
 
 class CGUIDialogSongInfo :
       public CGUIDialog
@@ -31,24 +31,31 @@ public:
   CGUIDialogSongInfo(void);
   ~CGUIDialogSongInfo(void) override;
   bool OnMessage(CGUIMessage& message) override;
-  void SetSong(CFileItem *item);
-  bool OnAction(const CAction &action) override;
+  bool SetSong(CFileItem* item);
+  void SetArtTypeList(CFileItemList& artlist);
+  bool OnAction(const CAction& action) override;
   bool OnBack(int actionID) override;
-  bool NeedsUpdate() const { return m_needsUpdate; };
+  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
 
   bool HasListItems() const override { return true; };
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
+  const CFileItemList& CurrentDirectory() const { return m_artTypeList; };
+  bool IsCancelled() const { return m_cancelled; };
+  void FetchComplete();
+
 protected:
   void OnInitWindow() override;
   void Update();
-  bool DownloadThumbnail(const std::string &thumbFile);
-  void OnGetThumb();
+  void OnGetArt();
   void SetUserrating(int userrating);
   void OnSetUserrating();
 
   CFileItemPtr m_song;
+  CFileItemList m_artTypeList;
+  CEvent m_event;
   int m_startUserrating;
   bool m_cancelled;
-  bool m_needsUpdate;
+  bool m_hasUpdatedUserrating;
   long m_albumId;
+
 };

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -174,7 +174,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
 
   // update the display
   case GUI_MSG_SCAN_FINISHED:
-  case GUI_MSG_REFRESH_THUMBS:
+  case GUI_MSG_REFRESH_THUMBS: // Never called as is secondary msg sent as GUI_MSG_NOTIFY_ALL
     Refresh();
     break;
 
@@ -529,10 +529,13 @@ void CGUIWindowMusicBase::ShowSongInfo(CFileItem* pItem)
     if (!pItem->HasMusicInfoTag())
       return;
 
-    dialog->SetSong(pItem);
-    dialog->Open();
-    if (dialog->NeedsUpdate())
-      Refresh(true); // update our file list
+    if (dialog->SetSong(pItem))  // Fetch full song info asynchronously
+    { 
+      dialog->Open();
+      if (dialog->HasUpdatedUserrating() && m_vecItems->GetSortMethod() == SortByUserRating)
+        // Refresh list to sort items and show new userrating sort label
+        Refresh();
+    }
   }
 }
 


### PR DESCRIPTION
Refactor Song Info dialog:
- Move  data read and write off the main thread to avoid possibility of locking UI. 
- Support selection of any type of art. 

---

1. Spearating data access from the main thread has been long wanted, see discussion #10951, and as promised then this delivers it. 
A busy dialog will be shown if for some reason fetching the data and art takes more than 500ms e.g. NAS drive is asleep or network issues, and so the user can cancel the action if they want.  On closing the dialog, updating user rating and art selection is also done in the background, not on the main thread.

2. Managing art for the song. Continuing the support of extended types music library artwork (see #13352 and #13101),  selecting  a thumbnail has been replaced with the facility to add other types of art, and change the art chosen for each type. Similar to video, the **Choose Art** button now brings up an art type selection dialog before letting the the user select the image to use for that type of art.

![Choose Art Type](https://i.imgur.com/KxigDQi.jpg)

I do not expect manual management of song art to be commonly used, extended art will be generally something provided by addons for the skins that show it, but such a feature is required for completeness. Similar art type selection will be added to the album and artist info dialogs in due course, hence the facility has been implemented with a new music utility that can be common to all.

The way `CMusicInfoLoader::LoadAdditionalTagInfo` fetches artist and album data as song item properties has also been improved.

For testing I used a modified version of this code that forced the data retrieveal to be slow. I'll get a test build up and encourage some additional user testing via the forum.

