### PR TITLE
[addons] service add-ons start and stop on profile login and logout

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1124,7 +1124,6 @@ bool CApplication::Initialize()
     else
     {
       CJSONRPC::Initialize();
-      CServiceBroker::GetServiceAddons().StartBeforeLogin();
 
       // activate the configured start window
       int firstWindow = g_SkinInfo->GetFirstWindow();
@@ -1146,10 +1145,7 @@ bool CApplication::Initialize()
 
   }
   else //No GUI Created
-  {
     CJSONRPC::Initialize();
-    CServiceBroker::GetServiceAddons().StartBeforeLogin();
-  }
 
   g_sysinfo.Refresh();
 
@@ -1172,7 +1168,8 @@ bool CApplication::Initialize()
   RegisterActionListener(&CPlayerController::GetInstance());
 
   CServiceBroker::GetRepositoryUpdater().Start();
-  CServiceBroker::GetServiceAddons().Start();
+  if (!m_ServiceManager->GetProfileManager().UsingLoginScreen())
+    CServiceBroker::GetServiceAddons().Start();
 
   CLog::Log(LOGNOTICE, "initialize done");
 

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -25,27 +25,12 @@
 
 namespace ADDON
 {
-
-  enum class START_OPTION
-  {
-    STARTUP,
-    LOGIN
-  };
-
   class CService: public CAddon
   {
   public:
     static std::unique_ptr<CService> FromExtension(CAddonInfo addonInfo, const cp_extension_t* ext);
 
-    explicit CService(CAddonInfo addonInfo) : CAddon(std::move(addonInfo)),
-        m_startOption(START_OPTION::LOGIN) {}
-
-    CService(CAddonInfo addonInfo, START_OPTION startOption);
-
-    START_OPTION GetStartOption() { return m_startOption; }
-
-  private:
-    START_OPTION m_startOption;
+    explicit CService(CAddonInfo addonInfo) : CAddon(std::move(addonInfo)) {}
   };
 
   class CServiceAddonManager
@@ -58,11 +43,6 @@ namespace ADDON
      * Start all services.
      */
     void Start();
-
-    /**
-     * Start services that have start option 'startup'.
-     */
-    void StartBeforeLogin();
 
     /**
      * Start service by add-on id.

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -79,6 +79,7 @@ static int LogOff(const std::vector<std::string>& params)
   if (CVideoLibraryQueue::GetInstance().IsRunning())
     CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
+  CServiceBroker::GetServiceAddons().Stop();
   CServiceBroker::GetNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
 
 


### PR DESCRIPTION
And no service add-ons are started _before_ profile login.

_This PR started life as a fix for some of the goofy behavior `start="startup"` caused, but now it's just getting the boot._

## Motivation and Context
`start="startup"` service add-ons made things goofy and weren't particularly useful. Simplify!

## How Has This Been Tested?
Manually by restarting Kodi with [these simple service add-ons](https://github.com/rmrector/repository.rector.stuff/raw/master/testing/service-startup-testing.zip) that log and notify when they start and stop, testing application with and without login screen, and switching profiles after login. I also checked that service add-ons are still started and stopped when enabled and disabled from the GUI after changing profiles.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Breaking change (technically, though I'm not sure how many service add-ons ever used it effectively)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

[This wiki page](https://kodi.wiki/view/HOW-TO:Automatically_start_addons_using_services) will need a note of this change.