### PR TITLE
[application] fix broken powermanagement after #13748.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -586,14 +586,14 @@ bool CApplication::Create(const CAppParamParser &params)
   CWIN32Util::SetThreadLocalLocale(true); // enable independent locale for each thread, see https://connect.microsoft.com/VisualStudio/feedback/details/794122
 #endif // TARGET_WINDOWS
 
+  // audio (OSX) depends on WinSystem
+  m_pWinSystem = CWinSystemBase::CreateWinSystem();
+  CServiceBroker::RegisterWinSystem(m_pWinSystem.get());
+
   if (!m_ServiceManager->InitStageTwo(params))
   {
     return false;
   }
-
-  // audio (OSX) depends on WinSystem
-  m_pWinSystem = CWinSystemBase::CreateWinSystem();
-  CServiceBroker::RegisterWinSystem(m_pWinSystem.get());
 
   m_pActiveAE.reset(new ActiveAE::CActiveAE());
   // start the AudioEngine


### PR DESCRIPTION
As I commented in #13748, that PR completely killed powermanagement functionality, because powermanager was no longer inited correctly.

This PR is my suggestion to fix this problem.  I runtime-tested it on macOS; no side effects spotted.

@Rechi @FernetMenta your opinion?