### PR TITLE
VideoPlayer: move switching to fullscreen from RM to VP

### DIFF
--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -97,7 +97,6 @@ public:
   void SendMessage(CDVDMsg* pMsg, int priority = 0) override = 0;
   virtual void EnableSubtitle(bool bEnable) = 0;
   virtual bool IsSubtitleEnabled() = 0;
-  virtual void EnableFullscreen(bool bEnable) = 0;
   virtual double GetSubtitleDelay() = 0;
   virtual void SetSubtitleDelay(double delay) = 0;
   bool IsStalled() const override = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1283,9 +1283,6 @@ void CVideoPlayer::Prepare()
   // give players a chance to reconsider now codecs are known
   CreatePlayers();
 
-  // allow renderer to switch to fullscreen if requested
-  m_VideoPlayerVideo->EnableFullscreen(m_playerOptions.fullscreen);
-
   if (m_omxplayer_mode)
   {
     if (!m_OmxPlayerState.av_clock.OMXInitialize(&m_clock))
@@ -2065,6 +2062,11 @@ void CVideoPlayer::HandlePlaySpeed()
 
       if (!m_State.streamsReady)
       {
+        if (m_playerOptions.fullscreen)
+        {
+          CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
+        }
+
         IPlayerCallback *cb = &m_callback;
         CFileItem fileItem = m_item;
         m_outboundEvents->Submit([=]() {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -89,7 +89,6 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
   m_iFrameRateErr = 0;
   m_iFrameRateLength = 0;
   m_bFpsInvalid = false;
-  m_bAllowFullscreen = false;
 }
 
 CVideoPlayerVideo::~CVideoPlayerVideo()
@@ -838,15 +837,12 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
 
   if (!m_renderManager.Configure(*pPicture,
                                 static_cast<float>(config_framerate),
-                                m_bAllowFullscreen,
                                 m_hints.orientation,
                                 m_pVideoCodec->GetAllowedReferences()))
   {
     CLog::Log(LOGERROR, "%s - failed to configure renderer", __FUNCTION__);
     return OUTPUT_ABORT;
   }
-
-  m_bAllowFullscreen = false;
 
   //try to calculate the framerate
   m_ptsTracker.Add(pPicture->pts);

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -74,7 +74,6 @@ public:
 
   void EnableSubtitle(bool bEnable) override { m_bRenderSubs = bEnable; }
   bool IsSubtitleEnabled() override { return m_bRenderSubs; }
-  void EnableFullscreen(bool bEnable) override { m_bAllowFullscreen = bEnable; }
   double GetSubtitleDelay() override { return m_iSubtitleDelay; }
   void SetSubtitleDelay(double delay) override { m_iSubtitleDelay = delay; }
   bool IsStalled() const override { return m_stalled; }
@@ -129,7 +128,6 @@ protected:
                              //this is increased exponentially from CVideoPlayerVideo::CalcFrameRate()
 
   bool m_bFpsInvalid;        // needed to ignore fps (e.g. dvd stills)
-  bool m_bAllowFullscreen;
   bool m_bRenderSubs;
   float m_fForcedAspectRatio;
   int m_speed;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -96,7 +96,7 @@ void CRenderManager::SetVideoSettings(CVideoSettings settings)
   }
 }
 
-bool CRenderManager::Configure(const VideoPicture& picture, float fps, bool fullscreen, unsigned int orientation, int buffers)
+bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned int orientation, int buffers)
 {
 
   // check if something has changed
@@ -154,7 +154,6 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, bool full
     m_dvdClock.SetVsyncAdjust(0);
     m_pConfigPicture.reset(new VideoPicture());
     m_pConfigPicture->CopyRef(picture);
-    m_fullscreen = fullscreen;
 
     CSingleLock lock2(m_presentlock);
     m_presentstep = PRESENT_READY;
@@ -300,12 +299,6 @@ void CRenderManager::FrameMove()
 
       firstFrame = true;
       FrameWait(50);
-
-      if (m_fullscreen)
-      {
-        CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
-        m_fullscreen = false;
-      }
     }
 
     CheckEnableClockSync();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -97,7 +97,7 @@ public:
 
   int GetSkippedFrames()  { return m_QueueSkip; }
 
-  bool Configure(const VideoPicture& picture, float fps, bool fullscreen, unsigned int orientation, int buffers = 0);
+  bool Configure(const VideoPicture& picture, float fps, unsigned int orientation, int buffers = 0);
   bool AddVideoPicture(const VideoPicture& picture, volatile std::atomic_bool& bStop, EINTERLACEMETHOD deintMethod, bool wait);
   void AddOverlay(CDVDOverlay* o, double pts);
 
@@ -210,7 +210,6 @@ protected:
   float m_fps = 0.0;
   unsigned int m_orientation = 0;
   int m_NumberBuffers = 0;
-  bool m_fullscreen = false;
   std::string m_stereomode;
 
   int m_lateframes = -1;

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -80,7 +80,6 @@ OMXPlayerVideo::OMXPlayerVideo(OMXClock *av_clock,
   m_stalled               = false;
   m_iSubtitleDelay        = 0;
   m_bRenderSubs           = false;
-  m_bAllowFullscreen      = false;
   m_iCurrentPts           = DVD_NOPTS_VALUE;
   m_fForcedAspectRatio    = 0.0f;
   bool small_mem = g_RBP.GetArmMem() < 256;
@@ -801,13 +800,11 @@ void OMXPlayerVideo::ResolutionUpdateCallBack(uint32_t width, uint32_t height, f
   picture.iDisplayWidth = iDisplayWidth;
   picture.iDisplayHeight = iDisplayHeight;
 
-  if(!m_renderManager.Configure(picture, m_fFrameRate, m_bAllowFullscreen, m_hints.orientation, 3))
+  if(!m_renderManager.Configure(picture, m_fFrameRate, m_hints.orientation, 3))
   {
     CLog::Log(LOGERROR, "%s - failed to configure renderer", __FUNCTION__);
     return;
   }
-
-  m_bAllowFullscreen = false; // only allow on first configure
 
   m_src_rect.SetRect(0, 0, 0, 0);
   m_dst_rect.SetRect(0, 0, 0, 0);

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.h
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.h
@@ -59,7 +59,6 @@ protected:
   std::atomic_bool          m_bAbortOutput;
   double                    m_iSubtitleDelay;
   bool                      m_bRenderSubs;
-  bool                      m_bAllowFullscreen;
 
   float                     m_fForcedAspectRatio;
 
@@ -114,10 +113,8 @@ public:
   void SetSubtitleDelay(double delay)               override { m_iSubtitleDelay = delay; }
   void EnableSubtitle(bool bEnable)                 override { m_bRenderSubs = bEnable; }
   bool IsSubtitleEnabled()                          override { return m_bRenderSubs; }
-  void EnableFullscreen(bool bEnable)               override { m_bAllowFullscreen = bEnable; }
   float GetAspectRatio()                                     { return m_renderManager.GetAspectRatio(); }
   void  SetVideoRect(const CRect &SrcRect, const CRect &DestRect);
   void ResolutionUpdateCallBack(uint32_t width, uint32_t height, float framerate, float pixel_aspect);
   static void ResolutionUpdateCallBack(void *ctx, uint32_t width, uint32_t height, float framerate, float pixel_aspect);
 };
-


### PR DESCRIPTION
fixes not going to fullscreen when starting a video while another one is playing