### PR TITLE
RetroPlayer: Improve logging

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAudio.cpp
@@ -36,10 +36,13 @@ CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo) :
   m_pAudioStream(nullptr),
   m_bAudioEnabled(true)
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Initializing audio");
 }
 
 CRetroPlayerAudio::~CRetroPlayerAudio()
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Deinitializing audio");
+
   CloseStream();
 }
 
@@ -74,12 +77,12 @@ bool CRetroPlayerAudio::OpenPCMStream(AEDataFormat format, unsigned int samplera
   if (m_pAudioStream != nullptr)
     CloseStream();
 
-  CLog::Log(LOGINFO, "RetroPlayerAudio: Creating audio stream, sample rate = %d", samplerate);
+  CLog::Log(LOGINFO, "RetroPlayer[AUDIO]: Creating audio stream, sample rate = %d", samplerate);
 
   // Resampling is not supported
   if (NormalizeSamplerate(samplerate) != samplerate)
   {
-    CLog::Log(LOGERROR, "RetroPlayerAudio: Resampling to %d not supported", NormalizeSamplerate(samplerate));
+    CLog::Log(LOGERROR, "RetroPlayer[AUDIO]: Resampling to %d not supported", NormalizeSamplerate(samplerate));
     return false;
   }
 
@@ -91,7 +94,7 @@ bool CRetroPlayerAudio::OpenPCMStream(AEDataFormat format, unsigned int samplera
 
   if (!m_pAudioStream)
   {
-    CLog::Log(LOGERROR, "RetroPlayerAudio: Failed to create audio stream");
+    CLog::Log(LOGERROR, "RetroPlayer[AUDIO]: Failed to create audio stream");
     return false;
   }
 
@@ -104,6 +107,8 @@ bool CRetroPlayerAudio::OpenPCMStream(AEDataFormat format, unsigned int samplera
 
 bool CRetroPlayerAudio::OpenEncodedStream(AVCodecID codec, unsigned int samplerate, const CAEChannelInfo& channelLayout)
 {
+  CLog::Log(LOGERROR, "RetroPlayer[AUDIO]: Encoded audio stream not supported");
+
   return true; //! @todo
 }
 
@@ -123,6 +128,8 @@ void CRetroPlayerAudio::CloseStream()
 {
   if (m_pAudioStream)
   {
+    CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Closing audio stream");
+
     CServiceBroker::GetActiveAE().FreeStream(m_pAudioStream);
     m_pAudioStream = nullptr;
   }

--- a/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerAutoSave.cpp
@@ -33,16 +33,22 @@ CRetroPlayerAutoSave::CRetroPlayerAutoSave(GAME::CGameClient &gameClient) :
   CThread("CRetroPlayerAutoSave"),
   m_gameClient(gameClient)
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Initializing autosave");
+
   Create(false);
 }
 
 CRetroPlayerAutoSave::~CRetroPlayerAutoSave()
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Deinitializing autosave");
+
   StopThread();
 }
 
 void CRetroPlayerAutoSave::Process()
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Autosave thread started");
+
   while (!m_bStop)
   {
     Sleep(AUTOSAVE_DURATION_SECS * 1000);
@@ -54,7 +60,9 @@ void CRetroPlayerAutoSave::Process()
     {
       std::string savePath = m_gameClient.GetPlayback()->CreateSavestate();
       if (!savePath.empty())
-        CLog::Log(LOGDEBUG, "Saved state to %s", CURL::GetRedacted(savePath).c_str());
+        CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Saved state to %s", CURL::GetRedacted(savePath).c_str());
     }
   }
+
+  CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Autosave thread ended");
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
@@ -21,6 +21,7 @@
 #include "RetroPlayerInput.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/EventPollHandle.h"
+#include "utils/log.h"
 
 using namespace KODI;
 using namespace RETRO;
@@ -28,11 +29,15 @@ using namespace RETRO;
 CRetroPlayerInput::CRetroPlayerInput(PERIPHERALS::CPeripherals &peripheralManager) :
   m_peripheralManager(peripheralManager)
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[INPUT]: Initializing input");
+
   m_inputPollHandle = m_peripheralManager.RegisterEventPoller();
 }
 
 CRetroPlayerInput::~CRetroPlayerInput()
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[INPUT]: Deinitializing input");
+
   m_inputPollHandle.reset();
 }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -20,6 +20,7 @@
 
 #include "RetroPlayerVideo.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/rendering/RenderTranslator.h"
 #include "cores/RetroPlayer/rendering/RPRenderManager.h"
 #include "utils/log.h"
 
@@ -30,18 +31,26 @@ CRetroPlayerVideo::CRetroPlayerVideo(CRPRenderManager& renderManager, CRPProcess
   m_renderManager(renderManager),
   m_processInfo(processInfo)
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[VIDEO]: Initializing video");
+
   m_renderManager.Initialize();
 }
 
 CRetroPlayerVideo::~CRetroPlayerVideo()
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[VIDEO]: Deinitializing video");
+
   CloseStream();
   m_renderManager.Deinitialize();
 }
 
 bool CRetroPlayerVideo::OpenPixelStream(AVPixelFormat pixfmt, unsigned int width, unsigned int height, unsigned int orientationDeg)
 {
-  CLog::Log(LOGINFO, "RetroPlayerVideo: Creating video stream with pixel format: %i, %dx%d", pixfmt, width, height);
+  CLog::Log(LOGDEBUG, "RetroPlayer[VIDEO]: Creating video stream - format %s, %ux%u, %u deg",
+      CRenderTranslator::TranslatePixelFormat(pixfmt),
+      width,
+      height,
+      orientationDeg);
 
   m_processInfo.SetVideoPixelFormat(pixfmt);
   m_processInfo.SetVideoDimensions(width, height);
@@ -51,6 +60,8 @@ bool CRetroPlayerVideo::OpenPixelStream(AVPixelFormat pixfmt, unsigned int width
 
 bool CRetroPlayerVideo::OpenEncodedStream(AVCodecID codec)
 {
+  CLog::Log(LOGERROR, "RetroPlayer[VIDEO]: Encoded video stream not supported");
+
   return false; //! @todo
 }
 
@@ -61,5 +72,7 @@ void CRetroPlayerVideo::AddData(const uint8_t* data, unsigned int size)
 
 void CRetroPlayerVideo::CloseStream()
 {
+  CLog::Log(LOGDEBUG, "RetroPlayer[VIDEO]: Closing video stream");
+
   m_renderManager.Flush();
 }

--- a/xbmc/cores/RetroPlayer/process/BaseRenderBufferPool.cpp
+++ b/xbmc/cores/RetroPlayer/process/BaseRenderBufferPool.cpp
@@ -22,6 +22,7 @@
 #include "IRenderBuffer.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h"
 #include "threads/SingleLock.h"
+#include "utils/log.h"
 
 using namespace KODI;
 using namespace RETRO;
@@ -99,6 +100,8 @@ IRenderBuffer *CBaseRenderBufferPool::GetBuffer(size_t size)
     }
     else
     {
+      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Creating render buffer for buffer pool");
+
       std::unique_ptr<IRenderBuffer> renderBufferPtr(CreateRenderBuffer(header));
       if (renderBufferPtr->Allocate(m_format, m_width, m_height, m_frameSize))
         renderBuffer = renderBufferPtr.release();

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -49,6 +49,7 @@ namespace RETRO
   public:
     virtual ~IRendererFactory() = default;
 
+    virtual std::string RenderSystemName() const = 0;
     virtual CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) = 0;
     virtual RenderBufferPoolVector CreateBufferPools() = 0;
   };
@@ -61,6 +62,9 @@ namespace RETRO
     static void RegisterRendererFactory(IRendererFactory *factory);
 
     virtual ~CRPProcessInfo();
+
+    const std::string &GetPlatformName() const { return m_platformName; }
+    std::string GetRenderSystemName(IRenderBufferPool *renderBufferPool) const;
 
     CRPBaseRenderer *CreateRenderer(IRenderBufferPool *renderBufferPool, const CRenderSettings &renderSettings);
 
@@ -88,19 +92,26 @@ namespace RETRO
     void SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max);
 
   protected:
-    CRPProcessInfo();
+    CRPProcessInfo(std::string platformName);
 
     static std::vector<ESCALINGMETHOD> GetScalingMethods();
 
+    // Static factories
     static CreateRPProcessControl m_processControl;
     static std::vector<std::unique_ptr<IRendererFactory>> m_rendererFactories;
     static CCriticalSection m_createSection;
 
+    // Construction parameters
+    const std::string m_platformName;
+
+    // Process info parameters
     CDataCacheCore *m_dataCache = nullptr;
 
+    // Rendering parameters
     std::unique_ptr<CRenderBufferManager> m_renderBufferManager;
 
   private:
+    // Rendering parameters
     std::unique_ptr<CRenderContext> m_renderContext;
     ESCALINGMETHOD m_defaultScalingMethod = VS_SCALINGMETHOD_AUTO;
   };

--- a/xbmc/cores/RetroPlayer/process/RenderBufferManager.cpp
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferManager.cpp
@@ -20,6 +20,7 @@
 
 #include "RenderBufferManager.h"
 #include "IRenderBufferPool.h"
+#include "RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "threads/SingleLock.h"
 
@@ -82,6 +83,22 @@ void CRenderBufferManager::FlushPools()
     for (const auto &pool : pools.pools)
       pool->Flush();
   }
+}
+
+std::string CRenderBufferManager::GetRenderSystemName(IRenderBufferPool *renderBufferPool) const
+{
+  CSingleLock lock(m_critSection);
+
+  for (const auto &pools : m_pools)
+  {
+    for (const auto &pool : pools.pools)
+    {
+      if (pool.get() == renderBufferPool)
+        return pools.factory->RenderSystemName();
+    }
+  }
+
+  return "";
 }
 
 bool CRenderBufferManager::HasScalingMethod(ESCALINGMETHOD scalingMethod) const

--- a/xbmc/cores/RetroPlayer/process/RenderBufferManager.h
+++ b/xbmc/cores/RetroPlayer/process/RenderBufferManager.h
@@ -44,6 +44,8 @@ namespace RETRO
     std::vector<IRenderBufferPool*> GetBufferPools();
     void FlushPools();
 
+    std::string GetRenderSystemName(IRenderBufferPool *renderBufferPool) const;
+
     bool HasScalingMethod(ESCALINGMETHOD scalingMethod) const;
 
   protected:

--- a/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.cpp
+++ b/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoX11::CRPProcessInfoX11() :
+  CRPProcessInfo("X11")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoX11::Create()
 {
   return new CRPProcessInfoX11();

--- a/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.h
+++ b/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoX11 : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoX11();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoAmlogic::CRPProcessInfoAmlogic() :
+  CRPProcessInfo("Amlogic")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoAmlogic::Create()
 {
   return new CRPProcessInfoAmlogic();

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoAmlogic : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoAmlogic();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.cpp
+++ b/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoAndroid::CRPProcessInfoAndroid() :
+  CRPProcessInfo("Android")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoAndroid::Create()
 {
   return new CRPProcessInfoAndroid();

--- a/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.h
+++ b/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoAndroid : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoAndroid();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoGbm::CRPProcessInfoGbm() :
+  CRPProcessInfo("GBM")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoGbm::Create()
 {
   return new CRPProcessInfoGbm();

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoGbm : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoGbm();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.cpp
+++ b/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoIOS::CRPProcessInfoIOS() :
+  CRPProcessInfo("iOS")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoIOS::Create()
 {
   return new CRPProcessInfoIOS();

--- a/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.h
+++ b/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.h
@@ -30,6 +30,8 @@ namespace RETRO
   class CRPProcessInfoIOS : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoIOS();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.cpp
+++ b/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoOSX::CRPProcessInfoOSX() :
+  CRPProcessInfo("macOS")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoOSX::Create()
 {
   return new CRPProcessInfoOSX();

--- a/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.h
+++ b/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoOSX : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoOSX();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.cpp
+++ b/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoPi::CRPProcessInfoPi() :
+  CRPProcessInfo("RPi")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoPi::Create()
 {
   return new CRPProcessInfoPi();

--- a/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.h
+++ b/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoPi : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoPi();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
@@ -23,6 +23,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoWayland::CRPProcessInfoWayland() :
+  CRPProcessInfo("Wayland")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoWayland::Create()
 {
   return new CRPProcessInfoWayland();

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
@@ -28,6 +28,8 @@ namespace RETRO
   class CRPProcessInfoWayland : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoWayland();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.cpp
+++ b/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.cpp
@@ -24,6 +24,11 @@
 using namespace KODI;
 using namespace RETRO;
 
+CRPProcessInfoWin::CRPProcessInfoWin() :
+  CRPProcessInfo("Windows")
+{
+}
+
 CRPProcessInfo* CRPProcessInfoWin::Create()
 {
   return new CRPProcessInfoWin();

--- a/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.h
+++ b/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.h
@@ -29,6 +29,8 @@ namespace RETRO
   class CRPProcessInfoWin : public CRPProcessInfo
   {
   public:
+    CRPProcessInfoWin();
+
     static CRPProcessInfo* Create();
     static void Register();
   };

--- a/xbmc/cores/RetroPlayer/rendering/RenderTranslator.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderTranslator.cpp
@@ -23,6 +23,23 @@
 using namespace KODI;
 using namespace RETRO;
 
+const char *CRenderTranslator::TranslatePixelFormat(AVPixelFormat format)
+{
+  switch (format)
+  {
+  case AV_PIX_FMT_0RGB32:
+    return "0RGB32";
+  case AV_PIX_FMT_RGB565:
+    return "RGB565";
+  case AV_PIX_FMT_RGB555:
+    return "RGB555";
+  default:
+    break;
+  }
+
+  return "unknown";
+}
+
 const char *CRenderTranslator::TranslateScalingMethod(ESCALINGMETHOD scalingMethod)
 {
   switch (scalingMethod)

--- a/xbmc/cores/RetroPlayer/rendering/RenderTranslator.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderTranslator.h
@@ -21,6 +21,8 @@
 
 #include "cores/IPlayer.h"
 
+#include "libavutil/pixfmt.h"
+
 namespace KODI
 {
 namespace RETRO
@@ -28,6 +30,11 @@ namespace RETRO
   class CRenderTranslator
   {
   public:
+    /*!
+     * \brief Translate a pixel format to a string suitable for logging
+     */
+    static const char *TranslatePixelFormat(AVPixelFormat format);
+
     /*!
      * \brief Translate a scaling method to a string suitable for logging
      */

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -23,6 +23,7 @@
 #include "cores/RetroPlayer/process/IRenderBufferPool.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "settings/Settings.h"
+#include "utils/log.h"
 #include "utils/MathUtils.h"
 #include "ServiceBroker.h"
 
@@ -76,7 +77,15 @@ bool CRPBaseRenderer::Configure(AVPixelFormat format, unsigned int width, unsign
   m_renderOrientation = orientation;
 
   if (!m_bufferPool->IsConfigured())
-    m_bufferPool->Configure(format, width, height);
+  {
+    CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Configuring buffer pool");
+
+    if (!m_bufferPool->Configure(format, width, height))
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Failed to configure buffer pool");
+      return false;
+    }
+  }
 
   ManageRenderArea();
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -34,7 +34,12 @@ using namespace RETRO;
 
 #define BUFFER_OFFSET(i) (static_cast<char*>(NULL) + (i))
 
-// --- CRendererFactoryGuiTexture ------------------------------------------------
+// --- CRendererFactoryGuiTexture ----------------------------------------------
+
+std::string CRendererFactoryGuiTexture::RenderSystemName() const
+{
+  return "GUITexture";
+}
 
 CRPBaseRenderer *CRendererFactoryGuiTexture::CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool)
 {

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.h
@@ -34,6 +34,7 @@ namespace RETRO
     virtual ~CRendererFactoryGuiTexture() = default;
 
     // implementation of IRendererFactory
+    std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
     RenderBufferPoolVector CreateBufferPools() override;
   };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -27,6 +27,11 @@ using namespace RETRO;
 
 // --- CRendererFactoryOpenGL --------------------------------------------------
 
+std::string CRendererFactoryOpenGL::RenderSystemName() const
+{
+  return "OpenGL";
+}
+
 CRPBaseRenderer *CRendererFactoryOpenGL::CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool)
 {
   return new CRPRendererOpenGL(settings, context, std::move(bufferPool));

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -36,6 +36,7 @@ namespace RETRO
     virtual ~CRendererFactoryOpenGL() = default;
 
     // implementation of IRendererFactory
+    std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
     RenderBufferPoolVector CreateBufferPools() override;
   };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -31,6 +31,11 @@ using namespace RETRO;
 
 // --- CRendererFactoryOpenGLES ------------------------------------------------
 
+std::string CRendererFactoryOpenGLES::RenderSystemName() const
+{
+  return "OpenGLES";
+}
+
 CRPBaseRenderer *CRendererFactoryOpenGLES::CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool)
 {
   return new CRPRendererOpenGLES(settings, context, std::move(bufferPool));

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -40,6 +40,7 @@ namespace RETRO
     virtual ~CRendererFactoryOpenGLES() = default;
 
     // implementation of IRendererFactory
+    std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
     RenderBufferPoolVector CreateBufferPools() override;
   };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -39,6 +39,11 @@ using namespace RETRO;
 
 // --- CWinRendererFactory -----------------------------------------------------
 
+std::string CWinRendererFactory::RenderSystemName() const
+{
+  return "DirectX";
+}
+
 CRPBaseRenderer *CWinRendererFactory::CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool)
 {
   return new CRPWinRenderer(settings, context, std::move(bufferPool));

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -44,6 +44,7 @@ namespace RETRO
     virtual ~CWinRendererFactory() = default;
 
     // implementation of IRendererFactory
+    std::string RenderSystemName() const override;
     CRPBaseRenderer *CreateRenderer(const CRenderSettings &settings, CRenderContext &context, std::shared_ptr<IRenderBufferPool> bufferPool) override;
     RenderBufferPoolVector CreateBufferPools() override;
   };


### PR DESCRIPTION
The renderer was written kinda hastily, and I've been told that logging important information is lacking. This PR augments logging and clarifies which subsystem the log line originates from.

## How Has This Been Tested?
RetroPlayer now produces the following log lines for normal gameplay (and from inspection, I've determined that most errors emit their error line):

```

// Kodi startup

 INFO: RetroPlayer[PROCESS]: Registering process control for X11
 INFO: RetroPlayer[RENDER]: Registering renderer factory for GUITexture

// Game load

 INFO: RetroPlayer[PROCESS]: Created process info for X11
DEBUG: RetroPlayer[PLAYER]: ---------------------------------------
DEBUG: RetroPlayer[PLAYER]: Game tag loaded
DEBUG: RetroPlayer[PLAYER]: URL:
DEBUG: RetroPlayer[PLAYER]: Title:
DEBUG: RetroPlayer[PLAYER]: Platform:
DEBUG: RetroPlayer[PLAYER]: Genres:
DEBUG: RetroPlayer[PLAYER]: Developer:
DEBUG: RetroPlayer[PLAYER]: Game Code:
DEBUG: RetroPlayer[PLAYER]: Region:
DEBUG: RetroPlayer[PLAYER]: Publisher:
DEBUG: RetroPlayer[PLAYER]: Format:
DEBUG: RetroPlayer[PLAYER]: Cartridge type:
DEBUG: RetroPlayer[PLAYER]: Game client: game.libretro.snes9x
DEBUG: RetroPlayer[PLAYER]: ---------------------------------------

// DLL load

DEBUG: RetroPlayer[AUDIO]: Initializing audio
DEBUG: RetroPlayer[VIDEO]: Initializing video
DEBUG: RetroPlayer[RENDER]: Initializing render manager
DEBUG: RetroPlayer[INPUT]: Initializing input
 INFO: RetroPlayer[PLAYER]: Opening: /home/garrett/Media/Software/ROMs (Unorganized)/Super Nintendo/Super Mario All-Stars (U) [!].smc

// Game load

DEBUG: RetroPlayer[PLAYER]: Using game client game.libretro.snes9x
DEBUG: RetroPlayer[SAVE]: Loading savestate /home/garrett/Media/Software/ROMs (Unorganized)/Super Nintendo/Super Mario All-Stars (U) [!].xml
DEBUG: RetroPlayer[SAVE]: Initializing autosave
DEBUG: Thread CRetroPlayerAutoSave start, auto delete: false
DEBUG: RetroPlayer[SAVE]: Autosave thread started
 INFO: RetroPlayer[AUDIO]: Creating audio stream, sample rate = 32000

// Create audio stream

DEBUG: RetroPlayer[VIDEO]: Creating video stream 256x224
 INFO: RetroPlayer[RENDER]: Configuring format RGB565, 256x224, 0 deg
 INFO: RetroPlayer[RENDER]: Renderer configured

// First frame

DEBUG: RetorPlayer[RENDER]: Configuring buffer pool
DEBUG: RetroPlayer[RENDER]: Creating render buffer for buffer pool
DEBUG: Previous line repeats 2 times.

// Gameplay, then close file

DEBUG: RetroPlayer[PLAYER]: Closing file
DEBUG: RetroPlayer[SAVE]: Deinitializing autosave
DEBUG: RetroPlayer[SAVE]: Autosave thread ended
DEBUG: RetroPlayer[SAVE]: Saved state to /home/garrett/Media/Software/ROMs (Unorganized)/Super Nintendo/Super Mario All-Stars (U) [!].sav

// Unload DLL

DEBUG: RetroPlayer[AUDIO]: Deinitializing audio
DEBUG: RetroPlayer[AUDIO]: Closing stream

// Close audio stream

DEBUG: RetroPlayer[VIDEO]: Deinitializing video
DEBUG: RetroPlayer[VIDEO]: Closing stream
DEBUG: RetroPlayer[RENDER]: Deinitializing render manager
DEBUG: RetroPlayer[PLAYER]: Closing file
DEBUG: RetroPlayer[INPUT]: Deinitializing input
```

It kinda highlights that some things aren't strictly ordered. I may reorder some stuff before merging.

@lrusak would you like to see any additional information?

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
