### PR TITLE
add application inbound port as a service

### DIFF
--- a/xbmc/AppInboundProtocol.cpp
+++ b/xbmc/AppInboundProtocol.cpp
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2005-2018 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AppInboundProtocol.h"
+#include "Application.h"
+
+CAppInboundProtocol::CAppInboundProtocol(CApplication &app) : m_pApp(app)
+{
+
+}
+
+bool CAppInboundProtocol::OnEvent(XBMC_Event &event)
+{
+  return m_pApp.OnEvent(event);
+}
+
+void CAppInboundProtocol::SetRenderGUI(bool renderGUI)
+{
+  m_pApp.SetRenderGUI(renderGUI);
+}

--- a/xbmc/AppInboundProtocol.h
+++ b/xbmc/AppInboundProtocol.h
@@ -1,0 +1,36 @@
+/*
+ *      Copyright (C) 2005-2018 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "windowing/XBMC_events.h"
+
+class CApplication;
+
+class CAppInboundProtocol
+{
+public:
+  CAppInboundProtocol(CApplication &app);
+  bool OnEvent(XBMC_Event &event);
+  void SetRenderGUI(bool renderGUI);
+
+protected:
+  CApplication &m_pApp;
+};

--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES Application.cpp
+            AppInboundProtocol.cpp
             ApplicationPlayer.cpp
             ApplicationStackHelper.cpp
             AppParamParser.cpp
@@ -39,6 +40,7 @@ set(SOURCES Application.cpp
 
 set(HEADERS AppParamParser.h
             Application.h
+            AppInboundProtocol.h
             ApplicationPlayer.h
             ApplicationStackHelper.h
             AutoSwitch.h
@@ -97,4 +99,3 @@ endif()
 if(CORE_SYSTEM_NAME STREQUAL windowsstore)
   set_target_properties(${CORE_LIBRARY} PROPERTIES STATIC_LIBRARY_FLAGS "/ignore:4264")
 endif()
-

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -227,3 +227,18 @@ void CServiceBroker::UnregisterAE()
 {
   m_pActiveAE = nullptr;
 }
+
+// application
+std::shared_ptr<CAppInboundProtocol> CServiceBroker::m_pAppPort;
+std::shared_ptr<CAppInboundProtocol> CServiceBroker::GetAppPort()
+{
+  return m_pAppPort;
+}
+void CServiceBroker::RegisterAppPort(std::shared_ptr<CAppInboundProtocol> port)
+{
+  m_pAppPort = port;
+}
+void CServiceBroker::UnregisterAppPort()
+{
+  m_pAppPort.reset();
+}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <memory>
+
 namespace ADDON {
 class CAddonMgr;
 class CBinaryAddonManager;
@@ -62,6 +64,7 @@ class CDatabaseManager;
 class CProfilesManager;
 class CEventLog;
 class CGUIComponent;
+class CAppInboundProtocol;
 
 namespace KODI
 {
@@ -128,8 +131,13 @@ public:
   static void RegisterAE(IAE *ae);
   static void UnregisterAE();
 
+  static std::shared_ptr<CAppInboundProtocol> GetAppPort();
+  static void RegisterAppPort(std::shared_ptr<CAppInboundProtocol> port);
+  static void UnregisterAppPort();
+
 private:
   static CGUIComponent* m_pGUI;
   static CWinSystemBase* m_pWinSystem;
   static IAE* m_pActiveAE;
+  static std::shared_ptr<CAppInboundProtocol> m_pAppPort;
 };

--- a/xbmc/XBApplicationEx.h
+++ b/xbmc/XBApplicationEx.h
@@ -48,7 +48,6 @@ public:
   // Overridable functions for the 3D scene created by the app
   virtual bool Initialize() { return true; }
   virtual bool Cleanup() { return true; }
-  virtual void SetRenderGUI(bool renderGUI) {};
 
 public:
   int Run(const CAppParamParser &params);

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -52,6 +52,7 @@
 #include "Util.h"
 #include "settings/Settings.h"
 #include "AppParamParser.h"
+#include "AppInboundProtocol.h"
 
 #include <algorithm>
 
@@ -281,7 +282,7 @@ bool CInputManager::ProcessEventServer(int windowId, float frameTime)
       newEvent.type = XBMC_MOUSEMOTION;
       newEvent.motion.x = (uint16_t)pos.x;
       newEvent.motion.y = (uint16_t)pos.y;
-      g_application.OnEvent(newEvent);  // had to call this to update g_Mouse position
+      CServiceBroker::GetAppPort()->OnEvent(newEvent);  // had to call this to update g_Mouse position
       return g_application.OnAction(CAction(ACTION_MOUSE_MOVE, pos.x, pos.y));
     }
   }

--- a/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
+++ b/xbmc/input/touch/generic/GenericTouchActionHandler.cpp
@@ -22,7 +22,7 @@
 
 #include <cmath>
 
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "guilib/GUIComponent.h"
@@ -171,7 +171,7 @@ int CGenericTouchActionHandler::QuerySupportedGestures(float x, float y)
 void CGenericTouchActionHandler::sendEvent(int actionId, float x, float y, float x2 /* = 0.0f */, float y2 /* = 0.0f */, float x3, float y3, int pointers /* = 1 */)
 {
   XBMC_Event newEvent{XBMC_TOUCH};
-  
+
   newEvent.touch.action = actionId;
   newEvent.touch.x = x;
   newEvent.touch.y = y;
@@ -181,7 +181,9 @@ void CGenericTouchActionHandler::sendEvent(int actionId, float x, float y, float
   newEvent.touch.y3 = y3;
   newEvent.touch.pointers = pointers;
 
-  g_application.OnEvent(newEvent);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(newEvent);
 }
 
 void CGenericTouchActionHandler::focusControl(float x, float y)
@@ -191,5 +193,7 @@ void CGenericTouchActionHandler::focusControl(float x, float y)
   newEvent.focus.x = static_cast<int> (std::round(x));
   newEvent.focus.y = static_cast<int> (std::round(y));
 
-  g_application.OnEvent(newEvent);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(newEvent);
 }

--- a/xbmc/platform/android/activity/AndroidMouse.cpp
+++ b/xbmc/platform/android/activity/AndroidMouse.cpp
@@ -21,7 +21,7 @@
 #include "AndroidMouse.h"
 #include "AndroidExtra.h"
 #include "XBMCApp.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/mouse/MouseStat.h"
 #include "ServiceBroker.h"
@@ -82,7 +82,9 @@ void CAndroidMouse::MouseMove(float x, float y)
   newEvent.type = XBMC_MOUSEMOTION;
   newEvent.motion.x = x;
   newEvent.motion.y = y;
-  g_application.OnEvent(newEvent);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(newEvent);
 }
 
 void CAndroidMouse::MouseButton(float x, float y, int32_t action, int32_t buttons)
@@ -107,7 +109,10 @@ void CAndroidMouse::MouseButton(float x, float y, int32_t action, int32_t button
     newEvent.button.button = XBMC_BUTTON_RIGHT;
   else if (checkButtons & AMOTION_EVENT_BUTTON_TERTIARY)
     newEvent.button.button = XBMC_BUTTON_MIDDLE;
-  g_application.OnEvent(newEvent);
+
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(newEvent);
 
   m_lastButtonState = buttons;
 }
@@ -137,7 +142,9 @@ void CAndroidMouse::MouseWheel(float x, float y, float value)
   newEvent.button.x = x;
   newEvent.button.y = y;
 
-  g_application.OnEvent(newEvent);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(newEvent);
 
   newEvent.type = XBMC_MOUSEBUTTONUP;
 

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -24,6 +24,8 @@
 
 #include "settings/AdvancedSettings.h"
 #include "Application.h"
+#include "AppInboundProtocol.h"
+#include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
@@ -314,14 +316,18 @@ using namespace KODI::MESSAGING;
 {
   PRINT_SIGNATURE();
   pause = TRUE;
-  g_application.SetRenderGUI(false);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->SetRenderGUI(false);
 }
 //--------------------------------------------------------------
 - (void) resumeAnimation
 {
   PRINT_SIGNATURE();
   pause = FALSE;
-  g_application.SetRenderGUI(true);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->SetRenderGUI(true);
 }
 //--------------------------------------------------------------
 - (void) startAnimation

--- a/xbmc/platform/darwin/ios/XBMCController.mm
+++ b/xbmc/platform/darwin/ios/XBMCController.mm
@@ -30,6 +30,7 @@
 #include "playlists/PlayList.h"
 #include "messaging/ApplicationMessenger.h"
 #include "Application.h"
+#include "AppInboundProtocol.h"
 #include "input/touch/generic/GenericTouchActionHandler.h"
 #include "guilib/GUIControl.h"
 #include "input/Key.h"
@@ -96,11 +97,16 @@ XBMCController *g_xbmcController;
 //--------------------------------------------------------------
 - (void) sendKeypressEvent: (XBMC_Event) event
 {
-  event.type = XBMC_KEYDOWN;
-  g_application.OnEvent(event);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
 
-  event.type = XBMC_KEYUP;
-  g_application.OnEvent(event);
+  if (appPort)
+  {
+    event.type = XBMC_KEYDOWN;
+    appPort->OnEvent(event);
+
+    event.type = XBMC_KEYUP;
+    appPort->OnEvent(event);
+  }
 }
 
 // START OF UIKeyInput protocol

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "LIRC.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "ServiceBroker.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/AdvancedSettings.h"
@@ -129,7 +129,9 @@ void CLirc::ProcessCode(char *buf)
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
     newEvent.keybutton.holdtime = 0;
-    g_application.OnEvent(newEvent);
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      appPort->OnEvent(newEvent);
     return;
   }
   else if (repeat > g_advancedSettings.m_remoteDelay)
@@ -138,6 +140,8 @@ void CLirc::ProcessCode(char *buf)
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
     newEvent.keybutton.holdtime = XbmcThreads::SystemClockMillis() - m_firstClickTime;
-    g_application.OnEvent(newEvent);
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      appPort->OnEvent(newEvent);
   }
 }

--- a/xbmc/platform/win10/input/RemoteControlXbox.cpp
+++ b/xbmc/platform/win10/input/RemoteControlXbox.cpp
@@ -19,8 +19,9 @@
  */
 
 #include "RemoteControlXbox.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "input/remote/IRRemote.h"
+#include "ServiceBroker.h"
 #include "threads/SystemClock.h"
 #include "utils/log.h"
 
@@ -67,7 +68,7 @@ void CRemoteControlXbox::Initialize()
 {
   auto dispatcher = CoreWindow::GetForCurrentThread()->Dispatcher;
   m_token = dispatcher->AcceleratorKeyActivated += ref new TypedEventHandler<CoreDispatcher^, AcceleratorKeyEventArgs^>
-    ([this](CoreDispatcher^ sender, AcceleratorKeyEventArgs^ args) 
+    ([this](CoreDispatcher^ sender, AcceleratorKeyEventArgs^ args)
   {
     if (IsRemoteDevice(args->DeviceId->Data()))
       HandleAcceleratorKey(sender, args);
@@ -91,7 +92,7 @@ void CRemoteControlXbox::HandleAcceleratorKey(CoreDispatcher^ sender, Accelerato
   auto button = TranslateVirtualKey(args->VirtualKey);
   if (!button)
     return;
-  
+
   XBMC_Event newEvent;
   newEvent.type = XBMC_BUTTON;
   newEvent.keybutton.button = button;
@@ -110,7 +111,11 @@ void CRemoteControlXbox::HandleAcceleratorKey(CoreDispatcher^ sender, Accelerato
     else
       newEvent.keybutton.holdtime = XbmcThreads::SystemClockMillis() - m_firstClickTime;
 
-    g_application.OnEvent(newEvent);
+    std::shared_ptr<CAppInboundProtocol> appPort;
+    appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      appPort->OnEvent(newEvent);
+
     break;
   }
   case CoreAcceleratorKeyEventType::KeyUp:
@@ -120,7 +125,10 @@ void CRemoteControlXbox::HandleAcceleratorKey(CoreDispatcher^ sender, Accelerato
       newEvent.keybutton.holdtime = XbmcThreads::SystemClockMillis() - m_firstClickTime;
 
     m_lastKey = VirtualKey::None;
-    g_application.OnEvent(newEvent);
+    std::shared_ptr<CAppInboundProtocol> appPort;
+    appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      appPort->OnEvent(newEvent);
     break;
   }
   case CoreAcceleratorKeyEventType::Character:
@@ -140,7 +148,9 @@ void CRemoteControlXbox::HandleMediaButton(Windows::Media::SystemMediaTransportC
   newEvent.type = XBMC_BUTTON;
   newEvent.keybutton.button = TranslateMediaKey(args->Button);;
   newEvent.keybutton.holdtime = 0;
-  g_application.OnEvent(newEvent);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(newEvent);
 }
 
 int32_t CRemoteControlXbox::TranslateVirtualKey(Windows::System::VirtualKey vk)

--- a/xbmc/platform/win32/input/IRServerSuite.cpp
+++ b/xbmc/platform/win32/input/IRServerSuite.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "IRServerSuite.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "IrssMessage.h"
 #include "platform/win32/CharsetConverter.h"
 #include "profiles/ProfilesManager.h"
@@ -384,7 +384,9 @@ bool CIRServerSuite::HandleRemoteEvent(CIrssMessage& message)
     newEvent.type = XBMC_BUTTON;
     newEvent.keybutton.button = button;
     newEvent.keybutton.holdtime = 0;
-    g_application.OnEvent(newEvent);
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      appPort->OnEvent(newEvent);
 
     delete[] deviceName;
     delete[] keycode;
@@ -472,7 +474,7 @@ int CIRServerSuite::ReadPacket(CIrssMessage &message)
   {
     char sizebuf[4];
     int iRead = ReadN(&sizebuf[0], 4);
-    if (iRead <= 0) 
+    if (iRead <= 0)
       return iRead; // error or nothing to read
 
     if (iRead != 4)

--- a/xbmc/windowing/WinEventsLinux.cpp
+++ b/xbmc/windowing/WinEventsLinux.cpp
@@ -22,7 +22,7 @@
 #include "WinEvents.h"
 #include "XBMC_events.h"
 #include "input/XBMC_keysym.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "input/mouse/MouseStat.h"
 #include "utils/log.h"
 #include "powermanagement/PowerManager.h"
@@ -59,12 +59,14 @@ bool CWinEventsLinux::MessagePump()
 
   bool ret = false;
   XBMC_Event event = {0};
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   while (1)
   {
     event = m_devices.ReadEvent();
     if (event.type != XBMC_NOEVENT)
     {
-      ret |= g_application.OnEvent(event);
+      if (appPort)
+        ret |= appPort->OnEvent(event);
     }
     else
     {
@@ -77,5 +79,7 @@ bool CWinEventsLinux::MessagePump()
 
 void CWinEventsLinux::MessagePush(XBMC_Event *ev)
 {
-  g_application.OnEvent(*ev);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(*ev);
 }

--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -22,6 +22,7 @@
 #include "xbmc/windowing/WinEvents.h"
 #include "WinEventsX11.h"
 #include "Application.h"
+#include "AppInboundProtocol.h"
 #include "messaging/ApplicationMessenger.h"
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
@@ -294,6 +295,7 @@ bool CWinEventsX11::MessagePump()
   bool ret = false;
   XEvent xevent;
   unsigned long serial = 0;
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
 
   while (m_display && XPending(m_display))
   {
@@ -325,13 +327,15 @@ bool CWinEventsX11::MessagePump()
     {
       case MapNotify:
       {
-        g_application.SetRenderGUI(true);
+        if (appPort)
+          appPort->SetRenderGUI(true);
         break;
       }
 
       case UnmapNotify:
       {
-        g_application.SetRenderGUI(false);
+        if (appPort)
+          appPort->SetRenderGUI(false);
         break;
       }
 
@@ -374,7 +378,8 @@ bool CWinEventsX11::MessagePump()
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = xevent.xconfigure.width;
         newEvent.resize.h = xevent.xconfigure.height;
-        ret |= g_application.OnEvent(newEvent);
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
         break;
       }
@@ -514,7 +519,8 @@ bool CWinEventsX11::MessagePump()
         newEvent.type = XBMC_MOUSEMOTION;
         newEvent.motion.x = (int16_t)xevent.xmotion.x;
         newEvent.motion.y = (int16_t)xevent.xmotion.y;
-        ret |= g_application.OnEvent(newEvent);
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -526,7 +532,8 @@ bool CWinEventsX11::MessagePump()
         newEvent.button.button = (unsigned char)xevent.xbutton.button;
         newEvent.button.x = (int16_t)xevent.xbutton.x;
         newEvent.button.y = (int16_t)xevent.xbutton.y;
-        ret |= g_application.OnEvent(newEvent);
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -538,7 +545,8 @@ bool CWinEventsX11::MessagePump()
         newEvent.button.button = (unsigned char)xevent.xbutton.button;
         newEvent.button.x = (int16_t)xevent.xbutton.x;
         newEvent.button.y = (int16_t)xevent.xbutton.y;
-        ret |= g_application.OnEvent(newEvent);
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -635,7 +643,10 @@ bool CWinEventsX11::ProcessKey(XBMC_Event &event)
     event.key.keysym.mod = (XBMCMod)m_keymodState;
   }
 
-  return g_application.OnEvent(event);
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+  if (appPort)
+    appPort->OnEvent(event);
+  return true;
 }
 
 XBMCKey CWinEventsX11::LookupXbmcKeySym(KeySym keysym)

--- a/xbmc/windowing/android/WinEventsAndroid.cpp
+++ b/xbmc/windowing/android/WinEventsAndroid.cpp
@@ -20,7 +20,7 @@
 
 #include "WinEventsAndroid.h"
 
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/InputManager.h"
@@ -106,7 +106,9 @@ bool CWinEventsAndroid::MessagePump()
       m_events.pop_front();
     }
 
-    ret |= g_application.OnEvent(pumpEvent);
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      ret |= appPort->OnEvent(pumpEvent);
 
     if (pumpEvent.type == XBMC_MOUSEBUTTONUP)
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_UNFOCUS_ALL, 0, 0, 0, 0);

--- a/xbmc/windowing/mir/WinEventsMir.cpp
+++ b/xbmc/windowing/mir/WinEventsMir.cpp
@@ -25,7 +25,8 @@
 #include <mir_toolkit/mir_client_library.h>
 #include <xkbcommon/xkbcommon-keysyms.h>
 
-#include "Application.h"
+#include "AppInboundProtocol.h"
+#include "ServiceBroker.h"
 #include "input/mouse/MouseStat.h"
 #include "input/Key.h"
 
@@ -337,6 +338,7 @@ void MirHandleEvent(MirWindow* window, MirEvent const* ev, void* context)
 bool CWinEventsMir::MessagePump()
 {
   auto ret = GetQueueSize();
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
 
   while (GetQueueSize())
   {
@@ -346,7 +348,9 @@ bool CWinEventsMir::MessagePump()
       e = m_events.front();
       m_events.pop();
     }
-    g_application.OnEvent(e);
+
+    if (appPort)
+      appPort->OnEvent(newEvent);
   }
 
   return ret;

--- a/xbmc/windowing/osx/WinEventsIOS.mm
+++ b/xbmc/windowing/osx/WinEventsIOS.mm
@@ -22,7 +22,7 @@
 #include "WinEventsIOS.h"
 #include "input/InputManager.h"
 #include "input/XBMC_vkeys.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "threads/CriticalSection.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/log.h"
@@ -34,6 +34,7 @@ static std::list<XBMC_Event> events;
 bool CWinEventsIOS::MessagePump()
 {
   bool ret = false;
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
 
   // Do not always loop, only pump the initial queued count events. else if ui keep pushing
   // events the loop won't finish then it will block xbmc main message loop.
@@ -49,7 +50,9 @@ bool CWinEventsIOS::MessagePump()
       pumpEvent = events.front();
       events.pop_front();
     }
-    ret = g_application.OnEvent(pumpEvent);
+
+    if (appPort)
+      ret = appPort->OnEvent(pumpEvent);
   }
   return ret;
 }

--- a/xbmc/windowing/osx/WinEventsSDL.cpp
+++ b/xbmc/windowing/osx/WinEventsSDL.cpp
@@ -20,6 +20,7 @@
 
 #include "WinEventsSDL.h"
 #include "Application.h"
+#include "AppInboundProtocol.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "GUIUserMessages.h"
@@ -53,7 +54,9 @@ bool CWinEventsSDL::MessagePump()
         //If the window was inconified or restored
         if( event.active.state & SDL_APPACTIVE )
         {
-          g_application.SetRenderGUI(event.active.gain != 0);
+          std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+          if (appPort)
+            appPort->SetRenderGUI(event.active.gain != 0);
           CServiceBroker::GetWinSystem()->NotifyAppActiveChange(g_application.GetRenderGUI());
         }
         else if (event.active.state & SDL_APPINPUTFOCUS)
@@ -87,7 +90,9 @@ bool CWinEventsSDL::MessagePump()
 
         // don't handle any more messages in the queue until we've handled keydown,
         // if a keyup is in the queue it will reset the keypress before it is handled.
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -100,7 +105,9 @@ bool CWinEventsSDL::MessagePump()
         newEvent.key.keysym.mod =(XBMCMod) event.key.keysym.mod;
         newEvent.key.keysym.unicode = event.key.keysym.unicode;
 
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -112,7 +119,9 @@ bool CWinEventsSDL::MessagePump()
         newEvent.button.x = event.button.x;
         newEvent.button.y = event.button.y;
 
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -124,7 +133,9 @@ bool CWinEventsSDL::MessagePump()
         newEvent.button.x = event.button.x;
         newEvent.button.y = event.button.y;
 
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
 
@@ -143,7 +154,9 @@ bool CWinEventsSDL::MessagePump()
         newEvent.motion.x = event.motion.x;
         newEvent.motion.y = event.motion.y;
 
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
       case SDL_VIDEORESIZE:
@@ -161,7 +174,9 @@ bool CWinEventsSDL::MessagePump()
         newEvent.type = XBMC_VIDEORESIZE;
         newEvent.resize.w = event.resize.w;
         newEvent.resize.h = event.resize.h;
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
         break;
       }
@@ -170,7 +185,9 @@ bool CWinEventsSDL::MessagePump()
         XBMC_Event newEvent;
         newEvent.type = XBMC_USEREVENT;
         newEvent.user.code = event.user.code;
-        ret |= g_application.OnEvent(newEvent);
+        std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+        if (appPort)
+          ret |= appPort->OnEvent(newEvent);
         break;
       }
       case SDL_VIDEOEXPOSE:

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -22,7 +22,7 @@
 #include "WinEventsOSX.h"
 #include "VideoSyncOsx.h"
 #include "OSScreenSaverOSX.h"
-#include "Application.h"
+#include "AppInboundProtocol.h"
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "CompileInfo.h"
@@ -104,7 +104,9 @@ using namespace WINDOWING;
       newEvent.type = XBMC_VIDEOMOVE;
       newEvent.move.x = window_origin.x;
       newEvent.move.y = window_origin.y;
-      g_application.OnEvent(newEvent);
+      std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+      if (appPort)
+        appPort->OnEvent(newEvent);
     }
   }
 }
@@ -130,26 +132,7 @@ using namespace WINDOWING;
   CWinSystemOSX *winsys = (CWinSystemOSX*)m_userdata;
 	if (!winsys)
     return;
-  /* placeholder, do not uncomment or you will SDL recurse into death
-  NSOpenGLContext* context = [NSOpenGLContext currentContext];
-  if (context)
-  {
-    if ([context view])
-    {
-      NSSize view_size = [[context view] frame].size;
-      XBMC_Event newEvent;
-      memset(&newEvent, 0, sizeof(newEvent));
-      newEvent.type = XBMC_VIDEORESIZE;
-      newEvent.resize.w = view_size.width;
-      newEvent.resize.h = view_size.height;
-      if (newEvent.resize.w * newEvent.resize.h)
-      {
-        g_application.OnEvent(newEvent);
-        CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
-      }
-    }
-  }
-  */
+
 }
 @end
 

--- a/xbmc/windowing/wayland/WinEventsWayland.cpp
+++ b/xbmc/windowing/wayland/WinEventsWayland.cpp
@@ -29,7 +29,8 @@
 
 #include <wayland-client.hpp>
 
-#include "Application.h"
+#include "AppInboundProtocol.h"
+#include "ServiceBroker.h"
 #include "threads/CriticalSection.h"
 #include "threads/SingleLock.h"
 #include "threads/Thread.h"
@@ -192,7 +193,7 @@ private:
           // Read away the char so we don't get another notification
           // Indepentent from m_roundtripQueue so there are no races
           char c;
-          read(m_pipeRead, &c, 1); 
+          read(m_pipeRead, &c, 1);
         }
       }
 
@@ -252,6 +253,7 @@ void CWinEventsWayland::RoundtripQueue(const wayland::event_queue_t& queue)
 
 bool CWinEventsWayland::MessagePump()
 {
+  std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   // Forward any events that may have been pushed to our queue
   while (true)
   {
@@ -271,7 +273,8 @@ bool CWinEventsWayland::MessagePump()
       m_queue.pop();
     }
 
-    g_application.OnEvent(event);
+    if (appPort)
+      appPort->OnEvent(event);
   }
 
   return true;


### PR DESCRIPTION
Add App inbound port as a service. Allows components like windowing or lirc to send events to CApp without using global g_application.
Use shared pointer for registration of serivce allows safe destruction.