### PR TITLE
fix cancel of GetDirectory

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -211,7 +211,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem, const std::string &player)
   if (item->GetPath() == "addons://update_all/")
   {
     UpdateAddons updater;
-    CGUIDialogBusy::Wait(&updater);
+    CGUIDialogBusy::Wait(&updater, 100, true);
     return true;
   }
   if (!item->m_bIsFolder)

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -48,7 +48,7 @@ public:
    \param allowCancel whether the user can cancel the wait, defaults to true.
    \return true if the runnable completes, false if the user cancels early.
    */
-  static bool Wait(IRunnable *runnable, unsigned int displaytime = 100, bool allowCancel = true);
+  static bool Wait(IRunnable *runnable, unsigned int displaytime, bool allowCancel);
 
   /*! \brief Wait on an event while displaying the busy dialog.
    Throws up the busy dialog after the given time.

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -157,7 +157,7 @@ bool CGUIDialogSimpleMenu::GetDirectoryItems(const std::string &path, CFileItemL
                                              const XFILE::CDirectory::CHints &hints)
 {
   CGetDirectoryItems getItems(path, items, hints);
-  if (!CGUIDialogBusy::Wait(&getItems))
+  if (!CGUIDialogBusy::Wait(&getItems, 100, true))
   {
     return false;
   }

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -131,7 +131,18 @@ bool CDirectory::GetDirectory(const std::string& strPath, CFileItemList &items, 
   CHints hints;
   hints.flags = flags;
   hints.mask = strMask;
-  return GetDirectory(strPath, items, hints);
+  const CURL pathToUrl(strPath);
+  return GetDirectory(pathToUrl, items, hints);
+}
+
+bool CDirectory::GetDirectory(const std::string& strPath, std::shared_ptr<IDirectory> pDirectory,
+                              CFileItemList &items, const std::string &strMask, int flags)
+{
+  CHints hints;
+  hints.flags = flags;
+  hints.mask = strMask;
+  const CURL pathToUrl(strPath);
+  return GetDirectory(pathToUrl, pDirectory, items, hints);
 }
 
 bool CDirectory::GetDirectory(const std::string& strPath, CFileItemList &items, const CHints &hints)
@@ -150,10 +161,17 @@ bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const std::
 
 bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const CHints &hints)
 {
+  CURL realURL = URIUtils::SubstitutePath(url);
+  std::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
+  return CDirectory::GetDirectory(url, pDirectory, items, hints);
+}
+
+bool CDirectory::GetDirectory(const CURL& url, std::shared_ptr<IDirectory> pDirectory,
+                              CFileItemList &items, const CHints &hints)
+{
   try
   {
     CURL realURL = URIUtils::SubstitutePath(url);
-    std::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
     if (!pDirectory.get())
       return false;
 

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -20,6 +20,7 @@
  */
 
 #include "IDirectory.h"
+#include <memory>
 #include <string>
 
 namespace XFILE
@@ -49,6 +50,11 @@ public:
                            , const std::string &strMask
                            , int flags);
 
+  static bool GetDirectory(const CURL& url,
+                           std::shared_ptr<IDirectory> pDirectory,
+                           CFileItemList &items,
+                           const CHints &hints);
+
   static bool GetDirectory(const CURL& url
                            , CFileItemList &items
                            , const CHints &hints);
@@ -62,6 +68,12 @@ public:
                            , CFileItemList &items
                            , const std::string &strMask
                            , int flags);
+
+  static bool GetDirectory(const std::string& strPath,
+                           std::shared_ptr<IDirectory> pDirectory,
+                           CFileItemList &items,
+                           const std::string &strMask,
+                           int flags);
 
   static bool GetDirectory(const std::string& strPath
                            , CFileItemList &items

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -582,6 +582,7 @@ void CPluginDirectory::SetProperty(int handle, const std::string &strProperty, c
 void CPluginDirectory::CancelDirectory()
 {
   m_cancelled = true;
+  m_fetchComplete.Set();
 }
 
 float CPluginDirectory::GetProgress() const

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -35,6 +35,7 @@ namespace XFILE
     CVirtualDirectory(void);
     ~CVirtualDirectory(void) override;
     bool GetDirectory(const CURL& url, CFileItemList &items) override;
+    void CancelDirectory() override;
     bool GetDirectory(const CURL& url, CFileItemList &items, bool bUseFileDirectories);
     void SetSources(const VECSOURCES& vecSources);
     inline unsigned int GetNumberOfSources() 
@@ -63,6 +64,7 @@ namespace XFILE
     void CacheThumbs(CFileItemList &items);
 
     VECSOURCES m_vecSources;
-    bool       m_allowNonLocalSources;
+    bool m_allowNonLocalSources;
+    std::shared_ptr<IDirectory> m_pDir;
   };
 }

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -38,6 +38,7 @@ class IRunnable
 {
 public:
   virtual void Run()=0;
+  virtual void Cancel() {};
   virtual ~IRunnable() = default;
 };
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -42,6 +42,7 @@
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "favourites/FavouritesService.h"
 #include "filesystem/File.h"
+#include "filesystem/DirectoryFactory.h"
 #include "filesystem/FileDirectoryFactory.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/PluginDirectory.h"
@@ -99,6 +100,10 @@ public:
   void Run() override
   {
     m_result = m_dir.GetDirectory(m_url, m_items, m_useDir);
+  }
+  void Cancel() override
+  {
+    m_dir.CancelDirectory();
   }
   bool m_result;
 protected:
@@ -2162,9 +2167,8 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
   if (m_useBusyDialog)
   {
     CGetDirectoryItems getItems(m_rootDir, url, items, useDir);
-    if (!CGUIDialogBusy::Wait(&getItems))
+    if (!CGUIDialogBusy::Wait(&getItems, 100, true))
     {
-      m_rootDir.CancelDirectory();
       return false;
     }
     return getItems.m_result;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -107,6 +107,10 @@ public:
   {
     m_result = m_dir.GetDirectory(m_url, m_items, false);
   }
+  void Cancel() override
+  {
+    m_dir.CancelDirectory();
+  }
   bool m_result;
 protected:
   XFILE::CVirtualDirectory &m_dir;
@@ -924,9 +928,8 @@ bool CGUIWindowFileManager::GetDirectory(int iList, const std::string &strDirect
   CURL pathToUrl(strDirectory);
 
   CGetDirectoryItems getItems(m_rootDir, pathToUrl, items);
-  if (!CGUIDialogBusy::Wait(&getItems))
+  if (!CGUIDialogBusy::Wait(&getItems, 100, true))
   {
-    m_rootDir.CancelDirectory();
     return false;
   }
   return getItems.m_result;


### PR DESCRIPTION
fix deadlock when GetDirectoy is cancelled (cancel of busy dialog)
those static GetDirectory methods really need a redisign. 