### PR TITLE
[swig] Revert PR #12490 now Trusty is no longer supported/able to build

### DIFF
--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -80,8 +80,7 @@ namespace XBMCAddon
 
     public:
       explicit Addon(const char* id = NULL);
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Addon();
+      ~Addon() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -78,8 +78,7 @@ namespace XBMCAddon
                   iControlRight(0), pGUIControl(NULL) {}
 
     public:
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Control();
+      ~Control() override;
 
 #ifndef SWIG
       virtual CGUIControl* Create();
@@ -674,8 +673,7 @@ namespace XBMCAddon
     class ControlSpin : public Control
     {
     public:
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~ControlSpin();
+      ~ControlSpin() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control_spin
@@ -799,8 +797,7 @@ namespace XBMCAddon
                   long alignment = XBFONT_LEFT, 
                   bool hasPath = false, long angle = 0);
 
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~ControlLabel();
+      ~ControlLabel() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control_label
@@ -1160,8 +1157,7 @@ namespace XBMCAddon
                   long _itemTextYOffset = CONTROL_TEXT_OFFSET_Y, long _itemHeight = 27, long _space = 2, 
                   long _alignmentY = XBFONT_CENTER_Y);
 
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~ControlList();
+      ~ControlList() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcgui_control_list

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -60,8 +60,7 @@ namespace XBMCAddon
     public:
 
       inline Dialog() = default;
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Dialog();
+      ~Dialog() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -603,14 +602,12 @@ namespace XBMCAddon
       bool                open;
 
     protected:
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual void deallocating();
+      void deallocating() override;
 
     public:
 
       DialogProgress() : dlg(NULL), open(false) {}
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~DialogProgress();
+      ~DialogProgress() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -744,14 +741,12 @@ namespace XBMCAddon
       bool open;
 
     protected:
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual void deallocating();
+      void deallocating() override;
 
     public:
 
       DialogBusy() : dlg(NULL), open(false) {}
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~DialogBusy();
+      ~DialogBusy() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -854,14 +849,12 @@ namespace XBMCAddon
       bool open;
 
     protected:
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual void deallocating();
+      void deallocating() override;
 
     public:
 
       DialogProgressBG() : dlg(NULL), handle(NULL), open(false) {}
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~DialogProgressBG();
+      ~DialogProgressBG() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -71,8 +71,7 @@ namespace XBMCAddon
           file->Open(filepath, XFILE::READ_NO_CACHE);
       }
 
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      inline virtual ~File() { delete file; }
+      inline ~File() override { delete file; }
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -62,8 +62,7 @@ namespace XBMCAddon
       explicit InfoTagMusic(const MUSIC_INFO::CMusicInfoTag& tag);
 #endif
       InfoTagMusic();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~InfoTagMusic();
+      ~InfoTagMusic() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagRadioRDS.h
+++ b/xbmc/interfaces/legacy/InfoTagRadioRDS.h
@@ -64,8 +64,7 @@ namespace XBMCAddon
       explicit InfoTagRadioRDS(const PVR::CPVRRadioRDSInfoTagPtr tag);
 #endif
       InfoTagRadioRDS();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~InfoTagRadioRDS();
+      ~InfoTagRadioRDS() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -63,8 +63,7 @@ namespace XBMCAddon
       explicit InfoTagVideo(const CVideoInfoTag& tag);
 #endif
       InfoTagVideo();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~InfoTagVideo();
+      ~InfoTagVideo() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Keyboard.h
+++ b/xbmc/interfaces/legacy/Keyboard.h
@@ -75,8 +75,7 @@ namespace XBMCAddon
 #endif
 
       Keyboard(const String& line = emptyString, const String& heading = emptyString, bool hidden = false);
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Keyboard();
+      ~Keyboard() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -106,8 +106,7 @@ namespace XBMCAddon
       }
 #endif
 
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~ListItem();
+      ~ListItem() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Monitor.h
+++ b/xbmc/interfaces/legacy/Monitor.h
@@ -317,8 +317,7 @@ namespace XBMCAddon
 #else
       bool abortRequested();
 #endif
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Monitor();
+      ~Monitor() override;
     };
     /** @} */
   }

--- a/xbmc/interfaces/legacy/PlayList.h
+++ b/xbmc/interfaces/legacy/PlayList.h
@@ -66,8 +66,7 @@ namespace XBMCAddon
 
     public:
       explicit PlayList(int playList);
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~PlayList();
+      ~PlayList() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -90,8 +90,7 @@ namespace XBMCAddon
       //  construction of a Player needs to identify whether or not any 
       //  callbacks will be executed asynchronously or not.
       explicit Player(int playerCore = 0);
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Player(void);
+      ~Player(void) override;
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/RenderCapture.h
+++ b/xbmc/interfaces/legacy/RenderCapture.h
@@ -59,8 +59,7 @@ namespace XBMCAddon
         m_width = 0;
         m_height = 0;
       }
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      inline virtual ~RenderCapture()
+      inline ~RenderCapture() override
       {
         g_application.GetAppPlayer().RenderCaptureRelease(m_captureId);
         delete [] m_buffer;

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -267,8 +267,7 @@ namespace XBMCAddon
     public:
       explicit Window(int existingWindowId = -1);
 
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~Window();
+      ~Window() override;
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool    OnMessage(CGUIMessage& message);

--- a/xbmc/interfaces/legacy/WindowDialog.h
+++ b/xbmc/interfaces/legacy/WindowDialog.h
@@ -64,8 +64,7 @@ namespace XBMCAddon
     {
     public:
       WindowDialog();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WindowDialog();
+      ~WindowDialog() override;
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool OnMessage(CGUIMessage& message) override;

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -119,8 +119,7 @@ namespace XBMCAddon
                 const String& defaultSkin = "Default",
                 const String& defaultRes = "720p",
                 bool isMedia = false);
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WindowXML();
+      ~WindowXML() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -539,8 +538,7 @@ namespace XBMCAddon
                       const String& defaultSkin = "Default",
                       const String& defaultRes = "720p");
 
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WindowXMLDialog();
+      ~WindowXMLDialog() override;
 
 #ifndef SWIG
       SWIGHIDDENVIRTUAL bool OnMessage(CGUIMessage &message) override;

--- a/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiErrorStream.h
@@ -45,8 +45,7 @@ namespace XBMCAddon
     {
     public:
       WsgiErrorStream();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WsgiErrorStream();
+      ~WsgiErrorStream() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiInputStream.h
@@ -34,8 +34,7 @@ namespace XBMCAddon
     {
     public:
       WsgiInputStreamIterator();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WsgiInputStreamIterator();
+      ~WsgiInputStreamIterator() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcwsgi_WsgiInputStream
@@ -116,8 +115,7 @@ namespace XBMCAddon
     {
     public:
       WsgiInputStream();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WsgiInputStream();
+      ~WsgiInputStream() override;
 
 #if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
       WsgiInputStreamIterator* begin();

--- a/xbmc/interfaces/legacy/wsgi/WsgiResponse.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiResponse.h
@@ -45,8 +45,7 @@ namespace XBMCAddon
     {
     public:
       WsgiResponse();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WsgiResponse();
+      ~WsgiResponse() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcwsgi_WsgiInputStreamIterator

--- a/xbmc/interfaces/legacy/wsgi/WsgiResponseBody.h
+++ b/xbmc/interfaces/legacy/wsgi/WsgiResponseBody.h
@@ -38,8 +38,7 @@ namespace XBMCAddon
     {
     public:
       WsgiResponseBody();
-      //! @todo Switch to 'override' usage once 14.04 (Trusty) hits EOL. swig <3.0 doesn't understand C++11
-      virtual ~WsgiResponseBody();
+      ~WsgiResponseBody() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       /// \ingroup python_xbmcwsgi_WsgiInputStreamIterator


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Revert #12490

## Motivation and Context
Apparently it is no longer possible to build on Trusty.

## How Has This Been Tested?
17.10 build, brief runtime test.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
