### PR TITLE
[AddonVideoCodec] (Re)initialize all VideoPicture members

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -198,9 +198,24 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
     pVideoPicture->iHeight = picture.height;
     pVideoPicture->pts = static_cast<double>(picture.pts);
     pVideoPicture->dts = DVD_NOPTS_VALUE;
-    pVideoPicture->color_range = 0;
-    pVideoPicture->color_space = 4;
     pVideoPicture->iFlags = 0;
+    pVideoPicture->chroma_position = 0;
+    pVideoPicture->colorBits = 8;
+    pVideoPicture->color_primaries = 0;
+    pVideoPicture->color_range = 0;
+    pVideoPicture->color_space = AVCOL_SPC_UNSPECIFIED;
+    pVideoPicture->color_transfer = 0;
+    pVideoPicture->hasDisplayMetadata = false;
+    pVideoPicture->hasLightMetadata = false;
+    pVideoPicture->iDuration = 0;
+    pVideoPicture->iFrameType = 0;
+    pVideoPicture->iRepeatPicture = 0;
+    pVideoPicture->pict_type = 0;
+    pVideoPicture->qp_table = nullptr;
+    pVideoPicture->qscale_type = 0;
+    pVideoPicture->qstride = 0;
+    pVideoPicture->stereoMode.clear();
+
     if (m_codecFlags & DVD_CODEC_CTRL_DROP)
       pVideoPicture->iFlags |= DVP_FLAG_DROPPED;
 


### PR DESCRIPTION
## Description
(Re)initialize all VideoPicture members

## Motivation and Context

currently uninitialized iRepeatCount lead to play issues

## How Has This Been Tested?
Win10 / Secure DRM encrypted stream

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
