### PR TITLE
[guiinfo] Fix LISTITEM_PROPRTY for bool and integer properties.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6455,7 +6455,13 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
     }
     if (item)
     {
-      bReturn = GetItemBool(item, contextWindow, condition);
+      if (condition == LISTITEM_PROPERTY)
+      {
+        if (item->HasProperty(info.GetData3()))
+          bReturn = item->GetProperty(info.GetData3()).asBoolean();
+      }
+      else
+        bReturn = GetItemBool(item, contextWindow, condition);
     }
     else
     {
@@ -6573,7 +6579,17 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
     }
     if (item)
     {
-      return GetItemInt(value, item, contextWindow, info.m_info);
+      if (info.m_info == LISTITEM_PROPERTY)
+      {
+        if (item->HasProperty(info.GetData3()))
+        {
+          value = item->GetProperty(info.GetData3()).asInteger();
+          return true;
+        }
+        return false;
+      }
+      else
+        return GetItemInt(value, item, contextWindow, info.m_info);
     }
     else
     {


### PR DESCRIPTION
Example: 'ListItem.Property(addon.orphaned)'.

Fixes a regression reported in the forum: https://forum.kodi.tv/showthread.php?tid=330696&pid=2733826#pid2733826

Runtime-tested on macOS, latest Kodi master.

@Jalle19 mind taking a look?