### PR TITLE
[ADDONS] Correction of anomaly and improvement - service.xbmc.versioncheck

### DIFF
--- a/addons/service.xbmc.versioncheck/addon.xml
+++ b/addons/service.xbmc.versioncheck/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.xbmc.versioncheck"
     name="Version Check"
-    version="0.3.281"
+    version="0.3.30"
     provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>

--- a/addons/service.xbmc.versioncheck/addon.xml
+++ b/addons/service.xbmc.versioncheck/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.xbmc.versioncheck"
        name="Version Check"
-      version="0.3.26"
+      version="0.3.27"
       provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>

--- a/addons/service.xbmc.versioncheck/addon.xml
+++ b/addons/service.xbmc.versioncheck/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.xbmc.versioncheck"
     name="Version Check"
-    version="0.3.28"
+    version="0.3.281"
     provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>

--- a/addons/service.xbmc.versioncheck/addon.xml
+++ b/addons/service.xbmc.versioncheck/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.xbmc.versioncheck"
-       name="Version Check"
-      version="0.3.27"
-      provider-name="Team Kodi">
+    name="Version Check"
+    version="0.3.28"
+    provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
     </requires>

--- a/addons/service.xbmc.versioncheck/changelog.txt
+++ b/addons/service.xbmc.versioncheck/changelog.txt
@@ -1,3 +1,9 @@
+v0.3.30
+- Replace the message box with a dialog busy box
+- Choice System update or Kodi update or the both
+- Add choice for autoremove old packages if system update
+- Fix unicodedata (missing import)
+
 v0.3.281
 - Fix Apt Upgrade
 

--- a/addons/service.xbmc.versioncheck/changelog.txt
+++ b/addons/service.xbmc.versioncheck/changelog.txt
@@ -1,3 +1,6 @@
+v0.3.27
+- Test mandatory password for sudo
+
 v0.3.256
 - Update version list
 

--- a/addons/service.xbmc.versioncheck/changelog.txt
+++ b/addons/service.xbmc.versioncheck/changelog.txt
@@ -1,3 +1,6 @@
+v0.3.281
+- Fix Apt Upgrade
+
 v0.3.28
 -  Improvement of log's traces
 

--- a/addons/service.xbmc.versioncheck/changelog.txt
+++ b/addons/service.xbmc.versioncheck/changelog.txt
@@ -1,3 +1,6 @@
+v0.3.28
+-  Improvement of log's traces
+
 v0.3.27
 - Test mandatory password for sudo
 

--- a/addons/service.xbmc.versioncheck/lib/aptdaemonhandler.py
+++ b/addons/service.xbmc.versioncheck/lib/aptdaemonhandler.py
@@ -19,12 +19,11 @@ import xbmc
 from .common import *
 
 try:
-    #import apt
     import apt
     from aptdaemon import client
     from aptdaemon import errors
-except:
-    log('python apt import error')
+except Exception as error:
+    log('python apt import error :%s' %error,xbmc.LOGERROR)
 
 class AptdaemonHandler:
 
@@ -36,7 +35,6 @@ class AptdaemonHandler:
             return False, False
         try:
             trans = self.aptclient.upgrade_packages([package])
-            #trans = self.aptclient.upgrade_packages("bla")
             trans.simulate(reply_handler=self._apttransstarted, error_handler=self._apterrorhandler)
             pkg = trans.packages[4][0]
             if pkg == package:
@@ -49,7 +47,7 @@ class AptdaemonHandler:
             return False, False
 
         except Exception as error:
-            log("Exception while checking versions: %s" %error)
+            log("Exception while checking versions: %s" %error,xbmc.LOGERROR)
             return False, False
 
     def _update_cache(self):
@@ -71,21 +69,21 @@ class AptdaemonHandler:
                 log("Version available  %s" %candidate)
                 return True
             else:
-                log("Already on newest version")
+                log("Already on newest version for %s" %package)
         elif not installed:
-                log("No installed package found")
+                log("No installed package found for %s" %package)
                 return False
         else:
             return False
 
     def upgrade_package(self, package):
         try:
-            log("Installing new version")
+            log("Installing new version for %s" %package)
             if self.aptclient.upgrade_packages([package], wait=True) == "exit-success":
-                log("Upgrade successful")
+                log("Install package %s successful" %package)
                 return True
         except Exception as error:
-            log("Exception during upgrade: %s" %error)
+            log("Exception during upgrade: %s" %error,xbmc.LOGERROR)
         return False
 
     def upgrade_system(self):
@@ -94,7 +92,7 @@ class AptdaemonHandler:
             if self.aptclient.upgrade_system(wait=True) == "exit-success":
                 return True
         except Exception as error:
-            log("Exception during system upgrade: %s" %error)
+            log("Exception during system upgrade: %s" %error,xbmc.LOGERROR)
         return False
 
     def _getpassword(self):
@@ -106,4 +104,4 @@ class AptdaemonHandler:
         pass
     
     def _apterrorhandler(self, error):
-        log("Apt Error %s" %error)
+        log("Apt Error %s" %error,xbmc.LOGERROR)

--- a/addons/service.xbmc.versioncheck/lib/aptdaemonhandler.py
+++ b/addons/service.xbmc.versioncheck/lib/aptdaemonhandler.py
@@ -23,7 +23,7 @@ try:
     from aptdaemon import client
     from aptdaemon import errors
 except Exception as error:
-    log('python apt import error :%s' %error,xbmc.LOGERROR)
+    log('python apt import error :%s' %error,xbmc.LOGWARNING)
 
 class AptdaemonHandler:
 

--- a/addons/service.xbmc.versioncheck/lib/common.py
+++ b/addons/service.xbmc.versioncheck/lib/common.py
@@ -58,14 +58,14 @@ def localise(id):
     string = normalize_string(ADDON.getLocalizedString(id))
     return string
 
-def log(txt):
+def log(txt,level_log=xbmc.LOGDEBUG):
     if sys.version_info[0] >= 3:
-        message = '%s: %s' % ("Version Check", txt.encode('utf-8'))
+        message = '{} v{}: {}'.format(ADDONNAME,ADDONVERSION, txt).encode("utf-8")
     else:
         if isinstance (txt,str):
-            txt = txt.decode("utf-8")
-        message = (u'%s: %s' % ("Version Check", txt)).encode("utf-8")
-    xbmc.log(msg=message, level=xbmc.LOGDEBUG)
+            txt = txt.decode("utf-8") 
+        message =(u'{} v{}: {}'.format(ADDONNAME,ADDONVERSION, txt)).encode("utf-8")
+    xbmc.log(msg=message, level=level_log)
 
 def get_password_from_user():
     keyboard = xbmc.Keyboard("", ADDONNAME + "," +localise(32022), True)

--- a/addons/service.xbmc.versioncheck/lib/common.py
+++ b/addons/service.xbmc.versioncheck/lib/common.py
@@ -16,8 +16,9 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import sys
-
 import os
+import unicodedata
+
 import xbmc
 import xbmcaddon
 import xbmcgui
@@ -84,24 +85,16 @@ def message_restart():
     if dialog_yesno(32014):
         xbmc.executebuiltin("RestartApp")
 
+def message_restart_system():
+    if dialog_yesno(32017):
+        xbmc.executebuiltin("Reboot")
+
 def dialog_yesno(line1 = 0, line2 = 0):
     return xbmcgui.Dialog().yesno(ADDONNAME,
                                   localise(line1),
                                   localise(line2))
 
-def upgrade_message(msg, oldversion, upgrade, msg_current, msg_available):
-    wait_for_end_of_video()
-
-    if ADDON.getSetting("lastnotified_version") < ADDONVERSION:
-        xbmcgui.Dialog().ok(ADDONNAME,
-                    localise(msg),
-                    localise(32001),
-                    localise(32002))
-        #ADDON.setSetting("lastnotified_version", ADDONVERSION)
-    else:
-        log("Already notified one time for upgrading.")
-
-def upgrade_message2( version_installed, version_available, version_stable, oldversion, upgrade,):
+def upgrade_message( version_installed, version_available, version_stable, oldversion, upgrade,):
     # shorten releasecandidate to rc
     if version_installed['tag'] == 'releasecandidate':
         version_installed['tag'] = 'rc'
@@ -115,8 +108,6 @@ def upgrade_message2( version_installed, version_available, version_stable, oldv
     msg_available = version_available['major'] + '.' + version_available['minor'] + ' ' + version_available['tag'] + version_available.get('tagversion','')
     msg_stable = version_stable['major'] + '.' + version_stable['minor'] + ' ' + version_stable['tag'] + version_stable.get('tagversion','')
     msg = localise(32034) %(msg_current, msg_available)
-
-    wait_for_end_of_video()
 
     # hack: convert current version number to stable string
     # so users don't get notified again. remove in future

--- a/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
+++ b/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
@@ -21,10 +21,9 @@ from .common import *
 try:
     from subprocess import check_output
     from subprocess import call
-    from subprocess import CalledProcessError    
-except:
-    log('subprocess import error')
-
+    from subprocess import CalledProcessError
+except Exception as error:
+    log('subprocess import error :%s' %error,xbmc.LOGERROR)
 
 class ShellHandlerApt:
 
@@ -48,7 +47,7 @@ class ShellHandlerApt:
         try:
             result = check_output([_cmd], shell=True).split("\n")
         except Exception as error:
-            log("ShellHandlerApt: exception while executing shell command %s: %s" %(_cmd, error))
+            log("ShellHandlerApt: exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False, False
 
         if result[0].replace(":", "") == package:
@@ -70,8 +69,9 @@ class ShellHandlerApt:
                 x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
             else:
                 x = check_output(_cmd.split())
+            log("Update cache successful")
         except Exception as error:
-            log("Exception while executing shell command %s: %s" %(_cmd, error))
+            log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False
 
         return True
@@ -85,9 +85,9 @@ class ShellHandlerApt:
                 log("Version available  %s" %candidate)
                 return True
             else:
-                log("Already on newest version")
+                log("Already on newest version for %s" %package)
         elif not installed:
-                log("No installed package found")
+                log("No installed package found for %s" %package)
                 return False
         else:
             return False
@@ -99,9 +99,9 @@ class ShellHandlerApt:
                 x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
             else:
                 x = check_output(_cmd.split())
-            log("Upgrade successful")
+            log("Install package %s successful" %package,True)
         except Exception as error:
-            log("Exception while executing shell command %s: %s" %(_cmd, error))
+            log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False
 
         return True
@@ -114,8 +114,9 @@ class ShellHandlerApt:
                 x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
             else:
                 x = check_output(_cmd.split())
+            log("Upgrade System successful")
         except Exception as error:
-            log("Exception while executing shell command %s: %s" %(_cmd, error))
+            log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False
 
         return True

--- a/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
+++ b/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
@@ -31,7 +31,7 @@ class ShellHandlerApt:
 
     def __init__(self, usesudo=False):
         self.sudo = usesudo
-        installed, candidate = self._check_versions("xbmc", False)
+        installed, candidate = self._check_versions("kodi", False)
         if not installed:
             # there is no package installed via repo, so we exit here
             log("No installed package found, exiting")
@@ -107,7 +107,7 @@ class ShellHandlerApt:
         return True
 
     def upgrade_system(self):
-        _cmd = "apt-get upgrade -y"
+        _cmd = "apt-get dist-upgrade -y"
         try:
             log("Upgrading system")
             if self.sudo:

--- a/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
+++ b/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
@@ -21,6 +21,7 @@ from .common import *
 try:
     from subprocess import check_output
     from subprocess import call
+    from subprocess import CalledProcessError    
 except:
     log('subprocess import error')
 
@@ -120,6 +121,12 @@ class ShellHandlerApt:
         return True
 
     def _getpassword(self):
-        if len(self._pwd) == 0:
-            self._pwd = get_password_from_user()
-        return self._pwd
+        try:
+            check_output('sudo -n true',shell=True)
+            log("No mandatory password")
+            return self._pwd
+        except CalledProcessError as sudotest:
+            log("Mandatory password for [SUDO]")
+            if len(self._pwd) == 0:
+                self._pwd = get_password_from_user()
+            return self._pwd

--- a/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
+++ b/addons/service.xbmc.versioncheck/lib/shellhandlerapt.py
@@ -23,7 +23,7 @@ try:
     from subprocess import call
     from subprocess import CalledProcessError
 except Exception as error:
-    log('subprocess import error :%s' %error,xbmc.LOGERROR)
+    log('subprocess import error :%s' %error,xbmc.LOGWARNING)
 
 class ShellHandlerApt:
 
@@ -34,7 +34,7 @@ class ShellHandlerApt:
         installed, candidate = self._check_versions("kodi", False)
         if not installed:
             # there is no package installed via repo, so we exit here
-            log("No installed package found, exiting")
+            log("No installed package found, exiting",xbmc.LOGNOTICE)
             import sys
             sys.exit(0)
 
@@ -59,7 +59,7 @@ class ShellHandlerApt:
                 candidate = False
             return installed, candidate
         else:
-            log("ShellHandlerApt: error during version check")
+            log("ShellHandlerApt: error during version check",xbmc.LOGERROR)
             return False, False
 
     def _update_cache(self):
@@ -69,7 +69,7 @@ class ShellHandlerApt:
                 x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
             else:
                 x = check_output(_cmd.split())
-            log("Update cache successful")
+            log("Update cache successful",xbmc.LOGNOTICE)
         except Exception as error:
             log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False
@@ -85,9 +85,9 @@ class ShellHandlerApt:
                 log("Version available  %s" %candidate)
                 return True
             else:
-                log("Already on newest version for %s" %package)
+                log("Already on newest version for %s" %package,xbmc.LOGNOTICE)
         elif not installed:
-                log("No installed package found for %s" %package)
+                log("No installed package found for %s" %package,xbmc.LOGNOTICE)
                 return False
         else:
             return False
@@ -99,7 +99,7 @@ class ShellHandlerApt:
                 x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
             else:
                 x = check_output(_cmd.split())
-            log("Install package %s successful" %package,True)
+            log("Install package %s successful" %package,xbmc.LOGNOTICE)
         except Exception as error:
             log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False
@@ -114,7 +114,7 @@ class ShellHandlerApt:
                 x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
             else:
                 x = check_output(_cmd.split())
-            log("Upgrade System successful")
+            log("Upgrade System successful",xbmc.LOGNOTICE)
         except Exception as error:
             log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
             return False
@@ -131,3 +131,37 @@ class ShellHandlerApt:
             if len(self._pwd) == 0:
                 self._pwd = get_password_from_user()
             return self._pwd
+
+    def check_upgrade_system_available(self):
+        _cmd = "apt list --upgradable"
+        try:
+            if self._update_cache():
+                if self.sudo:
+                    x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
+                else:
+                    x = check_output(_cmd.split())
+                n = len(x.splitlines())
+                if (n > 1):
+                    log("Upgrade system available",xbmc.LOGNOTICE)
+                    return True
+            log("No system update available",xbmc.LOGNOTICE)
+            return False
+        except Exception as error:
+            log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
+            return False
+
+        return True
+
+    def  autoremove_package(self):
+        _cmd = "apt-get autoremove -y "
+        try:
+            if self.sudo:
+                x = check_output('echo \'%s\' | sudo -S %s' %(self._getpassword(), _cmd), shell=True)
+            else:
+                x = check_output(_cmd.split())
+            log("Automatically remove old package successful",xbmc.LOGNOTICE)
+        except Exception as error:
+            log("Exception while executing shell command %s: %s" %(_cmd, error),xbmc.LOGERROR)
+            return False
+
+        return True

--- a/addons/service.xbmc.versioncheck/resources/language/English/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/English/strings.po
@@ -24,7 +24,15 @@ msgctxt "#32002"
 msgid "Visit Kodi.tv for more information."
 msgstr ""
 
-#empty strings from id 32003 to 32008
+#empty strings from id 32003 to 32006
+
+msgctxt "#32007"
+msgid "Check kodi upgrade available."
+msgstr ""
+
+msgctxt "#32008"
+msgid "Check system upgrade available."
+msgstr ""
 
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
@@ -58,7 +66,17 @@ msgctxt "#32016"
 msgid "There is a newer stable Kodi version available."
 msgstr ""
 
-#empty strings from id 32017 to 32019
+msgctxt "#32017"
+msgid "Do you want to system restart to finish the upgrade?"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Updates are available for the system, do you want to upgrade now?"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Updates are available for the system."
+msgstr ""
 
 msgctxt "#32020"
 msgid "General"
@@ -80,7 +98,21 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-#empty strings from id 32025 to 32029
+msgctxt "#32025"
+msgid "Use sudo"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Already on newest version for kodi."
+msgstr ""
+
+msgctxt "#32028"
+msgid "No system update available."
+msgstr ""
+
+msgctxt "#32029"
+msgid "Abort during upgrade."
+msgstr ""
 
 #. Used in OK dialog
 msgctxt "#32030"
@@ -110,4 +142,12 @@ msgstr ""
 #. Used in OK dialog
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
+msgstr ""
+
+msgctxt "#32037"
+msgid "Do you want checking updates?"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Autoremove old packages"
 msgstr ""

--- a/addons/service.xbmc.versioncheck/resources/language/French/strings.po
+++ b/addons/service.xbmc.versioncheck/resources/language/French/strings.po
@@ -24,6 +24,14 @@ msgctxt "#32002"
 msgid "Visit Kodi.tv for more information."
 msgstr "Consulter kodi.tv pour plus d'informations."
 
+msgctxt "#32007"
+msgid "Check kodi upgrade available."
+msgstr "Vérification de la mise à jour de Kodi"
+
+msgctxt "#32008"
+msgid "Check system upgrade available."
+msgstr "Vérification de la mise à jour système"
+
 msgctxt "#32009"
 msgid "Would you like to remove this reminder?"
 msgstr "Faut-il retirer ce rappel ?"
@@ -34,19 +42,19 @@ msgstr "Il est possible de l'activer / le désactiver depuis les paramètres de 
 
 msgctxt "#32011"
 msgid "Use your package manager(apt) to upgrade."
-msgstr "Utiliser votre gestionnaire de paquets (apt) pour mettre à niveau."
+msgstr "Utiliser votre gestionnaire de paquets (apt) pour la mise à jour."
 
 msgctxt "#32012"
 msgid "A new version is available, do you want to upgrade now?"
-msgstr "Une nouvelle version est disponible, faut-il mettre à niveau maintenant ?"
+msgstr "Une nouvelle version est disponible, faut-il effectuer la mise à jour maintenant ?"
 
 msgctxt "#32013"
 msgid "Upgrade successful"
-msgstr "Mise à niveau réussie"
+msgstr "Mise à jour réussie"
 
 msgctxt "#32014"
 msgid "Do you want to restart Kodi to finish the upgrade?"
-msgstr "Faut-il redémarrer Kodi pour terminer la mise à niveau ?"
+msgstr "Faut-il redémarrer Kodi pour terminer la mise à jour ?"
 
 msgctxt "#32015"
 msgid "Do you want to check the repository for a new version?"
@@ -55,6 +63,18 @@ msgstr "Faut-il vérifier sur le dépôt s’il existe une nouvelle version?"
 msgctxt "#32016"
 msgid "There is a newer stable Kodi version available."
 msgstr "Une nouvelle version stable de Kodi est disponible."
+
+msgctxt "#32017"
+msgid "Do you want to system restart to finish the upgrade?"
+msgstr "Voulez vous redémarrer le système pour finir la mise à jour?"
+
+msgctxt "#32018"
+msgid "Updates are available for the system, do you want to upgrade now?"
+msgstr "Des mise à jours sont disponibles pour le système. Voulez vous procéder à la mise à jour ?"
+
+msgctxt "#32019"
+msgid "Updates are available for the system."
+msgstr "Des mise à jours sont disponibles pour le système."
 
 msgctxt "#32020"
 msgid "General"
@@ -70,11 +90,27 @@ msgstr "Saisir le mot de passe"
 
 msgctxt "#32023"
 msgid "Linux: Upgrade complete system"
-msgstr "Linux : mettre à niveau le système complet"
+msgstr "Linux: Mettre à niveau le système complet"
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr "Linux : mettre à niveau en utilisant apt"
+msgstr "Linux: Mettre à niveau en utilisant apt"
+
+msgctxt "#32025"
+msgid "Use sudo"
+msgstr "Utiliser l'élévation de privilèges (sudo)"
+
+msgctxt "#32027"
+msgid "Already on newest version for kodi."
+msgstr "Vous avez déjà la dernier version de Kodi."
+
+msgctxt "#32028"
+msgid "No system update available."
+msgstr "Pas de mise à jour disponible pour votre système."
+
+msgctxt "#32029"
+msgid "Abort during upgrade."
+msgstr "Annulation pendant la mise à jour."
 
 msgctxt "#32030"
 msgid "A new stable version of Kodi is available."
@@ -99,3 +135,12 @@ msgstr "%s est utilisée alors que %s est disponible."
 msgctxt "#32035"
 msgid "It is recommended that you to upgrade to a newer version."
 msgstr "Il est recommandé de mettre à niveau vers une nouvelle version."
+
+msgctxt "#32037"
+msgid "Do you want checking updates?"
+msgstr "Voulez vous lancer une vérification des mise à jours ?"
+
+msgctxt "#32038"
+msgid "Autoremove old packages"
+msgstr "Nettoyer automatiquement les paquets obsolètes"
+

--- a/addons/service.xbmc.versioncheck/resources/settings.xml
+++ b/addons/service.xbmc.versioncheck/resources/settings.xml
@@ -2,7 +2,9 @@
 <settings>
     <category label="32020">
         <setting label="32021" type="bool" id="versioncheck_enable" default="true"/>
-        <setting label="32023" type="bool" id="upgrade_system" default="false"/>
-        <setting label="32024" type="bool" id="upgrade_apt" default="false"/>
+        <setting label="32024" type="bool" id="upgrade_apt" default="false" />
+        <setting label="32025" type="bool" id="upgrade_sudo" default="true" enable="eq(-1,true)" />
+	<setting label="32023" type="bool" id="upgrade_system" default="false" enable="eq(-2,true)"/>
+        <setting label="32038" type="bool" id="upgrade_autoremove" default="false" enable="eq(-1,true) + eq(-3,true)" />
     </category>
 </settings>

--- a/addons/service.xbmc.versioncheck/service.py
+++ b/addons/service.xbmc.versioncheck/service.py
@@ -95,11 +95,11 @@ def _versionchecklinux(packages):
                         message_upgrade_success()
                         message_restart()
                     else:
-                        log("Error during upgrade")
+                        log("Abort during upgrade %s" %packages[0],xbmc.LOGERROR)
         else:
-            log("Error: no handler found")
+            log("Error: no handler found",xbmc.LOGERROR)
     else:
-        log("Unsupported platform %s" %platform.dist()[0])
+        log("Unsupported platform %s" %platform.dist()[0],xbmc.LOGERROR)
         sys.exit(0)
 
 
@@ -108,5 +108,5 @@ if (__name__ == "__main__"):
     if ADDON.getSetting("versioncheck_enable") == "false":
         log("Disabled")
     else:
-        log('Version %s started' % ADDONVERSION)
+        log('Version %s started' % ADDONVERSION,xbmc.LOGINFO)
         Main()

--- a/addons/service.xbmc.versioncheck/service.py
+++ b/addons/service.xbmc.versioncheck/service.py
@@ -19,10 +19,10 @@
 
 import platform
 import xbmc
+import xbmcgui
 import lib.common
-from lib.common import log, dialog_yesno
+from lib.common import log, dialog_yesno, localise, wait_for_end_of_video
 from lib.common import upgrade_message as _upgrademessage
-from lib.common import upgrade_message2 as _upgrademessage2
 
 ADDON        = lib.common.ADDON
 ADDONVERSION = lib.common.ADDONVERSION
@@ -31,82 +31,99 @@ ADDONPATH    = lib.common.ADDONPATH
 ICON         = lib.common.ICON
 oldversion = False
 
-monitor = xbmc.Monitor()
 
 class Main:
     def __init__(self):
         linux = False
         packages = []
-
-        if monitor.waitForAbort(5):
-            sys.exit(0)
-
+        global dialogbg
+        dialogbg = xbmcgui.DialogProgressBG()
+        dialogbg.create('Version Check')
         if xbmc.getCondVisibility('System.Platform.Linux') and ADDON.getSetting("upgrade_apt") == 'true':
             packages = ['kodi']
-            _versionchecklinux(packages)
-        else:
-            oldversion, version_installed, version_available, version_stable = _versioncheck()
-            if oldversion:
-                _upgrademessage2( version_installed, version_available, version_stable, oldversion, False)
-                
-def _versioncheck():
-    # initial vars
-    from lib.jsoninterface import get_installedversion, get_versionfilelist
-    from lib.versions import compare_version
-    # retrieve versionlists from supplied version file
-    versionlist = get_versionfilelist()
-    # retrieve version installed
-    version_installed = get_installedversion()
-    # compare installed and available
-    oldversion, version_installed, version_available, version_stable = compare_version(version_installed, versionlist)
-    return oldversion, version_installed, version_available, version_stable
+            self._versionchecklinux(packages)
+        elif ADDON.getSetting("versioncheck_enable") == "true":
+            self._versioncheck()
+        dialogbg.close('Version Check')
 
+    def _versioncheck(self):
+        # initial vars
+        from lib.jsoninterface import get_installedversion, get_versionfilelist
+        from lib.versions import compare_version
+        # retrieve versionlists from supplied version file
+        versionlist = get_versionfilelist()
+        # retrieve version installed
+        version_installed = get_installedversion()
+        # copmpare installed and available
+        oldversion, version_installed, version_available, version_stable = compare_version(version_installed, versionlist)
+        if oldversion:
+            self._upgrademessage( version_installed, version_available, version_stable, oldversion, False)
+        dialogbg.update(100,'Version Check',localise(32027))
 
-def _versionchecklinux(packages):
-    if platform.dist()[0].lower() in ['ubuntu', 'debian', 'linuxmint']:
-        handler = False
-        result = False
-        try:
-            # try aptdaemon first
-            from lib.aptdaemonhandler import AptdaemonHandler
-            handler = AptdaemonHandler()
-        except:
-            # fallback to shell
-            # since we need the user password, ask to check for new version first
-            from lib.shellhandlerapt import ShellHandlerApt
-            sudo = True
-            handler = ShellHandlerApt(sudo)
-            if dialog_yesno(32015):
-                pass
-            elif dialog_yesno(32009, 32010):
-                log("disabling addon by user request")
-                ADDON.setSetting("versioncheck_enable", 'false')
-                return
-
-        if handler:
-            if handler.check_upgrade_available(packages[0]):
-                if _upgrademessage(32012, oldversion, True):
-                    if ADDON.getSetting("upgrade_system") == "false":
+    def _versionchecklinux(self,packages):
+        if platform.dist()[0].lower() in ['ubuntu', 'debian', 'linuxmint']:
+            handler = False
+            result = False
+            try:
+                # try aptdaemon first
+                from lib.aptdaemonhandler import AptdaemonHandler
+                handler = AptdaemonHandler()
+            except:
+                # fallback to shell
+                # since we need the user password, ask to check for new version first
+                from lib.shellhandlerapt import ShellHandlerApt
+                sudo = False
+                if ADDON.getSetting("upgrade_sudo") == "true":
+                    sudo = True
+                handler = ShellHandlerApt(sudo)
+            if handler:
+                if ADDON.getSetting("versioncheck_enable") == "true":
+                    dialogbg.update(10,'Version Check',localise(32007))
+                    if handler.check_upgrade_available(packages[0]):
+                        dialogbg.update(20,'Version Check',localise(32016))
                         result = handler.upgrade_package(packages[0])
+                        if result:
+                            from lib.common import message_upgrade_success, message_restart_app
+                            dialogbg.update(20,'Version Check',localise(32013))
+                            message_upgrade_success()
+                            message_restart()
+                        else:
+                            log("Abort during upgrade %s" %packages[0],xbmc.LOGERROR)
+                            dialogbg.update(20,'Version Check',localise(32029))
                     else:
-                        result = handler.upgrade_system()
-                    if result:
-                        from lib.common import message_upgrade_success, message_restart
-                        message_upgrade_success()
-                        message_restart()
+                        dialogbg.update(50,'Version Check',localise(32027))
+                if ADDON.getSetting("upgrade_system") == "true":
+                    dialogbg.update(60,'Version Check', localise (32008))
+                    if handler.check_upgrade_system_available():
+                        dialogbg.update(80,'Version Check',localise(32019))
+                        if dialog_yesno(32018):
+                          if ADDON.getSetting("upgrade_autoremove"):
+                            handler.autoremove_package()
+                          result = handler.upgrade_system()
+                          if result:
+                              from lib.common import message_upgrade_success, message_restart_system
+                              dialogbg.update(80,'Version Check',localise(32013))
+                              message_upgrade_success()
+                              message_restart_system()
+                          else:
+                              log("Abort during upgrade system",xbmc.LOGERROR)
+                              dialogbg.update(80,'Version Check',localise(32029))
                     else:
-                        log("Abort during upgrade %s" %packages[0],xbmc.LOGERROR)
+                        dialogbg.update(100,'Version Check',localise(32028))
+                dialogbg.update(100,'Version Check','')
+            else:
+                log("Error: no handler found",xbmc.LOGERROR)
+                dialogbg.update(100,'Version Check',localise(32029))
         else:
-            log("Error: no handler found",xbmc.LOGERROR)
-    else:
-        log("Unsupported platform %s" %platform.dist()[0],xbmc.LOGERROR)
-        sys.exit(0)
-
-
+            log("Unsupported platform %s" %platform.dist()[0],xbmc.LOGERROR)
+            sys.exit(0)
 
 if (__name__ == "__main__"):
-    if ADDON.getSetting("versioncheck_enable") == "false":
-        log("Disabled")
-    else:
-        log('Version %s started' % ADDONVERSION,xbmc.LOGINFO)
+    log('Service started',xbmc.LOGNOTICE)
+    monitor = xbmc.Monitor()
+    while not monitor.abortRequested():
+        wait_for_end_of_video()
         Main()
+        if monitor.waitForAbort(86400):
+            log('Bye bye',xbmc.LOGNOTICE)
+            break


### PR DESCRIPTION
Correction of anomaly and improvement of the service

## Description
I propose three evolutions of the service
Test if a password is required for sudo
Improved tracks for better visibility
Correct the update of the APT system
Fixed the display in UTF8. It was missing the library import
Replacing message boxes with dialog background

A commit by update

v0.3.30
- Replace the message box with a dialog backgroun box
- Choice System update or Kodi update or the both
- Add choice for autoremove old packages if system update
- Fix unicodedata (missing import)

v0.3.281
- Fix Apt Upgrade

v0.3.28
-  Improvement of log's traces

v0.3.27
- Test mandatory password for sudo

## Motivation and Context
The system update was only effective if there was an update of Kodi. I wanted to be able to treat both without depending on one or the other
Fix the display, forget the import of a library
Allow treatment in the background

## How Has This Been Tested?
Test on Ubuntu 17.10, 18.04, Raspberry pi 2 Stretch
with Kodi 18 alpha 2

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ X ] Improvement (non-breaking change which improves existing functionality)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X  ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ X ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ X ] All new and existing tests passed
