### PR TITLE
[application][pvr][estuary] Fixes after #13699

### DIFF
--- a/addons/skin.estuary/xml/DialogBusy.xml
+++ b/addons/skin.estuary/xml/DialogBusy.xml
@@ -6,12 +6,10 @@
 		<control type="group">
 			<visible>String.IsEmpty(Window(Home).Property(script.cinemavision.running))</visible>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<visible>!Window.IsActive(startup)</visible>
+			<visible>!Window.IsActive(startup) + !Player.Caching</visible>
 			<control type="image">
 				<texture>colors/black.png</texture>
 				<include>FullScreenDimensions</include>
-				<animation effect="fade" start="100" end="70" time="0" condition="true">Conditional</animation>
-				<animation effect="fade" start="100" end="0" time="240" condition="Window.IsVisible(fullscreenvideo) | Window.IsVisible(FullscreenGame)">Conditional</animation>
 			</control>
 			<control type="group">
 				<depth>DepthMax</depth>

--- a/addons/skin.estuary/xml/VideoFullScreen.xml
+++ b/addons/skin.estuary/xml/VideoFullScreen.xml
@@ -34,8 +34,6 @@
 		<control type="group" id="1">
 			<depth>DepthOSD+</depth>
 			<visible>Player.Caching</visible>
-			<animation delay="300" effect="fade" time="200">Visible</animation>
-			<animation effect="fade" delay="200" time="150">Hidden</animation>
 			<centerleft>50%</centerleft>
 			<width>110</width>
 			<centertop>50%</centertop>
@@ -63,6 +61,7 @@
 			</control>
 			<control type="label" id="1">
 				<description>buffering value</description>
+				<visible>Integer.IsGreater(Player.CacheLevel,0)</visible>
 				<label>$INFO[Player.CacheLevel]</label>
 				<centerleft>50%</centerleft>
 				<centertop>50%</centertop>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3978,7 +3978,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       CAnnouncementManager::GetInstance().Announce(Player, "xbmc", "OnPlay", m_itemCurrentFile, param);
 
       // we don't want a busy dialog when switching channels
-      if (!m_itemCurrentFile->IsPVR())
+      if (!m_itemCurrentFile->IsLiveTV())
       {
         m_playerEvent.Reset();
         CGUIDialogBusy* dialog = g_windowManager.GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);


### PR DESCRIPTION
Small fixes after #13699 

1) Show busy dialog when starting playback also for pvr recordings.
2) Ensure player cache level progress and busy spinner are not shown at the same time (prefer cache level progress), remove animations because switching between progress/busy must be instantly.

@ronie @FernetMenta good to go?