### PR TITLE
HOW-TO: Kill a global (CStereoscopicsManager)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1628,7 +1628,6 @@ bool CApplication::LoadSkin(const std::string& skinID)
   g_windowManager.AddMsgTarget(&CServiceBroker::GetPlaylistPlayer());
   g_windowManager.AddMsgTarget(&g_infoManager);
   g_windowManager.AddMsgTarget(&g_fontManager);
-  g_windowManager.AddMsgTarget(&CStereoscopicsManager::GetInstance());
   g_windowManager.SetCallback(*this);
   g_windowManager.Initialize();
   CTextureCache::GetInstance().Initialize();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1150,8 +1150,6 @@ bool CApplication::Initialize()
       // the startup window is considered part of the initialization as it most likely switches to the final window
       uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
 
-      CStereoscopicsManager::GetInstance().Initialize();
-
       if (!m_ServiceManager->InitStageThree())
       {
         CLog::Log(LOGERROR, "Application - Init3 failed");

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2107,7 +2107,7 @@ bool CApplication::OnAction(const CAction &action)
   }
 
   // forward action to graphic context and see if it can handle it
-  if (CStereoscopicsManager::GetInstance().OnAction(action))
+  if (CServiceBroker::GetStereoscopicsManager().OnAction(action))
     return true;
 
   if (m_appPlayer.IsPlaying())
@@ -3485,7 +3485,7 @@ void CApplication::OnAVChange()
 {
   CLog::LogF(LOGDEBUG, "CApplication::OnAVChange");
 
-  CStereoscopicsManager::GetInstance().OnStreamChange();
+  CServiceBroker::GetStereoscopicsManager().OnStreamChange();
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_AVCHANGE, 0, 0);
   g_windowManager.SendThreadMessage(msg);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10411,8 +10411,10 @@ std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, std::
   case LISTITEM_STEREOSCOPIC_MODE:
     {
       std::string stereoMode = item->GetProperty("stereomode").asString();
+
       if (stereoMode.empty() && item->HasVideoInfoTag())
-        stereoMode = CStereoscopicsManager::GetInstance().NormalizeStereoMode(item->GetVideoInfoTag()->m_streamDetails.GetStereoMode());
+        stereoMode = CStereoscopicsManager::NormalizeStereoMode(item->GetVideoInfoTag()->m_streamDetails.GetStereoMode());
+
       return stereoMode;
     }
   case LISTITEM_IMDBNUMBER:
@@ -10661,8 +10663,10 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
     else if (condition == LISTITEM_IS_STEREOSCOPIC)
     {
       std::string stereoMode = pItem->GetProperty("stereomode").asString();
+
       if (stereoMode.empty() && pItem->HasVideoInfoTag())
-          stereoMode = CStereoscopicsManager::GetInstance().NormalizeStereoMode(pItem->GetVideoInfoTag()->m_streamDetails.GetStereoMode());
+        stereoMode = CStereoscopicsManager::NormalizeStereoMode(pItem->GetVideoInfoTag()->m_streamDetails.GetStereoMode());
+
       if (!stereoMode.empty() && stereoMode != "mono")
         return true;
     }

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -185,3 +185,8 @@ CEventLog& CServiceBroker::GetEventLog()
 {
   return g_application.m_ServiceManager->GetEventLog();
 }
+
+CStereoscopicsManager &CServiceBroker::GetStereoscopicsManager()
+{
+  return g_application.m_ServiceManager->GetStereoscopicsManager();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -65,6 +65,7 @@ class CPlayerCoreFactory;
 class CDatabaseManager;
 class CProfilesManager;
 class CEventLog;
+class CStereoscopicsManager;
 
 namespace KODI
 {
@@ -120,4 +121,5 @@ public:
   static CDatabaseManager &GetDatabaseManager();
   static CProfilesManager &GetProfileManager();
   static CEventLog &GetEventLog();
+  static CStereoscopicsManager &GetStereoscopicsManager();
 };

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -230,7 +230,8 @@ bool CServiceManager::StartAudioEngine()
 // stage 3 is called after successful initialization of WindowManager
 bool CServiceManager::InitStageThree()
 {
-  m_stereoscopicsManager.reset(new CStereoscopicsManager(*m_settings));
+  m_stereoscopicsManager.reset(new CStereoscopicsManager(*m_settings,
+                                                         *m_dataCacheCore));
   m_stereoscopicsManager->Initialize();
 
   // Peripherals depends on strings being loaded before stage 3

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -230,7 +230,7 @@ bool CServiceManager::StartAudioEngine()
 // stage 3 is called after successful initialization of WindowManager
 bool CServiceManager::InitStageThree()
 {
-  m_stereoscopicsManager.reset(new CStereoscopicsManager);
+  m_stereoscopicsManager.reset(new CStereoscopicsManager(*m_settings));
   m_stereoscopicsManager->Initialize();
 
   // Peripherals depends on strings being loaded before stage 3

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -30,6 +30,7 @@
 #include "favourites/FavouritesService.h"
 #include "games/controllers/ControllerManager.h"
 #include "games/GameServices.h"
+#include "guilib/StereoscopicsManager.h"
 #include "peripherals/Peripherals.h"
 #include "PlayListPlayer.h"
 #include "profiles/ProfilesManager.h"
@@ -495,4 +496,9 @@ CProfilesManager &CServiceManager::GetProfileManager()
 CEventLog &CServiceManager::GetEventLog()
 {
   return m_profileManager->GetEventLog();
+}
+
+CStereoscopicsManager &CServiceManager::GetStereoscopicsManager()
+{
+  return *m_stereoscopicsManager;
 }

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -230,6 +230,9 @@ bool CServiceManager::StartAudioEngine()
 // stage 3 is called after successful initialization of WindowManager
 bool CServiceManager::InitStageThree()
 {
+  m_stereoscopicsManager.reset(new CStereoscopicsManager);
+  m_stereoscopicsManager->Initialize();
+
   // Peripherals depends on strings being loaded before stage 3
   m_peripherals->Initialise();
 
@@ -258,6 +261,7 @@ void CServiceManager::DeinitStageThree()
   m_contextMenuManager->Deinit();
   m_gameServices.reset();
   m_peripherals->Clear();
+  m_stereoscopicsManager.reset();
 }
 
 void CServiceManager::DeinitStageTwo()

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -91,6 +91,7 @@ class CPlayerCoreFactory;
 class CDatabaseManager;
 class CProfilesManager;
 class CEventLog;
+class CStereoscopicsManager;
 
 class CServiceManager
 {
@@ -157,6 +158,8 @@ public:
 
   CEventLog &GetEventLog();
 
+  CStereoscopicsManager &GetStereoscopicsManager();
+
 protected:
   struct delete_dataCacheCore
   {
@@ -212,4 +215,5 @@ protected:
   std::unique_ptr<CPlayerCoreFactory> m_playerCoreFactory;
   std::unique_ptr<CDatabaseManager> m_databaseManager;
   std::unique_ptr<CProfilesManager> m_profileManager;
+  std::unique_ptr<CStereoscopicsManager> m_stereoscopicsManager;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3673,7 +3673,10 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     hint.stills = true;
 
   if (hint.stereo_mode.empty())
-    hint.stereo_mode = CStereoscopicsManager::GetInstance().DetectStereoModeByString(m_item.GetPath());
+  {
+    const CStereoscopicsManager &stereoscopicsManager = CServiceBroker::GetStereoscopicsManager();
+    hint.stereo_mode = stereoscopicsManager.DetectStereoModeByString(m_item.GetPath());
+  }
 
   if (hint.flags & AV_DISPOSITION_ATTACHED_PIC)
     return false;

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -153,9 +153,8 @@ void CStereoscopicsManager::SetStereoMode(const RENDER_STEREO_MODE &mode)
 
   if (applyMode != currentMode && applyMode >= RENDER_STEREO_MODE_OFF)
   {
-    if (!CServiceBroker::GetRenderSystem().SupportsStereo(applyMode))
-      return;
-    m_settings.SetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE, applyMode);
+    if (CServiceBroker::GetRenderSystem().SupportsStereo(applyMode))
+      m_settings.SetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE, applyMode);
   }
 }
 

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -38,6 +38,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/lib/Setting.h"
+#include "settings/lib/SettingsManager.h"
 #include "settings/Settings.h"
 #include "rendering/RenderSystem.h"
 #include "utils/log.h"
@@ -105,9 +106,20 @@ CStereoscopicsManager::CStereoscopicsManager(CSettings &settings,
 {
   m_stereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
   m_lastStereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
+
+  std::set<std::string> settingSet{
+    CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE
+  };
+
+  m_settings.GetSettingsManager()->RegisterCallback(this, settingSet);
+
+  g_windowManager.AddMsgTarget(this);
 }
 
-CStereoscopicsManager::~CStereoscopicsManager(void) = default;
+CStereoscopicsManager::~CStereoscopicsManager(void)
+{
+  m_settings.GetSettingsManager()->UnregisterCallback(this);
+}
 
 void CStereoscopicsManager::Initialize(void)
 {

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -98,8 +98,10 @@ static const struct StereoModeMap StringToGuiModeMap[] =
 };
 
 
-CStereoscopicsManager::CStereoscopicsManager(CSettings &settings) :
-  m_settings(settings)
+CStereoscopicsManager::CStereoscopicsManager(CSettings &settings,
+                                             CDataCacheCore &dataCacheCore) :
+  m_settings(settings),
+  m_dataCacheCore(dataCacheCore)
 {
   m_stereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
   m_lastStereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
@@ -495,7 +497,7 @@ std::string CStereoscopicsManager::GetVideoStereoMode()
 {
   std::string playerMode;
   if (g_application.GetAppPlayer().IsPlaying())
-    playerMode = CServiceBroker::GetDataCacheCore().GetVideoStereoMode();
+    playerMode = m_dataCacheCore.GetVideoStereoMode();
   return playerMode;
 }
 

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -127,7 +127,7 @@ void CStereoscopicsManager::Initialize(void)
   SetStereoMode(RENDER_STEREO_MODE_OFF);
 }
 
-RENDER_STEREO_MODE CStereoscopicsManager::GetStereoMode(void)
+RENDER_STEREO_MODE CStereoscopicsManager::GetStereoMode(void) const
 {
   return (RENDER_STEREO_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
 }
@@ -159,7 +159,7 @@ void CStereoscopicsManager::SetStereoMode(const RENDER_STEREO_MODE &mode)
   }
 }
 
-RENDER_STEREO_MODE CStereoscopicsManager::GetNextSupportedStereoMode(const RENDER_STEREO_MODE &currentMode, int step)
+RENDER_STEREO_MODE CStereoscopicsManager::GetNextSupportedStereoMode(const RENDER_STEREO_MODE &currentMode, int step) const
 {
   RENDER_STEREO_MODE mode = currentMode;
   do {
@@ -170,7 +170,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetNextSupportedStereoMode(const RENDE
   return mode;
 }
 
-std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &needle)
+std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &needle) const
 {
   std::string stereoMode;
   std::string searchString(needle);
@@ -209,7 +209,7 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
   return stereoMode;
 }
 
-RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::string &heading)
+RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::string &heading /* = "" */) const
 {
   RENDER_STEREO_MODE mode = GetStereoMode();
   // if no stereo mode is set already, suggest mode of current video by preselecting it
@@ -255,7 +255,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
   return mode;
 }
 
-RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeOfPlayingVideo(void)
+RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeOfPlayingVideo(void) const
 {
   RENDER_STEREO_MODE mode = RENDER_STEREO_MODE_OFF;
   std::string playerMode = GetVideoStereoMode();
@@ -271,7 +271,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeOfPlayingVideo(void)
   return mode;
 }
 
-const std::string &CStereoscopicsManager::GetLabelForStereoMode(const RENDER_STEREO_MODE &mode) const
+std::string CStereoscopicsManager::GetLabelForStereoMode(const RENDER_STEREO_MODE &mode) const
 {
   int msgId;
   switch(mode) {
@@ -300,7 +300,7 @@ const std::string &CStereoscopicsManager::GetLabelForStereoMode(const RENDER_STE
   return g_localizeStrings.Get(msgId);
 }
 
-RENDER_STEREO_MODE CStereoscopicsManager::GetPreferredPlaybackMode(void)
+RENDER_STEREO_MODE CStereoscopicsManager::GetPreferredPlaybackMode(void) const
 {
   return (RENDER_STEREO_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE);
 }
@@ -505,7 +505,7 @@ void CStereoscopicsManager::ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool
   }
 }
 
-std::string CStereoscopicsManager::GetVideoStereoMode()
+std::string CStereoscopicsManager::GetVideoStereoMode() const
 {
   std::string playerMode;
   if (g_application.GetAppPlayer().IsPlaying())
@@ -513,7 +513,7 @@ std::string CStereoscopicsManager::GetVideoStereoMode()
   return playerMode;
 }
 
-bool CStereoscopicsManager::IsVideoStereoscopic()
+bool CStereoscopicsManager::IsVideoStereoscopic() const
 {
   std::string mode = GetVideoStereoMode();
   return !mode.empty() && mode != "mono";

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -98,7 +98,8 @@ static const struct StereoModeMap StringToGuiModeMap[] =
 };
 
 
-CStereoscopicsManager::CStereoscopicsManager(void)
+CStereoscopicsManager::CStereoscopicsManager(CSettings &settings) :
+  m_settings(settings)
 {
   m_stereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
   m_lastStereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
@@ -114,7 +115,7 @@ void CStereoscopicsManager::Initialize(void)
 
 RENDER_STEREO_MODE CStereoscopicsManager::GetStereoMode(void)
 {
-  return (RENDER_STEREO_MODE) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
+  return (RENDER_STEREO_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
 }
 
 void CStereoscopicsManager::SetStereoModeByUser(const RENDER_STEREO_MODE &mode)
@@ -140,7 +141,7 @@ void CStereoscopicsManager::SetStereoMode(const RENDER_STEREO_MODE &mode)
   {
     if (!CServiceBroker::GetRenderSystem().SupportsStereo(applyMode))
       return;
-    CServiceBroker::GetSettings().SetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE, applyMode);
+    m_settings.SetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE, applyMode);
   }
 }
 
@@ -287,7 +288,7 @@ const std::string &CStereoscopicsManager::GetLabelForStereoMode(const RENDER_STE
 
 RENDER_STEREO_MODE CStereoscopicsManager::GetPreferredPlaybackMode(void)
 {
-  return (RENDER_STEREO_MODE) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE);
+  return (RENDER_STEREO_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE);
 }
 
 int CStereoscopicsManager::ConvertVideoToGuiStereoMode(const std::string &mode)
@@ -506,7 +507,7 @@ bool CStereoscopicsManager::IsVideoStereoscopic()
 
 void CStereoscopicsManager::OnStreamChange()
 {
-  STEREOSCOPIC_PLAYBACK_MODE playbackMode = (STEREOSCOPIC_PLAYBACK_MODE) CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE);
+  STEREOSCOPIC_PLAYBACK_MODE playbackMode = (STEREOSCOPIC_PLAYBACK_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE);
   RENDER_STEREO_MODE mode = GetStereoMode();
 
   // early return if playback mode should be ignored and we're in no stereoscopic mode right now
@@ -517,7 +518,7 @@ void CStereoscopicsManager::OnStreamChange()
   {
     // exit stereo mode if started item is not stereoscopic
     // and if user prefers to stop 3D playback when movie is finished
-    if (mode != RENDER_STEREO_MODE_OFF && CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP))
+    if (mode != RENDER_STEREO_MODE_OFF && m_settings.GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP))
       SetStereoMode(RENDER_STEREO_MODE_OFF);
     return;
   }
@@ -538,7 +539,7 @@ void CStereoscopicsManager::OnStreamChange()
     // users selecting this option usually have to manually switch their TV into 3D mode
     // and would be annoyed by having to switch TV modes when next movies comes up
     // @todo probably add a new setting for just this behavior
-    if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP) == false)
+    if (m_settings.GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP) == false)
       return;
 
     // only change to new stereo mode if not yet in preferred stereo mode
@@ -604,7 +605,7 @@ void CStereoscopicsManager::OnStreamChange()
 void CStereoscopicsManager::OnPlaybackStopped(void)
 {
   RENDER_STEREO_MODE mode = GetStereoMode();
-  if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP) && mode != RENDER_STEREO_MODE_OFF)
+  if (m_settings.GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP) && mode != RENDER_STEREO_MODE_OFF)
     SetStereoMode(RENDER_STEREO_MODE_OFF);
   // reset user modes on playback end to start over new on next playback and not end up in a probably unwanted mode
   if (m_stereoModeSetByUser != RENDER_STEREO_MODE_OFF)

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -129,7 +129,7 @@ void CStereoscopicsManager::Initialize(void)
 
 RENDER_STEREO_MODE CStereoscopicsManager::GetStereoMode(void) const
 {
-  return (RENDER_STEREO_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
+  return static_cast<RENDER_STEREO_MODE>(m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE));
 }
 
 void CStereoscopicsManager::SetStereoModeByUser(const RENDER_STEREO_MODE &mode)
@@ -163,7 +163,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetNextSupportedStereoMode(const RENDE
 {
   RENDER_STEREO_MODE mode = currentMode;
   do {
-    mode = (RENDER_STEREO_MODE) ((mode + step) % RENDER_STEREO_MODE_COUNT);
+    mode = static_cast<RENDER_STEREO_MODE>((mode + step) % RENDER_STEREO_MODE_COUNT);
     if(CServiceBroker::GetRenderSystem().SupportsStereo(mode))
       break;
    } while (mode != currentMode);
@@ -227,7 +227,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
   std::vector<RENDER_STEREO_MODE> selectableModes;
   for (int i = RENDER_STEREO_MODE_OFF; i < RENDER_STEREO_MODE_COUNT; i++)
   {
-    RENDER_STEREO_MODE selectableMode = (RENDER_STEREO_MODE) i;
+    RENDER_STEREO_MODE selectableMode = static_cast<RENDER_STEREO_MODE>(i);
     if (CServiceBroker::GetRenderSystem().SupportsStereo(selectableMode))
     {
       selectableModes.push_back(selectableMode);
@@ -248,7 +248,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
 
   int iItem = pDlgSelect->GetSelectedItem();
   if (iItem > -1 && pDlgSelect->IsConfirmed())
-    mode = (RENDER_STEREO_MODE) selectableModes[iItem];
+    mode = static_cast<RENDER_STEREO_MODE>(selectableModes[iItem]);
   else
     mode = GetStereoMode();
 
@@ -264,7 +264,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeOfPlayingVideo(void) cons
   {
     int convertedMode = ConvertVideoToGuiStereoMode(playerMode);
     if (convertedMode > -1)
-      mode = (RENDER_STEREO_MODE) convertedMode;
+      mode = static_cast<RENDER_STEREO_MODE>(convertedMode);
   }
 
   CLog::Log(LOGDEBUG, "StereoscopicsManager: autodetected stereo mode for movie mode %s is: %s", playerMode.c_str(), ConvertGuiStereoModeToString(mode));
@@ -302,7 +302,7 @@ std::string CStereoscopicsManager::GetLabelForStereoMode(const RENDER_STEREO_MOD
 
 RENDER_STEREO_MODE CStereoscopicsManager::GetPreferredPlaybackMode(void) const
 {
-  return (RENDER_STEREO_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE);
+  return static_cast<RENDER_STEREO_MODE>(m_settings.GetInt(CSettings::SETTING_VIDEOSCREEN_PREFEREDSTEREOSCOPICMODE));
 }
 
 int CStereoscopicsManager::ConvertVideoToGuiStereoMode(const std::string &mode)
@@ -485,7 +485,7 @@ bool CStereoscopicsManager::OnAction(const CAction &action)
   {
     int stereoMode = ConvertStringToGuiStereoMode(action.GetName());
     if (stereoMode > -1)
-      SetStereoModeByUser( (RENDER_STEREO_MODE) stereoMode );
+      SetStereoModeByUser(static_cast<RENDER_STEREO_MODE>(stereoMode));
     return true;
   }
 
@@ -521,7 +521,7 @@ bool CStereoscopicsManager::IsVideoStereoscopic() const
 
 void CStereoscopicsManager::OnStreamChange()
 {
-  STEREOSCOPIC_PLAYBACK_MODE playbackMode = (STEREOSCOPIC_PLAYBACK_MODE) m_settings.GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE);
+  STEREOSCOPIC_PLAYBACK_MODE playbackMode = static_cast<STEREOSCOPIC_PLAYBACK_MODE>(m_settings.GetInt(CSettings::SETTING_VIDEOPLAYER_STEREOSCOPICPLAYBACKMODE));
   RENDER_STEREO_MODE mode = GetStereoMode();
 
   // early return if playback mode should be ignored and we're in no stereoscopic mode right now

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -106,12 +106,6 @@ CStereoscopicsManager::CStereoscopicsManager(void)
 
 CStereoscopicsManager::~CStereoscopicsManager(void) = default;
 
-CStereoscopicsManager& CStereoscopicsManager::GetInstance()
-{
-  static CStereoscopicsManager sStereoscopicsManager;
-  return sStereoscopicsManager;
-}
-
 void CStereoscopicsManager::Initialize(void)
 {
   // turn off stereo mode on XBMC startup

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -161,11 +161,15 @@ void CStereoscopicsManager::SetStereoMode(const RENDER_STEREO_MODE &mode)
 RENDER_STEREO_MODE CStereoscopicsManager::GetNextSupportedStereoMode(const RENDER_STEREO_MODE &currentMode, int step) const
 {
   RENDER_STEREO_MODE mode = currentMode;
-  do {
+
+  do
+  {
     mode = static_cast<RENDER_STEREO_MODE>((mode + step) % RENDER_STEREO_MODE_COUNT);
-    if(CServiceBroker::GetRenderSystem().SupportsStereo(mode))
+
+    if (CServiceBroker::GetRenderSystem().SupportsStereo(mode))
       break;
-   } while (mode != currentMode);
+  } while (mode != currentMode);
+
   return mode;
 }
 
@@ -211,6 +215,7 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
 RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::string &heading /* = "" */) const
 {
   RENDER_STEREO_MODE mode = GetStereoMode();
+
   // if no stereo mode is set already, suggest mode of current video by preselecting it
   if (mode == RENDER_STEREO_MODE_OFF)
     mode = GetStereoModeOfPlayingVideo();
@@ -227,6 +232,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
   for (int i = RENDER_STEREO_MODE_OFF; i < RENDER_STEREO_MODE_COUNT; i++)
   {
     RENDER_STEREO_MODE selectableMode = static_cast<RENDER_STEREO_MODE>(i);
+
     if (CServiceBroker::GetRenderSystem().SupportsStereo(selectableMode))
     {
       selectableModes.push_back(selectableMode);
@@ -235,6 +241,7 @@ RENDER_STEREO_MODE CStereoscopicsManager::GetStereoModeByUserChoice(const std::s
       if (mode == selectableMode)
         pDlgSelect->SetSelected( label );
     }
+
     // inject AUTO pseudo mode after OFF
     if (i == RENDER_STEREO_MODE_OFF)
     {
@@ -345,11 +352,13 @@ std::string CStereoscopicsManager::NormalizeStereoMode(const std::string &mode)
   if (!mode.empty() && mode != "mono")
   {
     int guiMode = ConvertStringToGuiStereoMode(mode);
+
     if (guiMode > -1)
       return ConvertGuiStereoModeToString((RENDER_STEREO_MODE) guiMode);
     else
       return mode;
   }
+
   return "mono";
 }
 
@@ -507,8 +516,10 @@ void CStereoscopicsManager::ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool
 std::string CStereoscopicsManager::GetVideoStereoMode() const
 {
   std::string playerMode;
+
   if (g_application.GetAppPlayer().IsPlaying())
     playerMode = m_dataCacheCore.GetVideoStereoMode();
+
   return playerMode;
 }
 
@@ -590,7 +601,7 @@ void CStereoscopicsManager::OnStreamChange()
 
       pDlgSelect->Open();
 
-      if(pDlgSelect->IsConfirmed())
+      if (pDlgSelect->IsConfirmed())
       {
         int iItem = pDlgSelect->GetSelectedItem();
         if      (iItem == idx_preferred) mode = preferred;
@@ -618,10 +629,13 @@ void CStereoscopicsManager::OnStreamChange()
 void CStereoscopicsManager::OnPlaybackStopped(void)
 {
   RENDER_STEREO_MODE mode = GetStereoMode();
+
   if (m_settings.GetBool(CSettings::SETTING_VIDEOPLAYER_QUITSTEREOMODEONSTOP) && mode != RENDER_STEREO_MODE_OFF)
     SetStereoMode(RENDER_STEREO_MODE_OFF);
+
   // reset user modes on playback end to start over new on next playback and not end up in a probably unwanted mode
   if (m_stereoModeSetByUser != RENDER_STEREO_MODE_OFF)
     m_lastStereoModeSetByUser = m_stereoModeSetByUser;
+
   m_stereoModeSetByUser = RENDER_STEREO_MODE_UNDEFINED;
 }

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -52,31 +52,36 @@ public:
   ~CStereoscopicsManager(void) override;
 
   void Initialize(void);
-  RENDER_STEREO_MODE GetStereoMode(void);
+
+  RENDER_STEREO_MODE GetStereoMode(void) const;
+
   void SetStereoModeByUser(const RENDER_STEREO_MODE &mode);
   void SetStereoMode(const RENDER_STEREO_MODE &mode);
-  RENDER_STEREO_MODE GetNextSupportedStereoMode(const RENDER_STEREO_MODE &currentMode, int step = 1);
-  std::string DetectStereoModeByString(const std::string &needle);
-  RENDER_STEREO_MODE GetStereoModeByUserChoice(const std::string &heading = "");
-  RENDER_STEREO_MODE GetStereoModeOfPlayingVideo(void);
-  const std::string &GetLabelForStereoMode(const RENDER_STEREO_MODE &mode) const;
-  RENDER_STEREO_MODE GetPreferredPlaybackMode(void);
-  int ConvertVideoToGuiStereoMode(const std::string &mode);
+
+  RENDER_STEREO_MODE GetNextSupportedStereoMode(const RENDER_STEREO_MODE &currentMode, int step = 1) const;
+  std::string DetectStereoModeByString(const std::string &needle) const;
+  RENDER_STEREO_MODE GetStereoModeByUserChoice(const std::string &heading = "") const;
+  RENDER_STEREO_MODE GetStereoModeOfPlayingVideo(void) const;
+  std::string GetLabelForStereoMode(const RENDER_STEREO_MODE &mode) const;
+  RENDER_STEREO_MODE GetPreferredPlaybackMode(void) const;
+  static int ConvertVideoToGuiStereoMode(const std::string &mode);
   /**
    * @brief will convert a string representation into a GUI stereo mode
    * @param mode The string to convert
    * @return -1 if not found, otherwise the according int of the RENDER_STEREO_MODE enum
    */
-  int ConvertStringToGuiStereoMode(const std::string &mode);
-  const char* ConvertGuiStereoModeToString(const RENDER_STEREO_MODE &mode);
+  static int ConvertStringToGuiStereoMode(const std::string &mode);
+  static const char* ConvertGuiStereoModeToString(const RENDER_STEREO_MODE &mode);
+
   /**
    * @brief Converts a stereoscopics related action/command from Builtins and JsonRPC into the according cAction ID.
    * @param command The command/action
    * @param parameter The parameter of the command
    * @return The integer of the according cAction or -1 if not valid
    */
-  CAction ConvertActionCommandToAction(const std::string &command, const std::string &parameter);
-  std::string NormalizeStereoMode(const std::string &mode);
+  static CAction ConvertActionCommandToAction(const std::string &command, const std::string &parameter);
+  static std::string NormalizeStereoMode(const std::string &mode);
+
   void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;
   void OnStreamChange();
   bool OnMessage(CGUIMessage &message) override;
@@ -90,8 +95,8 @@ public:
 private:
   void ApplyStereoMode(const RENDER_STEREO_MODE &mode, bool notify = true);
   void OnPlaybackStopped(void);
-  std::string GetVideoStereoMode();
-  bool IsVideoStereoscopic();
+  std::string GetVideoStereoMode() const;
+  bool IsVideoStereoscopic() const;
 
   // Construction parameters
   CSettings &m_settings;

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -64,13 +64,6 @@ public:
   RENDER_STEREO_MODE GetStereoModeOfPlayingVideo(void) const;
   std::string GetLabelForStereoMode(const RENDER_STEREO_MODE &mode) const;
   RENDER_STEREO_MODE GetPreferredPlaybackMode(void) const;
-  static int ConvertVideoToGuiStereoMode(const std::string &mode);
-  /**
-   * @brief will convert a string representation into a GUI stereo mode
-   * @param mode The string to convert
-   * @return -1 if not found, otherwise the according int of the RENDER_STEREO_MODE enum
-   */
-  static int ConvertStringToGuiStereoMode(const std::string &mode);
   static const char* ConvertGuiStereoModeToString(const RENDER_STEREO_MODE &mode);
 
   /**
@@ -97,6 +90,14 @@ private:
   void OnPlaybackStopped(void);
   std::string GetVideoStereoMode() const;
   bool IsVideoStereoscopic() const;
+
+  /**
+   * @brief will convert a string representation into a GUI stereo mode
+   * @param mode The string to convert
+   * @return -1 if not found, otherwise the according int of the RENDER_STEREO_MODE enum
+   */
+  static int ConvertStringToGuiStereoMode(const std::string &mode);
+  static int ConvertVideoToGuiStereoMode(const std::string &mode);
 
   // Construction parameters
   CSettings &m_settings;

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -31,6 +31,7 @@
 #include "rendering/RenderSystem.h"
 
 class CAction;
+class CDataCacheCore;
 class CSettings;
 
 enum STEREOSCOPIC_PLAYBACK_MODE
@@ -46,7 +47,8 @@ class CStereoscopicsManager : public ISettingCallback,
                               public IMsgTargetCallback
 {
 public:
-  CStereoscopicsManager(CSettings &settings);
+  CStereoscopicsManager(CSettings &settings,
+                        CDataCacheCore &dataCacheCore);
   ~CStereoscopicsManager(void) override;
 
   void Initialize(void);
@@ -93,6 +95,7 @@ private:
 
   // Construction parameters
   CSettings &m_settings;
+  CDataCacheCore &m_dataCacheCore;
 
   // Stereoscopic parameters
   RENDER_STEREO_MODE m_stereoModeSetByUser;

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -31,6 +31,7 @@
 #include "rendering/RenderSystem.h"
 
 class CAction;
+class CSettings;
 
 enum STEREOSCOPIC_PLAYBACK_MODE
 {
@@ -45,7 +46,7 @@ class CStereoscopicsManager : public ISettingCallback,
                               public IMsgTargetCallback
 {
 public:
-  CStereoscopicsManager(void);
+  CStereoscopicsManager(CSettings &settings);
   ~CStereoscopicsManager(void) override;
 
   void Initialize(void);
@@ -90,6 +91,10 @@ private:
   std::string GetVideoStereoMode();
   bool IsVideoStereoscopic();
 
+  // Construction parameters
+  CSettings &m_settings;
+
+  // Stereoscopic parameters
   RENDER_STEREO_MODE m_stereoModeSetByUser;
   RENDER_STEREO_MODE m_lastStereoModeSetByUser;
 };

--- a/xbmc/guilib/StereoscopicsManager.h
+++ b/xbmc/guilib/StereoscopicsManager.h
@@ -48,11 +48,6 @@ public:
   CStereoscopicsManager(void);
   ~CStereoscopicsManager(void) override;
 
-  /*!
-   * @return static instance of CStereoscopicsManager
-   */
-  static CStereoscopicsManager& GetInstance();
-
   void Initialize(void);
   RENDER_STEREO_MODE GetStereoMode(void);
   void SetStereoModeByUser(const RENDER_STEREO_MODE &mode);

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -392,7 +392,7 @@ static int SetProperty(const std::vector<std::string>& params)
  */
 static int SetStereoMode(const std::vector<std::string>& params)
 {
-  CAction action = CStereoscopicsManager::GetInstance().ConvertActionCommandToAction("SetStereoMode", params[0]);
+  CAction action = CStereoscopicsManager::ConvertActionCommandToAction("SetStereoMode", params[0]);
   if (action.GetID() != ACTION_NONE)
     CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(action)));
   else

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -107,7 +107,7 @@ JSONRPC_STATUS CGUIOperations::SetFullscreen(const std::string &method, ITranspo
 
 JSONRPC_STATUS CGUIOperations::SetStereoscopicMode(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  CAction action = CStereoscopicsManager::GetInstance().ConvertActionCommandToAction("SetStereoMode", parameterObject["mode"].asString());
+  CAction action = CStereoscopicsManager::ConvertActionCommandToAction("SetStereoMode", parameterObject["mode"].asString());
   if (action.GetID() != ACTION_NONE)
   {
     CApplicationMessenger::GetInstance().SendMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1, static_cast<void*>(new CAction(action)));
@@ -152,7 +152,11 @@ JSONRPC_STATUS CGUIOperations::GetPropertyValue(const std::string &property, CVa
   else if (property == "fullscreen")
     result = g_application.IsFullScreen();
   else if (property == "stereoscopicmode")
-    result = GetStereoModeObjectFromGuiMode( CStereoscopicsManager::GetInstance().GetStereoMode() );
+  {
+    const CStereoscopicsManager &stereoscopicsManager = CServiceBroker::GetStereoscopicsManager();
+
+    result = GetStereoModeObjectFromGuiMode(stereoscopicsManager.GetStereoMode());
+  }
   else
     return InvalidParams;
 
@@ -161,8 +165,10 @@ JSONRPC_STATUS CGUIOperations::GetPropertyValue(const std::string &property, CVa
 
 CVariant CGUIOperations::GetStereoModeObjectFromGuiMode(const RENDER_STEREO_MODE &mode)
 {
+  const CStereoscopicsManager &stereoscopicsManager = CServiceBroker::GetStereoscopicsManager();
+
   CVariant modeObj(CVariant::VariantTypeObject);
-  modeObj["mode"] = CStereoscopicsManager::GetInstance().ConvertGuiStereoModeToString(mode);
-  modeObj["label"] = CStereoscopicsManager::GetInstance().GetLabelForStereoMode(mode);
+  modeObj["mode"] = stereoscopicsManager.ConvertGuiStereoModeToString(mode);
+  modeObj["label"] = stereoscopicsManager.GetLabelForStereoMode(mode);
   return modeObj;
 }

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -762,24 +762,28 @@ void CDisplaySettings::SettingOptionsScreensFiller(SettingConstPtr setting, std:
 
 void CDisplaySettings::SettingOptionsStereoscopicModesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
+  const CStereoscopicsManager &stereoscopicsManager = CServiceBroker::GetStereoscopicsManager();
+
   for (int i = RENDER_STEREO_MODE_OFF; i < RENDER_STEREO_MODE_COUNT; i++)
   {
     RENDER_STEREO_MODE mode = (RENDER_STEREO_MODE) i;
     if (CServiceBroker::GetRenderSystem().SupportsStereo(mode))
-      list.push_back(std::make_pair(CStereoscopicsManager::GetInstance().GetLabelForStereoMode(mode), mode));
+      list.push_back(std::make_pair(stereoscopicsManager.GetLabelForStereoMode(mode), mode));
   }
 }
 
 void CDisplaySettings::SettingOptionsPreferredStereoscopicViewModesFiller(SettingConstPtr setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
 {
-  list.push_back(std::make_pair(CStereoscopicsManager::GetInstance().GetLabelForStereoMode(RENDER_STEREO_MODE_AUTO), RENDER_STEREO_MODE_AUTO)); // option for autodetect
+  const CStereoscopicsManager &stereoscopicsManager = CServiceBroker::GetStereoscopicsManager();
+
+  list.push_back(std::make_pair(stereoscopicsManager.GetLabelForStereoMode(RENDER_STEREO_MODE_AUTO), RENDER_STEREO_MODE_AUTO)); // option for autodetect
   // don't add "off" to the list of preferred modes as this doesn't make sense
   for (int i = RENDER_STEREO_MODE_OFF +1; i < RENDER_STEREO_MODE_COUNT; i++)
   {
     RENDER_STEREO_MODE mode = (RENDER_STEREO_MODE) i;
     // also skip "mono" mode which is no real stereoscopic mode
     if (mode != RENDER_STEREO_MODE_MONO && CServiceBroker::GetRenderSystem().SupportsStereo(mode))
-      list.push_back(std::make_pair(CStereoscopicsManager::GetInstance().GetLabelForStereoMode(mode), mode));
+      list.push_back(std::make_pair(stereoscopicsManager.GetLabelForStereoMode(mode), mode));
   }
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -807,7 +807,6 @@ void CSettings::UninitializeISettingsHandlers()
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application.GetAppPlayer().GetSeekHandler());
-  GetSettingsManager()->UnregisterCallback(&CStereoscopicsManager::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application);
   GetSettingsManager()->UnregisterCallback(&g_audioManager);
   GetSettingsManager()->UnregisterCallback(&g_charsetConverter);
@@ -883,10 +882,6 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_MUSICPLAYER_SEEKDELAY);
   settingSet.insert(CSettings::SETTING_MUSICPLAYER_SEEKSTEPS);
   GetSettingsManager()->RegisterCallback(&g_application.GetAppPlayer().GetSeekHandler(), settingSet);
-
-  settingSet.clear();
-  settingSet.insert(CSettings::SETTING_VIDEOSCREEN_STEREOSCOPICMODE);
-  GetSettingsManager()->RegisterCallback(&CStereoscopicsManager::GetInstance(), settingSet);
 
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
@@ -1012,7 +1007,6 @@ void CSettings::UninitializeISettingCallbacks()
   GetSettingsManager()->UnregisterCallback(&CMediaSettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&CDisplaySettings::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application.GetAppPlayer().GetSeekHandler());
-  GetSettingsManager()->UnregisterCallback(&CStereoscopicsManager::GetInstance());
   GetSettingsManager()->UnregisterCallback(&g_application);
   GetSettingsManager()->UnregisterCallback(&g_audioManager);
   GetSettingsManager()->UnregisterCallback(&g_charsetConverter);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -662,10 +662,14 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     }
   }
 
+  const CStereoscopicsManager &stereoscopicsManager = CServiceBroker::GetStereoscopicsManager();
+
   std::string stereoMode;
+
   // detect stereomode for videos
   if (item.HasVideoInfoTag())
     stereoMode = item.GetVideoInfoTag()->m_streamDetails.GetStereoMode();
+
   if (stereoMode.empty())
   {
     std::string path = item.GetPath();
@@ -676,14 +680,17 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     CVideoSettings itemVideoSettings;
     m_videoDatabase->Open();
     if (m_videoDatabase->GetVideoSettings(item, itemVideoSettings) && itemVideoSettings.m_StereoMode != RENDER_STEREO_MODE_OFF)
-      stereoMode = CStereoscopicsManager::GetInstance().ConvertGuiStereoModeToString( (RENDER_STEREO_MODE) itemVideoSettings.m_StereoMode );
+    {
+      stereoMode = CStereoscopicsManager::ConvertGuiStereoModeToString(static_cast<RENDER_STEREO_MODE>(itemVideoSettings.m_StereoMode));
+    }
     m_videoDatabase->Close();
 
     // still empty, try grabbing from filename
     //! @todo in case of too many false positives due to using the full path, extract the filename only using string utils
     if (stereoMode.empty())
-      stereoMode = CStereoscopicsManager::GetInstance().DetectStereoModeByString( path );
+      stereoMode = stereoscopicsManager.DetectStereoModeByString(path);
   }
+
   if (!stereoMode.empty())
-    item.SetProperty("stereomode", CStereoscopicsManager::GetInstance().NormalizeStereoMode(stereoMode));
+    item.SetProperty("stereomode", CStereoscopicsManager::NormalizeStereoMode(stereoMode));
 }

--- a/xbmc/windowing/rpi/RPIUtils.cpp
+++ b/xbmc/windowing/rpi/RPIUtils.cpp
@@ -170,7 +170,7 @@ bool CRPIUtils::SetNativeResolution(const RESOLUTION_INFO res, EGLSurface m_nati
     {
       CLog::Log(LOGDEBUG, "EGL set HDMI mode (%d,%d)=%d %s%s\n",
                           GETFLAGS_GROUP(res.dwFlags), GETFLAGS_MODE(res.dwFlags), success,
-                          CStereoscopicsManager::GetInstance().ConvertGuiStereoModeToString(stereo_mode),
+                          CStereoscopicsManager::ConvertGuiStereoModeToString(stereo_mode),
                           mode3d==HDMI_3D_FORMAT_FRAME_PACKING ? " FP" : mode3d==HDMI_3D_FORMAT_SBS_HALF ? " SBS" : mode3d==HDMI_3D_FORMAT_TB_HALF ? " TB" : "");
 
       sem_wait(&m_tv_synced);
@@ -179,7 +179,7 @@ bool CRPIUtils::SetNativeResolution(const RESOLUTION_INFO res, EGLSurface m_nati
     {
       CLog::Log(LOGERROR, "EGL failed to set HDMI mode (%d,%d)=%d %s%s\n",
                           GETFLAGS_GROUP(res.dwFlags), GETFLAGS_MODE(res.dwFlags), success,
-                          CStereoscopicsManager::GetInstance().ConvertGuiStereoModeToString(stereo_mode),
+                          CStereoscopicsManager::ConvertGuiStereoModeToString(stereo_mode),
                           mode3d==HDMI_3D_FORMAT_FRAME_PACKING ? " FP" : mode3d==HDMI_3D_FORMAT_SBS_HALF ? " SBS" : mode3d==HDMI_3D_FORMAT_TB_HALF ? " TB" : "");
     }
     m_DllBcmHost->vc_tv_unregister_callback(CallbackTvServiceCallback);

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -354,7 +354,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_windowManager.ChangeActiveWindow(firstWindow);
 
   g_application.UpdateLibraries();
-  CStereoscopicsManager::GetInstance().Initialize();
+  CServiceBroker::GetStereoscopicsManager().Initialize();
 
   // if the user interfaces has been fully initialized let everyone know
   if (uiInitializationFinished)


### PR DESCRIPTION
This PR kills the CStereoscopicsManager singleton, required for the login window refactor.

I'm writing this in the form of a HOW-TO because I think detangling Kodi's dependencies is a valuable skill that newcomers and team members alike should learn and practice.

## What is the root issue?
The root issue is that Kodi has a complicated dependency graph, so the order in which things are initialized/deinitialized is very important. When a class is global, we can't control this order, which is why things break.

## Globals? Singletons? What's the difference?
A global is a variable not owned by a class, e.g.

```c++
CApplication g_application;
```

A singleton is a static variable owned by a class, e.g.

```c++
CStereoscopicsManager& CStereoscopicsManager::GetInstance()
{
  static CStereoscopicsManager sStereoscopicsManager;
  return sStereoscopicsManager;
}
```

With singletons, the constructor is called on first access, so as long as things are accessed in order, Kodi doesn't crash on startup.

However, on shutdown, singletons are effectively globals, because we don't control the order of destruction. Therefore, I sometimes refer to singletons as globals.

## What is the solution?

Fernet has implemented a useful architectural tool for removing globals from our codebase.

See #13657 for an overview of this system.

## Step 1: Identify and remove the instance

Identify if the service is instantiated as a global or singleton. Remove this instance:

* [Remove CStereoscopicsManager instance](https://github.com/garbear/xbmc/commit/35dc0e9~11)

Singletons usually have private constructors. Make all constructors public.

## Step 2: Add instance to CServiceManager

First, identify if lines of code are listed in alphabetical or chronological order. Add the instance and try to match the ordering. In this case, services in CServiceManager are roughly in chronological order.

* [Add CStereoscopicsManager instance to CServiceManager](https://github.com/garbear/xbmc/commit/35dc0e9~10)

## Step 3: Move intialization/deintialization to CServiceManager

This part is tricky. Identify the closest stage where the instance is initialized and move it to CServiceManager:

* [Move CStereoscopicsManager init/deinit to CServiceManager](https://github.com/garbear/xbmc/commit/35dc0e9~9)

In this case, it was pretty easy. Init occurred right before Stage 3, so we move it into CServiceManager at the top of Stage 3.

Notice how deinit is done at the same relative place in the opposite order.

Before, CStereoscopicsManager was never deinitialized, so adding a deinit step in CServiceManager might cause crashes on shutdown. Regardless, we must be strict in CServiceManager, so we'll have to deal with shutdown crashes if any arise.

## Step 4: Replace local dependencies with references

A dependency is the use of a variable in another part of Kodi. These can be identified by searching StereoscopicsManager.cpp for all globals (starting with `g_`) and external services (starting with `CServiceBroker::`).

Here is a list of all dependencies in StereoscopicsManager.cpp:

* CServiceBroker::GetSettings()
* CServiceBroker::GetDataCacheCore()
* CServiceBroker::GetRenderSystem()
* g_advancedSettings
* g_windowManager
* g_localizeStrings
* g_graphicsContext
* g_application

We'll ignore the `g_` globals and Render System for now and focus on removing the first two CServiceBroker ones. If you're feeling adventurous, you can recursively kill the globals and singletons you come across. #13443 is my record of 4 in a single PR :)

### Step 4.1 - Settings

Because CStereoscopicsManager now belongs to CServiceManager, we can remove the use of CServiceBroker by passing references to the constructor upon creation. For example, here we replace access to CSettings with a reference that comes from CServiceManager:

* [Replace global access to Settings with a reference](https://github.com/garbear/xbmc/commit/35dc0e9~8)

Note that the reference was placed first in the list of private variables. Some helpful comments were added so future authors will know where to add new variables.

### Step 4.2 - Data Cache Core

Next, we do the same thing with CDataCacheCore. Notice that we place the new reference on the next line so we can scale to handle lots of dependencies with a clean git history:

* [Replace global access to Data Cache Core with reference](https://github.com/garbear/xbmc/commit/35dc0e9~7)

## Step 5: Make service registration local

Now we begin removing external access to the service. Move all service registration to the constructor, using the references we just exposed:

* [Make service registration local](https://github.com/garbear/xbmc/commit/35dc0e9~6)

## Step 6: Const-correctness and static cleanup

Take this opportunity to fix non-const and non-static functions:

* [Make functions const-correct and static](https://github.com/garbear/xbmc/commit/35dc0e9~5)
* [Make functions private that are only used internally](https://github.com/garbear/xbmc/commit/35dc0e9~4)

Calls to these functions are made throughout the codebase. Because we're touching all these calls, we can take this opportunity to propagate const-correctness and static-correctness through the codebase.

## Step 7: Replace external uses with CServiceBroker calls

The final step is to grep the codebase and make all the substitutions required:

* [Replace uses of singleton with CServiceBroker](https://github.com/garbear/xbmc/commit/35dc0e9~3)

Notice how our const-correctness and static-correctness are extended almost everywhere.

Congratulations! Global killed.

## Step 8: Cleanup

Some code in Kodi goes back 17 years, long before our current style guide was in place. If you touch code that doesn't conform to our style, it's courteous to clean up after yourself.

It's important that all code cleanup is separate from functional changes. Cleanup commits should be grouped together at the very beginning or very end of the PR. They should be marked as such in the commit message.

I've performed the following cleanup:

* [Cleanup: Replace C-style casts with C++ style casts](https://github.com/garbear/xbmc/commit/35dc0e9~2)
* [Cleanup: Fix early return](https://github.com/garbear/xbmc/commit/35dc0e9~1)
* [Cleanup: Whitespace improvements](https://github.com/garbear/xbmc/commit/35dc0e9)

## Step 9: Submit your PR

The commits in your PR should look like this one, except steps 1-7 should be squashed into a single commit. My steps were for demonstration purposes, and compilation breaks until all 7 are committed. Kodi should always compile between commits to aid in bisecting problems.

## Appendix: Dealing with the human aspect

Most globals were added in a time before our technomancers gifted us with information on what good architecture looks like. This doesn't mean the original authors wrote "crappy" code, just that they did the best with what they were given.

As a result, globals are pervasive and dependencies are tangled and, in the nightmare cases, circular. It is almost guaranteed that your hard work will break something for someone else. Fortunately, you'll find most devs are understanding of this.

This can daisy-chain, because a fix for your breakage can cause even more breakage. If you feel any author of downstream breakage gets undue blame, stick up for them as other devs were understanding for you.