### PR TITLE
[fix] save resume points on exit

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2801,6 +2801,9 @@ bool CApplication::Cleanup()
 
 void CApplication::Stop(int exitCode)
 {
+  CLog::Log(LOGNOTICE, "stop player");
+  m_appPlayer.ClosePlayer();
+
   {
     // close inbound port
     CServiceBroker::UnregisterAppPort();
@@ -2868,9 +2871,6 @@ void CApplication::Stop(int exitCode)
       CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
     CApplicationMessenger::GetInstance().Cleanup();
-
-    CLog::Log(LOGNOTICE, "stop player");
-    m_appPlayer.ClosePlayer();
 
     StopServices();
 


### PR DESCRIPTION
## Description
saving resume points is done with a job, so it has to happen before all jobs are cancelled

## Motivation and Context
fixes https://trac.kodi.tv/ticket/17757

## How Has This Been Tested?
started a video, exited kodi without stopping the file, restarted kodi and checked resume point

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
