### PR TITLE
allow playlist items in a playlist for files

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -300,7 +300,7 @@ bool CPlayListPlayer::Play(int iSong, std::string player, bool bAutoPlay /* = fa
   // check if the item itself is a playlist, and can be expanded
   // only allow a few levels, this could end up in a loop
   // if they refer to each other in a loop
-  for (int i=0;i<5;i++)
+  for (int i=0; i<5; i++)
   {
     if(!playlist.Expand(iSong))
       break;

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -467,8 +467,6 @@ bool CPlayList::Expand(int position)
     return false;
 
   std::string path = item->GetDynPath();
-  if (path.empty())
-    path = item->GetPath();
 
   if (!playlist->Load(path))
     return false;
@@ -485,14 +483,10 @@ bool CPlayList::Expand(int position)
 
   // @todo
   // never change original path (id) of a file item
-  // playlist items should be created with dynPath instead
-  if (item->GetDynPath() != item->GetPath())
+  for (int i = 0;i<playlist->size();i++)
   {
-    for (int i = 0;i<playlist->size();i++)
-    {
-      (*playlist)[i]->SetDynPath((*playlist)[i]->GetPath());
-      (*playlist)[i]->SetPath(item->GetPath());
-    }
+    (*playlist)[i]->SetDynPath((*playlist)[i]->GetPath());
+    (*playlist)[i]->SetPath(item->GetPath());
   }
 
   if (playlist->size() <= 0)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1095,8 +1095,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
       }
     }
 
-    if (autoplay && !g_partyModeManager.IsEnabled() && 
-        !pItem->IsPlayList())
+    if (autoplay && !g_partyModeManager.IsEnabled())
     {
       return OnPlayAndQueueMedia(pItem, player);
     }
@@ -1463,7 +1462,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item, std::string 
       if (nItem->m_bIsFolder)
         continue;
 
-      if (!nItem->IsPlayList() && !nItem->IsZIP() && !nItem->IsRAR() && (!nItem->IsDVDFile() || (URIUtils::GetFileName(nItem->GetPath()) == mainDVD)))
+      if (!nItem->IsZIP() && !nItem->IsRAR() && (!nItem->IsDVDFile() || (URIUtils::GetFileName(nItem->GetPath()) == mainDVD)))
         CServiceBroker::GetPlaylistPlayer().Add(iPlaylist, nItem);
 
       if (item->IsSamePath(nItem.get()))


### PR DESCRIPTION
PlaylistPlayer can already handle nested playlists. no reason for this limitation when playing files with "play next automatically" enabled