### PR TITLE
Make key "ó" visible.

### DIFF
--- a/system/keyboardlayouts/hungarian.xml
+++ b/system/keyboardlayouts/hungarian.xml
@@ -6,16 +6,16 @@ Default font lacks support for all characters
 <keyboardlayouts>
   <layout language="Hungarian" layout="QWERTZ">
     <keyboard>
-      <row>0123456789öüó</row>
+      <row>0123456789öü</row>
       <row>qwertzuiopőú</row>
       <row>asdfghjkléáű</row>
-      <row>íyxcvbnm,.-</row>
+      <row>íyxcvbnm,.-ó</row>
     </keyboard>
     <keyboard modifiers="shift">
-      <row>0123456789ÖÜÓ</row>
+      <row>0123456789ÖÜ</row>
       <row>QWERTZUIOPŐÚ</row>
       <row>ASDFGHJKLÉÁŰ</row>
-      <row>ÍYXCVBNM,.-</row>
+      <row>ÍYXCVBNM,.-Ó</row>
     </keyboard>
     <keyboard modifiers="symbol,shift+symbol">
       <row>§'"+!/=()~</row>


### PR DESCRIPTION
fix #17260

Fixing Hungarian keyboard layout.

## Description
Reorganized layout to make key "Ó" visible. It was the 13th in the top row but virtual keyboard shows only 12 keys in a row. This extra key has been moved to bottom row.


## Motivation and Context
One accented character was missing form Kodi Hungarian QWERTZ keyboard layout.

It is "Ó"

The complete set of Hungarian accented characters is: á,é,í,ó,ö,ő,ú,ű. The "ó" is missing from the keyboard, the others are OK.

I opened a ticket more than one year ago, however nothing happend. Now, I try to fix this by myself.
https://trac.kodi.tv/ticket/17260

## How Has This Been Tested?
I modified the hungarian.xml file and tested with Confluence and Estuary skins. It works fine.
Actually, this is a workaround only because the correct keyboard layout would need 13 keys in a row. But it is still much better than nothing.

## Screenshots (if appropriate):
See fixed layout attached.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
![hungarian](https://user-images.githubusercontent.com/5688778/37877558-4aa47510-305d-11e8-8908-513954667eec.jpg)
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
