### PR TITLE
DirectX: fix NaN in shaders

### DIFF
--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -129,7 +129,7 @@ float4 YUV2RGB(VS_OUTPUT In) : SV_TARGET
 
   float4 rgb = mul(YUV, g_ColorMatrix);
 #if defined(XBMC_COL_CONVERSION)
-  rgb.rgb = pow(mul(pow(rgb, g_gammaSrc), g_primMat), g_gammaDstInv).rgb;
+  rgb.rgb = pow(max(0.0, mul(pow(rgb, g_gammaSrc), g_primMat)), g_gammaDstInv).rgb;
 #endif
   return output4(rgb, In.TextureY);
 }


### PR DESCRIPTION
AMD devs don't follow data conversion rules in case of float to unorm. The algo described at
https://msdn.microsoft.com/ru-ru/library/windows/desktop/dd607323%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
there is NaN should be converted to 0. So we have to use this fix for AMD hardware.