### PR TITLE
support low keynumber keyboard input

### DIFF
--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -1030,6 +1030,16 @@ void CLinuxInputDevice::GetInfo(int fd)
     m_deviceMaxAxis = std::max(num_rels, num_abs) - 1;
   }
 
+  /* if no better fit and have at least 1 key */
+   if ((m_deviceType == LI_DEVICE_NONE) && (num_keys >= 1))
+  {
+    m_deviceType |= LI_DEVICE_KEYBOARD;
+    m_deviceCaps |= LI_CAPS_KEYS;
+
+    m_deviceMinKeyCode = 0;
+    m_deviceMaxKeyCode = 127;
+  }
+
   /* Decide which primary input device to be. */
   if (m_deviceType & LI_DEVICE_KEYBOARD)
     m_devicePreferredId = LI_DEVICE_KEYBOARD;
@@ -1044,16 +1054,6 @@ void CLinuxInputDevice::GetInfo(int fd)
     m_devicePreferredId = LI_DEVICE_JOYSTICK;
   else if (m_deviceType & LI_DEVICE_MOUSE)
     m_devicePreferredId = LI_DEVICE_MOUSE;
-  /* if no better fit and have at least 1 key */
-  else if (num_keys >= 1) 
-  {
-    m_deviceType |= LI_DEVICE_KEYBOARD;
-    m_deviceCaps |= LI_CAPS_KEYS;
-
-    m_deviceMinKeyCode = 0;
-    m_deviceMaxKeyCode = 127;
-    m_devicePreferredId = LI_DEVICE_KEYBOARD;
-  }
   else
     m_devicePreferredId = LI_DEVICE_NONE;
  

--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -1044,20 +1044,18 @@ void CLinuxInputDevice::GetInfo(int fd)
     m_devicePreferredId = LI_DEVICE_JOYSTICK;
   else if (m_deviceType & LI_DEVICE_MOUSE)
     m_devicePreferredId = LI_DEVICE_MOUSE;
-  else
+  /* if no better fit and have at least 1 key */
+  else if (num_keys >= 1) 
   {
-    /* if no better fit and have at least 1 key */
-    if (num_keys >= 1)
-    {
-      m_deviceType |= LI_DEVICE_KEYBOARD;
-      m_deviceCaps |= LI_CAPS_KEYS;
+    m_deviceType |= LI_DEVICE_KEYBOARD;
+    m_deviceCaps |= LI_CAPS_KEYS;
 
-      m_deviceMinKeyCode = 0;
-      m_deviceMaxKeyCode = 127;
-    }
-    else
-      m_devicePreferredId = LI_DEVICE_NONE;
-
+    m_deviceMinKeyCode = 0;
+    m_deviceMaxKeyCode = 127;
+  }
+  else
+    m_devicePreferredId = LI_DEVICE_NONE;
+ 
   //printf("type: %d\n", m_deviceType);
   //printf("caps: %d\n", m_deviceCaps);
   //printf("pref: %d\n", m_devicePreferredId);

--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -1052,6 +1052,7 @@ void CLinuxInputDevice::GetInfo(int fd)
 
     m_deviceMinKeyCode = 0;
     m_deviceMaxKeyCode = 127;
+    m_devicePreferredId = LI_DEVICE_KEYBOARD;
   }
   else
     m_devicePreferredId = LI_DEVICE_NONE;

--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -1045,7 +1045,18 @@ void CLinuxInputDevice::GetInfo(int fd)
   else if (m_deviceType & LI_DEVICE_MOUSE)
     m_devicePreferredId = LI_DEVICE_MOUSE;
   else
-    m_devicePreferredId = LI_DEVICE_NONE;
+  {
+    /* if no better fit and have at least 1 key */
+    if (num_keys >= 1)
+    {
+      m_deviceType |= LI_DEVICE_KEYBOARD;
+      m_deviceCaps |= LI_CAPS_KEYS;
+
+      m_deviceMinKeyCode = 0;
+      m_deviceMaxKeyCode = 127;
+    }
+    else
+      m_devicePreferredId = LI_DEVICE_NONE;
 
   //printf("type: %d\n", m_deviceType);
   //printf("caps: %d\n", m_deviceCaps);

--- a/xbmc/platform/linux/input/LinuxInputDevices.cpp
+++ b/xbmc/platform/linux/input/LinuxInputDevices.cpp
@@ -1031,7 +1031,7 @@ void CLinuxInputDevice::GetInfo(int fd)
   }
 
   /* if no better fit and have at least 1 key */
-   if ((m_deviceType == LI_DEVICE_NONE) && (num_keys >= 1))
+   if (m_deviceType == LI_DEVICE_NONE && num_keys >= 1)
   {
     m_deviceType |= LI_DEVICE_KEYBOARD;
     m_deviceCaps |= LI_CAPS_KEYS;


### PR DESCRIPTION
if drivers such as gpio_keys are used there may be keyboard inputs that support as little as 1 key, if no better fit for a device is found and there is at least 1 key then treat it as a keyboard. 

## Description
when running on linux kodi grabs the input devices and attempts to categorize them according to capabilities, however some inputs such as the gpio-keys driver don't fit neatly into kodi's classifications.
this change keeps the same behaviour for any devices that worked previously, but if the device doesn't fit into any category (falls through to LI_DEVICE_NONE) then if it has at least 1 key input it is classified as a keyboard instead.

## Motivation and Context
this change is required so that the gpio-keys driver and similar can be used with kodi.
this should fix https://trac.kodi.tv/ticket/17836

## How Has This Been Tested?
I have been unable to set up a build environment as yet so this is untested, if i get something set up i will update this pull request.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
