### PR TITLE
extend aarch64 pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,7 +277,6 @@ cmake_install.cmake
 /tools/depends/**/config.log
 /tools/depends/**/config.status
 /tools/depends/native/*/*native/
-/tools/depends/target/*/aarch64-linux-gnu/
 /tools/depends/native/JsonSchemaBuilder/bin/
 /tools/depends/native/TexturePacker/bin/
 /tools/depends/target/ffmpeg/.ffmpeg-installed

--- a/tools/depends/.gitignore
+++ b/tools/depends/.gitignore
@@ -15,9 +15,10 @@
 /target/*/x86/*
 /target/*/x86_64-linux-gnu-*/*
 /target/*/armeabi-v7a-*/*
-/target/*/arm-linux-gnueabihf-*/*
-/target/*/arm-linux-androideabi-*/*
-/target/*/arm-linux-gnueabi-*/*
+/target/*/arm*-linux-gnueabihf-*/*
+/target/*/arm*-linux-androideabi-*/*
+/target/*/arm*-linux-gnueabi-*/*
+/target/*/aarch64-linux-gnu-*/*
 /target/*/macosx*.*_x86_64-target-*/
 /target/*/macosx*.*_x86_64-target-*/*
 /target/*/macosx*.*_i386-target-*/


### PR DESCRIPTION
## Description
depend buid folders are currently not ignored due to recent changes in path names (-release / -debug) 
This PR fixes search pattern in .gitinore

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
