### PR TITLE
windowing: add overrides for UseLimitedColor for specific platforms

### DIFF
--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -239,7 +239,7 @@ REFRESHRATE CWinSystemBase::DefaultRefreshRate(int screen, std::vector<REFRESHRA
 
 bool CWinSystemBase::UseLimitedColor()
 {
-  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+  return false;
 }
 
 std::string CWinSystemBase::GetClipboardText(void)

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -456,6 +456,11 @@ bool CWinSystemX11::HasCalibration(const RESOLUTION_INFO &resInfo)
   return false;
 }
 
+bool CWinSystemX11::UseLimitedColor()
+{
+  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+}
+
 void CWinSystemX11::GetConnectedOutputs(std::vector<std::string> *outputs)
 {
   std::vector<XOutput> outs;

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -63,6 +63,7 @@ public:
   void Register(IDispResource *resource) override;
   void Unregister(IDispResource *resource) override;
   bool HasCalibration(const RESOLUTION_INFO &resInfo) override;
+  bool UseLimitedColor() override;
 
   // Local to WinSystemX11 only
   Display*  GetDisplay() { return m_dpy; }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -232,6 +232,11 @@ void CWinSystemGbm::WaitVBlank()
   m_DRM->WaitVBlank();
 }
 
+bool CWinSystemGbm::UseLimitedColor()
+{
+  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+}
+
 bool CWinSystemGbm::Hide()
 {
   return false;

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -53,6 +53,8 @@ public:
 
   void UpdateResolutions() override;
 
+  bool UseLimitedColor() override;
+
   bool Hide() override;
   bool Show(bool raise = true) override;
   virtual void Register(IDispResource *resource);

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -58,6 +58,7 @@ public:
   virtual bool Hide() override;
   virtual bool Show(bool raise = true) override;
   virtual void OnMove(int x, int y) override;
+  bool UseLimitedColor() override;
 
   virtual std::string GetClipboardText(void) override;
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1718,6 +1718,11 @@ void CWinSystemOSX::OnMove(int x, int y)
   HandlePossibleRefreshrateChange();
 }
 
+bool CWinSystemOSX::UseLimitedColor()
+{
+  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+}
+
 std::unique_ptr<IOSScreenSaver> CWinSystemOSX::GetOSScreenSaverImpl()
 {
   return std::unique_ptr<IOSScreenSaver> (new COSScreenSaverOSX);

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -443,6 +443,11 @@ void CWinSystemWayland::GetConnectedOutputs(std::vector<std::string>* outputs)
                    return UserFriendlyOutputName(pair.second); });
 }
 
+bool CWinSystemWayland::UseLimitedColor()
+{
+  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+}
+
 void CWinSystemWayland::UpdateResolutions()
 {
   CWinSystemBase::UpdateResolutions();

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -75,6 +75,8 @@ public:
   void FinishModeChange(RESOLUTION res) override;
   void FinishWindowResize(int newWidth, int newHeight) override;
 
+  bool UseLimitedColor() override;
+
   void UpdateResolutions() override;
   int GetNumScreens() override;
   int GetCurrentScreen() override;

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -739,6 +739,11 @@ std::string CWinSystemWin10::GetClipboardText()
   return KODI::PLATFORM::WINDOWS::FromW(unicode_text);
 }
 
+bool CWinSystemWin10::UseLimitedColor()
+{
+  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+}
+
 void CWinSystemWin10::NotifyAppFocusChange(bool bGaining)
 {
   m_inFocus = bGaining;

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -106,6 +106,8 @@ public:
   bool Hide() override;
   bool Show(bool raise = true) override;
   std::string GetClipboardText() override;
+  bool UseLimitedColor() override;
+
   // videosync
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1120,6 +1120,11 @@ std::string CWinSystemWin32::GetClipboardText()
   return utf8_text;
 }
 
+bool CWinSystemWin32::UseLimitedColor()
+{
+  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+}
+
 void CWinSystemWin32::NotifyAppFocusChange(bool bGaining)
 {
   if (m_state == WINDOW_STATE_FULLSCREEN && !m_IsAlteringWindow)

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -192,6 +192,8 @@ public:
   bool Hide() override;
   bool Show(bool raise = true) override;
   std::string GetClipboardText() override;
+  bool UseLimitedColor() override;
+
   // videosync
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 


### PR DESCRIPTION
This is a better solution than #13800 

same idea, don't enforce limited colour on platforms that don't support it (or haven't been tested)