### PR TITLE
[cleanup] remove ifdefs for old lib, os & compiler versions

### DIFF
--- a/cmake/modules/FindAlsa.cmake
+++ b/cmake/modules/FindAlsa.cmake
@@ -15,7 +15,7 @@
 #   ALSA::ALSA   - The Alsa library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_ALSA alsa QUIET)
+  pkg_check_modules(PC_ALSA alsa>=0.9 QUIET)
 endif()
 
 find_path(ALSA_INCLUDE_DIR NAMES alsa/asoundlib.h

--- a/cmake/modules/FindCdio.cmake
+++ b/cmake/modules/FindCdio.cmake
@@ -14,7 +14,7 @@
 #   CDIO::CDIO - The cdio library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_CDIO libcdio libiso9660 QUIET)
+  pkg_check_modules(PC_CDIO libcdio>=0.84 libiso9660 QUIET)
 endif()
 
 find_path(CDIO_INCLUDE_DIR NAMES cdio/cdio.h

--- a/cmake/modules/FindSSH.cmake
+++ b/cmake/modules/FindSSH.cmake
@@ -15,7 +15,7 @@
 #   SSH::SSH   - The SSH library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_SSH libssh QUIET)
+  pkg_check_modules(PC_SSH libssh>=0.6 QUIET)
 endif()
 
 find_path(SSH_INCLUDE_DIR NAMES libssh/libssh.h

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -40,13 +40,9 @@
 #undef PRAGMA_PACK_END
 
 #if defined(__GNUC__)
-  #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
-    #define ATTRIBUTE_PACKED __attribute__ ((packed))
-    #define PRAGMA_PACK 0
-  #if __GNUC__ >= 4
-    #define ATTRIBUTE_HIDDEN __attribute__ ((visibility ("hidden")))
-  #endif
-  #endif
+  #define ATTRIBUTE_PACKED __attribute__ ((packed))
+  #define PRAGMA_PACK 0
+  #define ATTRIBUTE_HIDDEN __attribute__ ((visibility ("hidden")))
 #endif
 
 #if !defined(ATTRIBUTE_PACKED)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -40,10 +40,8 @@
 #undef PRAGMA_PACK_END
 
 #if defined(__GNUC__)
-  #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
-    #define ATTRIBUTE_PACKED __attribute__ ((packed))
-    #define PRAGMA_PACK 0
-  #endif
+  #define ATTRIBUTE_PACKED __attribute__ ((packed))
+  #define PRAGMA_PACK 0
 #endif
 
 #if !defined(ATTRIBUTE_PACKED)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_epg_types.h
@@ -27,10 +27,8 @@
 #undef PRAGMA_PACK_END
 
 #if defined(__GNUC__)
-#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
 #define ATTRIBUTE_PACKED __attribute__ ((packed))
 #define PRAGMA_PACK 0
-#endif
 #endif
 
 #if !defined(ATTRIBUTE_PACKED)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -50,10 +50,8 @@ struct DemuxPacket;
 #undef PRAGMA_PACK_END
 
 #if defined(__GNUC__)
-#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
 #define ATTRIBUTE_PACKED __attribute__ ((packed))
 #define PRAGMA_PACK 0
-#endif
 #endif
 
 #if !defined(ATTRIBUTE_PACKED)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -926,9 +926,7 @@ void CAESinkALSA::GetDelay(AEDelayStatus& status)
 
   if (frames < 0)
   {
-#if SND_LIB_VERSION >= 0x000901 /* snd_pcm_forward() exists since 0.9.0rc8 */
     snd_pcm_forward(m_pcm, -frames);
-#endif
     frames = 0;
   }
 

--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -360,7 +360,6 @@ bool CSFTPSession::Connect(const std::string &host, unsigned int port, const std
     return false;
   }
 
-#if LIBSSH_VERSION_INT >= SSH_VERSION_INT(0,4,0)
   if (ssh_options_set(m_session, SSH_OPTIONS_USER, username.c_str()) < 0)
   {
     CLog::Log(LOGERROR, "SFTPSession: Failed to set username '%s' for session", username.c_str());
@@ -389,33 +388,6 @@ bool CSFTPSession::Connect(const std::string &host, unsigned int port, const std
 #endif
   ssh_options_set(m_session, SSH_OPTIONS_LOG_VERBOSITY, 0);
   ssh_options_set(m_session, SSH_OPTIONS_TIMEOUT, &timeout);  
-#else
-  SSH_OPTIONS* options = ssh_options_new();
-
-  if (ssh_options_set_username(options, username.c_str()) < 0)
-  {
-    CLog::Log(LOGERROR, "SFTPSession: Failed to set username '%s' for session", username.c_str());
-    return false;
-  }
-
-  if (ssh_options_set_host(options, host.c_str()) < 0)
-  {
-    CLog::Log(LOGERROR, "SFTPSession: Failed to set host '%s' for session", host.c_str());
-    return false;
-  }
-
-  if (ssh_options_set_port(options, port) < 0)
-  {
-    CLog::Log(LOGERROR, "SFTPSession: Failed to set port '%d' for session", port);
-    return false;
-  }
-  
-  ssh_options_set_timeout(options, timeout, 0);
-
-  ssh_options_set_log_verbosity(options, 0);
-
-  ssh_set_options(m_session, options);
-#endif
 
   if(ssh_connect(m_session))
   {
@@ -437,19 +409,11 @@ bool CSFTPSession::Connect(const std::string &host, unsigned int port, const std
     return false;
   }
 
-#if LIBSSH_VERSION_MINOR >= 6
   int method = ssh_userauth_list(m_session, NULL);
-#else
-  int method = ssh_auth_list(m_session);
-#endif
 
   // Try to authenticate with public key first
   int publicKeyAuth = SSH_AUTH_DENIED;
-#if LIBSSH_VERSION_MINOR >= 6
   if (method & SSH_AUTH_METHOD_PUBLICKEY && (publicKeyAuth = ssh_userauth_publickey_auto(m_session, NULL, NULL)) == SSH_AUTH_ERROR)
-#else
-  if (method & SSH_AUTH_METHOD_PUBLICKEY && (publicKeyAuth = ssh_userauth_autopubkey(m_session, NULL)) == SSH_AUTH_ERROR)
-#endif
   {
     CLog::Log(LOGERROR, "SFTPSession: Failed to authenticate via publickey '%s'", ssh_get_error(m_session));
     return false;

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -37,18 +37,6 @@
 
 class CURL;
 
-#if LIBSSH_VERSION_INT < SSH_VERSION_INT(0,3,2)
-#define ssh_session SSH_SESSION
-#endif
-
-#if LIBSSH_VERSION_INT < SSH_VERSION_INT(0,4,0)
-#define sftp_file SFTP_FILE*
-#define sftp_session SFTP_SESSION*
-#define sftp_attributes SFTP_ATTRIBUTES*
-#define sftp_dir SFTP_DIR*
-#define ssh_session ssh_session*
-#endif
-
 //five secs timeout for SFTP
 #define SFTP_TIMEOUT 5
 

--- a/xbmc/interfaces/swig/AddonModuleXbmc.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmc.i
@@ -34,7 +34,7 @@
 using namespace XBMCAddon;
 using namespace xbmc;
 
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
+#if defined(__GNUG__)
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 %}

--- a/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcaddon.i
@@ -30,7 +30,7 @@
 using namespace XBMCAddon;
 using namespace xbmcaddon;
 
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
+#if defined(__GNUG__)
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcgui.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcgui.i
@@ -38,7 +38,7 @@
 using namespace XBMCAddon;
 using namespace xbmcgui;
 
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
+#if defined(__GNUG__)
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcplugin.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcplugin.i
@@ -30,7 +30,7 @@
 using namespace XBMCAddon;
 using namespace xbmcplugin;
 
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
+#if defined(__GNUG__)
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcvfs.i
@@ -33,7 +33,7 @@
 using namespace XBMCAddon;
 using namespace xbmcvfs;
 
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
+#if defined(__GNUG__)
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 

--- a/xbmc/interfaces/swig/AddonModuleXbmcwsgi.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcwsgi.i
@@ -37,7 +37,7 @@
 using namespace XBMCAddon;
 using namespace xbmcwsgi;
 
-#if defined(__GNUG__) && (__GNUC__>4) || (__GNUC__==4 && __GNUC_MINOR__>=2)
+#if defined(__GNUG__)
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 

--- a/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
@@ -33,12 +33,6 @@ using namespace MEDIA_DETECT;
 using namespace CDDB;
 #endif
 
-#if defined (LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM > 83)
-#define CDTEXT_TITLE CDTEXT_FIELD_TITLE
-#define CDTEXT_PERFORMER CDTEXT_FIELD_PERFORMER
-#define CDTEXT_GENRE CDTEXT_FIELD_GENRE
-#endif
-
 CMusicInfoTagLoaderCDDA::CMusicInfoTagLoaderCDDA(void) = default;
 
 CMusicInfoTagLoaderCDDA::~CMusicInfoTagLoaderCDDA() = default;
@@ -119,7 +113,7 @@ bool CMusicInfoTagLoaderCDDA::Load(const std::string& strFileName, CMusicInfoTag
       trackinfo ti = pCdInfo->GetTrackInformation(iTrack);
 
       // Fill the fileitems music tag with CD-Text information, if available
-      std::string strTitle = ti.cdtext[CDTEXT_TITLE];
+      std::string strTitle = ti.cdtext[CDTEXT_FIELD_TITLE];
       if (!strTitle.empty())
       {
         // Tracknumber
@@ -132,20 +126,20 @@ bool CMusicInfoTagLoaderCDDA::Load(const std::string& strFileName, CMusicInfoTag
         xbmc_cdtext_t discCDText = pCdInfo->GetDiscCDTextInformation();
 
         // Artist: Use track artist or disc artist
-        std::string strArtist = ti.cdtext[CDTEXT_PERFORMER];
+        std::string strArtist = ti.cdtext[CDTEXT_FIELD_PERFORMER];
         if (strArtist.empty())
-          strArtist = discCDText[CDTEXT_PERFORMER];
+          strArtist = discCDText[CDTEXT_FIELD_PERFORMER];
         tag.SetArtist(strArtist);
 
         // Album
         std::string strAlbum;
-        strAlbum = discCDText[CDTEXT_TITLE];
+        strAlbum = discCDText[CDTEXT_FIELD_TITLE];
         tag.SetAlbum(strAlbum);
 
         // Genre: use track or disc genre
-        std::string strGenre = ti.cdtext[CDTEXT_GENRE];
+        std::string strGenre = ti.cdtext[CDTEXT_FIELD_GENRE];
         if (strGenre.empty())
-          strGenre = discCDText[CDTEXT_GENRE];
+          strGenre = discCDText[CDTEXT_FIELD_GENRE];
         tag.SetGenre( strGenre );
 
         tag.SetLoaded(true);

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -1247,11 +1247,7 @@ bool CTagLoaderTagLib::Load(const std::string& strFileName, CMusicInfoTag& tag, 
   else if (aiffFile)
     id3v2 = aiffFile->tag();
   else if (wavFile)
-#if TAGLIB_MAJOR_VERSION > 1 || TAGLIB_MINOR_VERSION > 8
     id3v2 = wavFile->ID3v2Tag();
-#else
-    id3v2 = wavFile->tag();
-#endif
   else if (wvFile)
     ape = wvFile->APETag(false);
   else if (mpcFile)

--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -28,12 +28,8 @@
  *
  */
 
-#include <linux/version.h>
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,16)
 typedef unsigned long kernel_ulong_t;
 #define BITS_PER_LONG    (sizeof(long)*8)
-#endif
 
 #include <linux/input.h>
 

--- a/xbmc/platform/win32/PlatformDefs.h
+++ b/xbmc/platform/win32/PlatformDefs.h
@@ -40,9 +40,6 @@ typedef intptr_t      ssize_t;
 #define SSIZE_MAX INTPTR_MAX
 #endif // !SSIZE_MAX
 
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
 #define ftello64 _ftelli64
 #define fseeko64 _fseeki64
 #ifndef strcasecmp
@@ -69,17 +66,6 @@ typedef intptr_t      ssize_t;
 #define PIXEL_RSHIFT 16
 #define PIXEL_GSHIFT 8
 #define PIXEL_BSHIFT 0
-#endif
-
-#if _MSC_VER < 1800
-#ifndef va_copy
-#define va_copy(dst, src) ((dst) = (src))
-#endif
-
-#define lrint(x) ((x) >= 0 ? ((int)((x) + 0.5)) : ((int)((x) - 0.5)))
-#define llrint(x) ((x) >= 0 ? ((__int64)((x) + 0.5)) : ((__int64)((x) - 0.5)))
-
-#define strtoll(p, e, b) _strtoi64(p, e, b)
 #endif
 
 extern "C" char * strptime(const char *buf, const char *fmt, struct tm *tm);

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -37,9 +37,6 @@
 #include "settings/AdvancedSettings.h"
 #include "GUIUserMessages.h"
 #include "utils/URIUtils.h"
-#if defined (LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM > 77) || defined (TARGET_DARWIN)
-#define USING_CDIO78
-#endif
 #include "guilib/GUIWindowManager.h"
 #include "FileItem.h"
 #include "Application.h"
@@ -314,49 +311,6 @@ DWORD CDetectDVDMedia::GetTrayState()
   if (strlen(dvdDevice) == 0)
     return DRIVE_NONE;
 
-#ifndef USING_CDIO78
-
-  int fd = 0;
-
-  fd = open(dvdDevice, O_RDONLY | O_NONBLOCK);
-  if (fd<0)
-  {
-    CLog::Log(LOGERROR, "Unable to open CD-ROM device %s for polling.", dvdDevice);
-    return DRIVE_NOT_READY;
-  }
-
-  int drivestatus = ioctl(fd, CDROM_DRIVE_STATUS, 0);
-
-  switch(drivestatus)
-  {
-  case CDS_NO_INFO:
-    m_dwTrayState = TRAY_CLOSED_NO_MEDIA;
-    break;
-
-  case CDS_NO_DISC:
-    m_dwTrayState = TRAY_CLOSED_NO_MEDIA;
-    break;
-
-  case CDS_TRAY_OPEN:
-    m_dwTrayState = TRAY_OPEN;
-    break;
-
-  case CDS_DISC_OK:
-    m_dwTrayState = TRAY_CLOSED_MEDIA_PRESENT;
-    break;
-
-  case CDS_DRIVE_NOT_READY:
-    close(fd);
-    return DRIVE_NOT_READY;
-
-  default:
-    m_dwTrayState = TRAY_CLOSED_NO_MEDIA;
-  }
-
-  close(fd);
-
-#else
-
   // The following code works with libcdio >= 0.78
   // To enable it, download and install the latest version from
   // http://www.gnu.org/software/libcdio/
@@ -393,7 +347,6 @@ DWORD CDetectDVDMedia::GetTrayState()
   else
     return DRIVE_NOT_READY;
 
-#endif // USING_CDIO78
 #endif // TARGET_POSIX
 
   if (m_dwTrayState == TRAY_CLOSED_MEDIA_PRESENT)

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -637,25 +637,14 @@ void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
   CSingleLock lock(*m_cdio);
 
   // Get the CD-Text , if any
-#if defined (LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM > 83)
   cdtext_t *pcdtext = static_cast<cdtext_t*>( cdio_get_cdtext(cdio) );
-#else
-  cdtext_t *pcdtext = (cdtext_t *)::cdio_get_cdtext(cdio, trackNum);
-#endif 
   
   if (pcdtext == NULL)
     return ;
 
-#if defined (LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM > 83)
   for (int i=0; i < MAX_CDTEXT_FIELDS; i++) 
     if (cdtext_get_const(pcdtext, (cdtext_field_t)i, trackNum))
       xcdt[(cdtext_field_t)i] = cdtext_field2str((cdtext_field_t)i);
-#else
-  // Same ids used in libcdio and for our structure + the ids are consecutive make this copy loop safe.
-  for (int i = 0; i < MAX_CDTEXT_FIELDS; i++)
-    if (pcdtext->field[i])
-      xcdt[(cdtext_field_t)i] = pcdtext->field[(cdtext_field_t)i];
-#endif
 #endif // TARGET_WINDOWS
 }
 

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -104,9 +104,7 @@ void CThread::SetThreadInfo()
 
 #if defined(HAVE_PTHREAD_SETNAME_NP)
 #ifdef TARGET_DARWIN
-#if(__MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 || __IPHONE_OS_VERSION_MIN_REQUIRED >= 30200)
   pthread_setname_np(m_ThreadName.c_str());
-#endif
 #else
   pthread_setname_np(m_ThreadId, m_ThreadName.c_str());
 #endif

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -28,11 +28,7 @@
 #include <string.h>
 #ifdef TARGET_FREEBSD
 #include <sys/param.h>
-#if __FreeBSD_version < 900031
-#include <sys/thr.h>
-#else
 #include <pthread_np.h>
-#endif
 #endif
 
 #include <signal.h>
@@ -89,13 +85,7 @@ void CThread::TermHandler() { }
 void CThread::SetThreadInfo()
 {
 #ifdef TARGET_FREEBSD
-#if __FreeBSD_version < 900031
-  long lwpid;
-  thr_self(&lwpid);
-  m_ThreadOpaque.LwpId = lwpid;
-#else
   m_ThreadOpaque.LwpId = pthread_getthreadid_np();
-#endif
 #elif defined(TARGET_ANDROID)
   m_ThreadOpaque.LwpId = gettid();
 #else

--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -34,16 +34,6 @@
 #include <openssl/crypto.h>
 #endif
 
-#ifdef HAVE_GCRYPT
-#include <gcrypt.h>
-#include <errno.h>
-
-#if GCRYPT_VERSION_NUMBER < 0x010600
-GCRY_THREAD_OPTION_PTHREAD_IMPL;
-#endif
-
-#endif
-
 /* ========================================================================= */
 /* openssl locking implementation for curl */
 #if defined(HAVE_OPENSSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -83,14 +73,6 @@ CryptThreadingInitializer::CryptThreadingInitializer()
   locks = new CCriticalSection*[numlocks];
   for (int i = 0; i < numlocks; i++)
     locks[i] = NULL;
-
-#ifdef HAVE_GCRYPT
-#if GCRYPT_VERSION_NUMBER < 0x010600
-  // set up gcrypt
-  gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-  attemptedToSetSSLMTHook = true;
-#endif
-#endif
 
   if (!attemptedToSetSSLMTHook)
     CLog::Log(LOGWARNING, "Could not determine the libcurl security library to set the locking scheme. This may cause problem with multithreaded use of ssl or libraries that depend on it (libcurl).");

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -1308,8 +1308,7 @@ std::string CSysInfo::GetBuildTargetPlatformVersionDecoded(void)
   static const int major = (__FreeBSD_version / 100000) % 100;
   static const int minor = (__FreeBSD_version / 1000) % 100;
   static const int Rxx = __FreeBSD_version % 1000;
-  if ((major < 9 && Rxx == 0) ||
-      __FreeBSD_version == 900044 || __FreeBSD_version == 901000)
+  if ((major < 9 && Rxx == 0))
     return StringUtils::Format("version %d.%d-RELEASE", major, minor);
   if (Rxx >= 500)
     return StringUtils::Format("version %d.%d-STABLE", major, minor);


### PR DESCRIPTION
## Motivation and Context
No need to keep ifdefs around, where it is questionable if other parts of the code work with such old versions.

## How Has This Been Tested?
compiled for Windows and Linux

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
