### PR TITLE
[cleanup] drop support for alsa lower than 1.0.27

### DIFF
--- a/cmake/modules/FindAlsa.cmake
+++ b/cmake/modules/FindAlsa.cmake
@@ -15,7 +15,7 @@
 #   ALSA::ALSA   - The Alsa library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_ALSA alsa>=0.9 QUIET)
+  pkg_check_modules(PC_ALSA alsa>=1.0.27 QUIET)
 endif()
 
 find_path(ALSA_INCLUDE_DIR NAMES alsa/asoundlib.h

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -25,7 +25,6 @@
 #include "cores/AudioEngine/Sinks/alsa/ALSAHControlMonitor.h"
 #include <stdint.h>
 
-#define ALSA_PCM_NEW_HW_PARAMS_API
 #include <alsa/asoundlib.h>
 
 #include "threads/CriticalSection.h"
@@ -61,8 +60,6 @@ private:
   CAEChannelInfo GetChannelLayoutLegacy(const AEAudioFormat& format, unsigned int minChannels, unsigned int maxChannels);
   CAEChannelInfo GetChannelLayout(const AEAudioFormat& format, unsigned int channels);
 
-#ifdef SND_CHMAP_API_VERSION
-  static bool AllowALSAMaps();
   static AEChannel ALSAChannelToAEChannel(unsigned int alsaChannel);
   static unsigned int AEChannelToALSAChannel(AEChannel aeChannel);
   static CAEChannelInfo ALSAchmapToAEChannelMap(snd_pcm_chmap_t* alsaMap);
@@ -71,7 +68,6 @@ private:
   static std::string ALSAchmapToString(snd_pcm_chmap_t* alsaMap);
   static CAEChannelInfo GetAlternateLayoutForm(const CAEChannelInfo& info);
   snd_pcm_chmap_t* SelectALSAChannelMap(const CAEChannelInfo& info);
-#endif
 
   void GetAESParams(const AEAudioFormat& format, std::string& params);
   void HandleError(const char* name, int err);


### PR DESCRIPTION
## Description
drop support for alsa lower than 1.0.27
alsa 1.0.27 was released in December 2013

## Motivation and Context
no need to keep ifdes for old lib versions

## How Has This Been Tested?
compiled for linux

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
