### PR TITLE
[guiinfo] Fix Player.IsInternetStream (PLAYER_ISINTERNETSTREAM)...

### DIFF
--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -516,7 +516,7 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case PLAYER_ISINTERNETSTREAM:
       if (item)
       {
-        value = URIUtils::IsInternetStream(item->GetPath());
+        value = URIUtils::IsInternetStream(item->GetDynPath());
         return true;
       }
       break;


### PR DESCRIPTION
...  to use `CFileItem::GetDynPath` instead of `CFileItem::GetPath`.

Should fix trac#17856 (https://trac.kodi.tv/ticket/17856). 

I provided a testbuild and now I'm waiting for bug submitter's feedback.

