### PR TITLE
AESinkALSA: only use S24NE4MSB with S32 alsa format

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -747,8 +747,10 @@ bool CAESinkALSA::InitializeHW(const ALSAConfig &inconfig, ALSAConfig &outconfig
       if (bits != fmtBits)
       {
         /* if we opened in 32bit and only have 24bits, signal it accordingly */
-        if (fmtBits == 32 && bits == 24)
+        if (fmt == SND_PCM_FORMAT_S32 && bits == 24)
           i = AE_FMT_S24NE4MSB;
+        else if (fmt == SND_PCM_FORMAT_S24 && bits == 24)
+          i = AE_FMT_S24NE4;
         else
           continue;
       }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -751,7 +751,9 @@ bool CAESinkALSA::InitializeHW(const ALSAConfig &inconfig, ALSAConfig &outconfig
 
       int fmtBits = CAEUtil::DataFormatToBits(i);
       int bits    = snd_pcm_hw_params_get_sbits(hw_params);
-      if (bits != fmtBits)
+
+      // skip bits check when alsa reports invalid sbits value
+      if (bits > 0 && bits != fmtBits)
       {
         /* if we opened in 32bit and only have 24bits, signal it accordingly */
         if (fmt == SND_PCM_FORMAT_S32 && bits == 24)


### PR DESCRIPTION
## Description
This PR fixes incorrect signaling of `AE_FMT_S24NE4MSB` format together with `SND_PCM_FORMAT_S24` alsa format. (fixes white noise on Rockchip and HDMI alsa device)

## Motivation and Context
Kodi incorrectly signals the `AE_FMT_S24NE4MSB` format using an alsa device limited to 24 significant bits when `SND_PCM_FORMAT_S24` is probed before `SND_PCM_FORMAT_S32`.

Fix this by only signaling `AE_FMT_S24NE4MSB` when probing `SND_PCM_FORMAT_S32`.

This issue can be observed on Rockchip platform when using the HDMI alsa device (hdmi-codec and dw-hdmi-i2s), current workaround have been to remove the signaling of 24 significant bits in kernel (https://github.com/Kwiboo/linux-rockchip/commit/1f19793a9437b295d7dfca822f511e487c47ef4a)

## How Has This Been Tested?
Before: AE_FMT_S24NE4MSB is wrongly used for S24
```
INFO: CAESinkALSA::Initialize - Opened device "hdmi:CARD=HDMI,DEV=0,AES0=0x04,AES1=0x82,AES2=0x00,AES3=0x00"
INFO: CAESinkALSA::InitializeHW - Your hardware does not support AE_FMT_FLOAT, trying other formats
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_FLOAT, fmt=FLOAT_LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE3, fmt=S24_3LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE4, fmt=S24_LE
INFO: CAESinkALSA::InitializeHW - AE_FMT_S24NE4 is valid, fmt=S24_LE fmtBits=32 bits=24
INFO: CAESinkALSA::InitializeHW - Using data format AE_FMT_S24NE4MSB
```

After: AE_FMT_S24NE4 is used for S24
```
INFO: CAESinkALSA::InitializeHW - Your hardware does not support AE_FMT_FLOAT, trying other formats
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_FLOAT, fmt=FLOAT_LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE3, fmt=S24_3LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE4, fmt=S24_LE
INFO: CAESinkALSA::InitializeHW - AE_FMT_S24NE4 is valid, fmt=S24_LE fmtBits=32 bits=24
INFO: CAESinkALSA::InitializeHW - Using data format AE_FMT_S24NE4
```

After: AE_FMT_S24NE4MSB is used for S32 and 24 significant bits (S24 support is removed in kernel driver)
```
INFO: CAESinkALSA::InitializeHW - Your hardware does not support AE_FMT_FLOAT, trying other formats
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_FLOAT, fmt=FLOAT_LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE3, fmt=S24_3LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE4, fmt=S24_LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S32NE, fmt=S32_LE
INFO: CAESinkALSA::InitializeHW - AE_FMT_S32NE is valid, fmt=S32_LE fmtBits=32 bits=24
INFO: CAESinkALSA::InitializeHW - Using data format AE_FMT_S24NE4MSB
```

After: AE_FMT_S32NE is used for S32 with 32 significant bits (S24 support is removed in kernel driver)
```
INFO: CAESinkALSA::InitializeHW - Your hardware does not support AE_FMT_FLOAT, trying other formats
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_FLOAT, fmt=FLOAT_LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE3, fmt=S24_3LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S24NE4, fmt=S24_LE
INFO: CAESinkALSA::InitializeHW - testing AE_FMT_S32NE, fmt=S32_LE
INFO: CAESinkALSA::InitializeHW - AE_FMT_S32NE is valid, fmt=S32_LE fmtBits=32 bits=32
INFO: CAESinkALSA::InitializeHW - Using data format AE_FMT_S32NE
```

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
