### PR TITLE
fix mouse scroll in fixedlist

### DIFF
--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -38,6 +38,7 @@ public:
   virtual ~CGUIFixedListContainer(void);
   virtual CGUIFixedListContainer *Clone() const { return new CGUIFixedListContainer(*this); };
 
+  virtual bool OnMouseOver(const CPoint &point);
   virtual bool OnAction(const CAction &action);
 
 protected:
@@ -68,5 +69,6 @@ private:
 
   int m_fixedCursor;    ///< default position the skinner wishes to use for the focused item
   int m_cursorRange;    ///< range that the focused item can vary when at the ends of the list
+  bool m_selectedFromMouse; ///< the mouse was used to focus this item, temp disable fixed cursor
 };
 


### PR DESCRIPTION
This change fixes the mouse usage in fixedlist container, where it would previously be very hard to select any item in the middle of the list.

<!--- Provide a general summary of your change in the Title above -->

## Description
There used to be a comment in GUIFixedListContainer saying

// calling SelectItem() here will focus the item and scroll, which
// isn't really what we're after

however, the subsequent dirty check triggered through DoProcess ->
GUIControlGroup::Process -> UpdateVisibility would trigger a
SelectItem nevertheless and render this old hack ineffective! Causing
the erratic and unusable scroll behaviour of the fixedlist when
hovering with the mouse.

To stop this, we introduce a new private flag that gets set whenever
the mouse is moved. This will tell the upcoming call to SelectItem to
ignore the fixed position scrolling and thus restore the original
mouse scrolling code in GUIFixedListContainer::SelectItemFromPoint
(which was broken due to this dirty refresh).
<!--- Describe your change in detail -->

## Motivation and Context
Fix for issue: https://trac.kodi.tv/ticket/17156
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
I tested this to now work properly with mouse and remote control.
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):
Video of problem: https://www.youtube.com/watch?v=D8uBPQjRHvM

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
