### PR TITLE
fix playing video strm files with autoplay

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -993,6 +993,9 @@ bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const
   if (HasProperty("IsHTTPDirectory"))
     return false;
 
+  if (!m_strDynPath.empty())
+    return URIUtils::IsInternetStream(m_strDynPath, bStrictCheck);
+
   return URIUtils::IsInternetStream(m_strPath, bStrictCheck);
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -59,6 +59,10 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
       if (!strImage.empty() && g_TextureManager.HasTexture(strImage))
         item->SetIconImage(strImage);
     }
+    if (item->GetVideoInfoTag())
+    {
+      item->SetDynPath(item->GetVideoInfoTag()->GetPath());
+    }
   }
   items.SetLabel(pNode->GetLocalizedName());
 

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -38,7 +38,7 @@ CPlayList* CPlayListFactory::Create(const std::string& filename)
 
 CPlayList* CPlayListFactory::Create(const CFileItem& item)
 {
-  if( item.IsInternetStream() )
+  if (item.IsInternetStream())
   {
     // Ensure the MIME type has been retrieved for http:// and shout:// streams
     if (item.GetMimeType().empty())
@@ -72,7 +72,11 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
       return new CPlayListWPL();
   }
 
-  std::string extension = URIUtils::GetExtension(item.GetPath());
+  std::string path = item.GetDynPath();
+  if (path.empty())
+    path = item.GetPath();
+
+  std::string extension = URIUtils::GetExtension(path);
   StringUtils::ToLower(extension);
 
   if (extension == ".m3u" || extension == ".strm")


### PR DESCRIPTION
Start fixing fileitem issues. The id (path) of a fileitem must never be changed after creation. Only one reason is that UI can't highlight currently playing item if path was changed.

Many components like any kind of players are not interested in the id which can be pluging:// or videodb://. Instead they are interested in real path. Real path should always be carried in dynPath.

Still a lot of work to get this right for the entire app ...