### PR TITLE
Support plugin sources for video library with metadata.local scraper + related improvements/fixes

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3253,6 +3253,10 @@ void CApplication::OnPlayBackStarted(const CFileItem &file)
 {
   CLog::LogF(LOGDEBUG,"CApplication::OnPlayBackStarted");
 
+  // check if VideoPlayer should set file item stream details from its current streams
+  if (file.GetProperty("get_stream_details_from_player").asBoolean())
+    m_appPlayer.SetUpdateStreamDetails();
+
 #ifdef HAS_PYTHON
   // informs python script currently running playback has started
   // (does nothing if python is not loaded)

--- a/xbmc/ApplicationPlayer.cpp
+++ b/xbmc/ApplicationPlayer.cpp
@@ -22,6 +22,7 @@
 #include "cores/DataCacheCore.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
+#include "cores/VideoPlayer/VideoPlayer.h"
 #include "guilib/GUIWindowManager.h"
 #include "cores/DataCacheCore.h"
 #include "Application.h"
@@ -990,4 +991,12 @@ void CApplicationPlayer::SetVideoSettings(CVideoSettings& settings)
 CSeekHandler& CApplicationPlayer::GetSeekHandler()
 {
   return m_seekHandler;
+}
+
+void CApplicationPlayer::SetUpdateStreamDetails()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  CVideoPlayer* vp = dynamic_cast<CVideoPlayer*>(player.get());
+  if (vp)
+    vp->SetUpdateStreamDetails();
 }

--- a/xbmc/ApplicationPlayer.h
+++ b/xbmc/ApplicationPlayer.h
@@ -160,6 +160,8 @@ public:
 
   CSeekHandler& GetSeekHandler();
 
+  void SetUpdateStreamDetails();
+
 private:
   std::shared_ptr<IPlayer> GetInternal() const;
   void CreatePlayer(const CPlayerCoreFactory &factory, const std::string &player, IPlayerCallback& callback);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3167,6 +3167,9 @@ std::string CFileItem::GetFolderThumb(const std::string &folderJPG /* = "folder.
 
 std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */) const
 {
+  if (IsPlugin() && HasVideoInfoTag() && !GetVideoInfoTag()->m_strTitle.empty())
+    return GetVideoInfoTag()->m_strTitle;
+
   if (IsLabelPreformatted())
     return GetLabel();
 

--- a/xbmc/InfoScanner.cpp
+++ b/xbmc/InfoScanner.cpp
@@ -36,7 +36,7 @@ bool CInfoScanner::IsExcluded(const std::string& strDirectory, const std::vector
   if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
     return true;
 
-  if (HasNoMedia(strDirectory))
+  if (!URIUtils::IsPlugin(strDirectory) && HasNoMedia(strDirectory))
   {
     CLog::Log(LOGWARNING, "Skipping item '%s' with '.nomedia' file in parent directory, it won't be added to the library.", CURL::GetRedacted(strDirectory).c_str());
     return true;

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -54,6 +54,7 @@ public:
     PLAYER_SET_SUBTITLESTREAM_VISIBLE, //
     PLAYER_SET_STATE,               // restore the VideoPlayer to a certain state
     PLAYER_SET_PROGRAM,
+    PLAYER_SET_UPDATE_STREAM_DETAILS, // player should update file item stream details with its current streams
     PLAYER_SEEK,                    //
     PLAYER_SEEK_CHAPTER,            //
     PLAYER_SETSPEED,                // set the playback speed

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -390,6 +390,8 @@ public:
   CVideoSettings GetVideoSettings() override;
   void SetVideoSettings(CVideoSettings& settings) override;
 
+  void SetUpdateStreamDetails();
+
 protected:
   friend class CSelectionStreams;
 
@@ -485,6 +487,8 @@ protected:
 
   void UpdateContent();
   void UpdateContentState();
+
+  void UpdateFileItemStreamDetails(CFileItem& item);
 
   bool m_players_created;
 
@@ -582,6 +586,8 @@ protected:
 
   bool m_HasVideo;
   bool m_HasAudio;
+
+  bool m_UpdateStreamDetails;
 
   std::atomic<bool> m_displayLost;
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -186,6 +186,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
     if (!resultItem.HasProperty("original_listitem_url"))
       resultItem.SetProperty("original_listitem_url", resultItem.GetPath());
     resultItem.SetPath(newDir.m_fileResult->GetPath());
+    resultItem.SetDynPath(std::string());
     resultItem.SetMimeType(newDir.m_fileResult->GetMimeType());
     resultItem.SetContentLookup(newDir.m_fileResult->ContentLookup());
     resultItem.UpdateInfo(*newDir.m_fileResult);

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -74,6 +74,19 @@ void CSaveFileState::DoWork(CFileItem& item,
       }
       else
       {
+        if (URIUtils::IsPlugin(progressTrackingFile) && !(item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId >= 0))
+        {
+          // FileItem from plugin can lack information, make sure all needed fields are set
+          CVideoInfoTag *tag = item.GetVideoInfoTag();
+          CStreamDetails streams = tag->m_streamDetails;
+          if (videodatabase.LoadVideoInfo(progressTrackingFile, *tag))
+          {
+            item.SetPath(progressTrackingFile);
+            item.ClearProperty("original_listitem_url");
+            tag->m_streamDetails = streams;
+          }
+        }
+
         bool updateListing = false;
         // No resume & watched status for livetv
         if (!item.IsLiveTV())

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -26,6 +26,9 @@
 
 class CStreamDetails;
 class CVariant;
+struct VideoStreamInfo;
+struct AudioStreamInfo;
+struct SubtitleStreamInfo;
 
 class CStreamDetail : public IArchivable, public ISerializable
 {
@@ -52,6 +55,7 @@ class CStreamDetailVideo : public CStreamDetail
 {
 public:
   CStreamDetailVideo();
+  CStreamDetailVideo(const VideoStreamInfo &info, int duration = 0);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(CStreamDetail *that) override;
@@ -69,6 +73,7 @@ class CStreamDetailAudio : public CStreamDetail
 {
 public:
   CStreamDetailAudio();
+  CStreamDetailAudio(const AudioStreamInfo &info);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(CStreamDetail *that) override;
@@ -82,6 +87,7 @@ class CStreamDetailSubtitle : public CStreamDetail
 {
 public:
   CStreamDetailSubtitle();
+  CStreamDetailSubtitle(const SubtitleStreamInfo &info);
   CStreamDetailSubtitle& operator=(const CStreamDetailSubtitle &that);
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
@@ -132,6 +138,7 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
 
+  bool SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo);
 private:
   CStreamDetail *NewStream(CStreamDetail::StreamType type);
   std::vector<CStreamDetail *> m_vecItems;

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "FileItem.h"
 #include "utils/ScraperUrl.h"
 #include "XBDateTime.h"
 
@@ -38,6 +39,7 @@ namespace VIDEO
     std::string strTitle;
     CDateTime   cDate;
     CScraperUrl cScraperUrl;
+    CFileItemPtr item;
     EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
     {
       iSeason     = Season;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -254,6 +254,7 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_TV_MPAA = 13,
   VIDEODB_ID_TV_STUDIOS = 14,
   VIDEODB_ID_TV_SORTTITLE = 15,
+  VIDEODB_ID_TV_TRAILER = 16,
   VIDEODB_ID_TV_MAX
 } VIDEODB_TV_IDS;
 
@@ -275,6 +276,7 @@ const struct SDbTableOffsets DbTvShowOffsets[] =
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strMPAARating)},
   { VIDEODB_TYPE_STRINGARRAY, my_offsetof(CVideoInfoTag,m_studio)},
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strSortTitle)},
+  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strTrailer)}
 };
 
 //! @todo is this comment valid for seasons? There is no offset structure or am I wrong?

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -837,6 +837,7 @@ public:
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);
   bool GetTvShowSeasons(int showId, std::map<int, int> &seasons);
+  bool GetTvShowNamedSeasons(int showId, std::map<int, std::string> &seasons);
   bool GetTvShowSeasonArt(int mediaId, std::map<int, std::map<std::string, std::string> > &seasonArt);
   bool GetArtTypes(const MediaType &mediaType, std::vector<std::string> &artTypes);
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -294,7 +294,8 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
   {
     TiXmlElement season("namedseason");
     season.SetAttribute("number", namedSeason.first);
-    season.SetValue(namedSeason.second);
+    TiXmlText value(namedSeason.second);
+    season.InsertEndChild(value);
     movie->InsertEndChild(season);
   }
  

--- a/xbmc/video/tags/CMakeLists.txt
+++ b/xbmc/video/tags/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES VideoInfoTagLoaderFactory.cpp
             VideoTagLoaderFFmpeg.cpp
-            VideoTagLoaderNFO.cpp)
+            VideoTagLoaderNFO.cpp
+            VideoTagLoaderPlugin.cpp)
 
 set(HEADERS IVideoInfoTagLoader.h
             VideoInfoTagLoaderFactory.h
             VideoTagLoaderFFmpeg.h
-            VideoTagLoaderNFO.h)
+            VideoTagLoaderNFO.h
+            VideoTagLoaderPlugin.h)
 
 core_add_library(video_tags)

--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.h
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.h
@@ -34,7 +34,8 @@ namespace VIDEO
     //! \param type Type of tag loader. In particular used for tvshows
     static IVideoInfoTagLoader* CreateLoader(const CFileItem& item,
                                              ADDON::ScraperPtr info,
-                                             bool lookInFolder);
+                                             bool lookInFolder,
+                                             bool forceRefresh = false);
 
   protected:
     // No instancing of this class

--- a/xbmc/video/tags/VideoTagLoaderPlugin.cpp
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.cpp
@@ -1,0 +1,77 @@
+/*
+ *      Copyright (C) 2005-2017 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "VideoTagLoaderPlugin.h"
+#include "FileItem.h"
+#include "URL.h"
+#include "filesystem/PluginDirectory.h"
+
+using namespace XFILE;
+
+CVideoTagLoaderPlugin::CVideoTagLoaderPlugin(const CFileItem& item, bool forceRefresh)
+  : IVideoInfoTagLoader(item, nullptr, false), m_force_refresh(forceRefresh)
+{
+  if (forceRefresh)
+    return;
+  // Preserve CFileItem video info and art to avoid info loss between creating VideoInfoTagLoaderFactory and calling Load()
+  if (m_item.HasVideoInfoTag())
+    m_tag.reset(new CVideoInfoTag(*m_item.GetVideoInfoTag()));
+  auto& art = item.GetArt();
+  if (!art.empty())
+    m_art.reset(new CGUIListItem::ArtMap(art));
+}
+
+bool CVideoTagLoaderPlugin::HasInfo() const
+{
+  return m_tag || m_force_refresh;
+}
+
+CInfoScanner::INFO_TYPE CVideoTagLoaderPlugin::Load(CVideoInfoTag& tag, bool, std::vector<EmbeddedArt>*)
+{
+  if (m_force_refresh)
+  {
+    // In case of force refresh call our plugin with option "kodi_action=refresh_info"
+    // Plugin must do all refreshing work at specified path and return directory containing one ListItem with video tag and art
+    // We cannot obtain all info from setResolvedUrl, because CPluginDirectory::GetPluginResult doesn't copy full art
+    CURL url(m_item.GetPath());
+    url.SetOption("kodi_action", "refresh_info");
+    CPluginDirectory plugin;
+    CFileItemList items;
+    if (!plugin.GetDirectory(url, items))
+      return CInfoScanner::ERROR_NFO;
+    if (!items.IsEmpty())
+    {
+      const CFileItemPtr &item = items[0];
+      m_art.reset(new CGUIListItem::ArtMap(item->GetArt()));
+      if (item->HasVideoInfoTag())
+      {
+        tag = *item->GetVideoInfoTag();
+        return CInfoScanner::FULL_NFO;
+      }
+    }
+  }
+  else if (m_tag)
+  {
+    // Otherwise just copy CFileItem video info to tag
+    tag = *m_tag;
+    return CInfoScanner::FULL_NFO;
+  }
+  return CInfoScanner::NO_NFO;
+}

--- a/xbmc/video/tags/VideoTagLoaderPlugin.h
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.h
@@ -1,0 +1,54 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2017 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IVideoInfoTagLoader.h"
+#include "video/VideoInfoTag.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+//! \brief Video tag loader from plugin source.
+class CVideoTagLoaderPlugin : public VIDEO::IVideoInfoTagLoader
+{
+public:
+  CVideoTagLoaderPlugin(const CFileItem& item, bool forceRefresh);
+
+  virtual ~CVideoTagLoaderPlugin() = default;
+
+  //! \brief Returns whether or not read has info.
+  bool HasInfo() const override;
+
+  //! \brief Load "tag" from plugin.
+  //! \param tag Tag to load info into
+  CInfoScanner::INFO_TYPE Load(CVideoInfoTag& tag, bool prioritise,
+                               std::vector<EmbeddedArt>* = nullptr) override;
+
+  inline std::unique_ptr<std::map<std::string, std::string>>& GetArt()
+  {
+    return m_art;
+  }
+protected:
+  std::unique_ptr<CVideoInfoTag> m_tag;
+  std::unique_ptr<std::map<std::string, std::string>> m_art;
+  bool m_force_refresh;
+};

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -917,7 +917,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       database.Open();
       ADDON::ScraperPtr info = database.GetScraperForPath(item->GetPath());
 
-      if (!item->IsLiveTV() && !item->IsPlugin() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
+      if (!item->IsLiveTV() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
       {
         if (info && info->Content() != CONTENT_NONE)
         {


### PR DESCRIPTION
## Description
This set of changes allows to use plugins as video source for Kodi media library with "Local information only" (metadata.local) scraper. Instead of reading NFO files (which is impossible for plugin sources) all needed information is taken directly from plugin's ListItem. This is non-breaking change, all other functionality (other video sources and/or other scrapers) remains unchanged. For Kodi 18.

Also related improvements/fixes are included, because without it this merge will be incomplete:
* [bugfix] when exporting media library tv show named seasons are not included
* [bugfix] fix named seasons xml tag formatting
* [improvement] save tv show trailers in media library database
* [improvement] get stream details from VideoPlayer (only on plugin request)

See detailed explanation below.

## Motivation and Context

### Scanning video library from plugin sources with metadata.local scraper
Since plugin content cannot be represented as files, we cannot use "Local information only" scraper to fetch data from NFO when plugin is used as video source. But plugin can have all needed information in ListItem, so we don't need to use any NFOs - just get video info tag and art directly from plugin's ListItem. Many plugins have enough information for video library, so making library from such plugins without having to write special external scrapers is very useful.

All we need to do:
1.  Write video tag loader specially for plugins with metadata.local scraper, which will perform the following functions:
    * copy video info tag from plugin ListItem to scanner;
    * in case of force refresh (e.g. user pressed "Refresh" button in video info dialog) call plugin again to fetch new data, copy video info tag and save art for further use.
2. Update scanner and refresher code to work with new video tag loader.
3. Allow plugin to calculate hash for directories itself and use it in scanner to prevent unneeded calls to plugin.
4. Prevent any attempts to fetch local data (e.g. art, actors) using files with plugin source (this data cannot be obtained anyway, so attempts to fetch anything local just will lead to unneeded subsequent calls to plugin and warnings in journal).

See mini-guide below for more details.

### Video library related fixes
1. Video plugins can provide season names for tv shows, so saving them on media library exporting is necessary.
2. Video plugins can provide trailers for tv shows, so saving them in media library database is desirable.

### Getting stream details from VideoPlayer
Currently stream details from video plugins (especially internet streams) are not obtained and saved in database. Also we should not call plugin to get stream details for internet streams before playing them or on directory listing (prevent multiple calls). The solution is to get stream details directly from VideoPlayer on closing file (the same as bookmark). We can use stream details (including stream duration) that VideoPlayer has already got, and save them to database with CSaveFileState. This is very useful for plugins that provide internet streaming content.

Since v18.2rc1 stream details are always updated.
~~To use this feature plugin must set "get_stream_details_from_player" boolean property to resulting ListItem, otherwise stream details will not be obtained.~~

### [MINI-GUIDE] Video library scanning support in plugins with metadata.local scraper
Follow these instructions to make your plugin fully compatible with media library scanning and refreshing with "Local information only" scraper:
1. Plugin URL format and video source content settings:
   * It's recommended to use URLs like "plugin://plugin.name/" or "plugin://plugin.name/folder/" for video source and pass all other parameters as options string ("?key=value").
   * Due to Kodi's plugin URL parenting rules if you are using URL for video source with options string ("plugin://plugin.name/?key=value") or pass all options as folder names ("plugin://plugin.name/opt1/opt2/"), a user have to set the same content and scraper for parent URL ("plugin://plugin.name/"). Try to avoid this, don't make a user to do double work. Also in this case you cannot set different settings for video sources (e.g. if your plugin provides both movies and tv shows).
2. You must provide all needed information in ListItem with setInfo(), setArt() etc. For episodes you must set correct season and episode numbers.
3. Don't use "Selected folder contains a single TV show". VideoScanner needs a separate folder to get tv show information from it.
4. You don't need to make additinal folders for seasons or separate folders for movies, you can list all episodes in one tv show folder or all movies in one folder.
5. IMPORTANT: In case of force refresh (e.g. user pressed "Refresh" button in video info dialog) your plugin will be called with URL that needs to be refreshed and option "kodi_action=refresh_info". Plugin must do all refreshing work at specified path and return directory containing one ListItem with updated video tag and art. Don't use setResolvedUrl(). This is the same as a simple video listing except that you have to refresh and return only specified item in directory, not all.
6. If your plugin can get information about tv show episodes before opening tv show folder (e.g. using cache), then on library scanning to avoid unneeded calls to plugin it's recommended to supply tv show ListItem with MD5 hash of folder contents as "hash" property with hex digest in upper case. Hash must include episode url and optionally episode file size (if not zero) and file date (if exists). All options must be utf-8 strings. Date format is "d.m.Y". Usually, only url is used. Example:
```
# Hashing tv show folder contents
m = hashlib.md5()
for episode in tvshow['episodes']:
    m.update(get_episode_url(tvshow, episode).encode('utf-8'))
    if episode['file_size']:
        m.update(str(episode['file_size']).encode('utf-8'))
    if episode['file_date']:
        m.update(episode['file_date'].strftime('%d.%m.%Y').encode('utf-8'))
item.setProperty('hash', m.hexdigest().upper())
```
## How Has This Been Tested?
* Build tested on Windows and Linux.
* Functionality tested with special [test plugin](https://github.com/AkariDN/plugin.video.testlib).
* Also I've tested functionality on a real plugin, but I can't share it now, because development in progress and it's still very raw. I hope this pull request will be merged and I can continue development, otherwise it's useless.

## Screenshots (if appropriate):
* [Selecting video source](https://i.imgur.com/Ox2rhrX.png)
* [Set tv shows content and metadata.local scraper](https://i.imgur.com/7fwJ01T.png)
* [Movies library view](https://i.imgur.com/4XO5Lql.jpg)
* [TV Shows library view](https://i.imgur.com/qFqhPpS.jpg)
* [TV Show details](https://i.imgur.com/BDxV4jK.jpg)
* [Episodes list](https://i.imgur.com/TlIB58H.jpg)
* [Episode details](https://i.imgur.com/pXX2UGM.jpg)

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
