### PR TITLE
LinuxRendererGLES: Fixed texture type for Mesa 18 compatibility

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -813,7 +813,7 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field, bool weave /*= false*
       CLog::Log(LOGERROR, "GL: Error initializing FBO");
       return;
     }
-    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA, GL_SHORT))
+    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA))
     {
       CLog::Log(LOGERROR, "GL: Error creating texture and binding to FBO");
       return;


### PR DESCRIPTION
## Description
Under Mesa 18 (tested on i915) playback of most media (other than 10bit/HDR) is broken (resulting in an FBO error and a black screen) due to a equally-sized but technically wrong type in a GLES texture creation call. This fixes that error.

## How Has This Been Tested?
Tested and confirmed working on my 7th Gen NUC on Ubuntu 18.04 with Mesa 18 and Linux 4.15. Another patch for an i915 issue on 4.15+ is coming later.

Please be advised that I have little experience in GL(ES) so tell me if you think this will break anything.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
