### PR TITLE
[Music]Fix when song info dialog called by Python with non-array artistid property 

### DIFF
--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -92,15 +92,20 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 
   std::string path(pItem->GetPath());
   // For songs in library set the (primary) song artist and album properties 
-  // Use song Id (not path) as called for items from either library or file view 
-  if (pItem->GetMusicInfoTag()->GetDatabaseId() > 0)
+  // Use song Id (not path) as called for items from either library or file view,
+  // but could also be listitem with tag loaded by a script
+  if (pItem->HasMusicInfoTag() && 
+      pItem->GetMusicInfoTag()->GetType() == MediaTypeSong && 
+      pItem->GetMusicInfoTag()->GetDatabaseId() > 0)
   {
     CMusicDatabase database;
     database.Open();
-    // May already have song artist ids as item property, otherwise fetch from song id
+    // May already have song artist ids as item property set when data read from
+    // db, but check property is valid array (scripts could set item properties 
+    // incorrectly), otherwise fetch artist using song id.
     CArtist artist;
     bool artistfound = false;
-    if (pItem->HasProperty("artistid"))
+    if (pItem->HasProperty("artistid") && pItem->GetProperty("artistid").isArray())
     {
       CVariant::const_iterator_array varid = pItem->GetProperty("artistid").begin_array();
       int idArtist = varid->asInteger();

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -65,8 +65,10 @@ public:
       return false;
     CFileItemPtr m_song = dialog->GetCurrentListItem();
 
-    // Fetch tag data from library using filename, or scanning file (if item not already have this loaded)
-    m_song->LoadMusicTag();
+    // Fetch tag data from library using filename of item path, or scanning file
+    // (if item does not already have this loaded)
+    if (!m_song->LoadMusicTag())
+      return false;
     if (dialog->IsCancelled())
       return false;
     // Fetch album and primary song artist data from library as properties


### PR DESCRIPTION
Fix issue when song info dialog is opened by an addon.  

`CMusicInfoLoader::LoadAdditionalTagInfo()` is expecting the item artistid property (if present) to be an array, as this is what is set by loading the data from the db. However this property is vulnerable to being set incorrectly by an addon which can only set string values. 

For example:
```
import xbmcgui

listitem = xbmcgui.ListItem('Foo')
listitem.setInfo('music', {'dbid': 1, 'mediatype': 'song'})
listitem.setProperty('artistid', '[1]')
xbmcgui.Dialog().info(listitem)
```
Thanks for spotting this @ronie
