### PR TITLE
[fix] throw exception if addDirectoryItem or setResolvedUrl called with nullptr

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmcplugin.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcplugin.cpp
@@ -31,6 +31,8 @@ namespace XBMCAddon
     bool addDirectoryItem(int handle, const String& url, const xbmcgui::ListItem* listItem,
                           bool isFolder, int totalItems)
     {
+      if (listItem == nullptr)
+        throw new XBMCAddon::WrongTypeException("None not allowed as argument for listitem");
       AddonClass::Ref<xbmcgui::ListItem> pListItem(listItem);
       pListItem->item->SetPath(url);
       pListItem->item->m_bIsFolder = isFolder;
@@ -69,6 +71,8 @@ namespace XBMCAddon
 
     void setResolvedUrl(int handle, bool succeeded, const xbmcgui::ListItem* listItem)
     {
+      if (listItem == nullptr)
+        throw new XBMCAddon::WrongTypeException("None not allowed as argument for listitem");
       AddonClass::Ref<xbmcgui::ListItem> pListItem(listItem);
       XFILE::CPluginDirectory::SetResolvedUrl(handle, succeeded, pListItem->item.get());
     }


### PR DESCRIPTION
## Description
`addDirectoryItem` and `setResolvedUrl` are called from python addons so never trust the parameters

## Motivation and Context
fixes https://trac.kodi.tv/ticket/17615

## How Has This Been Tested?
called `xbmcplugin.addDirectoryItem(int(sys.argv[1]), 'TEST', None)` from an python addon
called `xbmcplugin.setResolvedUrl(int(sys.argv[1]), False, None)` from an python addon

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
