### PR TITLE
[cmake] always pass compiler to libdvd

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -76,9 +76,6 @@ else()
   endforeach()
 
   set(DVDREAD_CFLAGS "${DVDREAD_CFLAGS} -I${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/include")
-  if(CMAKE_CROSSCOMPILING)
-    set(EXTRA_FLAGS "CC=${CMAKE_C_COMPILER}")
-  endif()
 
   if(APPLE)
     set(CMAKE_LD_FLAGS "-framework IOKit -framework CoreFoundation")
@@ -113,7 +110,7 @@ else()
                                                     --with-pic
                                                     --prefix=<INSTALL_DIR>
                                                     --libdir=<INSTALL_DIR>/lib
-                                                    "${EXTRA_FLAGS}"
+                                                    "CC=${CMAKE_C_COMPILER}"
                                                     "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
                                                     "LDFLAGS=${CMAKE_LD_FLAGS}"
                                   BUILD_BYPRODUCTS ${DVDCSS_LIBRARY})
@@ -154,7 +151,7 @@ else()
                                                   --with-pic
                                                   --prefix=<INSTALL_DIR>
                                                   --libdir=<INSTALL_DIR>/lib
-                                                  "${EXTRA_FLAGS}"
+                                                  "CC=${CMAKE_C_COMPILER}"
                                                   "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
                                                   "LDFLAGS=${CMAKE_LD_FLAGS}"
                               BUILD_BYPRODUCTS ${DVDREAD_LIBRARY})
@@ -198,7 +195,7 @@ else()
                                                   --with-pic
                                                   --prefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd
                                                   --libdir=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib
-                                                  "${EXTRA_FLAGS}"
+                                                  "CC=${CMAKE_C_COMPILER}"
                                                   "LDFLAGS=${CMAKE_LD_FLAGS} -L${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib"
                                                   "CFLAGS=${CMAKE_C_FLAGS} ${DVDREAD_CFLAGS}"
                                                   "DVDREAD_CFLAGS=${DVDREAD_CFLAGS}"


### PR DESCRIPTION
## Description
The same compiler used for Kodi should be used for libdvd libs.

## Motivation and Context
setting `CMAKE_C_COMPILER` (eg to clang or a specific gcc version) should result in libdvd also using that compiler

## How Has This Been Tested?
generated project with default compiler, clang and gcc-8
build libdvd with each of them

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
