### PR TITLE
Fix disappointing lack of games after entering cheat code

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -2,6 +2,10 @@
   <addon>audioencoder.kodi.builtin.aac</addon>
   <addon>audioencoder.kodi.builtin.wma</addon>
   <addon>game.controller.default</addon>
+  <!-- TODO: Remove game add-ons when no longer applicable -->
+  <addon optional="true">game.libretro</addon>
+  <addon optional="true">game.libretro.2048</addon>
+  <addon optional="true">game.libretro.mrboom</addon>
   <addon>kodi.binary.global.audioengine</addon>
   <addon>kodi.binary.global.main</addon>
   <addon>kodi.binary.global.general</addon>


### PR DESCRIPTION
Soon the word will be out. A secret cheat code will unlock games in Kodi's homescreen. The user tries endless combinations, tirelessly pressing buttons hoping for gratification. And then - victory! The user has enabled games! Only to see this:

![screen shot 2018-03-01 at 12 43 46 pm](https://user-images.githubusercontent.com/531482/36869064-40947208-1d4f-11e8-80f8-3809bc4a4a46.png)

This change makes games appear when the user first enters the cheat code. Now, they see this:

![screen shot 2018-03-01 at 12 46 36 pm](https://user-images.githubusercontent.com/531482/36869188-c0a6a07e-1d4f-11e8-847b-6a343b7e0375.png)

## How Has This Been Tested?
Tested with a clean install on OSX.
