### PR TITLE
[windows] protect device context with mutex.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -1118,17 +1118,6 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, VideoPicture* picture)
   picture->videoBuffer = m_videoBuffer;
   m_videoBuffer = nullptr;
 
-  int queued, discard, free;
-  m_processInfo.GetRenderBuffers(queued, discard, free);
-  if (free > 1)
-  {
-    DX::Windowing().RequestDecodingTime();
-  }
-  else
-  {
-    DX::Windowing().ReleaseDecodingTime();
-  }
-
   return true;
 }
 
@@ -1242,6 +1231,7 @@ bool CDecoder::OpenDecoder()
 
   m_context->decoder = m_decoder.Get();
   m_context->video_context = m_vcontext.Get();
+  m_context->context_mutex = DX::Windowing().GetContexMutex();
 
   return true;
 }

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -75,13 +75,18 @@ DX::DeviceResources::DeviceResources()
   , m_deviceNotify(nullptr)
   , m_stereoEnabled(false)
   , m_bDeviceCreated(false)
+  , m_ctx_mutex(INVALID_HANDLE_VALUE)
 {
+  m_ctx_mutex = CreateMutexExW(nullptr, nullptr, 0, SYNCHRONIZE);
 }
 
 DX::DeviceResources::~DeviceResources()
 {
   if (m_bDeviceCreated)
     Release();
+  if (m_ctx_mutex != INVALID_HANDLE_VALUE)
+    CloseHandle(m_ctx_mutex);
+  m_ctx_mutex = INVALID_HANDLE_VALUE;
 }
 
 void DX::DeviceResources::Release()
@@ -843,6 +848,9 @@ void DX::DeviceResources::Present()
   FinishCommandList();
   m_d3dContext->Flush();
 
+  if (m_ctx_mutex != INVALID_HANDLE_VALUE)
+    WaitForSingleObjectEx(m_ctx_mutex, INFINITE, FALSE);
+
   // The first argument instructs DXGI to block until VSync, putting the application
   // to sleep until the next VSync. This ensures we don't waste any cycles rendering
   // frames that will never be displayed to the screen.
@@ -863,6 +871,9 @@ void DX::DeviceResources::Present()
       CreateWindowSizeDependentResources();
     }
   }
+
+  if (m_ctx_mutex != INVALID_HANDLE_VALUE)
+    ReleaseMutex(m_ctx_mutex);
 
   if (m_d3dContext == m_deferrContext)
   {

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -134,6 +134,7 @@ namespace DX
     void SetWindow(Windows::UI::Core::CoreWindow^ window);
     void SetWindowPos(Windows::Foundation::Rect rect);
 #endif // TARGET_WINDOWS_STORE
+    HANDLE GetContexMutex() const { return m_ctx_mutex; }
 
   private:
     class CBackBuffer : public CD3DTexture
@@ -190,5 +191,6 @@ namespace DX
     std::vector<ID3DResource*> m_resources;
     bool m_stereoEnabled;
     bool m_bDeviceCreated;
+    HANDLE m_ctx_mutex;
   };
 }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -285,31 +285,7 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
     CD3DHelper::PSClearShaderResources(m_pContext);
   }
 
-  // time for decoder that may require the context
-  {
-    CSingleLock lock(m_decoderSection);
-    XbmcThreads::EndTime timer;
-    timer.Set(5);
-    while (!m_decodingTimer.IsTimePast() && !timer.IsTimePast())
-    {
-      m_decodingEvent.wait(lock, 1);
-    }
-  }
-
   PresentRenderImpl(rendered);
-}
-
-void CRenderSystemDX::RequestDecodingTime()
-{
-  CSingleLock lock(m_decoderSection);
-  m_decodingTimer.Set(3);
-}
-
-void CRenderSystemDX::ReleaseDecodingTime()
-{
-  CSingleLock lock(m_decoderSection);
-  m_decodingTimer.SetExpired();
-  m_decodingEvent.notify();
 }
 
 bool CRenderSystemDX::BeginRender()
@@ -678,6 +654,14 @@ void CRenderSystemDX::SetAlphaBlendEnable(bool enable)
 
   m_deviceResources->GetD3DContext()->OMSetBlendState(enable ? m_BlendEnableState.Get() : m_BlendDisableState.Get(), nullptr, 0xFFFFFFFF);
   m_BlendEnabled = enable;
+}
+
+HANDLE CRenderSystemDX::GetContexMutex() const
+{
+  if (m_deviceResources)
+    return m_deviceResources->GetContexMutex();
+
+  return INVALID_HANDLE_VALUE;
 }
 
 CD3DTexture* CRenderSystemDX::GetBackBuffer()

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -85,9 +85,8 @@ public:
   CD3DTexture* GetBackBuffer();
 
   void FlushGPU() const;
-  void RequestDecodingTime();
-  void ReleaseDecodingTime();
   void SetAlphaBlendEnable(bool enable);
+  HANDLE GetContexMutex() const;
 
   // empty overrides
   bool IsExtSupported(const char* extension) const override { return false; };
@@ -126,9 +125,6 @@ protected:
   Microsoft::WRL::ComPtr<ID3D11RasterizerState> m_RSScissorEnable;
   // stereo interlaced/checkerboard intermediate target
   CD3DTexture m_rightEyeTex;
-
-  XbmcThreads::EndTime m_decodingTimer;
-  XbmcThreads::ConditionVariable m_decodingEvent;
 
   std::shared_ptr<DX::DeviceResources> m_deviceResources;
 };


### PR DESCRIPTION
this is a proper solution to avoid a lack of decoding time because render loop locks context while waiting vsync.

@FernetMenta FYI