### PR TITLE
typo: missing vec4 in shader

### DIFF
--- a/system/shaders/GL/1.5/gl_stretch.glsl
+++ b/system/shaders/GL/1.5/gl_stretch.glsl
@@ -4,7 +4,7 @@ uniform sampler2D img;
 uniform float m_stretch;
 uniform float m_alpha;
 in vec2 m_cord;
-out fragColor;
+out vec4 fragColor;
 
 vec2 stretch(vec2 pos)
 {


### PR DESCRIPTION
This fixes the following error which is seen when playing SD material on ION2.
```
01:30:13.258 T:140624059390144  NOTICE: CInteropState::Init: vdpau gl interop initialized
01:30:13.282 T:140624059390144   ERROR: GL: Error compiling pixel shader
01:30:13.282 T:140624059390144   ERROR: 0(7) : error C0000: syntax error, unexpected ';', expecting '{' at token ";"
01:30:13.282 T:140624059390144   ERROR: GL: Error compiling fragment shader
01:30:13.282 T:140624059390144   ERROR: GL: Error compiling and linking video filter shader
01:30:13.282 T:140624059390144   ERROR: GL: Falling back to bilinear due to failure to init scaler
01:30:13.300 T:140624059390144  NOTICE: GL: Using VDPAU render method
```

Presumably this has never worked/been tested, so not entirely sure what effect it may now have...