### PR TITLE
Method for addon to detect external player

### DIFF
--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -350,6 +350,12 @@ namespace XBMCAddon
       return g_application.GetAppPlayer().IsPlayingRDS();
     }
 
+    bool Player::isExternalPlayer()
+    {
+      XBMC_TRACE;
+      return g_application.GetAppPlayer().IsExternalPlaying();
+    }
+
     String Player::getPlayingFile()
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -452,6 +452,25 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Player
+      /// @brief \python_func{ isExternalPlayer() }
+      ///-----------------------------------------------------------------------
+      /// Check for external player.
+      ///
+      /// @return                    True if kodi is playing using an
+      ///                            external player.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v18 New function added.
+      ///
+      isExternalPlayer();
+#else
+      bool isExternalPlayer();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Player
       /// @brief \python_func{ getPlayingFile() }
       ///-----------------------------------------------------------------------
       /// Returns the current playing file as a string.


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
Add a way for add-ons to detect if an external player is used for playback. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This allows for a more precise detection, especially when checking the current playback position. When an external player is used, the position remains 0.0 until the file is considered watched, which then returns 1.0. It is currently impossible to tell the difference between a normal position tick and the external player position tick. This is why I made this new addition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I compiled Kodi windows x64 to test.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
