### PR TITLE
[PVR] CPVRSettings: All settings instances must be re-inited on profile switch

### DIFF
--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -531,7 +531,7 @@ namespace PVR
     CEventSource<PVREvent> m_events;
 
     CPVRActionListener m_actionListener;
-    std::unique_ptr<CPVRSettings> m_settings;
+    CPVRSettings m_settings;
 
     CPVRChannelPtr m_playingChannel;
     CPVRRecordingPtr m_playingRecording;

--- a/xbmc/pvr/PVRSettings.h
+++ b/xbmc/pvr/PVRSettings.h
@@ -24,15 +24,19 @@
 #include <utility>
 
 #include "settings/lib/ISettingCallback.h"
+#include "settings/lib/ISettingsHandler.h"
 #include "settings/lib/Setting.h"
 
 namespace PVR
 {
-  class CPVRSettings : private ISettingCallback
+  class CPVRSettings : private ISettingsHandler, private ISettingCallback
   {
   public:
     explicit CPVRSettings(const std::set<std::string> & settingNames);
     ~CPVRSettings() override;
+
+    // ISettingsHandler implementation
+    void OnSettingsLoaded() override;
 
     // ISettingCallback implementation
     void OnSettingChanged(std::shared_ptr<const CSetting> setting) override;


### PR DESCRIPTION
`CPVRSettings` now implements interface `ISettingsHandler` and reloads settings in `OnSettingsLoaded`, which is called for example after a profile switch. This ensures all pvr settings are reloaded on profile switch. This did not happen before and led to several problems after switching profiles.

BTW: This also reverts caa64e638d789bdd12671b825d68545a21e0bfbd, because that special handling is no more needed.

Ofc, changes are runtime-tested. :-)

@Jalle19 mind taking a look.