### PR TITLE
[fix] add back libcdio 0.83 compatibility after 98565c188b

### DIFF
--- a/cmake/modules/FindCdio.cmake
+++ b/cmake/modules/FindCdio.cmake
@@ -14,7 +14,7 @@
 #   CDIO::CDIO - The cdio library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_CDIO libcdio>=0.84 libiso9660 QUIET)
+  pkg_check_modules(PC_CDIO libcdio>=0.78 libiso9660 QUIET)
 endif()
 
 find_path(CDIO_INCLUDE_DIR NAMES cdio/cdio.h

--- a/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
@@ -33,6 +33,13 @@ using namespace MEDIA_DETECT;
 using namespace CDDB;
 #endif
 
+//! @todo - remove after Ubuntu 16.04 (Xenial) is EOL
+#if !defined(LIBCDIO_VERSION_NUM) || (LIBCDIO_VERSION_NUM <= 83)
+#define CDTEXT_FIELD_TITLE CDTEXT_TITLE
+#define CDTEXT_FIELD_PERFORMER CDTEXT_PERFORMER
+#define CDTEXT_FIELD_GENRE CDTEXT_GENRE
+#endif
+
 CMusicInfoTagLoaderCDDA::CMusicInfoTagLoaderCDDA(void) = default;
 
 CMusicInfoTagLoaderCDDA::~CMusicInfoTagLoaderCDDA() = default;

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -637,14 +637,27 @@ void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
   CSingleLock lock(*m_cdio);
 
   // Get the CD-Text , if any
+#if defined(LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM >= 84)
   cdtext_t *pcdtext = static_cast<cdtext_t*>( cdio_get_cdtext(cdio) );
+#else
+  //! @todo - remove after Ubuntu 16.04 (Xenial) is EOL
+  cdtext_t *pcdtext = (cdtext_t *)::cdio_get_cdtext(cdio, trackNum);
+#endif 
   
   if (pcdtext == NULL)
     return ;
 
+#if defined(LIBCDIO_VERSION_NUM) && (LIBCDIO_VERSION_NUM >= 84)
   for (int i=0; i < MAX_CDTEXT_FIELDS; i++) 
     if (cdtext_get_const(pcdtext, (cdtext_field_t)i, trackNum))
       xcdt[(cdtext_field_t)i] = cdtext_field2str((cdtext_field_t)i);
+#else
+  //! @todo - remove after Ubuntu 16.04 (Xenial) is EOL
+  // Same ids used in libcdio and for our structure + the ids are consecutive make this copy loop safe.
+  for (int i = 0; i < MAX_CDTEXT_FIELDS; i++)
+    if (pcdtext->field[i])
+      xcdt[(cdtext_field_t)i] = pcdtext->field[(cdtext_field_t)i];
+#endif
 #endif // TARGET_WINDOWS
 }
 


### PR DESCRIPTION
## Motivation and Context
Ubuntu 16.04 (Xenial) has libcdio 0.83
I accidentally mixed up strictly greater and greater equal at #13595 

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
