### PR TITLE
VideoPlayer / pvr: set playing times to zero when opening a new file

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -710,17 +710,18 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
   }
 
   m_item = file;
-  m_callback.OnPlayBackStarted(m_item);
-
   m_playerOptions = options;
   // Try to resolve the correct mime type
   m_item.SetMimeTypeForInternetFile();
 
+  m_processInfo->SetPlayTimes(0,0,0,0);
   m_bAbortRequest = false;
   m_error = false;
   m_renderManager.PreInit();
 
   Create();
+
+  m_callback.OnPlayBackStarted(m_item);
 
   return true;
 }
@@ -2534,6 +2535,8 @@ void CVideoPlayer::HandleMessages()
 
       m_item = msg.GetItem();
       m_playerOptions = msg.GetOptions();
+
+      m_processInfo->SetPlayTimes(0,0,0,0);
 
       m_outboundEvents->Submit([this]() {
         m_callback.OnPlayBackStarted(m_item);

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -225,9 +225,12 @@ CDateTime CPVREpgInfoTag::GetCurrentPlayingTime() const
   if (CServiceBroker::GetPVRManager().GetPlayingChannel() == Channel() &&
       CServiceBroker::GetPVRManager().Clients()->IsTimeshifting())
   {
-    // timeshifting
-    return CDateTime(CServiceBroker::GetDataCacheCore().GetStartTime() +
-                     CServiceBroker::GetDataCacheCore().GetPlayTime() / 1000);
+    // timeshifting; start time valid?
+    time_t startTime = CServiceBroker::GetDataCacheCore().GetStartTime();
+    if (startTime > 0)
+    {
+      return CDateTime(startTime + CServiceBroker::GetDataCacheCore().GetPlayTime() / 1000);
+    }
   }
 
   // not timeshifting


### PR DESCRIPTION
fixes missing epg tag on channel switch caused by wrong playing time