### PR TITLE
[peripherals] Make CPeripherals::Initialise survive getting called wh…

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -106,6 +106,8 @@ CPeripherals::~CPeripherals()
 
 void CPeripherals::Initialise()
 {
+  Clear();
+
 #if !defined(TARGET_DARWIN_IOS)
   CDirectory::Create("special://profile/peripheral_data");
 


### PR DESCRIPTION
…en it is already initialisid. Fixes crash on profile switch after c5f5579

@notspiff mind doing the review? We discussed this internally.
@koying fyi