### PR TITLE
Replace global color_t type with UTILS::Color.

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -33,6 +33,7 @@
 #include "utils/TransformMatrix.h"
 #include "messaging/ApplicationMessenger.h"
 #include "threads/SingleLock.h"
+#include "utils/Color.h"
 #include "utils/log.h"
 
 extern "C" {
@@ -238,7 +239,7 @@ void CRPRenderManager::RenderControl(bool bClear, bool bUseAlpha, const CRect &r
   }
 
   // Calculate alpha
-  color_t alpha = 255;
+  UTILS::Color alpha = 255;
   if (bUseAlpha)
     alpha = m_renderContext.MergeAlpha(0xFF000000) >> 24;
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -225,7 +225,7 @@ RESOLUTION CRenderContext::GetVideoResolution()
   return m_graphicsContext.GetVideoResolution();
 }
 
-void CRenderContext::Clear(color_t color /* = 0 */)
+void CRenderContext::Clear(UTILS::Color color /* = 0 */)
 {
   m_graphicsContext.Clear(color);
 }
@@ -240,7 +240,7 @@ void CRenderContext::SetRenderingResolution(const RESOLUTION_INFO &res, bool nee
   m_graphicsContext.SetRenderingResolution(res, needsScaling);
 }
 
-color_t CRenderContext::MergeAlpha(color_t color)
+UTILS::Color CRenderContext::MergeAlpha(UTILS::Color color)
 {
   return m_graphicsContext.MergeAlpha(color);
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -21,6 +21,7 @@
 
 #include "windowing/Resolution.h"
 #include "rendering/RenderSystemTypes.h"
+#include "utils/Color.h"
 #include "utils/Geometry.h"
 
 class CCriticalSection;
@@ -86,10 +87,10 @@ namespace RETRO
     bool IsFullScreenVideo();
     bool IsCalibrating();
     RESOLUTION GetVideoResolution();
-    void Clear(color_t color = 0);
+    void Clear(UTILS::Color color = 0);
     RESOLUTION_INFO GetResInfo();
     void SetRenderingResolution(const RESOLUTION_INFO &res, bool needsScaling);
-    color_t MergeAlpha(color_t color);
+    UTILS::Color MergeAlpha(UTILS::Color color);
     void SetTransform(const TransformMatrix &matrix, float scaleX, float scaleY);
     void RemoveTransform();
     CRect StereoCorrection(const CRect &rect);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.cpp
@@ -24,6 +24,7 @@
 #include "filesystem/File.h"
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "utils/Color.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -34,14 +35,14 @@
 
 using namespace OVERLAY;
 
-static color_t colors[8] = { 0xFFFFFF00
-                          , 0xFFFFFFFF
-                          , 0xFF0099FF
-                          , 0xFF00FF00
-                          , 0xFFCCFF00
-                          , 0xFF00FFFF
-                          , 0xFFE5E5E5
-                          , 0xFFC0C0C0 };
+static UTILS::Color colors[8] = { 0xFFFFFF00
+                                , 0xFFFFFFFF
+                                , 0xFF0099FF
+                                , 0xFF00FF00
+                                , 0xFFCCFF00
+                                , 0xFF00FFFF
+                                , 0xFFE5E5E5
+                                , 0xFFC0C0C0 };
 
 CGUITextLayout* COverlayText::GetFontLayout(const std::string &font, int color, int height, int style,
                                             const std::string &fontcache, const std::string &fontbordercache)

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -490,7 +490,7 @@ void CD3DTexture::GenerateMipmaps()
 }
 
 // static methods
-void CD3DTexture::DrawQuad(const CPoint points[4], color_t color, CD3DTexture *texture, const CRect *texCoords, SHADER_METHOD options)
+void CD3DTexture::DrawQuad(const CPoint points[4], UTILS::Color color, CD3DTexture *texture, const CRect *texCoords, SHADER_METHOD options)
 {
   unsigned numViews = 0;
   ID3D11ShaderResourceView* views = nullptr;
@@ -504,7 +504,7 @@ void CD3DTexture::DrawQuad(const CPoint points[4], color_t color, CD3DTexture *t
   DrawQuad(points, color, numViews, &views, texCoords, options);
 }
 
-void CD3DTexture::DrawQuad(const CRect &rect, color_t color, CD3DTexture *texture, const CRect *texCoords, SHADER_METHOD options)
+void CD3DTexture::DrawQuad(const CRect &rect, UTILS::Color color, CD3DTexture *texture, const CRect *texCoords, SHADER_METHOD options)
 {
   CPoint points[] =
   {
@@ -516,7 +516,7 @@ void CD3DTexture::DrawQuad(const CRect &rect, color_t color, CD3DTexture *textur
   DrawQuad(points, color, texture, texCoords, options);
 }
 
-void CD3DTexture::DrawQuad(const CPoint points[4], color_t color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords, SHADER_METHOD options)
+void CD3DTexture::DrawQuad(const CPoint points[4], UTILS::Color color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords, SHADER_METHOD options)
 {
   XMFLOAT4 xcolor;
   CD3DHelper::XMStoreColor(&xcolor, color);
@@ -537,7 +537,7 @@ void CD3DTexture::DrawQuad(const CPoint points[4], color_t color, unsigned numVi
   pGUIShader->DrawQuad(verts[0], verts[1], verts[2], verts[3]);
 }
 
-void CD3DTexture::DrawQuad(const CRect &rect, color_t color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords, SHADER_METHOD options)
+void CD3DTexture::DrawQuad(const CRect &rect, UTILS::Color color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords, SHADER_METHOD options)
 {
   CPoint points[] =
   {

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "utils/Color.h"
 #include "utils/Geometry.h"
 #include "GUIColorManager.h"
 
@@ -116,16 +117,16 @@ public:
   void GenerateMipmaps();
 
   // static methods
-  static void DrawQuad(const CPoint points[4], color_t color, CD3DTexture *texture, const CRect *texCoords,
+  static void DrawQuad(const CPoint points[4], UTILS::Color color, CD3DTexture *texture, const CRect *texCoords,
     SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
 
-  static void DrawQuad(const CPoint points[4], color_t color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords,
+  static void DrawQuad(const CPoint points[4], UTILS::Color color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords,
     SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
 
-  static void DrawQuad(const CRect &coords, color_t color, CD3DTexture *texture, const CRect *texCoords,
+  static void DrawQuad(const CRect &coords, UTILS::Color color, CD3DTexture *texture, const CRect *texCoords,
     SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
 
-  static void DrawQuad(const CRect &coords, color_t color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords,
+  static void DrawQuad(const CRect &coords, UTILS::Color color, unsigned numViews, ID3D11ShaderResourceView **view, const CRect *texCoords,
     SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
 
   void OnDestroyDevice(bool fatal) override;

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -333,7 +333,7 @@ std::string CGUIButtonControl::GetLabel2() const
   return strLabel;
 }
 
-void CGUIButtonControl::PythonSetLabel(const std::string &strFont, const std::string &strText, color_t textColor, color_t shadowColor, color_t focusedColor)
+void CGUIButtonControl::PythonSetLabel(const std::string &strFont, const std::string &strText, UTILS::Color textColor, UTILS::Color shadowColor, UTILS::Color focusedColor)
 {
   m_label.GetLabelInfo().font = g_fontManager.GetFont(strFont);
   m_label.GetLabelInfo().textColor = textColor;
@@ -342,7 +342,7 @@ void CGUIButtonControl::PythonSetLabel(const std::string &strFont, const std::st
   SetLabel(strText);
 }
 
-void CGUIButtonControl::PythonSetDisabledColor(color_t disabledColor)
+void CGUIButtonControl::PythonSetDisabledColor(UTILS::Color disabledColor)
 {
   m_label.GetLabelInfo().disabledColor = disabledColor;
 }

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -28,6 +28,8 @@
  *
  */
 
+#include "utils/Color.h"
+
 #include "GUITexture.h"
 #include "GUILabel.h"
 #include "GUIControl.h"
@@ -71,8 +73,8 @@ public:
   virtual void SetMinWidth(float minWidth);
   void SetAlpha(unsigned char alpha);
 
-  void PythonSetLabel(const std::string &strFont, const std::string &strText, color_t textColor, color_t shadowColor, color_t focusedColor);
-  void PythonSetDisabledColor(color_t disabledColor);
+  void PythonSetLabel(const std::string &strFont, const std::string &strText, UTILS::Color textColor, UTILS::Color shadowColor, UTILS::Color focusedColor);
+  void PythonSetDisabledColor(UTILS::Color disabledColor);
 
   virtual void OnClick();
   bool HasClickActions() const { return m_clickActions.HasActionsMeetingCondition(); };

--- a/xbmc/guilib/GUIColorManager.cpp
+++ b/xbmc/guilib/GUIColorManager.cpp
@@ -89,10 +89,10 @@ bool CGUIColorManager::LoadXML(CXBMCTinyXML &xmlDoc)
   {
     if (color->FirstChild() && color->Attribute("name"))
     {
-      color_t value = 0xffffffff;
+      UTILS::Color value = 0xffffffff;
       sscanf(color->FirstChild()->Value(), "%x", (unsigned int*) &value);
       std::string name = color->Attribute("name");
-      iColor it = m_colors.find(name);
+      const auto it = m_colors.find(name);
       if (it != m_colors.end())
         (*it).second = value;
       else
@@ -104,17 +104,17 @@ bool CGUIColorManager::LoadXML(CXBMCTinyXML &xmlDoc)
 }
 
 // lookup a color and return it's hex value
-color_t CGUIColorManager::GetColor(const std::string &color) const
+UTILS::Color CGUIColorManager::GetColor(const std::string &color) const
 {
   // look in our color map
   std::string trimmed(color);
   StringUtils::TrimLeft(trimmed, "= ");
-  icColor it = m_colors.find(trimmed);
+  const auto it = m_colors.find(trimmed);
   if (it != m_colors.end())
     return (*it).second;
 
   // try converting hex directly
-  color_t value = 0;
+  UTILS::Color value = 0;
   sscanf(trimmed.c_str(), "%x", &value);
   return value;
 }

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -196,7 +196,7 @@ void CGUIControl::DoRender()
 
     if (m_hitColor != 0xffffffff)
     {
-      color_t color = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(m_hitColor);
+      UTILS::Color color = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(m_hitColor);
       CGUITexture::DrawQuad(CServiceBroker::GetWinSystem()->GetGfxContext().GenerateAABB(m_hitRect), color);
     }
 
@@ -946,7 +946,7 @@ void CGUIControl::UpdateControlStats()
   }
 }
 
-void CGUIControl::SetHitRect(const CRect &rect, const color_t &color)
+void CGUIControl::SetHitRect(const CRect &rect, const UTILS::Color &color)
 {
   m_hitRect = rect;
   m_hitColor = color;

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -29,6 +29,7 @@
 
 #include <vector>
 
+#include "utils/Color.h"
 #include "windowing/GraphicContext.h" // needed by any rendering operation (all controls)
 #include "GUIMessage.h"     // needed by practically all controls
 #include "VisibleEffect.h"  // needed for the CAnimation members
@@ -175,7 +176,7 @@ public:
   bool IsVisibleFromSkin() const { return m_visibleFromSkinCondition; };
   virtual bool IsDisabled() const;
   virtual void SetPosition(float posX, float posY);
-  virtual void SetHitRect(const CRect &rect, const color_t &color);
+  virtual void SetHitRect(const CRect &rect, const UTILS::Color &color);
   virtual void SetCamera(const CPoint &camera);
   virtual void SetStereoFactor(const float &factor);
   bool SetColorDiffuse(const KODI::GUILIB::GUIINFO::CGUIInfoColor &color);
@@ -342,7 +343,7 @@ protected:
   float m_height;
   float m_width;
   CRect m_hitRect;
-  color_t m_hitColor;
+  UTILS::Color m_hitColor;
   KODI::GUILIB::GUIINFO::CGUIInfoColor m_diffuseColor;
   int m_controlID;
   int m_parentID;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -541,7 +541,7 @@ bool CGUIControlFactory::GetScroller(const TiXmlNode *control, const std::string
   return false;
 }
 
-bool CGUIControlFactory::GetColor(const TiXmlNode *control, const char *strTag, color_t &value)
+bool CGUIControlFactory::GetColor(const TiXmlNode *control, const char *strTag, UTILS::Color &value)
 {
   const TiXmlElement* node = control->FirstChildElement(strTag);
   if (node && node->FirstChild())

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "GUIControl.h"
+#include "utils/Color.h"
 
 class CTextureInfo; // forward
 class CAspectRatio;
@@ -105,7 +106,7 @@ public:
   static bool GetInfoLabelFromElement(const TiXmlElement *element, KODI::GUILIB::GUIINFO::CGUIInfoLabel &infoLabel, int parentID);
   static void GetInfoLabel(const TiXmlNode *pControlNode, const std::string &labelTag, KODI::GUILIB::GUIINFO::CGUIInfoLabel &infoLabel, int parentID);
   static void GetInfoLabels(const TiXmlNode *pControlNode, const std::string &labelTag, std::vector<KODI::GUILIB::GUIINFO::CGUIInfoLabel> &infoLabels, int parentID);
-  static bool GetColor(const TiXmlNode* pRootNode, const char* strTag, color_t &value);
+  static bool GetColor(const TiXmlNode* pRootNode, const char* strTag, UTILS::Color &value);
   static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, KODI::GUILIB::GUIINFO::CGUIInfoColor &value, int parentID);
   static std::string FilterLabel(const std::string &label);
   static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -22,6 +22,7 @@
 #include "GUIWindowManager.h"
 #include "ServiceBroker.h"
 #include "utils/CharsetConverter.h"
+#include "utils/Color.h"
 #include "utils/Digest.h"
 #include "utils/Variant.h"
 #include "GUIKeyboardFactory.h"
@@ -552,10 +553,10 @@ bool CGUIEditControl::SetStyledText(const std::wstring &text)
   vecText styled;
   styled.reserve(text.size() + 1);
 
-  vecColors colors;
+  std::vector<UTILS::Color> colors;
   colors.push_back(m_label.GetLabelInfo().textColor);
   colors.push_back(m_label.GetLabelInfo().disabledColor);
-  color_t select = m_label.GetLabelInfo().selectedColor;
+  UTILS::Color select = m_label.GetLabelInfo().selectedColor;
   if (!select)
     select = 0xFFFF0000;
   colors.push_back(select);

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -63,8 +63,8 @@ float CScrollInfo::GetPixelsPerFrame()
   return pixelSpeed * m_averageFrameTime;
 }
 
-CGUIFont::CGUIFont(const std::string& strFontName, uint32_t style, color_t textColor,
-                  color_t shadowColor, float lineSpacing, float origHeight, CGUIFontTTFBase *font):
+CGUIFont::CGUIFont(const std::string& strFontName, uint32_t style, UTILS::Color textColor,
+                   UTILS::Color shadowColor, float lineSpacing, float origHeight, CGUIFontTTFBase *font):
   m_strFontName(strFontName)
 {
   m_style = style & FONT_STYLE_MASK;
@@ -89,7 +89,7 @@ std::string& CGUIFont::GetFontName()
   return m_strFontName;
 }
 
-void CGUIFont::DrawText( float x, float y, const vecColors &colors, color_t shadowColor,
+void CGUIFont::DrawText( float x, float y, const std::vector<UTILS::Color> &colors, UTILS::Color shadowColor,
                 const vecText &text, uint32_t alignment, float maxPixelWidth)
 {
   if (!m_font) return;
@@ -99,14 +99,14 @@ void CGUIFont::DrawText( float x, float y, const vecColors &colors, color_t shad
     return;
 
   maxPixelWidth = ROUND(maxPixelWidth / CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX());
-  vecColors renderColors;
+  std::vector<UTILS::Color> renderColors;
   for (unsigned int i = 0; i < colors.size(); i++)
     renderColors.push_back(CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(colors[i] ? colors[i] : m_textColor));
   if (!shadowColor) shadowColor = m_shadowColor;
   if (shadowColor)
   {
     shadowColor = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(shadowColor);
-    vecColors shadowColors;
+    std::vector<UTILS::Color> shadowColors;
     for (unsigned int i = 0; i < renderColors.size(); i++)
       shadowColors.push_back((renderColors[i] & 0xff000000) != 0 ? shadowColor : 0);
     m_font->DrawTextInternal(x + 1, y + 1, shadowColors, text, alignment, maxPixelWidth, false);
@@ -163,7 +163,7 @@ bool CGUIFont::UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo)
     return false;
 }
 
-void CGUIFont::DrawScrollingText(float x, float y, const vecColors &colors, color_t shadowColor,
+void CGUIFont::DrawScrollingText(float x, float y, const std::vector<UTILS::Color> &colors, UTILS::Color shadowColor,
                 const vecText &text, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo)
 {
   if (!m_font) return;
@@ -191,7 +191,7 @@ void CGUIFont::DrawScrollingText(float x, float y, const vecColors &colors, colo
   else
     offset = scrollInfo.m_totalWidth - scrollInfo.pixelPos;
 
-  vecColors renderColors;
+  std::vector<UTILS::Color> renderColors;
   for (unsigned int i = 0; i < colors.size(); i++)
     renderColors.push_back(CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(colors[i] ? colors[i] : m_textColor));
 
@@ -199,7 +199,7 @@ void CGUIFont::DrawScrollingText(float x, float y, const vecColors &colors, colo
   if (shadowColor)
   {
     shadowColor = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(shadowColor);
-    vecColors shadowColors;
+    std::vector<UTILS::Color> shadowColors;
     for (unsigned int i = 0; i < renderColors.size(); i++)
       shadowColors.push_back((renderColors[i] & 0xff000000) != 0 ? shadowColor : 0);
     for (float dx = -offset; dx < maxWidth; dx += scrollInfo.m_totalWidth)

--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -33,10 +33,10 @@
 #include <stdint.h>
 #include <vector>
 
+#include "utils/Color.h"
+
 typedef uint32_t character_t;
-typedef uint32_t color_t;
 typedef std::vector<character_t> vecText;
-typedef std::vector<color_t> vecColors;
 
 class CGUIFontTTFBase;
 
@@ -118,24 +118,24 @@ private:
 class CGUIFont
 {
 public:
-  CGUIFont(const std::string& strFontName, uint32_t style, color_t textColor,
-	   color_t shadowColor, float lineSpacing, float origHeight, CGUIFontTTFBase *font);
+  CGUIFont(const std::string& strFontName, uint32_t style, UTILS::Color textColor,
+	   UTILS::Color shadowColor, float lineSpacing, float origHeight, CGUIFontTTFBase *font);
   virtual ~CGUIFont();
 
   std::string& GetFontName();
 
-  void DrawText( float x, float y, color_t color, color_t shadowColor,
+  void DrawText( float x, float y, UTILS::Color color, UTILS::Color shadowColor,
                  const vecText &text, uint32_t alignment, float maxPixelWidth)
   {
-    vecColors colors;
+    std::vector<UTILS::Color> colors;
     colors.push_back(color);
     DrawText(x, y, colors, shadowColor, text, alignment, maxPixelWidth);
   };
 
-  void DrawText( float x, float y, const vecColors &colors, color_t shadowColor,
+  void DrawText( float x, float y, const std::vector<UTILS::Color> &colors, UTILS::Color shadowColor,
                  const vecText &text, uint32_t alignment, float maxPixelWidth);
 
-  void DrawScrollingText( float x, float y, const vecColors &colors, color_t shadowColor,
+  void DrawScrollingText( float x, float y, const std::vector<UTILS::Color> &colors, UTILS::Color shadowColor,
                  const vecText &text, uint32_t alignment, float maxPixelWidth, const CScrollInfo &scrollInfo);
 
   bool UpdateScrollInfo(const vecText &text, CScrollInfo &scrollInfo);
@@ -166,8 +166,8 @@ public:
 protected:
   std::string m_strFontName;
   uint32_t m_style;
-  color_t m_shadowColor;
-  color_t m_textColor;
+  UTILS::Color m_shadowColor;
+  UTILS::Color m_textColor;
   float m_lineSpacing;
   float m_origHeight;
   CGUIFontTTFBase *m_font; // the font object has the size information

--- a/xbmc/guilib/GUIFontCache.cpp
+++ b/xbmc/guilib/GUIFontCache.cpp
@@ -90,7 +90,7 @@ public:
 
   explicit CGUIFontCacheImpl(CGUIFontCache<Position, Value>* parent) : m_parent(parent) {}
   Value &Lookup(Position &pos,
-                const vecColors &colors, const vecText &text,
+                const std::vector<UTILS::Color> &colors, const vecText &text,
                 uint32_t alignment, float maxPixelWidth,
                 bool scrolling,
                 unsigned int nowMillis, bool &dirtyCache);
@@ -136,7 +136,7 @@ CGUIFontCache<Position, Value>::~CGUIFontCache()
 
 template<class Position, class Value>
 Value &CGUIFontCache<Position, Value>::Lookup(Position &pos,
-                                              const vecColors &colors, const vecText &text,
+                                              const std::vector<UTILS::Color> &colors, const vecText &text,
                                               uint32_t alignment, float maxPixelWidth,
                                               bool scrolling,
                                               unsigned int nowMillis, bool &dirtyCache)
@@ -149,13 +149,13 @@ Value &CGUIFontCache<Position, Value>::Lookup(Position &pos,
 
 template<class Position, class Value>
 Value &CGUIFontCacheImpl<Position, Value>::Lookup(Position &pos,
-                                                  const vecColors &colors, const vecText &text,
+                                                  const std::vector<UTILS::Color> &colors, const vecText &text,
                                                   uint32_t alignment, float maxPixelWidth,
                                                   bool scrolling,
                                                   unsigned int nowMillis, bool &dirtyCache)
 {
   const CGUIFontCacheKey<Position> key(pos,
-                                       const_cast<vecColors &>(colors), const_cast<vecText &>(text),
+                                       const_cast<std::vector<UTILS::Color> &>(colors), const_cast<vecText &>(text),
                                        alignment, maxPixelWidth,
                                        scrolling, CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIMatrix(),
                                        CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX(), CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleY());
@@ -211,13 +211,13 @@ void CGUIFontCacheImpl<Position, Value>::Flush()
 template CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::CGUIFontCache(CGUIFontTTFBase &font);
 template CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::~CGUIFontCache();
 template CGUIFontCacheEntry<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::~CGUIFontCacheEntry();
-template CGUIFontCacheStaticValue &CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Lookup(CGUIFontCacheStaticPosition &, const vecColors &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
+template CGUIFontCacheStaticValue &CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Lookup(CGUIFontCacheStaticPosition &, const std::vector<UTILS::Color> &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
 template void CGUIFontCache<CGUIFontCacheStaticPosition, CGUIFontCacheStaticValue>::Flush();
 
 template CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::CGUIFontCache(CGUIFontTTFBase &font);
 template CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::~CGUIFontCache();
 template CGUIFontCacheEntry<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::~CGUIFontCacheEntry();
-template CGUIFontCacheDynamicValue &CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Lookup(CGUIFontCacheDynamicPosition &, const vecColors &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
+template CGUIFontCacheDynamicValue &CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Lookup(CGUIFontCacheDynamicPosition &, const std::vector<UTILS::Color> &, const vecText &, uint32_t, float, bool, unsigned int, bool &);
 template void CGUIFontCache<CGUIFontCacheDynamicPosition, CGUIFontCacheDynamicValue>::Flush();
 
 void CVertexBuffer::clear()

--- a/xbmc/guilib/GUIFontCache.h
+++ b/xbmc/guilib/GUIFontCache.h
@@ -36,6 +36,7 @@
 #include <memory>
 #include <cassert>
 
+#include "utils/Color.h"
 #include "utils/TransformMatrix.h"
 
 #define FONT_CACHE_TIME_LIMIT (1000)
@@ -51,7 +52,7 @@ template<class Position>
 struct CGUIFontCacheKey
 {
   Position m_pos;
-  vecColors &m_colors;
+  std::vector<UTILS::Color> &m_colors;
   vecText &m_text;
   uint32_t m_alignment;
   float m_maxPixelWidth;
@@ -61,7 +62,7 @@ struct CGUIFontCacheKey
   float m_scaleY;
 
   CGUIFontCacheKey(Position pos,
-                   vecColors &colors, vecText &text,
+                   std::vector<UTILS::Color> &colors, vecText &text,
                    uint32_t alignment, float maxPixelWidth,
                    bool scrolling, const TransformMatrix &matrix,
                    float scaleX, float scaleY) :
@@ -85,7 +86,7 @@ struct CGUIFontCacheEntry
   CGUIFontCacheEntry(const CGUIFontCache<Position, Value> &cache, const CGUIFontCacheKey<Position> &key, unsigned int nowMillis) :
     m_cache(cache),
     m_key(key.m_pos,
-          *new vecColors, *new vecText,
+          *new std::vector<UTILS::Color>, *new vecText,
           key.m_alignment, key.m_maxPixelWidth,
           key.m_scrolling, m_matrix,
           key.m_scaleX, key.m_scaleY),
@@ -150,7 +151,7 @@ public:
   ~CGUIFontCache();
  
   Value &Lookup(Position &pos,
-                const vecColors &colors, const vecText &text,
+                const std::vector<UTILS::Color> &colors, const vecText &text,
                 uint32_t alignment, float maxPixelWidth,
                 bool scrolling,
                 unsigned int nowMillis, bool &dirtyCache);

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -96,7 +96,7 @@ static bool CheckFont(std::string& strPath, const std::string& newPath,
   return true;
 }
 
-CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName, const std::string& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border, float lineSpacing, float aspect, const RESOLUTION_INFO *sourceRes, bool preserveAspect)
+CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName, const std::string& strFilename, UTILS::Color textColor, UTILS::Color shadowColor, const int iSize, const int iStyle, bool border, float lineSpacing, float aspect, const RESOLUTION_INFO *sourceRes, bool preserveAspect)
 {
   float originalAspect = aspect;
 
@@ -412,8 +412,8 @@ void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)
     int iSize = 20;
     float aspect = 1.0f;
     float lineSpacing = 1.0f;
-    color_t shadowColor = 0;
-    color_t textColor = 0;
+    UTILS::Color shadowColor = 0;
+    UTILS::Color textColor = 0;
     int iStyle = FONT_STYLE_NORMAL;
 
     XMLUtils::GetString(fontNode, "name", fontName);

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -33,6 +33,7 @@
 
 #include "windowing/GraphicContext.h"
 #include "IMsgTargetCallback.h"
+#include "utils/Color.h"
 #include "utils/GlobalsHandling.h"
 
 // Forward
@@ -67,7 +68,7 @@ public:
 
   void Unload(const std::string& strFontName);
   void LoadFonts(const std::string &fontSet);
-  CGUIFont* LoadTTF(const std::string& strFontName, const std::string& strFilename, color_t textColor, color_t shadowColor, const int iSize, const int iStyle, bool border = false, float lineSpacing = 1.0f, float aspect = 1.0f, const RESOLUTION_INFO *res = NULL, bool preserveAspect = false);
+  CGUIFont* LoadTTF(const std::string& strFontName, const std::string& strFilename, UTILS::Color textColor, UTILS::Color shadowColor, const int iSize, const int iStyle, bool border = false, float lineSpacing = 1.0f, float aspect = 1.0f, const RESOLUTION_INFO *res = NULL, bool preserveAspect = false);
   CGUIFont* GetFont(const std::string& strFontName, bool fallback = true);
 
   /*! \brief return a default font

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -360,7 +360,7 @@ void CGUIFontTTFBase::End()
   LastEnd();
 }
 
-void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors, const vecText &text, uint32_t alignment, float maxPixelWidth, bool scrolling)
+void CGUIFontTTFBase::DrawTextInternal(float x, float y, const std::vector<UTILS::Color> &colors, const vecText &text, uint32_t alignment, float maxPixelWidth, bool scrolling)
 {
   Begin();
 
@@ -479,7 +479,7 @@ void CGUIFontTTFBase::DrawTextInternal(float x, float y, const vecColors &colors
     {
       // If starting text on a new line, determine justification effects
       // Get the current letter in the CStdString
-      color_t color = (*pos & 0xff0000) >> 16;
+      UTILS::Color color = (*pos & 0xff0000) >> 16;
       if (color >= colors.size())
         color = 0;
       color = colors[color];
@@ -808,7 +808,7 @@ bool CGUIFontTTFBase::CacheCharacter(wchar_t letter, uint32_t style, Character *
   return true;
 }
 
-void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *ch, color_t color, bool roundX, std::vector<SVertex> &vertices)
+void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *ch, UTILS::Color color, bool roundX, std::vector<SVertex> &vertices)
 {
   // actual image width isn't same as the character width as that is
   // just baseline width and height should include the descent

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include "utils/auto_buffer.h"
+#include "utils/Color.h"
 #include "utils/Geometry.h"
 
 #ifdef HAS_DX
@@ -59,9 +60,7 @@ typedef struct FT_BitmapGlyphRec_ *FT_BitmapGlyph;
 typedef struct FT_StrokerRec_ *FT_Stroker;
 
 typedef uint32_t character_t;
-typedef uint32_t color_t;
 typedef std::vector<character_t> vecText;
-typedef std::vector<color_t> vecColors;
 
 /*!
  \ingroup textures
@@ -122,7 +121,7 @@ protected:
   float GetLineHeight(float lineSpacing) const;
   float GetFontHeight() const { return m_height; }
 
-  void DrawTextInternal(float x, float y, const vecColors &colors, const vecText &text,
+  void DrawTextInternal(float x, float y, const std::vector<UTILS::Color> &colors, const vecText &text,
                             uint32_t alignment, float maxPixelWidth, bool scrolling);
 
   float m_height;
@@ -131,7 +130,7 @@ protected:
   // Stuff for pre-rendering for speed
   inline Character *GetCharacter(character_t letter);
   bool CacheCharacter(wchar_t letter, uint32_t style, Character *ch);
-  void RenderCharacter(float posX, float posY, const Character *ch, color_t color, bool roundX, std::vector<SVertex> &vertices);
+  void RenderCharacter(float posX, float posY, const Character *ch, UTILS::Color color, bool roundX, std::vector<SVertex> &vertices);
   void ClearCharacterCache();
 
   virtual CBaseTexture* ReallocTexture(unsigned int& newHeight) = 0;
@@ -155,7 +154,7 @@ protected:
   unsigned int GetTextureLineHeight() const;
   static const unsigned int spacing_between_characters_in_texture;
 
-  color_t m_color;
+  UTILS::Color m_color;
 
   Character *m_char;                 // our characters
   Character *m_charquick[LOOKUPTABLE_SIZE];     // ascii chars (7 styles) here

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -65,7 +65,7 @@ bool CGUILabel::SetColor(CGUILabel::COLOR color)
   return changed;
 }
 
-color_t CGUILabel::GetColor() const
+UTILS::Color CGUILabel::GetColor() const
 {
   switch (m_color)
   {
@@ -103,7 +103,7 @@ bool CGUILabel::Process(unsigned int currentTime)
 
 void CGUILabel::Render()
 {
-  color_t color = GetColor();
+  UTILS::Color color = GetColor();
   bool renderSolid = (m_color == COLOR_DISABLED);
   bool overFlows = (m_renderRect.Width() + 0.5f < m_textLayout.GetTextWidth()); // 0.5f to deal with floating point rounding issues
   if (overFlows && m_scrolling && !renderSolid)
@@ -162,7 +162,7 @@ bool CGUILabel::SetAlign(uint32_t align)
   return changed;
 }
 
-bool CGUILabel::SetStyledText(const vecText &text, const vecColors &colors)
+bool CGUILabel::SetStyledText(const vecText &text, const std::vector<UTILS::Color> &colors)
 {
   m_textLayout.UpdateStyled(text, colors, m_maxRect.Width());
   m_invalid = false;

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -28,6 +28,7 @@
 #include "GUITextLayout.h"
 #include "guiinfo/GUIInfoTypes.h"
 #include "GUIFont.h"
+#include "utils/Color.h"
 #include "utils/Geometry.h"
 
 class CLabelInfo
@@ -135,7 +136,7 @@ public:
    \param colors colors referenced in the styled text.
    \sa SetText, SetTextW
    */
-  bool SetStyledText(const vecText &text, const vecColors &colors);
+  bool SetStyledText(const vecText &text, const std::vector<UTILS::Color> &colors);
 
   /*! \brief Set the color to use for the label
    Sets the color to be used for this label.  Takes effect at the next render
@@ -225,7 +226,7 @@ public:
   static bool CheckAndCorrectOverlap(CGUILabel &label1, CGUILabel &label2);
   
 protected:
-  color_t GetColor() const;
+  UTILS::Color GetColor() const;
   
   /*! \brief Computes the final layout of the text
    Uses the maximal position and width of the text, as well as the text length

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -20,6 +20,7 @@
 
 #include "GUILabelControl.h"
 #include "utils/CharsetConverter.h"
+#include "utils/Color.h"
 #include "utils/StringUtils.h"
 
 using namespace KODI::GUILIB;
@@ -83,10 +84,10 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
     std::wstring utf16;
     g_charsetConverter.utf8ToW(label, utf16);
     vecText text; text.reserve(utf16.size()+1);
-    vecColors colors;
+    std::vector<UTILS::Color> colors;
     colors.push_back(m_label.GetLabelInfo().textColor);
     colors.push_back(m_label.GetLabelInfo().disabledColor);
-    color_t select = m_label.GetLabelInfo().selectedColor;
+    UTILS::Color select = m_label.GetLabelInfo().selectedColor;
     if (!select)
       select = 0xFFFF0000;
     colors.push_back(select);

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -22,6 +22,7 @@
 #include "ServiceBroker.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
+#include "utils/Color.h"
 #include "utils/RssManager.h"
 #include "utils/RssReader.h"
 #include "utils/StringUtils.h"
@@ -166,7 +167,7 @@ void CGUIRSSControl::Render()
 
     if (m_label.font)
     {
-      vecColors colors;
+      std::vector<UTILS::Color> colors;
       colors.push_back(m_label.textColor);
       colors.push_back(m_headlineColor);
       colors.push_back(m_channelColor);

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -34,9 +34,6 @@
 #include "GUILabel.h"
 #include "utils/IRssObserver.h"
 
-typedef uint32_t color_t;
-typedef std::vector<color_t> vecColors;
-
 class CRssReader;
 
 /*!

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -56,7 +56,7 @@ void CGUITextLayout::SetWrap(bool bWrap)
   m_wrap = bWrap;
 }
 
-void CGUITextLayout::Render(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, bool solid)
+void CGUITextLayout::Render(float x, float y, float angle, UTILS::Color color, UTILS::Color shadowColor, uint32_t alignment, float maxWidth, bool solid)
 {
   if (!m_font)
     return;
@@ -106,7 +106,7 @@ bool CGUITextLayout::UpdateScrollinfo(CScrollInfo &scrollInfo)
 }
 
 
-void CGUITextLayout::RenderScrolling(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo)
+void CGUITextLayout::RenderScrolling(float x, float y, float angle, UTILS::Color color, UTILS::Color shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo)
 {
   if (!m_font)
     return;
@@ -145,13 +145,13 @@ void CGUITextLayout::RenderScrolling(float x, float y, float angle, color_t colo
     CServiceBroker::GetWinSystem()->GetGfxContext().RemoveTransform();
 }
 
-void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outlineColor, uint32_t alignment, float maxWidth)
+void CGUITextLayout::RenderOutline(float x, float y, UTILS::Color color, UTILS::Color outlineColor, uint32_t alignment, float maxWidth)
 {
   if (!m_font)
     return;
 
   // set the outline color
-  vecColors outlineColors;
+  std::vector<UTILS::Color> outlineColors;
   if (m_colors.size())
     outlineColors.push_back(outlineColor);
 
@@ -240,14 +240,14 @@ void CGUITextLayout::UpdateCommon(const std::wstring &text, float maxWidth, bool
 {
   // parse the text for style information
   vecText parsedText;
-  vecColors colors;
+  std::vector<UTILS::Color> colors;
   ParseText(text, m_font ? m_font->GetStyle() : 0, m_textColor, colors, parsedText);
 
   // and update
   UpdateStyled(parsedText, colors, maxWidth, forceLTRReadingOrder);
 }
 
-void CGUITextLayout::UpdateStyled(const vecText &text, const vecColors &colors, float maxWidth, bool forceLTRReadingOrder)
+void CGUITextLayout::UpdateStyled(const vecText &text, const std::vector<UTILS::Color> &colors, float maxWidth, bool forceLTRReadingOrder)
 {
   // empty out our previous string
   m_lines.clear();
@@ -328,7 +328,7 @@ void CGUITextLayout::Filter(std::string &text)
 {
   std::wstring utf16;
   g_charsetConverter.utf8ToW(text, utf16, false);
-  vecColors colors;
+  std::vector<UTILS::Color> colors;
   vecText parsedText;
   ParseText(utf16, 0, 0xffffffff, colors, parsedText);
   utf16.clear();
@@ -337,7 +337,7 @@ void CGUITextLayout::Filter(std::string &text)
   g_charsetConverter.wToUTF8(utf16, text);
 }
 
-void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, color_t defaultColor, vecColors &colors, vecText &parsedText)
+void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, UTILS::Color defaultColor, std::vector<UTILS::Color> &colors, vecText &parsedText)
 {
   // run through the string, searching for:
   // [B] or [/B] -> toggle bold on and off
@@ -346,10 +346,10 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
   // [CAPS <option>] or [/CAPS] -> toggle capatilization on and off
 
   uint32_t currentStyle = defaultStyle; // start with the default font's style
-  color_t currentColor = 0;
+  UTILS::Color currentColor = 0;
 
   colors.push_back(defaultColor);
-  std::stack<color_t> colorStack;
+  std::stack<UTILS::Color> colorStack;
   colorStack.push(0);
 
   // these aren't independent, but that's probably not too much of an issue
@@ -361,7 +361,7 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
   while (pos != std::string::npos && pos + 1 < text.size())
   {
     uint32_t newStyle = 0;
-    color_t newColor = currentColor;
+    UTILS::Color newColor = currentColor;
     bool colorTagChange = false;
     bool newLine = false;
     // have a [ - check if it's an ON or OFF switch
@@ -427,8 +427,8 @@ void CGUITextLayout::ParseText(const std::wstring &text, uint32_t defaultStyle, 
       {
         std::string t;
         g_charsetConverter.wToUTF8(text.substr(pos + 5, finish - pos - 5), t);
-        color_t color = g_colorManager.GetColor(t);
-        vecColors::const_iterator it = std::find(colors.begin(), colors.end(), color);
+        UTILS::Color color = g_colorManager.GetColor(t);
+        const auto& it = std::find(colors.begin(), colors.end(), color);
         if (it == colors.end())
         { // create new color
           if (colors.size() <= 0xFF)
@@ -655,7 +655,7 @@ std::string CGUITextLayout::GetText() const
   return m_lastUtf8Text;
 }
 
-void CGUITextLayout::DrawText(CGUIFont *font, float x, float y, color_t color, color_t shadowColor, const std::string &text, uint32_t align)
+void CGUITextLayout::DrawText(CGUIFont *font, float x, float y, UTILS::Color color, UTILS::Color shadowColor, const std::string &text, uint32_t align)
 {
   if (!font) return;
   vecText utf32;

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -25,6 +25,8 @@
 #include <stdint.h>
 #include <vector>
 
+#include "utils/Color.h"
+
 #ifdef __GNUC__
 // under gcc, inline will only take place if optimizations are applied (-O). this will force inline even without optimizations.
 #define XBMC_FORCE_INLINE __attribute__((always_inline))
@@ -45,9 +47,7 @@ class CScrollInfo;
 // 6.  A new vector<CGUIString> is constructed
 
 typedef uint32_t character_t;
-typedef uint32_t color_t;
 typedef std::vector<character_t> vecText;
-typedef std::vector<color_t> vecColors;
 
 class CGUIString
 {
@@ -70,9 +70,9 @@ public:
   bool UpdateScrollinfo(CScrollInfo &scrollInfo);
 
   // main function to render strings
-  void Render(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, bool solid = false);
-  void RenderScrolling(float x, float y, float angle, color_t color, color_t shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo);
-  void RenderOutline(float x, float y, color_t color, color_t outlineColor, uint32_t alignment, float maxWidth);
+  void Render(float x, float y, float angle, UTILS::Color color, UTILS::Color shadowColor, uint32_t alignment, float maxWidth, bool solid = false);
+  void RenderScrolling(float x, float y, float angle, UTILS::Color color, UTILS::Color shadowColor, uint32_t alignment, float maxWidth, const CScrollInfo &scrollInfo);
+  void RenderOutline(float x, float y, UTILS::Color color, UTILS::Color outlineColor, uint32_t alignment, float maxWidth);
 
   /*! \brief Returns the precalculated width and height of the text to be rendered (in constant time).
    \param width [out] width of text
@@ -91,14 +91,14 @@ public:
   bool Update(const std::string &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
   bool UpdateW(const std::wstring &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
 
-  /*! \brief Update text from a pre-styled vecText/vecColors combination
+  /*! \brief Update text from a pre-styled vecText/std::vector<UTILS::Color> combination
    Allows styled text to be passed directly to the text layout.
    \param text the styled text to set.
    \param colors the colors used on the text.
    \param maxWidth the maximum width for wrapping text, defaults to 0 (no max width).
    \param forceLTRReadingOrder whether to force left to right reading order, defaults to false.
    */
-  void UpdateStyled(const vecText &text, const vecColors &colors, float maxWidth = 0, bool forceLTRReadingOrder = false);
+  void UpdateStyled(const vecText &text, const std::vector<UTILS::Color> &colors, float maxWidth = 0, bool forceLTRReadingOrder = false);
 
   unsigned int GetTextLength() const;
   void GetFirstText(vecText &text) const;
@@ -108,7 +108,7 @@ public:
   void SetMaxHeight(float fHeight);
 
 
-  static void DrawText(CGUIFont *font, float x, float y, color_t color, color_t shadowColor, const std::string &text, uint32_t align);
+  static void DrawText(CGUIFont *font, float x, float y, UTILS::Color color, UTILS::Color shadowColor, const std::string &text, uint32_t align);
   static void Filter(std::string &text);
 
 protected:
@@ -131,7 +131,7 @@ protected:
   void UseMonoFont(bool use) { m_font = use && m_monoFont ? m_monoFont : m_varFont; }
   
   // our text to render
-  vecColors m_colors;
+  std::vector<UTILS::Color> m_colors;
   std::vector<CGUIString> m_lines;
   typedef std::vector<CGUIString>::iterator iLine;
 
@@ -144,7 +144,7 @@ protected:
   bool  m_wrap;            // wrapping (true if justify is enabled!)
   float m_maxHeight;
   // the default color (may differ from the font objects defaults)
-  color_t m_textColor;
+  UTILS::Color m_textColor;
 
   std::string m_lastUtf8Text;
   std::wstring m_lastText;
@@ -163,6 +163,6 @@ private:
   };
   static void AppendToUTF32(const std::string &utf8, character_t colStyle, vecText &utf32);
   static void AppendToUTF32(const std::wstring &utf16, character_t colStyle, vecText &utf32);
-  static void ParseText(const std::wstring &text, uint32_t defaultStyle, color_t defaultColor, vecColors &colors, vecText &parsedText);
+  static void ParseText(const std::wstring &text, uint32_t defaultStyle, UTILS::Color defaultColor, std::vector<UTILS::Color> &colors, vecText &parsedText);
 };
 

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -171,7 +171,7 @@ void CGUITextureBase::Render()
   #define MIX_ALPHA(a,c) (((a * (c >> 24)) / 255) << 24) | (c & 0x00ffffff)
 
   // diffuse color
-  color_t color = (m_info.diffuseColor) ? (color_t)m_info.diffuseColor : m_diffuseColor;
+  UTILS::Color color = (m_info.diffuseColor) ? (UTILS::Color)m_info.diffuseColor : m_diffuseColor;
   if (m_alpha != 0xFF)
 	  color = MIX_ALPHA(m_alpha, color);
 
@@ -544,7 +544,7 @@ bool CGUITextureBase::SetAlpha(unsigned char alpha)
   return changed;
 }
 
-bool CGUITextureBase::SetDiffuseColor(color_t color)
+bool CGUITextureBase::SetDiffuseColor(UTILS::Color color)
 {
   bool changed = m_diffuseColor != color;
   m_diffuseColor = color;

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -29,10 +29,9 @@
  */
 
 #include "TextureManager.h"
+#include "utils/Color.h"
 #include "utils/Geometry.h"
 #include "guiinfo/GUIInfoTypes.h"
-
-typedef uint32_t color_t;
 
 // image alignment for <aspect>keep</aspect>, <aspect>scale</aspect> or <aspect>center</aspect>
 #define ASPECT_ALIGN_CENTER  0
@@ -98,7 +97,7 @@ public:
 
   bool SetVisible(bool visible);
   bool SetAlpha(unsigned char alpha);
-  bool SetDiffuseColor(color_t color);
+  bool SetDiffuseColor(UTILS::Color color);
   bool SetPosition(float x, float y);
   bool SetWidth(float width);
   bool SetHeight(float height);
@@ -133,12 +132,12 @@ protected:
   // functions that our implementation classes handle
   virtual void Allocate() {}; ///< called after our textures have been allocated
   virtual void Free() {};     ///< called after our textures have been freed
-  virtual void Begin(color_t color) {};
+  virtual void Begin(UTILS::Color color) {};
   virtual void Draw(float *x, float *y, float *z, const CRect &texture, const CRect &diffuse, int orientation)=0;
   virtual void End() {};
 
   bool m_visible;
-  color_t m_diffuseColor;
+  UTILS::Color m_diffuseColor;
 
   float m_posX;         // size of the frame
   float m_posY;

--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -38,7 +38,7 @@ CGUITextureD3D::~CGUITextureD3D()
 {
 }
 
-void CGUITextureD3D::Begin(color_t color)
+void CGUITextureD3D::Begin(UTILS::Color color)
 {
   CBaseTexture* texture = m_texture.m_textures[m_currentFrame];
   texture->LoadToGPU();
@@ -136,7 +136,7 @@ void CGUITextureD3D::Draw(float *x, float *y, float *z, const CRect &texture, co
   pGUIShader->DrawQuad(verts[0], verts[1], verts[2], verts[3]);
 }
 
-void CGUITextureD3D::DrawQuad(const CRect &rect, color_t color, CBaseTexture *texture, const CRect *texCoords)
+void CGUITextureD3D::DrawQuad(const CRect &rect, UTILS::Color color, CBaseTexture *texture, const CRect *texCoords)
 {
   unsigned numViews = 0;
   ID3D11ShaderResourceView* views = nullptr;

--- a/xbmc/guilib/GUITextureD3D.h
+++ b/xbmc/guilib/GUITextureD3D.h
@@ -29,21 +29,22 @@
  */
 
 #include "GUITexture.h"
+#include "utils/Color.h"
 
 class CGUITextureD3D : public CGUITextureBase
 {
 public:
   CGUITextureD3D(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureD3D();
-  static void DrawQuad(const CRect &coords, color_t color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
+  static void DrawQuad(const CRect &coords, UTILS::Color color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
 
 protected:
-  void Begin(color_t color);
+  void Begin(UTILS::Color color);
   void Draw(float *x, float *y, float *z, const CRect &texture, const CRect &diffuse, int orientation);
   void End();
 
 private:
-  color_t       m_col;
+  UTILS::Color       m_col;
 };
 
 #endif

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -36,7 +36,7 @@ CGUITextureGL::CGUITextureGL(float posX, float posY, float width, float height, 
   m_renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
 }
 
-void CGUITextureGL::Begin(color_t color)
+void CGUITextureGL::Begin(UTILS::Color color)
 {
   CBaseTexture* texture = m_texture.m_textures[m_currentFrame];
   texture->LoadToGPU();
@@ -249,7 +249,7 @@ void CGUITextureGL::Draw(float *x, float *y, float *z, const CRect &texture, con
   }
 }
 
-void CGUITextureGL::DrawQuad(const CRect &rect, color_t color, CBaseTexture *texture, const CRect *texCoords)
+void CGUITextureGL::DrawQuad(const CRect &rect, UTILS::Color color, CBaseTexture *texture, const CRect *texCoords)
 {
   CRenderSystemGL *renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
   if (texture)

--- a/xbmc/guilib/GUITextureGL.h
+++ b/xbmc/guilib/GUITextureGL.h
@@ -23,6 +23,7 @@
 #include "system_gl.h"
 
 #include "GUITexture.h"
+#include "utils/Color.h"
 
 class CRenderSystemGL;
 
@@ -30,10 +31,10 @@ class CGUITextureGL : public CGUITextureBase
 {
 public:
   CGUITextureGL(float posX, float posY, float width, float height, const CTextureInfo& texture);
-  static void DrawQuad(const CRect &coords, color_t color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
+  static void DrawQuad(const CRect &coords, UTILS::Color color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
 
 protected:
-  void Begin(color_t color) override;
+  void Begin(UTILS::Color color) override;
   void Draw(float *x, float *y, float *z, const CRect &texture, const CRect &diffuse, int orientation) override;
   void End() override;
 

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -36,7 +36,7 @@ CGUITextureGLES::CGUITextureGLES(float posX, float posY, float width, float heig
   m_renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
 }
 
-void CGUITextureGLES::Begin(color_t color)
+void CGUITextureGLES::Begin(UTILS::Color color)
 {
   CBaseTexture* texture = m_texture.m_textures[m_currentFrame];
   texture->LoadToGPU();
@@ -218,7 +218,7 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
   }
 }
 
-void CGUITextureGLES::DrawQuad(const CRect &rect, color_t color, CBaseTexture *texture, const CRect *texCoords)
+void CGUITextureGLES::DrawQuad(const CRect &rect, UTILS::Color color, CBaseTexture *texture, const CRect *texCoords)
 {
   CRenderSystemGLES *renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
   if (texture)

--- a/xbmc/guilib/GUITextureGLES.h
+++ b/xbmc/guilib/GUITextureGLES.h
@@ -24,6 +24,7 @@
 
 #include "system_gl.h"
 #include <vector>
+#include "utils/Color.h"
 
 struct PackedVertex
 {
@@ -39,9 +40,9 @@ class CGUITextureGLES : public CGUITextureBase
 {
 public:
   CGUITextureGLES(float posX, float posY, float width, float height, const CTextureInfo& texture);
-  static void DrawQuad(const CRect &coords, color_t color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
+  static void DrawQuad(const CRect &coords, UTILS::Color color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
 protected:
-  void Begin(color_t color);
+  void Begin(UTILS::Color color);
   void Draw(float *x, float *y, float *z, const CRect &texture, const CRect &diffuse, int orientation);
   void End();
 

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -24,6 +24,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "input/Key.h"
+#include "utils/Color.h"
 #include "WindowIDs.h"
 
 CGUIVideoControl::CGUIVideoControl(int parentID, int controlID, float posX, float posY, float width, float height)
@@ -54,7 +55,7 @@ void CGUIVideoControl::Render()
     TransformMatrix mat;
     CServiceBroker::GetWinSystem()->GetGfxContext().SetTransform(mat, 1.0, 1.0);
 
-    color_t alpha = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(0xFF000000) >> 24;
+    UTILS::Color alpha = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(0xFF000000) >> 24;
     if (g_application.GetAppPlayer().IsRenderingVideoLayer())
     {
       CRect old = CServiceBroker::GetWinSystem()->GetGfxContext().GetScissors();

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -38,6 +38,7 @@
 #include "ServiceBroker.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/AdvancedSettings.h"
+#include "utils/Color.h"
 #include "utils/Variant.h"
 #include "utils/StringUtils.h"
 
@@ -1096,7 +1097,7 @@ void CGUIWindow::RunUnloadActions() const
 void CGUIWindow::ClearBackground()
 {
   m_clearBackground.Update();
-  color_t color = m_clearBackground;
+  UTILS::Color color = m_clearBackground;
   if (color)
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(color);
 }

--- a/xbmc/guilib/guiinfo/GUIInfoTypes.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoTypes.cpp
@@ -66,7 +66,7 @@ CGUIInfoColor::CGUIInfoColor(uint32_t color)
   m_info = 0;
 }
 
-CGUIInfoColor &CGUIInfoColor::operator=(color_t color)
+CGUIInfoColor &CGUIInfoColor::operator=(UTILS::Color color)
 {
   m_color = color;
   m_info = 0;
@@ -87,7 +87,7 @@ bool CGUIInfoColor::Update()
 
   // Expand the infolabel, and then convert it to a color
   std::string infoLabel(CServiceBroker::GetGUI()->GetInfoManager().GetLabel(m_info));
-  color_t color = !infoLabel.empty() ? g_colorManager.GetColor(infoLabel.c_str()) : 0;
+  UTILS::Color color = !infoLabel.empty() ? g_colorManager.GetColor(infoLabel.c_str()) : 0;
   if (m_color != color)
   {
     m_color = color;

--- a/xbmc/guilib/guiinfo/GUIInfoTypes.h
+++ b/xbmc/guilib/guiinfo/GUIInfoTypes.h
@@ -30,9 +30,9 @@
 
 #include <string>
 #include <vector>
-#include <stdint.h>
 #include <functional>
 #include "interfaces/info/InfoBool.h"
+#include "utils/Color.h"
 
 class CGUIListItem;
 
@@ -58,24 +58,23 @@ private:
   bool m_value;
 };
 
-typedef uint32_t color_t;
-
 class CGUIInfoColor
 {
 public:
-  explicit CGUIInfoColor(color_t color = 0);
+  explicit CGUIInfoColor(UTILS::Color color = 0);
 
   CGUIInfoColor& operator=(const CGUIInfoColor &color);
-  CGUIInfoColor& operator=(color_t color);
-  operator color_t() const { return m_color; };
+  CGUIInfoColor& operator=(UTILS::Color color);
+  operator UTILS::Color() const { return m_color; };
 
   bool Update();
   void Parse(const std::string &label, int context);
 
 private:
-  color_t GetColor() const;
-  int     m_info;
-  color_t m_color;
+  UTILS::Color GetColor() const;
+
+  int m_info;
+  UTILS::Color m_color;
 };
 
 class CGUIInfoLabel

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -25,6 +25,7 @@
 #include "guilib/GUIControl.h"
 #include "guilib/GUIFont.h"
 #include "input/Key.h"
+#include "utils/Color.h"
 
 #include "Alternative.h"
 #include "Tuple.h"
@@ -718,7 +719,7 @@ namespace XBMCAddon
 #endif
 
 #ifndef SWIG
-      color_t color;
+      UTILS::Color color;
       std::string strTextureUp;
       std::string strTextureDown;
       std::string strTextureUpFocus;
@@ -870,8 +871,8 @@ namespace XBMCAddon
 
       std::string strFont;
       std::string strText;
-      color_t textColor;
-      color_t disabledColor;
+      UTILS::Color textColor;
+      UTILS::Color disabledColor;
       uint32_t align;
       bool bHasPath;
       int iAngle;
@@ -1072,8 +1073,8 @@ namespace XBMCAddon
       std::string strText;
       std::string strTextureFocus;
       std::string strTextureNoFocus;
-      color_t textColor;
-      color_t disabledColor;
+      UTILS::Color textColor;
+      UTILS::Color disabledColor;
       uint32_t align;
       bool bIsPassword;
 
@@ -1639,8 +1640,8 @@ namespace XBMCAddon
       std::string strFont;
       AddonClass::Ref<ControlSpin> pControlSpin;
 
-      color_t textColor;
-      color_t selectedColor;
+      UTILS::Color textColor;
+      UTILS::Color selectedColor;
       std::string strTextureButton;
       std::string strTextureButtonFocus;
 
@@ -1794,7 +1795,7 @@ namespace XBMCAddon
 
 #ifndef SWIG
       std::string strFont;
-      color_t textColor;
+      UTILS::Color textColor;
       std::vector<std::string> vecLabels;
       uint32_t align;
 
@@ -1980,7 +1981,7 @@ namespace XBMCAddon
 
 #ifndef SWIG
       std::string strFont;
-      color_t textColor;
+      UTILS::Color textColor;
 
       SWIGHIDDENVIRTUAL CGUIControl* Create() override;
 
@@ -2101,7 +2102,7 @@ namespace XBMCAddon
 
       std::string strFileName;
       int aspectRatio;
-      color_t colorDiffuse;
+      UTILS::Color colorDiffuse;
 
       SWIGHIDDENVIRTUAL CGUIControl* Create() override;
 #endif
@@ -2244,7 +2245,7 @@ namespace XBMCAddon
       std::string strTextureBg;
       std::string strTextureOverlay;
       int aspectRatio;
-      color_t colorDiffuse;
+      UTILS::Color colorDiffuse;
 
       SWIGHIDDENVIRTUAL CGUIControl* Create() override;
       ControlProgress() :
@@ -2460,10 +2461,10 @@ namespace XBMCAddon
 
       int textOffsetX;
       int textOffsetY;
-      color_t align;
+      UTILS::Color align;
       std::string strFont;
-      color_t textColor;
-      color_t disabledColor;
+      UTILS::Color textColor;
+      UTILS::Color disabledColor;
       int iAngle;
       int shadowColor;
       int focusedColor;
@@ -2777,14 +2778,14 @@ namespace XBMCAddon
       std::string strTextureRadioOffNoFocus;
       std::string strTextureRadioOnDisabled;
       std::string strTextureRadioOffDisabled;
-      color_t textColor;
-      color_t disabledColor;
+      UTILS::Color textColor;
+      UTILS::Color disabledColor;
       int textOffsetX;
       int textOffsetY; 
      uint32_t align;
       int iAngle;
-      color_t shadowColor;
-      color_t focusedColor;
+      UTILS::Color shadowColor;
+      UTILS::Color focusedColor;
 
       SWIGHIDDENVIRTUAL CGUIControl* Create() override;
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -302,16 +302,16 @@ void CSlideShowPic::UpdateVertices(float cur_x[4], float cur_y[4], const float n
 void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (!m_pImage || !m_bIsLoaded || m_bIsFinished) return ;
-  color_t alpha = m_alpha;
+  UTILS::Color alpha = m_alpha;
   if (m_iCounter <= m_transitionStart.length)
   { // do start transition
     if (m_transitionStart.type == CROSSFADE)
     { // fade in at 1x speed
-      alpha = (color_t)((float)m_iCounter / (float)m_transitionStart.length * 255.0f);
+      alpha = (UTILS::Color)((float)m_iCounter / (float)m_transitionStart.length * 255.0f);
     }
     else if (m_transitionStart.type == FADEIN_FADEOUT)
     { // fade in at 2x speed, then keep solid
-      alpha = (color_t)((float)m_iCounter / (float)m_transitionStart.length * 255.0f * 2);
+      alpha = (UTILS::Color)((float)m_iCounter / (float)m_transitionStart.length * 255.0f * 2);
       if (alpha > 255) alpha = 255;
     }
     else // m_transitionEffect == TRANSITION_NONE
@@ -411,11 +411,11 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
     m_bDrawNextImage = true;
     if (m_transitionEnd.type == CROSSFADE)
     { // fade out at 1x speed
-      alpha = 255 - (color_t)((float)(m_iCounter - m_transitionEnd.start) / (float)m_transitionEnd.length * 255.0f);
+      alpha = 255 - (UTILS::Color)((float)(m_iCounter - m_transitionEnd.start) / (float)m_transitionEnd.length * 255.0f);
     }
     else if (m_transitionEnd.type == FADEIN_FADEOUT)
     { // keep solid, then fade out at 2x speed
-      alpha = (color_t)((float)(m_transitionEnd.length - m_iCounter + m_transitionEnd.start) / (float)m_transitionEnd.length * 255.0f * 2);
+      alpha = (UTILS::Color)((float)(m_transitionEnd.length - m_iCounter + m_transitionEnd.start) / (float)m_transitionEnd.length * 255.0f * 2);
       if (alpha > 255) alpha = 255;
     }
     else // m_transitionEffect == TRANSITION_NONE
@@ -792,7 +792,7 @@ bool CSlideShowPic::UpdateVertexBuffer(Vertex* vertices)
 }
 #endif
 
-void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t color)
+void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, UTILS::Color color)
 {
 #ifdef HAS_DX
   Vertex vertex[5];

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -21,12 +21,12 @@
 
 #include "threads/CriticalSection.h"
 #include "guilib/DirtyRegion.h"
+#include "utils/Color.h"
 #include <string>
 #ifdef HAS_DX
 #include "guilib/GUIShaderDX.h"
 #include <wrl/client.h>
 #endif
-typedef uint32_t color_t;
 
 class CBaseTexture;
 
@@ -89,7 +89,7 @@ public:
 private:
   void SetTexture_Internal(int iSlideNumber, CBaseTexture* pTexture, DISPLAY_EFFECT dispEffect = EFFECT_RANDOM, TRANSITION_EFFECT transEffect = FADEIN_FADEOUT);
   void UpdateVertices(float cur_x[4], float cur_y[4], const float new_x[4], const float new_y[4], CDirtyRegionList &dirtyregions);
-  void Render(float *x, float *y, CBaseTexture* pTexture, color_t color);
+  void Render(float *x, float *y, CBaseTexture* pTexture, UTILS::Color color);
   CBaseTexture *m_pImage;
 
   int m_iOriginalWidth;
@@ -102,7 +102,7 @@ private:
   std::string m_strFileName;
   float m_fWidth;
   float m_fHeight;
-  color_t m_alpha;
+  UTILS::Color m_alpha;
   // stuff relative to middle position
   float m_fPosX;
   float m_fPosY;

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "RenderSystemTypes.h"
+#include "utils/Color.h"
 #include "utils/Geometry.h"
 #include "utils/TransformMatrix.h"
 #include "guilib/DirtyRegion.h"
@@ -49,7 +50,7 @@ public:
   virtual bool BeginRender() = 0;
   virtual bool EndRender() = 0;
   virtual void PresentRender(bool rendered, bool videoLayer) = 0;
-  virtual bool ClearBuffers(color_t color) = 0;
+  virtual bool ClearBuffers(UTILS::Color color) = 0;
   virtual bool IsExtSupported(const char* extension) const = 0;
 
   virtual void SetViewPort(const CRect& viewPort) = 0;

--- a/xbmc/rendering/RenderSystemTypes.h
+++ b/xbmc/rendering/RenderSystemTypes.h
@@ -19,10 +19,6 @@
  */
 #pragma once
 
-#include <stdint.h>
-
-using color_t = uint32_t;
-
 enum RENDER_STEREO_VIEW
 {
   RENDER_STEREO_VIEW_OFF,

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -307,7 +307,7 @@ bool CRenderSystemDX::EndRender()
   return true;
 }
 
-bool CRenderSystemDX::ClearBuffers(color_t color)
+bool CRenderSystemDX::ClearBuffers(UTILS::Color color)
 {
   if (!m_bRenderCreated)
     return false;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -26,6 +26,7 @@
 #include "DeviceResources.h"
 #include "threads/Condition.h"
 #include "threads/CriticalSection.h"
+#include "utils/Color.h"
 #include "rendering/RenderSystem.h"
 
 #include <vector>
@@ -56,7 +57,7 @@ public:
   bool BeginRender() override;
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
-  bool ClearBuffers(color_t color) override;
+  bool ClearBuffers(UTILS::Color color) override;
   void SetViewPort(const CRect& viewPort) override;
   void GetViewPort(CRect& viewPort) override;
   void RestoreViewPort() override;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -223,7 +223,7 @@ bool CRenderSystemGL::EndRender()
   return true;
 }
 
-bool CRenderSystemGL::ClearBuffers(color_t color)
+bool CRenderSystemGL::ClearBuffers(UTILS::Color color)
 {
   if (!m_bRenderCreated)
     return false;

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -23,6 +23,7 @@
 #include "system_gl.h"
 #include "GLShader.h"
 #include "rendering/RenderSystem.h"
+#include "utils/Color.h"
 
 enum ESHADERMETHOD
 {
@@ -47,7 +48,7 @@ public:
   bool BeginRender() override;
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
-  bool ClearBuffers(color_t color) override;
+  bool ClearBuffers(UTILS::Color color) override;
   bool IsExtSupported(const char* extension) const override;
 
   void SetVSync(bool vsync);

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -159,7 +159,7 @@ bool CRenderSystemGLES::EndRender()
   return true;
 }
 
-bool CRenderSystemGLES::ClearBuffers(color_t color)
+bool CRenderSystemGLES::ClearBuffers(UTILS::Color color)
 {
   if (!m_bRenderCreated)
     return false;

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -22,6 +22,7 @@
 
 #include "system_gl.h"
 #include "rendering/RenderSystem.h"
+#include "utils/Color.h"
 #include "GLESShader.h"
 
 enum ESHADERMETHOD
@@ -53,7 +54,7 @@ public:
   bool BeginRender() override;
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
-  bool ClearBuffers(color_t color) override;
+  bool ClearBuffers(UTILS::Color color) override;
   bool IsExtSupported(const char* extension) const override;
 
   void SetVSync(bool vsync);

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -87,6 +87,7 @@ set(HEADERS ActorProtocol.h
             CharsetConverter.h
             CharsetDetection.h
             CPUInfo.h
+            Color.h
             Crc32.h
             CryptThreading.h
             DatabaseUtils.h

--- a/xbmc/utils/Color.h
+++ b/xbmc/utils/Color.h
@@ -1,13 +1,3 @@
-/*!
-\file GUIColorManager.h
-\brief
-*/
-
-#ifndef GUILIB_COLORMANAGER_H
-#define GUILIB_COLORMANAGER_H
-
-#pragma once
-
 /*
  *      Copyright (C) 2005-2013 Team XBMC
  *      http://kodi.tv
@@ -27,40 +17,13 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
-/*!
- \ingroup textures
- \brief
- */
+#include <stdint.h>
 
-#include <map>
-#include <string>
-
-#include "utils/Color.h"
-
-class CXBMCTinyXML;
-
-class CGUIColorManager
+namespace UTILS
 {
-public:
-  CGUIColorManager(void);
-  virtual ~CGUIColorManager(void);
 
-  void Load(const std::string &colorFile);
+  typedef uint32_t Color;
 
-  UTILS::Color GetColor(const std::string &color) const;
-
-  void Clear();
-
-protected:
-  bool LoadXML(CXBMCTinyXML &xmlDoc);
-
-  std::map<std::string, UTILS::Color> m_colors;
-};
-
-/*!
- \ingroup textures
- \brief
- */
-extern CGUIColorManager g_colorManager;
-#endif
+} // namespace UTILS

--- a/xbmc/utils/TransformMatrix.h
+++ b/xbmc/utils/TransformMatrix.h
@@ -23,8 +23,9 @@
 #include <math.h>
 #include <memory>
 #include <string.h>
-#include <stdint.h>
 #include <algorithm>
+
+#include "utils/Color.h"
 
 #ifdef __GNUC__
 // under gcc, inline will only take place if optimizations are applied (-O). this will force inline even with optimizations.
@@ -32,8 +33,6 @@
 #else
 #define XBMC_FORCE_INLINE
 #endif
-
-typedef uint32_t color_t;
 
 class TransformMatrix
 {
@@ -237,9 +236,9 @@ public:
     return m[2][0] * x + m[2][1] * y + m[2][2] * z + m[2][3];
   }
 
-  inline color_t TransformAlpha(color_t colour) const XBMC_FORCE_INLINE
+  inline UTILS::Color TransformAlpha(UTILS::Color color) const XBMC_FORCE_INLINE
   {
-    return (color_t)(colour * alpha);
+    return static_cast<UTILS::Color>(color * alpha);
   }
 
   float m[3][4];

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -665,7 +665,7 @@ bool CTeletextDecoder::InitDecoder()
 
   /* set variable screeninfo for double buffering */
   m_YOffset       = 0;
-  m_TextureBuffer = new color_t [4*m_RenderInfo.Height*m_RenderInfo.Width];
+  m_TextureBuffer = new UTILS::Color [4*m_RenderInfo.Height*m_RenderInfo.Width];
 
   ClearFB(GetColorRGB(TXT_ColorTransp));
   ClearBB(GetColorRGB(TXT_ColorTransp)); /* initialize backbuffer */
@@ -1814,9 +1814,9 @@ void CTeletextDecoder::RenderCharBB(int Char, TextPageAttr_t *Attribute)
 
 void CTeletextDecoder::CopyBB2FB()
 {
-  color_t *src, *dst, *topsrc;
+  UTILS::Color *src, *dst, *topsrc;
   int screenwidth;
-  color_t fillcolor;
+  UTILS::Color fillcolor;
 
   /* line 25 */
   if (!m_RenderInfo.PageCatching)
@@ -1917,27 +1917,27 @@ void CTeletextDecoder::SetPosX(int column)
     m_RenderInfo.PosX += GetCurFontWidth();
 }
 
-void CTeletextDecoder::ClearBB(color_t Color)
+void CTeletextDecoder::ClearBB(UTILS::Color Color)
 {
   SDL_memset4(m_TextureBuffer + (m_RenderInfo.Height-m_YOffset)*m_RenderInfo.Width, Color, m_RenderInfo.Width*m_RenderInfo.Height);
 }
 
-void CTeletextDecoder::ClearFB(color_t Color)
+void CTeletextDecoder::ClearFB(UTILS::Color Color)
 {
   SDL_memset4(m_TextureBuffer + m_RenderInfo.Width*m_YOffset, Color, m_RenderInfo.Width*m_RenderInfo.Height);
 }
 
-void CTeletextDecoder::FillBorder(color_t Color)
+void CTeletextDecoder::FillBorder(UTILS::Color Color)
 {
   FillRect(m_TextureBuffer + (m_RenderInfo.Height-m_YOffset)*m_RenderInfo.Width, m_RenderInfo.Width, 0, 25*m_RenderInfo.FontHeight, m_RenderInfo.Width, m_RenderInfo.Height-(25*m_RenderInfo.FontHeight), Color);
   FillRect(m_TextureBuffer + m_RenderInfo.Width*m_YOffset, m_RenderInfo.Width, 0, 25*m_RenderInfo.FontHeight, m_RenderInfo.Width, m_RenderInfo.Height-(25*m_RenderInfo.FontHeight), Color);
 }
 
-void CTeletextDecoder::FillRect(color_t *buffer, int xres, int x, int y, int w, int h, color_t Color)
+void CTeletextDecoder::FillRect(UTILS::Color *buffer, int xres, int x, int y, int w, int h, UTILS::Color Color)
 {
   if (!buffer) return;
 
-  color_t *p = buffer + x + y * xres;
+  UTILS::Color *p = buffer + x + y * xres;
 
   if (w > 0)
   {
@@ -1949,10 +1949,10 @@ void CTeletextDecoder::FillRect(color_t *buffer, int xres, int x, int y, int w, 
   }
 }
 
-void CTeletextDecoder::DrawVLine(color_t *lfb, int xres, int x, int y, int l, color_t color)
+void CTeletextDecoder::DrawVLine(UTILS::Color *lfb, int xres, int x, int y, int l, UTILS::Color color)
 {
   if (!lfb) return;
-  color_t *p = lfb + x + y * xres;
+  UTILS::Color *p = lfb + x + y * xres;
 
   for ( ; l > 0 ; l--)
   {
@@ -1961,7 +1961,7 @@ void CTeletextDecoder::DrawVLine(color_t *lfb, int xres, int x, int y, int l, co
   }
 }
 
-void CTeletextDecoder::DrawHLine(color_t *lfb, int xres,int x, int y, int l, color_t color)
+void CTeletextDecoder::DrawHLine(UTILS::Color *lfb, int xres,int x, int y, int l, UTILS::Color color)
 {
   if (!lfb) return;
   if (l > 0)
@@ -1970,9 +1970,9 @@ void CTeletextDecoder::DrawHLine(color_t *lfb, int xres,int x, int y, int l, col
 
 void CTeletextDecoder::RenderDRCS(int xres,
                                  unsigned char *s,  /* pointer to char data, parity undecoded */
-                                 color_t *d,  /* pointer to frame buffer of top left pixel */
+                                 UTILS::Color *d,  /* pointer to frame buffer of top left pixel */
                                  unsigned char *ax, /* array[0..12] of x-offsets, array[0..10] of y-offsets for each pixel */
-                                 color_t fgcolor, color_t bgcolor)
+                                 UTILS::Color fgcolor, UTILS::Color bgcolor)
 {
   if (d == NULL) return;
 
@@ -1992,8 +1992,8 @@ void CTeletextDecoder::RenderDRCS(int xres,
         bit;
         bit >>= 1, x++)  /* bit mask (MSB left), column counter */
     {
-      color_t f1 = (c1 & bit) ? fgcolor : bgcolor;
-      color_t f2 = (c2 & bit) ? fgcolor : bgcolor;
+      UTILS::Color f1 = (c1 & bit) ? fgcolor : bgcolor;
+      UTILS::Color f2 = (c2 & bit) ? fgcolor : bgcolor;
       for (int i = 0; i < h; i++)
       {
         if (ax[x+1] > ax[x])
@@ -2008,7 +2008,7 @@ void CTeletextDecoder::RenderDRCS(int xres,
   }
 }
 
-void CTeletextDecoder::FillRectMosaicSeparated(color_t *lfb, int xres,int x, int y, int w, int h, color_t fgcolor, color_t bgcolor, int set)
+void CTeletextDecoder::FillRectMosaicSeparated(UTILS::Color *lfb, int xres,int x, int y, int w, int h, UTILS::Color fgcolor, UTILS::Color bgcolor, int set)
 {
   if (!lfb) return;
   FillRect(lfb,xres,x, y, w, h, bgcolor);
@@ -2018,9 +2018,9 @@ void CTeletextDecoder::FillRectMosaicSeparated(color_t *lfb, int xres,int x, int
   }
 }
 
-void CTeletextDecoder::FillTrapez(color_t *lfb, int xres,int x0, int y0, int l0, int xoffset1, int h, int l1, color_t color)
+void CTeletextDecoder::FillTrapez(UTILS::Color *lfb, int xres,int x0, int y0, int l0, int xoffset1, int h, int l1, UTILS::Color color)
 {
-  color_t *p = lfb + x0 + y0 * xres;
+  UTILS::Color *p = lfb + x0 + y0 * xres;
   int xoffset, l;
 
   for (int yoffset = 0; yoffset < h; yoffset++)
@@ -2033,10 +2033,10 @@ void CTeletextDecoder::FillTrapez(color_t *lfb, int xres,int x0, int y0, int l0,
   }
 }
 
-void CTeletextDecoder::FlipHorz(color_t *lfb, int xres,int x, int y, int w, int h)
+void CTeletextDecoder::FlipHorz(UTILS::Color *lfb, int xres,int x, int y, int w, int h)
 {
-  color_t buf[2048];
-  color_t *p = lfb + x + y * xres;
+  UTILS::Color buf[2048];
+  UTILS::Color *p = lfb + x + y * xres;
   int w1,h1;
 
   for (h1 = 0 ; h1 < h ; h1++)
@@ -2050,10 +2050,10 @@ void CTeletextDecoder::FlipHorz(color_t *lfb, int xres,int x, int y, int w, int 
   }
 }
 
-void CTeletextDecoder::FlipVert(color_t *lfb, int xres,int x, int y, int w, int h)
+void CTeletextDecoder::FlipVert(UTILS::Color *lfb, int xres,int x, int y, int w, int h)
 {
-  color_t buf[2048];
-  color_t *p = lfb + x + y * xres, *p1, *p2;
+  UTILS::Color buf[2048];
+  UTILS::Color *p = lfb + x + y * xres, *p1, *p2;
   int h1;
 
   for (h1 = 0 ; h1 < h/2 ; h1++)
@@ -2093,7 +2093,7 @@ int CTeletextDecoder::ShapeCoord(int param, int curfontwidth, int curFontHeight)
   }
 }
 
-void CTeletextDecoder::DrawShape(color_t *lfb, int xres, int x, int y, int shapenumber, int curfontwidth, int FontHeight, int curFontHeight, color_t fgcolor, color_t bgcolor, bool clear)
+void CTeletextDecoder::DrawShape(UTILS::Color *lfb, int xres, int x, int y, int shapenumber, int curfontwidth, int FontHeight, int curFontHeight, UTILS::Color fgcolor, UTILS::Color bgcolor, bool clear)
 {
   if (!lfb || shapenumber < 0x20 || shapenumber > 0x7e || (shapenumber == 0x7e && clear))
     return;
@@ -2179,7 +2179,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
 {
   int Row, Pitch;
   int glyph;
-  color_t bgcolor, fgcolor;
+  UTILS::Color bgcolor, fgcolor;
   int factor, xfactor;
   unsigned char *sbitbuffer;
 
@@ -2274,7 +2274,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
   if (national_subset_local == NAT_AR)
       m_RenderInfo.TTFShiftY = backupTTFshiftY - 2; // for arabic TTF font should be shifted up slightly
 
-  color_t *p;
+  UTILS::Color *p;
   int f; /* running counter for zoom factor */
   int he = m_sBit->height; // sbit->height should not be altered, I guess
   Row = factor * (m_Ascender - m_sBit->top + m_RenderInfo.TTFShiftY);
@@ -2297,7 +2297,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
   for (Row = he; Row; Row--) /* row counts up, but down may be a little faster :) */
   {
     int pixtodo = m_sBit->width;
-    color_t *pstart = p;
+    UTILS::Color *pstart = p;
 
     for (int Bit = xfactor * (m_sBit->left + m_RenderInfo.TTFShiftX); Bit > 0; Bit--) /* fill left margin */
     {
@@ -2310,7 +2310,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
     {
       for (int Bit = 0x80; Bit; Bit >>= 1)
       {
-        color_t color;
+        UTILS::Color color;
 
         if (--pixtodo < 0)
           break;
@@ -2366,7 +2366,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
   m_RenderInfo.TTFShiftY  = backupTTFshiftY; // restore TTFShiftY
 }
 
-int CTeletextDecoder::RenderChar(color_t *buffer,    // pointer to render buffer, min. FontHeight*2*xres
+int CTeletextDecoder::RenderChar(UTILS::Color *buffer,    // pointer to render buffer, min. FontHeight*2*xres
                                 int xres,                 // length of 1 line in render buffer
                                 int Char,                 // character to render
                                 int *pPosX,               // left border for rendering relative to *buffer, will be set to right border after rendering
@@ -2380,7 +2380,7 @@ int CTeletextDecoder::RenderChar(color_t *buffer,    // pointer to render buffer
                                 unsigned char *axdrcs,    // width and height of DRCS-chars
                                 int Ascender)             // Ascender of font
 {
-  color_t bgcolor, fgcolor;
+  UTILS::Color bgcolor, fgcolor;
   int factor, xfactor;
   int national_subset_local = m_txtCache->NationalSubset;
   int ymosaic[4];
@@ -2513,7 +2513,7 @@ int CTeletextDecoder::RenderChar(color_t *buffer,    // pointer to render buffer
         if (buffer)
         {
           int x,y,f,c;
-          color_t* p = buffer + *pPosX + PosY* xres;
+          UTILS::Color* p = buffer + *pPosX + PosY* xres;
           for (y=0; y<FontHeight;y++)
           {
             for (f=0; f<factor; f++)
@@ -3991,7 +3991,7 @@ void CTeletextDecoder::SetColors(unsigned short *pcolormap, int offset, int numb
   }
 }
 
-color_t CTeletextDecoder::GetColorRGB(enumTeletextColor ttc)
+UTILS::Color CTeletextDecoder::GetColorRGB(enumTeletextColor ttc)
 {
   switch (ttc)
   {
@@ -4009,10 +4009,10 @@ color_t CTeletextDecoder::GetColorRGB(enumTeletextColor ttc)
 
  /* Get colors for CLUTs 2+3 */
   int index = (int)ttc;
-  color_t color = (m_RenderInfo.tr0[index] << 24) |
-                  (m_RenderInfo.bl0[index] << 16) |
-                  (m_RenderInfo.gn0[index] << 8) |
-                   m_RenderInfo.rd0[index];
+  UTILS::Color color = (m_RenderInfo.tr0[index] << 24) |
+                       (m_RenderInfo.bl0[index] << 16) |
+                       (m_RenderInfo.gn0[index] << 8) |
+                        m_RenderInfo.rd0[index];
   return color;
 }
 

--- a/xbmc/video/Teletext.h
+++ b/xbmc/video/Teletext.h
@@ -22,6 +22,7 @@
 
 #include "TeletextDefines.h"
 #include "input/Key.h"
+#include "utils/Color.h"
 #include "guilib/GUITexture.h"
 
 // stuff for freetype
@@ -50,7 +51,7 @@ public:
 
   bool NeedRendering() { return m_updateTexture; }
   void RenderingDone() { m_updateTexture = false; }
-  color_t *GetTextureBuffer() { return m_TextureBuffer + (m_RenderInfo.Width*m_YOffset); }
+  UTILS::Color *GetTextureBuffer() { return m_TextureBuffer + (m_RenderInfo.Width*m_YOffset); }
   int GetHeight() { return m_RenderInfo.Height; }
   int GetWidth() { return m_RenderInfo.Width; }
   bool InitDecoder();
@@ -83,25 +84,25 @@ private:
   void SetFontWidth(int newWidth);
   int GetCurFontWidth();
   void SetPosX(int column);
-  void ClearBB(color_t Color);
-  void ClearFB(color_t Color);
-  void FillBorder(color_t Color);
-  void FillRect(color_t *buffer, int xres, int x, int y, int w, int h, color_t Color);
-  void DrawVLine(color_t *lfb, int xres, int x, int y, int l, color_t color);
-  void DrawHLine(color_t *lfb, int xres,int x, int y, int l, color_t color);
-  void FillRectMosaicSeparated(color_t *lfb, int xres,int x, int y, int w, int h, color_t fgcolor, color_t bgcolor, int set);
-  void FillTrapez(color_t *lfb, int xres,int x0, int y0, int l0, int xoffset1, int h, int l1, color_t color);
-  void FlipHorz(color_t *lfb, int xres,int x, int y, int w, int h);
-  void FlipVert(color_t *lfb, int xres,int x, int y, int w, int h);
+  void ClearBB(UTILS::Color Color);
+  void ClearFB(UTILS::Color Color);
+  void FillBorder(UTILS::Color Color);
+  void FillRect(UTILS::Color *buffer, int xres, int x, int y, int w, int h, UTILS::Color Color);
+  void DrawVLine(UTILS::Color *lfb, int xres, int x, int y, int l, UTILS::Color color);
+  void DrawHLine(UTILS::Color *lfb, int xres,int x, int y, int l, UTILS::Color color);
+  void FillRectMosaicSeparated(UTILS::Color *lfb, int xres,int x, int y, int w, int h, UTILS::Color fgcolor, UTILS::Color bgcolor, int set);
+  void FillTrapez(UTILS::Color *lfb, int xres,int x0, int y0, int l0, int xoffset1, int h, int l1, UTILS::Color color);
+  void FlipHorz(UTILS::Color *lfb, int xres,int x, int y, int w, int h);
+  void FlipVert(UTILS::Color *lfb, int xres,int x, int y, int w, int h);
   int ShapeCoord(int param, int curfontwidth, int curfontheight);
-  void DrawShape(color_t *lfb, int xres, int x, int y, int shapenumber, int curfontwidth, int fontheight, int curfontheight, color_t fgcolor, color_t bgcolor, bool clear);
+  void DrawShape(UTILS::Color *lfb, int xres, int x, int y, int shapenumber, int curfontwidth, int fontheight, int curfontheight, UTILS::Color fgcolor, UTILS::Color bgcolor, bool clear);
   void RenderDRCS(int xres,
-                  unsigned char *s,          /* pointer to char data, parity undecoded */
-                  color_t *d,                  /* pointer to frame buffer of top left pixel */
+                  unsigned char *s,         /* pointer to char data, parity undecoded */
+                  UTILS::Color *d,          /* pointer to frame buffer of top left pixel */
                   unsigned char *ax,        /* array[0..12] of x-offsets, array[0..10] of y-offsets for each pixel */
-                  color_t fgcolor, color_t bgcolor);
+                  UTILS::Color fgcolor, UTILS::Color bgcolor);
   void RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, TextPageAttr_t *Attribute, int zoom, int yoffset);
-  int RenderChar(color_t *buffer,             // pointer to render buffer, min. fontheight*2*xres
+  int RenderChar(UTILS::Color *buffer,      // pointer to render buffer, min. fontheight*2*xres
                  int xres,                  // length of 1 line in render buffer
                  int Char,                  // character to render
                  int *pPosX,                // left border for rendering relative to *buffer, will be set to right border after rendering
@@ -136,13 +137,13 @@ private:
   int SetNational(unsigned char sec);
   int NextHex(int i);
   void SetColors(unsigned short *pcolormap, int offset, int number);
-  color_t GetColorRGB(enumTeletextColor ttc);
+  UTILS::Color GetColorRGB(enumTeletextColor ttc);
 
   static FT_Error MyFaceRequester(FTC_FaceID face_id, FT_Library library, FT_Pointer request_data, FT_Face *aface);
 
-  std::string          m_teletextFont;     /* Path to teletext font */
+  std::string         m_teletextFont;     /* Path to teletext font */
   int                 m_YOffset;          /* Swap position for Front buffer and Back buffer */
-  color_t            *m_TextureBuffer;    /* Texture buffer to hold generated data */
+  UTILS::Color        *m_TextureBuffer;   /* Texture buffer to hold generated data */
   bool                m_updateTexture;    /* Update the texture if set */
   char                prevHeaderPage;     /* Needed for texture update if header is changed */
   char                prevTimeSec;        /* Needed for Time string update */

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -27,6 +27,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "settings/Settings.h"
+#include "utils/Color.h"
 
 static int teletextFadeAmount = 0;
 
@@ -124,7 +125,7 @@ void CGUIDialogTeletext::Render()
     MarkDirtyRegion();
   }
 
-  color_t color = ((color_t)(teletextFadeAmount * 2.55f) & 0xff) << 24 | 0xFFFFFF;
+  UTILS::Color color = (static_cast<UTILS::Color>(teletextFadeAmount * 2.55f) & 0xff) << 24 | 0xFFFFFF;
   CGUITexture::DrawQuad(m_vertCoords, color, m_pTxtTexture);
 
   CGUIDialog::Render();

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -746,7 +746,7 @@ void CGraphicContext::ResetScreenParameters(RESOLUTION res)
   ResetOverscan(res, info.Overscan);
 }
 
-void CGraphicContext::Clear(color_t color)
+void CGraphicContext::Clear(UTILS::Color color)
 {
   CServiceBroker::GetRenderSystem()->ClearBuffers(color);
 }
@@ -1068,9 +1068,9 @@ float CGraphicContext::GetGUIScaleY() const
   return m_finalTransform.scaleY;
 }
 
-color_t CGraphicContext::MergeAlpha(color_t color) const
+UTILS::Color CGraphicContext::MergeAlpha(UTILS::Color color) const
 {
-  color_t alpha = m_finalTransform.matrix.TransformAlpha((color >> 24) & 0xff);
+  UTILS::Color alpha = m_finalTransform.matrix.TransformAlpha((color >> 24) & 0xff);
   if (alpha > 255) alpha = 255;
   return ((alpha << 24) & 0xff000000) | (color & 0xffffff);
 }

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -29,6 +29,7 @@
 #include "utils/Geometry.h"               // for CRect/CPoint
 #include "Resolution.h"
 #include "rendering/RenderSystem.h"
+#include "utils/Color.h"
 
 // required by clients
 #include "ServiceBroker.h"
@@ -108,7 +109,7 @@ public:
   void ResetScreenParameters(RESOLUTION res);
   void CaptureStateBlock();
   void ApplyStateBlock();
-  void Clear(color_t color = 0);
+  void Clear(UTILS::Color color = 0);
   void GetAllowedResolutions(std::vector<RESOLUTION> &res);
 
   /* \brief Get UI scaling information from a given resolution to the screen resolution.
@@ -131,7 +132,7 @@ public:
   const TransformMatrix &GetGUIMatrix() const;
   float GetGUIScaleX() const;
   float GetGUIScaleY() const;
-  color_t MergeAlpha(color_t color) const;
+  UTILS::Color MergeAlpha(UTILS::Color color) const;
   void SetOrigin(float x, float y);
   void RestoreOrigin();
   void SetCameraPosition(const CPoint &camera);

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "ServiceBroker.h"
 #include "addons/binary-addons/AddonDll.h"
+#include "utils/Color.h"
 #include "windowing/GraphicContext.h"
 #include "guilib/GUITexture.h"
 
@@ -77,7 +78,7 @@ void CGUIWindowScreensaverDim::Process(unsigned int currentTime, CDirtyRegionLis
 void CGUIWindowScreensaverDim::Render()
 {
   // draw a translucent black quad - fading is handled by the window animation
-  color_t color = ((color_t)(m_dimLevel * 2.55f) & 0xff) << 24;
+  UTILS::Color color = (static_cast<UTILS::Color>(m_dimLevel * 2.55f) & 0xff) << 24;
   color = CServiceBroker::GetWinSystem()->GetGfxContext().MergeAlpha(color);
   CRect rect(0, 0, (float)CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(), (float)CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight());
   CGUITexture::DrawQuad(rect, color);


### PR DESCRIPTION
Defining our own `color_t` in global namespace recently led to build breakers on Windows when compiling using VS 2015. This PR removes `color_t` completely from our code base and replaces it with the new type `UTILS::Color`.

@Rechi @peak3d f.y.i.