### PR TITLE
[guiinfo] Implement time format "m" (TIME_FORMAT_M)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -444,8 +444,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.SeekStepSize`</b>,
 ///                  \anchor Player_SeekStepSize
@@ -462,8 +462,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.TimeSpeed`</b>,
 ///                  \anchor Player_TimeSpeed
@@ -480,8 +480,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.Duration`</b>,
 ///                  \anchor Player_Duration
@@ -493,8 +493,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.FinishTime`</b>,
 ///                  \anchor Player_FinishTime
@@ -506,8 +506,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.StartTime`</b>,
 ///                  \anchor Player_StartTime
@@ -519,8 +519,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`Player.SeekNumeric`</b>,
 ///                  \anchor Player_SeekNumeric
@@ -532,8 +532,8 @@ const infomap player_param[] =   {{ "art",              PLAYER_ITEM_ART }};
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 /// \table_end
 ///
@@ -811,8 +811,8 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///                  _string_,
 ///     Returns hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`System.Date`</b>,
 ///                  \anchor System_Date
@@ -3247,8 +3247,8 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     Returns the duration of the currently selected item in a container in
 ///     different formats: hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`ListItem.DBTYPE`</b>,
 ///                  \anchor ListItem_DBTYPE
@@ -4611,8 +4611,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the duration of the currently playing epg event in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventElapsedTime`</b>,
 ///                  \anchor PVR_EpgEventElapsedTime
@@ -4626,8 +4626,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the time of the current position of the currently playing epg event in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventRemainingTime`</b>,
 ///                  \anchor PVR_EpgEventRemainingTime
@@ -4641,8 +4641,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the remaining time for currently playing epg event in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventSeekTime`</b>,
 ///                  \anchor PVR_EpgEventSeekTime
@@ -4656,8 +4656,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the time the user is seeking within the currently playing epg event in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.EpgEventFinishTime`</b>,
 ///                  \anchor PVR_EpgEventFinishTime
@@ -4671,8 +4671,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the time the currently playing epg event will end in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftStart`</b>,
 ///                  \anchor PVR_TimeShiftStart
@@ -4686,8 +4686,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the start time of the timeshift buffer in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftEnd`</b>,
 ///                  \anchor PVR_TimeShiftEnd
@@ -4701,8 +4701,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the end time of the timeshift buffer in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftCur`</b>,
 ///                  \anchor PVR_TimeShiftCur
@@ -4716,8 +4716,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the current playback time within the timeshift buffer in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss). When 12 hour clock is used
 ///     (xx) will return AM/PM. Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 ///   \table_row3{   <b>`PVR.TimeShiftOffset`</b>,
 ///                  \anchor PVR_TimeShiftOffset
@@ -4731,8 +4731,8 @@ const infomap pvr[] =            {{ "isrecording",              PVR_IS_RECORDING
 ///     Returns the delta of timeshifted time to actual time in different formats:
 ///     Hours (hh)\, minutes (mm) or seconds (ss).
 ///     Also supported: (hh:mm)\, (mm:ss)\, (hh:mm:ss)\, (h:mm:ss).
-///     Added with Leia: (secs)\, (mins)\, (hours) for total time values.
-///     Example: 3661 seconds => hh=1\, mm=1\, ss=1\, hours=1\, mins=61\, secs=3661
+///     Added with Leia: (secs)\, (mins)\, (hours) for total time values and (m).
+///     Example: 3661 seconds => h=1\, hh=01\, m=1\, mm=01\, ss=01\, hours=1\, mins=61\, secs=3661
 ///   }
 /// \table_end
 ///

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6314,6 +6314,8 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const std::string &format)
     return TIME_FORMAT_HH_MM_SS_XX;
   else if (StringUtils::EqualsNoCase(format, "h"))
     return TIME_FORMAT_H;
+  else if (StringUtils::EqualsNoCase(format, "m"))
+    return TIME_FORMAT_M;
   else if (StringUtils::EqualsNoCase(format, "h:mm:ss"))
     return TIME_FORMAT_H_MM_SS;
   else if (StringUtils::EqualsNoCase(format, "h:mm:ss xx"))

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1501,6 +1501,8 @@ std::string CDateTime::GetAsLocalizedTime(TIME_FORMAT format) const
       return GetAsLocalizedTime(use12hourclock ? "hh:mm:ss xx" : "HH:mm:ss", true);
     case TIME_FORMAT_H:
       return GetAsLocalizedTime("h", false);
+    case TIME_FORMAT_M:
+      return GetAsLocalizedTime("m", false);
     case TIME_FORMAT_H_MM_SS:
       return GetAsLocalizedTime("h:mm:ss", true);
     case TIME_FORMAT_H_MM_SS_XX:

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -45,7 +45,8 @@ enum TIME_FORMAT { TIME_FORMAT_GUESS       =  0,
                    TIME_FORMAT_H_MM_SS_XX  = 27,
                    TIME_FORMAT_SECS        = 32,
                    TIME_FORMAT_MINS        = 64,
-                   TIME_FORMAT_HOURS       = 128 };
+                   TIME_FORMAT_HOURS       = 128,
+                   TIME_FORMAT_M           = 256 };
 
 class CDateTime;
 

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -866,6 +866,9 @@ long StringUtils::TimeStringToSeconds(const std::string &timeString)
 
 std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
 {
+  bool isNegative = lSeconds < 0;
+  lSeconds = std::abs(lSeconds);
+
   std::string strHMS;
   if (format == TIME_FORMAT_SECS)
     strHMS = StringUtils::Format("%i", lSeconds);
@@ -873,10 +876,10 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
     strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(lSeconds) / 60.0f));
   else if (format == TIME_FORMAT_HOURS)
     strHMS = StringUtils::Format("%i", lrintf(static_cast<float>(lSeconds) / 3600.0f));
+  else if (format & TIME_FORMAT_M)
+    strHMS += StringUtils::Format("%i", lSeconds % 3600 / 60);
   else
   {
-    bool isNegative = lSeconds < 0;
-    lSeconds = std::abs(lSeconds);
     int hh = lSeconds / 3600;
     lSeconds = lSeconds % 3600;
     int mm = lSeconds / 60;
@@ -892,9 +895,11 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
       strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", mm);
     if (format & TIME_FORMAT_SS)
       strHMS += StringUtils::Format(strHMS.empty() ? "%2.2i" : ":%2.2i", ss);
-    if (isNegative)
-      strHMS = "-" + strHMS;
   }
+
+  if (isNegative)
+    strHMS = "-" + strHMS;
+
   return strHMS;
 }
 


### PR DESCRIPTION
Requested multiple times in the forum: https://forum.kodi.tv/showthread.php?tid=301686&pid=2715169#pid2715169

The new time format is supported by all guiinfo labels supporting time format as parameter.

![screenshot000](https://user-images.githubusercontent.com/3226626/38776581-6a204738-4099-11e8-821b-ccba49147edd.png)

Runtime-tested on macOS, latest Kodi master.

@Jalle19 might taking a look.