### PR TITLE
[xbmc] Allow enter an user domain in GUI  for SMB protocol.

### DIFF
--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -54,6 +54,11 @@ public:
     m_strUserName = strUserName;
   }
 
+  void SetDomain(const std::string& strDomain)
+  {
+    m_strDomain = strDomain;
+  }
+
   void SetPassword(const std::string& strPassword)
   {
     m_strPassword = strPassword;

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -611,6 +611,7 @@ std::vector<std::string> CGUIDialogMediaSource::GetPaths() const
         CPasswordManager::GetInstance().SaveAuthenticatedURL(url);
         url.SetPassword("");
         url.SetUserName("");
+        url.SetDomain("");
       }
       paths.push_back(url.Get());
     }

--- a/xbmc/filesystem/SMBFile.cpp
+++ b/xbmc/filesystem/SMBFile.cpp
@@ -239,16 +239,15 @@ std::string CSMB::URLEncode(const CURL &url)
 
   std::string flat = "smb://";
 
-  if(url.GetDomain().length() > 0)
-  {
-    flat += URLEncode(url.GetDomain());
-    flat += ";";
-  }
-
   /* samba messes up of password is set but no username is set. don't know why yet */
   /* probably the url parser that goes crazy */
   if(url.GetUserName().length() > 0 /* || url.GetPassWord().length() > 0 */)
   {
+    if(url.GetDomain().length() > 0)
+    {
+      flat += URLEncode(url.GetDomain());
+      flat += ";";
+    }
     flat += URLEncode(url.GetUserName());
     if(url.GetPassWord().length() > 0)
     {

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -72,7 +72,13 @@ const TestURLGetWithoutUserDetailsData values[] = {
   { std::string("smb://god:universe@[00ff:1:0000:abde::]:8080/example"), std::string("smb://[00ff:1:0000:abde::]:8080/example"), false },
   { std::string("smb://god@[00ff:1:0000:abde::]:8080/example"), std::string("smb://USERNAME@[00ff:1:0000:abde::]:8080/example"), true },
   { std::string("smb://god:universe@00ff:1:0000:abde::/example"), std::string("smb://USERNAME:PASSWORD@00ff:1:0000:abde::/example"), true },
-  { std::string("http://god:universe@[00ff:1:0000:abde::]:8448/example|auth=digest"), std::string("http://USERNAME:PASSWORD@[00ff:1:0000:abde::]:8448/example|auth=digest"), true }
-  };
+  { std::string("http://god:universe@[00ff:1:0000:abde::]:8448/example|auth=digest"), std::string("http://USERNAME:PASSWORD@[00ff:1:0000:abde::]:8448/example|auth=digest"), true },
+  { std::string("smb://milkyway;god:universe@example.com/example"), std::string("smb://DOMAIN;USERNAME:PASSWORD@example.com/example"), true },
+  { std::string("smb://milkyway;god@example.com/example"), std::string("smb://DOMAIN;USERNAME@example.com/example"), true },
+  { std::string("smb://milkyway;@example.com/example"), std::string("smb://example.com/example"), true },
+  { std::string("smb://milkyway;god:universe@example.com/example"), std::string("smb://example.com/example"), false },
+  { std::string("smb://milkyway;god@example.com/example"), std::string("smb://example.com/example"), false },
+  { std::string("smb://milkyway;@example.com/example"), std::string("smb://example.com/example"), false },
+};
 
 INSTANTIATE_TEST_CASE_P(URL, TestURLGetWithoutUserDetails, ValuesIn(values));


### PR DESCRIPTION
see title. 

currently it's not possible in GUI somehow define domain for an user. this introduces an ability to enter user name in format 'DOMAIN\user' or `DOMAIN/user` and this will be properly handled.