### PR TITLE
VAAPI: add vp9 profile 2 support

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -589,9 +589,10 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
     }
     case AV_CODEC_ID_VP9:
     {
-      // VAAPI currently only supports Profile 0
       if (avctx->profile == FF_PROFILE_VP9_0)
         profile = VAProfileVP9Profile0;
+      else if (avctx->profile == FF_PROFILE_VP9_2)
+        profile = VAProfileVP9Profile2;
       else
         profile = VAProfileNone;
       if (!m_vaapiConfig.context->SupportsProfile(profile))


### PR DESCRIPTION
tested on GBM, needed for upcoming intel hardware

test file details
```
17:48:05.991 T:140409091110656    INFO: ffmpeg[7FB389FFB700]:     Stream #0:0(eng): Video: vp9 (Profile 2), yuv420p10le(tv, bt2020nc/bt2020/smpte2084), 3840x2160, SAR 1:1 DAR 16:9, 59.94 fps, 59.94 tbr, 1k tbn, 1k tbc (default)
```
relevant vainfo
```
VAProfileVP9Profile2            :	VAEntrypointVLD
```
