### PR TITLE
VideoPlayer: set starttime to zero if streaminfo is skipped

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -174,5 +174,6 @@ protected:
   int m_displayTime = 0;
   double m_dtsAtDisplayTime;
   bool m_seekToKeyFrame = false;
+  double m_startTime = 0;
 };
 


### PR DESCRIPTION
GetStreamTimes assumes that timestamps start with zero if internal demuxer is used. This is default for ffmpeg demuxer but does not work if we skip analyzing streams. For this case we have to set starttime by ourselves.
