### PR TITLE
HOW-TO: Clean up logic

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3855,10 +3855,20 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
 
   // disable screensaver lock from the login screen
   m_iScreenSaveLock = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_LOGIN_SCREEN ? 1 : 0;
+
   // set to Dim in the case of a dialog on screen or playing video
-  if (!forceType && (CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog() ||
-                     (m_appPlayer.IsPlayingVideo() && m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE)) ||
-                     CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan()))
+  bool bUseDim = false;
+  if (!forceType)
+  {
+    if (CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog())
+      bUseDim = true;
+    else if (m_appPlayer.IsPlayingVideo() && m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE))
+      bUseDim = true;
+    else if (CServiceBroker::GetPVRManager().GUIActions()->IsRunningChannelScan())
+      bUseDim = true;
+  }
+
+  if (bUseDim)
     m_screensaverIdInUse = "screensaver.xbmc.builtin.dim";
   else // Get Screensaver Mode
     m_screensaverIdInUse = m_ServiceManager->GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2667,9 +2667,12 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     {
       CSingleExit ex(g_graphicsContext);
       m_frameMoveGuard.unlock();
+
       // Calculate a window size between 2 and 10ms, 4 continuous requests let the window grow by 1ms
-      // WHen not playing video we allow it to increase to 80ms
-      unsigned int max_sleep = m_appPlayer.IsPlayingVideo() && !m_appPlayer.IsPausedPlayback() ? 10 : 80;
+      // When not playing video we allow it to increase to 80ms
+      unsigned int max_sleep = 10;
+      if (!m_appPlayer.IsPlayingVideo() || m_appPlayer.IsPausedPlayback())
+        max_sleep = 80;
       unsigned int sleepTime = std::max(static_cast<unsigned int>(2), std::min(m_ProcessedExternalCalls >> 2, max_sleep));
       Sleep(sleepTime);
       m_frameMoveGuard.lock();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4065,8 +4065,14 @@ bool CApplication::OnMessage(CGUIMessage& message)
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file, false);
 
       // Don't queue if next media type is different from current one
-      if ((!file.IsVideo() && m_appPlayer.IsPlayingVideo())
-          || ((!file.IsAudio() || file.IsVideo()) && m_appPlayer.IsPlayingAudio()))
+      bool bNothingToQueue = false;
+
+      if (!file.IsVideo() && m_appPlayer.IsPlayingVideo())
+        bNothingToQueue = true;
+      else if ((!file.IsAudio() || file.IsVideo()) && m_appPlayer.IsPlayingAudio())
+        bNothingToQueue = true;
+
+      if (bNothingToQueue)
       {
         m_appPlayer.OnNothingToQueueNotify();
         return true;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2076,15 +2076,36 @@ bool CApplication::OnAction(const CAction &action)
   bool bIsPlayingPVRChannel = (CServiceBroker::GetPVRManager().IsStarted() &&
                                CurrentFileItem().IsPVRChannel());
 
-  if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
-      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME ||
-      (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION && bIsPlayingPVRChannel) ||
-      ((CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD || (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_DIALOG_MUSIC_OSD && bIsPlayingPVRChannel)) &&
-        (action.GetID() == ACTION_NEXT_ITEM || action.GetID() == ACTION_PREV_ITEM || action.GetID() == ACTION_CHANNEL_UP || action.GetID() == ACTION_CHANNEL_DOWN)) ||
-      action.GetID() == ACTION_STOP)
+  bool bNotifyPlayer = false;
+  if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO)
+    bNotifyPlayer = true;
+  else if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME)
+    bNotifyPlayer = true;
+  else if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION && bIsPlayingPVRChannel)
+    bNotifyPlayer = true;
+  else if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_DIALOG_VIDEO_OSD ||
+          (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_DIALOG_MUSIC_OSD && bIsPlayingPVRChannel))
+  {
+    switch (action.GetID())
+    {
+      case ACTION_NEXT_ITEM:
+      case ACTION_PREV_ITEM:
+      case ACTION_CHANNEL_UP:
+      case ACTION_CHANNEL_DOWN:
+        bNotifyPlayer = true;
+        break;
+      default:
+        break;
+    }
+  }
+  else if (action.GetID() == ACTION_STOP)
+    bNotifyPlayer = true;
+
+  if (bNotifyPlayer)
   {
     if (m_appPlayer.OnAction(action))
       return true;
+
     // Player ignored action; popup the OSD
     if ((action.GetID() == ACTION_MOUSE_MOVE && (action.GetAmount(2) || action.GetAmount(3)))  // filter "false" mouse move from touch
         || action.GetID() == ACTION_MOUSE_LEFT_CLICK)

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -67,8 +67,18 @@ CAutorun::~CAutorun() = default;
 
 void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool ignoreplaying, bool startFromBeginning )
 {
-  if ((!ignoreplaying && (g_application.GetAppPlayer().IsPlayingAudio() || g_application.GetAppPlayer().IsPlayingVideo() || CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog())) || CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_LOGIN_SCREEN)
-    return ;
+  if (!ignoreplaying)
+  {
+    if (g_application.GetAppPlayer().IsPlayingAudio() ||
+        g_application.GetAppPlayer().IsPlayingVideo() ||
+        CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog())
+    {
+      return;
+    }
+  }
+
+  if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_LOGIN_SCREEN)
+    return;
 
   CCdInfo* pInfo = g_mediaManager.GetCdInfo(path);
 

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -360,8 +360,20 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
 
   if (m_bFullScreenRoot)
   {
-    bool allowDesktopRes = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) == ADJUST_REFRESHRATE_ALWAYS;
-    if (m_bFullScreenVideo || (!allowDesktopRes && g_application.GetAppPlayer().IsPlayingVideo()))
+    bool bTriggerUpdateRes = false;
+    if (m_bFullScreenVideo)
+      bTriggerUpdateRes = true;
+    else
+    {
+      bool allowDesktopRes = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) == ADJUST_REFRESHRATE_ALWAYS;
+      if (!allowDesktopRes)
+      {
+        if (g_application.GetAppPlayer().IsPlayingVideo())
+          bTriggerUpdateRes = true;
+      }
+    }
+
+    if (bTriggerUpdateRes)
       g_application.GetAppPlayer().TriggerUpdateResolution();
     else if (CDisplaySettings::GetInstance().GetCurrentResolution() > RES_DESKTOP)
       SetVideoResolution(CDisplaySettings::GetInstance().GetCurrentResolution(), false);


### PR DESCRIPTION
This contains the first 7 commits of #12995 unmodified. That PR fixed a bug, but unfortunately it furthered a weak design that should be removed. Still, I realized the cleanup commits would be equally valuable to whomever replaces this design.

I've labelled this PR as a HOW-TO because I explain the process I followed to clean up logic below.

Eventually I'll link to my HOW-TOs from the dev forum. For now I want them to be close to the code so I can incorporate feedback from the review process. If you just want to review the commits, skip this description.

## Why clean logic is important

It's all about readability. We should strive to write code for people, not computers. `if` statements impact the control flow. We want the control flow to be as easy to read and follow as possible.

## What bad `if` and ternary (`? :`) statements look like

Take the [first commit](https://github.com/xbmc/xbmc/commit/2d85c66~6). The previous logic roughly translates to:

```c++
if (A || B || (C &&D) || ((E || (F && G)) && (H && I && J && K)) || L)
  something();
```

Wow.

Ternary logic can also be unwieldy. For example, the previous logic in the second commit translates to:

```c++
X = (A && !B) ? Y : Z;
```

This statement isn't as offensive, but wouldn't it be more readable and maintanable by using a few more lines?

## How to clean up OR's

Generally, OR's are separated by creating a *sequence* of `if`'s on new lines with the same indentation. An initial flag is set, and the `if` statements are used to flip the flag. We can then use a final `if` that only depends on a single flag.

For example:

```c++
if (A || B)
  something()
```

becomes:

```c++
bool flag = false;

if (A)
  flag = true;
else if (B)
  flag = true;

if (flag)
  something();
```

This is demonstrated in the commit:

* [Improve logic for GUI_MSG_QUEUE_NEXT_ITEM in CApplication::OnMessage()](https://github.com/xbmc/xbmc/commit/2d85c66~2)

## How to clean up AND's

Generally, AND's are separated by creating a *series* of `if`'s by embedding indented blocks.

For example:

```c++
if (A && B)
  something()
```

becomes:

```c++
if (A)
{
  if (B)
    something();
}
```

This is demonstrated in the commit:

* [Improve logic in CAutorun::ExecuteAutorun()](https://github.com/xbmc/xbmc/commit/2d85c66~1)

## How to clean up ternary (`? :`) statements

As the name suggests, ternary statements can be split into three lines. For example,

```c++
X = (A && !B) ? Y : Z;
```

becomes:

```c++
X = Y;
if (!A || B)
  X = Z;
```

This is demonstrated in the commit:

* [Improve sleep time logic in CApplication::FrameMove()](https://github.com/xbmc/xbmc/commit/2d85c66~5)

## Extra credit: the `switch` statement

As a bonus, if the logic compares the same value to multiple constants, you can use a `switch` statement for a small performance boost.

For example (notice how I add a tricky OR at the end):

```c++
if (x == A || x == B || x == C || y == D)
  something();
```

becomes:

```
bool flag = false;

switch (x)
{
case A:
case B:
case C:
  flag = true;
  break;
default:
  if (y == D)
    flag = true;
  break;
}

if (flag)
  something();
```

This is demonstrated in the commit:

* [Clean up player notification logic in CApplication::OnAction()](https://github.com/xbmc/xbmc/commit/2d85c66~6)

Switch statements use *jump tables*, which can be faster than `if`s in some cases because branching slows down speculative execution.

## Choosing AND vs. OR

In general, I prefer the flag approach (OR) over the embedding indented blocks approach (AND) because less indentation makes the control flow easier to follow. Boolean algebra can be used to convert AND statements into ORs.

However, when a bunch of ANDs and ORs are combined, sometimes it makes things more complicated to use a single OR operator. It's really a process of trying different algebraic combinations to get the simplest-to-read control flow.

The last commit shows how I was given a convoluted condition and played around with boolean algebra until I eventually settled on what I considered most readable:

* [Improve logic in CGraphicContext::SetFullScreenVideo()](https://github.com/xbmc/xbmc/commit/2d85c66)

## How Has This Been Tested?
Tested as part of #12995. Commits are unchanged since exposure to eyeballs last November.

## Types of change
- [x] Cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
