### PR TITLE
[guiinfo] Fix Container.CanFilter (CONTAINER_CAN_FILTER).

### DIFF
--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -479,7 +479,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
       CGUIMediaWindow *window = GUIINFO::GetMediaWindow(contextWindow);
       if (window)
       {
-        value = window->CanFilterAdvanced();
+        value = !window->CanFilterAdvanced();
         return true;
       }
       break;


### PR DESCRIPTION
Fix info bool "Container.CanFilter" after #13754 

Problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=298461&pid=2727478#pid2727478

@MilhouseVH fyi