### PR TITLE
[Music] Fix endless rescraping of unfound album 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -795,6 +795,7 @@ msgctxt "#180"
 msgid "Duration"
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 #: xbmc/music/MusicDatabase.cpp
 msgctxt "#181"
 msgid "Select album"
@@ -1544,6 +1545,7 @@ msgctxt "#330"
 msgid "This may take some time..."
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 #: xbmc/music/MusicDatabase.cpp
 msgctxt "#331"
 msgid "Compressing database..."
@@ -1586,6 +1588,7 @@ msgctxt "#339"
 msgid "Optimized"
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#340"
 msgid "Various artists"
 msgstr ""
@@ -2313,11 +2316,17 @@ msgctxt "#504"
 msgid "Empty"
 msgstr ""
 
+#. label for library update progress bar when scanning media files 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#505"
 msgid "Loading media information from files..."
 msgstr ""
 
-#empty string with id 506
+#. label for library update progress bar when checking for new or changed media files
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
+msgctxt "#506"
+msgid "Checking media files..."
+msgstr ""
 
 msgctxt "#507"
 msgid "Sort by: Usage"
@@ -3142,6 +3151,7 @@ msgstr ""
 
 #empty strings from id 684 to 699
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 #: xbmc/music/MusicDatabase.cpp
 msgctxt "#700"
 msgid "Cleaning up library"
@@ -8458,6 +8468,7 @@ msgctxt "#16010"
 msgid "Enter the profile name"
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#16011"
 msgid "Enter the album name"
 msgstr ""
@@ -8526,6 +8537,7 @@ msgctxt "#16024"
 msgid "Cancelling..."
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#16025"
 msgid "Enter the artist name"
 msgstr ""
@@ -12443,10 +12455,12 @@ msgctxt "#20319"
 msgid "Scanning TV shows using {0:s}"
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#20320"
 msgid "Scanning artists using {0:s}"
 msgstr ""
 
+#: xbmc/music/infoscanner/MusicInfoScanner.cpp
 msgctxt "#20321"
 msgid "Scanning albums using {0:s}"
 msgstr ""

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -458,7 +458,10 @@ static std::string Prettify(const std::string& strDirectory)
 bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 {
   if (m_handle)
+  {
+    m_handle->SetTitle(g_localizeStrings.Get(506)); //"Checking media files..."
     m_handle->SetText(Prettify(strDirectory));
+  }
 
   std::set<std::string>::const_iterator it = m_seenPaths.find(strDirectory);
   if (it != m_seenPaths.end())
@@ -491,6 +494,9 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
       CLog::Log(LOGDEBUG, "%s Scanning dir '%s' as not in the database", __FUNCTION__, CURL::GetRedacted(strDirectory).c_str());
     else
       CLog::Log(LOGDEBUG, "%s Rescanning dir '%s' due to change", __FUNCTION__, CURL::GetRedacted(strDirectory).c_str());
+
+    if (m_handle)
+      m_handle->SetTitle(g_localizeStrings.Get(505)); //"Loading media information from files..."
 
     // filter items in the sub dir (for .cue sheet support)
     items.FilterCueItems();
@@ -912,10 +918,6 @@ int CMusicInfoScanner::RetrieveMusicInfo(const std::string& strDirectory, CFileI
  
     numAdded += album->songs.size();
   }
-
-  if (m_handle)
-    m_handle->SetTitle(g_localizeStrings.Get(505));
-
   return numAdded;
 }
 
@@ -1017,6 +1019,8 @@ void MUSIC_INFO::CMusicInfoScanner::ScrapeInfoAddedAlbums()
       }
     }
   }
+  // Clear list of albums added to prevent them being scraped again
+  m_albumsAdded.clear();
 }
 
 void MUSIC_INFO::CMusicInfoScanner::RetrieveArtistArt()


### PR DESCRIPTION
Fix endless rescraping during library update of single new album for which information is not found by the scraper.

Correctly update progress bar title during scanning. Show when just checking for new or changed files compared to when scanning metadata.
___

The endless scraping bug was reported by users here https://forum.kodi.tv/showthread.php?tid=328753
With "fetch additional information on update" enbaled, if only one new album was added to the music files, and that album was not found by the scraper, then on library update the album was endlessly rescraped until scraping was manualy stopped from the side blade.

The progress bar was also sometimes left showing an inaccurate title, saying it was either "Loading media information from files..." or worse "Scanning artists using XXX"  when is was actually just checking files looking for changed or new ones. Users were confused why Kodi keeps scraping old media when it is just checking hashes.
