### PR TITLE
[Estuary] Reintroduce/fix busy dialog animations after #13715.

### DIFF
--- a/addons/skin.estuary/xml/DialogBusy.xml
+++ b/addons/skin.estuary/xml/DialogBusy.xml
@@ -10,6 +10,8 @@
 			<control type="image">
 				<texture>colors/black.png</texture>
 				<include>FullScreenDimensions</include>
+				<animation effect="fade" start="100" end="70" time="0" condition="true">Conditional</animation>
+				<animation effect="fade" start="100" end="0" time="0" condition="Window.IsVisible(fullscreenvideo) | Window.IsVisible(FullscreenGame)">Conditional</animation>
 			</control>
 			<control type="group">
 				<depth>DepthMax</depth>

--- a/addons/skin.estuary/xml/VideoFullScreen.xml
+++ b/addons/skin.estuary/xml/VideoFullScreen.xml
@@ -61,7 +61,6 @@
 			</control>
 			<control type="label" id="1">
 				<description>buffering value</description>
-				<visible>Integer.IsGreater(Player.CacheLevel,0)</visible>
 				<label>$INFO[Player.CacheLevel]</label>
 				<centerleft>50%</centerleft>
 				<centertop>50%</centertop>


### PR DESCRIPTION
This PR partly reverts  https://github.com/xbmc/xbmc/commit/24a23d480584932bf76f8828d2d8f334ee3e96bd

Removing the animations was not a good idea, as it leads to a busy spinner on black background instead of the well-known nice semi transparent background while the busy spinner is active.