### PR TITLE
CActiveAEResampleFFMPEG: Add support to mix LFE in to stereo channels

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19720,6 +19720,18 @@ msgstr ""
 
 #empty strings from id 36443 to 36459
 
+msgctxt "#36457"
+msgid "Include LFE in stereo downmix"
+msgstr ""
+
+msgctxt "#36458"
+msgid "Include low frequency effects channel in stereo downmix. 100% - Full LFE volume. 10% to 90% - reduced LFE volume. 0% - LFE excluded from stereo downmix. Note: To avoid damaging your speakers only enable LFE downmix if your speakers can handle very low bass frequencies."
+msgstr ""
+
+msgctxt "#36459"
+msgid "%i %%"
+msgstr ""
+
 #. Description of settings with label #14112 "Enable event logging"
 #: system/settings/settings.xml
 msgctxt "#36460"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2479,6 +2479,18 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="audiooutput.mixlfe" type="integer" label="36457" help="36458">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>10</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="spinner" format="string">
+            <formatlabel>36459</formatlabel>
+          </control>
+        </setting>
         <setting id="audiooutput.processquality" type="integer" label="13505" help="36169">
           <requirement>HAS_AE_QUALITY_LEVELS</requirement>
           <level>2</level>

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEResampleFFMPEG.cpp
@@ -9,6 +9,8 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "ActiveAEResampleFFMPEG.h"
 #include "utils/log.h"
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
 
 extern "C" {
 #include "libavutil/channel_layout.h"
@@ -61,6 +63,12 @@ bool CActiveAEResampleFFMPEG::Init(SampleConfig dstConfig, SampleConfig srcConfi
   {
     CLog::Log(LOGERROR, "CActiveAEResampleFFMPEG::Init - create context failed");
     return false;
+  }
+
+  double mix_lfe = static_cast<float>(CServiceBroker::GetSettings()->GetInt("audiooutput.mixlfe")) / 100.0f;
+  if (mix_lfe)
+  {
+    av_opt_set_double(m_pContext, "lfe_mix_level", mix_lfe, 0);
   }
 
   if(quality == AE_QUALITY_HIGH)


### PR DESCRIPTION
## Description

Add support for mixing LFE in to stereo channels.

## Motivation and Context

It's understood that DSP is planned for Kodi in the near future but unclear whether this will be part of the feature-set.

## How Has This Been Tested?

See https://discourse.osmc.tv/t/testing-improved-lpcm-output-for-vero-4k/70867/78

We have had positive reports after including it in an update. It does not change current, default behaviour. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
