### PR TITLE
[PVR] Fix label2 for recordings file items after #11691.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -206,7 +206,7 @@ CFileItem::CFileItem(const CPVRRecordingPtr& record)
   m_pvrRecordingInfoTag = record;
   m_strPath = record->m_strFileNameAndPath;
   SetLabel(record->m_strTitle);
-  m_strLabel2 = record->m_strPlot;
+  m_strLabel2 = record->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false);
   FillInMimeType(false);
 }
 

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -324,9 +324,7 @@ bool CPVRRecordings::GetDirectory(const std::string& strPath, CFileItemList &ite
       current->UpdateMetadata(GetVideoDatabase());
 
       CFileItemPtr pFileItem(new CFileItem(current));
-      pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));
       pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
-      pFileItem->SetPath(current->m_strFileNameAndPath);
 
       // Set art
       if (!current->m_strIconPath.empty())
@@ -365,9 +363,7 @@ void CPVRRecordings::GetAll(CFileItemList &items, bool bDeleted)
     current->UpdateMetadata(GetVideoDatabase());
 
     CFileItemPtr pFileItem(new CFileItem(current));
-    pFileItem->SetLabel2(current->RecordingTimeAsLocalTime().GetAsLocalizedDateTime(true, false));
     pFileItem->m_dateTime = current->RecordingTimeAsLocalTime();
-    pFileItem->SetPath(current->m_strFileNameAndPath);
     pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pFileItem->GetPVRRecordingInfoTag()->GetPlayCount() > 0);
 
     items.Add(pFileItem);


### PR DESCRIPTION
#11691 revealed an ancient bug in the implementation of `CFileItem` carrying a `CPVRRecording`, which can be spotted as a visual glitch in "my recordings" window:.

![screenshot001](https://user-images.githubusercontent.com/3226626/38643883-f5b5f832-3dde-11e8-9b4b-f988e435c4f7.png)

Under some circumstances, triggered by the change #11691 introduced, Label2 of the item erroneously will be set to the recording's plot instead of the recording's time. Funny.

@Jalle19 mind taking a look.