### PR TITLE
[pvr][keymaps] Cleanup: Implement PVR 'direct channel input' and 'channel prev…

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -696,6 +696,32 @@
       <period mod="longpress">ChannelNumberSeparator</period>
     </keyboard>
   </FullscreenRadio>
+  <FullscreenLiveTvPreview>
+    <keyboard>
+      <return>Select</return>
+      <enter>Select</enter>
+    </keyboard>
+  </FullscreenLiveTvPreview>
+  <FullscreenRadioPreview>
+    <keyboard>
+      <return>Select</return>
+      <enter>Select</enter>
+    </keyboard>
+  </FullscreenRadioPreview>
+  <FullscreenLiveTvInput>
+    <keyboard>
+      <return>Select</return>
+      <enter>Select</enter>
+      <period>ChannelNumberSeparator</period>
+    </keyboard>
+  </FullscreenLiveTvInput>
+  <FullscreenRadioInput>
+    <keyboard>
+      <return>Select</return>
+      <enter>Select</enter>
+      <period>ChannelNumberSeparator</period>
+    </keyboard>
+  </FullscreenRadioInput>
   <PVROSDChannels>
     <keyboard>
       <period mod="longpress">ChannelNumberSeparator</period>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -589,6 +589,26 @@
       <pageminus>ChannelDown</pageminus>
     </remote>
   </FullscreenRadio>
+  <FullscreenLiveTvPreview>
+    <remote>
+      <select>Select</select>
+    </remote>
+  </FullscreenLiveTvPreview>
+  <FullscreenRadioPreview>
+    <remote>
+      <select>Select</select>
+    </remote>
+  </FullscreenRadioPreview>
+  <FullscreenLiveTvInput>
+    <remote>
+      <select>Select</select>
+    </remote>
+  </FullscreenLiveTvInput>
+  <FullscreenRadioInput>
+    <remote>
+      <select>Select</select>
+    </remote>
+  </FullscreenRadioInput>
   <PVROSDChannels>
     <remote>
       <back>Close</back>

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -147,8 +147,13 @@
 #define WINDOW_RADIO_TIMER_RULES          (WINDOW_PVR_ID_START+11)
 #define WINDOW_PVR_ID_END                 WINDOW_RADIO_TIMER_RULES
 
-#define WINDOW_FULLSCREEN_LIVETV          10800 // virtual window for PVR specific keymap bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
-#define WINDOW_FULLSCREEN_RADIO           10801 // virtual window for PVR radio specific keymaps with fallback to WINDOW_VISUALISATION
+// virtual windows for PVR specific keymap bindings in fullscreen playback
+#define WINDOW_FULLSCREEN_LIVETV          10800
+#define WINDOW_FULLSCREEN_RADIO           10801
+#define WINDOW_FULLSCREEN_LIVETV_PREVIEW  10802
+#define WINDOW_FULLSCREEN_RADIO_PREVIEW   10803
+#define WINDOW_FULLSCREEN_LIVETV_INPUT    10804
+#define WINDOW_FULLSCREEN_RADIO_INPUT     10805
 
 #define WINDOW_DIALOG_GAME_CONTROLLERS    10820
 #define WINDOW_GAMES                      10821

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -203,22 +203,17 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
   // try to get the action from the current window
   unsigned int actionID = GetActionCode(window, key, strAction);
 
-  // if it's invalid, try to get it from the global map
-  if (actionID == ACTION_NONE && fallback)
+  if (fallback)
   {
-    //! @todo Refactor fallback logic
-    int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
-    if (fallbackWindow > -1)
-      actionID = GetActionCode(fallbackWindow, key, strAction);
-
-    // still no valid action? use global map
-    if (actionID == ACTION_NONE)
-      actionID = GetActionCode(-1, key, strAction);
+    // if it's invalid, try to get it from fallback windows or the global map (window == -1)
+    while (actionID == ACTION_NONE && window > -1)
+    {
+      window = CWindowTranslator::GetFallbackWindow(window);
+      actionID = GetActionCode(window, key, strAction);
+    }
   }
 
-  // Now fill our action structure
-  CAction action(actionID, strAction, key);
-  return action;
+  return CAction(actionID, strAction, key);
 }
 
 bool CButtonTranslator::HasLongpressMapping(int window, const CKey &key)

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -221,11 +221,6 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
   return action;
 }
 
-CAction CButtonTranslator::GetGlobalAction(const CKey &key)
-{
-  return GetAction(-1, key, true);
-}
-
 bool CButtonTranslator::HasLongpressMapping(int window, const CKey &key)
 {
   // handle virtual windows

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -71,12 +71,6 @@ public:
    */
   CAction GetAction(int window, const CKey &key, bool fallback = true);
 
-  /*! \brief Obtain the global action configured for a given key
-   \param key the key to query the action for
-   \return the global action
-   */
-  CAction GetGlobalAction(const CKey &key);
-
   void RegisterMapper(const std::string &device, IButtonMapper *mapper);
   void UnregisterMapper(IButtonMapper *mapper);
 

--- a/xbmc/input/CustomControllerTranslator.cpp
+++ b/xbmc/input/CustomControllerTranslator.cpp
@@ -84,23 +84,16 @@ bool CCustomControllerTranslator::TranslateCustomControllerString(int windowId, 
   // Try to get the action from the current window
   if (!TranslateString(windowId, controllerName, buttonId, actionId, strAction))
   {
-    // If it's invalid, try to get it from a fallback window or the global map
-    int fallbackWindow = CWindowTranslator::GetFallbackWindow(windowId);
-    if (fallbackWindow > -1)
-      TranslateString(fallbackWindow, controllerName, buttonId, actionId, strAction);
-
-    // Still no valid action? Use global map
-    if (actionId == ACTION_NONE)
-      TranslateString(-1, controllerName, buttonId, actionId, strAction);
+    // if it's invalid, try to get it from fallback windows or the global map (windowId == -1)
+    while (actionId == ACTION_NONE && windowId > -1)
+    {
+      windowId = CWindowTranslator::GetFallbackWindow(windowId);
+      TranslateString(windowId, controllerName, buttonId, actionId, strAction);
+    }
   }
 
-  if (actionId != ACTION_NONE)
-  {
-    action = actionId;
-    return true;
-  }
-
-  return false;
+  action = actionId;
+  return actionId != ACTION_NONE;
 }
 
 bool CCustomControllerTranslator::TranslateString(int windowId, const std::string& controllerName, int buttonId, unsigned int& actionId, std::string& strAction)

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -966,11 +966,6 @@ CAction CInputManager::GetAction(int window, const CKey &key, bool fallback /* =
   return m_buttonTranslator->GetAction(window, key, fallback);
 }
 
-CAction CInputManager::GetGlobalAction(const CKey &key)
-{
-  return m_buttonTranslator->GetGlobalAction(key);
-}
-
 bool CInputManager::TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, int& action, std::string& strAction)
 {
   return m_customControllerTranslator->TranslateCustomControllerString(windowId, controllerName, buttonId, action, strAction);

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -261,14 +261,6 @@ public:
    */
   CAction GetAction(int window, const CKey &key, bool fallback = true);
 
-  /*! \brief Obtain the global action configured for a given key
-   *
-   * \param key the key to query the action for
-   *
-   * \return the global action
-   */
-  CAction GetGlobalAction(const CKey &key);
-
   bool TranslateCustomControllerString(int windowId, const std::string& controllerName, int buttonId, int& action, std::string& strAction);
 
   bool TranslateTouchAction(int windowId, int touchAction, int touchPointers, int &action, std::string &actionString);

--- a/xbmc/input/TouchTranslator.cpp
+++ b/xbmc/input/TouchTranslator.cpp
@@ -108,12 +108,12 @@ bool CTouchTranslator::TranslateTouchAction(int window, int touchAction, int tou
 
   if (!TranslateAction(window, touchAction, touchPointers, actionId, actionString))
   {
-    int fallbackWindow = CWindowTranslator::GetFallbackWindow(window);
-    if (fallbackWindow > -1)
-      TranslateAction(fallbackWindow, touchAction, touchPointers, actionId, actionString);
-
-    if (actionId == ACTION_NONE)
-      TranslateAction(-1, touchAction, touchPointers, actionId, actionString);
+    // if it's invalid, try to get it from fallback windows or the global map (window == -1)
+    while (actionId == ACTION_NONE && window > -1)
+    {
+      window = CWindowTranslator::GetFallbackWindow(window);
+      TranslateAction(window, touchAction, touchPointers, actionId, actionString);
+    }
   }
 
   action = actionId;

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -28,8 +28,6 @@
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "pvr/PVRGUIActions.h"
-#include "pvr/PVRManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 
@@ -49,10 +47,6 @@ CGUIWindowVisualisation::CGUIWindowVisualisation(void)
 
 bool CGUIWindowVisualisation::OnAction(const CAction &action)
 {
-  // Handle some actions "overloaded" by PVR (e.g. channel preview, direct channel number input).
-  if (CServiceBroker::GetPVRManager().GUIActions()->OnAction(action))
-    return true;
-
   bool passToVis = false;
   switch (action.GetID())
   {

--- a/xbmc/pvr/PVRActionListener.cpp
+++ b/xbmc/pvr/PVRActionListener.cpp
@@ -157,6 +157,28 @@ bool CPVRActionListener::OnAction(const CAction &action)
       return true;
     }
 
+    case ACTION_SELECT_ITEM:
+    {
+      if (!bIsPlayingPVR)
+        return false;
+
+      // If the button that caused this action matches action "Select" ...
+      if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH) &&
+          CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().IsPreview())
+      {
+        // ... and if "confirm channel switch" setting is active and a channel
+        // preview is currently shown, switch to the currently previewed channel.
+        CServiceBroker::GetPVRManager().GUIActions()->GetChannelNavigator().SwitchToCurrentChannel();
+        return true;
+      }
+      else if (CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().CheckInputAndExecuteAction())
+      {
+        // ... or if the action was processed by direct channel number input, we're done.
+        return true;
+      }
+      return false;
+    }
+
     case ACTION_MOVE_UP:
     case ACTION_NEXT_ITEM:
     case ACTION_CHANNEL_UP:

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -117,6 +117,11 @@ CPVRChannelNumber CPVRChannelNumberInputHandler::GetChannelNumber() const
   return CPVRChannelNumber(iChannelNumber, iSubChannelNumber);
 }
 
+bool CPVRChannelNumberInputHandler::HasChannelNumber() const
+{
+  return !m_inputBuffer.empty();
+}
+
 std::string CPVRChannelNumberInputHandler::GetChannelNumberAsString() const
 {
   CSingleLock lock(m_mutex);

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -60,6 +60,12 @@ public:
   virtual void AppendChannelNumberCharacter(char cCharacter);
 
   /*!
+   * @brief Check whether a channel number was entered.
+   * @return True if the handler currently holds a channel number, false otherwise.
+   */
+  bool HasChannelNumber() const;
+
+  /*!
    * @brief Get the currently entered channel number as a formatted string. Format is n digits with leading zeros, where n is the number of digits specified when calling the ctor.
    * @return the channel number string.
    */

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1831,29 +1831,6 @@ namespace PVR
     return m_channelNavigator;
   }
 
-  bool CPVRGUIActions::OnAction(const CAction &action)
-  {
-    // If the button that caused this action matches (global) action "Select" (OK)...
-    if (action.GetID() == ACTION_SELECT_ITEM ||
-        CServiceBroker::GetInputManager().GetGlobalAction(action.GetButtonCode()).GetID() == ACTION_SELECT_ITEM)
-    {
-      if (m_settings.GetBoolValue(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH) &&
-          GetChannelNavigator().IsPreview())
-      {
-        // ... and if "confirm channel switch" setting is active and a channel
-        // preview is currently shown, switch to the currently previewed channel.
-        GetChannelNavigator().SwitchToCurrentChannel();
-        return true;
-      }
-      else if (GetChannelNumberInputHandler().CheckInputAndExecuteAction())
-      {
-        // ... and action was processed by direct channel number input, we're done.
-          return true;
-      }
-    }
-    return false;
-  }
-
   void CPVRGUIActions::OnPlaybackStarted(const CFileItemPtr &item)
   {
     if (item->HasPVRChannelInfoTag())

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -374,12 +374,6 @@ namespace PVR
     CPVRGUIChannelNavigator &GetChannelNavigator();
 
     /*!
-     * @brief Process an action.
-     * @return True if the action was processed, false otherwise.
-     */
-    bool OnAction(const CAction &action);
-
-    /*!
      * @brief Inform GUI actions that playback of an item just started.
      * @param item The item that started to play.
      */

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -31,8 +31,6 @@
 #include "video/dialogs/GUIDialogSubtitleSettings.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
-#include "pvr/PVRGUIActions.h"
-#include "pvr/PVRManager.h"
 #include "video/dialogs/GUIDialogFullScreenInfo.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -94,10 +92,6 @@ CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
-  // Handle some actions "overloaded" by PVR (e.g. channel preview, direct channel number input).
-  if (CServiceBroker::GetPVRManager().GUIActions()->OnAction(action))
-    return true;
-
   switch (action.GetID())
   {
   case ACTION_SHOW_OSD:


### PR DESCRIPTION
…iew' actions/keybindings using virtual windows.

I was finally able to get rid of the PVR dependency of `CGUIWindowFullscreen` and `CGUIWindowVisualisation`.

PVR features 'direct channel number input' and 'channel preview OSD' require special key input handling, which is now implemented in a clean way using virtual windows 'on top' of the real video and music fullscreen windows these features are associated with. No more hardcoded PVR dependencies in the related full screen window classes and abilty to define the actions for the keys used for these features like we always do - using keyboard.xml and friends.

The concept of virtual windows is not new - it is already used for other purposes, for instance numeric seek input while playing videos/music(?). I just discovered and understood it and it came to my mind that this is the right solution for a problem that bugged me for a long time. ;-)

@Jalle19 @FernetMenta mind taking a look.