### PR TITLE
[artwork] Scrapers set separate artwork for a movie and the collection

### DIFF
--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -20,6 +20,7 @@
 #include "utils/Mime.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <cstring>
 #include <sstream>
 
@@ -370,7 +371,7 @@ std::string CScraperUrl::GetThumbURL(const CScraperUrl::SUrlEntry &entry)
   return entry.m_url + "|Referer=" + CURL::Encode(entry.m_spoof);
 }
 
-void CScraperUrl::GetThumbURLs(std::vector<std::string> &thumbs, const std::string &type, int season) const
+void CScraperUrl::GetThumbURLs(std::vector<std::string> &thumbs, const std::string &type, int season, bool unique) const
 {
   for (std::vector<SUrlEntry>::const_iterator iter = m_url.begin(); iter != m_url.end(); ++iter)
   {
@@ -379,7 +380,9 @@ void CScraperUrl::GetThumbURLs(std::vector<std::string> &thumbs, const std::stri
       if ((iter->m_type == CScraperUrl::URL_TYPE_GENERAL && season == -1)
        || (iter->m_type == CScraperUrl::URL_TYPE_SEASON && iter->m_season == season))
       {
-        thumbs.push_back(GetThumbURL(*iter));
+        std::string url = GetThumbURL(*iter);
+        if (!unique || std::find(thumbs.begin(), thumbs.end(), url) == thumbs.end())
+          thumbs.push_back(url);
       }
     }
   }

--- a/xbmc/utils/ScraperUrl.h
+++ b/xbmc/utils/ScraperUrl.h
@@ -61,8 +61,9 @@ public:
    \param thumbs [out] vector of thumb URLs to fill
    \param type the type of thumb URLs to fetch, if empty (the default) picks any
    \param season number of season that we want thumbs for, -1 indicates no season (the default)
+   \param unique avoid adding duplicate URLs when adding to a thumbs vector with existing items
    */
-  void GetThumbURLs(std::vector<std::string> &thumbs, const std::string &type = "", int season = -1) const;
+  void GetThumbURLs(std::vector<std::string> &thumbs, const std::string &type = "", int season = -1, bool unique = false) const;
   void Clear();
   static bool Get(const SUrlEntry&, std::string&, XFILE::CCurlFile& http,
                  const std::string& cacheContext);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2345,9 +2345,16 @@ int CVideoDatabase::SetDetailsForMovie(const std::string& strFilenameAndPath, CV
     {
       idSet = AddSet(details.m_set.title, details.m_set.overview);
       // add art if not available
-      std::map<std::string, std::string> setArt;
-      if (!GetArtForItem(idSet, MediaTypeVideoCollection, setArt))
-        SetArtForItem(idSet, MediaTypeVideoCollection, artwork);
+      if (!HasArtForItem(idSet, MediaTypeVideoCollection))
+      {
+        std::map<std::string, std::string> setArt;
+        for (const auto &it : artwork)
+        {
+          if (StringUtils::StartsWith(it.first, "set."))
+            setArt[it.first.substr(4)] = it.second;
+        }
+        SetArtForItem(idSet, MediaTypeVideoCollection, setArt.empty() ? artwork : setArt);
+      }
     }
 
     if (details.HasStreamDetails())
@@ -2459,9 +2466,8 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, c
       {
         idSet = AddSet(details.m_set.title, details.m_set.overview);
         // add art if not available
-        std::map<std::string, std::string> setArt;
-        if (!GetArtForItem(idSet, "set", setArt))
-          SetArtForItem(idSet, "set", artwork);
+        if (!HasArtForItem(idSet, MediaTypeVideoCollection))
+          SetArtForItem(idSet, MediaTypeVideoCollection, artwork);
       }
     }
 
@@ -4499,6 +4505,26 @@ bool CVideoDatabase::RemoveArtForItem(int mediaId, const MediaType &mediaType, c
     result &= RemoveArtForItem(mediaId, mediaType, i);
 
   return result;
+}
+
+bool CVideoDatabase::HasArtForItem(int mediaId, const MediaType &mediaType)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+
+    std::string sql = PrepareSQL("SELECT count(*) FROM art WHERE media_id=%i AND media_type='%s'", mediaId, mediaType.c_str());
+    m_pDS2->query(sql);
+    bool result = !m_pDS2->eof();
+    m_pDS2->close();
+    return result;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s(%d) failed", __FUNCTION__, mediaId);
+  }
+  return false;
 }
 
 bool CVideoDatabase::GetTvShowSeasons(int showId, std::map<int, int> &seasons)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -836,6 +836,7 @@ public:
   void SetArtForItem(int mediaId, const MediaType &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const MediaType &mediaType, std::map<std::string, std::string> &art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
+  bool HasArtForItem(int mediaId, const MediaType &mediaType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
   bool GetTvShowSeasons(int showId, std::map<int, int> &seasons);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -50,6 +50,7 @@
 #include "messaging/helpers/DialogOKHelper.h"
 
 #include <iterator>
+#include <string>
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 using namespace XFILE;
@@ -1831,12 +1832,15 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const
       std::string baseDir = StringUtils::Format("videodb://movies/sets/%d", item->GetVideoInfoTag()->m_iDbId);
       if (videodb.GetMoviesNav(baseDir, items))
       {
+        std::vector<std::string> allMovieThumbs;
         for (int i=0; i < items.Size(); i++)
         {
           CVideoInfoTag* pTag = items[i]->GetVideoInfoTag();
           pTag->m_strPictureURL.Parse();
-          pTag->m_strPictureURL.GetThumbURLs(thumbs, artType);
+          pTag->m_strPictureURL.GetThumbURLs(allMovieThumbs, artType);
+          pTag->m_strPictureURL.GetThumbURLs(thumbs, "set." + artType, -1, true);
         }
+        std::copy(allMovieThumbs.begin(), allMovieThumbs.end(), std::back_inserter(thumbs));
       }
     }
     else
@@ -2091,6 +2095,19 @@ bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
     if (videodb.GetMoviesNav(baseDir, movies))
     {
       int iFanart = 0;
+      for (int i=0; i < movies.Size(); i++)
+      {
+        movies[i]->GetVideoInfoTag()->m_strPictureURL.Parse();
+        movies[i]->GetVideoInfoTag()->m_strPictureURL.GetThumbURLs(thumbs, "set.fanart", -1, true);
+      }
+      for (auto &fanart : thumbs)
+      {
+        CFileItemPtr item(new CFileItem(StringUtils::Format("fanart://Remote{0}", iFanart++), false));
+        item->SetArt("thumb", fanart);
+        item->SetIconImage("DefaultPicture.png");
+        item->SetLabel(g_localizeStrings.Get(20441)); // "Remote fanart"
+        items.Add(item);
+      }
       for (int i=0; i < movies.Size(); i++)
       {
         // ensure the fanart is unpacked


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description

Scrapers still provide movie set/collection info in the same bundle of info as the movie itself, but instead of being assigned the same artwork as the first scanned movie, scrapers can add separate artwork as "set.poster", "set.fanart", and "set.[arttype]" for any art type and artwork will be split up to the correct media items before assigning to the database. This only affects adding new items with the `SetDetailsForMovie` method, JSON-RPC and GUI changes use `UpdateDetailsForMovie` and `SetArtForItem`.

Movies will get "poster", "banner", and so on like usual, and "set." will be stripped from set artwork and applied to movie collections as "poster", "fanart", and "[arttype]". There are no hardcoded art types so all artwork is treated the same. If no set artwork is available, artwork from the movie is added as before rather than leaving it empty.

The second commit adjusts the "Choose art" dialog to include the collection artwork, and still allows selection of artwork from all movies.

This still leaves collection artwork without a home in the file system, but I like what Dave has done recently with the "Artist information folder" in the music library and think it would fit us well here, rather than in each movie folder.

**Edit:** I tried to write a clearer description of what happens.

## Motivation and Context
[Forum thread](https://forum.kodi.tv/showthread.php?tid=327395). This is an alternative to #13371, and avoids duplicating collection artwork to movies in the database, and vice versa. This also works for other artwork like "clearlogo" and "banner", and all artwork is stored and referenced with the same artwork names used in the rest of the video library. Finally, the "set." prefix matches that used in other areas of Kodi ("artist.fanart", "tvshow.poster"), and as artwork can be freely named, avoids colliding with movie art types that just happen to start with "set" (some crazy skinner will one day find a use for artwork named [setter](https://vetstreet.brightspotcdn.com/dims4/default/06f9544/2147483647/thumbnail/645x380/quality/90/?url=https%3A%2F%2Fvetstreet-brightspot.s3.amazonaws.com%2F10%2Fc74e30a73411e0a0d50050568d634f%2Ffile%2FEnglish-Setter-2-645mk062311.jpg)).

## How Has This Been Tested?
Added some new movies to my test library, some with an associated collection, some without. Movies ended up with their own artwork, collections got their own artwork, and neither ended up with the other. I've also patched my main HTPC for live testing and a handful of new movies worked as described above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
