### PR TITLE
[windows] build cpluff from source

### DIFF
--- a/cmake/modules/FindCpluff.cmake
+++ b/cmake/modules/FindCpluff.cmake
@@ -6,8 +6,11 @@
 #
 # and link Kodi against the cpluff libraries.
 
-if(NOT WIN32)
-  find_package(EXPAT REQUIRED)
+find_package(EXPAT REQUIRED)
+if(CORE_SYSTEM_NAME MATCHES windows)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/lib/cpluff)
+  set(CPLUFF_LIBRARIES $<TARGET_FILE:libcpluff> ${EXPAT_LIBRARIES})
+else()
   string(REPLACE ";" " " defines "${CMAKE_C_FLAGS} ${SYSTEM_DEFINES} -I${EXPAT_INCLUDE_DIR}")
   get_filename_component(expat_dir ${EXPAT_LIBRARY} DIRECTORY)
   set(ldflags "-L${expat_dir}")
@@ -41,23 +44,8 @@ if(NOT WIN32)
                                      WORKING_DIRECTORY <SOURCE_DIR>)
 
   set(CPLUFF_LIBRARIES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/lib/libcpluff.a ${EXPAT_LIBRARIES})
-  set(CPLUFF_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/include)
-  set(CPLUFF_FOUND 1)
-  mark_as_advanced(CPLUFF_INCLUDE_DIRS CPLUFF_LIBRARIES)
-else()
-  find_path(CPLUFF_INCLUDE_DIR cpluff.h)
-  find_library(CPLUFF_LIBRARY NAMES cpluff)
-
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(Cpluff
-                                    REQUIRED_VARS CPLUFF_INCLUDE_DIR CPLUFF_LIBRARY)
-
-  if(CPLUFF_FOUND)
-    set(CPLUFF_LIBRARIES ${CPLUFF_LIBRARY})
-    set(CPLUFF_INCLUDE_DIRS ${CPLUFF_INCLUDE_DIR})
-  endif()
-  mark_as_advanced(CPLUFF_INCLUDE_DIRS CPLUFF_LIBRARY)
-
-  add_custom_target(libcpluff)
 endif()
+set(CPLUFF_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/include)
+set(CPLUFF_FOUND 1)
+mark_as_advanced(CPLUFF_INCLUDE_DIRS CPLUFF_LIBRARIES)
 set_target_properties(libcpluff PROPERTIES FOLDER "External Projects")

--- a/lib/cpluff/CMakeLists.txt
+++ b/lib/cpluff/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(libcpluff VERSION 0.1.4 LANGUAGES C)
+
+find_package(expat 2.2.0 REQUIRED)
+
+add_library(${PROJECT_NAME}
+  ${CMAKE_CURRENT_SOURCE_DIR}/kazlib/hash.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/kazlib/hash.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/kazlib/list.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/kazlib/list.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/context.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/cpluff.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/cpluff.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/defines.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/internal.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/logging.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/pcontrol.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/pinfo.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/ploader.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/pscan.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/psymbol.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/serial.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/thread.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/util.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/util.c
+)
+
+if(WIN32)
+  target_sources(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/thread_windows.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/win32/cpluffdef.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/win32/dirent.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/win32/dirent.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/win32/win32_utils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/libcpluff/win32/win32_utils.c
+  )
+endif()
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ${EXPAT_LIBRARIES})
+
+target_include_directories(${PROJECT_NAME}
+  PRIVATE
+  $<BUILD_INTERFACE:kazlib;libcpluff;libcpluff/win32;${EXPAT_INCLUDE_DIR}>
+  INTERFACE
+  $<INSTALL_INTERFACE:include>
+)
+
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+  XML_STATIC
+  CP_C_API=CP_EXPORT
+  _CRT_SECURE_NO_WARNINGS
+  _CRT_NONSTDC_NO_DEPRECATE
+)

--- a/lib/cpluff/libcpluff/internal.h
+++ b/lib/cpluff/libcpluff/internal.h
@@ -85,7 +85,11 @@ extern "C" {
 
 #if defined(_WIN32)
 #define DLHANDLE void *
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
+#define DLOPEN(name) LoadPackagedLibrary(name, 0)
+#else
 #define DLOPEN(name) LoadLibraryA(name)
+#endif
 #define DLSYM(handle, symbol) GetProcAddress(handle, symbol)
 #define DLCLOSE(handle) CloseHandle(handle)
 #define DLERROR() "WIN32 - TODO"

--- a/lib/cpluff/libcpluff/ploader.c
+++ b/lib/cpluff/libcpluff/ploader.c
@@ -41,6 +41,9 @@
 #include "defines.h"
 #include "util.h"
 #include "internal.h"
+#if defined(_WIN32)
+#include "win32_utils.h"
+#endif
 
 // Use XMLCALL if available
 #ifdef XMLCALL
@@ -1159,11 +1162,22 @@ CP_C_API cp_plugin_info_t * cp_load_plugin_descriptor(cp_context_t *context, con
 		file[path_len] = CP_FNAMESEP_CHAR;
 		strcpy(file + path_len + 1, CP_PLUGIN_DESCRIPTOR);
 
+#if defined(_WIN32)
+	wchar_t* fileW = to_utf16(file, 0);
+	fh = _wfopen(fileW, L"rb");
+	free(fileW);
+	if (!fh)
+	{
+		status = CP_ERR_IO;
+		break;
+	}
+#else
 		// Open the file 
 		if ((fh = fopen(file, "rb")) == NULL) {
 			status = CP_ERR_IO;
 			break;
 		}
+#endif
 
 		// Initialize descriptor parsing
 		status = init_descriptor_parsing(context, &plcontext, &parser, file);

--- a/lib/cpluff/libcpluff/win32/cpluffdef.h
+++ b/lib/cpluff/libcpluff/win32/cpluffdef.h
@@ -136,7 +136,11 @@
 
 #if defined(_WIN32)
 #  define CP_EXPORT __declspec(dllexport)
+#if defined(_WINDLL)
 #  define CP_IMPORT extern __declspec(dllimport)
+#else
+#  define CP_IMPORT
+#endif
 #  define CP_HIDDEN
 #elif defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
 #  define CP_EXPORT

--- a/lib/cpluff/libcpluff/win32/dirent.h
+++ b/lib/cpluff/libcpluff/win32/dirent.h
@@ -19,10 +19,6 @@ extern "C"
 
 typedef struct DIR DIR;
 
-#ifndef WIN32
-static int errno;
-#endif
-
 struct dirent
 {
     char *d_name;

--- a/lib/cpluff/libcpluff/win32/win32_utils.c
+++ b/lib/cpluff/libcpluff/win32/win32_utils.c
@@ -1,0 +1,73 @@
+/*-------------------------------------------------------------------------
+ * C-Pluff, a plug-in framework for C
+ * Copyright 2016 Team Kodi
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *-----------------------------------------------------------------------*/
+
+#include <stdlib.h>
+
+#include "win32_utils.h"
+
+wchar_t* to_utf16(const char* str, size_t length)
+{
+  if (length == 0)
+    length = strlen(str);
+  int result = MultiByteToWideChar(CP_UTF8, 0, str, length, NULL, 0);
+  if (result == 0)
+  {
+    return NULL;
+  }
+
+  int newLen = result + 1;
+  wchar_t* dirPath = malloc(newLen * 2);
+  result = MultiByteToWideChar(CP_UTF8, 0, str, length, dirPath, newLen);
+
+  if (result == 0)
+  {
+    free(dirPath);
+    return NULL;
+  }
+
+  dirPath[newLen - 1] = L'\0';
+  return dirPath;
+}
+
+char* to_utf8(const wchar_t* str, size_t length)
+{
+  if (length == 0)
+    length = wcslen(str);
+
+  int result = WideCharToMultiByte(CP_UTF8, 0, str, length, NULL, 0, NULL, NULL);
+  if (result == 0)
+    return NULL;
+
+  int newLen = result + 1;
+  char *newStr = malloc(newLen);
+  result = WideCharToMultiByte(CP_UTF8, 0, str, length, newStr, result, NULL, NULL);
+  if (result == 0)
+  {
+    free(newStr);
+    return NULL;
+  }
+
+  newStr[newLen - 1] = '\0';
+
+  return newStr;
+}

--- a/lib/cpluff/libcpluff/win32/win32_utils.h
+++ b/lib/cpluff/libcpluff/win32/win32_utils.h
@@ -1,0 +1,30 @@
+/*-------------------------------------------------------------------------
+ * C-Pluff, a plug-in framework for C
+ * Copyright 2016 Team Kodi
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *-----------------------------------------------------------------------*/
+
+#if !defined(WIN32_LEAN_AND_MEAN)
+  #define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+wchar_t* to_utf16(const char* str, size_t length);
+char* to_utf8(const wchar_t* str, size_t length);

--- a/project/BuildDependencies/scripts/0_package.target-win10-arm.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-arm.list
@@ -6,7 +6,6 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cpluff-0.1.3-win10-ARM-v140.7z
 crossguid-fef89a4-win10-ARM-v140.7z
 curl-7.52.1-win10-ARM-v140.7z
 expat-2.2.0-win10-ARM-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-win32.list
@@ -6,7 +6,6 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cpluff-0.1.3-win10-Win32-v140.7z
 crossguid-fef89a4-win10-Win32-v140.7z
 curl-7.52.1-win10-Win32-v140.7z
 expat-2.2.0-win10-Win32-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win10-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-win10-x64.list
@@ -6,7 +6,6 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cpluff-0.1.3-win10-x64-v140.7z
 crossguid-fef89a4-win10-x64-v140.7z
 curl-7.52.1-win10-x64-v140.7z
 expat-2.2.0-win10-x64-v140.7z

--- a/project/BuildDependencies/scripts/0_package.target-win32.list
+++ b/project/BuildDependencies/scripts/0_package.target-win32.list
@@ -6,7 +6,6 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cpluff-ed7874fc-win32-vc140.7z
 crossguid-8f399e-win32-vc140-v3.7z
 curl-7.48-win32-vc140.7z
 dnssd-765.50.9-win32-vc140-v2.7z

--- a/project/BuildDependencies/scripts/0_package.target-x64.list
+++ b/project/BuildDependencies/scripts/0_package.target-x64.list
@@ -6,7 +6,6 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
-cpluff-0.1.3-x64-vc140.7z
 crossguid-fef89a4-x64-vc140.7z
 curl-7.52.1-x64-vc140.7z
 dnssd-765.50.9-x64-vc140-v2.7z


### PR DESCRIPTION
## Description
build cpluff from source on windows (like it is done for all other platforms).

## Motivation and Context
cpluff version was updated and I don't want to build new precompiled libs, but still use the new version

## How Has This Been Tested?
runtime tested for Windows (Desktop & UWP)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
