### PR TITLE
Use override, fix interceptor class

### DIFF
--- a/xbmc/interfaces/legacy/WindowInterceptor.h
+++ b/xbmc/interfaces/legacy/WindowInterceptor.h
@@ -119,9 +119,6 @@ namespace XBMCAddon
     protected:
       CGUIWindow* get() override { return this; }
 
-      // this is only called from XBMC core and we only want it to return true every time
-      virtual bool Update(const String &strPath) { return true; }
-
     public:
       Interceptor(const char* specializedName,
                   Window* _window, int windowid) : P(windowid, ""),

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -83,7 +83,7 @@ namespace XBMCAddon
       // CGUIMediaWindow
       void GetContextButtons(int itemNumber, CContextButtons &buttons) override
       { XBMC_TRACE; if (up()) CGUIMediaWindow::GetContextButtons(itemNumber,buttons); else xwin->GetContextButtons(itemNumber,buttons); }
-      bool Update(const std::string &strPath) override
+      bool Update(const std::string &strPath, bool) override
       { XBMC_TRACE; return up() ? CGUIMediaWindow::Update(strPath) : xwin->Update(strPath); }
       void SetupShares() override { XBMC_TRACE; if(up()) CGUIMediaWindow::SetupShares(); else checkedv(SetupShares()); }
 

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -60,8 +60,8 @@ public:
   bool Restore() override;
   bool Hide() override;
   bool Show(bool raise = true) override;
-  virtual void Register(IDispResource *resource);
-  virtual void Unregister(IDispResource *resource);
+  void Register(IDispResource *resource) override;
+  void Unregister(IDispResource *resource) override;
   bool HasCalibration(const RESOLUTION_INFO &resInfo) override;
 
   // Local to WinSystemX11 only


### PR DESCRIPTION
- Trivial override usage
- A fix in the interceptor class. Started out as a warning quell, but I cannot quell them all due to the construct in use. @jimfcarroll please look at the last commit.