### PR TITLE
[guiinfo] Fix PLAYER_TITLE fallbacks.

### DIFF
--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -25,6 +25,7 @@
 #include "PartyModeManager.h"
 #include "PlayListPlayer.h"
 #include "URL.h"
+#include "Util.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/MusicInfoLoader.h"
 #include "music/MusicThumbLoader.h"
@@ -95,16 +96,16 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     switch (info.m_info)
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
-      // PLAYER_*
+      // PLAYER_* / MUSICPLAYER_* / LISTITEM_*
       /////////////////////////////////////////////////////////////////////////////////////////////
       case PLAYER_TITLE:
-        value = tag->GetTitle();
-        return !value.empty();
-
-      /////////////////////////////////////////////////////////////////////////////////////////////
-      // MUSICPLAYER_* / LISTITEM_*
-      /////////////////////////////////////////////////////////////////////////////////////////////
       case MUSICPLAYER_TITLE:
+        value = tag->GetTitle();
+        if (value.empty())
+          value = item->GetLabel();
+        if (value.empty())
+          value = CUtil::GetTitleFromPath(item->GetPath());
+        return true;
       case LISTITEM_TITLE:
         value = tag->GetTitle();
         return !value.empty();

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -26,6 +26,7 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
 #include "cores/DataCacheCore.h"
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "guilib/GUIComponent.h"
@@ -100,16 +101,16 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
     switch (info.m_info)
     {
       /////////////////////////////////////////////////////////////////////////////////////////////
-      // PLAYER_*
+      // PLAYER_* / VIDEOPLAYER_* / LISTITEM_*
       /////////////////////////////////////////////////////////////////////////////////////////////
       case PLAYER_TITLE:
-        value = tag->m_strTitle;
-        return !value.empty();
-
-      /////////////////////////////////////////////////////////////////////////////////////////////
-      // VIDEOPLAYER_* / LISTITEM_*
-      /////////////////////////////////////////////////////////////////////////////////////////////
       case VIDEOPLAYER_TITLE:
+        value = tag->m_strTitle;
+        if (value.empty())
+          value = item->GetLabel();
+        if (value.empty())
+          value = CUtil::GetTitleFromPath(item->GetPath());
+        return true;
       case LISTITEM_TITLE:
         value = tag->m_strTitle;
         return !value.empty();


### PR DESCRIPTION
Fixes a regression introduced with #13754 

Reported in the forum: https://forum.kodi.tv/showthread.php?tid=298461&pid=2726685#pid2726685

PLAYER_TITLE fallback handling (tag title -> item label -> filename) was broken.

@MilhouseVH fyi