### PR TITLE
[fix] handle multiselect addon setting

### DIFF
--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -617,14 +617,31 @@ bool CGUIControlButtonSetting::OnClick()
     if (controlFormat == "addon")
     {
       // prompt for the addon
-      std::shared_ptr<CSettingAddon> setting = std::static_pointer_cast<CSettingAddon>(m_pSetting);
-      std::string addonID = setting->GetValue();
-      if (CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonID, setting->AllowEmpty(),
-                                                buttonControl->ShowAddonDetails(), buttonControl->ShowInstalledAddons(),
-                                                buttonControl->ShowInstallableAddons(), buttonControl->ShowMoreAddons()) != 1)
+      std::shared_ptr<CSettingAddon> setting;
+      std::vector<std::string> addonIDs;
+      if (m_pSetting->GetType() == SettingType::List)
+      {
+        std::shared_ptr<CSettingList> settingList = std::static_pointer_cast<CSettingList>(m_pSetting);
+        setting = std::static_pointer_cast<CSettingAddon>(settingList->GetDefinition());
+        for (const SettingPtr addon : settingList->GetValue())
+          addonIDs.push_back(std::static_pointer_cast<CSettingAddon>(addon)->GetValue());
+      }
+      else
+      {
+        setting = std::static_pointer_cast<CSettingAddon>(m_pSetting);
+        addonIDs.push_back(setting->GetValue());
+      }
+
+      if (CGUIWindowAddonBrowser::SelectAddonID(setting->GetAddonType(), addonIDs, setting->AllowEmpty(),
+                                                buttonControl->ShowAddonDetails(), m_pSetting->GetType() == SettingType::List,
+                                                buttonControl->ShowInstalledAddons(), buttonControl->ShowInstallableAddons(),
+                                                buttonControl->ShowMoreAddons()) != 1)
         return false;
 
-      SetValid(setting->SetValue(addonID));
+      if (m_pSetting->GetType() == SettingType::List)
+        std::static_pointer_cast<CSettingList>(m_pSetting)->FromString(addonIDs);
+      else
+        SetValid(setting->SetValue(addonIDs[0]));
     }
     else if (controlFormat == "path" || controlFormat == "file" || controlFormat == "image")
       SetValid(GetPath(std::static_pointer_cast<CSettingPath>(m_pSetting), m_localizer));


### PR DESCRIPTION
## Description
Handle setting which have addons as type and multiselect enabled. Currently that crashes Kodi as `CSetting` is casted to a wrong type in that case.

## Motivation and Context
Fixes https://trac.kodi.tv/ticket/17709
@ronie FYI

## How Has This Been Tested?
Added the following to the settings of an addon and changed the settings from kodi.
```
<setting id="test" type="addon" label="1" default="" addontype="xbmc.gui.skin" multiselect="true" />
<setting id="test2" type="addon" label="2" default="" addontype="xbmc.gui.skin" />
```

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
