### PR TITLE
[music]Fix fanart for library items on playback from file view

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3333,7 +3333,6 @@ bool CFileItem::LoadMusicTag()
     if (musicDatabase.GetSongByFileName(m_strPath, song))
     {
       GetMusicInfoTag()->SetSong(song);
-      SetArt("thumb", song.strThumb);
       return true;
     }
     musicDatabase.Close();


### PR DESCRIPTION
Art type "thumb" was sometimes being added to a song with an empty URL, preventing artist fanart from  being shown on playback of library items from file view. 

A simple fix: `song.strThumb` is never read from the db, hence results in a blank entry. Since the art is managed elsewhere, this line should be removed from `CFileItem::LoadMusicTag()`. It was an historic mistake, the effects of which had been previously avoided because of code elsewhere that was recently removed. To test: play music that is in the library and has artist fanart from file view, note fanart shown on player OSD

@MilhouseVH this fixes the issue reported here https://forum.kodi.tv/showthread.php?tid=298461&pid=2730270#pid2730270