### PR TITLE
EGLUtils: Allow windowing system to set EGL context attributes

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -151,19 +151,12 @@ bool CEGLContextUtils::CreateDisplay(EGLDisplay display,
   return true;
 }
 
-bool CEGLContextUtils::CreateContext()
+bool CEGLContextUtils::CreateContext(const EGLint* contextAttribs)
 {
-  int client_version = 2;
-
-  const EGLint context_attribs[] =
-  {
-    EGL_CONTEXT_CLIENT_VERSION, client_version, EGL_NONE
-  };
-
   if (m_eglContext == EGL_NO_CONTEXT)
   {
     m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig,
-                                    EGL_NO_CONTEXT, context_attribs);
+                                    EGL_NO_CONTEXT, contextAttribs);
   }
 
   if (m_eglContext == EGL_NO_CONTEXT)

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -131,7 +131,7 @@ public:
                      EGLint rendering_api);
 
   bool CreateSurface(EGLNativeWindowType surface);
-  bool CreateContext();
+  bool CreateContext(const EGLint* contextAttribs);
   bool BindContext();
   bool SurfaceAttrib();
   void Destroy();

--- a/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogicGLESContext.cpp
@@ -67,7 +67,12 @@ bool CWinSystemAmlogicGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_pGLContext.CreateContext())
+  const EGLint contextAttribs[] =
+  {
+    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
+  };
+
+  if (!m_pGLContext.CreateContext(contextAttribs))
   {
     return false;
   }

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -62,7 +62,12 @@ bool CWinSystemAndroidGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_pGLContext.CreateContext())
+  const EGLint contextAttribs[] =
+  {
+    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
+  };
+
+  if (!m_pGLContext.CreateContext(contextAttribs))
   {
     return false;
   }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -104,7 +104,12 @@ bool CWinSystemGbmGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_pGLContext.CreateContext())
+  const EGLint contextAttribs[] =
+  {
+    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
+  };
+
+  if (!m_pGLContext.CreateContext(contextAttribs))
   {
     return false;
   }

--- a/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpiGLESContext.cpp
@@ -89,7 +89,12 @@ bool CWinSystemRpiGLESContext::CreateNewWindow(const std::string& name,
     return false;
   }
 
-  if (!m_pGLContext.CreateContext())
+  const EGLint contextAttribs[] =
+  {
+    EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE
+  };
+
+  if (!m_pGLContext.CreateContext(contextAttribs))
   {
     return false;
   }


### PR DESCRIPTION
This allows us to take the next step of allowing a 2.0 or 3.0 GLES context. This is also needed to get wayland to use the EGLContextUtils class.