### PR TITLE
[aml]Register lirc in AML after #13761

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -79,6 +79,7 @@ CWinSystemAmlogic::CWinSystemAmlogic() :
   AE::CAESinkFactory::ClearSinks();
   CAESinkALSA::Register();
   CLinuxPowerSyscall::Register();
+  m_lirc.reset(OPTIONALS::LircRegister());
   m_libinput->Start();
 }
 

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.h
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "platform/linux/input/LibInputHandler.h"
+#include "platform/linux/OptionalsReg.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "threads/CriticalSection.h"
 #include "windowing/WinSystem.h"
@@ -64,6 +65,6 @@ protected:
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;
-
+  std::unique_ptr<OPTIONALS::CLircContainer, OPTIONALS::delete_CLircContainer> m_lirc;
   std::unique_ptr<CLibInputHandler> m_libinput;
 };


### PR DESCRIPTION
See title,

Sigsegv on
void CLirc::Process()
{
  m_profileId = CServiceBroker::GetProfileManager().GetCurrentProfileId();
  m_irTranslator.Load("Lircmap.xml");

In LIRC.cpp