### PR TITLE
DVDVideoCodecAmlogic: remove pts-based frame rate tracking

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
@@ -73,20 +73,11 @@ void CAMLVideoBufferPool::Return(int id)
 
 /***************************************************************************/
 
-typedef struct frame_queue {
-  double dts;
-  double pts;
-  double sort_time;
-  struct frame_queue *nextframe;
-} frame_queue;
-
 CDVDVideoCodecAmlogic::CDVDVideoCodecAmlogic(CProcessInfo &processInfo)
   : CDVDVideoCodec(processInfo)
   , m_pFormatName("amcodec")
   , m_opened(false)
   , m_codecControlFlags(0)
-  , m_frame_queue(NULL)
-  , m_queue_depth(0)
   , m_framerate(0.0)
   , m_video_rate(0)
   , m_mpeg2_sequence(NULL)
@@ -94,13 +85,11 @@ CDVDVideoCodecAmlogic::CDVDVideoCodecAmlogic(CProcessInfo &processInfo)
   , m_bitparser(NULL)
   , m_bitstream(NULL)
 {
-  pthread_mutex_init(&m_queue_mutex, NULL);
 }
 
 CDVDVideoCodecAmlogic::~CDVDVideoCodecAmlogic()
 {
   Dispose();
-  pthread_mutex_destroy(&m_queue_mutex);
 }
 
 CDVDVideoCodec* CDVDVideoCodecAmlogic::Create(CProcessInfo &processInfo)
@@ -332,9 +321,6 @@ void CDVDVideoCodecAmlogic::Dispose(void)
   if (m_bitparser)
     delete m_bitparser, m_bitparser = NULL;
 
-  while (m_queue_depth)
-    FrameQueuePop();
-
   m_opened = false;
 }
 
@@ -392,9 +378,6 @@ bool CDVDVideoCodecAmlogic::AddData(const DemuxPacket &packet)
 
 void CDVDVideoCodecAmlogic::Reset(void)
 {
-  while (m_queue_depth)
-    FrameQueuePop();
-
   m_Codec->Reset();
   m_mpeg2_sequence_pts = 0;
   m_has_keyframe = false;
@@ -460,68 +443,6 @@ void CDVDVideoCodecAmlogic::SetSpeed(int iSpeed)
     m_Codec->SetSpeed(iSpeed);
 }
 
-void CDVDVideoCodecAmlogic::FrameQueuePop(void)
-{
-  if (!m_frame_queue || m_queue_depth == 0)
-    return;
-
-  pthread_mutex_lock(&m_queue_mutex);
-  // pop the top frame off the queue
-  frame_queue *top = m_frame_queue;
-  m_frame_queue = top->nextframe;
-  m_queue_depth--;
-  pthread_mutex_unlock(&m_queue_mutex);
-
-  // and release it
-  free(top);
-}
-
-void CDVDVideoCodecAmlogic::FrameQueuePush(double dts, double pts)
-{
-  frame_queue *newframe = (frame_queue*)calloc(sizeof(frame_queue), 1);
-  newframe->dts = dts;
-  newframe->pts = pts;
-  // if both dts or pts are good we use those, else use decoder insert time for frame sort
-  if ((newframe->pts != DVD_NOPTS_VALUE) || (newframe->dts != DVD_NOPTS_VALUE))
-  {
-    // if pts is borked (stupid avi's), use dts for frame sort
-    if (newframe->pts == DVD_NOPTS_VALUE)
-      newframe->sort_time = newframe->dts;
-    else
-      newframe->sort_time = newframe->pts;
-  }
-
-  pthread_mutex_lock(&m_queue_mutex);
-  frame_queue *queueWalker = m_frame_queue;
-  if (!queueWalker || (newframe->sort_time < queueWalker->sort_time))
-  {
-    // we have an empty queue, or this frame earlier than the current queue head.
-    newframe->nextframe = queueWalker;
-    m_frame_queue = newframe;
-  }
-  else
-  {
-    // walk the queue and insert this frame where it belongs in display order.
-    bool ptrInserted = false;
-    frame_queue *nextframe = NULL;
-    //
-    while (!ptrInserted)
-    {
-      nextframe = queueWalker->nextframe;
-      if (!nextframe || (newframe->sort_time < nextframe->sort_time))
-      {
-        // if the next frame is the tail of the queue, or our new frame is earlier.
-        newframe->nextframe = nextframe;
-        queueWalker->nextframe = newframe;
-        ptrInserted = true;
-      }
-      queueWalker = nextframe;
-    }
-  }
-  m_queue_depth++;
-  pthread_mutex_unlock(&m_queue_mutex);
-}
-
 void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double dts, double pts)
 {
   // mpeg2 handling
@@ -548,23 +469,5 @@ void CDVDVideoCodecAmlogic::FrameRateTracking(uint8_t *pData, int iSize, double 
       m_processInfo.SetVideoDAR(m_hints.aspect);
     }
     return;
-  }
-
-  // everything else
-  FrameQueuePush(dts, pts);
-
-  // we might have out-of-order pts,
-  // so make sure we wait for at least 8 values in sorted queue.
-  if (m_queue_depth > 16)
-  {
-    pthread_mutex_lock(&m_queue_mutex);
-
-    float cur_pts = m_frame_queue->pts;
-    if (cur_pts == DVD_NOPTS_VALUE)
-      cur_pts = m_frame_queue->dts;
-
-    pthread_mutex_unlock(&m_queue_mutex);
-
-    FrameQueuePop();
   }
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -28,7 +28,6 @@
 #include <atomic>
 
 class CAMLCodec;
-struct frame_queue;
 struct mpeg2_sequence;
 class CBitstreamParser;
 class CBitstreamConverter;
@@ -88,8 +87,6 @@ public:
 
 protected:
   void            Dispose(void);
-  void            FrameQueuePop(void);
-  void            FrameQueuePush(double dts, double pts);
   void            FrameRateTracking(uint8_t *pData, int iSize, double dts, double pts);
   //void            RemoveInfo(CDVDAmlogicInfo* info);
 
@@ -100,9 +97,6 @@ protected:
   bool            m_opened;
   int             m_codecControlFlags;
   CDVDStreamInfo  m_hints;
-  frame_queue    *m_frame_queue;
-  int32_t         m_queue_depth;
-  pthread_mutex_t m_queue_mutex;
   double          m_framerate;
   int             m_video_rate;
   float           m_aspect_ratio;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAmlogic.h
@@ -100,7 +100,6 @@ protected:
   bool            m_opened;
   int             m_codecControlFlags;
   CDVDStreamInfo  m_hints;
-  double          m_last_pts;
   frame_queue    *m_frame_queue;
   int32_t         m_queue_depth;
   pthread_mutex_t m_queue_mutex;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Follow-up for https://github.com/xbmc/xbmc/pull/13078

Removes frame rate tracking based on pts reported by Amlogic decoder which is often incorrect and causes improper FR shown in GUI/used by VP.

The incorrect behaviour without the patch applied can be reproduced with first samples from Kodi Wiki: http://kodi.wiki/view/Samples#Codecs.2C_Framerates_and_Subtitles

As far as I can tell the `frame_queue` is used only for frame rate tracking - correct me if I'm wrong.

## How Has This Been Tested?
LibreELEC community builds with Kodi Krypton (AMLCodec backported from Leia) and Kodi master branch.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
