### PR TITLE
Expose OnAVChange and OnAVStarted to python api

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3478,12 +3478,16 @@ void CApplication::OnPlayBackSeekChapter(int iChapter)
 
 void CApplication::OnAVStarted(const CFileItem &file)
 {
+  CLog::LogF(LOGDEBUG, "CApplication::OnAVStarted");
+
   CGUIMessage msg(GUI_MSG_PLAYBACK_AVSTARTED, 0, 0);
   g_windowManager.SendThreadMessage(msg);
 }
 
 void CApplication::OnAVChange()
 {
+  CLog::LogF(LOGDEBUG, "CApplication::OnAVChange");
+
   CStereoscopicsManager::GetInstance().OnStreamChange();
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_AVCHANGE, 0, 0);
@@ -4079,9 +4083,19 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
   case GUI_MSG_PLAYBACK_AVSTARTED:
     m_playerEvent.Set();
+#ifdef HAS_PYTHON
+    // informs python script currently running playback has started
+    // (does nothing if python is not loaded)
+    g_pythonParser.OnAVStarted(*m_itemCurrentFile);
+#endif
     return true;
 
   case GUI_MSG_PLAYBACK_AVCHANGE:
+#ifdef HAS_PYTHON
+    // informs python script currently running playback has started
+    // (does nothing if python is not loaded)
+    g_pythonParser.OnAVChange();
+#endif
       return true;
 
   case GUI_MSG_PLAYBACK_ERROR:

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -188,8 +188,26 @@ namespace XBMCAddon
 
     void Player::OnPlayBackStarted(const CFileItem &file)
     { 
+      // We only have fileItem due to us having to 
+      // implement the interface, we can't send it to python
+      // as we're not able to serialize it.
       XBMC_TRACE;
-      invokeCallback(new CallbackFunction<Player>(this,&Player::onPlayBackStarted));
+      invokeCallback(new CallbackFunction<Player>(this, &Player::onPlayBackStarted));
+    }
+
+    void Player::OnAVStarted(const CFileItem &file)
+    {
+      // We only have fileItem due to us having to 
+      // implement the interface, we can't send it to python
+      // as we're not able to serialize it.
+      XBMC_TRACE;
+      invokeCallback(new CallbackFunction<Player>(this, &Player::onAVStarted));
+    }
+
+    void Player::OnAVChange()
+    {
+      XBMC_TRACE;
+      invokeCallback(new CallbackFunction<Player>(this, &Player::onAVChange));
     }
 
     void Player::OnPlayBackEnded()
@@ -247,6 +265,16 @@ namespace XBMCAddon
     }
 
     void Player::onPlayBackStarted()
+    {
+      XBMC_TRACE;
+    }
+
+    void Player::onAVStarted()
+    {
+      XBMC_TRACE;
+    }
+
+    void Player::onAVChange()
     {
       XBMC_TRACE;
     }

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -218,11 +218,41 @@ namespace XBMCAddon
       ///-----------------------------------------------------------------------
       /// onPlayBackStarted method.
       ///
-      /// Will be called when Kodi starts playing a file.
+      /// Will be called when Kodi starts playing a file. Video or audio might not be available at this point.
       ///
       onPlayBackStarted();
 #else
       virtual void onPlayBackStarted();
+#endif
+
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_PlayerCB
+      /// @brief \python_func{ onAVStarted() }
+      ///-----------------------------------------------------------------------
+      /// onAVStarted method.
+      ///
+      /// Will be called when Kodi has a video- or audiostream.
+      ///
+      onAVStarted();
+#else
+      virtual void onAVStarted();
+#endif
+
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_PlayerCB
+      /// @brief \python_func{ onAVChange() }
+      ///-----------------------------------------------------------------------
+      /// onAVChange method.
+      ///
+      /// Will be called when Kodi has a video- or audiostream. Also happens when the stream changes.
+      ///
+      onAVChange();
+#else
+      virtual void onAVChange();
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -758,6 +788,8 @@ namespace XBMCAddon
 
 #if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
       SWIGHIDDENVIRTUAL void OnPlayBackStarted(const CFileItem &file) override;
+      SWIGHIDDENVIRTUAL void OnAVStarted(const CFileItem &file) override;
+      SWIGHIDDENVIRTUAL void OnAVChange() override;
       SWIGHIDDENVIRTUAL void OnPlayBackEnded() override;
       SWIGHIDDENVIRTUAL void OnPlayBackStopped() override;
       SWIGHIDDENVIRTUAL void OnPlayBackError() override;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -131,6 +131,30 @@ void XBPython::OnPlayBackStarted(const CFileItem &file)
   }
 }
 
+// message all registered callbacks that we changed stream
+void XBPython::OnAVStarted(const CFileItem &file)
+{
+  XBMC_TRACE;
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
+  for (PlayerCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
+  {
+    if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, (*it)))
+      ((IPlayerCallback*)(*it))->OnAVStarted(file);
+  }
+}
+
+// message all registered callbacks that we changed stream
+void XBPython::OnAVChange()
+{
+  XBMC_TRACE;
+  LOCK_AND_COPY(std::vector<void*>, tmp, m_vecPlayerCallbackList);
+  for (PlayerCallbackList::iterator it = tmp.begin(); (it != tmp.end()); ++it)
+  {
+    if (CHECK_FOR_ENTRY(m_vecPlayerCallbackList, (*it)))
+      ((IPlayerCallback*)(*it))->OnAVChange();
+  }
+}
+
 // message all registered callbacks that we paused playing
 void XBPython::OnPlayBackPaused()
 {

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -70,6 +70,8 @@ public:
   ~XBPython() override;
   void OnPlayBackEnded() override;
   void OnPlayBackStarted(const CFileItem &file) override;
+  void OnAVStarted(const CFileItem &file) override;
+  void OnAVChange() override;
   void OnPlayBackPaused() override;
   void OnPlayBackResumed() override;
   void OnPlayBackStopped() override;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Exposes the new `OnAVChange` via out python player interface.
I find the naming interesting, as I would have expected it to be called OnAVChange**d**, is that on purpose or an error?

The other problem is, that it seems to be called multiple times on video start. Tested it with two movies so far and it's been called for times on each start.

Unlike `onPlaybackStarted`, this does not include data about the file being used. While it's not a problem for my usecase it might be a problem for the ambilight guys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
For context https://trac.kodi.tv/ticket/17632#comment:2
Problem is that `onPlaybackStarted` triggers so early that the player might not be available. So everybody that tries to do stuff with the player then will fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested it with my trakt addon-

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
