### PR TITLE
Bump repository add-on to 3.1.0

### DIFF
--- a/addons/repository.xbmc.org/addon.xml
+++ b/addons/repository.xbmc.org/addon.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.xbmc.org"
 		name="Kodi Add-on repository"
-		version="3.0.5"
+		version="3.1.0"
 		provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.addon" version="12.0.0"/>
   </requires>
 	<extension point="xbmc.addon.repository">
+		<!-- Do not forget to bump add-on version when changing paths to force a repo refresh -->
 		<info>http://mirrors.kodi.tv/addons/leia/addons.xml.gz</info>
 		<checksum verify="sha256">http://mirrors.kodi.tv/addons/leia/addons.xml.gz?sha256</checksum>
 		<datadir>https://mirrors.kodi.tv/addons/leia</datadir>


### PR DESCRIPTION
Due to recent change to https URL, bump was forgotten earlier.

This leads to the problem that Kodi cannot install any add-ons until the repo is refreshed manually or after 24 hours.

Bumping the version now so people updating to alpha2 don't encounter problems.