### PR TITLE
amlcodec: reduce video decoder pre-buffering time, pre-buffer more only when decoder is busy

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.cpp
@@ -2154,7 +2154,7 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
     return CDVDVideoCodec::VC_ERROR;
 
   float timesize(GetTimeSize());
-  if(!m_drain && timesize < 1.0)
+  if(!m_drain && timesize < 0.2)
     return CDVDVideoCodec::VC_BUFFER;
 
   if (DequeueBuffer() == 0)
@@ -2185,7 +2185,11 @@ CDVDVideoCodec::VCReturn CAMLCodec::GetPicture(VideoPicture *pVideoPicture)
   else if (m_drain)
     return CDVDVideoCodec::VC_EOF;
   else
+  {
+    if (timesize < 1.0)
+      return CDVDVideoCodec::VC_BUFFER;
     usleep(5000);
+  }
 
   return CDVDVideoCodec::VC_NONE;
 }


### PR DESCRIPTION
Reduce Amlogic HW video decoder pre-buffering time, pre-buffer more only when decoder is busy.
This lets have more stable playback with less frame skips.

## Description
HW decoded playback on AML-based devices is not always smooth because of high latency of AML decoder. It requires to keep decoder buffer filled with undecoded packets and at the same time deliver decoded frames to the video player in time

This change lets keep better balance between filling the decoder buffer and delivering decoded frames for rendering by reducing pre-buffering time and filling the buffer further only when HW decoder is busy. From my test after the change video playback is more stable with less frame skips, especially for Live TV.

## Motivation and Context
Playback of some video types is not always smooth on AML.

## How Has This Been Tested?
Tested with different video types from different sources on WeTek Play (Linux 3.10) and WeTek Play 2 (Linux 3.14).

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
