### PR TITLE
[Music]Artist art in file view and on playback from fileview

### DIFF
--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -96,8 +96,9 @@ public:
       return false;
 
     // Load song art. 
-    // For songs in library this includes related album and artist(s) art, 
-    // otherwise just embedded or cached thumb is fetched.
+    // For songs in library this includes related album and artist(s) art.  
+    // Also fetches artist art for non library songs when artist can be found
+    // uniquely by name, otherwise just embedded or cached thumb is fetched.
     CMusicThumbLoader loader;
     loader.LoadItem(m_song.get());
     if (dialog->IsCancelled())
@@ -110,21 +111,6 @@ public:
     dialog->SetArtTypeList(artlist);
     if (dialog->IsCancelled())
       return false;
-
-    // Fetch artist art for non db songs when artist can be found uniquely by name
-    if (!m_song->IsMusicDb() && m_song->HasMusicInfoTag() && !m_song->GetMusicInfoTag()->GetArtist().empty())
-    {
-      CMusicDatabase db;
-      db.Open();
-      int idArtist = db.GetArtistByName(m_song->GetMusicInfoTag()->GetArtist()[0]);
-      if (idArtist > 0)
-      {
-        std::map<std::string, std::string> art;
-        if (db.GetArtForItem(idArtist, MediaTypeArtist, art))
-          m_song->AppendArt(art, "artist");
-      }
-      db.Close();
-    }
 
     // Tell waiting SongInfoDialog that job is complete
     dialog->FetchComplete();


### PR DESCRIPTION
Fetch artist art for songs not in the library for display in fileview and on playback from file view.

- This restores the display of primary artist fanart from file view, for both library and non-library music files,  that was dropped by  #13352. 
- It extends this facility to fetch **all types of art**, for all the song artists and all the album artists (not just the primary one), doing a lookup on artist name. Providing artist name is unique, and the artist is in the library, then art will be returned. 
- This art is available both in file view window for music files, and for the player OSD. As per  #13352 this is accessed by skins using  "artist.thumb", "artist.fanart", "artist.clearlogo", "artist.banner",  "artist1.thumb", "artist1.fanart", "artist1.clearlogo", "artist1.banner", "albumartist.thumb", "albumartist.fanart" etc. 
___________

The old implementation was removed because it was unnecessarily doing artist fanart lookup on artist name for _everything_, while #13352 correctly uses ID and gets more types of artist art not just fanart.  

The fix of #13854 allowed artist art to be shown during playback of library items from file view, when play started from the folders above the music files, but not on from the item itself. This limit was is because the music file item when viewed in fileview has thumb pre-loaded automatically, and full art was only being added when art was empty. This  PR restores that lookup by artist name for non-library albums and extends to other artist art types.

@MilhouseVH perhaps you could include this into a build for the user to test