### PR TITLE
[videoplayer][pvr] Remove deprecated IDispTime from CDVDInputStreamPV…

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9067,8 +9067,8 @@ int CGUIInfoManager::GetEpgEventSeekPercent() const
   int seekSize = g_application.GetAppPlayer().GetSeekHandler().GetSeekSize();
   if (seekSize != 0)
   {
-    float elapsedTime = static_cast<float>(CServiceBroker::GetPVRManager().GetElapsedTime() / 1000);
-    float totalTime = static_cast<float>(CServiceBroker::GetPVRManager().GetTotalTime() / 1000);
+    float elapsedTime = static_cast<float>(CServiceBroker::GetPVRManager().GetElapsedTime());
+    float totalTime = static_cast<float>(CServiceBroker::GetPVRManager().GetTotalTime());
     float percentPerSecond = 100.0f / totalTime;
     float percent = elapsedTime / totalTime * 100.0f + percentPerSecond * seekSize;
     return std::lrintf(percent);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.cpp
@@ -195,20 +195,6 @@ int64_t CDVDInputStreamPVRManager::GetLength()
   return CServiceBroker::GetPVRManager().Clients()->GetStreamLength();
 }
 
-int CDVDInputStreamPVRManager::GetTotalTime()
-{
-  if (!m_isRecording)
-    return CServiceBroker::GetPVRManager().GetTotalTime();
-  return 0;
-}
-
-int CDVDInputStreamPVRManager::GetTime()
-{
-  if (!m_isRecording)
-    return CServiceBroker::GetPVRManager().GetElapsedTime();
-  return 0;
-}
-
 bool CDVDInputStreamPVRManager::GetTimes(Times &times)
 {
   PVR_STREAM_TIMES streamTimes;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamPVRManager.h
@@ -41,7 +41,6 @@ class IDemux;
 class CDVDInputStreamPVRManager
   : public CDVDInputStream
   , public CDVDInputStream::ITimes
-  , public CDVDInputStream::IDisplayTime
   , public CDVDInputStream::IDemux
 {
 public:
@@ -62,11 +61,6 @@ public:
 
   CDVDInputStream::ITimes* GetITimes() override { return this; }
   bool GetTimes(Times &times) override;
-
-  // deprecated
-  CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
-  int GetTotalTime() override;
-  int GetTime() override;
 
   bool CanSeek() override;
   bool CanPause() override;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -855,13 +855,13 @@ bool CPVRGUIInfo::GetVideoLabel(const CFileItem *item, int iLabel, std::string &
 
 bool CPVRGUIInfo::GetSeekTimeLabel(int iSeekSize, std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString(GetElapsedTime() / 1000 + iSeekSize, TIME_FORMAT_GUESS).c_str();
+  strValue = StringUtils::SecondsToTimeString(GetElapsedTime() + iSeekSize, TIME_FORMAT_GUESS).c_str();
   return true;
 }
 
 void CPVRGUIInfo::CharInfoEpgEventDuration(std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString(m_iDuration / 1000, TIME_FORMAT_GUESS).c_str();
+  strValue = StringUtils::SecondsToTimeString(m_iDuration, TIME_FORMAT_GUESS).c_str();
 }
 
 void CPVRGUIInfo::CharInfoTimeshiftStartTime(std::string &strValue) const
@@ -886,18 +886,18 @@ void CPVRGUIInfo::CharInfoTimeshiftOffset(std::string &strValue) const
 
 void CPVRGUIInfo::CharInfoEpgEventElapsedTime(std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString(GetElapsedTime() / 1000, TIME_FORMAT_GUESS).c_str();
+  strValue = StringUtils::SecondsToTimeString(GetElapsedTime(), TIME_FORMAT_GUESS).c_str();
 }
 
 void CPVRGUIInfo::CharInfoEpgEventRemainingTime(std::string &strValue) const
 {
-  strValue = StringUtils::SecondsToTimeString((m_iDuration - GetElapsedTime()) / 1000, TIME_FORMAT_GUESS).c_str();
+  strValue = StringUtils::SecondsToTimeString(m_iDuration - GetElapsedTime(), TIME_FORMAT_GUESS).c_str();
 }
 
 void CPVRGUIInfo::CharInfoEpgEventFinishTime(std::string &strValue) const
 {
   CDateTime finishTime = CDateTime::GetCurrentDateTime();
-  finishTime += CDateTimeSpan(0, 0, 0, (m_iDuration - GetElapsedTime()) / 1000);
+  finishTime += CDateTimeSpan(0, 0, 0, m_iDuration - GetElapsedTime());
   strValue = finishTime.GetAsLocalizedTime("", false);
 }
 
@@ -1156,14 +1156,11 @@ int CPVRGUIInfo::GetElapsedTime(void) const
 
   if (m_playingEpgTag || m_iTimeshiftStartTime)
   {
-    /* Calculate here the position we have of the running live TV event.
-     * "position in ms" = ("current UTC" - "event start UTC") * 1000
-     */
     CDateTime current(m_iTimeshiftPlayTime);
     CDateTime start = m_playingEpgTag ? CDateTime(m_playingEpgTag->StartAsUTC())
                                       : CDateTime(m_iTimeshiftStartTime);
     CDateTimeSpan time = current > start ? current - start : CDateTimeSpan(0, 0, 0, 0);
-    return time.GetSecondsTotal() * 1000;
+    return time.GetSecondsTotal();
   }
   else
   {
@@ -1204,12 +1201,12 @@ void CPVRGUIInfo::UpdatePlayingTag(void)
       if (newTag)
       {
         m_playingEpgTag = newTag;
-        m_iDuration = m_playingEpgTag->GetDuration() * 1000;
+        m_iDuration = m_playingEpgTag->GetDuration();
       }
       else if (m_iTimeshiftEndTime > m_iTimeshiftStartTime)
       {
         m_playingEpgTag.reset();
-        m_iDuration = (m_iTimeshiftEndTime - m_iTimeshiftStartTime) * 1000;
+        m_iDuration = m_iTimeshiftEndTime - m_iTimeshiftStartTime;
       }
       else
       {
@@ -1225,7 +1222,7 @@ void CPVRGUIInfo::UpdatePlayingTag(void)
     {
       CSingleLock lock(m_critSection);
       m_playingEpgTag.reset();
-      m_iDuration = recording->GetDuration() * 1000;
+      m_iDuration = recording->GetDuration();
     }
   }
 }

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1146,13 +1146,6 @@ void CPVRGUIInfo::UpdateNextTimer(void)
 
 int CPVRGUIInfo::GetDuration(void) const
 {
-  if (!m_bHasTimeshiftData)
-  {
-    // fetch data
-    const_cast<CPVRGUIInfo*>(this)->UpdateTimeshift();
-    const_cast<CPVRGUIInfo*>(this)->UpdatePlayingTag();
-  }
-
   CSingleLock lock(m_critSection);
   return m_iDuration;
 }
@@ -1160,13 +1153,6 @@ int CPVRGUIInfo::GetDuration(void) const
 int CPVRGUIInfo::GetElapsedTime(void) const
 {
   CSingleLock lock(m_critSection);
-
-  if (!m_bHasTimeshiftData)
-  {
-    // fetch data
-    const_cast<CPVRGUIInfo*>(this)->UpdateTimeshift();
-    const_cast<CPVRGUIInfo*>(this)->UpdatePlayingTag();
-  }
 
   if (m_playingEpgTag || m_iTimeshiftStartTime)
   {

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -67,15 +67,16 @@ namespace PVR
     bool GetSeekTimeLabel(int iSeekSize, std::string &strValue) const;
 
     /*!
-     * @brief Get the total duration of the currently playing LiveTV item.
-     * @return The total duration in milliseconds or NULL if no channel is playing.
+     * @brief Get the total duration of the currently playing epg event or if no epg is
+     *        available the current lenght in seconds of the playing Live TV stream.
+     * @return The total duration in seconds or 0 if no channel is playing.
      */
     int GetDuration(void) const;
 
     /*!
      * @brief Get the elapsed time since the start of the currently playing epg event or if
-     *        no epg is available since the start of the playback of a LiveTV item.
-     * @return The time in milliseconds or 0 if no channel is playing.
+     *        no epg is available since the start of the playback of the current Live TV stream.
+     * @return The time in seconds or 0 if no channel is playing.
      */
     int GetElapsedTime(void) const;
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -397,15 +397,16 @@ namespace PVR
     void TriggerSearchMissingChannelIcons(void);
 
     /*!
-     * @brief Get the total duration of the currently playing LiveTV item.
-     * @return The total duration in milliseconds or NULL if no channel is playing.
+     * @brief Get the total duration of the currently playing epg event or if no epg is
+     *        available the current lenght in seconds of the playing Live TV stream.
+     * @return The total duration in seconds or 0 if no channel is playing.
      */
     int GetTotalTime(void) const;
 
     /*!
      * @brief Get the elapsed time since the start of the currently playing epg event or if
-     *        no epg is available since the start of the playback of a LiveTV item.
-     * @return The time in milliseconds or 0 if no channel is playing.
+     *        no epg is available since the start of the playback of the current Live TV stream.
+     * @return The time in seconds or 0 if no channel is playing.
      */
     int GetElapsedTime(void) const;
 


### PR DESCRIPTION
…RManager implementation and now obsolete data fetching from the CPVRGUIInfo methods once called by CDVDInputStreamPVRManager as none of the remaining callers does rely on immediate data availability - it's just UI labels now.

@FernetMenta as discussed internally.