### PR TITLE
[Android] add XBMCMediaDrmOnEventListener.java

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -81,6 +81,7 @@ set(package_files strings.xml
                   src/interfaces/XBMCNsdManagerResolveListener.java
                   src/interfaces/XBMCNsdManagerRegistrationListener.java
                   src/interfaces/XBMCNsdManagerDiscoveryListener.java
+                  src/interfaces/XBMCMediaDrmOnEventListener.java
                   src/model/TVEpisode.java
                   src/model/Movie.java
                   src/model/TVShow.java

--- a/tools/android/packaging/xbmc/src/interfaces/XBMCMediaDrmOnEventListener.java.in
+++ b/tools/android/packaging/xbmc/src/interfaces/XBMCMediaDrmOnEventListener.java.in
@@ -1,0 +1,15 @@
+package @APP_PACKAGE@.interfaces;
+
+import android.media.MediaDrm;
+import android.media.MediaDrm.OnEventListener;
+
+public class XBMCMediaDrmOnEventListener implements OnEventListener
+{
+  native void _onEvent(MediaDrm md, byte[] sessionId, int event, int extra, byte[] data);
+
+  @Override
+  public void onEvent(MediaDrm md, byte[] sessionId, int event, int extra, byte[] data)
+  {
+    _onEvent(md, sessionId, event, extra, data);
+  }
+}


### PR DESCRIPTION
## Description
Java implementation of MediaDrmEventListener (for JNI usage)

## Motivation and Context
MediaDRM will be switched from NDK -> JNI because of issues in the NDK.
The Java MediaDRM requires an Event Listener class which in turn notifies the C++ application via JNI that an event ovccurred

Because packaging / compiling / dexing of java components is part of the kodi packaging process, the class must be added to kodi.

## How Has This Been Tested?
Android DRM encrypted sample streams

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
