### PR TITLE
AE: init struct AESinkRegEntry

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -43,9 +43,9 @@ typedef void (*Cleanup)();
 struct AESinkRegEntry
 {
   std::string sinkName;
-  CreateSink createFunc;
-  Enumerate enumerateFunc;
-  Cleanup cleanupFunc;
+  CreateSink createFunc = nullptr;
+  Enumerate enumerateFunc = nullptr;
+  Cleanup cleanupFunc = nullptr;
 };
 
 class CAESinkFactory


### PR DESCRIPTION
init struct with defaults. fixes crash on exit for platforms not using cleanup

thanks to @koying for bringing this up