### PR TITLE
[Music]Automatically fetch any art type for artists and albums

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7187,6 +7187,7 @@ msgctxt "#13513"
 msgid "Remote art"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#13514"
 msgid "Local art"
@@ -12280,6 +12281,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 #: xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+#: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
 msgctxt "#20223"
 msgid "Artist information folder"
 msgstr ""

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -48,6 +48,7 @@
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
 #include "TextureCache.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/ProgressJob.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -476,6 +477,7 @@ void CGUIDialogMusicInfo::SetAlbum(const CAlbum& album, const std::string &path)
   m_item->SetPath(album.strPath); 
   
   m_startUserrating = m_album.iUserrating;
+  m_fallbackartpath.clear();
   m_bArtistInfo = false;
   m_hasUpdatedUserrating = false;
   m_hasRefreshed = false;
@@ -688,17 +690,37 @@ std::string CGUIDialogMusicInfo::GetContent()
 void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item)
 {
   std::string itemDir;
+  std::string artistFolder;
 
-  if (item.HasMusicInfoTag() && item.GetMusicInfoTag()->GetType() == MediaTypeSong)
-    itemDir = URIUtils::GetParentPath(item.GetMusicInfoTag()->GetURL());
-  else
-    itemDir = item.GetPath();
+  itemDir = item.GetPath();
+  if (item.HasMusicInfoTag())
+  {
+    if (item.GetMusicInfoTag()->GetType() == MediaTypeSong)
+      itemDir = URIUtils::GetParentPath(item.GetMusicInfoTag()->GetURL());
 
+    // For artist add Artist Info Folder path to browser sources 
+    if (item.GetMusicInfoTag()->GetType() == MediaTypeArtist)
+    {
+      artistFolder = CServiceBroker::GetSettings().GetString(CSettings::SETTING_MUSICLIBRARY_ARTISTSFOLDER);
+      if (!artistFolder.empty() && artistFolder.compare(itemDir) == 0)
+        itemDir.clear();  // skip *item when artist not have a unique path
+    }
+  }
+  // Add "*Item folder" path to file browser sources
   if (!itemDir.empty() && CDirectory::Exists(itemDir))
   {
     CMediaSource itemSource;
     itemSource.strName = g_localizeStrings.Get(36041);
     itemSource.strPath = itemDir;
+    sources.push_back(itemSource);
+  }
+  
+  // For artist add Artist Info Folder path to browser sources
+  if (!artistFolder.empty() && CDirectory::Exists(artistFolder))
+  {
+    CMediaSource itemSource;
+    itemSource.strName = "* " + g_localizeStrings.Get(20223);
+    itemSource.strPath = artistFolder;
     sources.push_back(itemSource);
   }
 }
@@ -808,47 +830,61 @@ void CGUIDialogMusicInfo::OnGetArt()
   }
 
   // Local art
-  // Album and artist thumbs can be found in local files
-  //! @todo: other art types could also be found locally especially artist fanart e.g "fanart.jpg"
-  std::string localThumb;
-  bool existsThumb = false;
-  if (type == "thumb")
-  { 
-    if (m_bArtistInfo)
+  std::string localArt;
+  std::vector<std::string> paths;
+  if (m_bArtistInfo)
+  {
+    // Individual artist subfolder within the Artist Information Folder
+    paths.emplace_back(m_artist.strPath);
+    // Fallback local to music files (when there is a unique folder)
+    paths.emplace_back(m_fallbackartpath);
+  }
+  else
+    // Album folder, when a unique one exists, no fallback
+    paths.emplace_back(m_album.strPath);
+  for (const auto& path : paths)
+  {
+    if (!localArt.empty() && CFile::Exists(localArt))
+      break;
+    if (!path.empty())
     {
-      // First look for thumb in the artists folder, the primary location     
-      if (!m_artist.strPath.empty())
-      {
-        localThumb = URIUtils::AddFileToFolder(m_artist.strPath, "folder.jpg");
-        existsThumb = CFile::Exists(localThumb);
-      }
-      // If not there fall back local to music files when there is a unique artist folder
-      if (!existsThumb && !m_fallbackartpath.empty())
-      {
-        localThumb = URIUtils::AddFileToFolder(m_fallbackartpath, "folder.jpg");
-        existsThumb = CFile::Exists(localThumb);
+      CFileItem item(path, true);
+      if (type == "thumb")
+        // Local music thumbnail images named by <musicthumbs>
+        localArt = item.GetUserMusicThumb(true);
+      else if (type == "fanart")
+        // Local fanart images named by <fanart>
+        localArt = item.GetLocalFanart();
+      else
+      { // Check case and ext insenitively for local images with type as name
+        // e.g. <arttype>.jpg 
+        CFileItemList items;
+        CDirectory::GetDirectory(path, items,
+            CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+            DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+        
+        for (int j = 0; j < items.Size(); j++)
+        {
+          std::string strCandidate = URIUtils::GetFileName(items[j]->GetPath());
+          URIUtils::RemoveExtension(strCandidate);
+          if (StringUtils::EqualsNoCase(strCandidate, type))
+          {
+            localArt = items[j]->GetPath();
+            break;
+          }
+        }
       }
     }
-    else
-    {
-      localThumb = m_item->GetUserMusicThumb(true);
-      if (m_item->IsMusicDb())
-      {
-        CFileItem item(m_item->GetMusicInfoTag()->GetURL(), false);
-        localThumb = item.GetUserMusicThumb(true);
-      }
-    }
-
-    if (CFile::Exists(localThumb))
-    {
-      CFileItemPtr item(new CFileItem("thumb://Local", false));
-      item->SetArt("thumb", localThumb);
-      item->SetLabel(g_localizeStrings.Get(20017));
-      items.Add(item);
-    }
+  } 
+  if (!localArt.empty() && CFile::Exists(localArt))
+  {
+    CFileItemPtr item(new CFileItem("Local Art: " + localArt, false));
+    item->SetArt("thumb", localArt);
+    item->SetLabel(g_localizeStrings.Get(13514)); // "Local art"
+    items.Add(item);
   }
 
-
+  // No art
   if (bHasArt && !bFallback)
   { // Actually has this type of art (not a fallback) so 
     // allow the user to delete it by selecting "no art".
@@ -912,8 +948,8 @@ void CGUIDialogMusicInfo::OnGetArt()
     }
     else if (result == "thumb://Thumb")
       newArt = m_item->GetArt("thumb");
-    else if (result == "thumb://Local")
-      newArt = localThumb;
+    else if (StringUtils::StartsWith(result, "Local Art: "))
+      newArt = localArt;
     else if (CFile::Exists(result))
       newArt = result;
     else // none

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1129,70 +1129,44 @@ void MUSIC_INFO::CMusicInfoScanner::RetrieveLocalArt()
       m_handle->SetProgress(count, m_albumsAdded.size());
     }
 
-    /*
-    Adjust album art for disc sets
-
-    When songs from an album are are all under a unique common folder (no songs
-    from other albums) but spread over multiple subfolders, then adjust the
-    album art by looking for local art in the (common) album folder.
-    It has already been during set by FindArtForAlbums() to either the art of
-    the last subfolder processed (if there is any), or to the first song in
-    that subfolder with embedded art (if there is any).
-    Not when songs from different albums are in one folder, no paths are returned.
-    */
-
+    // Fetch album path and any subfolders (disc sets).
+    // No paths found when songs from different albums are in one folder.
     std::vector<std::pair<std::string, int>> paths;
     m_musicDatabase.GetAlbumPaths(albumId, paths);
-    // Get album path, the common path when more than one 
     for (const auto& pathpair : paths)
     {
       if (album.strPath.empty())
         album.strPath = pathpair.first.c_str();
       else
+        // When more than one album path is the common path 
         URIUtils::GetCommonPath(album.strPath, pathpair.first.c_str());
     }
+    /*
+    Automatically fetch local art from album folder
+
+    Providing all songs from an album are are under a unique common album
+    folder (no songs from other albums) then thumb has been set to local art,
+    or failing that to embedded art, during scanning by FindArtForAlbums(). 
+    But when songs are also spread over multiple subfolders within it e.g. disc
+    sets, it will have been set to either the art of the last subfolder that was
+    processed (if there is any), or from the first song in that subfolder with
+    embedded art (if there is any). To correct this and find any thumb in the
+    (common) album folder add "thumb" to those missing.
+    */
+    std::map<std::string, std::string> art;
+    m_musicDatabase.GetArtForItem(albumId, MediaTypeAlbum, art);
+    std::vector<std::string> missing = GetMissingArtTypes(MediaTypeAlbum, art);
+    if (paths.size() > 1 && album.art.find("thumb") == album.art.end())
+      missing.emplace_back("thumb"); //Adjust album thumb for disc sets
+    if (!missing.empty())
+    {
+      SetAlbumArtwork(album, missing, album.strPath);
+    }
+
+    //Automatically fetch local art from disc set subfolders
     if (paths.size() > 1)
-    {      
-      // Get art from any local files in album folder.
-      // This has not been done during scan
-      CFileItem albumItem(album.strPath, true);
-      std::string albumArt = albumItem.GetUserMusicThumb(true);
-
-      /*
-      When we have a true disc set - subfolders AND songs tagged with same
-      unique discnumber in in each subfolder - save the disc cover art, and if
-      we don't have album folder art then use the first disc in set rather
-      than the last processed.
-      */
-      CMusicThumbLoader loader;
-      for (const auto& pathpair : paths)
-      {
-        int discnum = m_musicDatabase.GetDiscnumberForPathID(pathpair.second);
-        if (discnum > 0)
-        {
-          // Get art for path from textures db (could be embedded or local file)
-          CFileItem discItem(pathpair.first.c_str(), true);
-          std::string artURL = loader.GetCachedImage(discItem, "thumb");
-          if (!artURL.empty())
-          {
-            // Save the disc set cover art as album "thumb<disc number>"
-            std::string strArtType = StringUtils::Format("thumb%i", discnum);
-            m_musicDatabase.SetArtForItem(album.idAlbum, MediaTypeAlbum, strArtType, artURL);
-
-            if (albumArt.empty() && discnum == 1)
-            { // Use art for first disc in set as album art
-              albumArt = artURL;
-            }
-          }
-        }
-      }
-      // Save Album thumb
-      if (!albumArt.empty())
-      {
-        m_musicDatabase.SetArtForItem(album.idAlbum, MediaTypeAlbum, "thumb", albumArt);
-        // Assign art as folder thumb (in textures db) as well
-        loader.SetCachedImage(albumItem, "thumb", albumArt);
-      }
+    {          
+      SetDiscSetArtwork(album, paths);    
     }
 
     /*
@@ -1280,40 +1254,73 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
     return INFO_ERROR;
 
   CMusicAlbumInfo albumInfo;
+  INFO_RET albumDownloadStatus(INFO_CANCELLED);
+  std::string origArtist(album.GetAlbumArtistString());
+  std::string origAlbum(album.strAlbum);
 
-loop:
-  CLog::Log(LOGDEBUG, "%s downloading info for: %s", __FUNCTION__, album.strAlbum.c_str());
-  INFO_RET albumDownloadStatus = DownloadAlbumInfo(album, scraper, albumInfo, !bAllowSelection, pDialog);
-  if (albumDownloadStatus == INFO_NOT_FOUND)
+  bool stop(false);
+  while (!stop)
   {
-    if (pDialog && bAllowSelection)
+    stop = true;
+    CLog::Log(LOGDEBUG, "%s downloading info for: %s", __FUNCTION__, album.strAlbum.c_str());
+    albumDownloadStatus = DownloadAlbumInfo(album, scraper, albumInfo, !bAllowSelection, pDialog);
+    if (albumDownloadStatus == INFO_NOT_FOUND)
     {
-      if (!CGUIKeyboardFactory::ShowAndGetInput(album.strAlbum, CVariant{g_localizeStrings.Get(16011)}, false))
-        return INFO_CANCELLED;
-
-      std::string strTempArtist(album.GetAlbumArtistString());
-      if (!CGUIKeyboardFactory::ShowAndGetInput(strTempArtist, CVariant{g_localizeStrings.Get(16025)}, false))
-        return INFO_CANCELLED;
-
-      album.strArtistDesc = strTempArtist;
-      goto loop;
-    }
-    else
-    {
-      CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-        MediaTypeAlbum, album.strPath, 24146,
-        StringUtils::Format(g_localizeStrings.Get(24147).c_str(), MediaTypeAlbum, album.strAlbum.c_str()),
-        CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb()), CURL::GetRedacted(album.strPath), EventLevel::Warning)));
-    }
+      if (pDialog && bAllowSelection)
+      {
+        std::string strTempAlbum(album.strAlbum);
+        if (!CGUIKeyboardFactory::ShowAndGetInput(strTempAlbum, CVariant{ g_localizeStrings.Get(16011) }, false))
+          albumDownloadStatus = INFO_CANCELLED;
+        else
+        {
+          std::string strTempArtist(album.GetAlbumArtistString());
+          if (!CGUIKeyboardFactory::ShowAndGetInput(strTempArtist, CVariant{ g_localizeStrings.Get(16025) }, false))
+            albumDownloadStatus = INFO_CANCELLED;
+          else
+          {
+            album.strAlbum = strTempAlbum;
+            album.strArtistDesc = strTempArtist;
+            stop = false;
+          }
+        }
+      }
+      else
+      {
+        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
+          MediaTypeAlbum, album.strPath, 24146,
+          StringUtils::Format(g_localizeStrings.Get(24147).c_str(), MediaTypeAlbum, album.strAlbum.c_str()),
+          CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb()), CURL::GetRedacted(album.strPath), EventLevel::Warning)));
+      }
+    }    
   }
-  else if (albumDownloadStatus == INFO_ADDED)
+  
+  // Restore original album and artist name, possibly changed by manual entry
+  // to get info but should not change outside merge
+  album.strAlbum = origAlbum;
+  album.strArtistDesc = origArtist;
+
+  if (albumDownloadStatus == INFO_ADDED)
   {
     bool overridetags = CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_OVERRIDETAGS);
     album.MergeScrapedAlbum(albumInfo.GetAlbum(), overridetags);
     m_musicDatabase.UpdateAlbum(album);
-    GetAlbumArtwork(album.idAlbum, album);
     albumInfo.SetLoaded(true);
   }
+
+  // Check album art.
+  // Fill any gaps with local art files, or use first available from scraped
+  // list (when it has been successfuly scraped). Do this even when no info
+  // added (cancelled, not found or error), there may be new local art files.
+  m_musicDatabase.GetArtForItem(album.idAlbum, MediaTypeAlbum , album.art);
+  std::vector<std::string> missing = GetMissingArtTypes(MediaTypeAlbum, album.art);
+  if (!missing.empty())
+  {
+    if (album.strPath.empty())
+      m_musicDatabase.GetAlbumPath(album.idAlbum, album.strPath);
+    if (SetAlbumArtwork(album, missing, album.strPath))
+      albumDownloadStatus = INFO_ADDED; // Local art added
+  }
+
   return albumDownloadStatus;
 }
 
@@ -1326,27 +1333,40 @@ CMusicInfoScanner::UpdateDatabaseArtistInfo(CArtist& artist,
   if (!scraper)
     return INFO_ERROR;
 
-  CMusicArtistInfo artistInfo;    
-loop:
-  CLog::Log(LOGDEBUG, "%s downloading info for: %s", __FUNCTION__, artist.strArtist.c_str());
-  INFO_RET artistDownloadStatus = DownloadArtistInfo(artist, scraper, artistInfo, !bAllowSelection, pDialog);
-  if (artistDownloadStatus == INFO_NOT_FOUND)
+  CMusicArtistInfo artistInfo;
+  INFO_RET artistDownloadStatus(INFO_CANCELLED);
+  std::string origArtist(artist.strArtist);
+
+  bool stop(false);
+  while (!stop)
   {
-    if (pDialog && bAllowSelection)
+    stop = true;
+    CLog::Log(LOGDEBUG, "%s downloading info for: %s", __FUNCTION__, artist.strArtist.c_str());
+    artistDownloadStatus = DownloadArtistInfo(artist, scraper, artistInfo, !bAllowSelection, pDialog);
+    if (artistDownloadStatus == INFO_NOT_FOUND)
     {
-      if (!CGUIKeyboardFactory::ShowAndGetInput(artist.strArtist, CVariant{g_localizeStrings.Get(16025)}, false))
-        return INFO_CANCELLED;
-      goto loop;
-    }
-    else
-    {
-      CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
-        MediaTypeArtist, artist.strPath, 24146,
-        StringUtils::Format(g_localizeStrings.Get(24147).c_str(), MediaTypeArtist, artist.strArtist.c_str()),
-        CScraperUrl::GetThumbURL(artist.thumbURL.GetFirstThumb()), CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
+      if (pDialog && bAllowSelection)
+      {
+        if (!CGUIKeyboardFactory::ShowAndGetInput(artist.strArtist, CVariant{ g_localizeStrings.Get(16025) }, false))
+          artistDownloadStatus = INFO_CANCELLED;
+        else
+          stop = false;
+      }
+      else
+      {
+        CServiceBroker::GetEventLog().Add(EventPtr(new CMediaLibraryEvent(
+          MediaTypeArtist, artist.strPath, 24146,
+          StringUtils::Format(g_localizeStrings.Get(24147).c_str(), MediaTypeArtist, artist.strArtist.c_str()),
+          CScraperUrl::GetThumbURL(artist.thumbURL.GetFirstThumb()), CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
+      }
     }
   }
-  else if (artistDownloadStatus == INFO_ADDED)
+  
+  // Restore original artist name, possibly changed by manual entry to get info
+  // but should not change outside merge
+  artist.strArtist = origArtist;
+    
+  if (artistDownloadStatus == INFO_ADDED)
   {
     artist.MergeScrapedArtist(artistInfo.GetArtist(), CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_OVERRIDETAGS));
     m_musicDatabase.UpdateArtist(artist);
@@ -1356,7 +1376,7 @@ loop:
   // Check artist art.
   // Fill any gaps with local art files, or use first available from scraped
   // list (when it has been successfuly scraped). Do this even when no info
-  // added, there may be new local art files.
+  // added (cancelled, not found or error), there may be new local art files.
   m_musicDatabase.GetArtForItem(artist.idArtist, MediaTypeArtist, artist.art);
   std::vector<std::string> missing = GetMissingArtTypes(MediaTypeArtist, artist.art);
   if (!missing.empty())
@@ -1375,10 +1395,11 @@ loop:
       // artist, this will be blank
       m_musicDatabase.GetOldArtistPath(artist.idArtist, artfolder);
     }
-    SetArtistArtwork(artist, missing, artfolder);
+    if (SetArtistArtwork(artist, missing, artfolder))
+      artistDownloadStatus = INFO_ADDED; // Local art added
   }
 
-  return artistDownloadStatus;
+  return artistDownloadStatus; // Added, cancelled or not found
 }
 
 #define THRESHOLD .95f
@@ -1888,19 +1909,34 @@ void CMusicInfoScanner::ScannerWait(unsigned int milliseconds)
     XbmcThreads::ThreadSleep(milliseconds);
 }
 
+std::vector<std::string> CMusicInfoScanner::GetArtTypesToScan(const MediaType& mediaType)
+{
+  std::vector<std::string> arttypes;
+  // Get default types of art that are to be automatically fetched during scanning
+  if (mediaType == MediaTypeArtist)
+  {
+    arttypes = { "thumb", "fanart" };
+    arttypes.insert(arttypes.end(), g_advancedSettings.m_musicArtistExtraArt.begin(), 
+      g_advancedSettings.m_musicArtistExtraArt.end());
+  }
+  else if (mediaType == MediaTypeAlbum)
+  {
+    arttypes = { "thumb" };
+    arttypes.insert(arttypes.end(), g_advancedSettings.m_musicAlbumExtraArt.begin(), 
+      g_advancedSettings.m_musicAlbumExtraArt.end());
+  }
+
+  return arttypes;
+}
+
 std::vector<std::string> CMusicInfoScanner::GetMissingArtTypes(const MediaType& mediaType, const std::map<std::string, std::string>& art)
 {
   std::vector<std::string> missing;
   std::vector<std::string> arttypes;
-  // Set default types of art that are automatically fetched during scanning
-  if (mediaType == MediaTypeArtist)
-  {
-    arttypes = { "thumb", "fanart" };
-    arttypes.insert(arttypes.end(), g_advancedSettings.m_musicArtistExtraArt.begin(), g_advancedSettings.m_musicArtistExtraArt.end());
-  }
-  else if (mediaType == MediaTypeAlbum)
-    arttypes = { "thumb" };
-  
+  // Get default types of art that are automatically fetched during scanning
+  arttypes = GetArtTypesToScan(mediaType);
+
+  // Find the types which are missing from the given art 
   if (art.empty())
     missing = arttypes;
   else
@@ -1915,14 +1951,14 @@ std::vector<std::string> CMusicInfoScanner::GetMissingArtTypes(const MediaType& 
   return missing;
 }
 
-void CMusicInfoScanner::SetArtistArtwork(CArtist& artist, const std::vector<std::string>& missing, const std::string& artfolder)
-{   
+bool CMusicInfoScanner::SetArtistArtwork(CArtist& artist, const std::vector<std::string>& missing, const std::string& artfolder)
+{
   if (missing.empty())
-    return; // All types of artist art found
+    return false; // All types of artist art found
    
   // Any extra type of art missing, fetch the image files from the art folder.
   // Thumbs and fanart have own advanced settings for file names, what other
-  // art types to fetch automatically is optional to, but local file name must
+  // art types to fetch automatically is optional too, but local file name must
   // match the type
   CFileItemList items;
   bool extratype = false;
@@ -1938,6 +1974,7 @@ void CMusicInfoScanner::SetArtistArtwork(CArtist& artist, const std::vector<std:
         DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
 
   // Get missing art
+  int addedCount = 0;
   for (const auto& type : missing)
   {
     std::string strArt;
@@ -1985,11 +2022,199 @@ void CMusicInfoScanner::SetArtistArtwork(CArtist& artist, const std::vector<std:
       CTextureCache::GetInstance().BackgroundCacheImage(strArt);
       artist.art.insert(make_pair(type, strArt));
       m_musicDatabase.SetArtForItem(artist.idArtist, MediaTypeArtist, type, strArt);
+      addedCount++;
     }
   }
 
+  return addedCount > 0;
 }
 
+bool CMusicInfoScanner::SetAlbumArtwork(CAlbum& album, std::vector<std::string>& missing, const std::string& artfolder)
+{
+  if (album.thumbURL.m_url.empty())
+  {
+    if (artfolder.empty())
+      return false; // No local or scraped art to process
+  }
+  else if (CServiceBroker::GetSettings().GetBool(CSettings::SETTING_MUSICLIBRARY_PREFERONLINEALBUMART))
+  {  
+    // When "prefer online album art" enabled, and we have a scraped cover then
+    // if the thumb is embedded replace it by adding "thumb" to the missing types
+    std::map<std::string, std::string>::iterator it;
+    it = album.art.find("thumb");
+    if (it != album.art.end() && StringUtils::StartsWith(it->second, "image://"))
+      missing.emplace_back("thumb");
+  }
+
+  if (missing.empty())
+    return false; // All types of album art found
+
+  // Any extra type of art missing, fetch the image files from the art folder.
+  // Thumbs and fanart have own advanced settings for file names, what other
+  // art types to fetch automatically is optional too, but local file name must
+  // match the type
+  CFileItemList items;
+  bool extratype = false;
+  for (const auto& type : missing)
+    if (type != "thumb")
+    {
+      extratype = true;
+      break;
+    }
+  if (extratype)
+    CDirectory::GetDirectory(artfolder, items,
+      CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+      DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+
+  // Get missing art
+  int addedCount = 0;
+  for (const auto& type : missing)
+  {
+    std::string strArt;
+    if (!artfolder.empty())
+    {
+      CFileItem item(artfolder, true);
+      if (type == "thumb")
+        // Local music thumbnail images named by <musicthumbs>
+        strArt = item.GetUserMusicThumb(true);
+      else if (type == "fanart")
+        // Local music fanart images named by <fanart>
+        strArt = item.GetLocalFanart();
+      else
+      {
+        // Check for images with type as name case and ext insenitively
+        for (int j = 0; j < items.Size(); j++)
+        {
+          std::string strCandidate = URIUtils::GetFileName(items[j]->GetPath());
+          URIUtils::RemoveExtension(strCandidate);
+          if (StringUtils::EqualsNoCase(strCandidate, type))
+          {
+            strArt = items[j]->GetPath();
+            break;
+          }
+        }
+      }
+    }
+    // No local art, use first from scraped list. 
+    // Art type is encoded into the scraper XML held in thumbURL as optional
+    // "aspect=" field. Type "thumb" or "" returns URLs for all types of art
+    // including those without aspect. Those URL without aspect are also
+    // returned for all other type values.
+    // Historically albums do not have fanart, so there is no special handling
+    // of scraper results for it (unlike artist).
+    if (strArt.empty())
+    {
+      if (type == "thumb")
+        strArt = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb());
+      else
+        strArt = CScraperUrl::GetThumbURL(album.thumbURL.GetFirstThumb(type));
+    }
+    // Add art to album and library
+    if (!strArt.empty())
+    {
+      CTextureCache::GetInstance().BackgroundCacheImage(strArt);
+      album.art.insert(make_pair(type, strArt));
+      m_musicDatabase.SetArtForItem(album.idAlbum, MediaTypeAlbum, type, strArt);
+      addedCount++;
+    }
+  }
+
+  return addedCount > 0;
+}
+
+void CMusicInfoScanner::SetDiscSetArtwork(CAlbum& album, const std::vector<std::pair<std::string, int>>& paths)
+{
+  /*
+  Automatically fetch local art from disc set subfolders
+
+  When we have a true disc set - subfolders AND songs tagged with same unique
+  discnumber in each subfolder - save the local art (all types) for each disc.
+  */
+ 
+  if (paths.size() <= 1)
+    return;  // No disc subfolders to process
+  
+  // Get default types of art that are to be automatically fetched during scanning
+  std::vector<std::string> arttypes;
+  arttypes = GetArtTypesToScan(MediaTypeAlbum);
+
+  // Check that there are art types other than thumb to process
+  bool extratype = !g_advancedSettings.m_musicAlbumExtraArt.empty();
+
+  std::string firstDiscThumb;
+  int iDiscThumb = 10000;
+  for (const auto& pathpair : paths)
+  {
+    int discnum = m_musicDatabase.GetDiscnumberForPathID(pathpair.second);
+    if (discnum > 0)
+    {
+      CFileItemList items;
+      if (extratype)
+        // Fetch the image files from the disc folder.
+        CDirectory::GetDirectory(pathpair.first.c_str(), items,
+          CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+          DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+
+      for (const auto& type : arttypes)
+      {
+        CFileItem item(pathpair.first.c_str(), true);
+        std::string strArt;
+        std::string strArtType;
+        if (type == "thumb")
+        {
+          // Get thumb for path from textures db (could be embedded or local file)
+          CMusicThumbLoader loader;
+          strArt = loader.GetCachedImage(item, type);
+          if (!strArt.empty())
+          {
+            // Store thumb of first disc with a thumb
+            if (discnum < iDiscThumb)
+            {
+              iDiscThumb = discnum;
+              firstDiscThumb = strArt;
+            }
+          }
+        }
+        else if (type == "fanart")
+          // Local music fanart images named by <fanart>
+          strArt = item.GetLocalFanart();
+        else
+        {
+          // Check for images with type as name case and ext insenitively
+          for (int j = 0; j < items.Size(); j++)
+          {
+            std::string strCandidate = URIUtils::GetFileName(items[j]->GetPath());
+            URIUtils::RemoveExtension(strCandidate);
+            if (StringUtils::EqualsNoCase(strCandidate, type))
+            {
+              strArt = items[j]->GetPath();
+              break;
+            }
+          }
+        }
+        // Add disc set art as album art "<type><disc number>" and to library
+        if (!strArt.empty())
+        {
+          CTextureCache::GetInstance().BackgroundCacheImage(strArt);
+          strArtType = StringUtils::Format("%s%i", type.c_str(), discnum);
+          album.art.insert(make_pair(strArtType, strArt));
+          m_musicDatabase.SetArtForItem(album.idAlbum, MediaTypeAlbum, strArtType, strArt);
+        }
+      }
+    }
+  }
+  
+  // Finally if we still don't have album thumb then use the art from the
+  // first disc in the set with a thumb
+  if (!firstDiscThumb.empty() && album.art.find("thumb") == album.art.end())
+  {
+    m_musicDatabase.SetArtForItem(album.idAlbum, MediaTypeAlbum, "thumb", firstDiscThumb);
+    // Assign art as folder thumb (in textures db) as well
+    CMusicThumbLoader loader;
+    CFileItem albumItem(album.strPath, true);
+    loader.SetCachedImage(albumItem, "thumb", firstDiscThumb);
+  }
+}
 
 // This function is the Run() function of the IRunnable
 // CFileCountReader and runs in a separate thread.

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -152,6 +152,14 @@ protected:
    */
   INFO_RET DownloadArtistInfo(const CArtist& artist, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, bool bUseScrapedMBID, CGUIDialogProgress* pDialog = NULL);
 
+
+  /*! \brief Get the types of art for an artist or album that are to be
+  automatically fetched from local files during scanning
+  \param mediaType [in] artist or album
+  \return vector of art types that are to be fetched during scanning
+  */
+  std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
+
   /*! \brief Get the types of art for an artist or album that can be 
    automatically found during scanning, and are not in the provided set of art
    \param mediaType [in] artist or album
@@ -159,7 +167,7 @@ protected:
    \return vector of art types that are missing from the set
    */
   std::vector<std::string> GetMissingArtTypes(const MediaType& mediaType, const std::map<std::string, std::string>& art);
-  
+
   /*! \brief Set art for an artist
   Checks for the missing types of art in the given folder. If none is found
   there then it tries to use the first available art of that type from those
@@ -168,8 +176,32 @@ protected:
   \param artist [in/out] an artist, the art is set
   \param missing [in] vector of art types that are missing
   \param artfolder [in] path of the location to search for local art files
+  \return true when art is added
   */
-  void SetArtistArtwork(CArtist& artist, const std::vector<std::string>& missing, const std::string& artfolder);
+  bool SetArtistArtwork(CArtist& artist, const std::vector<std::string>& missing, const std::string& artfolder);
+
+  /*! \brief Set art for an album
+  Checks for the missing types of art in the given folder. If none is found
+  there then it tries to use the first available art of that type from those
+  listed in the album structure. Art found is saved in the album structure
+  and written to the music database. The images found are cached.
+  \param artist [in/out] an album, the art is set
+  \param missing [in] vector of art types that are missing
+  \param artfolder [in] path of the location to search for local art files
+  \return true when art is added
+  */
+  bool SetAlbumArtwork(CAlbum& album, std::vector<std::string>& missing, const std::string& artfolder);
+
+  /*! \brief Set art for an album with local art from disc set subfolders
+  When we have a true disc set - subfolders beneath the album folder AND the
+  music files in each sub folder tagged with same unique - this checks for the
+  all types of art in the given subfolders.
+  Art found is saved in the album structure and written to the music database.
+  The images found are cached.
+  \param artist [in/out] an album, the art is modified
+  \param paths [in] a set of pairs of disc subfolder path and disc number
+  */
+  void SetDiscSetArtwork(CAlbum& album, const std::vector<std::pair<std::string, int>>& paths);
 
   /*! \brief Scan in the ID3/Ogg/FLAC tags for a bunch of FileItems
    Given a list of FileItems, scan in the tags for those FileItems

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -152,15 +152,24 @@ protected:
    */
   INFO_RET DownloadArtistInfo(const CArtist& artist, const ADDON::ScraperPtr& scraper, MUSIC_GRABBER::CMusicArtistInfo& artistInfo, bool bUseScrapedMBID, CGUIDialogProgress* pDialog = NULL);
 
-  /*! \brief Get art for an artist
-   Checks for thumb and fanart in given folder, and in parent folders back up the artist path (if non-empty).
-   If none is found there then it tries to use the first available thumb and fanart from those listed in the
-   artist structure. Images found are cached.
-   \param artist [in] an artist
-   \param level [in] how many levels of folders to search in. 1 => just the folder
-   \return set of art type and file location (URL or path) pairs
+  /*! \brief Get the types of art for an artist or album that can be 
+   automatically found during scanning, and are not in the provided set of art
+   \param mediaType [in] artist or album
+   \param art [in] set of art type and file location (URL or path) pairs
+   \return vector of art types that are missing from the set
    */
-  std::map<std::string, std::string> GetArtistArtwork(const CArtist& artist, unsigned int level = 3);
+  std::vector<std::string> GetMissingArtTypes(const MediaType& mediaType, const std::map<std::string, std::string>& art);
+  
+  /*! \brief Set art for an artist
+  Checks for the missing types of art in the given folder. If none is found
+  there then it tries to use the first available art of that type from those
+  listed in the artist structure. Art found is saved in the artist structure
+  and written to the music database. The images found are cached.
+  \param artist [in/out] an artist, the art is set
+  \param missing [in] vector of art types that are missing
+  \param artfolder [in] path of the location to search for local art files
+  */
+  void SetArtistArtwork(CArtist& artist, const std::vector<std::string>& missing, const std::string& artfolder);
 
   /*! \brief Scan in the ID3/Ogg/FLAC tags for a bunch of FileItems
    Given a list of FileItems, scan in the tags for those FileItems
@@ -174,7 +183,6 @@ protected:
 
   void RetrieveLocalArt();
   void ScrapeInfoAddedAlbums();
-  void RetrieveArtistArt();
 
   /*! \brief Scan in the ID3/Ogg/FLAC tags for a bunch of FileItems
     Given a list of FileItems, scan in the tags for those FileItems

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -273,6 +273,7 @@ void CAdvancedSettings::Initialize()
 
   m_musicThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG";
   m_fanartImages = "fanart.jpg|fanart.png";
+  m_musicArtistExtraArt = { };
 
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryCleanOnUpdate = false;
@@ -745,6 +746,19 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         if (separator->FirstChild())
           m_musicArtistSeparators.push_back(separator->FirstChild()->ValueStr());
         separator = separator->NextSibling("separator");
+      }
+    }
+    // Music extra artist art
+    TiXmlElement* arttypes = pElement->FirstChildElement("artistextraart");
+    if (arttypes)
+    {
+      m_musicArtistExtraArt.clear();
+      TiXmlNode* arttype = arttypes->FirstChild("arttype");
+      while (arttype)
+      {
+        if (arttype->FirstChild())
+          m_musicArtistExtraArt.push_back(arttype->FirstChild()->ValueStr());
+        arttype = arttype->NextSibling("arttype");
       }
     }
   }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -274,6 +274,7 @@ void CAdvancedSettings::Initialize()
   m_musicThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG";
   m_fanartImages = "fanart.jpg|fanart.png";
   m_musicArtistExtraArt = { };
+  m_musicAlbumExtraArt = {};
 
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryCleanOnUpdate = false;
@@ -758,6 +759,19 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       {
         if (arttype->FirstChild())
           m_musicArtistExtraArt.push_back(arttype->FirstChild()->ValueStr());
+        arttype = arttype->NextSibling("arttype");
+      }
+    }
+    // Music extra album art
+    arttypes = pElement->FirstChildElement("albumextraart");
+    if (arttypes)
+    {
+      m_musicAlbumExtraArt.clear();
+      TiXmlNode* arttype = arttypes->FirstChild("arttype");
+      while (arttype)
+      {
+        if (arttype->FirstChild())
+          m_musicAlbumExtraArt.push_back(arttype->FirstChild()->ValueStr());
         arttype = arttype->NextSibling("arttype");
       }
     }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -251,6 +251,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     std::string m_musicThumbs;
     std::string m_fanartImages;
+    std::vector<std::string> m_musicArtistExtraArt;
 
     int m_iMusicLibraryRecentlyAddedItems;
     int m_iMusicLibraryDateAdded;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -252,6 +252,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_musicThumbs;
     std::string m_fanartImages;
     std::vector<std::string> m_musicArtistExtraArt;
+    std::vector<std::string> m_musicAlbumExtraArt;
 
     int m_iMusicLibraryRecentlyAddedItems;
     int m_iMusicLibraryDateAdded;


### PR DESCRIPTION
This extends the way thumbs and fanart (artists only) are currently handled to apply to _any_ music art type. It makes fetching additional art, from local files or scraper results, configurable rather than hard coded. This means showing additional art, such as "clearlogo" or "discart" or anything else people may dream up in the future, will just be a matter of either putting the image file in an appropriate place, or the scraper returning the URL for it ,  and then editing the skin.

It applies to:

1. Manual album and artist art selection (from the album/artist information dialog)
 When browsing for images for an art type the user will be offered related local images and scraper results.

2. Library update and refreshing additonal information 
Both scanning music files and scraping additional artist or album information will check for local art or failing that try to use srcaper results to fill any art that is missing.

This is both a logical continuation of recent music art enhancements, and something requested by users and skinners. 

I will put up a test build, and instructions for using/testing this feature will follow shortly. I appreciate anyone with an extensive collection of music and local artwork, especially additional types of art that would previously need addons such as CDart, Artwork Beef or Skin Helper Service, trying this out.