### PR TITLE
[pvr] Guide window: add confirmation dialog when user selects a futur…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1230,9 +1230,10 @@ msgctxt "#263"
 msgid "Allow remote control via HTTP"
 msgstr ""
 
-#. Label for a context menu entry to start/schedule a recording
+#. Label for a context menu entry / button to start/schedule a recording
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+#: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#264"
@@ -9972,7 +9973,9 @@ msgctxt "#19164"
 msgid "Could not start recording. Check the log for more information about this message."
 msgstr ""
 
+#. Label for "switch to channel" button""
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
+#: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 msgctxt "#19165"
 msgid "Switch"
 msgstr ""
@@ -10785,7 +10788,13 @@ msgctxt "#19301"
 msgid "Horizontal channels, no group selector"
 msgstr ""
 
-#empty strings from id 19302 to 19498
+#. text for yes no dialog shown when user selects a future programme in the guide window and default select action is 'smart select'
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+msgctxt "#19302"
+msgid "Do you want to record the selected programme or to switch to the current programme?"
+msgstr ""
+
+#empty strings from id 19303 to 19498
 
 #. label for epg genre value
 #: xbmc/epg/Epg.cpp

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -29,6 +29,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "view/GUIViewState.h"
@@ -39,6 +40,7 @@
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/windows/GUIEPGGridContainer.h"
 
+using namespace KODI::MESSAGING;
 using namespace PVR;
 
 CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string &xmlFile) :
@@ -397,7 +399,17 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                       if (tag->HasTimer())
                         CServiceBroker::GetPVRManager().GUIActions()->EditTimer(pItem);
                       else
-                        CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
+                      {
+                        HELPERS::DialogResponse ret
+                          = HELPERS::ShowYesNoDialogText(CVariant{19096}, // "Smart select"
+                                                          CVariant{19302}, // "Do you want to record the selected programme or to switch to the current programme?"
+                                                          CVariant{264}, // No => "Record"
+                                                          CVariant{19165}); // Yes => "Switch"
+                        if (ret == HELPERS::DialogResponse::NO)
+                          CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
+                        else if (ret == HELPERS::DialogResponse::YES)
+                          CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(pItem, true);
+                      }
                     }
                     else
                     {


### PR DESCRIPTION
…e programme in the guide window and default select action is 'smart select'. Avoids accidentally scheduled timers. Happened to myself several times and also to others.

![screenshot000](https://user-images.githubusercontent.com/3226626/39491337-4fb1f310-4d8c-11e8-9a6b-7ce091652b42.png)

Changes are runtime-tested on macOS, latest kodi master.