### PR TITLE
[cmake] pass compiler to & use ccache for FFmpeg

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -252,6 +252,7 @@ if(NOT FFMPEG_FOUND)
                                  -DENABLE_NEON=${ENABLE_NEON}
                                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                                 -DENABLE_CCACHE=${ENABLE_CCACHE}
                                  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                                  -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                                  -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -235,8 +235,6 @@ if(NOT FFMPEG_FOUND)
                    -DCROSSCOMPILING=${CMAKE_CROSSCOMPILING}
                    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                    -DOS=${OS}
-                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                    -DCMAKE_AR=${CMAKE_AR})
   endif()
 
@@ -252,6 +250,8 @@ if(NOT FFMPEG_FOUND)
                                  -DCORE_PLATFORM_NAME=${CORE_PLATFORM_NAME_LC}
                                  -DCPU=${CPU}
                                  -DENABLE_NEON=${ENABLE_NEON}
+                                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                                  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                                  -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                                  -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -4,7 +4,22 @@ cmake_minimum_required(VERSION 2.8)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
-set(ffmpeg_conf --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER})
+# ENABLE_CCACHE can have the following values ON|OFF|AUTO
+# During initial kodi project generation the forwarded ENABLE_CCACHE is empty, if ENABLE_CCACHE wasn't explicitly set.
+# This happens as FindFFmpeg is called before core_optional_dep(CCache) which sets ENABLE_CCACHE to AUTO in that case.
+# Therefore treat empty ENABLE_CCACHE like ON and AUTO.
+if(ENABLE_CCACHE STREQUAL "" OR ENABLE_CCACHE)
+  find_program(CCACHE_PROGRAM ccache)
+  if(CCACHE_PROGRAM)
+    set(USE_CCACHE ON)
+  endif()
+endif()
+
+if(USE_CCACHE)
+  set(ffmpeg_conf "--cc=${CCACHE_PROGRAM} ${CMAKE_C_COMPILER}" "--cxx=${CCACHE_PROGRAM} ${CMAKE_CXX_COMPILER}")
+else()
+  set(ffmpeg_conf --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER})
+endif()
 
 if(CROSSCOMPILING)
   set(pkgconf "PKG_CONFIG_LIBDIR=${DEPENDS_PATH}/lib/pkgconfig")


### PR DESCRIPTION
## Motivation and Context
use ccache on FreeBSD jenkins builder for FFmpeg

## How Has This Been Tested?
tested on linux without setting `ENABLE_CCACHE` and with setting `ENABLE_CCACHE` to ON & OFF
also tested with setting clang as compiler

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed