### PR TITLE
Avoid unncecessary DB access by GUI on update Item

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3875,7 +3875,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         if (m_itemCurrentFile->IsSamePath(item.get()))
         {
           m_itemCurrentFile->UpdateInfo(*item);
-          g_infoManager.SetCurrentItem(*m_itemCurrentFile);
+          g_infoManager.UpdateInfo(*item);
         }
       }
     }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9039,6 +9039,11 @@ void CGUIInfoManager::ResetCurrentItem()
   m_currentMovieDuration = "";
 }
 
+void CGUIInfoManager::UpdateInfo(const CFileItem & item)
+{
+  m_currentFile->UpdateInfo(item);
+}
+
 void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 {
   ResetCurrentItem();

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -142,6 +142,7 @@ public:
    */
   void SetCurrentItem(const CFileItem &item);
   void ResetCurrentItem();
+  void UpdateInfo(const CFileItem &item);
   // Current song stuff
   /// \brief Retrieves tag info (if necessary) and fills in our current song path.
   void SetCurrentSong(CFileItem &item);


### PR DESCRIPTION
Avoid unnecessary db access by GUI when app processing GUI_MSG_UPDATE_ITEM messages.

The movement of `GUI_MSG_UPDATE_ITEM` processing from `GUIInfoManager` to `CApplication` (to insure that CApp had the definative current item) in #13533 causes `GUIInfoManager::SetCurrentItem()`  to be called. This in turn reads data from either the music or video database, something that could delay rendering if access was slow. This database access is unnecessary, the item in the message already has all the data that is  needed. 

Previous processing of `GUI_MSG_UPDATE_ITEM` by `GUIInfoManager` only called `UpdateInfo()` for the GUI item that triggers the necessary invalidation and GUI refresh.  This fix restores this more efficient and suffient approach by replacing the call to `SetCurrentItem()` with `UpdateInfo()`

Note all other calls to  `GUIInfoManager::SetCurrentItem()` remain unchanged