### PR TITLE
Fix for IPTV channel switching delays.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -444,6 +444,12 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   }
   else if (!iformat || (strcmp(iformat->name, "mpegts") != 0))
   {
+    if (m_streaminfo == false)
+    {
+	av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
+	m_checkvideo = true;
+	skipCreateStreams = true;
+    }
     m_streaminfo = true;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
A user reports slow response when switching channels / zapping using a UDP IPTV service.

## Motivation and Context

Improvements can be made to zapping and less care needs to be taken when analysing UDP streams. 

Sometimes it can take seven or eight seconds to change channel.
This is because CDVDDemuxFFmpeg::Open ffmpeg's method calls avformat_find_stream_info method which has a default timeout value of five seconds.

This method has an argument describing whether stream information should be requested or not. For UDP streams, it is set to false. But this is later overwritten by:

```
// iformat is NULL because it is a udp stream and we don’t have the format type in advance
else if (!iformat || (strcmp(iformat->name, “mpegts”) != 0))
{
m_streaminfo = true;
}

````

We must be careful.

* If we completely disable the streaminfo request, video is not rendered at all.
* Setting the timeout to a hundred milliseconds works, but may not be safe. Five hundred milliseconds seems to work for users without any reported issues. This value has been chosen because it is used in ffmpeg and this value is even cited as being set as such to fix slow IPTV channel changes for Kodi. 

## How Has This Been Tested?

This has been included in OSMC since early January on Kodi Krypton without reports of issues.
It has also been included with our Kodi Leia test builds, but this does attract fewer users. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ x Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
