### PR TITLE
[application] Fix order of profile manager init

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -428,6 +428,11 @@ bool CApplication::Create(const CAppParamParser &params)
     }
   #endif
 
+  if (!m_ServiceManager->InitStageOnePointFive())
+    return false;
+
+  CSpecialProtocol::RegisterProfileManager(m_ServiceManager->GetProfileManager());
+
   // only the InitDirectories* for the current platform should return true
   bool inited = InitDirectoriesLinux();
   if (!inited)
@@ -453,11 +458,6 @@ bool CApplication::Create(const CAppParamParser &params)
 
   // Init our DllLoaders emu env
   init_emu_environ();
-
-  if (!m_ServiceManager->InitStageOnePointFive())
-    return false;
-
-  CSpecialProtocol::RegisterProfileManager(m_ServiceManager->GetProfileManager());
 
   CLog::Log(LOGNOTICE, "-----------------------------------------------------------------------");
   CLog::Log(LOGNOTICE, "Starting %s (%s). Platform: %s %s %d-bit", CSysInfo::GetAppName().c_str(), CSysInfo::GetVersion().c_str(),


### PR DESCRIPTION
## Description
Under gcc 8.x the unique_ptr check on profile manager fails.
InitDirectoriesLinux() tries to use the pointer and the
profile manager is not initialized until later. Init the profile
manager first and everyone else can use the pointer.

Fedora 28 and higher ship GCC 8.1. 

## Motivation and Context
This change allows kodi to start on Fedora 28+.

Backtrace prior to this patch:
#0  0x00007fffed996f4b in raise () from /lib64/libc.so.6
#1  0x00007fffed981591 in abort () from /lib64/libc.so.6
#2  0x0000555555e6f9f8 in std::__replacement_assert(char const*, int, char const*, char const*) ()
#3  0x0000555556787921 in CServiceManager::GetProfileManager() ()
#4  0x0000555556beae1e in XFILE::IDirectory::IDirectory() ()
#5  0x000055555600697d in XFILE::CPosixDirectory::CPosixDirectory() ()
#6  0x0000555556bcee85 in XFILE::CDirectoryFactory::Create(CURL const&) ()
#7  0x0000555556bcbc78 in XFILE::CDirectory::Exists(CURL const&, bool) ()
#8  0x0000555556bcc2e8 in XFILE::CDirectory::Exists(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
#9  0x00005555566e8f19 in CApplication::InitDirectoriesLinux() ()
#10 0x00005555566e94ef in CApplication::Create(CAppParamParser const&) ()
#11 0x00005555563b15ba in XBMC_Run ()
#12 0x0000555555de5eee in main ()

## How Has This Been Tested?
Compiled 18.0 a1 and ran on a Fedora 28 machine. Plays audio and video successfully.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
