### PR TITLE
[PVR] Parental check fix; Profile switch fix

### DIFF
--- a/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonCallbacksGUI.cpp
@@ -1780,10 +1780,12 @@ int CAddonCallbacksGUI::Dialog_Numeric_ShowAndVerifyPassword(char &strPassword, 
 bool CAddonCallbacksGUI::Dialog_Numeric_ShowAndVerifyInput(char &strPassword, unsigned int iMaxStringSize, const char *strHeading, bool bGetUserInput)
 {
   std::string str = &strPassword;
-  bool bRet = CGUIDialogNumeric::ShowAndVerifyInput(str, strHeading, bGetUserInput);
-  if (bRet)
+  if (CGUIDialogNumeric::ShowAndVerifyInput(str, strHeading, bGetUserInput) == InputVerificationResult::SUCCESS)
+  {
     strncpy(&strPassword, str.c_str(), iMaxStringSize);
-  return bRet;
+    return true;
+  }
+  return false;
 }
 
 bool CAddonCallbacksGUI::Dialog_Numeric_ShowAndGetTime(tm &time, const char *strHeading)

--- a/xbmc/addons/interfaces/GUI/dialogs/Numeric.cpp
+++ b/xbmc/addons/interfaces/GUI/dialogs/Numeric.cpp
@@ -108,10 +108,12 @@ bool Interface_GUIDialogNumeric::show_and_verify_input(void* kodiBase, const cha
   }
 
   std::string str = verify_in;
-  bool bRet = CGUIDialogNumeric::ShowAndVerifyInput(str, heading, verify_input);
-  if (bRet)
+  if (CGUIDialogNumeric::ShowAndVerifyInput(str, heading, verify_input) == InputVerificationResult::SUCCESS)
+  {
     *verify_out = strdup(str.c_str());
-  return bRet;
+    return true;
+  }
+  return false;
 }
 
 bool Interface_GUIDialogNumeric::show_and_get_time(void* kodiBase, tm* time, const char* heading)

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -24,6 +24,13 @@
 #include "PlatformDefs.h"
 #include "guilib/GUIDialog.h"
 
+enum class InputVerificationResult
+{
+  CANCELED,
+  FAILED,
+  SUCCESS
+};
+
 class CGUIDialogNumeric :
       public CGUIDialog
 {
@@ -42,7 +49,7 @@ public:
 
   static bool ShowAndVerifyNewPassword(std::string& strNewPassword);
   static int ShowAndVerifyPassword(std::string& strPassword, const std::string& strHeading, int iRetries);
-  static bool ShowAndVerifyInput(std::string& strPassword, const std::string& strHeading, bool bGetUserInput);
+  static InputVerificationResult ShowAndVerifyInput(std::string& strPassword, const std::string& strHeading, bool bGetUserInput);
 
   void SetHeading(const std::string &strHeading);
   void SetMode(INPUT_MODE mode, const SYSTEMTIME &initial);

--- a/xbmc/pvr/PVRGUIActions.h
+++ b/xbmc/pvr/PVRGUIActions.h
@@ -44,6 +44,13 @@ namespace PVR
     PlaybackTypeRadio
   };
 
+  enum class ParentalCheckResult
+  {
+    CANCELED,
+    FAILED,
+    SUCCESS
+  };
+
   class CPVRChannelSwitchingInputHandler : public CPVRChannelNumberInputHandler
   {
   public:
@@ -326,15 +333,15 @@ namespace PVR
     /*!
      * @brief Check if channel is parental locked. Ask for PIN if necessary.
      * @param channel The channel to do the check for.
-     * @return True if channel is unlocked (by default or PIN unlocked), false otherwise.
+     * @return the result of the check (success, failed, or canceled by user).
      */
-    bool CheckParentalLock(const CPVRChannelPtr &channel) const;
+    ParentalCheckResult CheckParentalLock(const CPVRChannelPtr &channel) const;
 
     /*!
      * @brief Open Numeric dialog to check for parental PIN.
-     * @return True if entered PIN was correct, false otherwise.
+     * @return the result of the check (success, failed, or canceled by user).
      */
-    bool CheckParentalPIN() const;
+    ParentalCheckResult CheckParentalPIN() const;
 
     /*!
      * @brief Check whether the system Kodi is running on can be powered down

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -141,13 +141,7 @@ CPVRManager::CPVRManager(void) :
     m_bFirstStart(true),
     m_bEpgsCreated(false),
     m_managerState(ManagerStateStopped),
-    m_parentalTimer(new CStopWatch),
-    m_settings({
-      CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
-      CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
-      CSettings::SETTING_PVRPARENTAL_ENABLED,
-      CSettings::SETTING_PVRPARENTAL_DURATION
-    })
+    m_parentalTimer(new CStopWatch)
 {
   CAnnouncementManager::GetInstance().AddAnnouncer(this);
 }
@@ -249,6 +243,13 @@ void CPVRManager::ResetProperties(void)
 
 void CPVRManager::Init()
 {
+  m_settings.reset(new CPVRSettings({
+    CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED,
+    CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD,
+    CSettings::SETTING_PVRPARENTAL_ENABLED,
+    CSettings::SETTING_PVRPARENTAL_DURATION
+  }));
+
   // initial check for enabled addons
   // if at least one pvr addon is enabled, PVRManager start up
   CJobManager::GetInstance().AddJob(new CPVRStartupJob(), nullptr);
@@ -472,10 +473,10 @@ void CPVRManager::Process(void)
 bool CPVRManager::SetWakeupCommand(void)
 {
 #if !defined(TARGET_DARWIN_IOS) && !defined(TARGET_WINDOWS_STORE)
-  if (!m_settings.GetBoolValue(CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED))
+  if (!m_settings->GetBoolValue(CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED))
     return false;
 
-  const std::string strWakeupCommand(m_settings.GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD));
+  const std::string strWakeupCommand(m_settings->GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD));
   if (!strWakeupCommand.empty() && m_timers)
   {
     time_t iWakeupTime;
@@ -677,11 +678,11 @@ bool CPVRManager::IsParentalLocked(const CPVRChannelPtr &channel)
   if (// different channel
       (!currentChannel || channel != currentChannel) &&
       // parental control enabled
-      m_settings.GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED) &&
+      m_settings->GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED) &&
       // channel is locked
       channel && channel->IsLocked())
   {
-    float parentalDurationMs = m_settings.GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION) * 1000.0f;
+    float parentalDurationMs = m_settings->GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION) * 1000.0f;
     bReturn = m_parentalTimer &&
         (!m_parentalTimer->IsRunning() ||
           m_parentalTimer->GetElapsedMilliseconds() > parentalDurationMs);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -531,7 +531,7 @@ namespace PVR
     CEventSource<PVREvent> m_events;
 
     CPVRActionListener m_actionListener;
-    CPVRSettings m_settings;
+    std::unique_ptr<CPVRSettings> m_settings;
 
     CPVRChannelPtr m_playingChannel;
     CPVRRecordingPtr m_playingRecording;

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -295,7 +295,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonRadioParentalLocked(CGUIMessage &
   bool selected(msg.GetParam1() == 1);
 
   // ask for PIN first
-  if (!CServiceBroker::GetPVRManager().GUIActions()->CheckParentalPIN())
+  if (CServiceBroker::GetPVRManager().GUIActions()->CheckParentalPIN() != ParentalCheckResult::SUCCESS)
   { // failed - reset to previous
     SET_CONTROL_SELECTED(GetID(), RADIOBUTTON_PARENTAL_LOCK, !selected);
     return false;

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -78,7 +78,7 @@ bool CheckMasterLock(const std::string &condition, const std::string &value, Set
 
 bool CheckPVRParentalPin(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)
 {
-  return CServiceBroker::GetPVRManager().GUIActions()->CheckParentalPIN();
+  return CServiceBroker::GetPVRManager().GUIActions()->CheckParentalPIN() == PVR::ParentalCheckResult::SUCCESS;
 }
 
 bool HasPeripherals(const std::string &condition, const std::string &value, SettingConstPtr setting, void *data)


### PR DESCRIPTION
Two fixes here:

1) Parental check: Do not show "wrong PIN entered" error box / do not write error log entry if user cancels out parental PIN dialog.

2) Profile switch: Reload PVR manager's settings on profile switch. For example "parentalenabled" value can be different  for different profiles.

Changes are runtime-tested on macOS , latest Kodi master.

@Jalle19 mind taking a look. Changes are straight forward, I guess.