### PR TITLE
Consolidate OpenSSL multi-threading initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ if(UNIX)
   option(ENABLE_INTERNAL_CROSSGUID "Enable internal crossguid?" ON)
   option(ENABLE_INTERNAL_RapidJSON "Enable internal rapidjson?" OFF)
   option(ENABLE_INTERNAL_FMT "Enable internal fmt?" OFF)
-  option(ENABLE_OPENSSL     "Enable OpenSSL?" ON)
 endif()
 # System options
 if(NOT WIN32)
@@ -122,6 +121,7 @@ set(required_deps Cdio
                   Iconv
                   LibDvd
                   Lzo2
+                  OpenSSL
                   PCRE
                   RapidJSON
                   Sqlite3
@@ -191,11 +191,6 @@ endif()
 
 if(NOT UDEV_FOUND)
   core_optional_dep(LibUSB)
-endif()
-
-if(ENABLE_OPENSSL)
-  core_require_dep(OpenSSL)
-  list(APPEND DEP_DEFINES "-DHAVE_OPENSSL=1")
 endif()
 
 if(ENABLE_UPNP)

--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -34,43 +34,6 @@ if(CURL_FOUND)
   set(CURL_INCLUDE_DIRS ${CURL_INCLUDE_DIR})
   set(CURL_LIBRARIES ${CURL_LIBRARY})
 
-  # Check whether OpenSSL inside libcurl is static.
-  if(UNIX)
-    if(NOT DEFINED HAS_CURL_STATIC AND CURL_LIBRARY MATCHES ".+\.a$" AND PC_CURL_STATIC_LDFLAGS)
-      set(HAS_CURL_STATIC TRUE)
-    endif()
-    if(NOT DEFINED HAS_CURL_STATIC)
-      get_filename_component(CURL_LIBRARY_DIR ${CURL_LIBRARY} DIRECTORY)
-      find_soname(CURL REQUIRED)
-
-      if(APPLE)
-        set(libchecker nm)
-        set(searchpattern "T [_]?CRYPTO_set_locking_call")
-      else()
-        set(libchecker readelf -s)
-        set(searchpattern "CRYPTO_set_locking_call")
-      endif()
-      execute_process(
-        COMMAND ${libchecker} ${CURL_LIBRARY_DIR}/${CURL_SONAME}
-        COMMAND grep -Eq ${searchpattern}
-        RESULT_VARIABLE HAS_CURL_STATIC)
-      unset(libchecker)
-      unset(searchpattern)
-      if(HAS_CURL_STATIC EQUAL 0)
-        set(HAS_CURL_STATIC TRUE)
-      else()
-        set(HAS_CURL_STATIC FALSE)
-      endif()
-      set(HAS_CURL_STATIC ${HAS_CURL_STATIC} CACHE INTERNAL
-          "OpenSSL is statically linked into Curl")
-      message(STATUS "OpenSSL is statically linked into Curl: ${HAS_CURL_STATIC}")
-    endif()
-  endif()
-
-  if(HAS_CURL_STATIC)
-    set(CURL_DEFINITIONS -DHAS_CURL_STATIC=1)
-  endif()
-
   if(NOT TARGET Curl::Curl)
     add_library(Curl::Curl UNKNOWN IMPORTED)
     set_target_properties(Curl::Curl PROPERTIES

--- a/xbmc/DllPaths_generated.h.in
+++ b/xbmc/DllPaths_generated.h.in
@@ -31,10 +31,6 @@
 #define DLL_PATH_LIBSHAIRPLAY  "@SHAIRPLAY_SONAME@"
 #define DLL_PATH_LIBCEC        "@LIBCEC_SONAME@"
 
-#ifndef DLL_PATH_LIBCURL
-#define DLL_PATH_LIBCURL       "@CURL_SONAME@"
-#endif
-
 /* VideoPlayer */
 #define DLL_PATH_LIBASS        "@ASS_SONAME@"
 #define DLL_PATH_LIBDVDNAV     "special://xbmcbin/system/players/VideoPlayer/libdvdnav-@ARCH@.so"

--- a/xbmc/DllPaths_generated_android.h.in
+++ b/xbmc/DllPaths_generated_android.h.in
@@ -32,10 +32,6 @@
 #define DLL_PATH_LIBSHAIRPLAY  "@SHAIRPLAY_SONAME@"
 #define DLL_PATH_LIBCEC        "@LIBCEC_SONAME@"
 
-#ifndef DLL_PATH_LIBCURL
-#define DLL_PATH_LIBCURL       "@CURL_SONAME@"
-#endif
-
 /* VideoPlayer */
 #define DLL_PATH_LIBASS        "@ASS_SONAME@"
 #define DLL_PATH_LIBDVDNAV     "libdvdnav-@ARCH@.so"

--- a/xbmc/DllPaths_win32.h
+++ b/xbmc/DllPaths_win32.h
@@ -22,7 +22,6 @@
  */
 
 /* libraries */
-#define DLL_PATH_LIBCURL       "special://xbmcbin/libcurl.dll"
 #define DLL_PATH_LIBNFS        "special://xbmcbin/libnfs.dll"
 #define DLL_PATH_LIBPLIST      "special://xbmcbin/libplist.dll"
 #define DLL_PATH_LIBSHAIRPLAY  "special://xbmcbin/shairplay.dll"

--- a/xbmc/filesystem/DllLibCurl.h
+++ b/xbmc/filesystem/DllLibCurl.h
@@ -71,10 +71,6 @@ public:
   struct curl_slist* slist_append(struct curl_slist* list, const char* to_append);
   void slist_free_all(struct curl_slist* list);
   const char* easy_strerror(CURLcode code);
-#if defined(HAS_CURL_STATIC)
-  void crypto_set_id_callback(unsigned long (*cb)(void));
-  void crypto_set_locking_callback(void (*cb)(int, int, const char*, int));
-#endif
 };
 
 class DllLibCurlGlobal : public DllLibCurl

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES ActorProtocol.cpp
             CharsetDetection.cpp
             CPUInfo.cpp
             Crc32.cpp
+            CryptThreading.cpp
             DatabaseUtils.cpp
             EndianSwap.cpp
             EmbeddedArt.cpp
@@ -87,6 +88,7 @@ set(HEADERS ActorProtocol.h
             CharsetDetection.h
             CPUInfo.h
             Crc32.h
+            CryptThreading.h
             DatabaseUtils.h
             EndianSwap.h
             EventStream.h
@@ -174,10 +176,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
 endif()
 
 if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)
-  list(APPEND SOURCES CryptThreading.cpp
-                      GLUtils.cpp)
-  list(APPEND HEADERS CryptThreading.h
-                      GLUtils.h)
+  list(APPEND SOURCES GLUtils.cpp)
+  list(APPEND HEADERS GLUtils.h)
 endif()
 
 if(CORE_SYSTEM_NAME STREQUAL android OR AML_FOUND)

--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -18,31 +18,24 @@
  *
  */
 
-#ifdef TARGET_WINDOWS
-#error "The threading options for the cryptography libraries don't need to be and shouldn't be set on Windows. Do not include CryptThreading in your windows project."
-#endif
-
 #include "CryptThreading.h"
 #include "threads/Thread.h"
 #include "utils/log.h"
 
-#ifndef HAVE_OPENSSL
-#define HAVE_OPENSSL
-#endif
-
-#ifdef HAVE_OPENSSL
 #include <openssl/crypto.h>
-#endif
 
-/* ========================================================================= */
-/* openssl locking implementation for curl */
-#if defined(HAVE_OPENSSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
-static CCriticalSection* getlock(int index)
+#define KODI_OPENSSL_NEEDS_LOCK_CALLBACK (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
+#if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
+namespace
 {
-  return g_cryptThreadingInitializer.get_lock(index);
+
+CCriticalSection* getlock(int index)
+{
+  return g_cryptThreadingInitializer.GetLock(index);
 }
 
-static void lock_callback(int mode, int type, const char* file, int line)
+void lock_callback(int mode, int type, const char* file, int line)
 {
   if (mode & CRYPTO_LOCK)
     getlock(type)->lock();
@@ -50,59 +43,45 @@ static void lock_callback(int mode, int type, const char* file, int line)
     getlock(type)->unlock();
 }
 
-static unsigned long thread_id()
+unsigned long thread_id()
 {
+  // C-style cast required due to vastly differing native ID return types
   return (unsigned long)CThread::GetCurrentThreadId();
 }
+
+}
 #endif
-/* ========================================================================= */
 
 CryptThreadingInitializer::CryptThreadingInitializer()
 {
-  bool attemptedToSetSSLMTHook = false;
-#if defined(HAVE_OPENSSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
-  // set up OpenSSL
-  numlocks = CRYPTO_num_locks();
+#if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
+  // OpenSSL < 1.1 needs integration code to support multi-threading
+  // This is absolutely required for libcurl if it uses the OpenSSL backend
+  m_locks.resize(CRYPTO_num_locks());
   CRYPTO_set_id_callback(thread_id);
   CRYPTO_set_locking_callback(lock_callback);
-  attemptedToSetSSLMTHook = true;
-#else
-  numlocks = 1;
 #endif
-
-  locks = new CCriticalSection*[numlocks];
-  for (int i = 0; i < numlocks; i++)
-    locks[i] = NULL;
-
-  if (!attemptedToSetSSLMTHook)
-    CLog::Log(LOGWARNING, "Could not determine the libcurl security library to set the locking scheme. This may cause problem with multithreaded use of ssl or libraries that depend on it (libcurl).");
-  
 }
 
 CryptThreadingInitializer::~CryptThreadingInitializer()
 {
-  CSingleLock l(locksLock);
-#if defined(HAVE_OPENSSL) && OPENSSL_VERSION_NUMBER < 0x10100000L
-  CRYPTO_set_locking_callback(NULL);
+#if KODI_OPENSSL_NEEDS_LOCK_CALLBACK
+  CSingleLock l(m_locksLock);
+  CRYPTO_set_locking_callback(nullptr);
+  m_locks.clear();
 #endif
-
-  for (int i = 0; i < numlocks; i++)
-    delete locks[i]; // I always forget ... delete is NULL safe.
-
-  delete [] locks;
 }
 
-CCriticalSection* CryptThreadingInitializer::get_lock(int index)
+CCriticalSection* CryptThreadingInitializer::GetLock(int index)
 {
-  CSingleLock l(locksLock);
-  CCriticalSection* curlock = locks[index];
-  if (curlock == NULL)
+  CSingleLock l(m_locksLock);
+  auto& curlock = m_locks[index];
+  if (!curlock)
   {
-    curlock = new CCriticalSection();
-    locks[index] = curlock;
+    curlock.reset(new CCriticalSection());
   }
 
-  return curlock;
+  return curlock.get();
 }
 
 

--- a/xbmc/utils/CryptThreading.h
+++ b/xbmc/utils/CryptThreading.h
@@ -20,24 +20,25 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
 #include "utils/GlobalsHandling.h"
 #include "threads/CriticalSection.h"
 
 class CryptThreadingInitializer
 {
-  CCriticalSection** locks;
-  int numlocks;
-  CCriticalSection locksLock;
+  std::vector<std::unique_ptr<CCriticalSection>> m_locks;
+  CCriticalSection m_locksLock;
 
 public:
   CryptThreadingInitializer();
   ~CryptThreadingInitializer();
 
-  CCriticalSection* get_lock(int index);
+  CCriticalSection* GetLock(int index);
 
 private:
-    CryptThreadingInitializer(const CryptThreadingInitializer &rhs) = delete;
-    CryptThreadingInitializer& operator=(const CryptThreadingInitializer&) = delete;
+  CryptThreadingInitializer(const CryptThreadingInitializer &rhs) = delete;
+  CryptThreadingInitializer& operator=(const CryptThreadingInitializer&) = delete;
 };
 
 XBMC_GLOBAL_REF(CryptThreadingInitializer,g_cryptThreadingInitializer);


### PR DESCRIPTION
OpenSSL is already being used on all platforms, and in #13647 we discussed making it required for digest calculation. This PR is about making OpenSSL required and consolodating the multi-threading initialization in one place for < 1.1. I have code ready for replacing `XBMC_MD5` with OpenSSL code that I'll PR after this is merged.

Currently, we're initializing OpenSSL multi-threading both in `DllLibCurl` and in `CryptThreadingInitializer` depending on different conditions. It might even be initialized twice since they are not mutually exclusive. So my proposal is to do everything once in `CryptThreadingInitializer` - it's not really related to libcurl any more since we need it for our own usage of openssl anyway.

I don't see how linking libcurl statically makes any difference, but I might very well be missing something, so let's see how badly this blows up in my face :-)