### PR TITLE
[Music]Fix FileItem::IsSamePath for albums and artists

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1506,6 +1506,12 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       return (item->GetProperty("item_start") == GetProperty("item_start"));
     return true;
   }
+  if (HasMusicInfoTag() && item->HasMusicInfoTag())
+  {
+    if (GetMusicInfoTag()->GetDatabaseId() != -1 && item->GetMusicInfoTag()->GetDatabaseId() != -1)
+      return ((GetMusicInfoTag()->GetDatabaseId() == item->GetMusicInfoTag()->GetDatabaseId()) &&
+        (GetMusicInfoTag()->GetType() == item->GetMusicInfoTag()->GetType()));
+  }
   if (HasVideoInfoTag() && item->HasVideoInfoTag())
   {
     if (GetVideoInfoTag()->m_iDbId != -1 && item->GetVideoInfoTag()->m_iDbId != -1)


### PR DESCRIPTION
When MusicInfoTags are available comparing the DBId and the Type is a both more accurate and quicker test that two items are the same path.

Without it `CFileItem::IsSamePath` can return false matches if the file items are albums or artists i.e. library items that do not have a URL.

A similar fix was applied for video 4 years ago in #4345, this is a much belated catch-up for music.