### PR TITLE
[guiinfo] Fix Listitem.PercentPlayed (LISTITEM_PERCENT_PLAYED) string…

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -387,15 +387,8 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         }
         break;
       case LISTITEM_PERCENT_PLAYED:
-      {
-        int iPercentPlayed = GetPercentPlayed(tag);
-        if (iPercentPlayed > 0)
-        {
-          value = StringUtils::Format("%d", iPercentPlayed);
-          return true;
-        }
-        break;
-      }
+        value = StringUtils::Format("%d", GetPercentPlayed(tag));
+        return true;
       case LISTITEM_VIDEO_CODEC:
         value = tag->m_streamDetails.GetVideoCodec();
         return true;


### PR DESCRIPTION
… label zero value handling.

Fixes a regression introduced with #13754 

Problem reported in the forum: https://forum.kodi.tv/showthread.php?tid=330696&pid=2728311#pid2728311

@Jalle19 mind taking a look (will merge if no response in 24h)