### PR TITLE
[cmake][addons] make pdb installation & packaging multi config aware

### DIFF
--- a/cmake/addons/CMakeLists.txt
+++ b/cmake/addons/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(kodi-addons)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
@@ -403,8 +403,12 @@ foreach(addon ${addons})
           endif()
 
           # create a forwarding target to the addon-package target
+          get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+          if(_isMultiConfig)
+            set(config --config $<CONFIG>)
+          endif()
           add_custom_target(package-${id}
-                    COMMAND ${CMAKE_COMMAND} --build ${id}-prefix/src/${id}-build --target addon-package
+                    COMMAND ${CMAKE_COMMAND} --build ${id}-prefix/src/${id}-build ${config} --target addon-package
                     DEPENDS ${id})
           add_dependencies(package-addons package-${id})
 

--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -6,8 +6,13 @@
 # Sadly we cannot extend the 'package' target, as it is a builtin target, see 
 # http://public.kitware.com/Bug/view.php?id=8438
 # Thus, we have to add an 'addon-package' target.
-add_custom_target(addon-package
-                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target package)
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_isMultiConfig)
+  add_custom_target(addon-package DEPENDS PACKAGE)
+else()
+  add_custom_target(addon-package
+                    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target package)
+endif()
 
 macro(add_cpack_workaround target version ext)
   if(NOT PACKAGE_DIR)

--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -247,21 +247,15 @@ macro (build_addon target prefix libs)
         endif()
       endif()
 
-      # in case of a VC++ project the installation location contains a $(Configuration) VS variable
-      # we replace it with ${CMAKE_BUILD_TYPE} (which doesn't cover the case when the build configuration
-      # is changed within Visual Studio)
-      string(REPLACE "$(Configuration)" "${CMAKE_BUILD_TYPE}" LIBRARY_LOCATION "${LIBRARY_LOCATION}")
-
       if(${prefix}_SOURCES)
         # install the generated DLL file
         install(PROGRAMS ${LIBRARY_LOCATION} DESTINATION ${target}
                 COMPONENT ${target}-${${prefix}_VERSION})
 
-        if(CMAKE_BUILD_TYPE MATCHES Debug)
-          # for debug builds also install the PDB file
-          install(FILES $<TARGET_PDB_FILE:${target}> DESTINATION ${target}
-                  COMPONENT ${target}-${${prefix}_VERSION})
-        endif()
+        # for debug builds also install the PDB file
+        install(FILES $<TARGET_PDB_FILE:${target}> DESTINATION ${target}
+                CONFIGURATIONS Debug RelWithDebInfo
+                COMPONENT ${target}-${${prefix}_VERSION})
       endif()
       if(${prefix}_CUSTOM_BINARY)
         install(FILES ${LIBRARY_LOCATION} DESTINATION ${target} RENAME ${LIBRARY_FILENAME})


### PR DESCRIPTION
## Description
`package-${id}` has to call `addon-package` with the same configuration it was called and `addon-package` has to do the same with `package` for multi configuration generators.
For multi configuration generators `CMAKE_BUILD_TYPE` doesn't always match the current configuration (as already mentioned in the code using it). `CONFIGURATIONS ` option for `install` command exists exactly for that reason.

## Motivation and Context
honour configuration for everything if using a multi configuration project (Visual Studio)

## How Has This Been Tested?
Compiled binary addons generated for Visual Studio and nmake in different configurations.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
