### PR TITLE
[Binary Addon] Generic interface provider callback

### DIFF
--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -28,6 +28,8 @@
 namespace ADDON
 {
 
+  typedef void* (*ADDON_GET_INTERFACE_FN)(const std::string &name, const std::string &version);
+
   class CAddonDll : public CAddon
   {
   public:
@@ -36,6 +38,8 @@ namespace ADDON
     ~CAddonDll() override;
 
     virtual ADDON_STATUS GetStatus();
+
+    static void RegisterInterface(ADDON_GET_INTERFACE_FN fn);
 
     // Implementation of IAddon via CAddon
     std::string LibPath() const override;
@@ -110,6 +114,8 @@ namespace ADDON
 
     bool UpdateSettingInActiveDialog(const char* id, const std::string& value);
 
+    static std::vector<ADDON_GET_INTERFACE_FN> s_registeredInterfaces;
+
     /// addon to kodi basic callbacks below
     //@{
 
@@ -137,6 +143,7 @@ namespace ADDON
     static bool set_setting_string(void* kodiBase, const char* id, const char* value);
     static void free_string(void* kodiBase, char* str);
     static void free_string_array(void* kodiBase, char** arr, int numElements);
+    static void* get_interface(void* kodiBase, const char* name, const char *version);
     //@}
   };
 

--- a/xbmc/addons/interfaces/CMakeLists.txt
+++ b/xbmc/addons/interfaces/CMakeLists.txt
@@ -10,4 +10,9 @@ set(HEADERS AddonInterfaces.h
             Filesystem.h
             Network.h)
 
+if(CORE_SYSTEM_NAME STREQUAL android)
+  list(APPEND SOURCES platform/android/System.cpp)
+  list(APPEND HEADERS platform/android/System.h)
+endif()
+
 core_add_library(addons_interfaces)

--- a/xbmc/addons/interfaces/platform/android/System.cpp
+++ b/xbmc/addons/interfaces/platform/android/System.cpp
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "System.h"
+#include "addons/binary-addons/AddonDll.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h"
+
+#include "platform/android/activity/XBMCApp.h"
+
+static AddonToKodiFuncTable_android_system function_table;
+
+namespace ADDON
+{
+
+void Interface_Android::Register()
+{
+  function_table.get_jni_env = get_jni_env;
+  function_table.get_sdk_version = get_sdk_version;
+  CAddonDll::RegisterInterface(Get);
+}
+
+void* Interface_Android::Get(const std::string &name, const std::string &version)
+{
+  if (name == INTERFACE_ANDROID_SYSTEM_NAME
+  && version >= INTERFACE_ANDROID_SYSTEM_VERSION_MIN
+  && version <= INTERFACE_ANDROID_SYSTEM_VERSION)
+    return &function_table;
+
+  return nullptr;
+};
+
+void* Interface_Android::get_jni_env()
+{
+  return xbmc_jnienv();
+}
+
+int Interface_Android::get_sdk_version()
+{
+  return CXBMCApp::get()->getActivity()->sdkVersion;
+}
+
+} //namespace ADDON

--- a/xbmc/addons/interfaces/platform/android/System.h
+++ b/xbmc/addons/interfaces/platform/android/System.h
@@ -1,0 +1,36 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+namespace ADDON
+{
+
+struct Interface_Android
+{
+  static void Register();
+  static void* Get(const std::string &name, const std::string &version);
+
+  static void* get_jni_env();
+  static int get_sdk_version();
+};
+
+} //namespace ADDON

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -176,6 +176,8 @@ typedef struct AddonToKodiFuncTable_Addon
   AddonToKodiFuncTable_kodi_filesystem* kodi_filesystem;
   AddonToKodiFuncTable_kodi_gui* kodi_gui;
   AddonToKodiFuncTable_kodi_network *kodi_network;
+
+  void* (*get_interface)(void* kodiBase, const char *name, const char *version);
 } AddonToKodiFuncTable_Addon;
 
 /*
@@ -601,6 +603,33 @@ inline std::string TranslateAddonStatus(ADDON_STATUS status)
 } /* namespace kodi */
 //----------------------------------------------------------------------------
 
+//==============================================================================
+namespace kodi {
+///
+/// \ingroup cpp_kodi
+/// @brief Returns a function table to a named interface
+///
+/// @return pointer to struct containing interface functions
+///
+///
+/// ------------------------------------------------------------------------
+///
+/// **Example:**
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/General.h>
+/// #include <kodi/platform/foo.h>
+/// ...
+/// FuncTable_foo *table = kodi::GetPlatformInfo(foo_name, foo_version);
+/// ...
+/// ~~~~~~~~~~~~~
+///
+inline void* GetInterface(const std::string &name, const std::string &version)
+{
+  AddonToKodiFuncTable_Addon* toKodi = ::kodi::addon::CAddonBase::m_interface->toKodi;
+
+  return toKodi->get_interface(toKodi->kodiBase, name.c_str(), version.c_str());
+}
+} /* namespace kodi */
 
 /*! addon creation macro
  * @todo cleanup this stupid big macro

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/CMakeLists.txt
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/CMakeLists.txt
@@ -19,6 +19,10 @@ set(HEADERS AddonBase.h
             xbmc_pvr_dll.h
             xbmc_pvr_types.h)
 
+if(CORE_SYSTEM_NAME STREQUAL android)
+  list(APPEND SOURCES platform/android/System.h)
+endif()
+
 if(NOT ENABLE_STATIC_LIBS)
   core_add_library(addons_kodi-addon-dev-kit_include_kodi)
 endif()

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h
@@ -1,0 +1,107 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../AddonBase.h"
+
+/*
+ * For interface between add-on and kodi.
+ *
+ * This structure defines the addresses of functions stored inside Kodi which
+ * are then available for the add-on to call
+ *
+ * All function pointers there are used by the C++ interface functions below.
+ * You find the set of them on xbmc/addons/interfaces/General.cpp
+ *
+ * Note: For add-on development itself this is not needed
+ */
+
+static const char* INTERFACE_ANDROID_SYSTEM_NAME = "ANDROID_SYSTEM";
+static const char* INTERFACE_ANDROID_SYSTEM_VERSION = "1.0.0";
+static const char* INTERFACE_ANDROID_SYSTEM_VERSION_MIN = "1.0.0";
+
+struct AddonToKodiFuncTable_android_system
+{
+  void* (*get_jni_env)();
+  int (*get_sdk_version)();
+};
+
+//==============================================================================
+///
+/// \defgroup cpp_kodi_platform  Interface - kodi::platform
+/// \ingroup cpp
+/// @brief **Android platform specific functions**
+///
+/// #include <kodi/platform/android/System.h>"
+///
+//------------------------------------------------------------------------------
+
+namespace kodi
+{
+namespace platform
+{
+  class CInterfaceAndroidSystem
+  {
+  public:
+    CInterfaceAndroidSystem()
+     : m_interface(static_cast<AddonToKodiFuncTable_android_system*>(GetInterface(INTERFACE_ANDROID_SYSTEM_NAME, INTERFACE_ANDROID_SYSTEM_VERSION)))
+     {};
+
+    //============================================================================
+    ///
+    /// \ingroup cpp_kodi_platform
+    /// @brief request an JNI env pointer for the calling thread.
+    /// JNI env has to be controlled by kodi because of the underlying
+    /// threading concep.
+    ///
+    /// @param[in]:
+    /// @return JNI env pointer for the calling thread
+    ///
+    inline void * GetJNIEnv()
+    {
+      if (m_interface)
+        return m_interface->get_jni_env();
+
+      return nullptr;
+    }
+    //----------------------------------------------------------------------------
+
+    //============================================================================
+    ///
+    /// \ingroup cpp_kodi_platform
+    /// @brief request the android sdk version to e.g. initialize JNIBase.
+    ///
+    /// @param[in]:
+    /// @return Android SDK version
+    ///
+    inline int GetSDKVersion()
+    {
+      if (m_interface)
+        return m_interface->get_sdk_version();
+
+      return 0;
+    }
+
+  private:
+    AddonToKodiFuncTable_android_system *m_interface;
+  };
+  //----------------------------------------------------------------------------
+} /* namespace platform */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -41,7 +41,7 @@
  * overview.
  */
 
-#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.12"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.13"
 #define ADDON_GLOBAL_VERSION_MAIN_MIN                 "1.0.12"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -109,13 +109,14 @@ public:
   virtual void onAudioFocusChange(int focusChange);
   virtual void doFrame(int64_t frameTimeNanos) override;
   virtual void onVisibleBehindCanceled() override;
-  
+
   // implementation of CJNIInputManagerInputDeviceListener
   void onInputDeviceAdded(int deviceId) override;
   void onInputDeviceChanged(int deviceId) override;
   void onInputDeviceRemoved(int deviceId) override;
 
   bool isValid() { return m_activity != NULL; }
+  const ANativeActivity *getActivity() const { return m_activity; }
 
   void onStart() override;
   void onResume() override;

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -41,6 +41,7 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h"
 #include "powermanagement/android/AndroidPowerSyscall.h"
+#include "addons/interfaces/platform/android/System.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglplatform.h>
@@ -86,7 +87,7 @@ bool CWinSystemAndroid::InitWindowSystem()
   RETRO::CRPProcessInfoAndroid::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
   CRendererMediaCodec::Register();
   CRendererMediaCodecSurface::Register();
-
+  ADDON::Interface_Android::Register();
   return CWinSystemBase::InitWindowSystem();
 }
 


### PR DESCRIPTION
## Description
Binary addons may need platform specific information to work as expected.
This PR adds a generic Interface provider to the Kodi binary addon system and as an example platform specific interface to some android system propertiesan android system info.

The new interface callback is implemented in kodi::Addon base class, is named GetInterface() and is designated to provide a pointer to a function table.

Min Addon Basel API version was not modified because the change does not affect existing functionality.
Therefore old binary addons should still work after this change 

## Motivation and Context
Get JNI MediaDrm working in binary addon (Android), because NDK is not working as expected / some functionality is not existant in NDK. 

## How Has This Been Tested?
Android + DRM encrypted sample streams

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
