### PR TITLE
[PVR] Fix return value of CDVDInputStreamPVRManager::SeekTime.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -354,7 +354,7 @@ bool CDVDInputStreamPVRManager::SeekTime(double timems, bool backwards, double *
   CPVRClientPtr client;
   if (CServiceBroker::GetPVRManager().Clients()->GetPlayingClient(client))
   {
-    return client->SeekTime(timems, backwards, startpts);
+    return client->SeekTime(timems, backwards, startpts) == PVR_ERROR_NO_ERROR;
   }
   return false;
 }


### PR DESCRIPTION
Fixes a regression introduced with #13094 

@FernetMenta good to go?