### PR TITLE
[guiinfo] Fix CGUIInfoManager::GetInt after #13754

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -49,7 +49,6 @@
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
 using namespace INFO;
-using namespace MUSIC_INFO;
 
 bool InfoBoolComparator(const InfoPtr &right, const InfoPtr &left)
 {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6355,7 +6355,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
 {
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
-    return GetMultiInfoInt(value, m_multiInfo[info - MULTI_INFO_START], contextWindow);
+    return GetMultiInfoInt(value, m_multiInfo[info - MULTI_INFO_START], contextWindow, item);
   }
   else if (info >= LISTITEM_START && info <= LISTITEM_END)
   {
@@ -6552,14 +6552,19 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
   return (info.m_info < 0) ? !bReturn : bReturn;
 }
 
-bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int contextWindow) const
+bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int contextWindow, const CGUIListItem *item) const
 {
   if (info.m_info >= LISTITEM_START && info.m_info <= LISTITEM_END)
   {
-    const CGUIListItemPtr item = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
+    CGUIListItemPtr itemPtr;
+    if (!item)
+    {
+      itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
+      item = itemPtr.get();
+    }
     if (item)
     {
-      return GetItemInt(value, item.get(), contextWindow, info.m_info);
+      return GetItemInt(value, item, contextWindow, info.m_info);
     }
     else
     {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -185,9 +185,9 @@ private:
   int TranslateMusicPlayerString(const std::string &info) const;
   static TIME_FORMAT TranslateTimeFormat(const std::string &format);
 
-  std::string GetMultiInfoLabel(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow = 0, std::string *fallback = nullptr) const;
-  bool GetMultiInfoInt(int &value, const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow = 0) const;
-  bool GetMultiInfoBool(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow = 0, const CGUIListItem *item = nullptr);
+  std::string GetMultiInfoLabel(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, std::string *fallback = nullptr) const;
+  bool GetMultiInfoInt(int &value, const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, const CGUIListItem *item) const;
+  bool GetMultiInfoBool(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, const CGUIListItem *item);
 
   std::string GetMultiInfoItemLabel(const CFileItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info, std::string *fallback = nullptr) const;
   std::string GetMultiInfoItemImage(const CFileItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info, std::string *fallback = nullptr) const;

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1700,12 +1700,6 @@ void CPVRGUIInfo::UpdateNextTimer(void)
   m_radioTimersInfo.UpdateNextTimer();
 }
 
-int CPVRGUIInfo::GetDuration(void) const
-{
-  CSingleLock lock(m_critSection);
-  return m_iDuration;
-}
-
 int CPVRGUIInfo::GetElapsedTime(void) const
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -1070,7 +1070,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem *item, const CGUIInfo &info, int& iV
   {
     case PVR_EPG_EVENT_DURATION:
     {
-      CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
+      const CPVREpgInfoTagPtr epgTag = !item->IsPVRRecording() ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag && epgTag != m_playingEpgTag)
         iValue = epgTag->GetDuration();
       else
@@ -1079,7 +1079,7 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem *item, const CGUIInfo &info, int& iV
     }
     case PVR_EPG_EVENT_PROGRESS:
     {
-      CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
+      const CPVREpgInfoTagPtr epgTag = !item->IsPVRRecording() ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag && epgTag != m_playingEpgTag)
         iValue = std::lrintf(epgTag->ProgressPercentage());
       else
@@ -1409,7 +1409,7 @@ void CPVRGUIInfo::CharInfoTimeshiftOffset(TIME_FORMAT format, std::string &strVa
 void CPVRGUIInfo::CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
   int iDuration = 0;
-  CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
+  const CPVREpgInfoTagPtr epgTag = !item->IsPVRRecording() ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iDuration = epgTag->GetDuration();
   else
@@ -1421,7 +1421,7 @@ void CPVRGUIInfo::CharInfoEpgEventDuration(const CFileItem *item, TIME_FORMAT fo
 void CPVRGUIInfo::CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT format, std::string &strValue) const
 {
   int iElapsed = 0;
-  CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
+  const CPVREpgInfoTagPtr epgTag = !item->IsPVRRecording() ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iElapsed = epgTag->Progress();
   else
@@ -1433,7 +1433,7 @@ void CPVRGUIInfo::CharInfoEpgEventElapsedTime(const CFileItem *item, TIME_FORMAT
 int CPVRGUIInfo::GetRemainingTime(const CFileItem *item) const
 {
   int iRemaining = 0;
-  CPVREpgInfoTagPtr epgTag = CPVRItem(item).GetEpgInfoTag();
+  const CPVREpgInfoTagPtr epgTag = !item->IsPVRRecording() ? CPVRItem(item).GetEpgInfoTag() : nullptr;
   if (epgTag && epgTag != m_playingEpgTag)
     iRemaining = epgTag->GetDuration() - epgTag->Progress();
   else

--- a/xbmc/pvr/PVRGUIInfo.h
+++ b/xbmc/pvr/PVRGUIInfo.h
@@ -64,20 +64,6 @@ namespace PVR
     bool GetBool(bool& value, const CGUIListItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info) const override;
 
     /*!
-     * @brief Get the total duration of the currently playing epg event or if no epg is
-     *        available the current lenght in seconds of the playing Live TV stream.
-     * @return The total duration in seconds or 0 if no channel is playing.
-     */
-    int GetDuration(void) const;
-
-    /*!
-     * @brief Get the elapsed time since the start of the currently playing epg event or if
-     *        no epg is available since the start of the playback of the current Live TV stream.
-     * @return The time in seconds or 0 if no channel is playing.
-     */
-    int GetElapsedTime(void) const;
-
-    /*!
      * @brief Clear the playing EPG tag.
      */
     void ResetPlayingTag(void);
@@ -146,6 +132,13 @@ namespace PVR
     void CharInfoTimeshiftEndTime(TIME_FORMAT format, std::string &strValue) const;
     void CharInfoTimeshiftPlayTime(TIME_FORMAT format, std::string &strValue) const;
     void CharInfoTimeshiftOffset(TIME_FORMAT format, std::string &strValue) const;
+
+    /*!
+     * @brief Get the elapsed time since the start of the currently playing epg event or if
+     *        no epg is available since the start of the playback of the current Live TV stream.
+     * @return The time in seconds or 0 if no channel is playing.
+     */
+    int GetElapsedTime(void) const;
 
     int GetRemainingTime(const CFileItem *item) const;
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -799,16 +799,6 @@ void CPVRManager::OnPlaybackEnded(const CFileItemPtr item)
   OnPlaybackStopped(item);
 }
 
-int CPVRManager::GetTotalTime(void) const
-{
-  return IsStarted() && m_guiInfo ? m_guiInfo->GetDuration() : 0;
-}
-
-int CPVRManager::GetElapsedTime(void) const
-{
-  return IsStarted() && m_guiInfo ? m_guiInfo->GetElapsedTime() : 0;
-}
-
 bool CPVRManager::IsRecording(void) const
 {
   return IsStarted() && m_timers ? m_timers->IsRecording() : false;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -358,20 +358,6 @@ namespace PVR
     void TriggerSearchMissingChannelIcons(void);
 
     /*!
-     * @brief Get the total duration of the currently playing epg event or if no epg is
-     *        available the current lenght in seconds of the playing Live TV stream.
-     * @return The total duration in seconds or 0 if no channel is playing.
-     */
-    int GetTotalTime(void) const;
-
-    /*!
-     * @brief Get the elapsed time since the start of the currently playing epg event or if
-     *        no epg is available since the start of the playback of the current Live TV stream.
-     * @return The time in seconds or 0 if no channel is playing.
-     */
-    int GetElapsedTime(void) const;
-
-    /*!
      * @brief Check whether names are still correct after the language settings changed.
      */
     void LocalizationChanged(void);


### PR DESCRIPTION
Fix CGUIInfoManager::GetInt to pass a given item to CGUIInfoManager::GetMultiInfoInt.

Regression reported in the forum: https://forum.kodi.tv/showthread.php?tid=330696&pid=2726079#pid2726079

Runtime-tested on macOS, latest Kodi master.

@Jalle19 if you find the time to review...