### PR TITLE
DVDVideoCodecDRMPRIME: remove depreciated ffmpeg function

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -171,23 +171,36 @@ void CDVDVideoCodecDRMPRIME::Register()
   CDVDFactoryCodec::RegisterHWVideoCodec("drm_prime", CDVDVideoCodecDRMPRIME::Create);
 }
 
-const AVCodec* CDVDVideoCodecDRMPRIME::FindDecoder(CDVDStreamInfo& hints)
+static const AVCodecHWConfig* FindHWConfig(const AVCodec* codec)
+{
+  const AVCodecHWConfig* config = nullptr;
+  for (int n = 0; (config = avcodec_get_hw_config(codec, n)); n++)
+  {
+    if (config->pix_fmt != AV_PIX_FMT_DRM_PRIME)
+      continue;
+
+    if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_INTERNAL))
+      return config;
+  }
+
+  return nullptr;
+}
+
+static const AVCodec* FindDecoder(CDVDStreamInfo& hints)
 {
   const AVCodec* codec = nullptr;
   void *i = 0;
 
   while ((codec = av_codec_iterate(&i)))
   {
-    if (av_codec_is_decoder(codec) && codec->id == hints.codec && codec->pix_fmts)
-    {
-      const AVPixelFormat* fmt = codec->pix_fmts;
-      while (*fmt != AV_PIX_FMT_NONE)
-      {
-        if (*fmt == AV_PIX_FMT_DRM_PRIME)
-          return codec;
-        fmt++;
-      }
-    }
+    if (!av_codec_is_decoder(codec))
+      continue;
+    if (codec->id != hints.codec)
+      continue;
+
+    const AVCodecHWConfig* config = FindHWConfig(codec);
+    if (config)
+      return codec;
   }
 
   return nullptr;
@@ -208,6 +221,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   if (!m_pCodecContext)
     return false;
 
+  m_pCodecContext->pix_fmt = AV_PIX_FMT_DRM_PRIME;
   m_pCodecContext->codec_tag = hints.codec_tag;
   m_pCodecContext->coded_width = hints.width;
   m_pCodecContext->coded_height = hints.height;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -211,6 +211,15 @@ static const AVCodec* FindDecoder(CDVDStreamInfo& hints)
   return nullptr;
 }
 
+static enum AVPixelFormat GetFormat(struct AVCodecContext* avctx, const enum AVPixelFormat* fmt)
+{
+  for (int n = 0; fmt[n] != AV_PIX_FMT_NONE; n++)
+    if (fmt[n] == AV_PIX_FMT_DRM_PRIME)
+      return fmt[n];
+
+  return AV_PIX_FMT_NONE;
+}
+
 bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
 {
   const AVCodec* pCodec = FindDecoder(hints);
@@ -241,6 +250,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   }
 
   m_pCodecContext->pix_fmt = AV_PIX_FMT_DRM_PRIME;
+  m_pCodecContext->get_format = GetFormat;
   m_pCodecContext->codec_tag = hints.codec_tag;
   m_pCodecContext->coded_width = hints.width;
   m_pCodecContext->coded_height = hints.height;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -25,6 +25,7 @@
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "windowing/gbm/WinSystemGbm.h"
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
@@ -179,6 +180,10 @@ static const AVCodecHWConfig* FindHWConfig(const AVCodec* codec)
     if (config->pix_fmt != AV_PIX_FMT_DRM_PRIME)
       continue;
 
+    if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+        config->device_type == AV_HWDEVICE_TYPE_DRM)
+      return config;
+
     if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_INTERNAL))
       return config;
   }
@@ -221,6 +226,20 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   if (!m_pCodecContext)
     return false;
 
+  const AVCodecHWConfig* pConfig = FindHWConfig(pCodec);
+  if (pConfig &&
+      (pConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+      pConfig->device_type == AV_HWDEVICE_TYPE_DRM)
+  {
+    CWinSystemGbm* winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+    if (av_hwdevice_ctx_create(&m_pCodecContext->hw_device_ctx, AV_HWDEVICE_TYPE_DRM, winSystem->GetDevicePath().c_str(), nullptr, 0) < 0)
+    {
+      CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unable to create hwdevice context", __FUNCTION__);
+      avcodec_free_context(&m_pCodecContext);
+      return false;
+    }
+  }
+
   m_pCodecContext->pix_fmt = AV_PIX_FMT_DRM_PRIME;
   m_pCodecContext->codec_tag = hints.codec_tag;
   m_pCodecContext->coded_width = hints.width;
@@ -239,6 +258,13 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   if (avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0)
   {
     CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unable to open codec", __FUNCTION__);
+    avcodec_free_context(&m_pCodecContext);
+    return false;
+  }
+
+  if (m_pCodecContext->pix_fmt != AV_PIX_FMT_DRM_PRIME)
+  {
+    CLog::Log(LOGNOTICE, "CDVDVideoCodecDRMPRIME::%s - unexpected pix fmt %s", __FUNCTION__, av_get_pix_fmt_name(m_pCodecContext->pix_fmt));
     avcodec_free_context(&m_pCodecContext);
     return false;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -171,10 +171,12 @@ void CDVDVideoCodecDRMPRIME::Register()
   CDVDFactoryCodec::RegisterHWVideoCodec("drm_prime", CDVDVideoCodecDRMPRIME::Create);
 }
 
-AVCodec* CDVDVideoCodecDRMPRIME::FindDecoder(CDVDStreamInfo& hints)
+const AVCodec* CDVDVideoCodecDRMPRIME::FindDecoder(CDVDStreamInfo& hints)
 {
-  AVCodec* codec = nullptr;
-  while ((codec = av_codec_next(codec)))
+  const AVCodec* codec = nullptr;
+  void *i = 0;
+
+  while ((codec = av_codec_iterate(&i)))
   {
     if (av_codec_is_decoder(codec) && codec->id == hints.codec && codec->pix_fmts)
     {
@@ -193,7 +195,7 @@ AVCodec* CDVDVideoCodecDRMPRIME::FindDecoder(CDVDStreamInfo& hints)
 
 bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
 {
-  AVCodec* pCodec = FindDecoder(hints);
+  const AVCodec* pCodec = FindDecoder(hints);
   if (!pCodec)
   {
     CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::%s - unable to find decoder for codec %d", __FUNCTION__, hints.codec);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -71,7 +71,6 @@ public:
   void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
 
 protected:
-  const AVCodec* FindDecoder(CDVDStreamInfo& hints);
   void Drain();
   void SetPictureParams(VideoPicture* pVideoPicture);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -71,7 +71,7 @@ public:
   void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
 
 protected:
-  virtual AVCodec* FindDecoder(CDVDStreamInfo& hints);
+  virtual const AVCodec* FindDecoder(CDVDStreamInfo& hints);
   virtual void Drain();
   virtual void SetPictureParams(VideoPicture* pVideoPicture);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -71,9 +71,9 @@ public:
   void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
 
 protected:
-  virtual const AVCodec* FindDecoder(CDVDStreamInfo& hints);
-  virtual void Drain();
-  virtual void SetPictureParams(VideoPicture* pVideoPicture);
+  const AVCodec* FindDecoder(CDVDStreamInfo& hints);
+  void Drain();
+  void SetPictureParams(VideoPicture* pVideoPicture);
 
   std::string m_name;
   int m_codecControlFlags = 0;

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -481,6 +481,9 @@ bool CDRMUtils::OpenDrm()
         drmModeFreeProperty(*m_connector->props_info);
         *m_connector->props_info = nullptr;
 
+        m_module = module;
+        m_device_path = device;
+
         CLog::Log(LOGDEBUG, "CDRMUtils::%s - opened device: %s using module: %s", __FUNCTION__, device.c_str(), module);
         return true;
       }

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -72,6 +72,9 @@ public:
   virtual bool InitDrm();
   virtual void DestroyDrm();
 
+  std::string GetModule() const { return m_module; }
+  std::string GetDevicePath() const { return m_device_path; }
+
   bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
   bool SetMode(RESOLUTION_INFO res);
   void WaitVBlank();
@@ -101,6 +104,8 @@ private:
   static void DrmFbDestroyCallback(struct gbm_bo *bo, void *data);
 
   int m_crtc_index;
+  std::string m_module;
+  std::string m_device_path;
 
   drmModeResPtr m_drm_resources = nullptr;
   drmModeCrtcPtr m_orig_crtc = nullptr;

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -61,6 +61,9 @@ public:
   virtual void Register(IDispResource *resource);
   virtual void Unregister(IDispResource *resource);
 
+  std::string GetModule() const { return m_DRM->GetModule(); }
+  std::string GetDevicePath() const { return m_DRM->GetDevicePath(); }
+
   std::shared_ptr<CDRMUtils> m_DRM;
 
 protected:


### PR DESCRIPTION
`av_codec_next` is depreciated in ffmpeg 4.0 see [here](https://www.ffmpeg.org/doxygen/trunk/group__lavc__core.html#ga424c2b3c23cc41f4ef93ef2034f5c901)