### PR TITLE
FIX: [vp] send OnPlaybackStarted when we have more info

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -707,7 +707,6 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
   }
 
   m_item = file;
-  m_callback.OnPlayBackStarted(m_item);
 
   m_playerOptions = options;
   // Try to resolve the correct mime type
@@ -1359,6 +1358,10 @@ void CVideoPlayer::Prepare()
   UpdatePlayState(0);
 
   SetCaching(CACHESTATE_FLUSH);
+
+  m_outboundEvents->Submit([this]() {
+    m_callback.OnPlayBackStarted(m_item);
+  });
 }
 
 void CVideoPlayer::Process()
@@ -2531,10 +2534,6 @@ void CVideoPlayer::HandleMessages()
 
       m_item = msg.GetItem();
       m_playerOptions = msg.GetOptions();
-
-      m_outboundEvents->Submit([this]() {
-        m_callback.OnPlayBackStarted(m_item);
-      });
 
       FlushBuffers(DVD_NOPTS_VALUE, true, true);
       m_renderManager.Flush(false);


### PR DESCRIPTION
Sends the "OnPlaybackStarted" at the end of "Prepare()" so that we have minimal information about what is being played.

Fixes regressions on plugins expecting "isPlayingVideo()" in "onPlayBackStarted" to be valid, eg probably fixes https://trac.kodi.tv/ticket/17632