### PR TITLE
[PVR] Implement smart direct channel number input

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -172,7 +172,6 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
     if (url.IsProtocol("upnp")) return new CUPnPDirectory();
 #endif
     if (url.IsProtocol("rss") || url.IsProtocol("rsss")) return new CRSSDirectory();
-    if (url.IsProtocol("pvr")) return new CPVRDirectory();
 #ifdef HAS_ZEROCONF
     if (url.IsProtocol("zeroconf")) return new CZeroconfDirectory();
 #endif
@@ -180,6 +179,9 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
     if (url.IsProtocol("nfs")) return new CNFSDirectory();
 #endif
   }
+
+  if (url.IsProtocol("pvr"))
+    return new CPVRDirectory();
 
   if (!url.GetProtocol().empty() && CServiceBroker::IsBinaryAddonCacheUp())
   {

--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -20,6 +20,7 @@
 
 #include "PVRChannelNumberInputHandler.h"
 
+#include <algorithm>
 #include <cstdlib>
 
 #include "settings/AdvancedSettings.h"
@@ -42,11 +43,33 @@ CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler(int iDelay, int iMa
 
 void CPVRChannelNumberInputHandler::OnTimeout()
 {
-  // call the overridden worker method
-  OnInputDone();
+  if (m_inputBuffer.empty())
+  {
+    CSingleLock lock(m_mutex);
+    m_label.erase();
+  }
+  else
+  {
+    // call the overridden worker method
+    OnInputDone();
 
-  CSingleLock lock(m_mutex);
-  m_inputBuffer.erase();
+    CSingleLock lock(m_mutex);
+
+    // erase input buffer immediately , but...
+    m_inputBuffer.erase();
+
+    // ... display the label for another .5 secs if we stopped the timer before regular timeout.
+    if (m_timer.IsRunning())
+      m_label.erase();
+    else
+      m_timer.Start(500);
+  }
+}
+
+void CPVRChannelNumberInputHandler::ExecuteAction()
+{
+  m_timer.Stop();
+  OnTimeout();
 }
 
 bool CPVRChannelNumberInputHandler::CheckInputAndExecuteAction()
@@ -55,7 +78,7 @@ bool CPVRChannelNumberInputHandler::CheckInputAndExecuteAction()
   if (channelNumber.IsValid())
   {
     // we have a valid channel number; execute the associated action now.
-    OnTimeout();
+    ExecuteAction();
     return true;
   }
   return false;
@@ -80,9 +103,41 @@ void CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(char cCharacter
   }
 
   if (m_inputBuffer.size() == static_cast<size_t>(m_iMaxDigits))
+  {
     m_inputBuffer.erase(m_inputBuffer.begin());
+    m_label = m_inputBuffer;
+  }
+  else if (m_inputBuffer.empty())
+  {
+    m_sortedChannelNumbers.clear();
+    GetChannelNumbers(m_sortedChannelNumbers);
+
+    std::sort(m_sortedChannelNumbers.begin(), m_sortedChannelNumbers.end());
+  }
 
   m_inputBuffer.append(&cCharacter, 1);
+  m_label = m_inputBuffer;
+
+  for (auto it = m_sortedChannelNumbers.begin(); it != m_sortedChannelNumbers.end();)
+  {
+    const std::string channel = *it;
+    ++it;
+
+    if (StringUtils::StartsWith(channel, m_inputBuffer))
+    {
+      if (it != m_sortedChannelNumbers.end() && StringUtils::StartsWith(*it, m_inputBuffer))
+      {
+        // there are alternative numbers; wait for more input
+        break;
+      }
+
+      // no alternatives; complete the number and fire immediately
+      m_inputBuffer = channel;
+      m_label = m_inputBuffer;
+      ExecuteAction();
+      return;
+    }
+  }
 
   if (!m_timer.IsRunning())
     m_timer.Start(m_iDelay);
@@ -122,10 +177,10 @@ bool CPVRChannelNumberInputHandler::HasChannelNumber() const
   return !m_inputBuffer.empty();
 }
 
-std::string CPVRChannelNumberInputHandler::GetChannelNumberAsString() const
+std::string CPVRChannelNumberInputHandler::GetChannelNumberLabel() const
 {
   CSingleLock lock(m_mutex);
-  return m_inputBuffer;
+  return m_label;
 }
 
 } // namespace PVR

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -19,6 +19,7 @@
  *
  */
 
+#include <vector>
 #include <string>
 
 #include "threads/CriticalSection.h"
@@ -49,6 +50,12 @@ public:
   void OnTimeout() override;
 
   /*!
+   * @brief Get the currently available channel numbers.
+   * @param channelNumbers The list to fill with the channel numbers.
+   */
+  virtual void GetChannelNumbers(std::vector<std::string>& channelNumbers) = 0;
+
+  /*!
    * @brief This method gets called after the channel number input timer has expired.
    */
   virtual void OnInputDone() = 0;
@@ -66,10 +73,10 @@ public:
   bool HasChannelNumber() const;
 
   /*!
-   * @brief Get the currently entered channel number as a formatted string. Format is n digits with leading zeros, where n is the number of digits specified when calling the ctor.
+   * @brief Get the currently entered channel number as a formatted string.
    * @return the channel number string.
    */
-  std::string GetChannelNumberAsString() const;
+  std::string GetChannelNumberLabel() const;
 
   /*!
    * @brief If a number was entered, execute the associated action.
@@ -93,9 +100,13 @@ protected:
   CCriticalSection m_mutex;
 
 private:
+  void ExecuteAction();
+
+  std::vector<std::string> m_sortedChannelNumbers;
   const int m_iDelay;
   const int m_iMaxDigits;
   std::string m_inputBuffer;
+  std::string m_label;
   CTimer m_timer;
 };
 

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -1862,6 +1862,18 @@ namespace PVR
     CPVRChannelNumberInputHandler::AppendChannelNumberCharacter(cCharacter);
   }
 
+  void CPVRChannelSwitchingInputHandler::GetChannelNumbers(std::vector<std::string>& channelNumbers)
+  {
+    CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
+    const CPVRChannelPtr playingChannel = pvrMgr.GetPlayingChannel();
+    if (playingChannel)
+    {
+      const CPVRChannelGroupPtr group = pvrMgr.ChannelGroups()->GetGroupAll(playingChannel->IsRadio());
+      if (group)
+        group->GetChannelNumbers(channelNumbers);
+    }
+  }
+
   void CPVRChannelSwitchingInputHandler::OnInputDone()
   {
     CPVRChannelNumber channelNumber = GetChannelNumber();

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -48,6 +48,7 @@ namespace PVR
   {
   public:
     // CPVRChannelNumberInputHandler implementation
+    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
     void AppendChannelNumberCharacter(char cCharacter) override;
     void OnInputDone() override;
 

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -865,7 +865,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem *item, const CGUIInfo &info, std::
       CharInfoTotalDiskSpace(strValue);
       return true;
     case PVR_CHANNEL_NUMBER_INPUT:
-      strValue = CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().GetChannelNumberAsString();
+      strValue = CServiceBroker::GetPVRManager().GUIActions()->GetChannelNumberInputHandler().GetChannelNumberLabel();
       return true;
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -554,6 +554,13 @@ int CPVRChannelGroup::GetMembers(CFileItemList &results, bool bGroupMembers /* =
   return results.Size() - iOrigSize;
 }
 
+void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumbers) const
+{
+  CSingleLock lock(m_critSection);
+  for (const auto& member : m_sortedMembers)
+    channelNumbers.emplace_back(member.channelNumber.FormattedChannelNumber());
+}
+
 CPVRChannelGroupPtr CPVRChannelGroup::GetNextGroup(void) const
 {
   return CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bRadio)->GetNextGroup(*this);

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -335,6 +335,12 @@ namespace PVR
     virtual int GetMembers(CFileItemList &results, bool bGroupMembers = true) const;
 
     /*!
+     * @brief Get the list of channel numbers in a group.
+     * @param channelNumbers The list to store the numbers in.
+     */
+    void GetChannelNumbers(std::vector<std::string>& channelNumbers) const;
+
+    /*!
      * @return The next channel group.
      */
     CPVRChannelGroupPtr GetNextGroup(void) const;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -308,6 +308,12 @@ std::string CGUIDialogPVRChannelsOSD::GetLastSelectedItemPath(int iGroupID) cons
   return "";
 }
 
+void CGUIDialogPVRChannelsOSD::GetChannelNumbers(std::vector<std::string>& channelNumbers)
+{
+  if (m_group)
+    m_group->GetChannelNumbers(channelNumbers);
+}
+
 void CGUIDialogPVRChannelsOSD::OnInputDone()
 {
   const CPVRChannelNumber channelNumber = GetChannelNumber();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -44,6 +44,7 @@ namespace PVR
     void Notify(const Observable &obs, const ObservableMessage msg) override;
 
     // CPVRChannelNumberInputHandler implementation
+    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
     void OnInputDone() override;
 
   protected:

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -338,6 +338,13 @@ void CGUIWindowPVRChannelsBase::OnInputDone()
   }
 }
 
+void CGUIWindowPVRChannelsBase::GetChannelNumbers(std::vector<std::string>& channelNumbers)
+{
+  const CPVRChannelGroupPtr group = GetChannelGroup();
+  if (group)
+    group->GetChannelNumbers(channelNumbers);
+}
+
 CGUIWindowPVRTVChannels::CGUIWindowPVRTVChannels()
   : CGUIWindowPVRChannelsBase(false, WINDOW_TV_CHANNELS, "MyPVRChannels.xml")
 {

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -38,6 +38,7 @@ namespace PVR
     bool OnAction(const CAction &action) override;
 
     // CPVRChannelNumberInputHandler implementation
+    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
     void OnInputDone() override;
 
   private:

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -669,6 +669,13 @@ void CGUIWindowPVRGuideBase::OnInputDone()
   }
 }
 
+void CGUIWindowPVRGuideBase::GetChannelNumbers(std::vector<std::string>& channelNumbers)
+{
+  const CPVRChannelGroupPtr group = GetChannelGroup();
+  if (group)
+    group->GetChannelNumbers(channelNumbers);
+}
+
 CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase *pGuideWindow)
 : CThread("epg-grid-refresh-timeline-items"),
   m_pGuideWindow(pGuideWindow),

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -53,6 +53,7 @@ namespace PVR
     bool RefreshTimelineItems();
 
     // CPVRChannelNumberInputHandler implementation
+    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
     void OnInputDone() override;
 
   protected:


### PR DESCRIPTION
Feature requested in the forum: https://forum.kodi.tv/showthread.php?tid=331022

I just exteded the feature requested there to be even more clever. ;-)

If direct channel number input is used, now on every typed character a check will be done, whether the already typed in part of the channel number is sufficient to identify the target channel number. If so, the number will be completed automatically and the channel switch will be done immediately, without need to press OK/Enter. Otherwise, the input handler will wait for the next character.

Example: possible channels: 1 2 10 11 33

Type "3" => immediately auto switch to "33"
Type "1" => type nothing until handler timeout =>auto switch to "1" after timeout
Type "1" => hit OK/Enter => switch to "1"
Type "1" => type another "1" before handler timeout => immediately switch to "11"
Type "8" => type nothing until handler timeout => nothing happens (invalid channel number)

I runtime-tested the changes with kodi latest master on macOS.

@Jalle19 mind taking a look.