### PR TITLE
 Implement generic DRM CryptoSession interface + python API

### DIFF
--- a/cmake/treedata/android/subdirs.txt
+++ b/cmake/treedata/android/subdirs.txt
@@ -10,6 +10,7 @@ xbmc/platform/linux/network             platform/linux/network
 xbmc/platform/linux/peripherals         platform/linux/peripherals
 xbmc/platform/android/activity          platform/android/activity
 xbmc/platform/android/bionic_supplement platform/android/bionicsupplement
+xbmc/platform/android/drm               platform/android/drm
 xbmc/platform/android/filesystem        platform/android/filesystem
 xbmc/platform/android/network           platform/android/network
 xbmc/platform/android/peripherals       platform/android/peripherals

--- a/cmake/treedata/common/drm.txt
+++ b/cmake/treedata/common/drm.txt
@@ -1,0 +1,1 @@
+xbmc/drm drm

--- a/tools/depends/target/libandroidjni/Makefile
+++ b/tools/depends/target/libandroidjni/Makefile
@@ -3,7 +3,7 @@ DEPS= ../../Makefile.include Makefile
 
 # lib name, version
 LIBNAME=libandroidjni
-VERSION=d5fd1b46484d103f51c93cf4a38784d7cddd8175
+VERSION=dfc7742daff2e9aa939fff0d9db010893f4b269e
 SOURCE=archive
 ARCHIVE=$(VERSION).tar.gz
 GIT_BASE_URL=https://github.com/xbmc

--- a/xbmc/commons/Buffer.h
+++ b/xbmc/commons/Buffer.h
@@ -217,15 +217,15 @@ namespace XbmcCommons
      *  that can be read out of the buffer or written into the
      *  buffer before it's finished.
      */
-    inline size_t remaining() { return mlimit - mposition; }
+    inline size_t remaining() const { return mlimit - mposition; }
 
     inline Buffer& put(const void* src, size_t bytes)
     { check(bytes); memcpy( buffer + mposition, src, bytes); mposition += bytes; return *this; }
     inline Buffer& get(void* dest, size_t bytes)
     { check(bytes); memcpy( dest, buffer + mposition, bytes); mposition += bytes; return *this; }
 
-    inline unsigned char* array() { return buffer; }
-    inline unsigned char* curPosition() { return buffer + mposition; }
+    inline unsigned char* data() const { return buffer; }
+    inline unsigned char* curPosition() const { return buffer + mposition; }
     inline Buffer& setPosition(size_t position) { mposition = position; return *this; }
     inline Buffer& forward(size_t positionIncrement)
     { check(positionIncrement); mposition += positionIncrement; return *this; }

--- a/xbmc/drm/CMakeLists.txt
+++ b/xbmc/drm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES CryptoSession.cpp)
+
+set(HEADERS CryptoSession.h)
+
+core_add_library(drm)

--- a/xbmc/drm/CryptoSession.cpp
+++ b/xbmc/drm/CryptoSession.cpp
@@ -1,0 +1,39 @@
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "CryptoSession.h"
+
+using namespace DRM;
+
+std::vector<GET_CRYPTO_SESSION_INTERFACE_FN> CCryptoSession::s_registeredInterfaces;
+
+void CCryptoSession::RegisterInterface(GET_CRYPTO_SESSION_INTERFACE_FN fn)
+{
+  s_registeredInterfaces.push_back(fn);
+}
+
+CCryptoSession* CCryptoSession::GetCryptoSession(const std::string &UUID, const std::string &cipherAlgo, const std::string &macAlgo)
+{
+  CCryptoSession* retVal = nullptr;
+  for (auto fn : s_registeredInterfaces)
+    if ((retVal = fn(UUID, cipherAlgo, macAlgo)))
+      break;
+  return retVal;
+}

--- a/xbmc/drm/CryptoSession.h
+++ b/xbmc/drm/CryptoSession.h
@@ -1,0 +1,63 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <vector>
+#include <map>
+#include <stdint.h>
+
+#include "commons/Buffer.h"
+
+namespace DRM
+{
+  class CCryptoSession;
+
+  typedef CCryptoSession* (*GET_CRYPTO_SESSION_INTERFACE_FN)(const std::string &UUID, const std::string &cipherAlgo, const std::string &hmacAlgo);
+
+  class CCryptoSession
+  {
+  public:
+    // Interface registration
+    static CCryptoSession* GetCryptoSession(const std::string &UUID, const std::string &cipherAlgo, const std::string &macAlgo);
+    virtual ~CCryptoSession() {};
+
+    // Interface methods
+    virtual XbmcCommons::Buffer GetKeyRequest(const XbmcCommons::Buffer &init, const std::string &mimeType, bool offlineKey, const std::map<std::string, std::string> &parameters) = 0;
+    virtual std::string GetPropertyString(const std::string &name) = 0;
+    virtual std::string ProvideKeyResponse(const XbmcCommons::Buffer &response) = 0;
+    virtual void RemoveKeys() = 0;
+    virtual void RestoreKeys(const std::string &keySetId) = 0;
+    virtual void SetPropertyString(const std::string &name, const std::string &value) = 0;
+
+    // Crypto methods
+    virtual XbmcCommons::Buffer Decrypt(const XbmcCommons::Buffer &cipherKeyId, const XbmcCommons::Buffer &input, const XbmcCommons::Buffer &iv) = 0;
+    virtual XbmcCommons::Buffer Encrypt(const XbmcCommons::Buffer &cipherKeyId, const XbmcCommons::Buffer &input, const XbmcCommons::Buffer &iv) = 0;
+    virtual XbmcCommons::Buffer Sign(const XbmcCommons::Buffer &macKeyId, const XbmcCommons::Buffer &message) = 0;
+    virtual bool Verify(const XbmcCommons::Buffer &macKeyId, const XbmcCommons::Buffer &message, const XbmcCommons::Buffer &signature ) = 0;
+
+  protected:
+    static void RegisterInterface(GET_CRYPTO_SESSION_INTERFACE_FN fn);
+
+  private:
+    static std::vector<GET_CRYPTO_SESSION_INTERFACE_FN> s_registeredInterfaces;
+  };
+
+} //namespace

--- a/xbmc/interfaces/legacy/CMakeLists.txt
+++ b/xbmc/interfaces/legacy/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES AddonCallback.cpp
             CallbackHandler.cpp
             Control.cpp
             Dialog.cpp
+            DrmCryptoSession.cpp
             File.cpp
             InfoTagMusic.cpp
             InfoTagRadioRDS.cpp
@@ -38,6 +39,7 @@ set(HEADERS Addon.h
             Control.h
             Dialog.h
             Dictionary.h
+            DrmCryptoSession.h
             Exception.h
             File.h
             InfoTagMusic.h

--- a/xbmc/interfaces/legacy/DrmCryptoSession.cpp
+++ b/xbmc/interfaces/legacy/DrmCryptoSession.cpp
@@ -1,0 +1,117 @@
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DrmCryptoSession.h"
+#include "drm/CryptoSession.h"
+
+using namespace XbmcCommons;
+
+namespace XBMCAddon
+{
+  namespace xbmcdrm
+  {
+    CryptoSession::CryptoSession(String UUID, String cipherAlgorithm, String macAlgorithm)
+      : m_cryptoSession(DRM::CCryptoSession::GetCryptoSession(UUID, cipherAlgorithm, macAlgorithm))
+    {
+    }
+
+    CryptoSession::~CryptoSession()
+    {
+      delete m_cryptoSession;
+    }
+
+    Buffer CryptoSession::GetKeyRequest(const Buffer &init, const String &mimeType, bool offlineKey, const std::map<String, String> &parameters)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->GetKeyRequest(init, mimeType, offlineKey, parameters);
+
+      return Buffer();
+    }
+
+    String CryptoSession::GetPropertyString(const String &name)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->GetPropertyString(name);
+
+      return "";
+    }
+
+    String CryptoSession::ProvideKeyResponse(const Buffer &response)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->ProvideKeyResponse(response);
+
+      return "";
+    }
+
+    void CryptoSession::RemoveKeys()
+    {
+      if (m_cryptoSession)
+        m_cryptoSession->RemoveKeys();
+    }
+
+    void CryptoSession::RestoreKeys(String keySetId)
+    {
+      if (m_cryptoSession)
+        m_cryptoSession->RestoreKeys(keySetId);
+    }
+
+    void CryptoSession::SetPropertyString(const String &name, const String &value)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->SetPropertyString(name, value);
+    }
+
+    /*******************Crypto section *****************/
+
+    Buffer CryptoSession::Decrypt(const Buffer &cipherKeyId, const Buffer &input, const Buffer &iv)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->Decrypt(cipherKeyId, input, iv);
+
+      return Buffer();
+    }
+
+    Buffer CryptoSession::Encrypt(const Buffer &cipherKeyId, const Buffer &input, const Buffer &iv)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->Encrypt(cipherKeyId, input, iv);
+
+      return Buffer();
+    }
+
+    Buffer CryptoSession::Sign(const Buffer &macKeyId, const Buffer &message)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->Sign(macKeyId, message);
+
+      return Buffer();
+    }
+
+    bool CryptoSession::Verify(const Buffer &macKeyId, const Buffer &message, const Buffer &signature)
+    {
+      if (m_cryptoSession)
+        return m_cryptoSession->Verify(macKeyId, message, signature);
+
+      return false;
+    }
+
+  } //namespace xbmcdrm
+} //namespace XBMCAddon

--- a/xbmc/interfaces/legacy/DrmCryptoSession.h
+++ b/xbmc/interfaces/legacy/DrmCryptoSession.h
@@ -1,0 +1,243 @@
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "AddonClass.h"
+#include "Exception.h"
+#include "commons/Buffer.h"
+
+namespace DRM
+{
+  class CCryptoSession;
+}
+
+namespace XBMCAddon
+{
+
+  typedef std::vector<char> charVec;
+
+  namespace xbmcdrm
+  {
+
+    XBMCCOMMONS_STANDARD_EXCEPTION(DRMException);
+
+    //
+    /// \defgroup python_drm CryptoSession
+    /// \ingroup python_xbmcdrm
+    /// @{
+    /// @brief <b>Kodi DRM CryptoSession class.</b>
+    ///--------------------------------------------------------------------------
+    /// \python_class{ xbmcdrm.CryptoSession(UUID) }
+    ///
+    /// @param UUID             String  16 byte UUID of the DRM system to use
+    /// @param cipherAlgorithm  String algorithm used for en- / decryption
+    /// @param macAlgorithm     String algorithm used for sign / verify
+    ///
+    /// @throws RuntimeException if the session can not be established 
+    ///
+    //
+    class CryptoSession : public AddonClass
+    {
+      DRM::CCryptoSession* m_cryptoSession;
+    public:
+
+      CryptoSession(String UUID, String cipherAlgorithm, String macAlgorithm);
+      ~CryptoSession() override;
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ GetKeyRequest(init, mimeType, offlineKey, optionalParameters) }
+      ///-----------------------------------------------------------------------
+      /// Generate a key request which is supposed to be send to the key server.
+      /// The servers response is passed to provideKeyResponse to activate the keys.
+      ///
+      /// @param      [byte] init Initialization bytes / depends on key system
+      /// @param      String mimeType Type of media which is xchanged, e.g. application/xml, video/mp4
+      /// @param      bool offlineKey Persistant (offline) or temporary (streaming) key
+      /// @param      [map] optionalParameters optional parameters / depends on key system
+      ///
+      /// @return     opaque key request data (challenge) which is send to key server
+      ///
+      GetKeyRequest(...);
+#else
+      XbmcCommons::Buffer GetKeyRequest(const XbmcCommons::Buffer &init, const String &mimeType, bool offlineKey, const std::map<String, String> &optionalParameters);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ GetPropertyString(name) }
+      ///-----------------------------------------------------------------------
+      /// Request a system specific property value of the DRM system
+      ///
+      /// @param      String Name name of the property to query
+      ///
+      /// @return     Value of the requested property
+      ///
+      GetPropertyString(...);
+#else
+      String GetPropertyString(const String &name);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ ProvideKeyResponse(response) }
+      ///-----------------------------------------------------------------------
+      /// Provide key data returned from key server. See getKeyRequest(...)
+      ///
+      /// @param      [byte] response Key data returned from key server
+      ///
+      /// @return     String If offline keays are requested, a keySetId which can be used later
+      ///                    with restoreKeys, empty for online / streaming) keys.
+      ///
+      ProvideKeyResponse(...);
+#else
+      String ProvideKeyResponse(const XbmcCommons::Buffer &response);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ RemoveKeys() }
+      ///-----------------------------------------------------------------------
+      /// removes all keys currently loaded in a session.
+      ///
+      /// @param      None
+      ///
+      /// @return     None
+      ///
+      RemoveKeys(...);
+#else
+      void RemoveKeys();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ RestoreKeys(keySetId) }
+      ///-----------------------------------------------------------------------
+      /// restores keys stored during previous provideKeyResponse call.
+      ///
+      /// @param      String keySetId
+      ///
+      /// @return     None
+      ///
+      RestoreKeys(...);
+#else
+      void RestoreKeys(String keySetId);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ SetPropertyString(name, value) }
+      ///-----------------------------------------------------------------------
+      /// Sets a system specific property value in the DRM system
+      ///
+      /// @param      String name   Name of the property to query
+      /// @param      String value  Value of the property to query
+      ///
+      /// @return     Value of the requested property
+      ///
+      SetPropertyString(...);
+#else
+      void SetPropertyString(const String &name, const String &value);
+#endif
+
+/*******************Crypto section *****************/
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ Decrypt(cipherKeyId, input, iv) }
+      ///-----------------------------------------------------------------------
+      /// Sets a system specific property value in the DRM system
+      ///
+      /// @param      [byte] cipherKeyId
+      /// @param      [byte] input
+      /// @param      [byte] iv
+      ///
+      /// @return     Decrypted input data
+      ///
+      Decrypt(...);
+#else
+      XbmcCommons::Buffer Decrypt(const XbmcCommons::Buffer &cipherKeyId, const XbmcCommons::Buffer &input, const XbmcCommons::Buffer &iv);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ Encrypt(cipherKeyId, input, iv) }
+      ///-----------------------------------------------------------------------
+      /// Sets a system specific property value in the DRM system
+      ///
+      /// @param      [byte] cipherKeyId
+      /// @param      [byte] input
+      /// @param      [byte] iv
+      ///
+      /// @return     Encrypted input data
+      ///
+      Encrypt(...);
+#else
+      XbmcCommons::Buffer Encrypt(const XbmcCommons::Buffer &cipherKeyId, const XbmcCommons::Buffer &input, const XbmcCommons::Buffer &iv);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ Sign(macKeyId, message) }
+      ///-----------------------------------------------------------------------
+      /// Sets a system specific property value in the DRM system
+      ///
+      /// @param      [byte] macKeyId
+      /// @param      [byte] message
+      ///
+      /// @return     [byte] Signature
+      ///
+      Sign(...);
+#else
+      XbmcCommons::Buffer Sign(const XbmcCommons::Buffer &macKeyId, const XbmcCommons::Buffer &message);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcdrm
+      /// @brief \python_func{ Verify(macKeyId, message, signature) }
+      ///-----------------------------------------------------------------------
+      /// Sets a system specific property value in the DRM system
+      ///
+      /// @param      [byte] macKeyId
+      /// @param      [byte] message
+      /// @param      [byte] signature
+      ///
+      /// @return     true if message verification succeded
+      ///
+      Verify(...);
+#else
+      bool Verify(const XbmcCommons::Buffer &macKeyId, const XbmcCommons::Buffer &message, const XbmcCommons::Buffer &signature);
+#endif
+
+    };
+    //@}
+  }
+}

--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -76,6 +76,7 @@
 #endif
 
 namespace PythonBindings {
+  void initModule_xbmcdrm(void);
   void initModule_xbmcgui(void);
   void initModule_xbmc(void);
   void initModule_xbmcplugin(void);
@@ -93,6 +94,7 @@ typedef struct
 
 static PythonModule PythonModules[] =
   {
+    { "xbmcdrm",    initModule_xbmcdrm    },
     { "xbmcgui",    initModule_xbmcgui    },
     { "xbmc",       initModule_xbmc       },
     { "xbmcplugin", initModule_xbmcplugin },

--- a/xbmc/interfaces/swig/AddonModuleXbmcdrm.i
+++ b/xbmc/interfaces/swig/AddonModuleXbmcdrm.i
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+%module xbmcdrm
+
+%{
+#if defined(TARGET_WINDOWS)
+#  include <windows.h>
+#endif
+
+#include "interfaces/legacy/DrmCryptoSession.h"
+#include "utils/log.h"
+
+using namespace XBMCAddon;
+using namespace xbmcdrm;
+
+#if defined(__GNUG__)
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
+%}
+
+%include "interfaces/legacy/swighelper.h"
+%include "interfaces/legacy/AddonString.h"
+%include "interfaces/legacy/DrmCryptoSession.h"

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(SWIG REQUIRED)
 
 # The generated bindings
 set(INPUTS AddonModuleXbmcaddon.i
+           AddonModuleXbmcdrm.i
            AddonModuleXbmcgui.i
            AddonModuleXbmc.i
            AddonModuleXbmcplugin.i

--- a/xbmc/platform/android/drm/CMakeLists.txt
+++ b/xbmc/platform/android/drm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES MediaDrmCryptoSession.cpp)
+
+set(HEADERS MediaDrmCryptoSession.h)
+
+core_add_library(anroid_drm)

--- a/xbmc/platform/android/drm/MediaDrmCryptoSession.cpp
+++ b/xbmc/platform/android/drm/MediaDrmCryptoSession.cpp
@@ -1,0 +1,246 @@
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MediaDrmCryptoSession.h"
+
+#include <androidjni/MediaDrm.h>
+#include <androidjni/UUID.h>
+#include <stdexcept>
+
+#include "utils/StringUtils.h"
+
+using namespace DRM;
+using namespace XbmcCommons;
+
+
+class CharVecBuffer : public Buffer
+{
+public:
+  inline CharVecBuffer(const Buffer &buf) : Buffer(buf) {};
+
+  inline CharVecBuffer(const std::vector<char> &vec)
+    : Buffer(vec.size())
+  {
+    memcpy(data(), vec.data(), vec.size());
+  }
+
+  inline operator std::vector<char>() const
+  {
+    return std::vector<char>(data(), data() + capacity());
+  }
+};
+
+
+void CMediaDrmCryptoSession::Register()
+{
+  CCryptoSession::RegisterInterface(CMediaDrmCryptoSession::Create);
+}
+
+CMediaDrmCryptoSession::CMediaDrmCryptoSession(const std::string &UUID, const std::string &cipherAlgo, const std::string &macAlgo)
+  : m_mediaDrm(nullptr)
+  , m_cryptoSession(nullptr)
+  , m_cipherAlgo(cipherAlgo)
+  , m_macAlgo(macAlgo)
+  , m_hasKeys(false)
+  , m_sessionId(nullptr)
+{
+  if (!StringUtils::EqualsNoCase(UUID, "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"))
+    throw std::runtime_error("mediaDrm: Invalid UUID size");
+
+  int64_t mostSigBits(0), leastSigBits(0);
+  const uint8_t uuidPtr[16] = {0xed,0xef,0x8b,0xa9,0x79,0xd6,0x4a,0xce,0xa3,0xc8,0x27,0xdc,0xd5,0x1d,0x21,0xed};
+  for (unsigned int i(0); i < 8; ++i)
+    mostSigBits = (mostSigBits << 8) | uuidPtr[i];
+  for (unsigned int i(8); i < 16; ++i)
+   leastSigBits = (leastSigBits << 8) | uuidPtr[i];
+
+  CJNIUUID uuid(mostSigBits, leastSigBits);
+
+  m_mediaDrm = new CJNIMediaDrm(uuid);
+
+  if (xbmc_jnienv()->ExceptionCheck())
+  {
+    xbmc_jnienv()->ExceptionClear();
+    throw std::runtime_error("Failure creating MediaDrm");
+  }
+
+  if (!OpenSession())
+    throw std::runtime_error("Unable to create a session");
+}
+
+CMediaDrmCryptoSession::~CMediaDrmCryptoSession()
+{
+  if (!m_mediaDrm)
+    return;
+
+  CloseSession();
+
+  m_mediaDrm->release();
+  delete m_mediaDrm, m_mediaDrm = nullptr;
+}
+
+CCryptoSession* CMediaDrmCryptoSession::Create(const std::string &UUID, const std::string &cipherAlgo, const std::string &macAlgo)
+{
+  CMediaDrmCryptoSession *res = nullptr;;
+  try
+  {
+    res = new CMediaDrmCryptoSession(UUID, cipherAlgo, macAlgo);
+  }
+  catch (std::runtime_error &e)
+  {
+    delete res, res = nullptr;
+  }
+  return res;
+}
+
+/*****************/
+
+// Interface methods
+Buffer CMediaDrmCryptoSession::GetKeyRequest(const Buffer &init,
+  const std::string &mimeType,
+  bool offlineKey,
+  const std::map<std::string, std::string> &parameters)
+{
+  if (m_mediaDrm && m_sessionId)
+  {
+    CJNIMediaDrmKeyRequest req = m_mediaDrm->getKeyRequest(*m_sessionId, CharVecBuffer(init), mimeType,
+      offlineKey ? CJNIMediaDrm::KEY_TYPE_OFFLINE : CJNIMediaDrm::KEY_TYPE_STREAMING, parameters);
+    return CharVecBuffer(req.getData());
+  }
+
+  return Buffer();
+}
+
+
+std::string CMediaDrmCryptoSession::GetPropertyString(const std::string &name)
+{
+  if (m_mediaDrm)
+    return m_mediaDrm->getPropertyString(name);
+
+  return "";
+}
+
+
+std::string CMediaDrmCryptoSession::ProvideKeyResponse(const Buffer &response)
+{
+  if (m_mediaDrm)
+  {
+    m_hasKeys = true;
+    std::vector<char> res = m_mediaDrm->provideKeyResponse(*m_sessionId, CharVecBuffer(response));
+    return std::string(res.data(), res.size());
+  }
+
+  return "";
+}
+
+void CMediaDrmCryptoSession::RemoveKeys()
+{
+  if (m_mediaDrm && m_sessionId && m_hasKeys)
+  {
+    CloseSession();
+    OpenSession();
+  }
+}
+
+void CMediaDrmCryptoSession::RestoreKeys(const std::string &keySetId)
+{
+  if (m_mediaDrm && keySetId != m_keySetId)
+  {
+    m_mediaDrm->restoreKeys(*m_sessionId, std::vector<char>(keySetId.begin(), keySetId.end()));
+    m_hasKeys = true;
+    m_keySetId = keySetId;
+  }
+}
+
+void CMediaDrmCryptoSession::SetPropertyString(const std::string &name, const std::string &value)
+{
+  if (m_mediaDrm)
+    m_mediaDrm->setPropertyString(name, value);
+}
+
+// Crypto methods
+Buffer CMediaDrmCryptoSession::Decrypt(const Buffer &cipherKeyId, const Buffer &input, const Buffer &iv)
+{
+  if (m_cryptoSession)
+    return CharVecBuffer(m_cryptoSession->decrypt(CharVecBuffer(cipherKeyId), CharVecBuffer(input), CharVecBuffer(iv)));
+
+  return Buffer();
+}
+
+Buffer CMediaDrmCryptoSession::Encrypt(const Buffer &cipherKeyId, const Buffer &input, const Buffer &iv)
+{
+  if (m_cryptoSession)
+    return CharVecBuffer(m_cryptoSession->encrypt(CharVecBuffer(cipherKeyId), CharVecBuffer(input), CharVecBuffer(iv)));
+
+  return Buffer();
+}
+
+Buffer CMediaDrmCryptoSession::Sign(const Buffer &macKeyId, const Buffer &message)
+{
+  if (m_cryptoSession)
+    return CharVecBuffer(m_cryptoSession->sign(CharVecBuffer(macKeyId), CharVecBuffer(message)));
+
+  return Buffer();
+}
+
+bool CMediaDrmCryptoSession::Verify(const Buffer &macKeyId, const Buffer &message, const Buffer &signature)
+{
+  if (m_cryptoSession)
+    return m_cryptoSession->verify(CharVecBuffer(macKeyId), CharVecBuffer(message), CharVecBuffer(signature));
+
+  return false;
+}
+
+//Private stuff
+bool CMediaDrmCryptoSession::OpenSession()
+{
+  m_sessionId = new CharVecBuffer(m_mediaDrm->openSession());
+  if (xbmc_jnienv()->ExceptionCheck())
+  {
+    delete m_sessionId, m_sessionId = nullptr;
+    xbmc_jnienv()->ExceptionClear();
+    return false;;
+  }
+
+  m_cryptoSession = new CJNIMediaDrmCryptoSession(m_mediaDrm->getCryptoSession(*m_sessionId, m_cipherAlgo, m_macAlgo));
+
+  if (xbmc_jnienv()->ExceptionCheck())
+  {
+    xbmc_jnienv()->ExceptionClear();
+    return false;
+  }
+  return true;
+}
+
+void CMediaDrmCryptoSession::CloseSession()
+{
+  if (m_sessionId)
+  {
+    m_mediaDrm->removeKeys(*m_sessionId);
+    m_mediaDrm->closeSession(*m_sessionId);
+
+    if (m_cryptoSession)
+      delete(m_cryptoSession), m_cryptoSession = nullptr;
+
+    delete m_sessionId, m_sessionId = nullptr;
+    m_hasKeys = false;
+    m_keySetId.clear();
+  }
+}

--- a/xbmc/platform/android/drm/MediaDrmCryptoSession.h
+++ b/xbmc/platform/android/drm/MediaDrmCryptoSession.h
@@ -1,0 +1,86 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "drm/CryptoSession.h"
+
+class CJNIMediaDrm;
+class CJNIMediaDrmCryptoSession;
+
+namespace DRM
+{
+  class CharVecBuffer : public XbmcCommons::Buffer
+  {
+  public:
+    inline CharVecBuffer(const XbmcCommons::Buffer &buf) : XbmcCommons::Buffer(buf) {};
+
+    inline CharVecBuffer(const std::vector<char> &vec)
+      : XbmcCommons::Buffer(vec.size())
+    {
+      memcpy(data(), vec.data(), vec.size());
+    }
+
+    inline operator std::vector<char>() const
+    {
+      return std::vector<char>(data(), data() + capacity());
+    }
+  };
+
+  class CharVecBuffer;
+
+  class CMediaDrmCryptoSession : public CCryptoSession
+  {
+  public:
+    static void Register();
+    CMediaDrmCryptoSession(const std::string &UUID, const std::string &cipherAlgo, const std::string &macAlgo);
+    virtual ~CMediaDrmCryptoSession();
+
+    // Interface methods
+    XbmcCommons::Buffer GetKeyRequest(const XbmcCommons::Buffer &init, const std::string &mimeType, bool offlineKey, const std::map<std::string, std::string> &parameters) override;
+    std::string GetPropertyString(const std::string &name) override;
+    std::string ProvideKeyResponse(const XbmcCommons::Buffer &response) override;
+    void RemoveKeys() override;
+    void RestoreKeys(const std::string &keySetId) override;
+    void SetPropertyString(const std::string &name, const std::string &value) override;
+
+    // Crypto methods
+    XbmcCommons::Buffer Decrypt(const XbmcCommons::Buffer &cipherKeyId, const XbmcCommons::Buffer &input, const XbmcCommons::Buffer &iv) override;
+    XbmcCommons::Buffer Encrypt(const XbmcCommons::Buffer &cipherKeyId, const XbmcCommons::Buffer &input, const XbmcCommons::Buffer &iv) override;
+    XbmcCommons::Buffer Sign(const XbmcCommons::Buffer &macKeyId, const XbmcCommons::Buffer &message) override;
+    bool Verify(const XbmcCommons::Buffer &macKeyId, const XbmcCommons::Buffer &message, const XbmcCommons::Buffer &signature ) override;
+
+  private:
+    static CCryptoSession* Create(const std::string &UUID, const std::string &cipherAlgo, const std::string &hmacAlgo);
+    bool OpenSession();
+    void CloseSession();
+
+    CJNIMediaDrm *m_mediaDrm;
+    CJNIMediaDrmCryptoSession *m_cryptoSession;
+
+    std::string m_cipherAlgo;
+    std::string  m_macAlgo;
+    std::string m_keySetId;
+
+    bool m_hasKeys;
+
+    CharVecBuffer *m_sessionId;
+  };
+
+} //namespace

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -42,6 +42,7 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h"
 #include "platform/android/powermanagement/AndroidPowerSyscall.h"
 #include "addons/interfaces/platform/android/System.h"
+#include "platform/android/drm/MediaDrmCryptoSession.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglplatform.h>
@@ -88,6 +89,7 @@ bool CWinSystemAndroid::InitWindowSystem()
   CRendererMediaCodec::Register();
   CRendererMediaCodecSurface::Register();
   ADDON::Interface_Android::Register();
+  DRM::CMediaDrmCryptoSession::Register();
   return CWinSystemBase::InitWindowSystem();
 }
 


### PR DESCRIPTION
## Description
Interface / framework for secure communication sessions.

Workflow:
- Client (kodi) retrieves a system specific challenge (=keyRequest) from CryptoSession
- Client sends this keyRequest secure to the key server
- Key server responses with a keyResponse (including keys and / or keyId's) which is provided to the Cryptosession
- After this key exchange the CryptoSessions en-/decrypt, sign and verify functions can be used.

This PR includes in the second commit the Android Widevine implementation, Other implementations (e.g. AES Key Wrap) will follow. 

## Motivation and Context
Some content provider require CryptoSession instead / on top of HTTPS.
The Implementation is quite generic and can also be used for streaming decryption and helps therefore transfering ownership of inputstream.adaptive to kodi (for next GSOC period)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
