### PR TITLE
[fix] replace fopen with CFile.OpenForWrite

### DIFF
--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -213,9 +213,9 @@ void CScreenShot::TakeScreenshot(const std::string &filename, bool sync)
   else
   {
     //make sure the file exists to avoid concurrency issues
-    FILE* fp = fopen(filename.c_str(), "w");
-    if (fp)
-      fclose(fp);
+    XFILE::CFile file;
+    if (file.OpenForWrite(filename))
+      file.Close();
     else
       CLog::Log(LOGERROR, "Unable to create file %s", CURL::GetRedacted(filename).c_str());
 


### PR DESCRIPTION
## Description
fopen can't handle urls like smb://, nfs://, special:// and others.

## Motivation and Context
fixes https://trac.kodi.tv/ticket/16947

## How Has This Been Tested?
set screenshot directory to a smb path and searched the log for `Unable to create file `

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
