### PR TITLE
VideoPlayer: vaapi - do not destruct postproc if buffers are still in…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -146,6 +146,7 @@ struct CVaapiDecodedPicture
 /**
  * Frame after having been processed by vpp
  */
+class CPostproc;
 struct CVaapiProcessedPicture
 {
   CVaapiProcessedPicture() = default;
@@ -168,12 +169,7 @@ struct CVaapiProcessedPicture
   VASurfaceID videoSurface;
   AVFrame *frame;
   int id;
-  enum
-  {
-    VPP_SRC,
-    FFMPEG_SRC,
-    SKIP_SRC
-  }source;
+  CPostproc *source = nullptr;
   bool crop;
 };
 
@@ -270,13 +266,13 @@ protected:
   void ProcessReturnProcPicture(int id);
   void ProcessSyncPicture();
   void ReleaseProcessedPicture(CVaapiProcessedPicture &pic);
-  void DropVppProcessedPictures();
   bool Init();
   bool Uninit();
   void Flush();
   void EnsureBufferPool();
   void ReleaseBufferPool(bool precleanup = false);
   bool CheckSuccess(VAStatus status);
+  void ReadyForDisposal(CPostproc *pp);
   CEvent m_outMsgEvent;
   CEvent *m_inMsgEvent;
   int m_state;
@@ -290,6 +286,7 @@ protected:
   std::shared_ptr<CVaapiBufferPool> m_bufferPool;
   CVaapiDecodedPicture m_currentPicture;
   CPostproc *m_pp;
+  std::list<std::shared_ptr<CPostproc>> m_discardedPostprocs;
   SDiMethods m_diMethods;
 };
 
@@ -446,6 +443,7 @@ protected:
 /**
  *  Base class
  */
+typedef void (COutput::*ReadyToDispose)(CPostproc *pool);
 class CPostproc
 {
 public:
@@ -454,11 +452,13 @@ public:
   virtual bool Init(EINTERLACEMETHOD method) = 0;
   virtual bool AddPicture(CVaapiDecodedPicture &inPic) = 0;
   virtual bool Filter(CVaapiProcessedPicture &outPic) = 0;
-  virtual void ClearRef(VASurfaceID surf) = 0;
+  virtual void ClearRef(CVaapiProcessedPicture &pic) = 0;
   virtual void Flush() = 0;
   virtual bool UpdateDeintMethod(EINTERLACEMETHOD method) = 0;
   virtual bool DoesSync() = 0;
   virtual bool WantsPic() {return true;}
+  virtual bool UseVideoSurface() = 0;
+  virtual void Discard(COutput *output, ReadyToDispose cb) { (output->*cb)(this); };
 protected:
   CVaapiConfig m_config;
   int m_step;
@@ -474,12 +474,17 @@ public:
   bool Init(EINTERLACEMETHOD method) override;
   bool AddPicture(CVaapiDecodedPicture &inPic) override;
   bool Filter(CVaapiProcessedPicture &outPic) override;
-  void ClearRef(VASurfaceID surf) override;
+  void ClearRef(CVaapiProcessedPicture &pic) override;
   void Flush() override;
   bool UpdateDeintMethod(EINTERLACEMETHOD method) override;
   bool DoesSync() override;
+  bool UseVideoSurface() override;
+  void Discard(COutput *output, ReadyToDispose cb) override;
 protected:
   CVaapiDecodedPicture m_pic;
+  ReadyToDispose m_cbDispose;
+  COutput *m_pOut;
+  int m_refsToSurfaces = 0;
 };
 
 /**
@@ -494,11 +499,13 @@ public:
   bool Init(EINTERLACEMETHOD method) override;
   bool AddPicture(CVaapiDecodedPicture &inPic) override;
   bool Filter(CVaapiProcessedPicture &outPic) override;
-  void ClearRef(VASurfaceID surf) override;
+  void ClearRef(CVaapiProcessedPicture &pic) override;
   void Flush() override;
   bool UpdateDeintMethod(EINTERLACEMETHOD method) override;
   bool DoesSync() override;
   bool WantsPic() override;
+  bool UseVideoSurface() override;
+  void Discard(COutput *output, ReadyToDispose cb) override;
 protected:
   bool CheckSuccess(VAStatus status);
   void Dispose();
@@ -512,6 +519,8 @@ protected:
   int m_currentIdx;
   int m_frameCount;
   EINTERLACEMETHOD m_vppMethod;
+  ReadyToDispose m_cbDispose;
+  COutput *m_pOut = nullptr;
 };
 
 /**
@@ -526,10 +535,12 @@ public:
   bool Init(EINTERLACEMETHOD method) override;
   bool AddPicture(CVaapiDecodedPicture &inPic) override;
   bool Filter(CVaapiProcessedPicture &outPic) override;
-  void ClearRef(VASurfaceID surf) override;
+  void ClearRef(CVaapiProcessedPicture &pic) override;
   void Flush() override;
   bool UpdateDeintMethod(EINTERLACEMETHOD method) override;
   bool DoesSync() override;
+  bool UseVideoSurface() override;
+  void Discard(COutput *output, ReadyToDispose cb) override;
 protected:
   bool CheckSuccess(VAStatus status);
   void Close();
@@ -544,6 +555,9 @@ protected:
   VideoPicture m_DVDPic;
   double m_frametime;
   double m_lastOutPts;
+  ReadyToDispose m_cbDispose;
+  COutput *m_pOut;
+  int m_refsToPics = 0;
 };
 
 }


### PR DESCRIPTION
fixes videocorruption caused by invalidation of surfaces that are still in use.