### PR TITLE
fix deadlock caused by blocking cb method

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3352,7 +3352,7 @@ void CApplication::OnPlayBackStopped()
   data["end"] = false;
   CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnStop", m_itemCurrentFile, data);
 
-  CGUIMessage msg( GUI_MSG_PLAYBACK_STOPPED, 0, 0 );
+  CGUIMessage msg(GUI_MSG_PLAYBACK_STOPPED, 0, 0);
   g_windowManager.SendThreadMessage(msg);
 }
 
@@ -3360,7 +3360,8 @@ void CApplication::OnPlayBackError()
 {
   //@todo Playlists can be continued by calling OnPlaybackEnded instead
   // open error dialog
-  HELPERS::ShowOKDialogText(CVariant{16026}, CVariant{16027});
+  CGUIMessage msg(GUI_MSG_PLAYBACK_ERROR, 0, 0);
+  g_windowManager.SendThreadMessage(msg);
   OnPlayBackStopped();
 }
 
@@ -4043,6 +4044,10 @@ bool CApplication::OnMessage(CGUIMessage& message)
       return true;
     }
     break;
+
+  case GUI_MSG_PLAYBACK_ERROR:
+    HELPERS::ShowOKDialogText(CVariant{16026}, CVariant{16027});
+    return true;
 
   case GUI_MSG_PLAYLISTPLAYER_STARTED:
   case GUI_MSG_PLAYLISTPLAYER_CHANGED:

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -139,3 +139,5 @@
 
 // Send to RDS Radiotext handlers to inform about changed data
 #define GUI_MSG_UPDATE_RADIOTEXT      GUI_MSG_USER + 41
+
+#define GUI_MSG_PLAYBACK_ERROR        GUI_MSG_USER + 42


### PR DESCRIPTION
fixes a deadlock reported by @ksooo 

blocking a thread not knowing its origin is never a good idea.