### PR TITLE
VAAPI: add vp8 support

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7132,7 +7132,16 @@ msgctxt "#13454"
 msgid "Enable this option to use hardware acceleration for the VP8 codec. If disabled the CPU will be used instead."
 msgstr ""
 
-#empty strings from id 13455 to 13456
+#: system/settings/settings.xml
+msgctxt "#13455"
+msgid "Use VP9 VAAPI"
+msgstr ""
+
+#. Description of setting with label #13453 "Use VP9 VAAPI"
+#: system/settings/settings.xml
+msgctxt "#13456"
+msgid "Enable this option to use hardware acceleration for the VP9 codec. If disabled the CPU will be used instead."
+msgstr ""
 
 #. Option for video related setting #13454: sw filter
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7121,7 +7121,18 @@ msgctxt "#13452"
 msgid "Enable this option to use hardware acceleration for VC-1 based codecs. If disabled the CPU will be used instead. Especially VC-1 interlaced fails hard on Intel hardware."
 msgstr ""
 
-#empty strings from id 13453 to 13456
+#: system/settings/settings.xml
+msgctxt "#13453"
+msgid "Use VP8 VAAPI"
+msgstr ""
+
+#. Description of setting with label #13453 "Use VP8 VAAPI"
+#: system/settings/settings.xml
+msgctxt "#13454"
+msgid "Enable this option to use hardware acceleration for the VP8 codec. If disabled the CPU will be used instead."
+msgstr ""
+
+#empty strings from id 13455 to 13456
 
 #. Option for video related setting #13454: sw filter
 #: system/settings/settings.xml

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -112,6 +112,18 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.usevaapivp9" type="boolean" parent="videoplayer.usevaapi" label="13455" help="13456">
+          <requirement>HAVE_LIBVA</requirement>
+          <visible>false</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.usevaapi" operator="is">true</condition>
+            </dependency>
+          </dependencies>
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.prefervaapirender" type="boolean" parent="videoplayer.usevaapi" label="13457" help="36433">
           <requirement>HAVE_LIBVA</requirement>
           <visible>false</visible>

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -100,6 +100,18 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.usevaapivp8" type="boolean" parent="videoplayer.usevaapi" label="13453" help="13454">
+          <requirement>HAVE_LIBVA</requirement>
+          <visible>false</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.usevaapi" operator="is">true</condition>
+            </dependency>
+          </dependencies>
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.prefervaapirender" type="boolean" parent="videoplayer.usevaapi" label="13457" help="36433">
           <requirement>HAVE_LIBVA</requirement>
           <visible>false</visible>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -506,6 +506,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
     { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
     { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2 },
     { AV_CODEC_ID_VP8, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP8 },
+    { AV_CODEC_ID_VP9, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP9 },
   };
 
   auto entry = settings_map.find(avctx->codec_id);
@@ -1206,6 +1207,7 @@ void CDecoder::Register(IVaapiWinSystem *winSystem, bool deepColor)
   CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1)->SetVisible(true);
   CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2)->SetVisible(true);
   CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP8)->SetVisible(true);
+  CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP9)->SetVisible(true);
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -505,6 +505,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
     { AV_CODEC_ID_WMV3, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
     { AV_CODEC_ID_VC1, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 },
     { AV_CODEC_ID_MPEG2VIDEO, CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2 },
+    { AV_CODEC_ID_VP8, CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP8 },
   };
 
   auto entry = settings_map.find(avctx->codec_id);
@@ -591,6 +592,13 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
         profile = VAProfileHEVCMain;
       else
         profile = VAProfileNone;
+      if (!m_vaapiConfig.context->SupportsProfile(profile))
+        return false;
+      break;
+    }
+    case AV_CODEC_ID_VP8:
+    {
+      profile = VAProfileVP8Version0_3;
       if (!m_vaapiConfig.context->SupportsProfile(profile))
         return false;
       break;
@@ -1197,6 +1205,7 @@ void CDecoder::Register(IVaapiWinSystem *winSystem, bool deepColor)
   CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4)->SetVisible(true);
   CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1)->SetVisible(true);
   CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2)->SetVisible(true);
+  CServiceBroker::GetSettings().GetSetting(CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP8)->SetVisible(true);
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -167,6 +167,7 @@ const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPI = "videoplayer.usevaap
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2 = "videoplayer.usevaapimpeg2";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4 = "videoplayer.usevaapimpeg4";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 = "videoplayer.usevaapivc1";
+const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP8 = "videoplayer.usevaapivp8";
 const std::string CSettings::SETTING_VIDEOPLAYER_PREFERVAAPIRENDER = "videoplayer.prefervaapirender";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEDXVA2 = "videoplayer.usedxva2";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEOMXPLAYER = "videoplayer.useomxplayer";

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -168,6 +168,7 @@ const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2 = "videoplayer.us
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG4 = "videoplayer.usevaapimpeg4";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIVC1 = "videoplayer.usevaapivc1";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP8 = "videoplayer.usevaapivp8";
+const std::string CSettings::SETTING_VIDEOPLAYER_USEVAAPIVP9 = "videoplayer.usevaapivp9";
 const std::string CSettings::SETTING_VIDEOPLAYER_PREFERVAAPIRENDER = "videoplayer.prefervaapirender";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEDXVA2 = "videoplayer.usedxva2";
 const std::string CSettings::SETTING_VIDEOPLAYER_USEOMXPLAYER = "videoplayer.useomxplayer";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -121,6 +121,7 @@ public:
   static const std::string SETTING_VIDEOPLAYER_USEVAAPIMPEG2;
   static const std::string SETTING_VIDEOPLAYER_USEVAAPIMPEG4;
   static const std::string SETTING_VIDEOPLAYER_USEVAAPIVC1;
+  static const std::string SETTING_VIDEOPLAYER_USEVAAPIVP8;
   static const std::string SETTING_VIDEOPLAYER_PREFERVAAPIRENDER;
   static const std::string SETTING_VIDEOPLAYER_USEDXVA2;
   static const std::string SETTING_VIDEOPLAYER_USEOMXPLAYER;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -122,6 +122,7 @@ public:
   static const std::string SETTING_VIDEOPLAYER_USEVAAPIMPEG4;
   static const std::string SETTING_VIDEOPLAYER_USEVAAPIVC1;
   static const std::string SETTING_VIDEOPLAYER_USEVAAPIVP8;
+  static const std::string SETTING_VIDEOPLAYER_USEVAAPIVP9;
   static const std::string SETTING_VIDEOPLAYER_PREFERVAAPIRENDER;
   static const std::string SETTING_VIDEOPLAYER_USEDXVA2;
   static const std::string SETTING_VIDEOPLAYER_USEOMXPLAYER;


### PR DESCRIPTION
used on Gemini lake hardware

Kodi log: http://ix.io/19fI
```
12:33:32.155 T:139942141953792   DEBUG: CDVDVideoCodecFFmpeg - Updated codec: ff-vp8-vaapi
```
vainfo relevance:
```
      VAProfileVP8Version0_3          :	VAEntrypointVLD
```