### PR TITLE
Fix crash in SetCurrentMovie

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9130,7 +9130,7 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
   *m_currentFile = item;
 
   /* also call GetMovieInfo() when a VideoInfoTag is already present or additional info won't be present in the tag */
-  if (!m_currentFile->HasPVRChannelInfoTag())
+  if (!m_currentFile->HasPVRChannelInfoTag() && m_currentFile->HasVideoInfoTag())
   {
     CVideoDatabase dbs;
     if (dbs.Open())
@@ -9143,6 +9143,7 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
       dbs.Close();
     }
   }
+  CLog::Log(LOGDEBUG, "CGUIInfoManager::SetCurrentMovie(%s) about to load art", CURL::GetRedacted(item.GetPath()).c_str());
 
   // Find a thumb for this file.
   if (!item.HasArt("thumb"))
@@ -9173,6 +9174,7 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
     }
   }
 
+  CLog::Log(LOGDEBUG, "CGUIInfoManager::SetCurrentMovie(%s) about to FillInDefaultIcon", CURL::GetRedacted(item.GetPath()).c_str());
   item.FillInDefaultIcon();
   m_currentMovieThumb = item.GetArt("thumb");
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2163,6 +2163,8 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
                                 "JOIN path ON path.idPath = files.idPath "
                                 "LEFT JOIN bookmark ON bookmark.idFile = files.idFile AND bookmark.type = %i "
                                 "WHERE files.idFile = %i", CBookmark::RESUME, idFile);
+
+    CLog::Log(LOGDEBUG, LOGDATABASE, "%s (%s), query = %s", __FUNCTION__, CURL::GetRedacted(strFilenameAndPath).c_str(), sql.c_str());
     if (!m_pDS->query(sql))
       return false;
 


### PR DESCRIPTION
Users have reported some segfault crashes on the end of video playback since #13533 was merged.  I believe this is because `CGUIInfoManager::SetCurrentMovie()` is attempting to access a VideoInfoTag that no longer exists. 

In effect there is a race between application processing of `GUI_MSG_PLAYBACK_ENDED` message that resets the current item and removes the VideoInfoTag, and `CGUIInfoManager::SetCurrentMovie` that runs on a separate thread trying to access that tag. 

In #13533 the processing of `GUI_MSG_UPDATE_ITEM` messages for the current item was moved from `CGUIInfoManager` to the application in order to keep m_itemCurrentFile as the primary source of  current item data. Prior to that only the GUI copy of the current item was being updated by update item messages, leaving the application out of date and resulting in inconsistent UI values.  Doing this added a call to sync `CGUIInfoManager` with the application, and that job can happen after the item has reset.

The crash has proved difficult to reproduce on my dev env, so this will need testing on other platforms to prove it is the fix.
