### PR TITLE
[xbmc] move registration powersyscall and remote control to platform …

### DIFF
--- a/xbmc/platform/darwin/CMakeLists.txt
+++ b/xbmc/platform/darwin/CMakeLists.txt
@@ -2,15 +2,13 @@ set(SOURCES AutoPool.mm
             DarwinUtils.mm
             DarwinNSUserDefaults.mm
             DictionaryUtils.mm
-            OSXGNUReplacements.c
-            PlatformDarwin.cpp)
+            OSXGNUReplacements.c)
 
 set(HEADERS AutoPool.h
             DarwinNSUserDefaults.h
             DarwinUtils.h
             DictionaryUtils.h
             NSLogDebugHelpers.h
-            OSXGNUReplacements.h
-            PlatformDarwin.h)
+            OSXGNUReplacements.h)
 
 core_add_library(platform_darwin)

--- a/xbmc/platform/overrides/android/PlatformAndroid.cpp
+++ b/xbmc/platform/overrides/android/PlatformAndroid.cpp
@@ -21,6 +21,10 @@
 #include "PlatformAndroid.h"
 #include <stdlib.h>
 #include "filesystem/SpecialProtocol.h"
+#include "platform/android/powermanagement/AndroidPowerSyscall.h"
+#if HAS_LIRC
+#include "platform/linux/input/LIRC.h"
+#endif
 
 CPlatform* CPlatform::CreateInstance()
 {
@@ -39,5 +43,9 @@ CPlatformAndroid::~CPlatformAndroid()
 
 void CPlatformAndroid::Init()
 {
-    setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+  CAndroidPowerSyscall::Register();
+#if HAS_LIRC
+  CRemoteControl::Register();
+#endif
 }

--- a/xbmc/platform/overrides/freebsd/PlatformFreeBSD.cpp
+++ b/xbmc/platform/overrides/freebsd/PlatformFreeBSD.cpp
@@ -18,21 +18,25 @@
  *
  */
 
-#include "PlatformDarwin.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
+#include "PlatformFreeBSD.h"
+#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
+#if HAS_LIRC
+#include "platform/linux/input/LIRC.h"
+#endif
 
-CPlatformDarwin::CPlatformDarwin()
+CPlatform* CPlatform::CreateInstance()
 {
-  
+  return new CPlatformFreeBSD();
 }
 
-CPlatformDarwin::~CPlatformDarwin()
-{
-  
-}
+CPlatformFreeBSD::CPlatformFreeBSD() = default;
 
-void CPlatformDarwin::Init()
+CPlatformFreeBSD::~CPlatformFreeBSD() = default;
+
+void CPlatformFreeBSD::Init()
 {
-    setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
+  CLinuxPowerSyscall::Register();
+#if HAS_LIRC
+  CRemoteControl::Register();
+#endif
 }

--- a/xbmc/platform/overrides/freebsd/PlatformFreeBSD.h
+++ b/xbmc/platform/overrides/freebsd/PlatformFreeBSD.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  *      Copyright (C) 2016 Team Kodi
  *      http://kodi.tv
@@ -18,28 +20,16 @@
  *
  */
 
-#include "PlatformDarwinOSX.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
-#if HAS_LIRC
-#include "platform/linux/input/LIRC.h"
-#endif
+#include "platform/Platform.h"
 
-CPlatform* CPlatform::CreateInstance()
+class CPlatformFreeBSD : public CPlatform
 {
-  return new CPlatformDarwinOSX();
-}
-
-CPlatformDarwinOSX::CPlatformDarwinOSX() = default;
-
-CPlatformDarwinOSX::~CPlatformDarwinOSX() = default;
-
-void CPlatformDarwinOSX::Init()
-{
-  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
-  CCocoaPowerSyscall::Register();
-#if HAS_LIRC
-  CRemoteControl::Register();
-#endif
-}
+  public:
+    /**\brief C'tor */
+    CPlatformFreeBSD();
+  
+    /**\brief D'tor */
+    virtual ~CPlatformFreeBSD();
+  
+    void Init() override;
+};

--- a/xbmc/platform/overrides/ios/PlatformDarwinIOS.cpp
+++ b/xbmc/platform/overrides/ios/PlatformDarwinIOS.cpp
@@ -18,11 +18,26 @@
  *
  */
 
-#include "platform/darwin/PlatformDarwin.h"
+#include "PlatformDarwinIOS.h"
 #include <stdlib.h>
 #include "filesystem/SpecialProtocol.h"
+#if HAS_LIRC
+#include "platform/linux/input/LIRC.h"
+#endif
 
 CPlatform* CPlatform::CreateInstance()
 {
-  return new CPlatformDarwin();
+  return new CPlatformDarwinIOS();
+}
+
+CPlatformDarwinIOS::CPlatformDarwinIOS() = default;
+
+CPlatformDarwinIOS::~CPlatformDarwinIOS() = default;
+
+void CPlatformDarwinIOS::Init()
+{
+  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
+#if HAS_LIRC
+  CRemoteControl::Register();
+#endif
 }

--- a/xbmc/platform/overrides/ios/PlatformDarwinIOS.h
+++ b/xbmc/platform/overrides/ios/PlatformDarwinIOS.h
@@ -22,14 +22,14 @@
 
 #include "platform/Platform.h"
 
-class CPlatformDarwin : public CPlatform
+class CPlatformDarwinIOS : public CPlatform
 {
   public:
     /**\brief C'tor */
-    CPlatformDarwin();
+    CPlatformDarwinIOS();
   
     /**\brief D'tor */
-    virtual ~CPlatformDarwin();
+    virtual ~CPlatformDarwinIOS();
   
     void Init() override;
 };

--- a/xbmc/platform/overrides/linux/PlatformLinux.cpp
+++ b/xbmc/platform/overrides/linux/PlatformLinux.cpp
@@ -18,27 +18,24 @@
  *
  */
 
-#include "PlatformDarwinOSX.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
+#include "PlatformLinux.h"
+#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 #if HAS_LIRC
 #include "platform/linux/input/LIRC.h"
 #endif
 
 CPlatform* CPlatform::CreateInstance()
 {
-  return new CPlatformDarwinOSX();
+  return new CPlatformLinux();
 }
 
-CPlatformDarwinOSX::CPlatformDarwinOSX() = default;
+CPlatformLinux::CPlatformLinux() = default;
 
-CPlatformDarwinOSX::~CPlatformDarwinOSX() = default;
+CPlatformLinux::~CPlatformLinux() = default;
 
-void CPlatformDarwinOSX::Init()
+void CPlatformLinux::Init()
 {
-  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
-  CCocoaPowerSyscall::Register();
+  CLinuxPowerSyscall::Register();
 #if HAS_LIRC
   CRemoteControl::Register();
 #endif

--- a/xbmc/platform/overrides/linux/PlatformLinux.h
+++ b/xbmc/platform/overrides/linux/PlatformLinux.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  *      Copyright (C) 2016 Team Kodi
  *      http://kodi.tv
@@ -18,28 +20,16 @@
  *
  */
 
-#include "PlatformDarwinOSX.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
-#if HAS_LIRC
-#include "platform/linux/input/LIRC.h"
-#endif
+#include "platform/Platform.h"
 
-CPlatform* CPlatform::CreateInstance()
+class CPlatformLinux : public CPlatform
 {
-  return new CPlatformDarwinOSX();
-}
-
-CPlatformDarwinOSX::CPlatformDarwinOSX() = default;
-
-CPlatformDarwinOSX::~CPlatformDarwinOSX() = default;
-
-void CPlatformDarwinOSX::Init()
-{
-  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
-  CCocoaPowerSyscall::Register();
-#if HAS_LIRC
-  CRemoteControl::Register();
-#endif
-}
+  public:
+    /**\brief C'tor */
+    CPlatformLinux();
+  
+    /**\brief D'tor */
+    virtual ~CPlatformLinux();
+  
+    void Init() override;
+};

--- a/xbmc/platform/overrides/osx/PlatformDarwinOSX.h
+++ b/xbmc/platform/overrides/osx/PlatformDarwinOSX.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  *      Copyright (C) 2016 Team Kodi
  *      http://kodi.tv
@@ -18,28 +20,16 @@
  *
  */
 
-#include "PlatformDarwinOSX.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
-#if HAS_LIRC
-#include "platform/linux/input/LIRC.h"
-#endif
+#include "platform/Platform.h"
 
-CPlatform* CPlatform::CreateInstance()
+class CPlatformDarwinOSX : public CPlatform
 {
-  return new CPlatformDarwinOSX();
-}
-
-CPlatformDarwinOSX::CPlatformDarwinOSX() = default;
-
-CPlatformDarwinOSX::~CPlatformDarwinOSX() = default;
-
-void CPlatformDarwinOSX::Init()
-{
-  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
-  CCocoaPowerSyscall::Register();
-#if HAS_LIRC
-  CRemoteControl::Register();
-#endif
-}
+  public:
+    /**\brief C'tor */
+    CPlatformDarwinOSX();
+  
+    /**\brief D'tor */
+    virtual ~CPlatformDarwinOSX();
+  
+    void Init() override;
+};

--- a/xbmc/platform/overrides/windows/PlatformWin32.cpp
+++ b/xbmc/platform/overrides/windows/PlatformWin32.cpp
@@ -18,28 +18,21 @@
  *
  */
 
-#include "PlatformDarwinOSX.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
-#if HAS_LIRC
-#include "platform/linux/input/LIRC.h"
-#endif
+#include "PlatformWin32.h"
+#include "platform/win32/input/IRServerSuite.h"
+#include "platform/win32/powermanagement/Win32PowerSyscall.h"
 
 CPlatform* CPlatform::CreateInstance()
 {
-  return new CPlatformDarwinOSX();
+  return new CPlatformWin32();
 }
 
-CPlatformDarwinOSX::CPlatformDarwinOSX() = default;
+CPlatformWin32::CPlatformWin32() = default;
 
-CPlatformDarwinOSX::~CPlatformDarwinOSX() = default;
+CPlatformWin32::~CPlatformWin32() = default;
 
-void CPlatformDarwinOSX::Init()
+void CPlatformWin32::Init()
 {
-  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
-  CCocoaPowerSyscall::Register();
-#if HAS_LIRC
   CRemoteControl::Register();
-#endif
+  CWin32PowerSyscall::Register();
 }

--- a/xbmc/platform/overrides/windows/PlatformWin32.h
+++ b/xbmc/platform/overrides/windows/PlatformWin32.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  *      Copyright (C) 2016 Team Kodi
  *      http://kodi.tv
@@ -18,28 +20,16 @@
  *
  */
 
-#include "PlatformDarwinOSX.h"
-#include <stdlib.h>
-#include "filesystem/SpecialProtocol.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
-#if HAS_LIRC
-#include "platform/linux/input/LIRC.h"
-#endif
+#include "platform/Platform.h"
 
-CPlatform* CPlatform::CreateInstance()
+class CPlatformWin32 : public CPlatform
 {
-  return new CPlatformDarwinOSX();
-}
-
-CPlatformDarwinOSX::CPlatformDarwinOSX() = default;
-
-CPlatformDarwinOSX::~CPlatformDarwinOSX() = default;
-
-void CPlatformDarwinOSX::Init()
-{
-  setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 0);
-  CCocoaPowerSyscall::Register();
-#if HAS_LIRC
-  CRemoteControl::Register();
-#endif
-}
+  public:
+    /**\brief C'tor */
+    CPlatformWin32();
+  
+    /**\brief D'tor */
+    virtual ~CPlatformWin32();
+  
+    void Init() override;
+};

--- a/xbmc/platform/overrides/windowsstore/PlatformWin10.cpp
+++ b/xbmc/platform/overrides/windowsstore/PlatformWin10.cpp
@@ -22,6 +22,9 @@
 #include <stdlib.h>
 #include "filesystem/SpecialProtocol.h"
 #include "platform/Environment.h"
+#include "platform/win10/input/RemoteControlXbox.h"
+#include "platform/win10/powermanagement/Win10PowerSyscall.h"
+#include "utils/SystemInfo.h"
 
 CPlatform* CPlatform::CreateInstance()
 {
@@ -35,4 +38,9 @@ CPlatformWin10::~CPlatformWin10() = default;
 void CPlatformWin10::Init()
 {
   CEnvironment::setenv("SSL_CERT_FILE", CSpecialProtocol::TranslatePath("special://xbmc/system/certs/cacert.pem").c_str(), 1);
+  CPowerSyscall::Register();
+  if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Xbox)
+  {
+    CRemoteControlXbox::Register();
+  }
 }

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -30,9 +30,6 @@
 #if HAS_GLES
 #include "guilib/GUIFontTTFGL.h"
 #endif
-#if HAS_LIRC
-#include "platform/linux/input/LIRC.h"
-#endif
 
 CWinSystemBase::CWinSystemBase()
 {
@@ -42,9 +39,6 @@ CWinSystemBase::CWinSystemBase()
     m_gfxContext->ResetScreenParameters((RESOLUTION)i);
     m_gfxContext->ResetOverscan((RESOLUTION)i, CDisplaySettings::GetInstance().GetResolutionInfo(i).Overscan);
   }
-#if HAS_LIRC
-  CRemoteControl::Register();
-#endif
 }
 
 CWinSystemBase::~CWinSystemBase() = default;

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -41,7 +41,6 @@
 #include "WinEventsX11.h"
 #include "input/InputManager.h"
 #include "OSScreenSaverX11.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 
 using namespace KODI::MESSAGING;
 using namespace KODI::WINDOWING;
@@ -64,7 +63,6 @@ CWinSystemX11::CWinSystemX11() : CWinSystemBase()
 
   m_winEventsX11 = new CWinEventsX11(*this);
   m_winEvents.reset(m_winEventsX11);
-  CLinuxPowerSyscall::Register();
 }
 
 CWinSystemX11::~CWinSystemX11() = default;

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -34,7 +34,6 @@
 #include "cores/AudioEngine/Sinks/AESinkALSA.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/Resolution.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 #include "settings/Settings.h"
 #include "settings/DisplaySettings.h"
 #include "guilib/DispResource.h"
@@ -79,7 +78,6 @@ CWinSystemAmlogic::CWinSystemAmlogic()
   // Register sink
   AE::CAESinkFactory::ClearSinks();
   CAESinkALSA::Register();
-  CLinuxPowerSyscall::Register();
 }
 
 CWinSystemAmlogic::~CWinSystemAmlogic()

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -40,7 +40,6 @@
 #include "cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h"
-#include "platform/android/powermanagement/AndroidPowerSyscall.h"
 #include "addons/interfaces/platform/android/System.h"
 
 #include <EGL/egl.h>
@@ -62,7 +61,6 @@ CWinSystemAndroid::CWinSystemAndroid()
   m_android = nullptr;
 
   m_winEvents.reset(new CWinEventsAndroid());
-  CAndroidPowerSyscall::Register();
 }
 
 CWinSystemAndroid::~CWinSystemAndroid()

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -27,7 +27,6 @@
 
 #include "OptionalsReg.h"
 #include "windowing/GraphicContext.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 #include "settings/DisplaySettings.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
@@ -69,7 +68,6 @@ CWinSystemGbm::CWinSystemGbm() :
   }
 
   m_winEvents.reset(new CWinEventsLinux());
-  CLinuxPowerSyscall::Register();
 }
 
 bool CWinSystemGbm::InitWindowSystem()

--- a/xbmc/windowing/mir/WinSystemMir.cpp
+++ b/xbmc/windowing/mir/WinSystemMir.cpp
@@ -24,7 +24,6 @@
 #include <string.h>
 
 #include "windowing/GraphicContext.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 #include "settings/DisplaySettings.h"
 #include "utils/log.h"
 #include "WinEventsMir.h"
@@ -36,7 +35,6 @@ CWinSystemMir::CWinSystemMir() :
 {
   m_eWindowSystem = WINDOW_SYSTEM_MIR;
   m_winEvents.reset(new CWinEventsMir());
-  CLinuxPowerSyscall::Register();
 }
 
 bool CWinSystemMir::InitWindowSystem()

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -38,7 +38,6 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.h"
 #include "guilib/DispResource.h"
 #include "guilib/GUIWindowManager.h"
-#include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/DisplaySettings.h"
@@ -618,7 +617,6 @@ CWinSystemOSX::CWinSystemOSX() : CWinSystemBase(), m_lostDeviceTimer(this)
 
   AE::CAESinkFactory::ClearSinks();
   CAESinkDARWINOSX::Register();
-  CCocoaPowerSyscall::Register();
 }
 
 CWinSystemOSX::~CWinSystemOSX()

--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -35,7 +35,6 @@
 #include "../WinEventsLinux.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/AESinkPi.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglplatform.h>
@@ -56,7 +55,6 @@ CWinSystemRpi::CWinSystemRpi()
   m_winEvents.reset(new CWinEventsLinux());
   AE::CAESinkFactory::ClearSinks();
   CAESinkPi::Register();
-  CLinuxPowerSyscall::Register();
 }
 
 CWinSystemRpi::~CWinSystemRpi()

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -34,7 +34,6 @@
 #include "input/InputManager.h"
 #include "input/touch/generic/GenericTouchActionHandler.h"
 #include "input/touch/generic/GenericTouchInputHandler.h"
-#include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 #include "platform/linux/PlatformConstants.h"
 #include "platform/linux/TimeUtils.h"
 #include "messaging/ApplicationMessenger.h"
@@ -173,7 +172,6 @@ CWinSystemWayland::CWinSystemWayland()
     }
   }
   m_winEvents.reset(new CWinEventsWayland());
-  CLinuxPowerSyscall::Register();
 }
 
 CWinSystemWayland::~CWinSystemWayland() noexcept

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -26,8 +26,6 @@
 #include "windowing/GraphicContext.h"
 #include "messaging/ApplicationMessenger.h"
 #include "platform/win10/AsyncHelpers.h"
-#include "platform/win10/input/RemoteControlXbox.h"
-#include "platform/win10/powermanagement/Win10PowerSyscall.h"
 #include "platform/win32/CharsetConverter.h"
 #include "rendering/dx/DirectXHelper.h"
 #include "rendering/dx/RenderContext.h"
@@ -74,11 +72,6 @@ CWinSystemWin10::CWinSystemWin10()
   {
     CAESinkWASAPI::Register();
   }
-  else if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::WindowsDeviceFamily::Xbox)
-  {
-    CRemoteControlXbox::Register();
-  }
-  CPowerSyscall::Register();
 }
 
 CWinSystemWin10::~CWinSystemWin10()

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -29,8 +29,6 @@
 #include "guilib/gui3d.h"
 #include "messaging/ApplicationMessenger.h"
 #include "platform/win32/CharsetConverter.h"
-#include "platform/win32/input/IRServerSuite.h"
-#include "platform/win32/powermanagement/Win32PowerSyscall.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -68,8 +66,6 @@ CWinSystemWin32::CWinSystemWin32()
   AE::CAESinkFactory::ClearSinks();
   CAESinkDirectSound::Register();
   CAESinkWASAPI::Register();
-  CWin32PowerSyscall::Register();
-  CRemoteControl::Register();
 }
 
 CWinSystemWin32::~CWinSystemWin32()


### PR DESCRIPTION
…overrides.

## Description
not all things can be registered at windowing initialization.
this fixes the late registration of powersyscall implementation and returns proper powermanager functionality.

I've moved registration of remote control to platform. I think it's the best place to register such things.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
Tested on `Win32-x64` and `WinUWP-x64`

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
