### PR TITLE
[GUI] DialogNetworkSetup: fix impossibility to edit network source.

### DIFF
--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -71,6 +71,8 @@ protected:
   void UpdateButtons();
   void Reset();
 
+  void UpdateAvailableProtocols();
+
   int m_protocol; //!< Currently selected protocol
   std::vector<Protocol> m_protocols; //!< List of available protocols
   std::string m_server;


### PR DESCRIPTION
in case if a path isn't empty method CGUIDialogNetworkSetup::SetPath fails because all available protocols aren't loaded yet.
to fix this we have to move loading protocols at the top of SetPath method.