### PR TITLE
ADD: [droid] support for binary addons by repo

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -503,12 +503,14 @@ public class Splash extends Activity
         sXbmcHome = "";
       }
     }
+    File fCacheDir = getCacheDir();
     if (sXbmcHome.isEmpty())
     {
-      File fCacheDir = getCacheDir();
       sXbmcHome = fCacheDir.getAbsolutePath() + "/apk";
       fXbmcHome = new File(sXbmcHome);
     }
+    File fLibCache = new File(fCacheDir.getAbsolutePath() + "/lib");
+    fLibCache.mkdirs();
 
     sXbmcdata = XBMCProperties.getStringProperty("xbmc.data", "");
     if (!sXbmcdata.isEmpty())

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -853,10 +853,6 @@ bool CApplication::InitDirectoriesLinux()
   }
   CSpecialProtocol::SetXBMCBinAddonPath(appBinPath + "/addons");
 
-#if defined(TARGET_ANDROID)
-  CXBMCApp::InitDirectories();
-#endif
-
   return true;
 #else
   return false;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -929,11 +929,6 @@ void CXBMCApp::SetSystemVolume(float percent)
     android_printf("CXBMCApp::SetSystemVolume: Could not get Audio Manager");
 }
 
-void CXBMCApp::InitDirectories()
-{
-  CSpecialProtocol::SetXBMCBinAddonPath(getApplicationInfo().nativeLibraryDir.c_str());
-}
-
 void CXBMCApp::onReceive(CJNIIntent intent)
 {
   std::string action = intent.getAction();
@@ -1178,10 +1173,10 @@ void CXBMCApp::SetupEnv()
   StringUtils::ToLower(appName);
   std::string className = CCompileInfo::GetPackage();
 
+  std::string cacheDir = getCacheDir().getAbsolutePath();
   std::string xbmcHome = CJNISystem::getProperty("xbmc.home", "");
   if (xbmcHome.empty())
   {
-    std::string cacheDir = getCacheDir().getAbsolutePath();
     setenv("KODI_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
     setenv("KODI_HOME", (cacheDir + "/apk/assets").c_str(), 0);
   }
@@ -1190,6 +1185,7 @@ void CXBMCApp::SetupEnv()
     setenv("KODI_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
     setenv("KODI_HOME", (xbmcHome + "/assets").c_str(), 0);
   }
+  setenv("KODI_BINADDON_PATH", (cacheDir + "/lib").c_str(), 0);
 
   std::string externalDir = CJNISystem::getProperty("xbmc.data", "");
   if (externalDir.empty())

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -161,7 +161,6 @@ public:
   static int GetMaxSystemVolume();
   static float GetSystemVolume();
   static void SetSystemVolume(float percent);
-  static void InitDirectories();
 
   static void SetRefreshRate(float rate);
   static void SetDisplayMode(int mode);


### PR DESCRIPTION
This allows to install binary addons on android via zip files or repo.

As of API 17 or 19, the droid dynamic linker works pretty much the same as on linux.
The only peculiarity is that the place where binary addons are installed is mounted "noexec", so we cannot dlopen them in-place.

This copies the bin addon so to the app cache, which is alway mounted "exec", before dlopen'ing.
It is only copied if size or data differs from the installed so, and never deleted, to prevent unnecessary flash wear.

An android "clear cache" starts from scratch.