### PR TITLE
VideoPlayer: do an accurate seek for auto-resume

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1344,7 +1344,10 @@ void CVideoPlayer::Prepare()
     if (m_pDemuxer)
     {
       if (m_pDemuxer->SeekTime(starttime, true, &startpts))
+      {
+        FlushBuffers(starttime / 1000 * AV_TIME_BASE, true, true);
         CLog::Log(LOGDEBUG, "%s - starting demuxer from: %d", __FUNCTION__, starttime);
+      }
       else
         CLog::Log(LOGDEBUG, "%s - failed to start demuxing from: %d", __FUNCTION__, starttime);
     }


### PR DESCRIPTION
fix/feature for https://trac.kodi.tv/ticket/17808

We have never done an accurate seek for resume point. Means we may have hit resume point exactly only by chance.
Maybe it was not that clear because trackingitem did not porperly record last playing position.