### PR TITLE
Fix crash when stopping the application

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -107,6 +107,12 @@ CAESinkALSA::CAESinkALSA() :
 
 CAESinkALSA::~CAESinkALSA()
 {
+  m_controlMonitor.Clear();
+
+#ifdef HAVE_LIBUDEV
+  m_deviceMonitor.Stop();
+#endif
+
   Deinitialize();
 }
 


### PR DESCRIPTION
The ALSADeviceMonitor and the ALSAHControlMonitor need to be
stopped when the sink is destroyed.
Otherwise it may trigger a "device change event" when the windowing
system is destroyed and results in a segfault.
I can trigger this reliably without this fix using GBM and ALSA.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
