### PR TITLE
lirc: work around buggy client lib

### DIFF
--- a/xbmc/platform/linux/input/LIRC.h
+++ b/xbmc/platform/linux/input/LIRC.h
@@ -35,6 +35,7 @@ public:
 protected:
   void Process() override;
   void ProcessCode(char *buf);
+  bool CheckDaemon();
 
   int m_fd = -1;
   uint32_t m_firstClickTime = 0;


### PR DESCRIPTION
lirc client lib does not close socket if connect fails. as a result system runs out of file handles if lirc is not running