### PR TITLE
VideoPlayer: OpenGL - make sure rgb values are not neg after yuv2rgb …

### DIFF
--- a/system/shaders/GL/1.2/gl_yuv2rgb_basic.glsl
+++ b/system/shaders/GL/1.2/gl_yuv2rgb_basic.glsl
@@ -122,7 +122,7 @@ vec4 process()
 #endif
 
 #if defined(XBMC_COL_CONVERSION)
-  rgb.rgb = pow(rgb.rgb, vec3(m_gammaSrc));
+  rgb.rgb = pow(max(vec3(0), rgb.rgb), vec3(m_gammaSrc));
   rgb.rgb = max(vec3(0), m_primMat * rgb.rgb);
   rgb.rgb = pow(rgb.rgb, vec3(m_gammaDstInv));
 #endif

--- a/system/shaders/GL/1.5/gl_yuv2rgb_basic.glsl
+++ b/system/shaders/GL/1.5/gl_yuv2rgb_basic.glsl
@@ -93,7 +93,7 @@ vec4 process()
   rgb.a = m_alpha;
 
 #if defined(XBMC_COL_CONVERSION)
-  rgb.rgb = pow(rgb.rgb, vec3(m_gammaSrc));
+  rgb.rgb = pow(max(vec3(0), rgb.rgb), vec3(m_gammaSrc));
   rgb.rgb = max(vec3(0), m_primMat * rgb.rgb);
   rgb.rgb = pow(rgb.rgb, vec3(m_gammaDstInv));
 


### PR DESCRIPTION
When converting from yuv to rgb, and in particular from limited color range to full, resulting rgb values may be slightly negative. We have to make sure not to feed negative values into to pow operation.