### PR TITLE
 Temporarily enable standalone game add-ons included for testing

### DIFF
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -2,6 +2,9 @@
   <addon>audioencoder.kodi.builtin.aac</addon>
   <addon>audioencoder.kodi.builtin.wma</addon>
   <addon>game.controller.default</addon>
+  <addon optional="true">game.libretro</addon>
+  <addon optional="true">game.libretro.2048</addon>
+  <addon optional="true">game.libretro.mrboom</addon>
   <addon>kodi.binary.global.audioengine</addon>
   <addon>kodi.binary.global.main</addon>
   <addon>kodi.binary.global.general</addon>


### PR DESCRIPTION
This PR replaces #13603. I am resubmitting because of my inappropriate use of humor for that PR, instead of a detailed description of why the change is needed temporarily, what it entails, what our alternatives are and when it will be reverted.

I should have learned from https://github.com/xbmc/repo-binary-addons/pull/103. I was expecting pushback due to the increase in binary size, compilation time, and a reasonable amount of bike-shedding. Instead, I was clear in why it was needed and what it entailed. Merged in hours. By @MartijnKaijser, nonetheless. Lesson learned, lesson forgotten.

Excuse my wall of text. I just want to fully communicate these ideas.

## Root issue

The root issue of this PR is the abuse of our current packaging system. This is a quick and dirty solution that undermines the large effort required to distribute binary add-ons properly, which includes #13600 and out-of-process execution on mobile platforms.

## Why a quick and dirty solution is needed

One word: Accessibility. I'll explain what this means:

As developers, we overlook our privilege of being exposed to technology for much of our lives. Through exposure to technology, people become masters in the use (and, for some, creation) of technology. However, most of the world lacks access to various forms of technology. This results in a barrier to use and benefit from such technology.

Poverty is only one form of this lack of access. Deprecation is another; when USB ports were introduced, it no longer matters that controller hubs (like the SNES multitap) only worked in port 2. And what happens to the concept of *wired* controllers when a 10-year-old's first and all subsequent consoles and devices only use wireless controllers and peripherals?

As a result, we get the "technical divide" - the idea that access to technology results in "haves" and "have-nots". So far, I've only received feedback from those on the same side of the technical divide as us. This PR is about bridging the technical divide, by decoupling games from the concept of "Kodi add-ons", which is a barrier to those who don't understand Kodi add-ons.

## How this solves the problem

By isolating the connection between games and add-ons in our add-on manifest, we offload the barrier from the people I'm hoping to get feedback from.

## What I've done to solve this problem

Several years ago I added a feature which I call "just-in-time installation". This lets us ship Kodi with no game add-ons installed (or installed but disabled), with no effect on the user's access to games. Games still appear in the GUI. The user can even launch games with no add-ons installed or enabled. When needed, add-ons are installed or enabled "just-in-time", which is the very last moment before the game is actually shown on the screen. (The user is made fully aware that installation is taking place.)

Because emulated games can be launched without an emulator installed, we bridge the technical divide by exposing emulation to those without a concept of emulation (namely: every 10-year-old I've met ever).

LibreELEC can host and execute binary add-ons, so I've been testing just-in-time installation with their builds for years. It has been very successful and perfectly accomplishes my goal of accessibility.

## Why this solution doesn't work for us currently

Just-in-time installation only works for game add-ons that use external files, not for standalone game add-ons.

I chose to test with standalone game add-ons to avoid the use of external files. Not due to legal aspects, but simply because there's less complexity. (Legal aspect arguments are moot anyways, because VideoPlayer only launches external files.)

I chose to not enable just-in-time installation for standalone add-ons because we only have two. The ones we ship. And they're not that great of games. The extra code just isn't worth it.

## Alternative solutions to this PR

### 1.

I could add just-in-time installation for standalone add-ons. This would benefit the exactly two standalone add-ons that we have. It would require much code, and including or reverting any is a risk for our upcoming final release.

Adding 3 lines of XML is a much easier and (importantly) more reversible solution.

### 2.

Or we could drop these two add-ons and ship an add-on that launches (possibly only legal) external files. The add-on will be enabled just-in-time. This successfully accomplishes the goal of decoupling games from Kodi add-ons. However, it adds an even greater barrier, because it requires the user to obtain said files, add the source, navigate to them, and launch them.

## When will this be reverted?

Let's decide this. I don't care. I just want feedback from users who are marginalized by those on our side of the technical divide.