### PR TITLE
Add log why inputstream passes invalid streams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -30,6 +30,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 
 CInputStreamProvider::CInputStreamProvider(ADDON::BinaryAddonBasePtr addonBase, kodi::addon::IAddonInstance* parentInstance)
   : m_addonBase(addonBase)
@@ -343,13 +344,19 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
 {
   INPUTSTREAM_INFO stream = m_struct.toAddon.get_stream(&m_struct, streamId);
   if (stream.m_streamType == INPUTSTREAM_INFO::TYPE_NONE)
+  {
+    CLog::Log(LOGWARNING,"CInputStreamAddon::GetStream: Invalid stream type:%d", stream.m_streamType);
     return nullptr;
+  }
 
   std::string codecName(stream.m_codecName);
   StringUtils::ToLower(codecName);
   AVCodec *codec = avcodec_find_decoder_by_name(codecName.c_str());
   if (!codec)
+  {
+    CLog::Log(LOGWARNING,"CInputStreamAddon::GetStream: Invalid stream codec:%s", codecName.c_str());
     return nullptr;
+  }
 
   CDemuxStream *demuxStream;
 
@@ -383,7 +390,10 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
     demuxStream = subtitleStream;
   }
   else
+  {
+    CLog::Log(LOGWARNING,"CInputStreamAddon::GetStream: Stream type not implemented: %d", stream.m_streamType);
     return nullptr;
+  }
 
   demuxStream->name = stream.m_name;
   demuxStream->codec = codec->id;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -125,7 +125,10 @@ bool CVideoPlayerVideo::OpenStream(CDVDStreamInfo hint)
         hint.codec == AV_CODEC_ID_MPEG4 ||
         hint.codec == AV_CODEC_ID_WMV3 ||
         hint.codec == AV_CODEC_ID_VC1)
+    {
+      CLog::Log(LOGWARNING, "%s: Video codec %d without extra_data not supported", __FUNCTION__, hint.codec);
       return false;
+    }
   }
 
   CLog::Log(LOGNOTICE, "Creating video codec with codec id: %i", hint.codec);


### PR DESCRIPTION
## Description
If inputstream provides streams which are not supported, currently a single "Unsupported stream" appears in log (from VideoPlayer). This PR adds warnings with the reason why. 

## Motivation and Context
Spend some hours debugging to find out why my dolby vision streams do not start.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
