### PR TITLE
windows: update patch utility to 2.7.6

### DIFF
--- a/cmake/scripts/windows/tools/patch.cmake
+++ b/cmake/scripts/windows/tools/patch.cmake
@@ -2,7 +2,7 @@ find_program(PATCH_FOUND NAMES patch patch.exe)
 if(PATCH_FOUND)
   message(STATUS "patch utility found at ${PATCH_FOUND}")
 else()
-  set(PATCH_ARCHIVE_NAME "patch-2.5.9-7-bin-3")
+  set(PATCH_ARCHIVE_NAME "patch-2.7.6-bin")
   set(PATCH_ARCHIVE "${PATCH_ARCHIVE_NAME}.zip")
   set(PATCH_URL "${KODI_MIRROR}/build-deps/win32/${PATCH_ARCHIVE}")
   set(PATCH_DOWNLOAD ${BUILD_DIR}/download/${PATCH_ARCHIVE})
@@ -28,6 +28,11 @@ else()
 
   # copy patch.exe into the output directory
   file(INSTALL ${PATCH_BINARY_PATH} DESTINATION ${ADDON_DEPENDS_PATH}/bin)
+  # copy patch depends
+  file(GLOB PATCH_BINARIES ${PATCH_PATH}/bin/*.dll)
+  if(NOT "${PATCH_BINARIES}" STREQUAL "")
+    file(INSTALL ${PATCH_BINARIES} DESTINATION ${ADDON_DEPENDS_PATH}/bin)
+  endif()
 
   # make sure that cmake can find the copied patch.exe
   find_program(PATCH_FOUND NAMES patch patch.exe)

--- a/cmake/scripts/windowsstore/tools/patch.cmake
+++ b/cmake/scripts/windowsstore/tools/patch.cmake
@@ -2,7 +2,7 @@ find_program(PATCH_FOUND NAMES patch patch.exe)
 if(PATCH_FOUND)
   message(STATUS "patch utility found at ${PATCH_FOUND}")
 else()
-  set(PATCH_ARCHIVE_NAME "patch-2.5.9-7-bin-3")
+  set(PATCH_ARCHIVE_NAME "patch-2.7.6-bin")
   set(PATCH_ARCHIVE "${PATCH_ARCHIVE_NAME}.zip")
   set(PATCH_URL "${KODI_MIRROR}/build-deps/win32/${PATCH_ARCHIVE}")
   set(PATCH_DOWNLOAD ${BUILD_DIR}/download/${PATCH_ARCHIVE})
@@ -28,6 +28,11 @@ else()
 
   # copy patch.exe into the output directory
   file(INSTALL ${PATCH_BINARY_PATH} DESTINATION ${ADDON_DEPENDS_PATH}/bin)
+  # copy patch depends
+  file(GLOB PATCH_BINARIES ${PATCH_PATH}/bin/*.dll)
+  if(NOT "${PATCH_BINARIES}" STREQUAL "")
+    file(INSTALL ${PATCH_BINARIES} DESTINATION ${ADDON_DEPENDS_PATH}/bin)
+  endif()
 
   # make sure that cmake can find the copied patch.exe
   find_program(PATCH_FOUND NAMES patch patch.exe)


### PR DESCRIPTION
## Description
update the patch utility to v2.7.6 taken from msys-git

## Motivation and Context
the old version has the issue with CRLF/LF missmatching between a patch file and targets. It causes patching failure in case of mismatch of line endings. the new version has no the issue.

@Rechi I didn't find a version without shared lib dependencies. I've tried to compile it by myself with mingw but with no success, seems it requires a patch to build with mingw toolchain.