### PR TITLE
[videolibrary] Assign extra artwork from file system

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -317,6 +317,12 @@ void CAdvancedSettings::Initialize()
   m_bVideoScannerIgnoreErrors = false;
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
 
+  m_videoEpisodeExtraArt = {};
+  m_videoTvShowExtraArt = {};
+  m_videoTvSeasonExtraArt = {};
+  m_videoMovieExtraArt = {};
+  m_videoMusicVideoExtraArt = {};
+
   m_iEpgUpdateCheckInterval = 300; /* check if tables need to be updated every 5 minutes */
   m_iEpgCleanupInterval = 900;     /* remove old entries from the EPG every 15 minutes */
   m_iEpgActiveTagCheckInterval = 60; /* check for updated active tags every minute */
@@ -772,32 +778,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         separator = separator->NextSibling("separator");
       }
     }
-    // Music extra artist art
-    TiXmlElement* arttypes = pElement->FirstChildElement("artistextraart");
-    if (arttypes)
-    {
-      m_musicArtistExtraArt.clear();
-      TiXmlNode* arttype = arttypes->FirstChild("arttype");
-      while (arttype)
-      {
-        if (arttype->FirstChild())
-          m_musicArtistExtraArt.push_back(arttype->FirstChild()->ValueStr());
-        arttype = arttype->NextSibling("arttype");
-      }
-    }
-    // Music extra album art
-    arttypes = pElement->FirstChildElement("albumextraart");
-    if (arttypes)
-    {
-      m_musicAlbumExtraArt.clear();
-      TiXmlNode* arttype = arttypes->FirstChild("arttype");
-      while (arttype)
-      {
-        if (arttype->FirstChild())
-          m_musicAlbumExtraArt.push_back(arttype->FirstChild()->ValueStr());
-        arttype = arttype->NextSibling("arttype");
-      }
-    }
+
+    SetExtraArtwork(pElement->FirstChildElement("artistextraart"), m_musicArtistExtraArt);
+    SetExtraArtwork(pElement->FirstChildElement("albumextraart"), m_musicAlbumExtraArt);
   }
 
   pElement = pRootElement->FirstChildElement("videolibrary");
@@ -812,6 +795,12 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "importwatchedstate", m_bVideoLibraryImportWatchedState);
     XMLUtils::GetBoolean(pElement, "importresumepoint", m_bVideoLibraryImportResumePoint);
     XMLUtils::GetInt(pElement, "dateadded", m_iVideoLibraryDateAdded);
+
+    SetExtraArtwork(pElement->FirstChildElement("episodeextraart"), m_videoEpisodeExtraArt);
+    SetExtraArtwork(pElement->FirstChildElement("tvshowextraart"), m_videoTvShowExtraArt);
+    SetExtraArtwork(pElement->FirstChildElement("tvseasonextraart"), m_videoTvSeasonExtraArt);
+    SetExtraArtwork(pElement->FirstChildElement("movieextraart"), m_videoMovieExtraArt);
+    SetExtraArtwork(pElement->FirstChildElement("musicvideoextraart"), m_videoMusicVideoExtraArt);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");
@@ -1460,5 +1449,19 @@ void CAdvancedSettings::SetExtraLogLevel(const std::vector<CVariant> &components
       continue;
 
     m_extraLogLevels |= static_cast<int>(it->asInteger());
+  }
+}
+
+void CAdvancedSettings::SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap)
+{
+  if (!arttypes)
+    return
+  artworkMap.clear();
+  const TiXmlNode* arttype = arttypes->FirstChild("arttype");
+  while (arttype)
+  {
+    if (arttype->FirstChild())
+      artworkMap.push_back(arttype->FirstChild()->ValueStr());
+    arttype = arttype->NextSibling("arttype");
   }
 }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -266,6 +266,11 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bVideoLibraryExportAutoThumbs;
     bool m_bVideoLibraryImportWatchedState;
     bool m_bVideoLibraryImportResumePoint;
+    std::vector<std::string> m_videoEpisodeExtraArt;
+    std::vector<std::string> m_videoTvShowExtraArt;
+    std::vector<std::string> m_videoTvSeasonExtraArt;
+    std::vector<std::string> m_videoMovieExtraArt;
+    std::vector<std::string> m_videoMusicVideoExtraArt;
 
     bool m_bVideoScannerIgnoreErrors;
     int m_iVideoLibraryDateAdded;
@@ -382,4 +387,5 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void SetExtraLogLevel(const std::vector<CVariant> &components);
     void Initialize();
     void Clear();
+    void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap);
 };

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoInfoScanner.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "ServiceBroker.h"
@@ -1441,9 +1442,6 @@ namespace VIDEO
 
     // get and cache thumb images
     std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(ContentToMediaType(content, pItem->m_bIsFolder));
-    std::vector<std::string>::iterator i = find(artTypes.begin(), artTypes.end(), "fanart");
-    if (i != artTypes.end())
-      artTypes.erase(i); // fanart is handled below
     bool lookForThumb = find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end() &&
                         art.find("thumb") == art.end();
     // find local art
@@ -1480,7 +1478,7 @@ namespace VIDEO
     {
       for (auto& it : pItem->GetVideoInfoTag()->m_coverArt)
       {
-        if (art.find(it.m_type) == art.end())
+        if (std::find(artTypes.begin(), artTypes.end(), it.m_type) != artTypes.end() && art.find(it.m_type) == art.end())
         {
           std::string thumb = CTextureUtils::GetWrappedImageURL(pItem->GetPath(),
                                                                 "video_" + it.m_type);
@@ -1489,11 +1487,10 @@ namespace VIDEO
       }
     }
 
-    // get & save fanart image (treated separately due to it being stored in m_fanart)
-    bool isEpisode = (content == CONTENT_TVSHOWS && !pItem->m_bIsFolder);
-    if (!isEpisode && art.find("fanart") == art.end())
+    // add online fanart (treated separately due to it being stored in m_fanart)
+    if (find(artTypes.begin(), artTypes.end(), "fanart") != artTypes.end() && art.find("fanart") == art.end())
     {
-      std::string fanart = GetFanart(pItem, useLocal);
+      std::string fanart = pItem->GetVideoInfoTag()->m_fanart.GetImageURL();
       if (!fanart.empty())
         art.insert(std::make_pair("fanart", fanart));
     }
@@ -1507,7 +1504,7 @@ namespace VIDEO
       if (aspect.empty())
         // temporary support for XML music video scrapers that share music album scraper bits
         aspect = content == CONTENT_MUSICVIDEOS ? "poster" : "thumb";
-      if (art.find(aspect) != art.end())
+      if (find(artTypes.begin(), artTypes.end(), aspect) == artTypes.end() || art.find(aspect) != art.end())
         continue;
       std::string image = GetImage(url, pItem->GetPath());
       if (!image.empty())
@@ -1538,18 +1535,6 @@ namespace VIDEO
       thumb = URIUtils::AddFileToFolder(strPath, thumb);
     }
     return thumb;
-  }
-
-  std::string CVideoInfoScanner::GetFanart(CFileItem *pItem, bool useLocal)
-  {
-    if (!pItem)
-      return "";
-    std::string fanart = pItem->GetArt("fanart");
-    if (fanart.empty() && useLocal)
-      fanart = pItem->FindLocalArt("fanart.jpg", true);
-    if (fanart.empty())
-      fanart = pItem->GetVideoInfoTag()->m_fanart.GetImageURL();
-    return fanart;
   }
 
   CInfoScanner::INFO_RET
@@ -1992,7 +1977,7 @@ namespace VIDEO
       if (aspect.empty())
         aspect = "thumb";
       std::map<std::string, std::string>& art = seasonArt[url.m_season];
-      if (art.find(aspect) != art.end())
+      if (find(artTypes.begin(), artTypes.end(), aspect) == artTypes.end() || art.find(aspect) != art.end())
         continue;
       std::string image = CScraperUrl::GetThumbURL(url);
       if (!image.empty())

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -98,7 +98,6 @@ namespace VIDEO
      */
     static void GetSeasonThumbs(const CVideoInfoTag &show, std::map<int, std::map<std::string, std::string> > &art, const std::vector<std::string> &artTypes, bool useLocal = true);
     static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
-    static std::string GetFanart(CFileItem *pItem, bool useLocal);
 
     bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
 

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -223,27 +223,38 @@ static void SetupRarOptions(CFileItem& item, const std::string& path)
 
 std::vector<std::string> CVideoThumbLoader::GetArtTypes(const std::string &type)
 {
+  const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   std::vector<std::string> ret;
+  std::vector<std::string> extraart;
   if (type == MediaTypeEpisode)
-    ret.push_back("thumb");
-  else if (type == MediaTypeTvShow || type == MediaTypeSeason)
   {
-    ret.push_back("banner");
-    ret.push_back("poster");
-    ret.push_back("fanart");
+    ret = { "thumb" };
+    extraart = advancedSettings->m_videoEpisodeExtraArt;
   }
-  else if (type == MediaTypeMovie || type == MediaTypeMusicVideo || type == MediaTypeVideoCollection)
+  else if (type == MediaTypeTvShow)
   {
-    ret.push_back("poster");
-    ret.push_back("fanart");
+    ret = { "poster", "fanart", "banner" };
+    extraart = advancedSettings->m_videoTvShowExtraArt;
   }
-  else if (type.empty()) // unknown - just throw everything in
+  else if (type == MediaTypeSeason)
   {
-    ret.push_back("poster");
-    ret.push_back("banner");
-    ret.push_back("thumb");
-    ret.push_back("fanart");
+    ret = { "poster", "fanart", "banner" };
+    extraart = advancedSettings->m_videoTvSeasonExtraArt;
   }
+  else if (type == MediaTypeMovie || type == MediaTypeVideoCollection)
+  {
+    ret = { "poster", "fanart" };
+    extraart = advancedSettings->m_videoMovieExtraArt;
+  }
+  else if (type == MediaTypeMusicVideo)
+  {
+    ret = { "poster", "fanart" };
+    extraart = advancedSettings->m_videoMusicVideoExtraArt;
+  }
+  else if (type.empty()) // unknown, just the basics
+    ret = { "poster", "fanart", "banner", "thumb" };
+
+  ret.insert(ret.end(), extraart.begin(), extraart.end());
   return ret;
 }
 


### PR DESCRIPTION
with a whitelist configuration in AS.xml, and apply the whitelist to scraper results.

<!--- Provide a general summary of your change in the Title above -->

## Description
Find and assign extra artwork like 'clearlogo' and 'landscape' from the local file system. Configured with a whitelist in advancedsettings.xml, which also applies to artwork from scrapers. Scrapers may not need switches for each individual art type, leaving that up to this configuration.

Files must be named as the name used in the library, so 'clearlogo.png' or 'movie file name-clearlogo.png', not 'logo.png'. Kodi exports the artwork to these file names.

"banner" is still hard-coded for TV shows and seasons. That's still wired up as a fallback "thumb" in some places that will be best handled in another PR. And "fanart" is still hard-coded for most media items, as that is treated differently than other artwork in many parts of Kodi.

Movie set artwork isn't exactly supported; when a new movie set is added Kodi still copies all artwork from one of the movies, which can be limited by `movieextraart`.

White list configuration modeled on Dave's work on #13848 for the music library.

```xml
<advancedsettings>
  <videolibrary>
    <tvshowextraart>
        <arttype>clearlogo</arttype>
        <arttype>landscape</arttype>
    </tvshowextraart>
    <movieextraart>
        <arttype>landscape</arttype>
    </movieextraart>
  </videolibrary>
</advancedsettings>
```

Plus `tvseasonextraart`, `episodeextraart`, and `musicvideoextraart`.

## How Has This Been Tested?
Manually, testing movies and TV shows with a couple configurations. Could use more eyes.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
