### PR TITLE
[fix] call av_dump_format with redacted url

### DIFF
--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -24,7 +24,6 @@
 #include "utils/StringUtils.h"
 #include "threads/Thread.h"
 #include "settings/AdvancedSettings.h"
-#include "URL.h"
 #include <map>
 
 static thread_local CFFmpegLog* CFFmpegLogTls;
@@ -119,18 +118,8 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
   int pos, start = 0;
   while ((pos = buffer.find_first_of('\n', start)) >= 0)
   {
-    if(pos > start)
-    {
-      std::vector<std::string> toLog = StringUtils::Split(buffer.substr(start, pos - start), "from '");
-      if (toLog.size() > 1)
-      {
-       size_t pos = toLog[1].find_first_of('\'');
-       std::string url = CURL::GetRedacted(toLog[1].substr(0, pos - 1));
-       toLog[0] += url + toLog[1].substr(pos);
-      }
-
-      CLog::Log(type, "%s%s", prefix.c_str(), toLog[0].c_str());
-    }
+    if (pos > start)
+      CLog::Log(type, "%s%s", prefix.c_str(), buffer.substr(start, pos - start).c_str());
     start = pos+1;
   }
   buffer.erase(0, start);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -505,7 +505,7 @@ bool CDVDDemuxFFmpeg::Open(std::shared_ptr<CDVDInputStream> pInput, bool streami
   m_pFormatContext->flags |= AVFMT_FLAG_NONBLOCK;
 
   // print some extra information
-  av_dump_format(m_pFormatContext, 0, strFile.c_str(), 0);
+  av_dump_format(m_pFormatContext, 0, CURL::GetRedacted(strFile).c_str(), 0);
 
   // deprecated, will be always set in future versions
   m_pFormatContext->flags |= AVFMT_FLAG_KEEP_SIDE_DATA;


### PR DESCRIPTION
## Description
call av_dump_format with redacted url instead of adjusting it in the FFmpeg log call back

## Motivation and Context
missing last char of file name in log lines

## How Has This Been Tested?
`av_dump_format` is not called from any FFmpeg lib and only one call from Kodi

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

@fritsch @MilhouseVH FYI