### PR TITLE
[GBM] add better vendor EGL header compatibility

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -136,7 +136,7 @@ bool CWinSystemGbm::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  m_nativeWindow = m_GBM->m_surface;
+  m_nativeWindow = reinterpret_cast<EGLNativeWindowType>(m_GBM->m_surface);
 
   CLog::Log(LOGDEBUG, "CWinSystemGbm::%s - initialized GBM", __FUNCTION__);
   return true;


### PR DESCRIPTION
## Description
It may be the case that your EGL headers shipped with your vendor image are not defining gbm_surface
but fbdev_window, mali_native_window or another unique name, while this is wrong for gbm enabled userspace libraries it could still be the case that other software still rely on fbdev_window and therefor the EGL headers may stay on different type defines

https://github.com/rockchip-linux/libmali/blob/rockchip/include/EGL/eglplatform.h#L73
https://github.com/rockchip-linux/libmali/blob/rockchip/include/FBDEV/eglplatform.h#L73

## Motivation and Context
it would generate an error on compile time
`error: cannot convert ‘gbm_surface*’ to ‘EGLNativeWindowType {aka fbdev_window*}’ in assignment `

this small change fixes any possible compile error regardless of what type define is used

this is a duplicate of #13641, sorry i tried to make one commit but my branch got deleted

## How Has This Been Tested?
Building on SBC gbm enabled devices

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
