### PR TITLE
Verify add-on zip authenticity

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -8,7 +8,7 @@
   </requires>
 	<extension point="xbmc.addon.repository">
 		<info>http://mirrors.kodi.tv/addons/leia/addons.xml.gz</info>
-		<checksum>http://mirrors.kodi.tv/addons/leia/addons.xml.gz?sha256</checksum>
+		<checksum verify="sha256">http://mirrors.kodi.tv/addons/leia/addons.xml.gz?sha256</checksum>
 		<datadir>https://mirrors.kodi.tv/addons/leia</datadir>
 		<artdir>http://mirrors.kodi.tv/addons/leia</artdir>
 		<hashes>sha256</hashes>

--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -9,7 +9,7 @@
 	<extension point="xbmc.addon.repository">
 		<info>http://mirrors.kodi.tv/addons/leia/addons.xml.gz</info>
 		<checksum>http://mirrors.kodi.tv/addons/leia/addons.xml.gz.md5</checksum>
-		<datadir>http://mirrors.kodi.tv/addons/leia</datadir>
+		<datadir>https://mirrors.kodi.tv/addons/leia</datadir>
 		<hashes>true</hashes>
 	</extension>
 	<extension point="xbmc.addon.metadata">

--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -8,10 +8,10 @@
   </requires>
 	<extension point="xbmc.addon.repository">
 		<info>http://mirrors.kodi.tv/addons/leia/addons.xml.gz</info>
-		<checksum>http://mirrors.kodi.tv/addons/leia/addons.xml.gz.md5</checksum>
+		<checksum>http://mirrors.kodi.tv/addons/leia/addons.xml.gz?sha256</checksum>
 		<datadir>https://mirrors.kodi.tv/addons/leia</datadir>
 		<artdir>http://mirrors.kodi.tv/addons/leia</artdir>
-		<hashes>true</hashes>
+		<hashes>sha256</hashes>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="af_ZA">Installeer Byvoegsels vanaf Kodi.tv</summary>

--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -10,6 +10,7 @@
 		<info>http://mirrors.kodi.tv/addons/leia/addons.xml.gz</info>
 		<checksum>http://mirrors.kodi.tv/addons/leia/addons.xml.gz.md5</checksum>
 		<datadir>https://mirrors.kodi.tv/addons/leia</datadir>
+		<artdir>http://mirrors.kodi.tv/addons/leia</artdir>
 		<hashes>true</hashes>
 	</extension>
 	<extension point="xbmc.addon.metadata">

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -199,11 +199,10 @@ bool CAddonInstaller::InstallOrUpdate(const std::string &addonID, bool backgroun
 {
   AddonPtr addon;
   RepositoryPtr repo;
-  std::string hash;
-  if (!CAddonInstallJob::GetAddonWithHash(addonID, repo, addon, hash))
+  if (!CAddonInstallJob::GetAddon(addonID, repo, addon))
     return false;
 
-  return DoInstall(addon, repo, hash, background, modal);
+  return DoInstall(addon, repo, background, modal);
 }
 
 void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& version, const std::string& repoId)
@@ -221,22 +220,17 @@ void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& ve
   if (!CServiceBroker::GetAddonMgr().GetAddon(repoId, repo, ADDON_REPOSITORY))
     return;
 
-  std::string hash;
-  if (!std::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon, hash))
-    return;
-  DoInstall(addon, std::static_pointer_cast<CRepository>(repo), hash, true, false);
+  DoInstall(addon, std::static_pointer_cast<CRepository>(repo), true, false);
 }
 
-bool CAddonInstaller::DoInstall(const AddonPtr &addon, const RepositoryPtr& repo,
-    const std::string &hash /* = "" */, bool background /* = true */, bool modal /* = false */,
-    bool autoUpdate /* = false*/)
+bool CAddonInstaller::DoInstall(const AddonPtr &addon, const RepositoryPtr& repo, bool background /* = true */, bool modal /* = false */, bool autoUpdate /* = false*/)
 {
   // check whether we already have the addon installing
   CSingleLock lock(m_critSection);
   if (m_downloadJobs.find(addon->ID()) != m_downloadJobs.end())
     return false;
 
-  CAddonInstallJob* installJob = new CAddonInstallJob(addon, repo, hash, autoUpdate);
+  CAddonInstallJob* installJob = new CAddonInstallJob(addon, repo, autoUpdate);
   if (background)
   {
     // Workaround: because CAddonInstallJob is blocking waiting for other jobs, it needs to be run
@@ -434,9 +428,8 @@ void CAddonInstaller::InstallUpdates()
     {
       AddonPtr toInstall;
       RepositoryPtr repo;
-      std::string hash;
-      if (CAddonInstallJob::GetAddonWithHash(addon->ID(), repo, toInstall, hash))
-        DoInstall(toInstall, repo, hash, true, false, true);
+      if (CAddonInstallJob::GetAddon(addon->ID(), repo, toInstall))
+        DoInstall(toInstall, repo, true, false, true);
     }
   }
 }
@@ -474,19 +467,17 @@ int64_t CAddonInstaller::EnumeratePackageFolder(std::map<std::string,CFileItemLi
   return size;
 }
 
-CAddonInstallJob::CAddonInstallJob(const AddonPtr &addon, const AddonPtr &repo,
-    const std::string &hash, bool isAutoUpdate)
+CAddonInstallJob::CAddonInstallJob(const AddonPtr &addon, const RepositoryPtr &repo, bool isAutoUpdate)
   : m_addon(addon),
     m_repo(repo),
-    m_hash(hash),
     m_isAutoUpdate(isAutoUpdate)
 {
   AddonPtr dummy;
   m_isUpdate = CServiceBroker::GetAddonMgr().GetAddon(addon->ID(), dummy, ADDON_UNKNOWN, false);
 }
 
-bool CAddonInstallJob::GetAddonWithHash(const std::string& addonID, RepositoryPtr& repo,
-    ADDON::AddonPtr& addon, std::string& hash)
+bool CAddonInstallJob::GetAddon(const std::string& addonID, RepositoryPtr& repo,
+    ADDON::AddonPtr& addon)
 {
   if (!CServiceBroker::GetAddonMgr().FindInstallableById(addonID, addon))
     return false;
@@ -496,7 +487,8 @@ bool CAddonInstallJob::GetAddonWithHash(const std::string& addonID, RepositoryPt
     return false;
 
   repo = std::static_pointer_cast<CRepository>(tmp);
-  return repo->GetAddonHash(addon, hash);
+
+  return true;
 }
 
 bool CAddonInstallJob::DoWork()
@@ -524,12 +516,27 @@ bool CAddonInstallJob::DoWork()
     std::string dest = "special://home/addons/packages/";
     std::string package = URIUtils::AddFileToFolder("special://home/addons/packages/",
                                                     URIUtils::GetFileName(m_addon->Path()));
-    if (URIUtils::HasSlashAtEnd(m_addon->Path()))
+    if (!m_repo && URIUtils::HasSlashAtEnd(m_addon->Path()))
     { // passed in a folder - all we need do is copy it across
       installFrom = m_addon->Path();
     }
     else
     {
+      std::string path{m_addon->Path()};
+      std::string hash;
+      if (m_repo)
+      {
+        CRepository::ResolveResult resolvedAddon = m_repo->ResolvePathAndHash(m_addon);
+        path = resolvedAddon.location;
+        hash = resolvedAddon.hash;
+        if (path.empty())
+        {
+          CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to resolve addon install source path", m_addon->ID().c_str());
+          ReportInstallError(m_addon->ID(), m_addon->ID());
+          return false;
+        }
+      }
+
       CAddonDatabase db;
       if (!db.Open())
       {
@@ -538,13 +545,16 @@ bool CAddonInstallJob::DoWork()
         return false;
       }
 
-      std::string md5;
       // check that we don't already have a valid copy
-      if (!m_hash.empty() && CFile::Exists(package))
+      if (!hash.empty())
       {
-        if (db.GetPackageHash(m_addon->ID(), package, md5) && m_hash != md5)
+        std::string hashExisting;
+        if (db.GetPackageHash(m_addon->ID(), package, hashExisting) && hash != hashExisting)
         {
           db.RemovePackage(package);
+        }
+        if (CFile::Exists(package))
+        {
           CFile::Delete(package);
         }
       }
@@ -552,7 +562,6 @@ bool CAddonInstallJob::DoWork()
       // zip passed in - download + extract
       if (!CFile::Exists(package))
       {
-        std::string path(m_addon->Path());
         if (!DownloadPackage(path, dest))
         {
           CFile::Delete(package);
@@ -565,15 +574,15 @@ bool CAddonInstallJob::DoWork()
 
       // at this point we have the package - check that it is valid
       SetText(g_localizeStrings.Get(24077));
-      if (!m_hash.empty())
+      if (!hash.empty())
       {
         md5 = CUtil::GetFileDigest(package, KODI::UTILITY::CDigest::Type::MD5);
-        if (!StringUtils::EqualsNoCase(md5, m_hash))
+        if (!StringUtils::EqualsNoCase(md5, hash))
         {
           CFile::Delete(package);
 
           CLog::Log(LOGERROR, "CAddonInstallJob[%s]: MD5 mismatch after download. Expected %s, was %s",
-              m_addon->ID().c_str(), m_hash.c_str(), md5.c_str());
+              m_addon->ID().c_str(), hash.c_str(), md5.c_str());
           ReportInstallError(m_addon->ID(), URIUtils::GetFileName(package));
           return false;
         }
@@ -702,7 +711,7 @@ bool CAddonInstallJob::DoFileOperation(FileAction action, CFileItemList &items, 
   return result;
 }
 
-bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& repo)
+bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryPtr& repo)
 {
   SetText(g_localizeStrings.Get(24079));
   auto deps = m_addon->GetDependencies();
@@ -745,15 +754,14 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& r
         {
           RepositoryPtr repoForDep;
           AddonPtr addon;
-          std::string hash;
-          if (!CAddonInstallJob::GetAddonWithHash(addonID, repoForDep, addon, hash))
+          if (!CAddonInstallJob::GetAddon(addonID, repoForDep, addon))
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to find dependency %s", m_addon->ID().c_str(), addonID.c_str());
             ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
             return false;
           }
 
-          CAddonInstallJob dependencyJob(addon, repoForDep, hash, false);
+          CAddonInstallJob dependencyJob(addon, repoForDep, false);
 
           // pass our progress indicators to the temporary job and don't allow it to
           // show progress or information updates (no progress, title or text changes)

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -125,12 +125,11 @@ private:
   /*! \brief Install an addon from a repository or zip
    \param addon the AddonPtr describing the addon
    \param repo the repository to install addon from
-   \param hash the hash to verify the install. Defaults to "".
    \param background whether to install in the background or not. Defaults to true.
    \return true on successful install, false on failure.
    */
   bool DoInstall(const ADDON::AddonPtr &addon, const ADDON::RepositoryPtr &repo,
-      const std::string &hash = "", bool background = true, bool modal = false, bool autoUpdate = false);
+      bool background = true, bool modal = false, bool autoUpdate = false);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -154,8 +153,7 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr& addon, const ADDON::AddonPtr& repo,
-      const std::string& hash, bool isAutoUpdate);
+  CAddonInstallJob(const ADDON::AddonPtr& addon, const ADDON::RepositoryPtr& repo, bool isAutoUpdate);
 
   bool DoWork() override;
 
@@ -166,13 +164,12 @@ public:
    *  \param hash Hash of the add-on
    *  \return True if the add-on and its hash were found, false otherwise.
    */
-  static bool GetAddonWithHash(const std::string& addonID, ADDON::RepositoryPtr& repo,
-      ADDON::AddonPtr& addon, std::string& hash);
+  static bool GetAddon(const std::string& addonID, ADDON::RepositoryPtr& repo, ADDON::AddonPtr& addon);
 
 private:
   void OnPreInstall();
   void OnPostInstall();
-  bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
+  bool Install(const std::string &installFrom, const ADDON::RepositoryPtr& repo = ADDON::RepositoryPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 
   bool DoFileOperation(FileAction action, CFileItemList &items, const std::string &file, bool useSameJob = true);
@@ -185,8 +182,7 @@ private:
   void ReportInstallError(const std::string& addonID, const std::string& fileName, const std::string& message = "");
 
   ADDON::AddonPtr m_addon;
-  ADDON::AddonPtr m_repo;
-  std::string m_hash;
+  ADDON::RepositoryPtr m_repo;
   bool m_isUpdate;
   bool m_isAutoUpdate;
 };

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -42,6 +42,11 @@ namespace ADDON
 void cp_fatalErrorHandler(const char *msg);
 void cp_logger(cp_log_severity_t level, const char *msg, const char *apid, void *user_data);
 
+namespace {
+// Note that all of these characters are url-safe
+const std::string VALID_ADDON_IDENTIFIER_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_@!$";
+}
+
 /**********************************************************
  * CAddonMgr
  *
@@ -78,6 +83,15 @@ bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder
 {
   if (!plugin || !plugin->identifier)
     return false;
+
+  // Check addon identifier for forbidden characters
+  // The identifier is used e.g. in URLs so we shouldn't allow just
+  // any character to go through.
+  if (std::string{plugin->identifier}.find_first_not_of(VALID_ADDON_IDENTIFIER_CHARACTERS) != std::string::npos)
+  {
+    CLog::Log(LOGERROR, "Plugin identifier {} is invalid", plugin->identifier);
+    return false;
+  }
 
   if (!PlatformSupportsAddon(plugin))
     return false;

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -287,8 +287,8 @@ namespace ADDON
     std::vector<DependencyInfo> GetDepsRecursive(const std::string& id);
 
     static AddonPtr Factory(const cp_plugin_info_t* plugin, TYPE type);
-    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions = false);
-    static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder);
+    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions = false, std::string assetBasePath = "");
+    static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, std::string const& assetBasePath);
 
   private:
     CAddonMgr& operator=(CAddonMgr const&) = delete;

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -24,7 +24,16 @@
 #include <ctype.h>
 
 #include "AddonVersion.h"
+#include "utils/log.h"
 #include "utils/StringUtils.h"
+
+namespace {
+// Add-on versions are used e.g. in file names and should
+// not have too much freedom in their accepted characters
+// Things that should be allowed: e.g. 0.1.0~beta3+git010cab3
+// Note that all of these characters are url-safe
+const std::string VALID_ADDON_VERSION_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.+_@~";
+}
 
 namespace ADDON
 {
@@ -42,7 +51,18 @@ namespace ADDON
     if (pos != std::string::npos)
     {
       mRevision = mUpstream.substr(pos+1);
+      if (mRevision.find_first_not_of(VALID_ADDON_VERSION_CHARACTERS) != std::string::npos)
+      {
+        CLog::Log(LOGERROR, "AddonVersion: {} is not a valid revision number", mRevision);
+        mRevision = "";
+      }
       mUpstream.erase(pos);
+    }
+
+    if (mUpstream.find_first_not_of(VALID_ADDON_VERSION_CHARACTERS) != std::string::npos)
+    {
+      CLog::Log(LOGERROR, "AddonVersion: {} is not a valid version", mUpstream);
+      mUpstream = "0.0.0";
     }
   }
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -119,6 +119,11 @@ CRepository::DirInfo CRepository::ParseDirConfiguration(cp_cfg_element_t* config
   dir.checksum = mgr.GetExtValue(configuration, "checksum");
   dir.info = mgr.GetExtValue(configuration, "info");
   dir.datadir = mgr.GetExtValue(configuration, "datadir");
+  dir.artdir = mgr.GetExtValue(configuration, "artdir");
+  if (dir.artdir.empty())
+  {
+    dir.artdir = dir.datadir;
+  }
   dir.hashes = mgr.GetExtValue(configuration, "hashes") == "true";
   dir.version = AddonVersion{mgr.GetExtValue(configuration, "@minversion")};
   return dir;

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -40,6 +40,8 @@ namespace ADDON
       AddonVersion version{""};
       std::string info;
       std::string checksum;
+      bool verifyChecksum{false};
+      KODI::UTILITY::CDigest::Type checksumType;
       std::string datadir;
       std::string artdir;
       bool hashes{false};
@@ -77,7 +79,7 @@ namespace ADDON
 
   private:
     static bool FetchChecksum(const std::string& url, std::string& checksum) noexcept;
-    static bool FetchIndex(const DirInfo& repo, VECADDONS& addons) noexcept;
+    static bool FetchIndex(const DirInfo& repo, std::string const& digest, VECADDONS& addons) noexcept;
 
     static DirInfo ParseDirConfiguration(cp_cfg_element_t* configuration);
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -40,12 +40,10 @@ namespace ADDON
       AddonVersion version{""};
       std::string info;
       std::string checksum;
-      bool verifyChecksum{false};
-      KODI::UTILITY::CDigest::Type checksumType;
+      KODI::UTILITY::CDigest::Type checksumType{KODI::UTILITY::CDigest::Type::INVALID};
       std::string datadir;
       std::string artdir;
-      bool hashes{false};
-      KODI::UTILITY::CDigest::Type hashType;
+      KODI::UTILITY::CDigest::Type hashType{KODI::UTILITY::CDigest::Type::INVALID};
     };
 
     typedef std::vector<DirInfo> DirList;
@@ -72,8 +70,7 @@ namespace ADDON
     struct ResolveResult
     {
       std::string location;
-      std::string hash;
-      KODI::UTILITY::CDigest::Type hashType;
+      KODI::UTILITY::TypedDigest digest;
     };
     ResolveResult ResolvePathAndHash(AddonPtr const& addon) const;
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -63,6 +63,13 @@ namespace ADDON
 
     FetchStatus FetchIfChanged(const std::string& oldChecksum, std::string& checksum, VECADDONS& addons) const;
 
+    struct ResolveResult
+    {
+      std::string location;
+      std::string hash;
+    };
+    ResolveResult ResolvePathAndHash(AddonPtr const& addon) const;
+
   private:
     static bool FetchChecksum(const std::string& url, std::string& checksum) noexcept;
     static bool FetchIndex(const DirInfo& repo, VECADDONS& addons) noexcept;

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "Addon.h"
+#include "utils/Digest.h"
 #include "utils/Job.h"
 #include "utils/ProgressJob.h"
 
@@ -36,13 +37,13 @@ namespace ADDON
   public:
     struct DirInfo
     {
-      DirInfo() : version("0.0.0"), hashes(false) {}
-      AddonVersion version;
+      AddonVersion version{""};
       std::string info;
       std::string checksum;
       std::string datadir;
       std::string artdir;
-      bool hashes;
+      bool hashes{false};
+      KODI::UTILITY::CDigest::Type hashType;
     };
 
     typedef std::vector<DirInfo> DirList;
@@ -70,6 +71,7 @@ namespace ADDON
     {
       std::string location;
       std::string hash;
+      KODI::UTILITY::CDigest::Type hashType;
     };
     ResolveResult ResolvePathAndHash(AddonPtr const& addon) const;
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -41,6 +41,7 @@ namespace ADDON
       std::string info;
       std::string checksum;
       std::string datadir;
+      std::string artdir;
       bool hashes;
     };
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -27,6 +27,8 @@
 #include "utils/Job.h"
 #include "utils/ProgressJob.h"
 
+struct cp_cfg_element_t;
+
 namespace ADDON
 {
   class CRepository : public CAddon
@@ -73,6 +75,8 @@ namespace ADDON
   private:
     static bool FetchChecksum(const std::string& url, std::string& checksum) noexcept;
     static bool FetchIndex(const DirInfo& repo, VECADDONS& addons) noexcept;
+
+    static DirInfo ParseDirConfiguration(cp_cfg_element_t* configuration);
 
     DirList m_dirs;
   };

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1061,8 +1061,8 @@ bool CCurlFile::Open(const CURL& url)
     }
   }
 
-  char* efurl;
-  if (CURLE_OK == g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL,&efurl) && efurl)
+  std::string efurl = GetInfoString(CURLINFO_EFFECTIVE_URL);
+  if (!efurl.empty())
   {
     if (m_url != efurl)
     {
@@ -1098,8 +1098,8 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
 
-  char* efurl;
-  if (CURLE_OK == g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL,&efurl) && efurl)
+  std::string efurl = GetInfoString(CURLINFO_EFFECTIVE_URL);
+  if (!efurl.empty())
     m_url = efurl;
 
   m_opened = true;
@@ -1767,6 +1767,23 @@ void CCurlFile::SetRequestHeader(const std::string& header, long value)
 std::string CCurlFile::GetURL(void)
 {
   return m_url;
+}
+
+std::string CCurlFile::GetRedirectURL()
+{
+  return GetInfoString(CURLINFO_REDIRECT_URL);
+}
+
+std::string CCurlFile::GetInfoString(int infoType)
+{
+  char* info{};
+  CURLcode result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, static_cast<XCURL::CURLINFO> (infoType), &info);
+  if (result != CURLE_OK)
+  {
+    CLog::Log(LOGERROR, "Info string request for type {} failed with result code {}", infoType, result);
+    return "";
+  }
+  return (info ? info : "");
 }
 
 /* STATIC FUNCTIONS */

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -535,10 +535,6 @@ void CCurlFile::SetCommonOptions(CReadState* state)
     state->m_curlAliasList = g_curlInterface.slist_append(state->m_curlAliasList, "ICY 200 OK");
   g_curlInterface.easy_setopt(h, CURLOPT_HTTP200ALIASES, state->m_curlAliasList);
 
-  // never verify peer, we don't have any certificates to do this
-  g_curlInterface.easy_setopt(h, CURLOPT_SSL_VERIFYPEER, 0);
-  g_curlInterface.easy_setopt(h, CURLOPT_SSL_VERIFYHOST, 0);
-
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_URL, m_url.c_str());
   g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_TRANSFERTEXT, CURL_OFF);
 

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -94,6 +94,7 @@ namespace XFILE
 
       const CHttpHeader& GetHttpHeader() const { return m_state->m_httpheader; }
       std::string GetURL(void);
+      std::string GetRedirectURL();
 
       /* static function that will get content type of a file */
       static bool GetHttpHeader(const CURL &url, CHttpHeader &headers);
@@ -156,6 +157,7 @@ namespace XFILE
       void SetRequestHeaders(CReadState* state);
       void SetCorrectHeaders(CReadState* state);
       bool Service(const std::string& strURL, std::string& strHTML);
+      std::string GetInfoString(int infoType);
 
     protected:
       CReadState* m_state;

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -24,9 +24,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_FILE_H__A7ED6320_C362_49CB_8925_6C6C8CAE7B78__INCLUDED_)
-#define AFX_FILE_H__A7ED6320_C362_49CB_8925_6C6C8CAE7B78__INCLUDED_
-
 #pragma once
 
 #include <iostream>
@@ -234,4 +231,3 @@ private:
 };
 
 }
-#endif // !defined(AFX_FILE_H__A7ED6320_C362_49CB_8925_6C6C8CAE7B78__INCLUDED_)

--- a/xbmc/utils/Digest.cpp
+++ b/xbmc/utils/Digest.cpp
@@ -53,6 +53,11 @@ EVP_MD const * TypeToEVPMD(CDigest::Type type)
 
 }
 
+std::ostream& operator<<(std::ostream& os, TypedDigest const& digest)
+{
+  return os << "{" << CDigest::TypeToString(digest.type) << "}" << digest.value;
+}
+
 std::string CDigest::TypeToString(Type type)
 {
   switch (type)
@@ -65,6 +70,8 @@ std::string CDigest::TypeToString(Type type)
       return "sha256";
     case Type::SHA512:
       return "sha512";
+    case Type::INVALID:
+      return "invalid";
     default:
       throw std::invalid_argument("Unknown digest type");
   }

--- a/xbmc/utils/Digest.h
+++ b/xbmc/utils/Digest.h
@@ -22,8 +22,12 @@
 
 #include <openssl/evp.h>
 
+#include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
+
+#include "StringUtils.h"
 
 namespace KODI
 {
@@ -41,7 +45,8 @@ public:
     MD5,
     SHA1,
     SHA256,
-    SHA512
+    SHA512,
+    INVALID
   };
 
   /**
@@ -107,6 +112,40 @@ private:
   std::unique_ptr<EVP_MD_CTX, MdCtxDeleter> m_context;
   EVP_MD const* m_md;
 };
+
+struct TypedDigest
+{
+  CDigest::Type type{CDigest::Type::INVALID};
+  std::string value;
+
+  TypedDigest()
+  {}
+
+  TypedDigest(CDigest::Type type, std::string const& value)
+  : type(type), value(value)
+  {}
+
+  bool Empty() const
+  {
+    return (type == CDigest::Type::INVALID || value.empty());
+  }
+};
+
+inline bool operator==(TypedDigest const& left, TypedDigest const& right)
+{
+  if (left.type != right.type)
+  {
+    throw std::logic_error("Cannot compare digests of different type");
+  }
+  return StringUtils::EqualsNoCase(left.value, right.value);
+}
+
+inline bool operator!=(TypedDigest const& left, TypedDigest const& right)
+{
+  return !(left == right);
+}
+
+std::ostream& operator<<(std::ostream& os, TypedDigest const& digest);
 
 }
 }

--- a/xbmc/utils/test/TestDigest.cpp
+++ b/xbmc/utils/test/TestDigest.cpp
@@ -23,6 +23,7 @@
 #include "gtest/gtest.h"
 
 using KODI::UTILITY::CDigest;
+using KODI::UTILITY::TypedDigest;
 
 TEST(TestDigest, Digest_Empty)
 {
@@ -68,4 +69,43 @@ TEST(TestDigest, Digest_SHA512)
 {
   EXPECT_STREQ(CDigest::Calculate(CDigest::Type::SHA512, "").c_str(), "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
   EXPECT_STREQ(CDigest::Calculate(CDigest::Type::SHA512, "asdf").c_str(), "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1");
+}
+
+TEST(TestDigest, TypedDigest_Empty)
+{
+  TypedDigest t1, t2;
+  EXPECT_EQ(t1, t2);
+  EXPECT_EQ(t1.type, CDigest::Type::INVALID);
+  EXPECT_EQ(t1.value, "");
+  EXPECT_TRUE(t1.Empty());
+  t1.type = CDigest::Type::SHA1;
+  EXPECT_TRUE(t1.Empty());
+}
+
+TEST(TestDigest, TypedDigest_SameType)
+{
+  TypedDigest t1{CDigest::Type::SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709"};
+  TypedDigest t2{CDigest::Type::SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80708"};
+  EXPECT_NE(t1, t2);
+  EXPECT_FALSE(t1.Empty());
+}
+
+TEST(TestDigest, TypedDigest_CompareCase)
+{
+  TypedDigest t1{CDigest::Type::SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80708"};
+  TypedDigest t2{CDigest::Type::SHA1, "da39A3EE5e6b4b0d3255bfef95601890afd80708"};
+  EXPECT_EQ(t1, t2);
+}
+
+TEST(TestDigest, TypedDigest_DifferingType)
+{
+  TypedDigest t1{CDigest::Type::SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709"};
+  TypedDigest t2{CDigest::Type::SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"};
+  // Silence "unused expression" warning
+  bool a;
+  EXPECT_THROW(a = (t1 == t2), std::logic_error);
+  // Silence "unused variable" warning
+  (void)a;
+  EXPECT_THROW(a = (t1 != t2), std::logic_error);
+  (void)a;
 }


### PR DESCRIPTION
Enable SSL connections for add-on zip downloads from the official repository and verify the downloaded files with the hashes provided in the redirect

(for the server side: cc @kib  @wsnipex)

Rationale
---
We've long been discussing how to make the Kodi update mechanism more secure (or rather, not *completely* insecure) with things like TUF etc.
TUF is unfortunately a very difficult path, so I would like to propose this as an interim "solution" for Leia.

It does not prevent all (or even most) of the bad things TUF would. But it at least doesn't make it so dead simple to own a Kodi installation via network and means we don't have to trust the mirrors as much as we do now.
The principle is: We get the hash and location of the zip file from the central mirror redirector run by ourselves (`mirrors.kodi.tv`). Since we do that over SSL, the hash cannot be tampered with. The redirector can then give us the URI of the file on a mirror of its choice, be it HTTP or HTTPS. Using SSL connections for all mirrors is not an option at the moment since many of those do not support it yet.

This is still WIP, but I want to get early feedback whether this is the direction we want to be going in first. The basic principle is implemented.

Problems
---
* If we decide to do this, it implies that we cannot later remove the mirror redirect and the `Content-Sha256` header without breaking updates in older installations.
* Third-party repositories do not directly benefit from this except when they duplicate our mirror setup. If they don't have too much traffic or can handle it, they should just use HTTPS. We might want to show a warning when a repository neither has this hash feature nor uses a SSL connection - or even make it unsupported?

TODO
---
- [x] Decide whether the old `.md5` code path should be kept (for 3rdparty repositories? does someone use it?)
- [x] Only enable the check when it is enabled for the repository
- [x] Fix base64 encoding in mirrorbits
- [x] Split `icondir` from `datadir` so Kodi doesn't use SSL connections for downloading the icons
- [x] Switch everything to sha256
- [x] Check whether we can secure `addons.xml` further and if it opens up any attack vectors
- [x] Wiki changes: https://kodi.wiki/view/Add-on_repositories