### PR TITLE
[PVR] Guide window: Reintroduce 'wrap around' when navigating the epg grid

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -267,8 +267,8 @@
 				<rulerunit>6</rulerunit>
 				<onleft>9000</onleft>
 				<onright>60</onright>
-				<onup>$PARAM[control_onup_id]</onup>
-				<ondown>$PARAM[control_id]</ondown>
+				<onup>$PARAM[control_onupdown_id]</onup>
+				<ondown>$PARAM[control_onupdown_id]</ondown>
 				<viewtype label="$PARAM[viewtype_label]">list</viewtype>
 				<progresstexture border="$PARAM[progress_texture_border]" colordiffuse="button_focus">$PARAM[progress_texture]</progresstexture>
 				<rulerdatelayout width="1700" height="45" condition="$PARAM[has_rulerdate_layout]">

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -114,7 +114,7 @@
 							<param name="control_id" value="50"/>
 							<param name="control_orientation" value="vertical"/>
 							<param name="control_top" value="55"/>
-							<param name="control_onup_id" value="11"/>
+							<param name="control_onupdown_id" value="11"/>
 							<param name="viewtype_label" value="19298"/>
 							<param name="progress_texture_border" value="0,60,18,14"/>
 							<param name="progress_texture" value="windows/pvr/epg_progress_vertical.png"/>
@@ -128,7 +128,7 @@
 							<param name="control_id" value="51"/>
 							<param name="control_orientation" value="horizontal"/>
 							<param name="control_top" value="55"/>
-							<param name="control_onup_id" value="11"/>
+							<param name="control_onupdown_id" value="11"/>
 							<param name="viewtype_label" value="19297"/>
 							<param name="progress_texture_border" value="5,10,5,10"/>
 							<param name="progress_texture" value="windows/pvr/epg_progress_horizontal.png"/>
@@ -142,7 +142,7 @@
 							<param name="control_id" value="52"/>
 							<param name="control_orientation" value="vertical"/>
 							<param name="control_top" value="0"/>
-							<param name="control_onup_id" value="52"/>
+							<param name="control_onupdown_id" value="52"/>
 							<param name="viewtype_label" value="19301"/>
 							<param name="progress_texture_border" value="0,60,18,14"/>
 							<param name="progress_texture" value="windows/pvr/epg_progress_vertical.png"/>
@@ -156,7 +156,7 @@
 							<param name="control_id" value="53"/>
 							<param name="control_orientation" value="horizontal"/>
 							<param name="control_top" value="0"/>
-							<param name="control_onup_id" value="53"/>
+							<param name="control_onupdown_id" value="53"/>
 							<param name="viewtype_label" value="19300"/>
 							<param name="progress_texture_border" value="5,10,5,10"/>
 							<param name="progress_texture" value="windows/pvr/epg_progress_horizontal.png"/>

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -1674,6 +1674,62 @@ void CGUIEPGGridContainer::GoToDate(const CDateTime &date)
   SetBlock(offset);
 }
 
+void CGUIEPGGridContainer::GoToTop()
+{
+  if (m_orientation == VERTICAL)
+  {
+    if (m_gridModel->HasChannelItems())
+      GoToChannel(0);
+  }
+  else
+  {
+    if (m_gridModel->HasProgrammeItems())
+      GoToBlock(0);
+  }
+}
+
+void CGUIEPGGridContainer::GoToBottom()
+{
+  if (m_orientation == VERTICAL)
+  {
+    if (m_gridModel->HasChannelItems())
+      GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+  }
+  else
+  {
+    if (m_gridModel->HasProgrammeItems())
+      GoToBlock(m_gridModel->ProgrammeItemsSize() - 1);
+  }
+}
+
+void CGUIEPGGridContainer::GoToMostLeft()
+{
+  if (m_orientation == VERTICAL)
+  {
+    if (m_gridModel->HasProgrammeItems())
+      GoToBlock(m_gridModel->ProgrammeItemsSize() - 1);
+  }
+  else
+  {
+    if (m_gridModel->HasChannelItems())
+      GoToChannel(m_gridModel->ChannelItemsSize() - 1);
+  }
+}
+
+void CGUIEPGGridContainer::GoToMostRight()
+{
+  if (m_orientation == VERTICAL)
+  {
+    if (m_gridModel->HasProgrammeItems())
+      GoToBlock(0);
+  }
+  else
+  {
+    if (m_gridModel->HasChannelItems())
+      GoToChannel(0);
+  }
+}
+
 void CGUIEPGGridContainer::SetTimelineItems(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd)
 {
   int iRulerUnit;

--- a/xbmc/pvr/windows/GUIEPGGridContainer.h
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.h
@@ -87,6 +87,10 @@ namespace PVR
     void GoToEnd();
     void GoToNow();
     void GoToDate(const CDateTime &date);
+    void GoToTop();
+    void GoToBottom();
+    void GoToMostLeft();
+    void GoToMostRight();
 
     void SetTimelineItems(const std::unique_ptr<CFileItemList> &items, const CDateTime &gridStart, const CDateTime &gridEnd);
     /*!

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -71,6 +71,8 @@ namespace PVR
     bool OnContextButtonNow();
     bool OnContextButtonDate();
 
+    bool ShouldNavigateToGridContainer(int iAction);
+
     void StartRefreshTimelineItemsThread();
     void StopRefreshTimelineItemsThread();
 


### PR DESCRIPTION
This neat feature was lost with introduction of the channel selector in guide window. This PR reintroduces it.

![guide-wrap](https://user-images.githubusercontent.com/3226626/36629691-ccfdcb12-1959-11e8-92a8-8e1d236946b0.gif)

@chewitt fyi