### PR TITLE
Component logging disabled on fresh install / Video component not pre…

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2855,12 +2855,12 @@
         </setting>
         <setting id="debug.extralogging" type="boolean" label="666" help="36394">
           <level>1</level>
-          <default>true</default>
+          <default>false</default>
           <control type="toggle" />
         </setting>
         <setting id="debug.setextraloglevel" type="list[integer]" parent="debug.extralogging" label="668" help="36534">
           <level>1</level>
-          <default>32768</default>
+          <default></default>
           <constraints>
             <options>loggingcomponents</options>
             <delimiter>,</delimiter>


### PR DESCRIPTION
…selected

## Description

PR changes default settings on fresh install:
- Component logging deactive
- Video component NOT preselected

## Motivation and Context
Too many log spam user reports

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
