### PR TITLE
XBDateTime: Use correct timezone shift based on the date.

### DIFF
--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -207,9 +207,6 @@ public:
   void SetValid(bool yesNo);
   bool IsValid() const;
 
-  static void ResetTimezoneBias(void);
-  static CDateTimeSpan GetTimezoneBias(void);
-
 private:
   bool ToFileTime(const SYSTEMTIME& time, FILETIME& fileTime) const;
   bool ToFileTime(const time_t& time, FILETIME& fileTime) const;

--- a/xbmc/platform/linux/LinuxTimezone.cpp
+++ b/xbmc/platform/linux/LinuxTimezone.cpp
@@ -142,8 +142,6 @@ void CLinuxTimezone::OnSettingChanged(std::shared_ptr<const CSetting> setting)
   if (settingId == CSettings::SETTING_LOCALE_TIMEZONE)
   {
     SetTimezone(std::static_pointer_cast<const CSettingString>(setting)->GetValue());
-
-    CDateTime::ResetTimezoneBias();
   }
   else if (settingId == CSettings::SETTING_LOCALE_TIMEZONECOUNTRY)
   {
@@ -156,7 +154,6 @@ void CLinuxTimezone::OnSettingChanged(std::shared_ptr<const CSetting> setting)
 void CLinuxTimezone::OnSettingsLoaded()
 {
   SetTimezone(CServiceBroker::GetSettings()->GetString(CSettings::SETTING_LOCALE_TIMEZONE));
-  CDateTime::ResetTimezoneBias();
 }
 
 std::vector<std::string> CLinuxTimezone::GetCounties()

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1527,8 +1527,6 @@ namespace PVR
         return false;
     }
 
-    CDateTime::ResetTimezoneBias();
-
     CLog::LogFC(LOGDEBUG, LOGPVR, "PVR clearing %s database", bResetEPGOnly ? "EPG" : "PVR and EPG");
 
     pDlgProgress->SetHeading(CVariant{313}); // "Cleaning database"


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
The current XBDateTime code assumes a constant timezone shift for all dates based on the current time. This shift uses LocalFileTimeToFileTime and FileTimeToLocalFileTime when performing the timezone shifts to correct for timezone shifts as a function of date. It also removes the static ResetTimezoneBias and GetTimezoneBias methods since they are not longer used with this change.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Timezone shifts are not constant because of daylight saving time and historical shifts for different timezone regions. This is a quick fix for Kodi bug tracker bug [#17665.](https://trac.kodi.tv/ticket/17665) I intend to write a follow-up cleanup which switches this code over to C++11 chrono, and use the proposed timezone library for C++20: https://github.com/HowardHinnant/date .
## How Has This Been Tested?
I've run the Kodi google test suite. I also ran Kodi with mythpvr addon to check the recording dates. My recording dates now show the correct local times across the DST time barrier. Previously, they would shift by an hour based on the current DST status.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
