### PR TITLE
AESinkAudioTrack: Implement getTimestamp

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -640,12 +640,16 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   if (m_offset > 0)
     m_headPos -= m_offset;
 
+  bool old_aml_workaround = false;
   // this makes EAC3 working even when AML is not enabled
   if (aml_present() && m_info.m_wantsIECPassthrough &&
       (m_encoding == CJNIAudioFormat::ENCODING_DTS_HD ||
        m_encoding == CJNIAudioFormat::ENCODING_E_AC3 ||
        m_encoding == CJNIAudioFormat::ENCODING_DOLBY_TRUEHD))
+  {
     normHead_pos /= m_sink_frameSize;  // AML wants sink in 48k but returns pos in 192k
+    old_aml_workaround = true;
+  }
 
   if (m_passthrough && !m_info.m_wantsIECPassthrough)
   {
@@ -668,7 +672,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
     delay = 0;
 
   double d = GetMovingAverageDelay(delay);
-  if (m_delayTimer.IsTimePast())
+  if (!old_aml_workaround && m_delayTimer.IsTimePast())
   {
     CJNIAudioTimestamp ts;
     double now = CJNISystem::nanoTime();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -78,6 +78,9 @@ private:
   // by the package duration. This is only used for non IEC passthrough
   XbmcThreads::EndTime  m_extTimer;
 
+  // We query getTimestamp for audio every some seconds
+  XbmcThreads::EndTime m_delayTimer;
+
   // We maintain our linear weighted average delay counter in here
   // The n-th value (timely oldest value) is weighted with 1/n
   // the newest value gets a weight of 1


### PR DESCRIPTION
This implements getTimestamp according to the documentation:

> After the clock is advancing at a stable rate, query for a new timestamp approximately once every 10 seconds to once per minute. Calling this method more often is inefficient. It is also counter-productive to call this method more often than recommended, because the short-term differences between successive timestamp reports are not meaningful.

Needs testing.
To test: Turn on debug logging, play a Video and after 2 minutes provide the logfile.