### PR TITLE
Added DPMS for GBM/DRMAtomic

### DIFF
--- a/xbmc/powermanagement/DPMSSupport.cpp
+++ b/xbmc/powermanagement/DPMSSupport.cpp
@@ -267,6 +267,31 @@ bool DPMSSupport::PlatformSpecificDisablePowerSaving()
   return (IORegistryEntrySetCFProperty(r, CFSTR("IORequestIdle"), kCFBooleanFalse) == 0);
 }
 
+#elif defined(HAVE_GBM)
+#include "ServiceBroker.h"
+#include "windowing/gbm/WinSystemGbm.h"
+void DPMSSupport::PlatformSpecificInit()
+{
+  m_supportedModes.push_back(OFF);
+}
+bool DPMSSupport::PlatformSpecificEnablePowerSaving(PowerSavingMode mode)
+{
+  CWinSystemGbm *winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+  switch(mode)
+  {
+  case OFF:
+    return winSystem->Hide();
+  default:
+    return false;
+  }
+}
+
+bool DPMSSupport::PlatformSpecificDisablePowerSaving()
+{
+  CWinSystemGbm *winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+  winSystem->Show();
+}
+
 #else
 // Not implemented on this platform
 void DPMSSupport::PlatformSpecificInit()

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -140,7 +140,7 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       return;
     }
 
-    if (!AddCrtcProperty(m_req, m_crtc->crtc->crtc_id, "ACTIVE", 1))
+    if (!AddCrtcProperty(m_req, m_crtc->crtc->crtc_id, "ACTIVE", m_active ? 1 : 0)
     {
       return;
     }
@@ -263,6 +263,14 @@ void CDRMAtomic::DestroyDrm()
 bool CDRMAtomic::SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo)
 {
   m_need_modeset = true;
+
+  return true;
+}
+
+bool CDRMAtomic::SetActive(bool active)
+{
+  m_need_modeset = true;
+  m_active = active;
 
   return true;
 }

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -29,6 +29,7 @@ public:
   ~CDRMAtomic() { DestroyDrm(); };
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override;
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
+  virtual bool SetActive(bool active) override;
   virtual bool InitDrm() override;
   virtual void DestroyDrm() override;
 
@@ -40,4 +41,5 @@ private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
 
   bool m_need_modeset;
+  bool m_active = true;
 };

--- a/xbmc/windowing/gbm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/DRMLegacy.h
@@ -29,9 +29,11 @@ public:
   ~CDRMLegacy() { DestroyDrm(); };
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override;
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) override;
+  virtual bool SetActive(bool active) override;
   virtual bool InitDrm() override;
 
 private:
+  bool AddConnectorProperty(const char *name, int value);
   bool WaitingForFlip();
   bool QueueFlip(struct gbm_bo *bo);
   static void PageFlipHandler(int fd, unsigned int frame, unsigned int sec,

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -68,6 +68,7 @@ public:
   virtual ~CDRMUtils() = default;
   virtual void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) {};
   virtual bool SetVideoMode(RESOLUTION_INFO res, struct gbm_bo *bo) { return false; };
+  virtual bool SetActive(bool active) { return false; };
   virtual bool InitDrm();
   virtual void DestroyDrm();
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -234,12 +234,16 @@ void CWinSystemGbm::WaitVBlank()
 
 bool CWinSystemGbm::Hide()
 {
-  return false;
+  bool ret = m_DRM->SetActive(false);
+  FlipPage(false, false);
+  return ret;
 }
 
 bool CWinSystemGbm::Show(bool raise)
 {
-  return true;
+  bool ret = m_DRM->SetActive(true);
+  FlipPage(false, false);
+  return ret;
 }
 
 void CWinSystemGbm::Register(IDispResource *resource)


### PR DESCRIPTION
## Description
This is an (admittedly pretty crude, this is my first contribution to Kodi) attempt to add support for DPMS (Display Power Management Signaling) to the GBM code, currently only to the atomic modesetting part.

## Motivation and Context
All DPMS-related functionality including sleep timer and ToggleDPMS() for software-based power management doesn't work when using the GBM backend.

## How Has This Been Tested?
Has been tested on a 7th-gen Intel NUC running Linux 4.15 feeding a 4K60Hz HDMI monitor and is working. Has been tested on the Nouveau driver with atomic modesetting disabled and doesn't break anything (but DPMS doesn't work since it is currently not implemented for legacy modesetting).

Should have minimal impact on other code.

## Types of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
