### PR TITLE
[PVR] Direct channel number input improvement

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
@@ -70,7 +70,7 @@ CGUITextLayout* COverlayText::GetFontLayout(const std::string &font, int color, 
                                                     , style
                                                     , true, 1.0f, 1.0f, &pal, true);
     if (!subtitle_font || !border_font)
-      CLog::Log(LOGERROR, "CGUIWindowFullScreen::OnMessage(WINDOW_INIT) - Unable to load subtitle font");
+      CLog::Log(LOGERROR, "COverlayText::GetFontLayout - Unable to load subtitle font");
     else
       return new CGUITextLayout(subtitle_font, true, 0, border_font);
   }

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -27,7 +27,6 @@
 #include "GUIUserMessages.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "input/InputManager.h"
 #include "input/Key.h"
 #include "pvr/PVRGUIActions.h"
 #include "pvr/PVRManager.h"
@@ -50,17 +49,9 @@ CGUIWindowVisualisation::CGUIWindowVisualisation(void)
 
 bool CGUIWindowVisualisation::OnAction(const CAction &action)
 {
-  if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH) &&
-      CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreview() &&
-      (action.GetID() == ACTION_SELECT_ITEM ||
-       CServiceBroker::GetInputManager().GetGlobalAction(action.GetButtonCode()).GetID() == ACTION_SELECT_ITEM))
-  {
-    // If confirm channel switch is active, channel preview is currently shown
-    // and the button that caused this action matches (global) action "Select" (OK)
-    // switch to the channel currently displayed within the preview.
-    CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().SwitchToCurrentChannel();
+  // Handle some actions "overloaded" by PVR (e.g. channel preview, direct channel number input).
+  if (CServiceBroker::GetPVRManager().GUIActions()->OnAction(action))
     return true;
-  }
 
   bool passToVis = false;
   switch (action.GetID())

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -49,6 +49,18 @@ void CPVRChannelNumberInputHandler::OnTimeout()
   m_inputBuffer.erase();
 }
 
+bool CPVRChannelNumberInputHandler::CheckInputAndExecuteAction()
+{
+  const CPVRChannelNumber channelNumber = GetChannelNumber();
+  if (channelNumber.IsValid())
+  {
+    // we have a valid channel number; execute the associated action now.
+    OnTimeout();
+    return true;
+  }
+  return false;
+}
+
 void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter)
 {
   if (cCharacter != CPVRChannelNumber::SEPARATOR && (cCharacter < '0' || cCharacter > '9'))

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -65,6 +65,12 @@ public:
    */
   std::string GetChannelNumberAsString() const;
 
+  /*!
+   * @brief If a number was entered, execute the associated action.
+   * @return True, if the action was executed, false otherwise.
+   */
+  bool CheckInputAndExecuteAction();
+
 protected:
   /*!
    * @brief Get the currently entered channel number.

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1121,11 +1121,6 @@ namespace PVR
 
   bool CPVRGUIActions::SwitchToChannel(const CFileItemPtr &item, bool bCheckResume) const
   {
-    return SwitchToChannel(item, bCheckResume, m_settings.GetBoolValue(CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN));
-  }
-
-  bool CPVRGUIActions::SwitchToChannel(const CFileItemPtr &item, bool bCheckResume, bool bFullscreen) const
-  {
     if (item->m_bIsFolder)
       return false;
 
@@ -1163,7 +1158,7 @@ namespace PVR
         }
       }
 
-      StartPlayback(new CFileItem(channel), bFullscreen);
+      StartPlayback(new CFileItem(channel), m_settings.GetBoolValue(CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN));
       return true;
     }
 
@@ -1266,7 +1261,7 @@ namespace PVR
 
     CLog::Log(LOGNOTICE, "PVRGUIActions - %s - start playback of channel '%s'", __FUNCTION__, item->GetPVRChannelInfoTag()->ChannelName().c_str());
     CServiceBroker::GetPVRManager().SetPlayingGroup(group);
-    return SwitchToChannel(item, true, m_settings.GetBoolValue(CSettings::SETTING_PVRPLAYBACK_SWITCHTOFULLSCREEN));
+    return SwitchToChannel(item, true);
   }
 
   bool CPVRGUIActions::PlayMedia(const CFileItemPtr &item) const

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -474,15 +474,6 @@ namespace PVR
     void CheckAndSwitchToFullscreen(bool bFullscreen) const;
 
     /*!
-     * @brief Switch channel.
-     * @param item containing a channel or an epg tag.
-     * @param bCheckResume controls resume check in case a recording for the current epg event is present.
-     * @param bFullscreen start playback fullscreen or not.
-     * @return true on success, false otherwise.
-     */
-    bool SwitchToChannel(const CFileItemPtr &item, bool bCheckResume, bool bFullscreen) const;
-
-    /*!
      * @brief Start playback of the given item.
      * @param bFullscreen start playback fullscreen or not.
      * @param item containing a channel or a recording.

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -29,6 +29,7 @@
 #include "pvr/PVRSettings.h"
 #include "pvr/PVRTypes.h"
 
+class CAction;
 class CFileItem;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
 
@@ -371,6 +372,12 @@ namespace PVR
      * @return the navigator.
      */
     CPVRGUIChannelNavigator &GetChannelNavigator();
+
+    /*!
+     * @brief Process an action.
+     * @return True if the action was processed, false otherwise.
+     */
+    bool OnAction(const CAction &action);
 
     /*!
      * @brief Inform GUI actions that playback of an item just started.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -69,6 +69,10 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
 
         if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK)
         {
+          // If direct channel number input is active, select the entered channel.
+          if (CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().CheckInputAndExecuteAction())
+            return true;
+
           /* Switch to channel */
           GotoChannel(iItem);
           return true;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -140,6 +140,17 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
     case GUI_MSG_CLICKED:
       if (message.GetSenderId() == m_viewControl.GetCurrentControl())
       {
+        if (message.GetParam1() == ACTION_SELECT_ITEM ||
+            message.GetParam1() == ACTION_MOUSE_LEFT_CLICK)
+        {
+          // If direct channel number input is active, select the entered channel.
+          if (CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().CheckInputAndExecuteAction())
+          {
+            bReturn = true;
+            break;
+          }
+        }
+
         int iItem = m_viewControl.GetSelectedItem();
         if (iItem >= 0 && iItem < m_vecItems->Size())
         {

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -335,6 +335,17 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
     {
       if (message.GetSenderId() == m_viewControl.GetCurrentControl())
       {
+        if (message.GetParam1() == ACTION_SELECT_ITEM ||
+            message.GetParam1() == ACTION_MOUSE_LEFT_CLICK)
+        {
+          // If direct channel number input is active, select the entered channel.
+          if (CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().CheckInputAndExecuteAction())
+          {
+            bReturn = true;
+            break;
+          }
+        }
+
         int iItem = m_viewControl.GetSelectedItem();
         if (iItem >= 0 && iItem < m_vecItems->Size())
         {

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -43,7 +43,6 @@
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
 #include "XBDateTime.h"
-#include "input/InputManager.h"
 #include "windowing/WinSystem.h"
 #include "cores/IPlayer.h"
 #include "guiinfo/GUIInfoLabels.h"
@@ -95,17 +94,9 @@ CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
-  if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH) &&
-      CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreview() &&
-      (action.GetID() == ACTION_SELECT_ITEM ||
-       CServiceBroker::GetInputManager().GetGlobalAction(action.GetButtonCode()).GetID() == ACTION_SELECT_ITEM))
-  {
-    // If confirm channel switch is active, channel preview is currently shown
-    // and the button that caused this action matches (global) action "Select" (OK)
-    // switch to the channel currently displayed within the preview.
-    CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().SwitchToCurrentChannel();
+  // Handle some actions "overloaded" by PVR (e.g. channel preview, direct channel number input).
+  if (CServiceBroker::GetPVRManager().GUIActions()->OnAction(action))
     return true;
-  }
 
   switch (action.GetID())
   {


### PR DESCRIPTION
By pressing "OK" (Enter) you can now shortcut the direct channel number input delay and trigger the associated action immediately. Formerly, you had to wait for the internal timeout after that the action gets executed automatically. Ofc, this does still work.

(Last commit is unrelated, just something random I came across by luck, and fixes just a log text.)

@Jalle19 good to go?