### PR TITLE
Add support for scanning AVI files

### DIFF
--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
@@ -41,7 +41,7 @@ IVideoInfoTagLoader* CVideoInfoTagLoaderFactory::CreateLoader(const CFileItem& i
   delete nfo;
 
   if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MYVIDEOS_USETAGS) &&
-      (item.IsType(".mkv") || item.IsType(".mp4")))
+      (item.IsType(".mkv") || item.IsType(".mp4") || item.IsType(".avi")))
   {
     CVideoTagLoaderFFmpeg* ff = new CVideoTagLoaderFFmpeg(item, info, lookInFolder);
     if (ff->HasInfo())

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.h
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.h
@@ -66,5 +66,8 @@ protected:
 
   //! \brief Load tags from MP4 file.
   CInfoScanner::INFO_TYPE LoadMP4(CVideoInfoTag& tag, std::vector<EmbeddedArt>* art);
+
+  //! \brief Load tags from AVI file.
+  CInfoScanner::INFO_TYPE LoadAVI(CVideoInfoTag& tag, std::vector<EmbeddedArt>* art);
 };
 


### PR DESCRIPTION

Allow scanning of AVI movies

## Description

Now that PR 13519 has been merged, a user is now able to query a movie description from IMDB directly from the metatag key/value stored in MP4 or MKV files. This commit extends the mechanism to the legacy but very common MP4(XviD)+MP3 AVI containers (aka RIFF).

## Motivation and Context
The existing scanning mechanism already allow scanning of MP4 and MKV but a user may want to still keep the original AVI unchanged for simplicity instead of converting and possibly degrading the movie to a different container. There are a wide variety of container type, but XviD is still very common nowadays and user may want to keep those file around for legacy appliance.

## How Has This Been Tested?
System is Debian/9.3. xbmc was forked from commit 78aafccf8fcf45e1b38f0af8b6003bc511f20f9a.

The implementation was based of the documentation of ffmpeg support AVI tags at:

* https://wiki.multimedia.cx/index.php/FFmpeg_Metadata#AVI

This documentation makes it clear that RIFF based container cannot contains much information, but only limited set of values making it a perfect fit for `CInfoScanner::TITLE_NFO` requirements.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
