### PR TITLE
Roll back PR #13454

### DIFF
--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -27,19 +27,19 @@
 #include "URL.h"
 #include <map>
 
-static thread_local CFFmpegLog* CFFmpegLogTls;
+static XbmcThreads::ThreadLocal<CFFmpegLog> CFFmpegLogTls;
 
 void CFFmpegLog::SetLogLevel(int level)
 {
   CFFmpegLog::ClearLogLevel();
   CFFmpegLog *log = new CFFmpegLog();
   log->level = level;
-  CFFmpegLogTls = log;
+  CFFmpegLogTls.set(log);
 }
 
 int CFFmpegLog::GetLogLevel()
 {
-  CFFmpegLog* log = CFFmpegLogTls;
+  CFFmpegLog* log = CFFmpegLogTls.get();
   if (!log)
     return -1;
   return log->level;
@@ -47,8 +47,8 @@ int CFFmpegLog::GetLogLevel()
 
 void CFFmpegLog::ClearLogLevel()
 {
-  CFFmpegLog* log = CFFmpegLogTls;
-  CFFmpegLogTls = nullptr;
+  CFFmpegLog* log = CFFmpegLogTls.get();
+  CFFmpegLogTls.set(nullptr);
   if (log)
     delete log;
 }

--- a/xbmc/interfaces/legacy/AddonUtils.cpp
+++ b/xbmc/interfaces/legacy/AddonUtils.cpp
@@ -25,6 +25,7 @@
 #include "LanguageHook.h"
 #ifdef ENABLE_XBMC_TRACE_API
 #include "utils/log.h"
+#include "threads/ThreadLocal.h"
 #endif
 
 namespace XBMCAddonUtils
@@ -81,7 +82,7 @@ namespace XBMCAddonUtils
   }
 
 #ifdef ENABLE_XBMC_TRACE_API
-  static thread_local TraceGuard* tlParent;
+  static XbmcThreads::ThreadLocal<TraceGuard> tlParent;
 
   static char** getSpacesArray(int size)
   {
@@ -104,19 +105,19 @@ namespace XBMCAddonUtils
 
   TraceGuard::TraceGuard(const char* _function) :function(_function) 
   {
-    parent = tlParent;
+    parent = tlParent.get();
     depth = parent == NULL ? 0 : parent->depth + 1;
 
-    tlParent = this;
+    tlParent.set(this);
 
     CLog::Log(LOGDEBUG, "%sNEWADDON Entering %s", spaces[depth], function); 
   }
 
   TraceGuard::TraceGuard() :function(NULL) 
   {
-    parent = tlParent;
+    parent = tlParent.get();
     depth = parent == NULL ? 0 : parent->depth + 1;
-    tlParent = this;
+    tlParent.set(this);
     // silent
   }
 
@@ -126,7 +127,7 @@ namespace XBMCAddonUtils
       CLog::Log(LOGDEBUG, "%sNEWADDON Leaving %s", spaces[depth], function);
 
     // need to pop the stack
-    tlParent = this->parent;
+    tlParent.set(this->parent);
   }
 #endif
 

--- a/xbmc/interfaces/legacy/LanguageHook.cpp
+++ b/xbmc/interfaces/legacy/LanguageHook.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "LanguageHook.h"
+#include "threads/ThreadLocal.h"
 #include "utils/GlobalsHandling.h"
 
 namespace XBMCAddon
@@ -26,7 +27,7 @@ namespace XBMCAddon
   // just need a place for the vtab
   LanguageHook::~LanguageHook() = default;
 
-  static thread_local LanguageHook* addonLanguageHookTls;
+  static XbmcThreads::ThreadLocal<LanguageHook> addonLanguageHookTls;
   static bool threadLocalInitialized = false;
   static xbmcutil::InitFlag initer(threadLocalInitialized);
 
@@ -34,18 +35,18 @@ namespace XBMCAddon
   {
     XBMC_TRACE;
     languageHook->Acquire();
-    addonLanguageHookTls = languageHook;
+    addonLanguageHookTls.set(languageHook);
   }
 
   LanguageHook* LanguageHook::GetLanguageHook()
   {
-    return threadLocalInitialized ? addonLanguageHookTls : NULL;
+    return threadLocalInitialized ? addonLanguageHookTls.get() : NULL;
   }
 
   void LanguageHook::ClearLanguageHook()
   {
-    LanguageHook* lh = addonLanguageHookTls;
-    addonLanguageHookTls = NULL;
+    LanguageHook* lh = addonLanguageHookTls.get();
+    addonLanguageHookTls.set(NULL);
     if (lh)
       lh->Release();
   }

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -38,7 +38,7 @@ namespace XBMCAddon
 {
   namespace xbmcgui
   {
-    thread_local ref* InterceptorBase::upcallTls;
+    XbmcThreads::ThreadLocal<ref> InterceptorBase::upcallTls;
 
     /**
      * Used in add/remove control. It only locks if it's given a 

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -37,7 +37,6 @@
 
 #include "platform/MessagePrinter.h"
 #include "utils/log.h"
-#include "commons/Exception.h"
 
 extern "C" int XBMC_Run(bool renderGUI, const CAppParamParser &params)
 {

--- a/xbmc/storage/win10/Win10StorageProvider.cpp
+++ b/xbmc/storage/win10/Win10StorageProvider.cpp
@@ -26,7 +26,6 @@
 #include "storage/MediaManager.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
-#include "utils/StringUtils.h"
 
 using namespace Windows::Foundation;
 using namespace Windows::Devices::Enumeration;

--- a/xbmc/storage/windows/Win32StorageProvider.cpp
+++ b/xbmc/storage/windows/Win32StorageProvider.cpp
@@ -24,7 +24,6 @@
 #include "storage/MediaManager.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
-#include "utils/StringUtils.h"
 
 #include <SetupAPI.h>
 #include <ShlObj.h>

--- a/xbmc/threads/CMakeLists.txt
+++ b/xbmc/threads/CMakeLists.txt
@@ -15,7 +15,15 @@ set(HEADERS Atomics.h
             SystemClock.h
             Thread.h
             ThreadImpl.h
+            ThreadLocal.h
             Timer.h
-            platform/ThreadImpl.h)
+            platform/Condition.h
+            platform/CriticalSection.h
+            platform/ThreadImpl.h
+            platform/ThreadLocal.h)
+
+if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)
+  list(APPEND SOURCES platform/pthreads/Implementation.cpp)
+endif()
 
 core_add_library(threads)

--- a/xbmc/threads/Condition.h
+++ b/xbmc/threads/Condition.h
@@ -20,61 +20,13 @@
 
 #pragma once
 
-#include "threads/SingleLock.h"
-#include "threads/Helpers.h"
-#include "threads/SystemClock.h"
+#include "threads/platform/Condition.h"
 
-#include <condition_variable>
-#include <chrono>
+#include "threads/SystemClock.h"
+#include <stdio.h>
 
 namespace XbmcThreads
 {
-
-  /**
-   * This is a thin wrapper around std::condition_variable_any. It is subject
-   *  to "spurious returns" as it is built on boost which is built on posix
-   *  on many of our platforms.
-   */
-  class ConditionVariable
-  {
-  private:
-    std::condition_variable_any cond;
-    ConditionVariable(const ConditionVariable&) = delete;
-    ConditionVariable& operator=(const ConditionVariable&) = delete;
-
-  public:
-    ConditionVariable() = default;
-
-    inline void wait(CCriticalSection& lock) 
-    {
-      int count  = lock.count;
-      lock.count = 0;
-      cond.wait(lock.get_underlying());
-      lock.count = count;
-    }
-
-    inline bool wait(CCriticalSection& lock, unsigned long milliseconds) 
-    { 
-      int count  = lock.count;
-      lock.count = 0;
-      std::cv_status res = cond.wait_for(lock.get_underlying(), std::chrono::milliseconds(milliseconds));
-      lock.count = count;
-      return res == std::cv_status::no_timeout;
-    }
-
-    inline void wait(CSingleLock& lock) { wait(lock.get_underlying()); }
-    inline bool wait(CSingleLock& lock, unsigned long milliseconds) { return wait(lock.get_underlying(), milliseconds); }
-
-    inline void notifyAll() 
-    { 
-      cond.notify_all();
-    }
-
-    inline void notify() 
-    { 
-      cond.notify_one();
-    }
-  };
 
   /**
    * This is a condition variable along with its predicate. This allows the use of a 

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -22,6 +22,7 @@
 
 #include "threads/SystemClock.h"
 #include "Thread.h"
+#include "threads/ThreadLocal.h"
 #include "threads/SingleLock.h"
 #include "commons/Exception.h"
 #include <stdlib.h>
@@ -30,7 +31,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-static thread_local CThread* currentThread;
+static XbmcThreads::ThreadLocal<CThread> currentThread;
 
 #include "threads/platform/ThreadImpl.cpp"
 
@@ -121,7 +122,7 @@ THREADFUNC CThread::staticThread(void* data)
 
   CLog::Log(LOGDEBUG,"Thread %s start, auto delete: %s", name.c_str(), (autodelete ? "true" : "false"));
 
-  currentThread = pThread;
+  currentThread.set(pThread);
   pThread->m_StartEvent.Set();
 
   pThread->Action();
@@ -182,7 +183,7 @@ bool CThread::IsCurrentThread() const
 
 CThread* CThread::GetCurrentThread()
 {
-  return currentThread;
+  return currentThread.get();
 }
 
 void CThread::Sleep(unsigned int milliseconds)

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include "Event.h"
 #include "threads/ThreadImpl.h"
+#include "threads/ThreadLocal.h"
 
 #ifdef TARGET_DARWIN
 #include <mach/mach.h>

--- a/xbmc/threads/ThreadLocal.h
+++ b/xbmc/threads/ThreadLocal.h
@@ -20,4 +20,5 @@
 
 #pragma once
 
-#include "threads/platform/CriticalSection.h"
+#include "threads/platform/ThreadLocal.h"
+

--- a/xbmc/threads/platform/Condition.h
+++ b/xbmc/threads/platform/Condition.h
@@ -20,4 +20,9 @@
 
 #pragma once
 
-#include "threads/platform/CriticalSection.h"
+#if (defined TARGET_POSIX)
+#include "threads/platform/pthreads/Condition.h"
+#elif (defined TARGET_WINDOWS)
+#include "threads/platform/win/Condition.h"
+#endif
+

--- a/xbmc/threads/platform/CriticalSection.h
+++ b/xbmc/threads/platform/CriticalSection.h
@@ -20,4 +20,8 @@
 
 #pragma once
 
-#include "threads/platform/CriticalSection.h"
+#if (defined TARGET_POSIX)
+#include "threads/platform/pthreads/CriticalSection.h"
+#elif (defined TARGET_WINDOWS)
+#include "threads/platform/win/CriticalSection.h"
+#endif

--- a/xbmc/threads/platform/ThreadLocal.h
+++ b/xbmc/threads/platform/ThreadLocal.h
@@ -20,4 +20,8 @@
 
 #pragma once
 
-#include "threads/platform/CriticalSection.h"
+#if (defined TARGET_POSIX)
+#include "threads/platform/pthreads/ThreadLocal.h"
+#elif (defined TARGET_WINDOWS)
+#include "threads/platform/win/ThreadLocal.h"
+#endif

--- a/xbmc/threads/platform/pthreads/Condition.h
+++ b/xbmc/threads/platform/pthreads/Condition.h
@@ -1,0 +1,106 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "threads/SingleLock.h"
+#include "threads/Helpers.h"
+
+#include <pthread.h>
+
+#ifdef TARGET_DARWIN
+  #include <sys/time.h> //for gettimeofday
+#else
+  #include <time.h> //for clock_gettime
+#endif
+
+namespace XbmcThreads
+{
+
+  /**
+   * This is a thin wrapper around boost::condition_variable. It is subject
+   *  to "spurious returns" as it is built on boost which is built on posix
+   *  on many of our platforms.
+   */
+  class ConditionVariable
+  {
+  private:
+    pthread_cond_t cond;
+
+    ConditionVariable(const ConditionVariable&) = delete;
+    ConditionVariable& operator=(const ConditionVariable&) = delete;
+  public:
+    
+    inline ConditionVariable() 
+    { 
+      pthread_cond_init(&cond,NULL); 
+    }
+
+    inline ~ConditionVariable() 
+    { 
+      pthread_cond_destroy(&cond);
+    }
+
+    inline void wait(CCriticalSection& lock) 
+    {
+      int count  = lock.count;
+      lock.count = 0;
+      pthread_cond_wait(&cond,&lock.get_underlying().mutex);
+      lock.count = count;
+    }
+
+    inline bool wait(CCriticalSection& lock, unsigned long milliseconds) 
+    { 
+      struct timespec ts;
+
+#ifdef TARGET_DARWIN
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+      ts.tv_nsec = tv.tv_usec * 1000;
+      ts.tv_sec  = tv.tv_sec;
+#else
+      clock_gettime(CLOCK_REALTIME, &ts);
+#endif
+
+      ts.tv_nsec += milliseconds % 1000 * 1000000;
+      ts.tv_sec  += milliseconds / 1000 + ts.tv_nsec / 1000000000;
+      ts.tv_nsec %= 1000000000;
+      int count  = lock.count;
+      lock.count = 0;
+      int res    = pthread_cond_timedwait(&cond,&lock.get_underlying().mutex,&ts);
+      lock.count = count;
+      return res == 0;
+    }
+
+    inline void wait(CSingleLock& lock) { wait(lock.get_underlying()); }
+    inline bool wait(CSingleLock& lock, unsigned long milliseconds) { return wait(lock.get_underlying(), milliseconds); }
+
+    inline void notifyAll() 
+    { 
+      pthread_cond_broadcast(&cond);
+    }
+
+    inline void notify() 
+    { 
+      pthread_cond_signal(&cond);
+    }
+  };
+
+}

--- a/xbmc/threads/platform/pthreads/CriticalSection.h
+++ b/xbmc/threads/platform/pthreads/CriticalSection.h
@@ -1,0 +1,67 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <pthread.h>
+#include <errno.h>
+
+#include "threads/Lockables.h"
+#include "threads/Helpers.h"
+
+namespace XbmcThreads
+{
+
+  // forward declare in preparation for the friend declaration
+  class ConditionVariable;
+
+  namespace pthreads
+  {
+    class RecursiveMutex
+    {
+      pthread_mutexattr_t* getRecursiveAttr();
+      pthread_mutex_t mutex;
+
+      // needs access to 'mutex'
+      friend class XbmcThreads::ConditionVariable;
+    public:
+      inline RecursiveMutex() { pthread_mutex_init(&mutex,getRecursiveAttr()); }
+      
+      inline ~RecursiveMutex() { pthread_mutex_destroy(&mutex); }
+
+      inline void lock() { pthread_mutex_lock(&mutex); }
+
+      inline void unlock() { pthread_mutex_unlock(&mutex); }
+        
+      inline bool try_lock() { return (pthread_mutex_trylock(&mutex) == 0); }
+    };
+  }
+}
+
+
+/**
+ * A CCriticalSection is a CountingLockable whose implementation is a 
+ *  native recursive mutex.
+ *
+ * This is not a typedef because of a number of "class CCriticalSection;" 
+ *  forward declarations in the code that break when it's done that way.
+ */
+class CCriticalSection : public XbmcThreads::CountingLockable<XbmcThreads::pthreads::RecursiveMutex> {};
+

--- a/xbmc/threads/platform/pthreads/Implementation.cpp
+++ b/xbmc/threads/platform/pthreads/Implementation.cpp
@@ -1,0 +1,60 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "threads/Lockables.h"
+#include "threads/platform/pthreads/CriticalSection.h"
+#include "threads/Helpers.h"
+
+#include <pthread.h>
+
+namespace XbmcThreads
+{
+  namespace pthreads
+  {
+    // ==========================================================
+    static pthread_mutexattr_t recursiveAttr;
+
+    static bool setRecursiveAttr() 
+    {
+      static bool alreadyCalled = false; // initialized to 0 in the data segment prior to startup init code running
+      if (!alreadyCalled)
+      {
+        pthread_mutexattr_init(&recursiveAttr);
+        pthread_mutexattr_settype(&recursiveAttr,PTHREAD_MUTEX_RECURSIVE);
+#if !defined(__arm__) && !defined(TARGET_ANDROID)
+        pthread_mutexattr_setprotocol(&recursiveAttr,PTHREAD_PRIO_INHERIT);
+#endif
+        alreadyCalled = true;
+      }
+      return true; // note, we never call destroy.
+    }
+
+    static bool recursiveAttrSet = setRecursiveAttr();
+
+    pthread_mutexattr_t* RecursiveMutex::getRecursiveAttr()
+    {
+      if (!recursiveAttrSet) // this is only possible in the single threaded startup code
+        recursiveAttrSet = setRecursiveAttr();
+      return &recursiveAttr;
+    }
+    // ==========================================================
+  }
+}
+

--- a/xbmc/threads/platform/pthreads/ThreadLocal.h
+++ b/xbmc/threads/platform/pthreads/ThreadLocal.h
@@ -20,4 +20,25 @@
 
 #pragma once
 
-#include "threads/platform/CriticalSection.h"
+#include <pthread.h>
+
+namespace XbmcThreads
+{
+  /**
+   * A thin wrapper around pthreads thread specific storage
+   * functionality.
+   */
+  template <typename T> class ThreadLocal
+  {
+    pthread_key_t key;
+  public:
+    inline ThreadLocal() : key(0) { pthread_key_create(&key,NULL); }
+
+    inline ~ThreadLocal() { pthread_key_delete(key); }
+
+    inline void set(T* val) { pthread_setspecific(key,(void*)val); }
+
+    inline T* get() { return (T*)pthread_getspecific(key); }
+  };
+}
+

--- a/xbmc/threads/platform/win/CMakeLists.txt
+++ b/xbmc/threads/platform/win/CMakeLists.txt
@@ -1,4 +1,7 @@
-set(HEADERS ThreadImpl.h)
+set(HEADERS Condition.h
+            CriticalSection.h
+            ThreadImpl.h
+            ThreadLocal.h)
 if(NOT CORE_SYSTEM_NAME STREQUAL windowsstore)
   set(SOURCES Win32Exception.cpp)
   set(HEADERS ${HEADERS} Win32Exception.h)

--- a/xbmc/threads/platform/win/Condition.h
+++ b/xbmc/threads/platform/win/Condition.h
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "threads/SingleLock.h"
+#include "threads/Helpers.h"
+
+#include <windows.h>
+
+namespace XbmcThreads
+{
+  /**
+   * This is condition variable implementation that uses the underlying
+   *  Windows mechanisms and assumes Vista (or later)
+   */
+  class ConditionVariable
+  {
+    CONDITION_VARIABLE cond;
+
+    // SleepConditionVariableCS requires the condition variable be entered
+    //  only once.
+    struct AlmostExit 
+    {
+      unsigned int count;
+      CCriticalSection& cc;
+      inline explicit AlmostExit(CCriticalSection& pcc) : count(pcc.exit(1)), cc(pcc) { cc.count = 0; }
+      inline ~AlmostExit() { cc.count = 1; cc.restore(count); }
+    };
+
+    ConditionVariable(const ConditionVariable&) = delete;
+    ConditionVariable& operator=(const ConditionVariable&) = delete;
+  public:
+    inline ConditionVariable() { InitializeConditionVariable(&cond); }
+
+    // apparently, windows condition variables do not need to be deleted
+    inline ~ConditionVariable() { }
+
+    inline void wait(CCriticalSection& lock) 
+    { 
+      AlmostExit ae(lock);
+      // even the windows implementation is capable of spontaneous wakes
+      SleepConditionVariableCS(&cond,&lock.get_underlying().mutex,INFINITE);
+    }
+
+    inline bool wait(CCriticalSection& lock, unsigned long milliseconds) 
+    { 
+      AlmostExit ae(lock);
+      return SleepConditionVariableCS(&cond,&lock.get_underlying().mutex,milliseconds) ? true : false;
+    }
+
+    inline void wait(CSingleLock& lock) { wait(lock.get_underlying()); }
+    inline bool wait(CSingleLock& lock, unsigned long milliseconds) { return wait(lock.get_underlying(), milliseconds); }
+    inline void notifyAll() { WakeAllConditionVariable(&cond); }
+    inline void notify() { WakeConditionVariable(&cond); }
+  };
+}

--- a/xbmc/threads/platform/win/CriticalSection.h
+++ b/xbmc/threads/platform/win/CriticalSection.h
@@ -1,0 +1,79 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "threads/Lockables.h"
+
+#include <windows.h>
+
+namespace XbmcThreads
+{
+
+  // forward declare in preparation for the friend declaration
+  class ConditionVariable;
+
+  namespace windows
+  {
+    class RecursiveMutex
+    {
+      CRITICAL_SECTION mutex;
+
+      // needs access to 'mutex'
+      friend class XbmcThreads::ConditionVariable;
+    public:
+      inline RecursiveMutex()
+      {
+        InitializeCriticalSection(&mutex);
+      }
+      
+      inline ~RecursiveMutex()
+      {
+        DeleteCriticalSection(&mutex);
+      }
+
+      inline void lock()
+      {
+        EnterCriticalSection(&mutex);
+      }
+
+      inline void unlock()
+      {
+        LeaveCriticalSection(&mutex);
+      }
+        
+      inline bool try_lock()
+      {
+        return TryEnterCriticalSection(&mutex) ? true : false;
+      }
+    };
+  }
+}
+
+
+/**
+ * A CCriticalSection is a CountingLockable whose implementation is a 
+ *  native recursive mutex.
+ *
+ * This is not a typedef because of a number of "class CCriticalSection;" 
+ *  forward declarations in the code that break when it's done that way.
+ */
+class CCriticalSection : public XbmcThreads::CountingLockable<XbmcThreads::windows::RecursiveMutex> {};
+

--- a/xbmc/threads/platform/win/ThreadLocal.h
+++ b/xbmc/threads/platform/win/ThreadLocal.h
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <windows.h>
+#include "commons/Exception.h"
+
+namespace XbmcThreads
+{
+  /**
+   * A thin wrapper around windows thread specific storage
+   * functionality.
+   */
+  template <typename T> class ThreadLocal
+  {
+    DWORD key;
+  public:
+    inline ThreadLocal()
+    {
+       if ((key = TlsAlloc()) == TLS_OUT_OF_INDEXES)
+          throw XbmcCommons::UncheckedException("Ran out of Windows TLS Indexes. Windows Error Code %d",(int)GetLastError());
+    }
+
+    inline ~ThreadLocal() 
+    {
+       if (!TlsFree(key))
+          throw XbmcCommons::UncheckedException("Failed to free Tls %d, Windows Error Code %d",(int)key, (int)GetLastError());
+    }
+
+    inline void set(T* val)
+    {
+       if (!TlsSetValue(key,(LPVOID)val))
+          throw XbmcCommons::UncheckedException("Failed to set Tls %d, Windows Error Code %d",(int)key, (int)GetLastError());
+    }
+
+    inline T* get() { return (T*)TlsGetValue(key); }
+  };
+}
+

--- a/xbmc/threads/test/CMakeLists.txt
+++ b/xbmc/threads/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestEvent.cpp
-            TestSharedSection.cpp)
+            TestSharedSection.cpp
+            TestThreadLocal.cpp)
 
 set(HEADERS TestHelpers.h)
 

--- a/xbmc/threads/test/TestThreadLocal.cpp
+++ b/xbmc/threads/test/TestThreadLocal.cpp
@@ -1,0 +1,117 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "threads/ThreadLocal.h"
+
+#include "threads/Event.h"
+#include "TestHelpers.h"
+
+using namespace XbmcThreads;
+
+bool destructorCalled = false;
+
+class Thingy
+{
+public:
+  inline ~Thingy() { destructorCalled = true; }
+};
+
+Thingy* staticThingy = NULL;
+CEvent gate;
+ThreadLocal<Thingy> staticThreadLocal;
+
+void cleanup()
+{
+  if (destructorCalled)
+    staticThingy = NULL;
+  destructorCalled = false;
+}
+
+CEvent waiter;
+class Runnable : public IRunnable
+{
+public:
+  bool waiting;
+  bool threadLocalHadValue;
+  ThreadLocal<Thingy>& threadLocal;
+
+  inline Runnable(ThreadLocal<Thingy>& tl) : waiting(false), threadLocal(tl) {}
+  inline void Run() override
+  {
+    staticThingy = new Thingy;
+    staticThreadLocal.set(staticThingy);
+    waiting = true;
+    gate.Set();
+    waiter.Wait();
+    waiting = false;
+
+    threadLocalHadValue = staticThreadLocal.get() != NULL;
+    gate.Set();
+  }
+};
+
+class GlobalThreadLocal : public Runnable
+{
+public:
+  GlobalThreadLocal() : Runnable(staticThreadLocal) {}
+};
+
+class StackThreadLocal : public Runnable
+{
+public:
+  ThreadLocal<Thingy> threadLocal;
+  inline StackThreadLocal() : Runnable(threadLocal) {}
+};
+
+TEST(TestThreadLocal, DISABLED_Simple)
+{
+  GlobalThreadLocal runnable;
+  thread t(runnable);
+
+  gate.Wait();
+  EXPECT_TRUE(runnable.waiting);
+  EXPECT_TRUE(staticThingy != NULL);
+  EXPECT_TRUE(staticThreadLocal.get() == NULL);
+  waiter.Set();
+  gate.Wait();
+  EXPECT_TRUE(runnable.threadLocalHadValue);
+  EXPECT_TRUE(!destructorCalled);
+  delete staticThingy;
+  EXPECT_TRUE(destructorCalled);
+  cleanup();
+}
+
+TEST(TestThreadLocal, DISABLED_Stack)
+{
+  StackThreadLocal runnable;
+  thread t(runnable);
+
+  gate.Wait();
+  EXPECT_TRUE(runnable.waiting);
+  EXPECT_TRUE(staticThingy != NULL);
+  EXPECT_TRUE(runnable.threadLocal.get() == NULL);
+  waiter.Set();
+  gate.Wait();
+  EXPECT_TRUE(runnable.threadLocalHadValue);
+  EXPECT_TRUE(!destructorCalled);
+  delete staticThingy;
+  EXPECT_TRUE(destructorCalled);
+  cleanup();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->
Roll back PR #13454 . It removed the mutex PTHREAD_PRIO_INHERIT ability which can't be duplicated with C++11 std lib functionality.

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
