### PR TITLE
[win10] filesystem: handle win-lib file/directory as a local resources.

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -148,6 +148,9 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
 #endif
   if (url.IsProtocol("resource")) return new CResourceDirectory();
   if (url.IsProtocol("events")) return new CEventsDirectory();
+#ifdef TARGET_WINDOWS_STORE
+  if (CWinLibraryDirectory::IsValid(url)) return new CWinLibraryDirectory();
+#endif
 
   bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();
   if (networkAvailable)
@@ -175,9 +178,6 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
 #endif
 #ifdef HAS_FILESYSTEM_NFS
     if (url.IsProtocol("nfs")) return new CNFSDirectory();
-#endif
-#ifdef TARGET_WINDOWS_STORE
-    if (CWinLibraryDirectory::IsValid(url)) return new CWinLibraryDirectory();
 #endif
   }
 

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -140,6 +140,9 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   else if (url.IsProtocol("bluray")) return new CBlurayFile();
 #endif
   else if (url.IsProtocol("resource")) return new CResourceFile();
+#ifdef TARGET_WINDOWS_STORE
+  else if (CWinLibraryFile::IsValid(url)) return new CWinLibraryFile();
+#endif
 
   bool networkAvailable = CServiceBroker::GetNetwork().IsAvailable();
   if (networkAvailable)
@@ -167,9 +170,6 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
 #endif
 #ifdef HAS_UPNP
     else if (url.IsProtocol("upnp")) return new CUPnPFile();
-#endif
-#ifdef TARGET_WINDOWS_STORE
-    else if (CWinLibraryFile::IsValid(url)) return new CWinLibraryFile();
 #endif
   }
 


### PR DESCRIPTION
`win-lib://` was added mistakenly to network section of file and directory factories


