### PR TITLE
[cmake][windows] require SDK 10.0.14393.0 or higher

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -1,3 +1,12 @@
+# Minimum SDK version we support
+set(VS_MINIMUM_SDK_VERSION 10.0.14393.0)
+
+if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_SDK_VERSION)
+  message(FATAL_ERROR "Detected Windows SDK version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}.\n"
+    "Windows SDK ${VS_MINIMUM_SDK_VERSION} or higher is required.\n"
+    "INFO: Windows SDKs can be installed from the Visual Studio installer.")
+endif()
+
 # -------- Architecture settings ---------
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -1,3 +1,12 @@
+# Minimum SDK version we support
+set(VS_MINIMUM_SDK_VERSION 10.0.14393.0)
+
+if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_SDK_VERSION)
+  message(FATAL_ERROR "Detected Windows SDK version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}.\n"
+    "Windows SDK ${VS_MINIMUM_SDK_VERSION} or higher is required.\n"
+    "INFO: Windows SDKs can be installed from the Visual Studio installer.")
+endif()
+
 # -------- Architecture settings ---------
 
 check_symbol_exists(_X86_ "Windows.h" _X86_)
@@ -102,9 +111,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF")
 # remove warning
 set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4264")
-
-# Minimum SDK version we support
-set(VS_MINIMUM_SDK_VERSION 10.0.14393.0)
 
 
 # -------- Visual Studio options ---------


### PR DESCRIPTION
## Motivation and Context
report already during project generation that a higher Windows SDK is needed instead of later failing to build because of undefined symbols.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
