### PR TITLE
Fix crash on exit

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -98,3 +98,12 @@ void CAESinkFactory::EnumerateEx(std::vector<AESinkInfo> &list, bool force)
       list.push_back(info);
   }
 }
+
+void CAESinkFactory::Cleanup()
+{
+  for (auto reg : m_AESinkRegEntry)
+  {
+    if (reg.second.cleanupFunc)
+      reg.second.cleanupFunc();
+  }
+}

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -38,12 +38,14 @@ struct AESinkInfo
 
 typedef IAESink* (*CreateSink)(std::string &device, AEAudioFormat &desiredFormat);
 typedef void (*Enumerate)(AEDeviceInfoList &list, bool force);
+typedef void (*Cleanup)();
 
 struct AESinkRegEntry
 {
   std::string sinkName;
   CreateSink createFunc;
   Enumerate enumerateFunc;
+  Cleanup cleanupFunc;
 };
 
 class CAESinkFactory
@@ -55,6 +57,7 @@ public:
   static void ParseDevice(std::string &device, std::string &driver);
   static IAESink *Create(std::string &device, AEAudioFormat &desiredFormat);
   static void EnumerateEx(std::vector<AESinkInfo> &list, bool force);
+  static void Cleanup();
 
 protected:
   static std::map<std::string, AESinkRegEntry> m_AESinkRegEntry;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -82,6 +82,8 @@ void CActiveAESink::Dispose()
 
   delete m_packer;
   m_packer = nullptr;
+
+  CAESinkFactory::Cleanup();
 }
 
 AEDeviceType CActiveAESink::GetDeviceType(const std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -116,6 +116,7 @@ void CAESinkALSA::Register()
   entry.sinkName = "ALSA";
   entry.createFunc = CAESinkALSA::Create;
   entry.enumerateFunc = CAESinkALSA::EnumerateDevicesEx;
+  entry.cleanupFunc = CAESinkALSA::Cleanup;
   AE::CAESinkFactory::RegisterSink(entry);
 }
 
@@ -1663,6 +1664,14 @@ void CAESinkALSA::sndLibErrorHandler(const char *file, int line, const char *fun
     free(errorStr);
   }
   va_end(arg);
+}
+
+void CAESinkALSA::Cleanup()
+{
+#if HAVE_LIBUDEV
+  m_deviceMonitor.Stop();
+#endif
+  m_controlMonitor.Clear();
 }
 
 #if HAVE_LIBUDEV

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -45,6 +45,7 @@ public:
   static void Register();
   static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
+  static void Cleanup();
 
   bool Initialize(AEAudioFormat &format, std::string &device) override;
   void Deinitialize() override;


### PR DESCRIPTION
Second attempt after: https://github.com/xbmc/xbmc/pull/13596

This adds a Disposal-Method to the SinkFactory and let's sinks register a method for cleaning stuff that is for example static like those alsa monitors.

@FernetMenta @fritsch could you have another look?
