### PR TITLE
Fix missing include in StringUtils.cpp

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -40,6 +40,7 @@
 #include "Util.h"
 #include <functional>
 #include <array>
+#include <iomanip>
 #include <assert.h>
 #include <math.h>
 #include <time.h>


### PR DESCRIPTION
Fix for build error introduced in #13681 