### PR TITLE
GuiInfoManager: Restore Announcements

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9227,6 +9227,8 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 
   SetChanged();
   NotifyObservers(ObservableMessageCurrentItem);
+  // todo this should be handled by one of the observers above and forwarded
+  g_application.m_ServiceManager->GetAnnouncementManager().Announce(ANNOUNCEMENT::Info, "xbmc", "OnChanged");
 }
 
 void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)

--- a/xbmc/interfaces/IAnnouncer.h
+++ b/xbmc/interfaces/IAnnouncer.h
@@ -69,6 +69,8 @@ namespace ANNOUNCEMENT
       return "PVR";
     case Other:
       return "Other";
+    case Info:
+      return "Info";
     default:
       return "Unknown";
     }


### PR DESCRIPTION
This restores part of https://github.com/xbmc/xbmc/commit/cc809c0f2673775aecbb370e04beeb13e78200d0?w=6 to get the functionality back