### PR TITLE
[Music]Refactor Artist/Album Information Dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14189,6 +14189,7 @@ msgctxt "#21890"
 msgid "Select artist"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
 #: xbmc/music/ContextMenus.h
 msgctxt "#21891"
 msgid "Artist information"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -128,6 +128,7 @@
 #include "peripherals/devices/PeripheralImon.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/MusicUtils.h"
+#include "music/MusicThumbLoader.h"
 
 // Windows includes
 #include "guilib/GUIWindowManager.h"
@@ -4824,6 +4825,18 @@ void CApplication::UpdateLibraries()
     CLog::LogF(LOGNOTICE, "Starting music library startup scan");
     StartMusicScan("", !m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_BACKGROUNDUPDATE));
   }
+}
+
+void CApplication::UpdateCurrentPlayArt()
+{
+  if (!m_appPlayer.IsPlayingAudio())
+    return;
+  //Clear and reload the art for the currenty playing item to show updated  art on OSD
+  m_itemCurrentFile->ClearArt();
+  CMusicThumbLoader loader;
+  loader.LoadItem(m_itemCurrentFile.get());
+  // Mirror changes to GUI item
+  g_infoManager.SetCurrentItem(*m_itemCurrentFile);
 }
 
 bool CApplication::IsVideoScanning() const

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -284,6 +284,8 @@ public:
 
   void UpdateLibraries();
 
+  void UpdateCurrentPlayArt();
+
   bool ExecuteXBMCAction(std::string action, const CGUIListItemPtr &item = NULL);
 
   bool OnEvent(XBMC_Event& newEvent);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1503,7 +1503,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
   if (!item)
     return false;
 
-  if (item->GetPath() == m_strPath)
+  if (!m_strPath.empty() && item->GetPath() == m_strPath)
   {
     if (item->HasProperty("item_start") || HasProperty("item_start"))
       return (item->GetProperty("item_start") == GetProperty("item_start"));

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -84,6 +84,7 @@
 #include "GUIUserMessages.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
+#include "music/dialogs/GUIDialogSongInfo.h"
 #include "storage/MediaManager.h"
 #include "utils/TimeUtils.h"
 #include "threads/SingleLock.h"
@@ -7779,7 +7780,9 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
           if (window)
           {
             if (window->GetID() == WINDOW_DIALOG_MUSIC_INFO)
-              content = static_cast<CGUIDialogMusicInfo*>(window)->CurrentDirectory().GetContent();
+              content = static_cast<CGUIDialogMusicInfo*>(window)->GetContent();
+            else if (window->GetID() == WINDOW_DIALOG_SONG_INFO)
+              content = static_cast<CGUIDialogSongInfo*>(window)->GetContent();
             else if (window->GetID() == WINDOW_DIALOG_VIDEO_INFO)
               content = static_cast<CGUIDialogVideoInfo*>(window)->CurrentDirectory().GetContent();
           }

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -100,7 +100,7 @@ namespace XBMCAddon
       }
       else if (listitem->item->HasMusicInfoTag())
       {
-        CGUIDialogMusicInfo::ShowFor(*listitem->item);
+        CGUIDialogMusicInfo::ShowFor(listitem->item.get());
         return true;
       }
       return false;

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -420,7 +420,7 @@ bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
   }
   else if (fileItem->HasMusicInfoTag())
   {
-    CGUIDialogMusicInfo::ShowFor(*fileItem.get());
+    CGUIDialogMusicInfo::ShowFor(fileItem.get());
     return true;
   }
   return false;

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -37,7 +37,7 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
 
 bool CMusicInfo::Execute(const CFileItemPtr& item) const
 {
-  CGUIDialogMusicInfo::ShowFor(*item);
+  CGUIDialogMusicInfo::ShowFor(item.get());
   return true;
 }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5456,20 +5456,6 @@ bool CMusicDatabase::GetAlbumPath(int idAlbum, std::string &basePath)
   return false;
 }
 
-bool CMusicDatabase::SaveAlbumThumb(int idAlbum, const std::string& strThumb)
-{
-  SetArtForItem(idAlbum, MediaTypeAlbum, "thumb", strThumb);
-  //! @todo We should prompt the user to update the art for songs
-  std::string sql = PrepareSQL("UPDATE art"
-                              " SET url='-'"
-                              " WHERE media_type='song'"
-                              " AND type='thumb'"
-                              " AND media_id IN"
-                              " (SELECT idSong FROM song WHERE idAlbum=%ld)", idAlbum);
-  ExecuteQuery(sql);
-  return true;
-}
-
 // Get old "artist path" - where artist.nfo and art was located v17 and below.
 // It is the path common to all albums by an (album) artist, but ensure it is unique 
 // to that artist and not shared with other artists. Previously this caused incorrect nfo 
@@ -5755,6 +5741,25 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist &artist)
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
   }
   return false;
+}
+
+bool CMusicDatabase::IsSongArtist(int idSong, int idArtist)
+{
+  std::string strSQL = PrepareSQL(
+    "SELECT 1 FROM song_artist "
+    "WHERE song_artist.idSong= %i AND "
+    "song_artist.idArtist = %i AND song_artist.idRole = 1",
+    idSong, idArtist);
+  return GetSingleValue(strSQL).empty(); 
+}
+
+bool CMusicDatabase::IsSongAlbumArtist(int idSong, int idArtist)
+{
+  std::string strSQL = PrepareSQL(
+    "SELECT 1 FROM song JOIN album_artist ON song.idAlbum = album_artist.idAlbum "   
+    "WHERE song.idSong = %i AND album_artist.idArtist = %i",
+    idSong, idArtist);
+  return GetSingleValue(strSQL).empty();
 }
 
 int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::string& strArtist)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1424,6 +1424,75 @@ bool CMusicDatabase::DeleteArtistDiscography(int idArtist)
   return ExecuteQuery(strSQL);
 }
 
+bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS.get()) return false;
+
+    // Combine entries from discography and album tables
+    // When title in both, album entry will be before disco entry
+    std::string strSQL;
+    strSQL = PrepareSQL("SELECT strAlbum, "
+      "CAST(discography.strYear as INT) AS iYear, -1 AS idAlbum "
+      "FROM discography "
+      "WHERE discography.idArtist = %i "
+      "UNION "
+      "SELECT strAlbum, iYear, album.idAlbum "
+      "FROM album JOIN album_artist ON album_artist.idAlbum = album.idAlbum "
+      "WHERE album_artist.idArtist = %i "
+      "ORDER BY iYear, strAlbum, idAlbum DESC",       
+      idArtist, idArtist);
+
+    if (!m_pDS->query(strSQL))
+      return false;
+    int iRowsFound = m_pDS->num_rows();
+    if (iRowsFound == 0)
+    {
+      m_pDS->close();
+      return true;
+    }
+
+    std::string strAlbum;
+    std::string strLastAlbum;
+    int iLastID = -1;
+    while (!m_pDS->eof())
+    {
+      int idAlbum = m_pDS->fv("idAlbum").get_asInt();
+      strAlbum = m_pDS->fv("strAlbum").get_asString();
+      if (!strAlbum.empty())
+      {
+        if (strAlbum.compare(strLastAlbum) != 0)
+        { // Save new title (from album or discography)
+          CFileItemPtr pItem(new CFileItem(strAlbum));
+          pItem->SetLabel2(m_pDS->fv("iYear").get_asString());
+          pItem->GetMusicInfoTag()->SetDatabaseId(idAlbum, "album");
+
+          items.Add(pItem);
+          strLastAlbum = strAlbum;
+          iLastID = idAlbum;
+        }
+        else if (idAlbum > 0 && iLastID < 0)
+        { // Amend previously saved discography item to set album ID
+          items[items.Size() - 1]->GetMusicInfoTag()->SetDatabaseId(idAlbum, "album");
+        }
+      }
+      m_pDS->next();
+    }
+
+    // cleanup
+    m_pDS->close();
+
+    return true;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  }
+  return false;
+}
+
 int CMusicDatabase::AddRole(const std::string &strRole)
 {
   int idRole = -1;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -323,6 +323,8 @@ public:
   int GetArtistByName(const std::string& strArtist);
   int GetArtistByMatch(const CArtist& artist);
   bool GetArtistFromSong(int idSong, CArtist &artist);
+  bool IsSongArtist(int idSong, int idArtist);
+  bool IsSongAlbumArtist(int idSong, int idArtist);
   std::string GetRoleById(int id);
 
   /*! \brief Propagate artist sort name into the concatenated artist sort name strings
@@ -474,7 +476,6 @@ public:
   /////////////////////////////////////////////////
   // Art
   /////////////////////////////////////////////////
-  bool SaveAlbumThumb(int idAlbum, const std::string &thumb);
   /*! \brief Sets art for a database item.
    Sets a single piece of art for a database item.
    \param mediaId the id in the media (song/artist/album) table.

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -318,6 +318,7 @@ public:
   bool ClearArtistLastScrapedTime(int idArtist);
   int  AddArtistDiscography(int idArtist, const std::string& strAlbum, const std::string& strYear);
   bool DeleteArtistDiscography(int idArtist);
+  bool GetArtistDiscography(int idArtist, CFileItemList& items);
 
   std::string GetArtistById(int id);
   int GetArtistByName(const std::string& strArtist);

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -47,8 +47,10 @@ namespace MUSIC_UTILS
   bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist);
 
   /*! \brief Helper function to asynchronously update art in the music database
+  and then refresh the album & artist art of the currently playing song.
   For the song, album or artist this adds a job to the queue to update the art table
-  modifying, adding or deleting that type of art,
+  modifying, adding or deleting that type of art. Changes to album or artist art are
+  then passed to the currently playing song (if there is one).
   \param item a shared pointer to a music CFileItem (song, album or artist)
   \param strType the type of art e.g. "fanart" or "thumb" etc.
   \param strArt art URL, when empty the entry for that type of art is deleted. 

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2018 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,51 +19,193 @@
  */
 
 #include "GUIDialogMusicInfo.h"
-#include "guilib/GUIWindowManager.h"
+#include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "dialogs/GUIDialogSelect.h"
-#include "GUIPassword.h"
-#include "GUIUserMessages.h"
-#include "music/MusicDatabase.h"
-#include "music/tags/MusicInfoTag.h"
-#include "filesystem/File.h"
 #include "FileItem.h"
-#include "profiles/ProfilesManager.h"
-#include "storage/MediaManager.h"
-#include "settings/MediaSourceSettings.h"
-#include "input/Key.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
-#include "utils/URIUtils.h"
-#include "utils/StringUtils.h"
-#include "TextureCache.h"
+#include "GUIPassword.h"
+#include "GUIUserMessages.h"
+#include "input/Key.h"
+#include "music/MusicDatabase.h"
 #include "music/MusicThumbLoader.h"
+#include "music/MusicUtils.h"
+#include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicNav.h"
-#include "filesystem/Directory.h"
+#include "profiles/ProfilesManager.h"
 #include "ServiceBroker.h"
+#include "settings/MediaSourceSettings.h"
+#include "settings/Settings.h"
+#include "storage/MediaManager.h"
+#include "settings/MediaSourceSettings.h"
+#include "TextureCache.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 
 using namespace XFILE;
+using namespace MUSIC_INFO;
 
 #define CONTROL_BTN_REFRESH      6
 #define CONTROL_USERRATING       7
 #define CONTROL_BTN_GET_THUMB   10
-#define CONTROL_BTN_GET_FANART  12
 
 #define CONTROL_LIST            50
 
+#define TIME_TO_BUSY_DIALOG 500
+
+class CGetInfoJob : public CJob
+{
+public:
+  ~CGetInfoJob(void) override = default;
+
+  // Fetch full album/artist information including art types list
+  bool DoWork() override
+  {
+    CGUIDialogMusicInfo *dialog = CServiceBroker::GetGUI()->GetWindowManager().
+	  GetWindow<CGUIDialogMusicInfo>(WINDOW_DIALOG_MUSIC_INFO);
+    if (!dialog)
+      return false;
+    if (dialog->IsCancelled())
+      return false;
+    CFileItemPtr m_item = dialog->GetCurrentListItem();
+    CMusicInfoTag& tag = *m_item->GetMusicInfoTag();
+
+    CMusicDatabase database;
+    database.Open();
+    // May only have partially populated item, so fetch all artist or album data from db
+    if (tag.GetType() == MediaTypeArtist)
+    {
+      int artistId = tag.GetDatabaseId();
+      CArtist artist;
+      if (!database.GetArtist(artistId, artist))
+        return false;
+      tag.SetArtist(artist);
+      CMusicDatabase::SetPropertiesFromArtist(*m_item, artist);
+      m_item->SetLabel(artist.strArtist);
+
+      // Get artist folder where local art could be found
+      // Get the *name* of the folder for this artist within the Artist Info folder (may not exist).
+      // If there is no Artist Info folder specified in settings this will be blank
+      database.GetArtistPath(artist, artist.strPath);
+      // Get the old location for those album artists with a unique folder (local to music files)
+      // If there is no folder for the artist and *only* the artist this will be blank
+      std::string oldartistpath;
+      bool oldpathfound = database.GetOldArtistPath(artist.idArtist, oldartistpath);
+
+      // Set up path for *item folder when browsing for art, by default this is
+      // in the Artist Info Folder (when it exists), but could end up blank
+      std::string artistItemPath = artist.strPath;
+      if (!CDirectory::Exists(artistItemPath))
+      {
+        // Fall back local to music files (historic location for those album artists with a unique folder)
+        // although there may not be such a unique folder for the arist
+        if (oldpathfound)
+          artistItemPath = oldartistpath;
+        else
+          // Fall back further to browse the Artist Info Folder itself
+          artistItemPath = CServiceBroker::GetSettings().GetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER);
+      }        
+      m_item->SetPath(artistItemPath);
+      
+      // Store info as CArtist as well as item properties
+      dialog->SetArtist(artist, oldartistpath);
+
+      // Fetch artist discography as scraped from online sources
+      //! @todo: make links to library albums more efficient, always include those albums
+      dialog->SetDiscography();
+    }
+    else
+    { 
+      // tag.GetType == MediaTypeAlbum
+      int albumId = tag.GetDatabaseId();
+      CAlbum album;
+      if (!database.GetAlbum(albumId, album))
+        return false;
+      tag.SetAlbum(album);
+      CMusicDatabase::SetPropertiesFromAlbum(*m_item, album);
+
+      // Get album folder where local art could be found
+      database.GetAlbumPath(albumId, album.strPath);
+      // Set up path for *item folder when browsing for art
+      m_item->SetPath(album.strPath);
+      // Store info as CAlbum as well as item properties
+      dialog->SetAlbum(album, album.strPath);
+
+      // Set the list of songs and related art
+      dialog->SetSongs(album.songs);     
+    }
+    database.Close();
+
+
+    /* 
+      Load current art (to CGUIListItem.m_art)
+      For albums this includes related artist(s) art and artist fanart set as 
+      fallback album fanart.
+      Clear item art first to ensure fresh not cached/partial art
+    */
+    m_item->ClearArt();
+    CMusicThumbLoader loader;
+    loader.LoadItem(m_item.get());
+
+    
+    // Fill vector of possible art types with current art, when it exists,
+    // for display on the art type selection dialog
+    CFileItemList artlist;
+    MUSIC_UTILS::FillArtTypesList(*m_item, artlist);
+    dialog->SetArtTypeList(artlist);
+    if (dialog->IsCancelled())
+      return false;
+
+    
+    // Tell waiting MusicDialog that job is complete
+    dialog->FetchComplete();
+
+    return true;
+  }
+};
+
+class CSetUserratingJob : public CJob
+{
+  int idAlbum;
+  int iUserrating;
+public:
+  CSetUserratingJob(int albumId, int userrating) :
+    idAlbum(albumId),
+    iUserrating(userrating)
+  { }
+
+  ~CSetUserratingJob(void) override = default;
+
+  bool DoWork(void) override
+  {
+    // Asynchronously update userrating in library
+    CMusicDatabase db;
+    if (db.Open())
+    {
+      db.SetAlbumUserrating(idAlbum, iUserrating);
+      db.Close();
+    }
+
+    return true;
+  }
+};
+
 CGUIDialogMusicInfo::CGUIDialogMusicInfo(void)
     : CGUIDialog(WINDOW_DIALOG_MUSIC_INFO, "DialogMusicInfo.xml")
-      , m_albumItem(new CFileItem)
+    , m_item(new CFileItem)
 {
   m_bRefresh = false;
   m_albumSongs = new CFileItemList;
   m_loadType = KEEP_IN_MEMORY;
   m_startUserrating = -1;
-  m_needsUpdate = false;
+  m_hasUpdatedUserrating = false;
   m_bViewReview = false;
-  m_hasUpdatedThumb = false; 
   m_bArtistInfo = false;
+  m_cancelled = false;
+  m_artTypeList.Clear();
 }
 
 CGUIDialogMusicInfo::~CGUIDialogMusicInfo(void)
@@ -77,17 +219,25 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     {
-      if (m_startUserrating != m_albumItem->GetMusicInfoTag()->GetUserrating())
+      m_artTypeList.Clear();
+      // For albums update user rating if it has changed
+      if(!m_bArtistInfo && m_startUserrating != m_item->GetMusicInfoTag()->GetUserrating())
       {
-        CMusicDatabase db;
-        if (db.Open())
-        {
-          m_needsUpdate = true;
-          db.SetAlbumUserrating(m_albumItem->GetMusicInfoTag()->GetAlbumId(), m_albumItem->GetMusicInfoTag()->GetUserrating());
-          db.Close();
-        }
-      }
+        m_hasUpdatedUserrating = true;
 
+        // Asynchronously update song userrating in library
+        CSetUserratingJob *job = new CSetUserratingJob(m_item->GetMusicInfoTag()->GetAlbumId(), 
+                                                       m_item->GetMusicInfoTag()->GetUserrating());
+        CJobManager::GetInstance().AddJob(job, NULL);
+
+        // Send a message to all windows to tell them to update the album fileitem
+        // This communicates the rating change to the music lib window.
+        // The music lib window item is updated to but changes to the rating when it is the sort 
+        // do not show on screen until refresh() that fetches the list from scratch, sorts etc.
+        CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_item);
+        CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+      }
+    
       CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_LIST);
       OnMessage(msg);
       m_albumSongs->Clear();
@@ -100,6 +250,7 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
       m_bViewReview = true;
       m_bRefresh = false;
       Update();
+      m_cancelled = false;
       return true;
     }
     break;
@@ -120,7 +271,8 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTN_GET_THUMB)
       {
-        OnGetThumb();
+        OnGetArt();
+        return true;
       }
       else if (iControl == CONTROL_LIST)
       {
@@ -137,10 +289,6 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
           return true;
         }
       }
-      else if (iControl == CONTROL_BTN_GET_FANART)
-      {
-        OnGetFanart();
-      }
     }
     break;
   }
@@ -150,7 +298,7 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
 
 bool CGUIDialogMusicInfo::OnAction(const CAction &action)
 {
-  int userrating = m_albumItem->GetMusicInfoTag()->GetUserrating();
+  int userrating = m_item->GetMusicInfoTag()->GetUserrating();
   if (action.GetID() == ACTION_INCREASE_RATING)
   {
     SetUserrating(userrating + 1);
@@ -169,55 +317,55 @@ bool CGUIDialogMusicInfo::OnAction(const CAction &action)
   return CGUIDialog::OnAction(action);
 }
 
+bool CGUIDialogMusicInfo::SetItem(CFileItem* item)
+{
+  *m_item = *item;
+  m_event.Reset();
+  m_cancelled = false;  // Happens before win_init
+
+  // In a separate job fetch info and fill list of art types.
+  int jobid = CJobManager::GetInstance().AddJob(new CGetInfoJob(), nullptr, CJob::PRIORITY_LOW);
+
+  // Wait to get all data before show, allowing user to to cancel if fetch is slow
+  if (!CGUIDialogBusy::WaitOnEvent(m_event, TIME_TO_BUSY_DIALOG))
+  {
+    // Cancel job still waiting in queue (unlikely)
+    CJobManager::GetInstance().CancelJob(jobid);
+    // Flag to stop job already in progress
+    m_cancelled = true;
+    return false;
+  }
+
+  return true;
+}
+
 void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const std::string &path)
 {
   m_album = album;
-  SetSongs(m_album.songs);
-  *m_albumItem = CFileItem(path, true);
-  m_albumItem->GetMusicInfoTag()->SetAlbum(m_album);
-  CMusicDatabase::SetPropertiesFromAlbum(*m_albumItem, m_album);
-
-  // Load all album and related artist art (to CGUIListItem.m_art)
-  // This includes artist fanart set as fallback album fanart
-  CMusicThumbLoader loader;
-  loader.LoadItem(m_albumItem.get());
-
+  m_item->SetPath(album.strPath); 
+  
   m_startUserrating = m_album.iUserrating;
-  m_hasUpdatedThumb = false;
   m_bArtistInfo = false;
-  m_needsUpdate = false;
+  m_hasUpdatedUserrating = false;
 
   // CurrentDirectory() returns m_albumSongs (a convenient CFileItemList)
   // Set content so can return dialog CONTAINER_CONTENT as "albums"
   m_albumSongs->SetContent("albums");
   // Copy art from ListItem so CONTAINER_ART returns album art
-  m_albumSongs->SetArt(m_albumItem->GetArt());
+  m_albumSongs->SetArt(m_item->GetArt());
 }
 
 void CGUIDialogMusicInfo::SetArtist(const CArtist& artist, const std::string &path)
 {
   m_artist = artist;
-  SetDiscography();
-  *m_albumItem = CFileItem(path, true);
-  m_albumItem->SetLabel(artist.strArtist);
-  m_albumItem->GetMusicInfoTag()->SetAlbumArtist(m_artist.strArtist);
-  m_albumItem->GetMusicInfoTag()->SetArtist(m_artist.strArtist);
-  m_albumItem->GetMusicInfoTag()->SetLoaded(true);
-  m_albumItem->GetMusicInfoTag()->SetGenre(m_artist.genre);
-  m_albumItem->GetMusicInfoTag()->SetDatabaseId(m_artist.idArtist, MediaTypeArtist);
-  CMusicDatabase::SetPropertiesFromArtist(*m_albumItem,m_artist);
-
-  CMusicThumbLoader loader;
-  loader.LoadItem(m_albumItem.get());
-
-  m_hasUpdatedThumb = false;
+  m_fallbackartpath = path;
   m_bArtistInfo = true;
 
   // CurrentDirectory() returns m_albumSongs (a convenient CFileItemList)
   // Set content so can return dialog CONTAINER_CONTENT as "artists"
   m_albumSongs->SetContent("artists"); 
   // Copy art from ListItem so CONTAINER_ART returns artist art
-  m_albumSongs->SetArt(m_albumItem->GetArt());
+  m_albumSongs->SetArt(m_item->GetArt());
 }
 
 void CGUIDialogMusicInfo::SetSongs(const VECSONGS &songs) const
@@ -278,7 +426,6 @@ void CGUIDialogMusicInfo::Update()
 {
   if (m_bArtistInfo)
   {
-    SET_CONTROL_VISIBLE(CONTROL_BTN_GET_FANART);
     SET_CONTROL_HIDDEN(CONTROL_USERRATING);
 
     CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_albumSongs);
@@ -288,7 +435,6 @@ void CGUIDialogMusicInfo::Update()
   else
   {
     SET_CONTROL_VISIBLE(CONTROL_USERRATING);
-    SET_CONTROL_HIDDEN(CONTROL_BTN_GET_FANART);
 
     CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_albumSongs);
     OnMessage(message);
@@ -297,8 +443,9 @@ void CGUIDialogMusicInfo::Update()
 
   const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
 
-  // disable the GetThumb button if the user isn't allowed it
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+  // Disable the Choose Art button if the user isn't allowed it
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB, 
+    profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
 }
 
 void CGUIDialogMusicInfo::SetLabel(int iControl, const std::string& strLabel)
@@ -317,27 +464,27 @@ void CGUIDialogMusicInfo::OnInitWindow()
 {
   SET_CONTROL_LABEL(CONTROL_BTN_REFRESH, 184);
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);
-  SET_CONTROL_LABEL(CONTROL_BTN_GET_THUMB, 13405);
-  SET_CONTROL_LABEL(CONTROL_BTN_GET_FANART, 20413);
+  SET_CONTROL_LABEL(CONTROL_BTN_GET_THUMB, 13511);
 
   if (m_bArtistInfo)
     SET_CONTROL_HIDDEN(CONTROL_USERRATING);
-  else
-    SET_CONTROL_HIDDEN(CONTROL_BTN_GET_FANART);
 
   CGUIDialog::OnInitWindow();
 }
 
+void CGUIDialogMusicInfo::FetchComplete()
+{
+  //Trigger the event to indicate data has been fetched
+  m_event.Set();
+}
+
 void CGUIDialogMusicInfo::SetUserrating(int userrating) const
 {
-  if (userrating < 0) userrating = 0;
-  if (userrating > 10) userrating = 10;
-  if (userrating != m_albumItem->GetMusicInfoTag()->GetUserrating())
+  userrating = std::max(userrating, 0);
+  userrating = std::min(userrating, 10);
+  if (userrating != m_item->GetMusicInfoTag()->GetUserrating())
   {
-    m_albumItem->GetMusicInfoTag()->SetUserrating(userrating);
-    // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
-    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_albumItem);
-    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+    m_item->GetMusicInfoTag()->SetUserrating(userrating);
   }
 }
 
@@ -355,10 +502,10 @@ void CGUIDialogMusicInfo::OnGetThumb()
   CFileItemList items;
 
   // Current thumb
-  if (CFile::Exists(m_albumItem->GetArt("thumb")))
+  if (CFile::Exists(m_item->GetArt("thumb")))
   {
     CFileItemPtr item(new CFileItem("thumb://Current", false));
-    item->SetArt("thumb", m_albumItem->GetArt("thumb"));
+    item->SetArt("thumb", m_item->GetArt("thumb"));
     item->SetLabel(g_localizeStrings.Get(20016));
     items.Add(item);
   }
@@ -415,7 +562,7 @@ void CGUIDialogMusicInfo::OnGetThumb()
   }
   else
   {
-    localThumb = m_albumItem->GetUserMusicThumb();
+    localThumb = m_item->GetUserMusicThumb();
     existsThumb = CFile::Exists(localThumb);
   }
   if (existsThumb)
@@ -439,7 +586,7 @@ void CGUIDialogMusicInfo::OnGetThumb()
   std::string result;
   bool flip=false;
   VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
-  AddItemPathToFileBrowserSources(sources, *m_albumItem);
+  AddItemPathToFileBrowserSources(sources, *m_item);
   g_mediaManager.GetLocalDrives(sources);
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(1030), result, &flip))
     return;   // user cancelled
@@ -462,12 +609,12 @@ void CGUIDialogMusicInfo::OnGetThumb()
   CMusicDatabase db;
   if (db.Open())
   {
-    db.SetArtForItem(m_albumItem->GetMusicInfoTag()->GetDatabaseId(), m_albumItem->GetMusicInfoTag()->GetType(), "thumb", newThumb);
+    db.SetArtForItem(m_item->GetMusicInfoTag()->GetDatabaseId(), m_item->GetMusicInfoTag()->GetType(), "thumb", newThumb);
     db.Close();
   }
 
-  m_albumItem->SetArt("thumb", newThumb);
-  m_hasUpdatedThumb = true;
+  m_item->SetArt("thumb", newThumb);
+
 
   // tell our GUI to completely reload all controls (as some of them
   // are likely to have had this image in use so will need refreshing)
@@ -483,10 +630,10 @@ void CGUIDialogMusicInfo::OnGetFanart()
 {
   CFileItemList items;
 
-  if (m_albumItem->HasArt("fanart"))
+  if (m_item->HasArt("fanart"))
   {
     CFileItemPtr itemCurrent(new CFileItem("fanart://Current",false));
-    itemCurrent->SetArt("thumb", m_albumItem->GetArt("fanart"));
+    itemCurrent->SetArt("thumb", m_item->GetArt("fanart"));
     itemCurrent->SetLabel(g_localizeStrings.Get(20440));
     items.Add(itemCurrent);
   }
@@ -553,7 +700,7 @@ void CGUIDialogMusicInfo::OnGetFanart()
   std::string result;
   bool flip = false;
   VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
-  AddItemPathToFileBrowserSources(sources, *m_albumItem);
+  AddItemPathToFileBrowserSources(sources, *m_item);
   g_mediaManager.GetLocalDrives(sources);
   if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(20437), result, &flip, 20445))
     return;   // user cancelled
@@ -582,12 +729,12 @@ void CGUIDialogMusicInfo::OnGetFanart()
   CMusicDatabase db;
   if (db.Open())
   {
-    db.SetArtForItem(m_albumItem->GetMusicInfoTag()->GetDatabaseId(), m_albumItem->GetMusicInfoTag()->GetType(), "fanart", result);
+    db.SetArtForItem(m_item->GetMusicInfoTag()->GetDatabaseId(), m_item->GetMusicInfoTag()->GetType(), "fanart", result);
     db.Close();
   }
 
-  m_albumItem->SetArt("fanart", result);
-  m_hasUpdatedThumb = true;
+  m_item->SetArt("fanart", result);
+
   // tell our GUI to completely reload all controls (as some of them
   // are likely to have had this image in use so will need refreshing)
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
@@ -616,7 +763,7 @@ void CGUIDialogMusicInfo::OnSearch(const CFileItem* pItem)
 
 CFileItemPtr CGUIDialogMusicInfo::GetCurrentListItem(int offset)
 {
-  return m_albumItem;
+  return m_item;
 }
 
 void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item)
@@ -637,29 +784,230 @@ void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, c
   }
 }
 
+void CGUIDialogMusicInfo::SetArtTypeList(CFileItemList& artlist)
+{
+  m_artTypeList.Copy(artlist);
+}
+
+/*
+Allow user to choose artwork for the artist or album
+For each type of art the options are:
+1.  Current art
+2.  Local art (thumb found by filename)
+3.  Remote art (scraped list of urls from online sources e.g. fanart.tv)
+5.  Embedded art (@todo)
+6.  None
+*/
+void CGUIDialogMusicInfo::OnGetArt()
+{
+  std::string type = MUSIC_UTILS::ShowSelectArtTypeDialog(m_artTypeList);
+  if (type.empty())
+    return; // Cancelled
+
+  CFileItemList items;
+  CGUIListItem::ArtMap primeArt = m_item->GetArt(); // art without fallbacks
+  bool bHasArt = m_item->HasArt(type);
+  bool bFallback(false);
+  if (bHasArt)
+  {
+    // Check if that type of art is actually a fallback, e.g. artist fanart
+    CGUIListItem::ArtMap::const_iterator i = primeArt.find(type);
+    bFallback = (i == primeArt.end());
+  }
+
+  // Build list of possible images of that art type
+  if (bHasArt)
+  {
+    // Add item for current artwork
+    // For album it could be a fallback from artist
+    CFileItemPtr item(new CFileItem("thumb://Current", false));
+    item->SetArt("thumb", m_item->GetArt(type));
+    item->SetIconImage("DefaultPicture.png");
+    item->SetLabel(g_localizeStrings.Get(13512));
+    items.Add(item);
+  }
+  else if (m_item->HasArt("thumb"))
+  { 
+    // For missing art of that type add the thumb (when it exists and not a fallback)
+    CGUIListItem::ArtMap::const_iterator i = primeArt.find("thumb");
+    if (i != primeArt.end())
+    {
+      CFileItemPtr item(new CFileItem("thumb://Thumb", false));
+      item->SetArt("thumb", m_item->GetArt("thumb"));
+      if (m_bArtistInfo)
+        item->SetIconImage("DefaultArtistCover.png");
+      else
+        item->SetIconImage("DefaultAlbumCover.png");
+      item->SetLabel(g_localizeStrings.Get(21371));
+      items.Add(item);
+    }
+  }
+
+ // Grab the thumbnails of this art type scraped from the web
+  std::vector<std::string> remotethumbs;
+  if (type == "fanart" && m_bArtistInfo)
+  {
+    // Scraped artist fanart URLs are held separately from other art types
+    //! @todo Change once scraping all art types is unified
+    for (unsigned int i = 0; i < m_artist.fanart.GetNumFanarts(); i++)
+    {
+      std::string strItemPath;
+      strItemPath = StringUtils::Format("fanart://Remote%i", i);
+      CFileItemPtr item(new CFileItem(strItemPath, false));
+      std::string thumb = m_artist.fanart.GetPreviewURL(i);
+      std::string wrappedthumb = CTextureUtils::GetWrappedThumbURL(thumb);
+      remotethumbs.push_back(wrappedthumb); // Store for lookup after selection
+      item->SetArt("thumb", wrappedthumb);
+      item->SetIconImage("DefaultPicture.png");
+      item->SetLabel(g_localizeStrings.Get(20441));
+
+      items.Add(item);
+    }
+  }
+  else
+  {
+    if (m_bArtistInfo)
+      m_artist.thumbURL.GetThumbURLs(remotethumbs, type);
+    else
+      m_album.thumbURL.GetThumbURLs(remotethumbs, type);
+
+    for (unsigned int i = 0; i < remotethumbs.size(); ++i)
+    {
+      std::string strItemPath;
+      strItemPath = StringUtils::Format("thumb://Remote%i", i);
+      CFileItemPtr item(new CFileItem(strItemPath, false));
+      item->SetArt("thumb", remotethumbs[i]);
+      item->SetIconImage("DefaultPicture.png");
+      item->SetLabel(g_localizeStrings.Get(13513));
+
+      items.Add(item);
+    }
+  }
+
+  // Local art
+  // Album and artist thumbs can be found in local files
+  //! @todo: additional art types could also be found locally e.g "poster.jpg"
+  std::string localThumb;
+  bool existsThumb = false;
+  if (type == "thumb")
+  { 
+    if (m_bArtistInfo)
+    {
+      // First look for thumb in the artists folder, the primary location     
+      if (!m_artist.strPath.empty())
+      {
+        localThumb = URIUtils::AddFileToFolder(m_artist.strPath, "folder.jpg");
+        existsThumb = CFile::Exists(localThumb);
+      }
+      // If not there fall back local to music files when there is a unique artist folder
+      if (!existsThumb && !m_fallbackartpath.empty())
+      {
+        localThumb = URIUtils::AddFileToFolder(m_fallbackartpath, "folder.jpg");
+        existsThumb = CFile::Exists(localThumb);
+      }
+    }
+    else
+    {
+      localThumb = m_item->GetUserMusicThumb(true);
+      if (m_item->IsMusicDb())
+      {
+        CFileItem item(m_item->GetMusicInfoTag()->GetURL(), false);
+        localThumb = item.GetUserMusicThumb(true);
+      }
+    }
+
+    if (CFile::Exists(localThumb))
+    {
+      CFileItemPtr item(new CFileItem("thumb://Local", false));
+      item->SetArt("thumb", localThumb);
+      item->SetLabel(g_localizeStrings.Get(20017));
+      items.Add(item);
+    }
+  }
+  //! @todo Artist fanart can also be in local file
+
+  if (bHasArt && !bFallback)
+  { // Actually has this type of art (not a fallback) so 
+    // allow the user to delete it by selecting "no art".
+    CFileItemPtr item(new CFileItem("thumb://None", false));
+    if (m_bArtistInfo)
+      item->SetIconImage("DefaultArtist.png");
+    else
+      item->SetIconImage("DefaultAlbumCover.png");
+    item->SetLabel(g_localizeStrings.Get(13515));
+    items.Add(item);
+  }
+
+  //! @todo: Add support for extracting embedded art from song files to use for album
+
+  // Show list of possible art for user selection
+  // Note that during selection thumbs of *all* images shown are cached. When 
+  // browsing folders there could be many irrelevant thumbs cached that are
+  // never used by Kodi again, but there is no obvious way to clear these 
+  // thumbs from the cache automatically.
+  std::string result;
+  VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
+  CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(sources, *m_item);
+  g_mediaManager.GetLocalDrives(sources);
+  if (CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result) &&
+    result != "thumb://Current")
+  {
+    // User didn't choose the one they have. 
+    // Overwrite with the new art or clear it
+    std::string newArt;
+    if (StringUtils::StartsWith(result, "thumb://Remote"))
+    {
+      int number = atoi(result.substr(14).c_str());
+      newArt = remotethumbs[number];
+    }
+    else if (StringUtils::StartsWith(result, "fanart://Remote"))
+    {
+      int number = atoi(result.substr(15).c_str());
+      newArt = remotethumbs[number];
+    }
+    else if (result == "thumb://Thumb")
+      newArt = m_item->GetArt("thumb");
+    else if (result == "thumb://Local")
+      newArt = localThumb;
+    else if (CFile::Exists(result))
+      newArt = result;
+    else // none
+      newArt.clear();
+
+    // Asynchronously update that type of art in the database and then
+    // refresh artist, album and fallback art of currently playing song
+    MUSIC_UTILS::UpdateArtJob(m_item, type, newArt);
+
+    // Update local item and art list with current art
+    m_item->SetArt(type, newArt);
+    for (const auto artitem : m_artTypeList)
+    {
+      if (artitem->GetProperty("artType") == type)
+      {
+        artitem->SetArt("thumb", newArt);
+        break;
+      }
+    }
+
+    // Get new artwork to show in other places e.g. on music lib window, but this does 
+    // not update artist, album or fallback art for the currently playing song as it 
+    // is a different item with different ID and media type
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, m_item);
+    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+  }
+
+  // Re-open the art type selection dialog as we come back from
+  // the image selection dialog
+  OnGetArt();
+}
+
 void CGUIDialogMusicInfo::OnSetUserrating() const
 {
-  CGUIDialogSelect *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
-  if (dialog)
-  {
-    // If we refresh and then try to set the rating there will be an items already here...
-    dialog->Reset();
+  int userrating = MUSIC_UTILS::ShowSelectRatingDialog(m_item->GetMusicInfoTag()->GetUserrating());
+  if (userrating < 0) // Nothing selected, so rating unchanged
+    return;
 
-    dialog->SetHeading(CVariant{ 38023 });
-    dialog->Add(g_localizeStrings.Get(38022));
-    for (int i = 1; i <= 10; i++)
-      dialog->Add(StringUtils::Format("%s: %i", g_localizeStrings.Get(563).c_str(), i));
-
-    dialog->SetSelected(m_albumItem->GetMusicInfoTag()->GetUserrating());
-
-    dialog->Open();
-
-    int iItem = dialog->GetSelectedItem();
-    if (iItem < 0)
-      return;
-
-    SetUserrating(iItem);
-  }
+  SetUserrating(userrating);  
 }
 
 void CGUIDialogMusicInfo::ShowFor(CFileItem item)

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -41,40 +41,46 @@ public:
   bool SetItem(CFileItem* item);
   void SetAlbum(const CAlbum& album, const std::string &path);
   void SetArtist(const CArtist& artist, const std::string &path);
-  bool NeedRefresh() const { return m_bRefresh; };
   bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
+  bool HasRefreshed() const { return m_hasRefreshed; };
 
   bool HasListItems() const override { return true; };
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
-  const CFileItemList& CurrentDirectory() const { return *m_albumSongs; };
+  std::string GetContent();
   static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
-  void SetDiscography() const;
+  void SetDiscography(CMusicDatabase& database) const;
   void SetSongs(const VECSONGS &songs) const;
   void SetArtTypeList(CFileItemList& artlist);
+  void SetScrapedInfo(bool bScraped) { m_scraperAddInfo = bScraped;  }
+  CArtist& GetArtist() { return m_artist; };
+  CAlbum& GetAlbum() { return m_album; };
   bool IsArtistInfo() const { return m_bArtistInfo; };
   bool IsCancelled() const { return m_cancelled; };
+  bool HasScrapedInfo() const { return m_scraperAddInfo; };
   void FetchComplete();
+  void RefreshInfo();
 
-  static void ShowFor(CFileItem item);
+  static void ShowForAlbum(int idAlbum);
+  static void ShowForArtist(int idArtist);
+  static void ShowFor(CFileItem* pItem);
 protected:
   void OnInitWindow() override;
   void Update();
   void SetLabel(int iControl, const std::string& strLabel);
-  void OnGetThumb();
-  void OnGetFanart();
   void OnGetArt();
-  void OnSearch(const CFileItem* pItem);
+  void OnAlbumInfo(int id);
+  void OnArtistInfo(int id);
   void OnSetUserrating() const;
   void SetUserrating(int userrating) const;
 
   CAlbum m_album;
   CArtist m_artist;
   int m_startUserrating;
-  bool m_bViewReview;
-  bool m_bRefresh;
   bool m_hasUpdatedUserrating;
+  bool m_hasRefreshed;
   bool m_bArtistInfo;
   bool m_cancelled;
+  bool m_scraperAddInfo;
   CFileItemList* m_albumSongs;
   CFileItemPtr m_item;
   CFileItemList m_artTypeList;

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2018 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -25,6 +25,7 @@
 #include "music/Artist.h"
 #include "music/Album.h"
 #include "FileItem.h"
+#include "threads/Event.h"
 
 class CFileItem;
 class CFileItemList;
@@ -37,16 +38,22 @@ public:
   ~CGUIDialogMusicInfo(void) override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
+  bool SetItem(CFileItem* item);
   void SetAlbum(const CAlbum& album, const std::string &path);
   void SetArtist(const CArtist& artist, const std::string &path);
   bool NeedRefresh() const { return m_bRefresh; };
-  bool NeedsUpdate() const { return m_needsUpdate; };
-  bool HasUpdatedThumb() const { return m_hasUpdatedThumb; };
+  bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; };
 
   bool HasListItems() const override { return true; };
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
   const CFileItemList& CurrentDirectory() const { return *m_albumSongs; };
   static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
+  void SetDiscography() const;
+  void SetSongs(const VECSONGS &songs) const;
+  void SetArtTypeList(CFileItemList& artlist);
+  bool IsArtistInfo() const { return m_bArtistInfo; };
+  bool IsCancelled() const { return m_cancelled; };
+  void FetchComplete();
 
   static void ShowFor(CFileItem item);
 protected:
@@ -55,8 +62,7 @@ protected:
   void SetLabel(int iControl, const std::string& strLabel);
   void OnGetThumb();
   void OnGetFanart();
-  void SetSongs(const VECSONGS &songs) const;
-  void SetDiscography() const;
+  void OnGetArt();
   void OnSearch(const CFileItem* pItem);
   void OnSetUserrating() const;
   void SetUserrating(int userrating) const;
@@ -66,9 +72,12 @@ protected:
   int m_startUserrating;
   bool m_bViewReview;
   bool m_bRefresh;
-  bool m_needsUpdate;
-  bool m_hasUpdatedThumb;
+  bool m_hasUpdatedUserrating;
   bool m_bArtistInfo;
-  CFileItemPtr   m_albumItem;
+  bool m_cancelled;
   CFileItemList* m_albumSongs;
+  CFileItemPtr m_item;
+  CFileItemList m_artTypeList;
+  CEvent m_event;
+  std::string m_fallbackartpath;
 };

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -34,10 +34,12 @@
 #include "music/MusicUtils.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicBase.h"
+#include "profiles/ProfilesManager.h"
+#include "ServiceBroker.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
+#include "TextureCache.h"
 #include "Util.h"
-#include "ServiceBroker.h"
 
 using namespace XFILE;
 
@@ -70,7 +72,11 @@ public:
     // Fetch tag data from library using filename of item path, or scanning file
     // (if item does not already have this loaded)
     if (!m_song->LoadMusicTag())
+    {
+      // Stop SongInfoDialog waiting
+      dialog->FetchComplete();
       return false;
+    }
     if (dialog->IsCancelled())
       return false;
     // Fetch album and primary song artist data from library as properties
@@ -171,15 +177,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_ALBUMINFO)
       {
-        CGUIWindowMusicBase *window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowMusicBase>(WINDOW_MUSIC_NAV);
-        if (window)
-        {
-          CFileItem item(*m_song);
-          std::string path = StringUtils::Format("musicdb://albums/%li",m_albumId);
-          item.SetPath(path);
-          item.m_bIsFolder = true;
-          window->OnItemInfo(&item, true);
-        }
+        CGUIDialogMusicInfo::ShowForAlbum(m_albumId);
         return true;
       }
       else if (iControl == CONTROL_BTN_GET_THUMB)
@@ -199,17 +197,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
             break;
           int idArtist = m_song->GetMusicInfoTag()->GetContributors()[iItem].GetArtistId();
           if (idArtist > 0)
-          {
-              CGUIWindowMusicBase *window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowMusicBase>(WINDOW_MUSIC_NAV);
-              if (window)
-              {
-                CFileItem item(*m_song);
-                std::string path = StringUtils::Format("musicdb://artists/%i", idArtist);
-                item.SetPath(path);
-                item.m_bIsFolder = true;
-                window->OnItemInfo(&item, true);
-              }
-          }
+            CGUIDialogMusicInfo::ShowForArtist(idArtist);
           return true;
         }
       }
@@ -266,6 +254,11 @@ void CGUIDialogSongInfo::OnInitWindow()
   else
     CONTROL_ENABLE(CONTROL_USERRATING);
 
+  // Disable the Choose Art button if the user isn't allowed it
+  const CProfilesManager &profileManager = CServiceBroker::GetProfileManager();
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
+    profileManager.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser);
+
   SET_CONTROL_HIDDEN(CONTROL_BTN_REFRESH);
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);
   SET_CONTROL_LABEL(CONTROL_BTN_GET_THUMB, 13511);
@@ -316,12 +309,6 @@ bool CGUIDialogSongInfo::SetSong(CFileItem* item)
     return false;
   }
 
-  // CurrentDirectory() returns m_artTypeList (a convenient CFileItemList)
-  // Set content so can return dialog CONTAINER_CONTENT as "songs"
-  m_artTypeList.SetContent("songs");
-  // Copy art from ListItem so CONTAINER_ART returns song art
-  m_artTypeList.SetArt(m_song->GetArt());
-
   // Store initial userrating
   m_startUserrating = m_song->GetMusicInfoTag()->GetUserrating();
   m_hasUpdatedUserrating = false;
@@ -336,6 +323,11 @@ void CGUIDialogSongInfo::SetArtTypeList(CFileItemList& artlist)
 CFileItemPtr CGUIDialogSongInfo::GetCurrentListItem(int offset)
 {
   return m_song;
+}
+
+std::string CGUIDialogSongInfo::GetContent()
+{
+  return "songs";
 }
 
 /*
@@ -403,6 +395,19 @@ void CGUIDialogSongInfo::OnGetArt()
       item->SetLabel(g_localizeStrings.Get(20017));
       items.Add(item);
     }
+  }
+
+  // Clear these local images from cache so user will see any recent 
+  // local file changes immediately
+  for (auto& item : items)
+  {
+    std::string thumb(item->GetArt("thumb"));
+    if (thumb.empty())
+      continue;
+    CTextureCache::GetInstance().ClearCachedImage(thumb);
+    // Remove any thumbnail of local image too (created when browsing files)
+    std::string thumbthumb(CTextureUtils::GetWrappedThumbURL(thumb));
+    CTextureCache::GetInstance().ClearCachedImage(thumbthumb);
   }
 
   if (bHasArt && !bFallback)
@@ -484,4 +489,31 @@ void CGUIDialogSongInfo::OnSetUserrating()
     return;
 
   SetUserrating(userrating);
+}
+
+void CGUIDialogSongInfo::ShowFor(CFileItem* pItem)
+{
+  if (pItem->m_bIsFolder)
+    return;
+  if (!pItem->IsMusicDb())
+    pItem->LoadMusicTag();
+  if (!pItem->HasMusicInfoTag())
+    return;
+
+  CGUIDialogSongInfo *dialog = CServiceBroker::GetGUI()->GetWindowManager().
+    GetWindow<CGUIDialogSongInfo>(WINDOW_DIALOG_SONG_INFO);
+  if (dialog)
+  {
+    if (dialog->SetSong(pItem))  // Fetch full song info asynchronously
+    {
+      dialog->Open();
+      if (dialog->HasUpdatedUserrating())
+      {
+        auto window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowMusicBase>(WINDOW_MUSIC_NAV);
+        if (window)
+          window->RefreshContent("songs");
+      }
+    }
+  }
+
 }

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -39,10 +39,12 @@ public:
 
   bool HasListItems() const override { return true; };
   CFileItemPtr GetCurrentListItem(int offset = 0) override;
-  const CFileItemList& CurrentDirectory() const { return m_artTypeList; };
+  std::string GetContent();
+  //const CFileItemList& CurrentDirectory() const { return m_artTypeList; };
   bool IsCancelled() const { return m_cancelled; };
   void FetchComplete();
 
+  static void ShowFor(CFileItem* pItem);
 protected:
   void OnInitWindow() override;
   void Update();

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -301,7 +301,7 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
   CGUIDialogMusicInfo::ShowFor(item.get());
 }
 
-void CGUIWindowMusicBase::RefreshContent(std::string strContent)
+void CGUIWindowMusicBase::RefreshContent(const std::string& strContent)
 {
   if ( CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_MUSIC_NAV &&
     m_vecItems->GetContent() == strContent &&

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -48,9 +48,8 @@ public:
   bool OnAction(const CAction &action) override;
   bool OnBack(int actionID) override;
 
-  void OnItemInfo(CFileItem *pItem, bool bShowInfo = false);
-
   void DoScan(const std::string &strPath, bool bRescan = false);
+  void RefreshContent(std::string strContent);
 
   /*! \brief Prompt the user if he wants to start a scan for this folder
   \param path the path to assign content for
@@ -89,19 +88,12 @@ protected:
   bool OnPlayMedia(int iItem, const std::string &player = "") override;
 
   void RetrieveMusicInfo();
-  void OnItemInfo(int iItem, bool bShowInfo = true);
+  void OnItemInfo(int iItem);
   void OnItemInfoAll(const std::string strPath, bool refresh = false);
   virtual void OnQueueItem(int iItem);
   enum ALLOW_SELECTION { SELECTION_ALLOWED = 0, SELECTION_AUTO, SELECTION_FORCED };
-  bool FindAlbumInfo(const CFileItem* album, MUSIC_GRABBER::CMusicAlbumInfo& albumInfo, ALLOW_SELECTION allowSelection);
-  bool FindArtistInfo(const CFileItem* artist, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, ALLOW_SELECTION allowSelection);
-
-  void ShowAlbumInfo(CFileItem* pItem);
-  void ShowArtistInfo(CFileItem* pItem);
-  void ShowSongInfo(CFileItem* pItem);
-
+  
   void OnRipTrack(int iItem);
-  void OnSearch();
   void LoadPlayList(const std::string& strPlayList) override;
   virtual void OnRemoveSource(int iItem);
 

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -4,7 +4,7 @@
 */
 #pragma once
 /*
- *      Copyright (C) 2005-2013 Team XBMC
+ *      Copyright (C) 2005-2018 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -96,10 +96,9 @@ protected:
   bool FindAlbumInfo(const CFileItem* album, MUSIC_GRABBER::CMusicAlbumInfo& albumInfo, ALLOW_SELECTION allowSelection);
   bool FindArtistInfo(const CFileItem* artist, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, ALLOW_SELECTION allowSelection);
 
-  bool ShowAlbumInfo(const CFileItem *pItem, bool bShowInfo = true);
-  void ShowArtistInfo(const CFileItem *pItem, bool bShowInfo = true);
+  void ShowAlbumInfo(CFileItem* pItem);
+  void ShowArtistInfo(CFileItem* pItem);
   void ShowSongInfo(CFileItem* pItem);
-  void UpdateThumb(const CAlbum &album, const std::string &path);
 
   void OnRipTrack(int iItem);
   void OnSearch();

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -49,7 +49,7 @@ public:
   bool OnBack(int actionID) override;
 
   void DoScan(const std::string &strPath, bool bRescan = false);
-  void RefreshContent(std::string strContent);
+  void RefreshContent(const std::string& strContent);
 
   /*! \brief Prompt the user if he wants to start a scan for this folder
   \param path the path to assign content for

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -120,7 +120,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
             m_viewControl.SetSelectedItem(i);
             i = -1;
             if (url.GetOption("showinfo") == "true")
-              OnItemInfo(pItem.get(), true);
+              OnItemInfo(i);
             break;
           }
         }


### PR DESCRIPTION
Refactor artist/album Info dialog:
- Move data read and write off the main thread to avoid possibility of locking UI.
- Support selection of any type of art.
- Correctly update the artwork for the currently playing song if the related album or artist art changes.
- Improve artist discography list to always show all the albums in the music library by that artist, and then any additional titles scraped from online sources.
- Clear local images from cache prior to image selection in attempt to immediately  show any recent external changes made to the contents of the file.

This is a follow-on from #13533 that improved the song info dialog, and some further minor enhancements (lessons learned) have also been added to that dialog too. Much of the initial explanation for that PR applies here too.
