### PR TITLE
threads: let the app die on exceptions

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -205,12 +205,6 @@ void CThread::Action()
     if (IsAutoDelete())
       return;
   }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s - thread %s, Unhandled exception caught in thread startup, aborting. auto delete: %d", __FUNCTION__, m_ThreadName.c_str(), IsAutoDelete());
-    if (IsAutoDelete())
-      return;
-  }
 
   try
   {
@@ -220,10 +214,6 @@ void CThread::Action()
   {
     e.LogThrowMessage("Process");
   }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s - thread %s, Unhandled exception caught in thread process, aborting. auto delete: %d", __FUNCTION__, m_ThreadName.c_str(), IsAutoDelete());
-  }
 
   try
   {
@@ -232,10 +222,6 @@ void CThread::Action()
   catch (const XbmcCommons::UncheckedException &e)
   {
     e.LogThrowMessage("OnExit");
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s - thread %s, Unhandled exception caught in thread OnExit, aborting. auto delete: %d", __FUNCTION__, m_ThreadName.c_str(), IsAutoDelete());
   }
 }
 


### PR DESCRIPTION
continuing after an exceptions makes no sense. just makes it hard to track down the root cause.