### PR TITLE
amlcodec: cleanup and simplify 3D handling code

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AMLCodec.h
@@ -71,8 +71,6 @@ private:
   void          SetVideoContrast(const int contrast);
   void          SetVideoBrightness(const int brightness);
   void          SetVideoSaturation(const int saturation);
-  bool          SetVideo3dMode(const int mode3d);
-  std::string   GetStereoMode();
   bool          OpenAmlVideo(const CDVDStreamInfo &hints);
   void          CloseAmlVideo();
   std::string   GetVfmMap(const std::string &name);
@@ -96,8 +94,8 @@ private:
   CRect            m_display_rect;
 
   int              m_view_mode = -1;
-  RENDER_STEREO_MODE m_stereo_mode = RENDER_STEREO_MODE_OFF;
-  RENDER_STEREO_VIEW m_stereo_view = RENDER_STEREO_VIEW_OFF;
+  RENDER_STEREO_MODE m_guiStereoMode = RENDER_STEREO_MODE_OFF;
+  RENDER_STEREO_VIEW m_guiStereoView = RENDER_STEREO_VIEW_OFF;
   float            m_zoom = -1.0f;
   int              m_contrast = -1;
   int              m_brightness = -1;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -667,15 +667,7 @@ GLint CRenderSystemGLES::GUIShaderGetBrightness()
 
 bool CRenderSystemGLES::SupportsStereo(RENDER_STEREO_MODE mode) const
 {
-  switch(mode)
-  {
-    case RENDER_STEREO_MODE_INTERLACED:
-      if (g_sysinfo.HasHW3DInterlaced())
-        return true;
-
-    default:
-      return CRenderSystemBase::SupportsStereo(mode);
-  }
+  return CRenderSystemBase::SupportsStereo(mode);
 }
 
 GLint CRenderSystemGLES::GUIShaderGetModel()

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -54,22 +54,6 @@ bool aml_present()
   return has_aml == 1;
 }
 
-bool aml_hw3d_present()
-{
-  static int has_hw3d = -1;
-  if (has_hw3d == -1)
-  {
-    if (SysfsUtils::Has("/sys/class/ppmgr/ppmgr_3d_mode") ||
-        SysfsUtils::Has("/sys/class/amhdmitx/amhdmitx0/config"))
-      has_hw3d = 1;
-    else
-      has_hw3d = 0;
-    if (has_hw3d)
-      CLog::Log(LOGNOTICE, "AML 3D support detected");
-  }
-  return has_hw3d == 1;
-}
-
 bool aml_wired_present()
 {
   static int has_wired = -1;
@@ -137,10 +121,6 @@ bool aml_permissions()
     if (!SysfsUtils::HasRW("/sys/class/audiodsp/digital_raw"))
     {
       CLog::Log(LOGERROR, "AML: no rw on /sys/class/audiodsp/digital_raw");
-    }
-    if (!SysfsUtils::HasRW("/sys/class/ppmgr/ppmgr_3d_mode"))
-    {
-      CLog::Log(LOGERROR, "AML: no rw on /sys/class/ppmgr/ppmgr_3d_mode");
     }
     if (!SysfsUtils::HasRW("/sys/class/amhdmitx/amhdmitx0/config"))
     {

--- a/xbmc/utils/AMLUtils.h
+++ b/xbmc/utils/AMLUtils.h
@@ -54,7 +54,6 @@ enum AML_SUPPORT_H264_4K2K
 
 bool aml_present();
 bool aml_permissions();
-bool aml_hw3d_present();
 bool aml_wired_present();
 bool aml_support_hevc();
 bool aml_support_hevc_4k2k();

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -828,17 +828,6 @@ bool CSysInfo::IsAeroDisabled()
   return false;
 }
 
-bool CSysInfo::HasHW3DInterlaced()
-{
-#if defined(TARGET_ANDROID)
-#if defined(HAS_LIBAMCODEC)
-  if (aml_hw3d_present())
-    return true;
-#endif
-#endif
-  return false;
-}
-
 CSysInfo::WindowsVersion CSysInfo::m_WinVer = WindowsVersionUnknown;
 
 bool CSysInfo::IsWindowsVersion(WindowsVersion ver)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -126,7 +126,6 @@ public:
   bool HasInternet();
   bool HasVideoToolBoxDecoder();
   bool IsAeroDisabled();
-  bool HasHW3DInterlaced();
   static bool IsWindowsVersion(WindowsVersion ver);
   static bool IsWindowsVersionAtLeast(WindowsVersion ver);
   static WindowsVersion GetWindowsVersion();


### PR DESCRIPTION
Cleanup and simplify AMLCodec 3D handling code.

## Description
AMLCodec historically uses AML kernel 3D post process manager for 3D to 2D conversion. In AML kernel 3.10 that worked more or less, but in kernel 3.14 it doesn't work at all and when you select 2D mode for a 3D video it just freezes. Because of that in LibreELEC AML 3D post process manager is disabled. When it is disabled Kodi just emulates 3D to 2D conversion by setting proper destination rectangle for video, displaying only top view for top/bottom (TAB) videos or only left view for left/right (SBS) videos. Because 3D to 2D coversion using AML 3D post process manager is not stable and causes problems I have removed that code from AMLCodec, but 3D to 2D conversion still continues to function properly.

Also I have removed the AMSTREAM_IOC_GET_3D_TYPE IOCTL call because it doesn't have any sense when AML 3D post process manager is disabled, and always returns 0. Moreover AMSTREAM_IOC_GET_3D_TYPE IOCTL was introduced only with kernel 3.14, so Kodi doesn't compile for older AML devices that use kernel 3.10, such as WeTek Core.

## Motivation and Context
* Cleanup and simplify code
* Kodi doesn't compile for AML devices that use Linux kernel 3.10.

## How Has This Been Tested?
Tested by playing TAB and SBS videos in 3D and 2D modes on a WeTek Hub (S905) connected to 3D TV.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
