### PR TITLE
[xbmc] fix credentials in an URL in case of VFS add-on.

### DIFF
--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -105,6 +105,16 @@ void CPasswordManager::SaveAuthenticatedURL(const CURL &url, bool saveToProfile)
   m_temporaryCache[GetServerLookup(path)] = authenticatedPath;
 }
 
+bool CPasswordManager::IsURLSupported(const CURL &url)
+{
+  if ( url.IsProtocol("smb")
+    || url.IsProtocol("nfs")
+    || url.IsProtocol("sftp"))
+    return true;
+
+  return false;
+}
+
 void CPasswordManager::Clear()
 {
   m_temporaryCache.clear();
@@ -174,11 +184,14 @@ void CPasswordManager::Save() const
 
 std::string CPasswordManager::GetLookupPath(const CURL &url) const
 {
-  return "smb://" + url.GetHostName() + "/" + url.GetShareName();
+  if (url.IsProtocol("sftp"))
+    return GetServerLookup(url.Get());
+
+  return url.GetProtocol() + "://" + url.GetHostName() + "/" + url.GetShareName();
 }
 
 std::string CPasswordManager::GetServerLookup(const std::string &path) const
 {
   CURL url(path);
-  return "smb://" + url.GetHostName() + "/";
+  return url.GetProtocol() + "://" + url.GetHostName() + "/";
 }

--- a/xbmc/PasswordManager.h
+++ b/xbmc/PasswordManager.h
@@ -80,9 +80,9 @@ public:
   void SaveAuthenticatedURL(const CURL &url, bool saveToProfile = true);
 
   /*!
-   \brief Save an authenticated URL.
+   \brief Is an URL is supported (by the manager)
 
-   This routine chacks that an URL is supported by the manager
+   This routine checks that an URL is supported by the manager
 
    \param url the URL to check.
    \return true if the URL is supported

--- a/xbmc/PasswordManager.h
+++ b/xbmc/PasswordManager.h
@@ -80,6 +80,17 @@ public:
   void SaveAuthenticatedURL(const CURL &url, bool saveToProfile = true);
 
   /*!
+   \brief Save an authenticated URL.
+
+   This routine chacks that an URL is supported by the manager
+
+   \param url the URL to check.
+   \return true if the URL is supported
+   \sa CURL, IsURLSupported
+   */
+  bool IsURLSupported(const CURL &url);
+
+  /*!
    \brief Clear any previously cached passwords
    */
   void Clear();

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -601,11 +601,11 @@ std::vector<std::string> CGUIDialogMediaSource::GetPaths() const
   for (int i = 0; i < m_paths->Size(); i++)
   {
     if (!m_paths->Get(i)->GetPath().empty())
-    { // strip off the user and password for smb paths (anything that the password manager can auth)
+    { // strip off the user and password for supported paths (anything that the password manager can auth)
       // and add the user/pass to the password manager - note, we haven't confirmed that it works
-      // at this point, but if it doesn't, the user will get prompted anyway in SMBDirectory.
+      // at this point, but if it doesn't, the user will get prompted anyway in implementation.
       CURL url(m_paths->Get(i)->GetPath());
-      if (url.IsProtocol("smb"))
+      if (CPasswordManager::GetInstance().IsURLSupported(url) && !url.GetUserName().empty())
       {
         CPasswordManager::GetInstance().SaveAuthenticatedURL(url);
         url.SetPassword("");

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -27,6 +27,7 @@
 #include "DirectoryCache.h"
 #include "Directory.h"
 #include "FileCache.h"
+#include "PasswordManager.h"
 #include "system.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -314,9 +315,13 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     if (!m_pFile)
       return false;
 
+    CURL authUrl(url);
+    if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+      CPasswordManager::GetInstance().AuthenticateURL(authUrl);
+
     try
     {
-      if (!m_pFile->Open(url))
+      if (!m_pFile->Open(authUrl))
       {
         SAFE_DELETE(m_pFile);
         return false;
@@ -336,7 +341,11 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
         
         if (pNewUrl.get())
         {
-          if (!m_pFile->Open(*pNewUrl))
+          CURL newAuthUrl(*pNewUrl);
+          if (CPasswordManager::GetInstance().IsURLSupported(newAuthUrl))
+            CPasswordManager::GetInstance().AuthenticateURL(newAuthUrl);
+
+          if (!m_pFile->Open(newAuthUrl))
           {
             SAFE_DELETE(m_pFile);
             return false;
@@ -344,7 +353,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
         }
         else
         {        
-          if (!m_pFile->Open(url))
+          if (!m_pFile->Open(authUrl))
           {
             SAFE_DELETE(m_pFile);
             return false;
@@ -393,10 +402,13 @@ bool CFile::OpenForWrite(const CURL& file, bool bOverWrite)
   try
   {
     CURL url = URIUtils::SubstitutePath(file);
+    CURL authUrl = url;
+    if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+      CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
     m_pFile = CFileFactory::CreateLoader(url);
 
-    if (m_pFile && m_pFile->OpenForWrite(url, bOverWrite))
+    if (m_pFile && m_pFile->OpenForWrite(authUrl, bOverWrite))
     {
       // add this file to our directory cache (if it's stored)
       g_directoryCache.AddFile(url.Get());
@@ -422,6 +434,9 @@ bool CFile::Exists(const std::string& strFileName, bool bUseCache /* = true */)
 bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
 {
   CURL url(URIUtils::SubstitutePath(file));
+  CURL authUrl = url;
+  if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+    CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
   try
   {
@@ -438,7 +453,7 @@ bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
     if (!pFile.get())
       return false;
 
-    return pFile->Exists(url);
+    return pFile->Exists(authUrl);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (CRedirectException *pRedirectEx)
@@ -464,10 +479,16 @@ bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
             if (bPathInCache)
               return false;
           }
-          return pImp->Exists(*pNewUrl);
+          CURL newAuthUrl = *pNewUrl;
+          if (CPasswordManager::GetInstance().IsURLSupported(newAuthUrl))
+            CPasswordManager::GetInstance().AuthenticateURL(newAuthUrl);
+
+          return pImp->Exists(newAuthUrl);
         }
         else
-          return pImp->Exists(url);
+        {
+          return pImp->Exists(authUrl);
+        }
       }
     }
   }
@@ -506,13 +527,16 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
     return -1;
 
   CURL url(URIUtils::SubstitutePath(file));
+  CURL authUrl = url;
+  if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+    CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
   try
   {
     std::unique_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
       return -1;
-    return pFile->Stat(url, buffer);
+    return pFile->Stat(authUrl, buffer);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (CRedirectException *pRedirectEx)
@@ -528,14 +552,21 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
         
       if (pNewUrl.get())
       {
-        if (pImp.get() && !pImp->Stat(*pNewUrl, buffer))
+        if (pImp.get())
         {
-          return 0;
+          CURL newAuthUrl = *pNewUrl;
+          if (CPasswordManager::GetInstance().IsURLSupported(newAuthUrl))
+            CPasswordManager::GetInstance().AuthenticateURL(newAuthUrl);
+
+          if (!pImp->Stat(newAuthUrl, buffer))
+          {
+            return 0;
+          }
         }
       }
       else     
       {
-        if (pImp.get() && !pImp->Stat(url, buffer))
+        if (pImp.get() && !pImp->Stat(authUrl, buffer))
         {
           return 0;
         }
@@ -846,12 +877,15 @@ bool CFile::Delete(const CURL& file)
   try
   {
     CURL url(URIUtils::SubstitutePath(file));
+    CURL authUrl = url;
+    if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+      CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
     std::unique_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
       return false;
 
-    if(pFile->Delete(url))
+    if(pFile->Delete(authUrl))
     {
       g_directoryCache.ClearFile(url.Get());
       return true;
@@ -881,11 +915,18 @@ bool CFile::Rename(const CURL& file, const CURL& newFile)
     CURL url(URIUtils::SubstitutePath(file));
     CURL urlnew(URIUtils::SubstitutePath(newFile));
 
+    CURL authUrl = url;
+    if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+      CPasswordManager::GetInstance().AuthenticateURL(authUrl);
+    CURL authUrlNew = urlnew;
+    if (CPasswordManager::GetInstance().IsURLSupported(authUrlNew))
+      CPasswordManager::GetInstance().AuthenticateURL(authUrlNew);
+
     std::unique_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
       return false;
 
-    if(pFile->Rename(url, urlnew))
+    if(pFile->Rename(authUrl, authUrlNew))
     {
       g_directoryCache.ClearFile(url.Get());
       g_directoryCache.AddFile(urlnew.Get());
@@ -912,12 +953,15 @@ bool CFile::SetHidden(const CURL& file, bool hidden)
   try
   {
     CURL url(URIUtils::SubstitutePath(file));
+    CURL authUrl = url;
+    if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+      CPasswordManager::GetInstance().AuthenticateURL(authUrl);
 
     std::unique_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile.get())
       return false;
 
-    return pFile->SetHidden(url, hidden);
+    return pFile->SetHidden(authUrl, hidden);
   }
   catch(...)
   {
@@ -1190,7 +1234,12 @@ bool CFileStream::Open(const CURL& filename)
 
   CURL url(URIUtils::SubstitutePath(filename));
   m_file = CFileFactory::CreateLoader(url);
-  if(m_file && m_file->Open(url))
+
+  CURL authUrl = url;
+  if (CPasswordManager::GetInstance().IsURLSupported(authUrl))
+    CPasswordManager::GetInstance().AuthenticateURL(authUrl);
+
+  if(m_file && m_file->Open(authUrl))
   {
     m_buffer.Attach(m_file);
     return true;


### PR DESCRIPTION
see title

## Description
currently we hide credentials for smb urls and store them into PasswordManager. Internal smb implementation knows about this and properly gets credentials from the manager and operates with full url but a VFS add-on can't do this. To fix this I've move this logic to lower level to CDirectory and CFile. This allows smb VFS add-on work properly. Also PasswordManager supports nfs/sftp now.
