### PR TITLE
osx: no limited color range on osx, fix log spam

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -58,7 +58,6 @@ public:
   virtual bool Hide() override;
   virtual bool Show(bool raise = true) override;
   virtual void OnMove(int x, int y) override;
-  bool UseLimitedColor() override;
 
   virtual std::string GetClipboardText(void) override;
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1701,11 +1701,6 @@ void CWinSystemOSX::OnMove(int x, int y)
   HandlePossibleRefreshrateChange();
 }
 
-bool CWinSystemOSX::UseLimitedColor()
-{
-  return CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
-}
-
 std::unique_ptr<IOSScreenSaver> CWinSystemOSX::GetOSScreenSaverImpl()
 {
   return std::unique_ptr<IOSScreenSaver> (new COSScreenSaverOSX);


### PR DESCRIPTION
see title. https://github.com/xbmc/xbmc/pull/13803 incorrectly added override for osx