### PR TITLE
[Music]Fetching local art for multi-folder albums (disc sets)

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5468,7 +5468,7 @@ bool CMusicDatabase::GetAlbumPath(int idAlbum, std::string& basePath)
   if (!GetAlbumPaths(idAlbum, paths))
     return false;
 
-  for (auto pathpair : paths)
+  for (const auto& pathpair : paths)
   {
     if (basePath.empty())
       basePath = pathpair.first.c_str();

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -342,7 +342,9 @@ public:
   bool GetPaths(std::set<std::string> &paths);
   bool SetPathHash(const std::string &path, const std::string &hash);
   bool GetPathHash(const std::string &path, std::string &hash);
+  bool GetAlbumPaths(int idAlbum, std::vector<std::pair<std::string, int>>& paths);
   bool GetAlbumPath(int idAlbum, std::string &basePath);
+  int GetDiscnumberForPathID(int idPath);
   bool GetOldArtistPath(int idArtist, std::string &path);
   bool GetArtistPath(const CArtist& artist, std::string &path);
   bool GetAlbumFolder(const CAlbum& album, const std::string &strAlbumPath, std::string &strFolder);

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -176,6 +176,7 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
     if (artfound)
     {
       std::string fanartfallback;
+      bool bDiscSetThumbSet = false;
       std::map<std::string, std::string> artmap;
       for (auto artitem : art)
       {
@@ -200,8 +201,21 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
 
         // Add fallback art for "thumb" and "fanart" art types only
         // Set album thumb as the fallback used when song thumb is missing
-        if (tag.GetType() == MediaTypeSong && artitem.mediaType == MediaTypeAlbum && artitem.artType == "thumb")
-          item.SetArtFallback(artitem.artType, artname);
+        // or use extra album thumb when part of disc set 
+        if (tag.GetType() == MediaTypeSong && artitem.mediaType == MediaTypeAlbum)
+        {
+          if (artitem.artType == "thumb" && !bDiscSetThumbSet)
+            item.SetArtFallback(artitem.artType, artname);
+          else if (StringUtils::StartsWith(artitem.artType, "thumb"))
+          {
+            int number = atoi(artitem.artType.substr(5).c_str());
+            if (number > 0 && tag.GetDiscNumber() == number)
+            {
+              item.SetArtFallback("thumb", artname);
+              bDiscSetThumbSet = true;
+            }
+          }
+        }
 
         // For albums and songs set fallback fanart from the artist.
         // For songs prefer primary song artist over primary albumartist fanart as fallback fanart 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1216,7 +1216,7 @@ void MUSIC_INFO::CMusicInfoScanner::RetrieveLocalArt()
     std::vector<std::pair<std::string, int>> paths;
     m_musicDatabase.GetAlbumPaths(albumId, paths);
     // Get album path, the common path when more than one 
-    for (auto pathpair : paths)
+    for (const auto& pathpair : paths)
     {
       if (album.strPath.empty())
         album.strPath = pathpair.first.c_str();
@@ -1237,7 +1237,7 @@ void MUSIC_INFO::CMusicInfoScanner::RetrieveLocalArt()
       than the last processed.
       */
       CMusicThumbLoader loader;
-      for (auto pathpair : paths)
+      for (const auto& pathpair : paths)
       {
         int discnum = m_musicDatabase.GetDiscnumberForPathID(pathpair.second);
         if (discnum > 0)

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -172,6 +172,7 @@ protected:
    */
   int RetrieveMusicInfo(const std::string& strDirectory, CFileItemList& items);
 
+  void RetrieveLocalArt();
   void ScrapeInfoAddedAlbums();
   void RetrieveArtistArt();
 
@@ -208,9 +209,8 @@ protected:
   int m_scanType; // 0 - load from files, 1 - albums, 2 - artists
   CMusicDatabase m_musicDatabase;
 
-  std::vector<int> m_albumsAdded;
-  std::set<int> m_artistsArt;
-
+  std::set<int> m_albumsAdded;
+ 
   std::set<std::string> m_seenPaths;
   int m_flags;
   CThread m_fileCountReader;


### PR DESCRIPTION
Fix a long standing problem fetching local art when the album is split across multiple subfolders e.g. disc sets. Generally improve handling of art for disc sets as a small _initial step_ in enhancing disc set support. Make some other small improvements to fetching local artist art too.
___
Users  have long reported that sometimes images from the album folder get used as artist art, and not getting the album art they expected. See https://forum.kodi.tv/showthread.php?tid=329388&pid=2725958#pid2725958 for one recent example.  One cause at least was the way scanning treated music files in this kind of layout:
```
mymusic/artist1/album1/CD1/track01.mp3
mymusic/artist1/album1/CD1/track02.mp3
...
mymusic/artist1/album1/CD2/track01.mp3
mymusic/artist1/album1/CD2/track02.mp3
...
```
It was assuming that the parent and grand-parent folders of the music files would be the album and artist folders respectively, and they are not.  Each subfolder was scanned independantly of the other and treated as the album folder, so the album art was taken from last subfolder or the songs in that subfolder only.

The solution was to have a “fetch local art” phase for the processed albums and artists once file scan completed. This made it possible  make use of art from the subfolders, when they contain music files with the same DISKNUMBER tag, as fallback song thumbs. So for example if `mymusic/artist1/album1/CD1/folder.jpg` exists, and all the music files have the same album and same embedded cover art, then it will appear when songs from that disc are listed or played.  

Fetching local art is part of both initial scanning, and any subsequent scraping from remote sites or NFO files (on "Query for all" or "Refresh").  When artist art was missing, and no infomation was fetched from remote sites, the process did not check for local art. It meant that when a user added local art for such a lesser known artist they either had to set it manually, add and NFO file too or drop and re-add the music files for that artist. This is also fixed, and checking locally for missing art done as part of scraping.

To aid manual art selection, especially for disc sets, the Song Info Dialog now offers album folder as the `*itemfolder` when browsing for art, in preference to the parent folder of the song (not always the same).

Tested myself using all combinations of albums with multiple subfolders and art, but will put up a test build and invite more user testing.
