### PR TITLE
Provide firewalld service definitions

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -127,6 +127,13 @@ install(FILES ${CMAKE_SOURCE_DIR}/tools/Linux/packaging/media/icon256x256.png
         DESTINATION ${datarootdir}/icons/hicolor/256x256/apps
         COMPONENT kodi)
 
+# Install firewalld service definitions
+install(FILES ${CMAKE_SOURCE_DIR}/tools/Linux/firewalld-services/kodi-eventserver.xml
+              ${CMAKE_SOURCE_DIR}/tools/Linux/firewalld-services/kodi-http.xml
+              ${CMAKE_SOURCE_DIR}/tools/Linux/firewalld-services/kodi-jsonrpc.xml
+        DESTINATION ${prefix}/lib/firewalld/services
+        COMPONENT kodi)
+
 # Install docs
 install(FILES ${CMAKE_SOURCE_DIR}/copying.txt
               ${CMAKE_SOURCE_DIR}/LICENSE.GPL

--- a/tools/Linux/firewalld-services/kodi-eventserver.xml
+++ b/tools/Linux/firewalld-services/kodi-eventserver.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kodi EventServer</short>
+  <description>Kodi is a free cross-platform media-player jukebox and entertainment hub.  Enable this option to remotely control Kodi via its EventServer API.</description>
+  <port protocol="udp" port="9777"/>
+</service>

--- a/tools/Linux/firewalld-services/kodi-http.xml
+++ b/tools/Linux/firewalld-services/kodi-http.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kodi web interface</short>
+  <description>Kodi is a free cross-platform media-player jukebox and entertainment hub.  Enable this option to remotely control Kodi via its web interface.</description>
+  <port protocol="tcp" port="8080"/>
+</service>

--- a/tools/Linux/firewalld-services/kodi-jsonrpc.xml
+++ b/tools/Linux/firewalld-services/kodi-jsonrpc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kodi JSON-RPC</short>
+  <description>Kodi is a free cross-platform media-player jukebox and entertainment hub.  Enable this option to remotely control Kodi via its JSON-RPC API.</description>
+  <port protocol="tcp" port="9090"/>
+</service>


### PR DESCRIPTION
## Description
On some Linux distributions, including [`firewalld` service definition files](https://www.firewalld.org/documentation/man-pages/firewalld.service.html) will cause the associated network ports to appear in the distribution’s `firewall-config` GUI for opening or closing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
I'm new to using Kodi, and realised that I would need to open firewall ports on my Fedora workstation in order to control it remotely.  The [HOW-TO:Install Kodi on Fedora 26 using RPMFusion packages](https://kodi.wiki/view/HOW-TO:Install_Kodi_on_Fedora_26_using_RPMFusion_packages) wiki page suggests that I might like to disable the firewall entirely, which is probably good advice if you have a machine dedicated to running Kodi, but is less ideal if the computer also performs other tasks.  Instead, we can provide hints to `firewalld` about the ports that Kodi uses, to make it easier for the user to open the necessary ports.

I'm sure other ports will be required to enable other Kodi features, but hopefully defining these few ports is a step in the right direction.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
I applied this change as a patch to [RPMFusion's Kodi package](https://pkgs.rpmfusion.org/cgit/free/kodi.git/) (master, `7877ce2`, packaging Kodi 18.0a1-Leia) and used `rfpkg mockbuild` to successfully build Fedora 29 packages that included the new files.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change ~~requires~~ benefits from a change to the documentation, ~~either Doxygen or~~ wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
