### PR TITLE
MMAL: Render improvements for 10bit and side-by-side UV

### DIFF
--- a/xbmc/cores/RetroPlayer/process/rbpi/RenderBufferPoolMMAL.cpp
+++ b/xbmc/cores/RetroPlayer/process/rbpi/RenderBufferPoolMMAL.cpp
@@ -66,7 +66,7 @@ bool CRenderBufferPoolMMAL::ConfigureInternal()
 
   m_alignedWidth = m_width;
   m_alignedHeight = m_height;
-  const unsigned int bpp = g_RBP.GetFrameGeometry(m_mmal_format, m_width, m_height).bytes_per_pixel;
+  const unsigned int bpp = g_RBP.GetFrameGeometry(m_mmal_format, m_width, m_height).getBytesPerPixel();
   m_frameSize = m_width * m_height * bpp;
 
   if (m_frameSize == 0)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -379,6 +379,14 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   {
     case AV_CODEC_ID_H264:
       // H.264
+      switch (hints.profile)
+      {
+        // Cannot hardware decode Hi10P without artifacts - switch to software on Pi2/Pi3
+        case FF_PROFILE_H264_HIGH_10:
+        case FF_PROFILE_H264_HIGH_10_INTRA:
+          if (g_RBP.RaspberryPiVersion() > 1)
+            return false;
+      }
       m_codingType = MMAL_ENCODING_H264;
       m_pFormatName = "mmal-h264";
       if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_SUPPORTMVC))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -189,6 +189,9 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *frame, int flags)
     int aligned_height = frame->height;
     // ffmpeg requirements
     AlignedSize(dec->m_avctx, aligned_width, aligned_height);
+    // GPU requirements
+    aligned_width = ALIGN_UP(aligned_width, 32);
+    aligned_height = ALIGN_UP(aligned_height, 16);
     pool->Configure(dec->m_fmt, frame->width, frame->height, aligned_width, aligned_height, 0);
   }
   CMMALYUVBuffer *YUVBuffer = dynamic_cast<CMMALYUVBuffer *>(pool->Get());

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -94,11 +94,17 @@ void CMMALYUVBuffer::GetStrides(int(&strides)[YuvImage::MAX_PLANES])
   strides[2] = geo.stride_c;
 }
 
-void CMMALYUVBuffer::SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES])
+void CMMALYUVBuffer::SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES])
 {
   std::shared_ptr<CMMALPool> pool = std::dynamic_pointer_cast<CMMALPool>(m_pool);
   assert(pool);
-  pool->SetDimensions(width, height, strides[0], height);
+  pool->SetDimensions(width, height, strides, planeOffsets);
+}
+
+void CMMALYUVBuffer::SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES])
+{
+  const int (&planeOffsets)[YuvImage::MAX_PLANES] = {};
+  SetDimensions(width, height, strides, planeOffsets);
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -276,7 +276,8 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 
   if (frame)
   {
-    if ((frame->format != AV_PIX_FMT_YUV420P && frame->format != AV_PIX_FMT_BGR0 && frame->format != AV_PIX_FMT_RGB565LE) ||
+    if ((frame->format != AV_PIX_FMT_YUV420P && frame->format != AV_PIX_FMT_YUV420P10 && frame->format != AV_PIX_FMT_YUV420P12 && frame->format != AV_PIX_FMT_YUV420P14 && frame->format != AV_PIX_FMT_YUV420P16 &&
+        frame->format != AV_PIX_FMT_BGR0 && frame->format != AV_PIX_FMT_RGB565LE) ||
         frame->buf[1] != nullptr || frame->buf[0] == nullptr)
     {
       CLog::Log(LOGERROR, "%s::%s frame format invalid format:%d buf:%p,%p", CLASSNAME, __func__,

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -40,9 +40,10 @@ public:
   CMMALYUVBuffer(int id);
   virtual ~CMMALYUVBuffer();
   uint8_t* GetMemPtr() override;
-  virtual void GetPlanes(uint8_t*(&planes)[YuvImage::MAX_PLANES]);
-  virtual void GetStrides(int(&strides)[YuvImage::MAX_PLANES]);
-  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]);
+  virtual void GetPlanes(uint8_t*(&planes)[YuvImage::MAX_PLANES]) override;
+  virtual void GetStrides(int(&strides)[YuvImage::MAX_PLANES]) override;
+  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) override;
+  virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) override;
   CGPUMEM *Allocate(int size, void *opaque) { m_gmem = new CGPUMEM(size, true); if (m_gmem) m_gmem->m_opaque = opaque; return m_gmem; }
   CGPUMEM *GetMem() { return m_gmem; }
 protected:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -44,7 +44,7 @@ public:
   virtual void GetStrides(int(&strides)[YuvImage::MAX_PLANES]) override;
   virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) override;
   virtual void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) override;
-  CGPUMEM *Allocate(int size, void *opaque) { m_gmem = new CGPUMEM(size, true); if (m_gmem) m_gmem->m_opaque = opaque; return m_gmem; }
+  CGPUMEM *Allocate(int size, void *opaque);
   CGPUMEM *GetMem() { return m_gmem; }
 protected:
   CGPUMEM *m_gmem = nullptr;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -268,8 +268,11 @@ void CMMALPool::Configure(AVPixelFormat format, int size)
   Configure(format, 0, 0, 0, 0, size);
 }
 
-void CMMALPool::SetDimensions(int width, int height, int alignedWidth, int alignedHeight)
+void CMMALPool::SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES])
 {
+  assert(m_geo.bytes_per_pixel);
+  int alignedWidth = strides[0] ? strides[0] / m_geo.bytes_per_pixel : width;
+  int alignedHeight = planeOffsets[1] ? planeOffsets[1] / strides[0] : height;
   Configure(AV_PIX_FMT_NONE, width, height, alignedWidth, alignedHeight, 0);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -227,7 +227,7 @@ uint32_t CMMALPool::TranslateFormat(AVPixelFormat pixfmt)
 void CMMALPool::Configure(AVPixelFormat format, int width, int height, int alignedWidth, int alignedHeight, int size)
 {
   CSingleLock lock(m_critSection);
-  if (m_mmal_format == MMAL_ENCODING_UNKNOWN)
+  if (format != AV_PIX_FMT_NONE)
     m_mmal_format = TranslateFormat(format);
   m_width = width;
   m_height = height;
@@ -242,13 +242,13 @@ void CMMALPool::Configure(AVPixelFormat format, int width, int height, int align
     {
       if (alignedWidth)
       {
-        m_geo.stride_y = alignedWidth;
-        m_geo.stride_c = alignedWidth>>1;
+        m_geo.stride_y = alignedWidth * m_geo.bytes_per_pixel;
+        m_geo.stride_c = alignedWidth * m_geo.bytes_per_pixel >> 1;
       }
       if (alignedHeight)
       {
         m_geo.height_y = alignedHeight;
-        m_geo.height_c = alignedHeight>>1;
+        m_geo.height_c = alignedHeight >> 1;
       }
     }
   }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -598,6 +598,7 @@ CMMALRenderer::CMMALRenderer() : CThread("MMALRenderer"), m_processThread(this, 
   m_deint_aligned_height = 0;
   m_cachedSourceRect.SetRect(0, 0, 0, 0);
   m_cachedDestRect.SetRect(0, 0, 0, 0);
+  m_isPi1 = g_RBP.RaspberryPiVersion() == 1;
 
   m_queue_process = mmal_queue_create();
   m_processThread.Create();
@@ -740,7 +741,7 @@ void CMMALRenderer::Run()
         {
           interlace_method = VS_INTERLACEMETHOD_MMAL_ADVANCED;
           // avoid advanced deinterlace when using software decode and HD resolution
-          if (omvb->m_state == MMALStateFFDec && omvb->Width() * omvb->Height() > 720*576)
+          if ((omvb->m_state == MMALStateFFDec || m_isPi1) && omvb->Width() * omvb->Height() > 720*576)
             interlace_method = VS_INTERLACEMETHOD_MMAL_BOB;
         }
         bool interlace = (omvb->mmal_buffer->flags & MMAL_BUFFER_HEADER_VIDEO_FLAG_INTERLACED) ? true:false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -198,6 +198,11 @@ CMMALPool::~CMMALPool()
 std::vector<CMMALPool::MMALEncodingTable> CMMALPool::mmal_encoding_table =
 {
   { AV_PIX_FMT_YUV420P,  MMAL_ENCODING_I420 },
+  { AV_PIX_FMT_YUVJ420P, MMAL_ENCODING_I420 },
+  { AV_PIX_FMT_YUV420P10,MMAL_ENCODING_I420_16, },
+  { AV_PIX_FMT_YUV420P12,MMAL_ENCODING_I420_16, },
+  { AV_PIX_FMT_YUV420P14,MMAL_ENCODING_I420_16, },
+  { AV_PIX_FMT_YUV420P16,MMAL_ENCODING_I420_16, },
   { AV_PIX_FMT_RGBA,     MMAL_ENCODING_RGBA, },
   { AV_PIX_FMT_BGRA,     MMAL_ENCODING_BGRA },
   { AV_PIX_FMT_RGB0,     MMAL_ENCODING_RGBA },
@@ -236,7 +241,7 @@ void CMMALPool::Configure(AVPixelFormat format, int width, int height, int align
   if (m_mmal_format != MMAL_ENCODING_UNKNOWN)
   {
     m_geo = g_RBP.GetFrameGeometry(m_mmal_format, alignedWidth, alignedHeight);
-    if (m_mmal_format != MMAL_ENCODING_YUVUV128)
+    if (m_mmal_format != MMAL_ENCODING_YUVUV128 && m_mmal_format != MMAL_ENCODING_YUVUV64_16 )
     {
       if (alignedWidth)
       {
@@ -728,6 +733,7 @@ void CMMALRenderer::Run()
     {
       if (buffer->length > 0)
       {
+        int yuv16 = omvb->Encoding() == MMAL_ENCODING_I420_16 || omvb->Encoding() == MMAL_ENCODING_YUVUV64_16;
         EINTERLACEMETHOD last_interlace_method = m_interlace_method;
         EINTERLACEMETHOD interlace_method = m_videoSettings.m_InterlaceMethod;
         if (interlace_method == VS_INTERLACEMETHOD_AUTO)
@@ -757,13 +763,17 @@ void CMMALRenderer::Run()
             interlace_method = VS_INTERLACEMETHOD_MMAL_BOB_HALF;
         }
 
-        if (interlace_method == VS_INTERLACEMETHOD_NONE)
+        if (interlace_method == VS_INTERLACEMETHOD_NONE && !yuv16)
         {
           if (m_deint_input)
             DestroyDeinterlace();
         }
-        else if (m_deint_input || interlace)
-          CheckConfigurationDeint(omvb->Width(), omvb->Height(), omvb->AlignedWidth(), omvb->AlignedHeight(), omvb->Encoding(), interlace_method);
+
+        if (yuv16)
+          interlace_method = VS_INTERLACEMETHOD_NONE;
+
+        if (yuv16 || (interlace_method != VS_INTERLACEMETHOD_NONE && (m_deint_input || interlace)))
+          CheckConfigurationDeint(omvb->Width(), omvb->Height(), omvb->AlignedWidth(), omvb->AlignedHeight(), omvb->Encoding(), interlace_method, omvb->BitsPerPixel());
 
         if (!m_deint_input)
           m_interlace_method = VS_INTERLACEMETHOD_NONE;
@@ -1362,7 +1372,7 @@ void CMMALRenderer::DestroyDeinterlace()
   m_deint = nullptr;
 }
 
-bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding, EINTERLACEMETHOD interlace_method)
+bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding, EINTERLACEMETHOD interlace_method, int bitsPerPixel)
 {
   MMAL_STATUS_T status;
   bool sizeChanged = width != m_deint_width || height != m_deint_height || aligned_width != m_deint_aligned_width || aligned_height != m_deint_aligned_height;
@@ -1371,6 +1381,7 @@ bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uin
   bool advanced_deinterlace = interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED || interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF;
   bool half_framerate = interlace_method == VS_INTERLACEMETHOD_MMAL_ADVANCED_HALF || interlace_method == VS_INTERLACEMETHOD_MMAL_BOB_HALF;
   uint32_t output_encoding = advanced_deinterlace ? MMAL_ENCODING_YUVUV128 : MMAL_ENCODING_I420;
+  const char *component = interlace_method == VS_INTERLACEMETHOD_NONE ? "vc.ril.isp" : "vc.ril.image_fx";
 
   if (!m_bConfigured)
   {
@@ -1383,7 +1394,7 @@ bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uin
     CLog::Log(LOGDEBUG, LOGVIDEO, "%s::%s CreateDeinterlace", CLASSNAME, __func__);
 
     /* Create deinterlace component with attached pool */
-    m_deint_output_pool = std::make_shared<CMMALPool>("vc.ril.image_fx", false, 3, 0, output_encoding, MMALStateDeint);
+    m_deint_output_pool = std::make_shared<CMMALPool>(component, false, 3, 0, output_encoding, MMALStateDeint);
     if (!m_deint_output_pool)
     {
       CLog::Log(LOGERROR, "%s::%s Failed to create pool for deint output", CLASSNAME, __func__);
@@ -1402,10 +1413,10 @@ bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uin
   if (m_deint_input && (sizeChanged || deinterlaceChanged || encodingChanged))
   {
     assert(m_deint_input != nullptr && m_deint_input->format != nullptr && m_deint_input->format->es != nullptr);
-    CLog::Log(LOGDEBUG, "%s::%s Changing Deint dimensions from %dx%d (%dx%d) to %dx%d (%dx%d) %.4s->%.4s mode %d->%d", CLASSNAME, __func__,
+    CLog::Log(LOGDEBUG, "%s::%s Changing Deint dimensions from %dx%d (%dx%d) to %dx%d (%dx%d) %.4s->%.4s mode %d->%d bpp:%d", CLASSNAME, __func__,
         m_deint_input->format->es->video.crop.width, m_deint_input->format->es->video.crop.height,
         m_deint_input->format->es->video.width, m_deint_input->format->es->video.height, width, height, aligned_width, aligned_height,
-        (char *)&m_deint_input->format->encoding, (char *)&encoding, m_interlace_method, interlace_method);
+        (char *)&m_deint_input->format->encoding, (char *)&encoding, m_interlace_method, interlace_method, bitsPerPixel);
 
     // we need to disable port when parameters change
     if (m_deint_input && m_deint_input->is_enabled)
@@ -1467,22 +1478,36 @@ bool CMMALRenderer::CheckConfigurationDeint(uint32_t width, uint32_t height, uin
     }
   }
 
+
   if (m_deint_output && (sizeChanged || deinterlaceChanged || encodingChanged))
   {
-    MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imfx_param = {{MMAL_PARAMETER_IMAGE_EFFECT_PARAMETERS, sizeof(imfx_param)},
-          advanced_deinterlace ? MMAL_PARAM_IMAGEFX_DEINTERLACE_ADV : MMAL_PARAM_IMAGEFX_DEINTERLACE_FAST, 4, {5, 0, half_framerate, 1 }};
-
-    status = mmal_port_parameter_set(m_deint_output, &imfx_param.hdr);
-    if (status != MMAL_SUCCESS)
+    if (interlace_method != VS_INTERLACEMETHOD_NONE)
     {
-      CLog::Log(LOGERROR, "%s::%s Failed to set deinterlace parameters (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-      return false;
-    }
+      MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imfx_param = {{MMAL_PARAMETER_IMAGE_EFFECT_PARAMETERS, sizeof(imfx_param)},
+            advanced_deinterlace ? MMAL_PARAM_IMAGEFX_DEINTERLACE_ADV : MMAL_PARAM_IMAGEFX_DEINTERLACE_FAST, 4, {5, 0, half_framerate, 1 }};
 
-    // Image_fx assumed 3 frames of context. simple deinterlace doesn't require this
-    status = mmal_port_parameter_set_uint32(m_deint_input, MMAL_PARAMETER_EXTRA_BUFFERS, 6 - 5 + advanced_deinterlace ? 2:0);
-    if (status != MMAL_SUCCESS)
-      CLog::Log(LOGERROR, "%s::%s Failed to enable extra buffers on %s (status=%x %s)", CLASSNAME, __func__, m_deint_input->name, status, mmal_status_to_string(status));
+      status = mmal_port_parameter_set(m_deint_output, &imfx_param.hdr);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed to set deinterlace parameters (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return false;
+      }
+
+      // Image_fx assumed 3 frames of context. simple deinterlace doesn't require this
+      status = mmal_port_parameter_set_uint32(m_deint_input, MMAL_PARAMETER_EXTRA_BUFFERS, 6 - 5 + advanced_deinterlace ? 2:0);
+      if (status != MMAL_SUCCESS)
+        CLog::Log(LOGERROR, "%s::%s Failed to enable extra buffers on %s (status=%x %s)", CLASSNAME, __func__, m_deint_input->name, status, mmal_status_to_string(status));
+    }
+    else
+    {
+      // We need to scale the YUV to 16-bit
+      status = mmal_port_parameter_set_int32(m_deint_input, MMAL_PARAMETER_CCM_SHIFT, 16-bitsPerPixel-1);
+      if (status != MMAL_SUCCESS)
+        CLog::Log(LOGERROR, "%s::%s Failed to configure MMAL_PARAMETER_CCM_SHIFT on %s (status=%x %s)", CLASSNAME, __func__, m_deint_input->name, status, mmal_status_to_string(status));
+      status = mmal_port_parameter_set_uint32(m_deint_output, MMAL_PARAMETER_OUTPUT_SHIFT, 1);
+      if (status != MMAL_SUCCESS)
+        CLog::Log(LOGERROR, "%s::%s Failed to configure MMAL_PARAMETER_OUTPUT_SHIFT on %s (status=%x %s)", CLASSNAME, __func__, m_deint_output->name, status, mmal_status_to_string(status));
+    }
   }
 
   if (m_deint_output && (sizeChanged || deinterlaceChanged || encodingChanged))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -273,6 +273,9 @@ void CMMALPool::SetDimensions(int width, int height, const int (&strides)[YuvIma
   int alignedWidth = strides[0] ? strides[0] / m_geo.getBytesPerPixel() : width;
   int alignedHeight = planeOffsets[1] ? planeOffsets[1] / strides[0] : height;
   Configure(AV_PIX_FMT_NONE, width, height, alignedWidth, alignedHeight, 0);
+  // libwv side-by-side UV format
+  if (planeOffsets[2] - planeOffsets[1] == strides[1] >> 1)
+    m_mmal_format = MMAL_ENCODING_I420_S;
 }
 
 inline bool CMMALPool::IsConfigured()
@@ -285,6 +288,8 @@ bool CMMALPool::IsCompatible(AVPixelFormat format, int size)
 {
   CSingleLock lock(m_critSection);
   uint32_t mmal_format = TranslateFormat(format);
+  if (m_mmal_format == MMAL_ENCODING_I420_S && mmal_format == MMAL_ENCODING_I420)
+    return true;
   if (m_mmal_format == mmal_format &&
       m_size == size)
     return true;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -69,8 +69,9 @@ public:
   static uint32_t TranslateFormat(AVPixelFormat pixfmt);
   virtual int Width() { return m_width; }
   virtual int Height() { return m_height; }
-  virtual int AlignedWidth() { return m_geo.stride_y / m_geo.bytes_per_pixel; }
-  virtual int AlignedHeight() { return m_geo.height_y; }
+  virtual int AlignedWidth() { return m_mmal_format == MMAL_ENCODING_YUVUV128 || m_mmal_format == MMAL_ENCODING_YUVUV64_16 ? 0 : m_geo.getStrideY() / m_geo.getBytesPerPixel(); }
+  virtual int AlignedHeight() { return m_mmal_format == MMAL_ENCODING_YUVUV128 || m_mmal_format == MMAL_ENCODING_YUVUV64_16 ? 0 : m_geo.getHeightY(); }
+  virtual int BitsPerPixel() { return m_geo.getBitsPerPixel(); }
   virtual uint32_t &Encoding() { return m_mmal_format; }
   virtual int Size() { return m_size; }
   AVRpiZcFrameGeometry &GetGeometry() { return m_geo; }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -58,7 +58,7 @@ public:
   virtual bool IsConfigured() override;
   virtual bool IsCompatible(AVPixelFormat format, int size) override;
 
-  void SetDimensions(int width, int height, int alignedWidth, int alignedHeight);
+  void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]);
   MMAL_COMPONENT_T *GetComponent() { return m_component; }
   CMMALBuffer *GetBuffer(uint32_t timeout);
   void Prime();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -190,6 +190,7 @@ protected:
   RENDER_STEREO_MODE        m_video_stereo_mode;
   RENDER_STEREO_MODE        m_display_stereo_mode;
   bool                      m_StereoInvert;
+  bool                      m_isPi1;
 
   CCriticalSection m_sharedSection;
   MMAL_COMPONENT_T *m_vout;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -111,7 +111,6 @@ public:
   CMMALBuffer(int id);
   virtual ~CMMALBuffer();
   MMAL_BUFFER_HEADER_T *mmal_buffer = nullptr;
-  uint32_t m_encoding = MMAL_ENCODING_UNKNOWN;
   float m_aspect_ratio = 0.0f;
   MMALState m_state = MMALStateNone;
   bool m_rendered = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -124,6 +124,7 @@ public:
   virtual int AlignedWidth() { return Pool()->AlignedWidth(); }
   virtual int AlignedHeight() { return Pool()->AlignedHeight(); }
   virtual uint32_t &Encoding() { return Pool()->Encoding(); }
+  virtual int BitsPerPixel() { return Pool()->BitsPerPixel(); }
   virtual void Update();
 
   void SetVideoDeintMethod(std::string method);
@@ -212,7 +213,7 @@ protected:
   uint32_t m_deint_width, m_deint_height, m_deint_aligned_width, m_deint_aligned_height;
   MMAL_FOURCC_T m_deinterlace_out_encoding;
   void DestroyDeinterlace();
-  bool CheckConfigurationDeint(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding, EINTERLACEMETHOD interlace_method);
+  bool CheckConfigurationDeint(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding, EINTERLACEMETHOD interlace_method, int bitsPerPixel);
 
   bool CheckConfigurationVout(uint32_t width, uint32_t height, uint32_t aligned_width, uint32_t aligned_height, uint32_t encoding);
   uint32_t m_vsync_count;

--- a/xbmc/cores/omxplayer/OMXVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXVideo.cpp
@@ -82,6 +82,7 @@ COMXVideo::COMXVideo(CRenderManager& renderManager, CProcessInfo &processInfo) :
   m_settings_changed  = false;
   m_setStartTime      = false;
   m_transform         = OMX_DISPLAY_ROT0;
+  m_isPi1             = g_RBP.RaspberryPiVersion() == 1;
 }
 
 COMXVideo::~COMXVideo()
@@ -232,7 +233,7 @@ bool COMXVideo::PortSettingsChanged(ResolutionUpdateInfo &resinfo)
 
   EINTERLACEMETHOD interlace_method = m_processInfo.GetVideoSettings().m_InterlaceMethod;
   if (interlace_method == VS_INTERLACEMETHOD_AUTO)
-    interlace_method = VS_INTERLACEMETHOD_MMAL_ADVANCED;
+    interlace_method = m_isPi1 ? VS_INTERLACEMETHOD_MMAL_BOB : VS_INTERLACEMETHOD_MMAL_ADVANCED;
 
   if (m_deinterlace && interlace_method != VS_INTERLACEMETHOD_NONE)
   {

--- a/xbmc/cores/omxplayer/OMXVideo.h
+++ b/xbmc/cores/omxplayer/OMXVideo.h
@@ -109,6 +109,7 @@ protected:
   bool              m_failed_eos;
   OMX_DISPLAYTRANSFORMTYPE m_transform;
   bool              m_settings_changed;
+  bool              m_isPi1;
   CRenderManager&   m_renderManager;
   CProcessInfo&     m_processInfo;
   static bool NaluFormatStartCodes(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize);

--- a/xbmc/platform/linux/RBP.cpp
+++ b/xbmc/platform/linux/RBP.cpp
@@ -444,6 +444,7 @@ AVRpiZcFrameGeometry CRBP::GetFrameGeometry(uint32_t encoding, unsigned short vi
     geo.setHeightY(video_height);
     break;
   case MMAL_ENCODING_I420:
+  case MMAL_ENCODING_I420_S:
     geo.setStrideY((video_width + 31) & ~31);
     geo.setStrideC(geo.getStrideY() >> 1);
     geo.setHeightY((video_height + 15) & ~15);

--- a/xbmc/platform/linux/RBP.cpp
+++ b/xbmc/platform/linux/RBP.cpp
@@ -401,9 +401,12 @@ CGPUMEM::CGPUMEM(unsigned int numbytes, bool cached)
 
 CGPUMEM::~CGPUMEM()
 {
-  mem_unlock(g_RBP.GetMBox(), m_vc_handle);
-  vcsm_unlock_ptr(m_arm);
-  vcsm_free(m_vcsm_handle);
+  if (m_vc_handle)
+    mem_unlock(g_RBP.GetMBox(), m_vc_handle);
+  if (m_arm)
+    vcsm_unlock_ptr(m_arm);
+  if (m_vcsm_handle)
+    vcsm_free(m_vcsm_handle);
 }
 
 // Call this to clean and invalidate a region of memory

--- a/xbmc/platform/linux/RBP.cpp
+++ b/xbmc/platform/linux/RBP.cpp
@@ -419,37 +419,37 @@ void CGPUMEM::Flush()
 
 AVRpiZcFrameGeometry CRBP::GetFrameGeometry(uint32_t encoding, unsigned short video_width, unsigned short video_height)
 {
-  AVRpiZcFrameGeometry geo = {};
-  geo.stripes = 1;
-  geo.bytes_per_pixel = 1;
+  AVRpiZcFrameGeometry geo;
+  geo.setStripes(1);
+  geo.setBitsPerPixel(8);
 
   switch (encoding)
   {
   case MMAL_ENCODING_RGBA: case MMAL_ENCODING_BGRA:
-    geo.bytes_per_pixel = 4;
-    geo.stride_y = video_width * geo.bytes_per_pixel;
-    geo.height_y = video_height;
+    geo.setBitsPerPixel(32);
+    geo.setStrideY(video_width * geo.getBytesPerPixel());
+    geo.setHeightY(video_height);
     break;
   case MMAL_ENCODING_RGB24: case MMAL_ENCODING_BGR24:
-    geo.bytes_per_pixel = 3;
-    geo.stride_y = video_width * geo.bytes_per_pixel;
-    geo.height_y = video_height;
+    geo.setBitsPerPixel(32);
+    geo.setStrideY(video_width * geo.getBytesPerPixel());
+    geo.setHeightY(video_height);
     break;
   case MMAL_ENCODING_RGB16: case MMAL_ENCODING_BGR16:
-    geo.bytes_per_pixel = 2;
-    geo.stride_y = video_width * geo.bytes_per_pixel;
-    geo.height_y = video_height;
+    geo.setBitsPerPixel(16);
+    geo.setStrideY(video_width * geo.getBytesPerPixel());
+    geo.setHeightY(video_height);
     break;
   case MMAL_ENCODING_I420:
-    geo.stride_y = (video_width + 31) & ~31;
-    geo.stride_c = geo.stride_y >> 1;
-    geo.height_y = (video_height + 15) & ~15;
-    geo.height_c = geo.height_y >> 1;
-    geo.planes_c = 2;
+    geo.setStrideY((video_width + 31) & ~31);
+    geo.setStrideC(geo.getStrideY() >> 1);
+    geo.setHeightY((video_height + 15) & ~15);
+    geo.setHeightC(geo.getHeightY() >> 1);
+    geo.setPlanesC(2);
     break;
   case MMAL_ENCODING_OPAQUE:
-    geo.stride_y = video_width;
-    geo.height_y = video_height;
+    geo.setStrideY(video_width);
+    geo.setHeightY(video_height);
     break;
   case MMAL_ENCODING_YUVUV128:
   {
@@ -460,12 +460,12 @@ AVRpiZcFrameGeometry CRBP::GetFrameGeometry(uint32_t encoding, unsigned short vi
     int rc = get_image_params(GetMBox(), &img);
     assert(rc == 0);
     const unsigned int stripe_w = 128;
-    geo.stride_y = stripe_w;
-    geo.stride_c = stripe_w;
-    geo.height_y = ((intptr_t)img.extra.uv.u - (intptr_t)img.image_data) / stripe_w;
-    geo.height_c = img.pitch / stripe_w - geo.height_y;
-    geo.planes_c = 1;
-    geo.stripes = (video_width + stripe_w - 1) / stripe_w;
+    geo.setStrideY(stripe_w);
+    geo.setStrideC(stripe_w);
+    geo.setHeightY(((intptr_t)img.extra.uv.u - (intptr_t)img.image_data) / stripe_w);
+    geo.setHeightC(img.pitch / stripe_w - geo.getHeightY());
+    geo.setPlanesC(1);
+    geo.setStripes((video_width + stripe_w - 1) / stripe_w);
     break;
   }
   default: assert(0);

--- a/xbmc/platform/linux/RBP.h
+++ b/xbmc/platform/linux/RBP.h
@@ -36,16 +36,37 @@
 #include "threads/Event.h"
 
 
-typedef struct AVRpiZcFrameGeometry
+class AVRpiZcFrameGeometry
 {
-  unsigned int stride_y;
-  unsigned int height_y;
-  unsigned int stride_c;
-  unsigned int height_c;
-  unsigned int planes_c;
-  unsigned int stripes;
-  unsigned int bytes_per_pixel;
-} AVRpiZcFrameGeometry;
+public:
+  unsigned int getStrideY() { return stride_y; }
+  unsigned int getHeightY() { return height_y; }
+  unsigned int getStrideC() { return stride_c; }
+  unsigned int getHeightC() { return height_c; }
+  unsigned int getPlanesC() { return planes_c; }
+  unsigned int getStripes() { return stripes; }
+  unsigned int getBitsPerPixel() { return bits_per_pixel; }
+  unsigned int getBytesPerPixel() { return (bits_per_pixel + 7) >> 3; }
+  unsigned int getSizeY() { return stride_y * height_y; }
+  unsigned int getSizeC() { return stride_c * height_c; }
+  unsigned int getSize() { return (getSizeY() + getSizeC() * getPlanesC()) * getStripes(); }
+  void setStrideY(unsigned int v) { stride_y = v; }
+  void setHeightY(unsigned int v) { height_y = v; }
+  void setStrideC(unsigned int v) { stride_c = v; }
+  void setHeightC(unsigned int v) { height_c = v; }
+  void setPlanesC(unsigned int v) { planes_c = v; }
+  void setStripes(unsigned int v) { stripes = v; }
+  void setBitsPerPixel(unsigned int v) { bits_per_pixel = v; }
+  void setBytesPerPixel(unsigned int v) { bits_per_pixel = v * 8; }
+private:
+  unsigned int stride_y = 0;
+  unsigned int height_y = 0;
+  unsigned int stride_c = 0;
+  unsigned int height_c = 0;
+  unsigned int planes_c = 0;
+  unsigned int stripes = 0;
+  unsigned int bits_per_pixel = 0;
+};
 
 class CGPUMEM
 {


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Improvements from test branch that allow rendering of 10-bit formats (e.g. Hi10P) and the side-by-side UV format that widevine has recently moved to.

## Motivation and Context
Allows Hi10P video to be displayed (after software decode) without artefacts.
Gets widevine decode working again after recent update.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Been in Milhouse nightly builds for a long time

<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
