### PR TITLE
[guiinfo][PVR] Another bunch of (PVR) guiinfo fixes and improvements

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -131,8 +131,7 @@
 				<label>$VAR[SeekTimeLabelVar]</label>
 				<font>font45</font>
 				<shadowcolor>black</shadowcolor>
-				<visible>!Player.ChannelPreviewActive</visible>
-				<animation effect="fade" start="0" end="100" time="200" delay="1000">Visible</animation>
+				<visible>!Player.ChannelPreviewActive | VideoPlayer.HasEpg</visible>
 			</control>
 			<control type="label" id="40000">
 				<centerleft>50%</centerleft>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4252,46 +4252,6 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///                  _boolean_,
 ///     Returns true if there are timers present who currently not do recording
 ///   }
-///   \table_row3{   <b>`PVR.NowRecordingTitle`</b>,
-///                  \anchor PVR_NowRecordingTitle
-///                  _string_,
-///     Title of the programme being recorded
-///   }
-///   \table_row3{   <b>`PVR.NowRecordingDateTime`</b>,
-///                  \anchor PVR_NowRecordingDateTime
-///                  _Date/Time string_,
-///     Start date and time of the current recording
-///   }
-///   \table_row3{   <b>`PVR.NowRecordingChannel`</b>,
-///                  \anchor PVR_NowRecordingChannel
-///                  _string_,
-///     Channel name of the current recording
-///   }
-///   \table_row3{   <b>`PVR.NowRecordingChannelIcon`</b>,
-///                  \anchor PVR_NowRecordingChannelIcon
-///                  _string_,
-///     Icon of the current recording channel
-///   }
-///   \table_row3{   <b>`PVR.NextRecordingTitle`</b>,
-///                  \anchor PVR_NextRecordingTitle
-///                  _string_,
-///     Title of the next programme that will be recorded
-///   }
-///   \table_row3{   <b>`PVR.NextRecordingDateTime`</b>,
-///                  \anchor PVR_NextRecordingDateTime
-///                  _Date/Time string_,
-///     Start date and time of the next recording
-///   }
-///   \table_row3{   <b>`PVR.NextRecordingChannel`</b>,
-///                  \anchor PVR_NextRecordingChannel
-///                  _string_,
-///     Channel name of the next recording
-///   }
-///   \table_row3{   <b>`PVR.NextRecordingChannelIcon`</b>,
-///                  \anchor PVR_NextRecordingChannelIcon
-///                  _string_,
-///     Icon of the next recording channel
-///   }
 ///   \table_row3{   <b>`PVR.BackendName`</b>,
 ///                  \anchor PVR_BackendName
 ///                  _string_,
@@ -4371,31 +4331,6 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///                  \anchor PVR_IsPlayingEpgTag
 ///                  _boolean_,
 ///     Returns true when an epg tag is being watched.
-///   }
-///   \table_row3{   <b>`PVR.EpgEventDuration`</b>,
-///                  \anchor PVR_EpgEventDuration
-///                  _string_,
-///     Returns the duration of the currently playing epg event
-///   }
-///   \table_row3{   <b>`PVR.EpgEventElapsedTime`</b>,
-///                  \anchor PVR_EpgEventElapsedTime
-///                  _string_,
-///     Returns the time of the current position of the currently playing epg event
-///   }
-///   \table_row3{   <b>`PVR.EpgEventRemainingTime`</b>,
-///                  \anchor PVR_EpgEventRemainingTime
-///                  _string_,
-///     Returns the remaining time for currently playing epg event
-///   }
-///   \table_row3{   <b>`PVR.EpgEventSeekTime`</b>,
-///                  \anchor PVR_EpgEventSeekTime
-///                  _string_,
-///     Returns the time the user is seeking within the currently playing epg event
-///   }
-///   \table_row3{   <b>`PVR.EpgEventFinishTime`</b>,
-///                  \anchor PVR_EpgEventFinishTime
-///                  _string_,
-///     Returns the time the currently playing epg event will end
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventProgress`</b>,
 ///                  \anchor PVR_EpgEventProgress
@@ -4477,30 +4412,50 @@ const infomap playlist[] =       {{ "length",           PLAYLIST_LENGTH },
 ///                  _boolean_,
 ///     Returns true when for channel is timeshift available
 ///   }
-///   \table_row3{   <b>`PVR.TimeShiftStart`</b>,
-///                  \anchor PVR_TimeShiftStart
-///                  _time string_,
-///     Start position of the timeshift
-///   }
-///   \table_row3{   <b>`PVR.TimeShiftEnd`</b>,
-///                  \anchor PVR_TimeShiftEnd
-///                  _time string_,
-///     End position of the timeshift
-///   }
-///   \table_row3{   <b>`PVR.TimeShiftCur`</b>,
-///                  \anchor PVR_TimeShiftCur
-///                  _time string_,
-///     Current position of the timeshift
-///   }
 ///   \table_row3{   <b>`PVR.TimeShiftProgress`</b>,
 ///                  \anchor PVR_TimeShiftProgress
 ///                  _integer_,
 ///     Returns the position of currently timeshifted title on TV as integer
 ///   }
-///   \table_row3{   <b>`PVR.TimeShiftOffset`</b>,
-///                  \anchor PVR_TimeShiftOffset
-///                  _integer_,
-///     Returns the delta of timeshifted time to actual time
+///   \table_row3{   <b>`PVR.NowRecordingTitle`</b>,
+///                  \anchor PVR_NowRecordingTitle
+///                  _string_,
+///     Title of the programme being recorded
+///   }
+///   \table_row3{   <b>`PVR.NowRecordingDateTime`</b>,
+///                  \anchor PVR_NowRecordingDateTime
+///                  _Date/Time string_,
+///     Start date and time of the current recording
+///   }
+///   \table_row3{   <b>`PVR.NowRecordingChannel`</b>,
+///                  \anchor PVR_NowRecordingChannel
+///                  _string_,
+///     Channel name of the current recording
+///   }
+///   \table_row3{   <b>`PVR.NowRecordingChannelIcon`</b>,
+///                  \anchor PVR_NowRecordingChannelIcon
+///                  _string_,
+///     Icon of the current recording channel
+///   }
+///   \table_row3{   <b>`PVR.NextRecordingTitle`</b>,
+///                  \anchor PVR_NextRecordingTitle
+///                  _string_,
+///     Title of the next programme that will be recorded
+///   }
+///   \table_row3{   <b>`PVR.NextRecordingDateTime`</b>,
+///                  \anchor PVR_NextRecordingDateTime
+///                  _Date/Time string_,
+///     Start date and time of the next recording
+///   }
+///   \table_row3{   <b>`PVR.NextRecordingChannel`</b>,
+///                  \anchor PVR_NextRecordingChannel
+///                  _string_,
+///     Channel name of the next recording
+///   }
+///   \table_row3{   <b>`PVR.NextRecordingChannelIcon`</b>,
+///                  \anchor PVR_NextRecordingChannelIcon
+///                  _string_,
+///     Icon of the next recording channel
 ///   }
 ///   \table_row3{   <b>`PVR.TVNowRecordingTitle`</b>,
 ///                  \anchor PVR_TVNowRecordingTitle
@@ -4636,14 +4591,6 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
                                   { "hastvchannels",            PVR_HAS_TV_CHANNELS },
                                   { "hasradiochannels",         PVR_HAS_RADIO_CHANNELS },
                                   { "hasnonrecordingtimer",     PVR_HAS_NONRECORDING_TIMER },
-                                  { "nowrecordingtitle",        PVR_NOW_RECORDING_TITLE },
-                                  { "nowrecordingdatetime",     PVR_NOW_RECORDING_DATETIME },
-                                  { "nowrecordingchannel",      PVR_NOW_RECORDING_CHANNEL },
-                                  { "nowrecordingchannelicon",  PVR_NOW_RECORDING_CHAN_ICO },
-                                  { "nextrecordingtitle",       PVR_NEXT_RECORDING_TITLE },
-                                  { "nextrecordingdatetime",    PVR_NEXT_RECORDING_DATETIME },
-                                  { "nextrecordingchannel",     PVR_NEXT_RECORDING_CHANNEL },
-                                  { "nextrecordingchannelicon", PVR_NEXT_RECORDING_CHAN_ICO },
                                   { "backendname",              PVR_BACKEND_NAME },
                                   { "backendversion",           PVR_BACKEND_VERSION },
                                   { "backendhost",              PVR_BACKEND_HOST },
@@ -4660,11 +4607,6 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
                                   { "isplayingradio",           PVR_IS_PLAYING_RADIO },
                                   { "isplayingrecording",       PVR_IS_PLAYING_RECORDING },
                                   { "isplayingepgtag",          PVR_IS_PLAYING_EPGTAG },
-                                  { "epgeventduration",         PVR_EPG_EVENT_DURATION },
-                                  { "epgeventelapsedtime",      PVR_EPG_EVENT_ELAPSED_TIME },
-                                  { "epgeventremainingtime",    PVR_EPG_EVENT_REMAINING_TIME },
-                                  { "epgeventfinishtime",       PVR_EPG_EVENT_FINISH_TIME },
-                                  { "epgeventseektime",         PVR_EPG_EVENT_SEEK_TIME },
                                   { "epgeventprogress",         PVR_EPG_EVENT_PROGRESS },
                                   { "actstreamclient",          PVR_ACTUAL_STREAM_CLIENT },
                                   { "actstreamdevice",          PVR_ACTUAL_STREAM_DEVICE },
@@ -4681,11 +4623,7 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
                                   { "actstreammux",             PVR_ACTUAL_STREAM_MUX },
                                   { "actstreamprovidername",    PVR_ACTUAL_STREAM_PROVIDER },
                                   { "istimeshift",              PVR_IS_TIMESHIFTING },
-                                  { "timeshiftstart",           PVR_TIMESHIFT_START_TIME },
-                                  { "timeshiftend",             PVR_TIMESHIFT_END_TIME },
-                                  { "timeshiftcur",             PVR_TIMESHIFT_PLAY_TIME },
                                   { "timeshiftprogress",        PVR_TIMESHIFT_PROGRESS },
-                                  { "timeshiftoffset",          PVR_TIMESHIFT_OFFSET },
                                   { "nowrecordingtitle",        PVR_NOW_RECORDING_TITLE },
                                   { "nowrecordingdatetime",     PVR_NOW_RECORDING_DATETIME },
                                   { "nowrecordingchannel",      PVR_NOW_RECORDING_CHANNEL },
@@ -4719,6 +4657,142 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
                                   { "channelnumberinput",         PVR_CHANNEL_NUMBER_INPUT },
                                   { "canrecordplayingchannel",    PVR_CAN_RECORD_PLAYING_CHANNEL },
                                   { "isrecordingplayingchannel",  PVR_IS_RECORDING_PLAYING_CHANNEL }};
+
+/// \page modules__General__List_of_gui_access
+/// \section modules__General__List_of_gui_access_PvrTimes PvrTimes
+/// @{
+/// \table_start
+///   \table_h3{ Labels, Type, Description }
+///   \table_row3{   <b>`PVR.EpgEventDuration`</b>,
+///                  \anchor PVR_EpgEventDuration
+///                  _string_,
+///     Returns the duration of the currently playing epg event in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.EpgEventDuration(format)`</b>,
+///                  \anchor PVR_EpgEventDuration_format
+///                  _string_,
+///     Returns the duration of the currently playing epg event in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.EpgEventElapsedTime`</b>,
+///                  \anchor PVR_EpgEventElapsedTime
+///                  _string_,
+///     Returns the time of the current position of the currently playing epg event in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.EpgEventElapsedTime(format)`</b>,
+///                  \anchor PVR_EpgEventElapsedTime_format
+///                  _string_,
+///     Returns the time of the current position of the currently playing epg event in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.EpgEventRemainingTime`</b>,
+///                  \anchor PVR_EpgEventRemainingTime
+///                  _string_,
+///     Returns the remaining time for currently playing epg event in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.EpgEventRemainingTime(format)`</b>,
+///                  \anchor PVR_EpgEventRemainingTime_format
+///                  _string_,
+///     Returns the remaining time for currently playing epg event in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.EpgEventSeekTime`</b>,
+///                  \anchor PVR_EpgEventSeekTime
+///                  _string_,
+///     Returns the time the user is seeking within the currently playing epg event in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.EpgEventSeekTime(format)`</b>,
+///                  \anchor PVR_EpgEventSeekTime_format
+///                  _string_,
+///     Returns the time the user is seeking within the currently playing epg event in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.EpgEventFinishTime`</b>,
+///                  \anchor PVR_EpgEventFinishTime
+///                  _string_,
+///     Returns the time the currently playing epg event will end in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.EpgEventFinishTime(format)`</b>,
+///                  \anchor PVR_EpgEventFinishTime_format
+///                  _string_,
+///     Returns the time the currently playing epg event will end in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftStart`</b>,
+///                  \anchor PVR_TimeShiftStart
+///                  _string_,
+///     Returns the start time of the timeshift buffer in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftStart(format)`</b>,
+///                  \anchor PVR_TimeShiftStart_format
+///                  _string_,
+///     Returns the start time of the timeshift buffer in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftEnd`</b>,
+///                  \anchor PVR_TimeShiftEnd
+///                  _string_,
+///     Returns the end time of the timeshift buffer in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftEnd(format)`</b>,
+///                  \anchor PVR_TimeShiftEnd_format
+///                  _string_,
+///     Returns the end time of the timeshift buffer in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftCur`</b>,
+///                  \anchor PVR_TimeShiftCur
+///                  _string_,
+///     Returns the current playback time within the timeshift buffer in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftCur(format)`</b>,
+///                  \anchor PVR_TimeShiftCur_format
+///                  _string_,
+///     Returns the current playback time within the timeshift buffer in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftOffset`</b>,
+///                  \anchor PVR_TimeShiftOffset
+///                  _string_,
+///     Returns the delta of timeshifted time to actual time in the
+///     format hh:mm:ss. hh: will be omitted if hours value is zero.
+///   }
+///   \table_row3{   <b>`PVR.TimeShiftOffset(format)`</b>,
+///                  \anchor PVR_TimeShiftOffset_format
+///                  _string_,
+///     Returns the delta of timeshifted time to actual time in different formats:
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
+///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///   }
+/// \table_end
+///
+/// -----------------------------------------------------------------------------
+/// @}
+const infomap pvr_times[] =      {{ "epgeventduration",       PVR_EPG_EVENT_DURATION },
+                                  { "epgeventelapsedtime",    PVR_EPG_EVENT_ELAPSED_TIME },
+                                  { "epgeventremainingtime",  PVR_EPG_EVENT_REMAINING_TIME },
+                                  { "epgeventfinishtime",     PVR_EPG_EVENT_FINISH_TIME },
+                                  { "epgeventseektime",       PVR_EPG_EVENT_SEEK_TIME },
+                                  { "timeshiftstart",         PVR_TIMESHIFT_START_TIME },
+                                  { "timeshiftend",           PVR_TIMESHIFT_END_TIME },
+                                  { "timeshiftcur",           PVR_TIMESHIFT_PLAY_TIME },
+                                  { "timeshiftoffset",        PVR_TIMESHIFT_OFFSET }};
 
 /// \page modules__General__List_of_gui_access
 /// \section modules__General__List_of_gui_access_ADSP ADSP
@@ -5791,6 +5865,11 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         if (prop.name == pvr[i].str)
           return pvr[i].val;
       }
+      for (size_t i = 0; i < sizeof(pvr_times) / sizeof(infomap); i++)
+      {
+        if (prop.name == pvr_times[i].str)
+          return AddMultiInfo(GUIInfo(pvr_times[i].val, TranslateTimeFormat(prop.param())));
+      }
     }
     else if (cat.name == "adsp")
     {
@@ -6000,14 +6079,6 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
 
   switch (info)
   {
-  case PVR_NEXT_RECORDING_CHANNEL:
-  case PVR_NEXT_RECORDING_CHAN_ICO:
-  case PVR_NEXT_RECORDING_DATETIME:
-  case PVR_NEXT_RECORDING_TITLE:
-  case PVR_NOW_RECORDING_CHANNEL:
-  case PVR_NOW_RECORDING_CHAN_ICO:
-  case PVR_NOW_RECORDING_DATETIME:
-  case PVR_NOW_RECORDING_TITLE:
   case PVR_BACKEND_NAME:
   case PVR_BACKEND_VERSION:
   case PVR_BACKEND_HOST:
@@ -6019,10 +6090,6 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case PVR_BACKEND_NUMBER:
   case PVR_TOTAL_DISKSPACE:
   case PVR_NEXT_TIMER:
-  case PVR_EPG_EVENT_DURATION:
-  case PVR_EPG_EVENT_ELAPSED_TIME:
-  case PVR_EPG_EVENT_REMAINING_TIME:
-  case PVR_EPG_EVENT_FINISH_TIME:
   case PVR_EPG_EVENT_PROGRESS:
   case PVR_ACTUAL_STREAM_CLIENT:
   case PVR_ACTUAL_STREAM_DEVICE:
@@ -6037,10 +6104,14 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case PVR_ACTUAL_STREAM_SERVICE:
   case PVR_ACTUAL_STREAM_MUX:
   case PVR_ACTUAL_STREAM_PROVIDER:
-  case PVR_TIMESHIFT_START_TIME:
-  case PVR_TIMESHIFT_END_TIME:
-  case PVR_TIMESHIFT_PLAY_TIME:
-  case PVR_TIMESHIFT_OFFSET:
+  case PVR_NOW_RECORDING_TITLE:
+  case PVR_NOW_RECORDING_CHANNEL:
+  case PVR_NOW_RECORDING_CHAN_ICO:
+  case PVR_NOW_RECORDING_DATETIME:
+  case PVR_NEXT_RECORDING_TITLE:
+  case PVR_NEXT_RECORDING_CHANNEL:
+  case PVR_NEXT_RECORDING_CHAN_ICO:
+  case PVR_NEXT_RECORDING_DATETIME:
   case PVR_TV_NOW_RECORDING_TITLE:
   case PVR_TV_NOW_RECORDING_CHANNEL:
   case PVR_TV_NOW_RECORDING_CHAN_ICO:
@@ -6058,9 +6129,6 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case PVR_RADIO_NEXT_RECORDING_CHAN_ICO:
   case PVR_RADIO_NEXT_RECORDING_DATETIME:
     CServiceBroker::GetPVRManager().TranslateCharInfo(m_currentFile, info, strLabel);
-    break;
-  case PVR_EPG_EVENT_SEEK_TIME:
-    CServiceBroker::GetPVRManager().GetSeekTimeLabel(g_application.GetAppPlayer().GetSeekHandler().GetSeekSize(), strLabel);
     break;
   case PVR_CHANNEL_NUMBER_INPUT:
     strLabel = CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().GetChannelNumberAsString();
@@ -8025,6 +8093,10 @@ CGUIControl* CGUIInfoManager::GetActiveContainer(int containerId, int contextWin
 /// \brief Examines the multi information sent and returns the string as appropriate
 std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow, std::string *fallback)
 {
+  std::string strValue;
+  if (CServiceBroker::GetPVRManager().GetMultiInfoLabel(m_currentFile, info, strValue))
+    return strValue;
+
   if (info.m_info == SKIN_STRING)
   {
     return CSkinSettings::GetInstance().GetString(info.GetData1());
@@ -8086,6 +8158,14 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextW
   else if (info.m_info == PLAYER_SEEKTIME)
   {
     return GetCurrentSeekTime((TIME_FORMAT)info.GetData1());
+  }
+  else if (info.m_info == PVR_EPG_EVENT_SEEK_TIME)
+  {
+    std::string strLabel;
+    CServiceBroker::GetPVRManager().GetSeekTimeLabel(g_application.GetAppPlayer().GetSeekHandler().GetSeekSize(),
+                                                     static_cast<TIME_FORMAT>(info.GetData1()),
+                                                     strLabel);
+    return strLabel;
   }
   else if (info.m_info == PLAYER_SEEKOFFSET)
   {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -540,8 +540,10 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///   \table_row3{   <b>`Player.SeekOffset(format)`</b>,
 ///                  \anchor Player_SeekOffset_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). Also supported: (hh:mm)\,
-///     (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Returns hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.SeekStepSize`</b>,
 ///                  \anchor Player_SeekStepSize
@@ -556,9 +558,10 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///   \table_row3{   <b>`Player.TimeRemaining(format)`</b>,
 ///                  \anchor Player_TimeRemaining_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is
-///     used (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\,
-///     (hh:mm:ss)\, (hh:mm:ss).
+///     Returns hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.TimeSpeed`</b>,
 ///                  \anchor Player_TimeSpeed
@@ -573,9 +576,10 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///   \table_row3{   <b>`Player.Time(format)`</b>,
 ///                  \anchor Player_Time_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is
-///     used (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\,
-///     (hh:mm:ss)\, (hh:mm:ss).
+///     Returns hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.Duration`</b>,
 ///                  \anchor Player_Duration
@@ -585,9 +589,10 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///   \table_row3{   <b>`Player.Duration(format)`</b>,
 ///                  \anchor Player_Duration_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
-///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\,
-///     (hh:mm:ss).
+///     Returns hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.FinishTime`</b>,
 ///                  \anchor Player_FinishTime
@@ -597,9 +602,10 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///   \table_row3{   <b>`Player.FinishTime(format)`</b>,
 ///                  \anchor Player_FinishTime_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is
-///     used (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\,
-///     (hh:mm:ss)\, (hh:mm:ss).
+///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.StartTime`</b>,
 ///                  \anchor Player_StartTime
@@ -609,9 +615,10 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///   \table_row3{   <b>`Player.StartTime(format)`</b>,
 ///                  \anchor Player_StartTime_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is
-///     used (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\,
-///     (hh:mm:ss)\, (hh:mm:ss).
+///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.SeekNumeric`</b>,
 ///                  \anchor Player_SeekNumeric
@@ -622,8 +629,9 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  \anchor Player_SeekNumeric_format
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
-///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\,
-///     (hh:mm:ss).
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 /// \table_end
 ///
@@ -899,9 +907,10 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///   \table_row3{   <b>`System.Time(format)`</b>,
 ///                  \anchor System_Time_format
 ///                  _string_,
-///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is
-///     used (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\,
-///     (hh:mm:ss)\, (hh:mm:ss). (xx) option added after dharma
+///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`System.Date`</b>,
 ///                  \anchor System_Date
@@ -4673,8 +4682,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_EpgEventDuration_format
 ///                  _string_,
 ///     Returns the duration of the currently playing epg event in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventElapsedTime`</b>,
 ///                  \anchor PVR_EpgEventElapsedTime
@@ -4686,8 +4697,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_EpgEventElapsedTime_format
 ///                  _string_,
 ///     Returns the time of the current position of the currently playing epg event in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventRemainingTime`</b>,
 ///                  \anchor PVR_EpgEventRemainingTime
@@ -4699,8 +4712,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_EpgEventRemainingTime_format
 ///                  _string_,
 ///     Returns the remaining time for currently playing epg event in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventSeekTime`</b>,
 ///                  \anchor PVR_EpgEventSeekTime
@@ -4712,8 +4727,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_EpgEventSeekTime_format
 ///                  _string_,
 ///     Returns the time the user is seeking within the currently playing epg event in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventFinishTime`</b>,
 ///                  \anchor PVR_EpgEventFinishTime
@@ -4725,8 +4742,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_EpgEventFinishTime_format
 ///                  _string_,
 ///     Returns the time the currently playing epg event will end in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftStart`</b>,
 ///                  \anchor PVR_TimeShiftStart
@@ -4738,8 +4757,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_TimeShiftStart_format
 ///                  _string_,
 ///     Returns the start time of the timeshift buffer in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftEnd`</b>,
 ///                  \anchor PVR_TimeShiftEnd
@@ -4751,8 +4772,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_TimeShiftEnd_format
 ///                  _string_,
 ///     Returns the end time of the timeshift buffer in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftCur`</b>,
 ///                  \anchor PVR_TimeShiftCur
@@ -4764,8 +4787,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_TimeShiftCur_format
 ///                  _string_,
 ///     Returns the current playback time within the timeshift buffer in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
+///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftOffset`</b>,
 ///                  \anchor PVR_TimeShiftOffset
@@ -4777,8 +4802,10 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///                  \anchor PVR_TimeShiftOffset_format
 ///                  _string_,
 ///     Returns the delta of timeshifted time to actual time in different formats:
-///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used (xx) will
-///     return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (hh:mm:ss).
+///     Hours (hh)\, minutes (mm) or seconds (ss).
+///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
+///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
 ///   }
 /// \table_end
 ///
@@ -6023,6 +6050,9 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const std::string &format)
   else if (StringUtils::EqualsNoCase(format, "h:mm:ss")) return TIME_FORMAT_H_MM_SS;
   else if (StringUtils::EqualsNoCase(format, "h:mm:ss xx")) return TIME_FORMAT_H_MM_SS_XX;
   else if (StringUtils::EqualsNoCase(format, "xx")) return TIME_FORMAT_XX;
+  else if (StringUtils::EqualsNoCase(format, "secs")) return TIME_FORMAT_SECS;
+  else if (StringUtils::EqualsNoCase(format, "mins")) return TIME_FORMAT_MINS;
+  else if (StringUtils::EqualsNoCase(format, "hours")) return TIME_FORMAT_HOURS;
   return TIME_FORMAT_GUESS;
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6057,7 +6057,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   case PVR_RADIO_NEXT_RECORDING_CHANNEL:
   case PVR_RADIO_NEXT_RECORDING_CHAN_ICO:
   case PVR_RADIO_NEXT_RECORDING_DATETIME:
-    CServiceBroker::GetPVRManager().TranslateCharInfo(info, strLabel);
+    CServiceBroker::GetPVRManager().TranslateCharInfo(m_currentFile, info, strLabel);
     break;
   case PVR_EPG_EVENT_SEEK_TIME:
     CServiceBroker::GetPVRManager().GetSeekTimeLabel(g_application.GetAppPlayer().GetSeekHandler().GetSeekSize(), strLabel);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6871,7 +6871,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
     case PVR_ACTUAL_STREAM_SNR_PROGR:
     case PVR_BACKEND_DISKSPACE_PROGR:
     case PVR_TIMESHIFT_PROGRESS:
-      value = CServiceBroker::GetPVRManager().TranslateIntInfo(*m_currentFile, info);
+      value = CServiceBroker::GetPVRManager().TranslateIntInfo(m_currentFile, info);
       return true;
     case SYSTEM_BATTERY_LEVEL:
       value = CServiceBroker::GetPowerManager().BatteryLevel();

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -311,6 +311,7 @@ private:
   static std::string GetEpgEventTitle(const PVR::CPVREpgInfoTagPtr& epgTag);
   static std::string FormatRatingAndVotes(float rating, int votes);
   bool IsPlayerChannelPreviewActive() const;
+  std::string GetItemDuration(const CFileItem *item, TIME_FORMAT format) const;
 };
 
 /*!

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "threads/CriticalSection.h"
+#include "guiinfo/GUIInfo.h"
 #include "guilib/IMsgTargetCallback.h"
 #include "guilib/GUIControl.h"
 #include "messaging/IMessageTarget.h"
@@ -53,33 +54,6 @@ namespace INFO
 
 // forward
 class CGUIWindow;
-
-// structure to hold multiple integer data
-// for storage referenced from a single integer
-class GUIInfo
-{
-public:
-  GUIInfo(int info, uint32_t data1 = 0, int data2 = 0, uint32_t flag = 0)
-  {
-    m_info = info;
-    m_data1 = data1;
-    m_data2 = data2;
-    if (flag)
-      SetInfoFlag(flag);
-  }
-  bool operator ==(const GUIInfo &right) const
-  {
-    return (m_info == right.m_info && m_data1 == right.m_data1 && m_data2 == right.m_data2);
-  };
-  uint32_t GetInfoFlag() const;
-  uint32_t GetData1() const;
-  int GetData2() const;
-  int m_info;
-private:
-  void SetInfoFlag(uint32_t flag);
-  uint32_t m_data1;
-  int m_data2;
-};
 
 /*!
  \ingroup strings

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -138,7 +138,6 @@ public:
   std::string GetDuration(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
 
   /*! \brief Set currently playing file item
-   \param blocking whether to run in current thread (true) or background thread (false)
    */
   void SetCurrentItem(const CFileItem &item);
   void ResetCurrentItem();

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -42,7 +42,10 @@ enum TIME_FORMAT { TIME_FORMAT_GUESS       =  0,
                    TIME_FORMAT_HH_MM_SS_XX = 15,
                    TIME_FORMAT_H           = 16,
                    TIME_FORMAT_H_MM_SS     = 19,
-                   TIME_FORMAT_H_MM_SS_XX  = 27};
+                   TIME_FORMAT_H_MM_SS_XX  = 27,
+                   TIME_FORMAT_SECS        = 32,
+                   TIME_FORMAT_MINS        = 64,
+                   TIME_FORMAT_HOURS       = 128 };
 
 class CDateTime;
 

--- a/xbmc/guiinfo/CMakeLists.txt
+++ b/xbmc/guiinfo/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS GUIInfoLabels.h)
+set(HEADERS GUIInfo.h
+            GUIInfoLabels.h)
 
 if(NOT ENABLE_STATIC_LIBS)
   core_add_library(guiinfo)

--- a/xbmc/guiinfo/GUIInfo.h
+++ b/xbmc/guiinfo/GUIInfo.h
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+// structure to hold multiple integer data
+// for storage referenced from a single integer
+class GUIInfo
+{
+public:
+  GUIInfo(int info, uint32_t data1 = 0, int data2 = 0, uint32_t flag = 0)
+  {
+    m_info = info;
+    m_data1 = data1;
+    m_data2 = data2;
+    if (flag)
+      SetInfoFlag(flag);
+  }
+  bool operator ==(const GUIInfo &right) const
+  {
+    return (m_info == right.m_info && m_data1 == right.m_data1 && m_data2 == right.m_data2);
+  };
+  uint32_t GetInfoFlag() const;
+  uint32_t GetData1() const;
+  int GetData2() const;
+  int m_info;
+private:
+  void SetInfoFlag(uint32_t flag);
+  uint32_t m_data1;
+  int m_data2;
+};

--- a/xbmc/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guiinfo/GUIInfoLabels.h
@@ -822,7 +822,7 @@
 
 //! @todo There are issues with the LISTITEM_PROPERTY range, breakage occurs when more than 200 properties are used in skins.
 #define LISTITEM_PROPERTY_START     (LISTITEM_START + 200)
-#define LISTITEM_PROPERTY_END       (LISTITEM_PROPERTY_START + 2300)
+#define LISTITEM_PROPERTY_END       (LISTITEM_PROPERTY_START + 2500)
 #define LISTITEM_END                (LISTITEM_PROPERTY_END)
 
 #define MUSICPLAYER_PROPERTY_OFFSET       1300  // 200 id's reserved for musicplayer props.
@@ -830,8 +830,9 @@
 #define LISTITEM_RATING_OFFSET      1700 // 200 id's reserved for listitem ratings.
 #define LISTITEM_VOTES_OFFSET       1900 // 200 id's reserved for listitem votes.
 #define LISTITEM_RATING_AND_VOTES_OFFSET  2100 // 200 id's reserved for listitem ratingandvotes.
+#define LISTITEM_DURATION_OFFSET    2300 // 200 id's reserved for listitem duration.
 
-#define CONDITIONAL_LABEL_START       LISTITEM_END + 1 // 37501
+#define CONDITIONAL_LABEL_START       LISTITEM_END + 1 // 37701
 #define CONDITIONAL_LABEL_END         38500
 
 // the multiple information vector

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -179,10 +179,12 @@ namespace PVR
         m_iChannelInfoJobId = -1;
       }
 
-      m_currentChannel = m_playingChannel;
-
-      if (m_currentChannel)
-        item.reset(new CFileItem(m_playingChannel));
+      if (m_currentChannel != m_playingChannel)
+      {
+        m_currentChannel = m_playingChannel;
+        if (m_playingChannel)
+          item.reset(new CFileItem(m_playingChannel));
+      }
     }
 
     if (item)
@@ -206,9 +208,12 @@ namespace PVR
       CSingleLock lock(m_critSection);
 
       m_playingChannel = channel;
-      m_currentChannel = m_playingChannel;
-
-      item.reset(new CFileItem(m_playingChannel));
+      if (m_currentChannel != m_playingChannel)
+      {
+        m_currentChannel = m_playingChannel;
+        if (m_playingChannel)
+          item.reset(new CFileItem(m_playingChannel));
+      }
     }
 
     if (item)

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -31,6 +31,8 @@
 #include "pvr/PVRTypes.h"
 #include "pvr/addons/PVRClients.h"
 
+class GUIInfo;
+
 namespace PVR
 {
   class CPVRGUIInfo : private CThread,
@@ -59,12 +61,22 @@ namespace PVR
     bool GetVideoLabel(const CFileItem *item, int iLabel, std::string &strValue) const;
 
     /*!
+     * @brief Get a GUIInfoManager multi info label.
+     * @param item The item to get the label for.
+     * @param info The GUI info (label id + additional data).
+     * @param strValue Will be filled with the requested label value.
+     * @return True if the requested label value was set, false otherwise.
+     */
+    bool GetMultiInfoLabel(const CFileItem *item, const GUIInfo &info, std::string &strValue) const;
+
+    /*!
      * @brief Get a GUIInfoManager seek time label for the currently playing epg tag.
      * @param iSeekSize The seconds to be seeked from the current playback position.
+     * @param format The time format for the label.
      * @param strValue Will be filled with the requested label value.
      * @return True if the label value was set, false otherwise.
      */
-    bool GetSeekTimeLabel(int iSeekSize, std::string &strValue) const;
+    bool GetSeekTimeLabel(int iSeekSize, TIME_FORMAT format, std::string &strValue) const;
 
     /*!
      * @brief Get the total duration of the currently playing epg event or if no epg is
@@ -198,10 +210,10 @@ namespace PVR
 
     void UpdateTimersToggle(void);
 
-    void CharInfoEpgEventDuration(const CFileItem *item, std::string &strValue) const;
-    void CharInfoEpgEventElapsedTime(const CFileItem *item, std::string &strValue) const;
-    void CharInfoEpgEventRemainingTime(const CFileItem *item, std::string &strValue) const;
-    void CharInfoEpgEventFinishTime(const CFileItem *item, std::string &strValue) const;
+    void CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const;
+    void CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const;
+    void CharInfoEpgEventRemainingTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const;
+    void CharInfoEpgEventFinishTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const;
     void CharInfoBackendNumber(std::string &strValue) const;
     void CharInfoTotalDiskSpace(std::string &strValue) const;
     void CharInfoSignal(std::string &strValue) const;
@@ -223,10 +235,12 @@ namespace PVR
     void CharInfoService(std::string &strValue) const;
     void CharInfoMux(std::string &strValue) const;
     void CharInfoProvider(std::string &strValue) const;
-    void CharInfoTimeshiftStartTime(std::string &strValue) const;
-    void CharInfoTimeshiftEndTime(std::string &strValue) const;
-    void CharInfoTimeshiftPlayTime(std::string &strValue) const;
-    void CharInfoTimeshiftOffset(std::string &strValue) const;
+    void CharInfoTimeshiftStartTime(TIME_FORMAT format, std::string &strValue) const;
+    void CharInfoTimeshiftEndTime(TIME_FORMAT format, std::string &strValue) const;
+    void CharInfoTimeshiftPlayTime(TIME_FORMAT format, std::string &strValue) const;
+    void CharInfoTimeshiftOffset(TIME_FORMAT format, std::string &strValue) const;
+
+    int GetRemainingTime(const CFileItem *item) const;
 
     /** @name GUIInfoManager data */
     //@{
@@ -275,9 +289,6 @@ namespace PVR
     time_t                          m_iTimeshiftEndTime;
     time_t                          m_iTimeshiftPlayTime;
     unsigned int                    m_iTimeshiftOffset;
-    std::string                     m_strTimeshiftStartTime;
-    std::string                     m_strTimeshiftEndTime;
-    std::string                     m_strTimeshiftPlayTime;
 
     CCriticalSection                m_critSection;
 

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -46,7 +46,7 @@ namespace PVR
     void Notify(const Observable &obs, const ObservableMessage msg) override;
 
     bool TranslateBoolInfo(DWORD dwInfo) const;
-    bool TranslateCharInfo(DWORD dwInfo, std::string &strValue) const;
+    bool TranslateCharInfo(const CFileItem *item, DWORD dwInfo, std::string &strValue) const;
     int TranslateIntInfo(const CFileItem *item, DWORD dwInfo) const;
 
     /*!
@@ -198,10 +198,10 @@ namespace PVR
 
     void UpdateTimersToggle(void);
 
-    void CharInfoEpgEventDuration(std::string &strValue) const;
-    void CharInfoEpgEventElapsedTime(std::string &strValue) const;
-    void CharInfoEpgEventRemainingTime(std::string &strValue) const;
-    void CharInfoEpgEventFinishTime(std::string &strValue) const;
+    void CharInfoEpgEventDuration(const CFileItem *item, std::string &strValue) const;
+    void CharInfoEpgEventElapsedTime(const CFileItem *item, std::string &strValue) const;
+    void CharInfoEpgEventRemainingTime(const CFileItem *item, std::string &strValue) const;
+    void CharInfoEpgEventFinishTime(const CFileItem *item, std::string &strValue) const;
     void CharInfoBackendNumber(std::string &strValue) const;
     void CharInfoTotalDiskSpace(std::string &strValue) const;
     void CharInfoSignal(std::string &strValue) const;

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -47,7 +47,7 @@ namespace PVR
 
     bool TranslateBoolInfo(DWORD dwInfo) const;
     bool TranslateCharInfo(DWORD dwInfo, std::string &strValue) const;
-    int TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const;
+    int TranslateIntInfo(const CFileItem *item, DWORD dwInfo) const;
 
     /*!
      * @brief Get a GUIInfoManager video label.

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -829,9 +829,14 @@ bool CPVRManager::GetVideoLabel(const CFileItem *item, int iLabel, std::string &
   return IsStarted() && m_guiInfo ? m_guiInfo->GetVideoLabel(item, iLabel, strValue) : false;
 }
 
-bool CPVRManager::GetSeekTimeLabel(int iSeekSize, std::string &strValue) const
+bool CPVRManager::GetMultiInfoLabel(const CFileItem *item, const GUIInfo &info, std::string &strValue) const
 {
-  return IsStarted() && m_guiInfo ? m_guiInfo->GetSeekTimeLabel(iSeekSize, strValue) : false;
+  return IsStarted() && m_guiInfo ? m_guiInfo->GetMultiInfoLabel(item, info, strValue) : false;
+}
+
+bool CPVRManager::GetSeekTimeLabel(int iSeekSize, TIME_FORMAT format, std::string &strValue) const
+{
+  return IsStarted() && m_guiInfo ? m_guiInfo->GetSeekTimeLabel(iSeekSize, format, strValue) : false;
 }
 
 bool CPVRManager::IsRecording(void) const

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -819,7 +819,7 @@ bool CPVRManager::TranslateCharInfo(DWORD dwInfo, std::string &strValue) const
   return IsStarted() && m_guiInfo ? m_guiInfo->TranslateCharInfo(dwInfo, strValue) : false;
 }
 
-int CPVRManager::TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const
+int CPVRManager::TranslateIntInfo(const CFileItem *item, DWORD dwInfo) const
 {
   return IsStarted() && m_guiInfo ? m_guiInfo->TranslateIntInfo(item, dwInfo) : 0;
 }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -814,9 +814,9 @@ bool CPVRManager::TranslateBoolInfo(DWORD dwInfo) const
    return IsStarted() && m_guiInfo ? m_guiInfo->TranslateBoolInfo(dwInfo) : false;
 }
 
-bool CPVRManager::TranslateCharInfo(DWORD dwInfo, std::string &strValue) const
+bool CPVRManager::TranslateCharInfo(const CFileItem *item, DWORD dwInfo, std::string &strValue) const
 {
-  return IsStarted() && m_guiInfo ? m_guiInfo->TranslateCharInfo(dwInfo, strValue) : false;
+  return IsStarted() && m_guiInfo ? m_guiInfo->TranslateCharInfo(item, dwInfo, strValue) : false;
 }
 
 int CPVRManager::TranslateIntInfo(const CFileItem *item, DWORD dwInfo) const

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -163,10 +163,11 @@ namespace PVR
 
     /*!
      * @brief Get a GUIInfoManager character string.
+     * @param item The item to get the value for.
      * @param dwInfo The string to get.
      * @return The requested string or an empty one if it wasn't found.
      */
-    bool TranslateCharInfo(DWORD dwInfo, std::string &strValue) const;
+    bool TranslateCharInfo(const CFileItem *item, DWORD dwInfo, std::string &strValue) const;
 
     /*!
      * @brief Get a GUIInfoManager integer.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -42,6 +42,7 @@
 
 class CStopWatch;
 class CVariant;
+class GUIInfo;
 
 namespace PVR
 {
@@ -194,12 +195,22 @@ namespace PVR
     bool GetVideoLabel(const CFileItem *item, int iLabel, std::string &strValue) const;
 
     /*!
+     * @brief Get a GUIInfoManager multi info label.
+     * @param item The item to get the label for.
+     * @param info The GUI info (label id + additional data).
+     * @param strValue Will be filled with the requested label value.
+     * @return True if the requested label value was set, false otherwise.
+     */
+    bool GetMultiInfoLabel(const CFileItem *item, const GUIInfo &info, std::string &strValue) const;
+
+    /*!
      * @brief Get a GUIInfoManager seek time label for the currently playing epg tag.
      * @param iSeekSize The seconds to be seeked from the current playback position.
+     * @param format The time format for the label.
      * @param strValue Will be filled with the requested label value.
      * @return True if the label value was set, false otherwise.
      */
-    bool GetSeekTimeLabel(int iSeekSize, std::string &strValue) const;
+    bool GetSeekTimeLabel(int iSeekSize, TIME_FORMAT format, std::string &strValue) const;
 
     /*!
      * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -174,7 +174,7 @@ namespace PVR
      * @param dwInfo The integer to get.
      * @return The requested integer or 0 if it wasn't found.
      */
-    int TranslateIntInfo(const CFileItem &item, DWORD dwInfo) const;
+    int TranslateIntInfo(const CFileItem *item, DWORD dwInfo) const;
 
     /*!
      * @brief Get a GUIInfoManager boolean.

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -865,26 +865,35 @@ long StringUtils::TimeStringToSeconds(const std::string &timeString)
 
 std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
 {
-  bool isNegative = lSeconds < 0;
-  lSeconds = std::abs(lSeconds);
-  int hh = lSeconds / 3600;
-  lSeconds = lSeconds % 3600;
-  int mm = lSeconds / 60;
-  int ss = lSeconds % 60;
-
-  if (format == TIME_FORMAT_GUESS)
-    format = (hh >= 1) ? TIME_FORMAT_HH_MM_SS : TIME_FORMAT_MM_SS;
   std::string strHMS;
-  if (format & TIME_FORMAT_HH)
-    strHMS += StringUtils::Format("%2.2i", hh);
-  else if (format & TIME_FORMAT_H)
-    strHMS += StringUtils::Format("%i", hh);
-  if (format & TIME_FORMAT_MM)
-    strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", mm);
-  if (format & TIME_FORMAT_SS)
-    strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", ss);
-  if (isNegative)
-    strHMS = "-" + strHMS;
+  if (format == TIME_FORMAT_SECS)
+    strHMS = StringUtils::Format("%i", lSeconds);
+  else if (format == TIME_FORMAT_MINS)
+    strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(lSeconds) / 60.0f));
+  else if (format == TIME_FORMAT_HOURS)
+    strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(lSeconds) / 3600.0f));
+  else
+  {
+    bool isNegative = lSeconds < 0;
+    lSeconds = std::abs(lSeconds);
+    int hh = lSeconds / 3600;
+    lSeconds = lSeconds % 3600;
+    int mm = lSeconds / 60;
+    int ss = lSeconds % 60;
+
+    if (format == TIME_FORMAT_GUESS)
+      format = (hh >= 1) ? TIME_FORMAT_HH_MM_SS : TIME_FORMAT_MM_SS;
+    if (format & TIME_FORMAT_HH)
+      strHMS += StringUtils::Format("%2.2i", hh);
+    else if (format & TIME_FORMAT_H)
+      strHMS += StringUtils::Format("%i", hh);
+    if (format & TIME_FORMAT_MM)
+      strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", mm);
+    if (format & TIME_FORMAT_SS)
+      strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", ss);
+    if (isNegative)
+      strHMS = "-" + strHMS;
+  }
   return strHMS;
 }
 


### PR DESCRIPTION
1. Fixed PVR.EpgEventDuration, PVR.EpgEvent(Elapsed|Remaining|Finish)Time to support channel preview. Look for the changing times in the OSD when using channel preview...

2. PVR.EpgEventDuration, PVREpgEvent(Elapsed|Remaining|Finish|Seek)Time, PVR.Timeshift(Start|Cur|End|Offset) now support time format strings. Example: `$INFO[PVR.EpgEventElapsedTime(hh:mm:ss)]`

3.  All (!) labels using time format strings now support the new formats 'secs' 'mins' and 'hours'. Example: Player.Duration for a 145 minutes movie: hh:mm:ss=02:25:00, hh=02, mm=25, ss=00, hours=2, mins=145, secs=8700

4. ListItem.Duration now supports time format strings. Example: `$INFO[ListItem.Duration(mins)]`
 
5. Some random refactorings and fixes along the way.

@ronie @phil65 @HitcherUK @BigNoid  heads-up, please. Would be nice if one of you could announce this changes in the forum. ;-)
@Jalle19 are you in the mood for another code review?