### PR TITLE
Remove use of g_application from CApplication

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -296,7 +296,7 @@ void CApplication::HandleWinEvents()
     switch(newEvent.type)
     {
       case XBMC_QUIT:
-        if (!g_application.m_bStop)
+        if (!m_bStop)
           CApplicationMessenger::GetInstance().PostMsg(TMSG_QUIT);
         break;
       case XBMC_VIDEORESIZE:
@@ -324,10 +324,10 @@ void CApplication::HandleWinEvents()
         break;
       case XBMC_SETFOCUS:
         // Reset the screensaver
-        g_application.ResetScreenSaver();
-        g_application.WakeUpScreenSaverAndDPMS();
+        ResetScreenSaver();
+        WakeUpScreenSaverAndDPMS();
         // Send a mouse motion event with no dx,dy for getting the current guiitem selected
-        g_application.OnAction(CAction(ACTION_MOUSE_MOVE, 0, static_cast<float>(newEvent.focus.x), static_cast<float>(newEvent.focus.y), 0, 0));
+        OnAction(CAction(ACTION_MOUSE_MOVE, 0, static_cast<float>(newEvent.focus.x), static_cast<float>(newEvent.focus.y), 0, 0));
         break;
       default:
         CServiceBroker::GetInputManager().OnEvent(newEvent);
@@ -2072,7 +2072,9 @@ bool CApplication::OnAction(const CAction &action)
   }
 
   // Now check with the player if action can be handled.
-  bool bIsPlayingPVRChannel = (CServiceBroker::GetPVRManager().IsStarted() && g_application.CurrentFileItem().IsPVRChannel());
+  bool bIsPlayingPVRChannel = (CServiceBroker::GetPVRManager().IsStarted() &&
+                               CurrentFileItem().IsPVRChannel());
+
   if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
       g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
       (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION && bIsPlayingPVRChannel) ||
@@ -2470,13 +2472,13 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     if (!pSlideShow) return;
 
     // stop playing file
-    if (m_appPlayer.IsPlayingVideo()) g_application.StopPlaying();
+    if (m_appPlayer.IsPlayingVideo()) StopPlaying();
 
     if (g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
       g_windowManager.PreviousWindow();
 
-    g_application.ResetScreenSaver();
-    g_application.WakeUpScreenSaverAndDPMS();
+    ResetScreenSaver();
+    WakeUpScreenSaverAndDPMS();
 
     if (g_windowManager.GetActiveWindow() != WINDOW_SLIDESHOW)
       g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
@@ -2516,7 +2518,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     if (!pSlideShow) return;
 
     if (m_appPlayer.IsPlayingVideo())
-      g_application.StopPlaying();
+      StopPlaying();
 
     pSlideShow->Reset();
 
@@ -2539,7 +2541,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
       if (items.Size() == 0)
       {
         m_ServiceManager->GetSettings().SetString(CSettings::SETTING_SCREENSAVER_MODE, "screensaver.xbmc.builtin.dim");
-        g_application.ActivateScreenSaver();
+        ActivateScreenSaver();
       }
       else
         g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
@@ -4169,7 +4171,7 @@ void CApplication::Process()
 
   // process messages, even if a movie is playing
   CApplicationMessenger::GetInstance().ProcessMessages();
-  if (g_application.m_bStop) return; //we're done, everything has been unloaded
+  if (m_bStop) return; //we're done, everything has been unloaded
 
   // update sound
   m_appPlayer.DoAudioWork();
@@ -4834,7 +4836,7 @@ bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList, CPlay
 
   // if the playlist contains an internet stream, this file will be used
   // to generate a thumbnail for musicplayer.cover
-  g_application.m_strPlayListFile = strPlayList;
+  m_strPlayListFile = strPlayList;
 
   // add the items to the playlist player
   CServiceBroker::GetPlaylistPlayer().Add(iPlaylist, playlist);

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -20,7 +20,6 @@
 
 #include "ServiceBroker.h"
 #include "Application.h"
-#include "rendering/RenderSystem.h"
 #include "windowing/WinSystem.h"
 
 using namespace KODI;
@@ -154,8 +153,7 @@ CWinSystemBase& CServiceBroker::GetWinSystem()
 
 CRenderSystemBase& CServiceBroker::GetRenderSystem()
 {
-  CRenderSystemBase &renderSystem = dynamic_cast<CRenderSystemBase&>(g_application.m_ServiceManager->GetWinSystem());
-  return renderSystem;
+  return *g_application.m_ServiceManager->GetWinSystem().GetRenderSystem();
 }
 
 CPowerManager& CServiceBroker::GetPowerManager()

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -42,6 +42,7 @@ struct REFRESHRATE
   int   ResInfo_Index;
 };
 
+class CRenderSystemBase;
 class IRenderLoop;
 
 class CWinSystemBase
@@ -51,6 +52,9 @@ public:
   virtual ~CWinSystemBase();
 
   static std::unique_ptr<CWinSystemBase> CreateWinSystem();
+
+  // Access render system interface
+  virtual CRenderSystemBase *GetRenderSystem() { return nullptr; }
 
   // windowing interfaces
   virtual bool InitWindowSystem();

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -34,6 +34,9 @@ class CWinSystemX11GLContext : public CWinSystemX11, public CRenderSystemGL
 public:
   CWinSystemX11GLContext();
   ~CWinSystemX11GLContext() override;
+
+  // Implementation of CWinSystem via CWinSystemX11
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   void FinishWindowResize(int newWidth, int newHeight) override;

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.h
@@ -31,6 +31,8 @@ public:
   CWinSystemAmlogicGLESContext() = default;
   virtual ~CWinSystemAmlogicGLESContext() = default;
 
+  // Implementation of CWinSystemBase via CWinSystemAmlogic
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.h
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.h
@@ -31,6 +31,8 @@ public:
   CWinSystemAndroidGLESContext() = default;
   virtual ~CWinSystemAndroidGLESContext() = default;
 
+  // Implementation of CWinSystemBase via CWinSystemAndroid
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -33,6 +33,8 @@ public:
   CWinSystemGbmGLESContext() = default;
   virtual ~CWinSystemGbmGLESContext() = default;
 
+  // Implementation of CWinSystemBase via CWinSystemGbm
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
   bool CreateNewWindow(const std::string& name,

--- a/xbmc/windowing/mir/WinSystemMirGLContext.h
+++ b/xbmc/windowing/mir/WinSystemMirGLContext.h
@@ -32,6 +32,8 @@ public:
   CWinSystemMirGLContext() = default;
   virtual ~CWinSystemMirGLContext() = default;
 
+  // Implementation of CWinSystemBase via CWinSystemMir
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
                        RESOLUTION_INFO& res) override;

--- a/xbmc/windowing/mir/WinSystemMirGLESContext.h
+++ b/xbmc/windowing/mir/WinSystemMirGLESContext.h
@@ -32,6 +32,8 @@ public:
   CWinSystemMirGLESContext() = default;
   virtual ~CWinSystemMirGLESContext() = default;
 
+  // Implementation of CWinSystemBase via CWinSystemMir
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
                        RESOLUTION_INFO& res) override;

--- a/xbmc/windowing/osx/WinSystemIOS.h
+++ b/xbmc/windowing/osx/WinSystemIOS.h
@@ -37,6 +37,8 @@ public:
   CWinSystemIOS();
   virtual ~CWinSystemIOS();
 
+  // Implementation of CWinSystemBase
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool DestroyWindowSystem() override;
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;

--- a/xbmc/windowing/osx/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/WinSystemOSXGL.h
@@ -29,6 +29,9 @@ class CWinSystemOSXGL : public CWinSystemOSX, public CRenderSystemGL
 public:
   CWinSystemOSXGL();
   virtual ~CWinSystemOSXGL();
+
+  // Implementation of CWinSystemBase via CWinSystemOSX
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.h
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.h
@@ -30,6 +30,8 @@ public:
   CWinSystemRpiGLESContext() = default;
   virtual ~CWinSystemRpiGLESContext() = default;
 
+  // Implementation of CWinSystemBase via CWinSystemRpi
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.h
@@ -34,7 +34,10 @@ namespace WAYLAND
 class CWinSystemWaylandEGLContextGL : public CWinSystemWaylandEGLContext, public CRenderSystemGL
 {
 public:
+  // Implementation of CWinSystemBase via CWinSystemWaylandEGLContext
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
+
 protected:
   bool CreateContext() override;
   void SetContextSize(CSizeInt size) override;

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.h
@@ -34,7 +34,10 @@ namespace WAYLAND
 class CWinSystemWaylandEGLContextGLES : public CWinSystemWaylandEGLContext, public CRenderSystemGLES
 {
 public:
+  // Implementation of CWinSystemBase via CWinSystemWaylandEGLContext
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool InitWindowSystem() override;
+
 protected:
   bool CreateContext() override;
   void SetContextSize(CSizeInt size) override;

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -31,6 +31,8 @@ public:
   CWinSystemWin10DX();
   ~CWinSystemWin10DX();
 
+  // Implementation of CWinSystemBase via CWinSystemWin10
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -36,6 +36,8 @@ public:
   CWinSystemWin32DX();
   ~CWinSystemWin32DX();
 
+  // Implementation of CWinSystemBase via CWinSystemWin32
+  CRenderSystemBase *GetRenderSystem() override { return this; }
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;


### PR DESCRIPTION
This removes use of g_application and CServiceBroker from CApplication.

Instead of g_application, local variables are referenced directly. Instead of CServiceBroker, access occurs through m_ServiceManager.

I've beefed up the PR description to explain a little more:

## Background
In 2016, fernet submitted #9389 which addressed a crash on exit I couldn't fix. It adds two classes:

* CServiceManager
* CServiceBroker

CServiceManager is a temporary solution used as a tool to change a global into a local variable. In CServiceManager, the startup/shutdown order is controlled. Notice that shutdown happens exactly in the opposite order than startup.

CServiceBroker is used to access the previously-global services. The point of a second class is "separation of concerns" - storage of variables is separated from retrieval.

Look at ServiceBroker.h, it does not include anything. So clients won’t depend on anything by including ServiceBroker. Further clients are not interested in how services are managed or the order in which they get launched.

## Credits

Thanks to fernetmenta for the general architecture and some verbiage above.