### PR TITLE
Python: Normalize Python exception before processing

### DIFF
--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -176,6 +176,14 @@ namespace PythonBindings
     if (exc_type == NULL && exc_value == NULL && exc_traceback == NULL)
       return false;
 
+    // See https://docs.python.org/3/c-api/exceptions.html#c.PyErr_NormalizeException
+    PyErr_NormalizeException(&exc_type, &exc_value, &exc_traceback);
+#if PY_MAJOR_VERSION > 2
+    if (exc_traceback != NULL) {
+      PyException_SetTraceback(exc_value, exc_traceback);
+    }
+#endif
+
     exceptionType.clear();
     exceptionValue.clear();
     exceptionTraceback.clear();


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This PR adds normalization of Python exceptions before extracting info for logging to the Kodi log.

## Motivation and Context
Normalization of exceptions is required both in Python 2 and 3 according to the docs: https://docs.python.org/3/c-api/exceptions.html#c.PyErr_NormalizeException, but in Python 2 processing unnormalized exceptions did not cause any issues, except maybe in some rare cases. But in Python 3 normalization is absolutely necessary for proper Python exception logging. For more info see this forum discussion: https://forum.kodi.tv/showthread.php?tid=328084

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
