### PR TITLE
separate and organize DPMS support

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -48,7 +48,6 @@ class CFileItemList;
 class CKey;
 class CSeekHandler;
 class CInertialScrollingHandler;
-class DPMSSupport;
 class CSplash;
 class CBookmark;
 class IActionListener;
@@ -422,7 +421,6 @@ protected:
 
   bool m_bInhibitIdleShutdown = false;
 
-  std::unique_ptr<DPMSSupport> m_dpms;
   bool m_dpmsIsActive = false;
   bool m_dpmsIsManual = false;
 

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -252,7 +252,6 @@ void CServiceBroker::UnregisterAppPort()
   m_pAppPort.reset();
 }
 
-
 CDecoderFilterManager* CServiceBroker::m_decoderFilterManager = nullptr;
 void CServiceBroker::RegisterDecoderFilterManager(CDecoderFilterManager* manager)
 {

--- a/xbmc/platform/darwin/osx/powermanagement/CMakeLists.txt
+++ b/xbmc/platform/darwin/osx/powermanagement/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(SOURCES CocoaPowerSyscall.cpp)
-
 set(HEADERS CocoaPowerSyscall.h)
 
 core_add_library(platform_darwin_osx_powermanagement)

--- a/xbmc/powermanagement/DPMSSupport.cpp
+++ b/xbmc/powermanagement/DPMSSupport.cpp
@@ -7,300 +7,38 @@
  */
 
 #include "DPMSSupport.h"
+
+#include "ServiceBroker.h"
+#include "settings/lib/Setting.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
-#include <assert.h>
+
+#include <array>
 #include <string>
-#ifdef TARGET_WINDOWS
-#include "windowing/GraphicContext.h"
-#include "rendering/dx/RenderContext.h"
-#endif
 
-//////// Generic, non-platform-specific code
-
-static const char* const MODE_NAMES[DPMSSupport::NUM_MODES] =
-  { "STANDBY", "SUSPEND", "OFF" };
-
-bool DPMSSupport::CheckValidMode(PowerSavingMode mode)
+CDPMSSupport::CDPMSSupport()
 {
-  if (mode > NUM_MODES)
+  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (settingsComponent)
   {
-    CLog::Log(LOGERROR, "Invalid power-saving mode %d", mode);
-    return false;
-  }
-  return true;
-}
-
-const char* DPMSSupport::GetModeName(PowerSavingMode mode)
-{
-  if (!CheckValidMode(mode)) return NULL;
-  return MODE_NAMES[mode];
-}
-
-DPMSSupport::DPMSSupport()
-{
-  PlatformSpecificInit();
-
-  if (!m_supportedModes.empty())
-  {
-    std::string modes_message;
-    for (size_t i = 0; i < m_supportedModes.size(); i++)
+    auto settings = settingsComponent->GetSettings();
+    if (settings)
     {
-      assert(CheckValidMode(m_supportedModes[i]));
-      modes_message += " ";
-      modes_message += MODE_NAMES[m_supportedModes[i]];
+      auto setting = settings->GetSetting(CSettings::SETTING_POWERMANAGEMENT_DISPLAYSOFF);
+      if (setting)
+        setting->SetRequirementsMet(true);
     }
-    CLog::Log(LOGDEBUG, "DPMS: supported power-saving modes:%s",
-              modes_message.c_str());
   }
 }
 
-bool DPMSSupport::IsModeSupported(PowerSavingMode mode) const
+bool CDPMSSupport::IsModeSupported(PowerSavingMode mode) const
 {
-  if (!CheckValidMode(mode)) return false;
-  for (size_t i = 0; i < m_supportedModes.size(); i++)
+  for (const auto& supportedModes : m_supportedModes)
   {
-    if (m_supportedModes[i] == mode) return true;
+    if (supportedModes == mode)
+      return true;
   }
+
   return false;
 }
-
-bool DPMSSupport::EnablePowerSaving(PowerSavingMode mode)
-{
-  if (!CheckValidMode(mode)) return false;
-  if (!IsModeSupported(mode))
-  {
-    CLog::Log(LOGERROR, "DPMS: power-saving mode %s is not supported",
-              MODE_NAMES[mode]);
-    return false;
-  }
-
-  if (!PlatformSpecificEnablePowerSaving(mode)) return false;
-
-  CLog::Log(LOGINFO, "DPMS: enabled power-saving mode %s",
-            GetModeName(mode));
-  return true;
-}
-
-bool DPMSSupport::DisablePowerSaving()
-{
-  if (!PlatformSpecificDisablePowerSaving()) return false;
-  CLog::Log(LOGINFO, "DPMS: disabled power-saving");
-  return true;
-}
-
-///////// Platform-specific support
-
-#if defined(HAVE_X11)
-#include "ServiceBroker.h"
-#include "windowing/X11/WinSystemX11.h"
-//// X Windows
-
-#include <X11/Xlib.h>
-#include <X11/extensions/dpms.h>
-
-// Mapping of PowerSavingMode to X11's mode constants.
-static const CARD16 X_DPMS_MODES[] =
-  { DPMSModeStandby, DPMSModeSuspend, DPMSModeOff };
-
-void DPMSSupport::PlatformSpecificInit()
-{
-  CWinSystemX11 *winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
-  Display* dpy = winSystem->GetDisplay();
-  if (dpy == NULL)
-    return;
-
-  int event_base, error_base;   // we ignore these
-  if (!DPMSQueryExtension(dpy, &event_base, &error_base)) {
-    CLog::Log(LOGINFO, "DPMS: X11 extension not present, power-saving"
-              " will not be available");
-    return;
-  }
-
-  if (!DPMSCapable(dpy)) {
-    CLog::Log(LOGINFO, "DPMS: display does not support power-saving");
-    return;
-  }
-
-  m_supportedModes.push_back(SUSPEND); // best compromise
-  m_supportedModes.push_back(OFF);     // next best
-  m_supportedModes.push_back(STANDBY); // rather lame, < 80% power according to
-                                       // DPMS spec
-}
-
-bool DPMSSupport::PlatformSpecificEnablePowerSaving(PowerSavingMode mode)
-{
-  CWinSystemX11 *winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
-  Display* dpy = winSystem->GetDisplay();
-  if (dpy == NULL)
-    return false;
-
-  // This is not needed on my ATI Radeon, but the docs say that DPMSForceLevel
-  // after a DPMSDisable (from SDL) should not normally work.
-  DPMSEnable(dpy);
-  DPMSForceLevel(dpy, X_DPMS_MODES[mode]);
-  // There shouldn't be any errors if we called DPMSEnable; if they do happen,
-  // they're asynchronous and messy to detect.
-  XFlush(dpy);
-  return true;
-}
-
-bool DPMSSupport::PlatformSpecificDisablePowerSaving()
-{
-  CWinSystemX11 *winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
-  Display* dpy = winSystem->GetDisplay();
-  if (dpy == NULL)
-    return false;
-
-  DPMSForceLevel(dpy, DPMSModeOn);
-  DPMSDisable(dpy);
-  XFlush(dpy);
-
-  winSystem->RecreateWindow();
-
-  return true;
-}
-
-/////  Add other platforms here.
-#elif defined(TARGET_WINDOWS)
-void DPMSSupport::PlatformSpecificInit()
-{
-#ifdef TARGET_WINDOWS_DESKTOP
-  // Assume we support DPMS. Is there a way to test it?
-  m_supportedModes.push_back(OFF);
-  m_supportedModes.push_back(STANDBY);
-#else
-  CLog::Log(LOGINFO, "DPMS: not supported on this platform");
-#endif
-}
-
-bool DPMSSupport::PlatformSpecificEnablePowerSaving(PowerSavingMode mode)
-{
-  if(!CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot())
-  {
-    CLog::Log(LOGDEBUG, "DPMS: not in fullscreen, power saving disabled");
-    return false;
-  }
-  switch(mode)
-  {
-#ifdef TARGET_WINDOWS_DESKTOP
-  case OFF:
-    // Turn off display
-    return SendMessage(DX::Windowing()->GetHwnd(), WM_SYSCOMMAND, SC_MONITORPOWER, (LPARAM) 2) == 0;
-  case STANDBY:
-    // Set display to low power
-    return SendMessage(DX::Windowing()->GetHwnd(), WM_SYSCOMMAND, SC_MONITORPOWER, (LPARAM) 1) == 0;
-#endif
-  default:
-    return true;
-  }
-}
-
-bool DPMSSupport::PlatformSpecificDisablePowerSaving()
-{
-#ifdef TARGET_WINDOWS_STORE
-  return false;
-#else
-  // Turn display on
-  return SendMessage(DX::Windowing()->GetHwnd(), WM_SYSCOMMAND, SC_MONITORPOWER, (LPARAM) -1) == 0;
-#endif
-}
-
-#elif defined(TARGET_DARWIN_OSX)
-#include <IOKit/IOKitLib.h>
-#include <CoreFoundation/CFNumber.h>
-
-void DPMSSupport::PlatformSpecificInit()
-{
-  m_supportedModes.push_back(OFF);
-  m_supportedModes.push_back(STANDBY);
-}
-
-bool DPMSSupport::PlatformSpecificEnablePowerSaving(PowerSavingMode mode)
-{
-  bool status;
-  // http://lists.apple.com/archives/Cocoa-dev/2007/Nov/msg00267.html
-  // This is an unsupported system call that might kernel panic on PPC boxes
-  // The reported OSX-PPC panic is unverified so we are going to enable this until
-  // we find out which OSX-PPC boxes have problems, then add detect/disable for those boxes.
-  io_registry_entry_t r = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/IOResources/IODisplayWrangler");
-  if(!r) return false;
-
-  switch(mode)
-  {
-  case OFF:
-    // Turn off display
-    status = (IORegistryEntrySetCFProperty(r, CFSTR("IORequestIdle"), kCFBooleanTrue) == 0);
-    break;
-  case STANDBY:
-    // Set display to low power
-    status = (IORegistryEntrySetCFProperty(r, CFSTR("IORequestIdle"), kCFBooleanTrue) == 0);
-    break;
-  default:
-    status = false;
-    break;
-  }
-  return status;
-}
-
-bool DPMSSupport::PlatformSpecificDisablePowerSaving()
-{
-  // http://lists.apple.com/archives/Cocoa-dev/2007/Nov/msg00267.html
-  // This is an unsupported system call that might kernel panic on PPC boxes
-  // The reported OSX-PPC panic is unverified so we are going to enable this until
-  // we find out which OSX-PPC boxes have problems, then add detect/disable for those boxes.
-  io_registry_entry_t r = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/IOResources/IODisplayWrangler");
-  if(!r) return false;
-
-  // Turn display on
-  return (IORegistryEntrySetCFProperty(r, CFSTR("IORequestIdle"), kCFBooleanFalse) == 0);
-}
-
-#elif defined(HAVE_GBM)
-#include "ServiceBroker.h"
-#include "windowing/gbm/WinSystemGbm.h"
-
-using namespace KODI::WINDOWING::GBM;
-
-void DPMSSupport::PlatformSpecificInit()
-{
-  m_supportedModes.push_back(OFF);
-}
-bool DPMSSupport::PlatformSpecificEnablePowerSaving(PowerSavingMode mode)
-{
-  CWinSystemGbm *winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-  switch(mode)
-  {
-  case OFF:
-    return winSystem->Hide();
-  default:
-    return false;
-  }
-}
-
-bool DPMSSupport::PlatformSpecificDisablePowerSaving()
-{
-  CWinSystemGbm *winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
-  winSystem->Show();
-  return true;
-}
-
-#else
-// Not implemented on this platform
-void DPMSSupport::PlatformSpecificInit()
-{
-  CLog::Log(LOGINFO, "DPMS: not supported on this platform");
-}
-
-bool DPMSSupport::PlatformSpecificEnablePowerSaving(PowerSavingMode mode)
-{
-  return false;
-}
-
-bool DPMSSupport::PlatformSpecificDisablePowerSaving()
-{
-  return false;
-}
-
-#endif  // platform ifdefs
-
-

--- a/xbmc/powermanagement/DPMSSupport.h
+++ b/xbmc/powermanagement/DPMSSupport.h
@@ -15,60 +15,42 @@
 // power-saving features are available for that screen, and it is able to
 // turn power-saving on an off.
 // Note that SDL turns off DPMS timeouts at the beginning of the application.
-class DPMSSupport
+class CDPMSSupport
 {
 public:
   // All known DPMS power-saving modes, on any platform.
   enum PowerSavingMode
   {
-    STANDBY, SUSPEND, OFF,
-    NUM_MODES
+    STANDBY,
+    SUSPEND,
+    OFF,
+    NUM_MODES,
   };
 
-  // Initializes an instance tied to the specified Surface. The Surface object
-  // must be alive for as long as this instance is in use.
-  DPMSSupport();
+  CDPMSSupport();
+  virtual ~CDPMSSupport() = default;
 
   // Whether power-saving is supported on this screen.
   bool IsSupported() const { return !m_supportedModes.empty(); }
+
   // Which power-saving modes are supported, in the order of preference (i.e.
   // the first mode should be the best choice).
   const std::vector<PowerSavingMode>& GetSupportedModes() const
   {
     return m_supportedModes;
   }
+
   // Whether a given mode is supported.
   bool IsModeSupported(PowerSavingMode mode) const;
 
-  // Untranslated name of the mode, for logging.
-  static const char* GetModeName(PowerSavingMode mode);
-  // Returns true if the given mode is valid (a member of PowerSavingMode).
-  // Returns false and logs an error message otherwise.
-  static bool CheckValidMode(PowerSavingMode mode);
-
   // Turns on the specified power-saving mode, which must be valid
   // and supported. Returns false if this failed.
-  bool EnablePowerSaving(PowerSavingMode mode);
+  virtual bool EnablePowerSaving(PowerSavingMode mode) = 0;
+
   // Turns off power-saving mode. You should only call this if the display
   // is currently in a power-saving mode, to avoid visual artifacts.
-  bool DisablePowerSaving();
+  virtual bool DisablePowerSaving() = 0;
 
-private:
+protected:
   std::vector<PowerSavingMode> m_supportedModes;
-
-  // Platform-specific code: add new #ifdef'ed implementations in the .cc file.
-  //
-  // Initializes DPMS support. Should populate m_supportedModes with the
-  // preferred order of the modes, if supported, otherwise leave it empty.
-  // If the latter, it should log a message about exactly why DPMS is not
-  // available.
-  void PlatformSpecificInit();
-  // Should turn on power-saving on the current platform. The mode is
-  // guaranteed to be one of m_supportedModes. Should return false on failure,
-  // and log a (platform-specific) ERROR message.
-  bool PlatformSpecificEnablePowerSaving(PowerSavingMode mode);
-  // Should turn off power-saving on the current platform. Should return
-  // false on failure and log a (platform-specific) ERROR message.
-  bool PlatformSpecificDisablePowerSaving();
 };
-

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -9,6 +9,7 @@
 #include "WinSystem.h"
 #include "ServiceBroker.h"
 #include "guilib/DispResource.h"
+#include "powermanagement/DPMSSupport.h"
 #include "windowing/GraphicContext.h"
 #include "settings/DisplaySettings.h"
 #include "settings/lib/Setting.h"
@@ -263,4 +264,9 @@ void CWinSystemBase::DriveRenderLoop()
 CGraphicContext& CWinSystemBase::GetGfxContext()
 {
   return *m_gfxContext;
+}
+
+std::shared_ptr<CDPMSSupport> CWinSystemBase::GetDPMSManager()
+{
+  return m_dpms;
 }

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -30,6 +30,7 @@ struct REFRESHRATE
   int   ResInfo_Index;
 };
 
+class CDPMSSupport;
 class CGraphicContext;
 class CRenderSystemBase;
 class IRenderLoop;
@@ -150,6 +151,8 @@ public:
    */
   virtual void* GetHWContext() { return nullptr; }
 
+  std::shared_ptr<CDPMSSupport> GetDPMSManager();
+
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);
   virtual std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() { return nullptr; }
@@ -168,4 +171,5 @@ protected:
 
   std::unique_ptr<IWinEvents> m_winEvents;
   std::unique_ptr<CGraphicContext> m_gfxContext;
+  std::shared_ptr<CDPMSSupport> m_dpms;
 };

--- a/xbmc/windowing/X11/CMakeLists.txt
+++ b/xbmc/windowing/X11/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCES GLContextEGL.cpp
             WinSystemX11.cpp
             WinSystemX11GLContext.cpp
             XRandR.cpp
-            VideoSyncOML.cpp)
+            VideoSyncOML.cpp
+            X11DPMSSupport.cpp)
 
 set(HEADERS GLContext.h
             GLContextEGL.h
@@ -16,7 +17,8 @@ set(HEADERS GLContext.h
             WinSystemX11.h
             WinSystemX11GLContext.h
             XRandR.h
-            VideoSyncOML.h)
+            VideoSyncOML.h
+            X11DPMSSupport.h)
 
 if(GLX_FOUND)
   list(APPEND SOURCES GLContextGLX.cpp

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -29,6 +29,7 @@
 
 #include "OptionalsReg.h"
 #include "platform/linux/OptionalsReg.h"
+#include "X11DPMSSupport.h"
 
 using namespace KODI;
 
@@ -260,6 +261,7 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
     return success;
   }
 
+  m_dpms = std::make_shared<CX11DPMSSupport>();
   VIDEOPLAYER::CProcessInfoX11::Register();
   RETRO::CRPProcessInfoX11::Register();
   RETRO::CRPProcessInfoX11::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);

--- a/xbmc/windowing/X11/X11DPMSSupport.cpp
+++ b/xbmc/windowing/X11/X11DPMSSupport.cpp
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "X11DPMSSupport.h"
+
+#include "ServiceBroker.h"
+#include "utils/log.h"
+#include "windowing/X11/WinSystemX11.h"
+
+#include <X11/Xlib.h>
+#include <X11/extensions/dpms.h>
+
+namespace
+{
+// Mapping of PowerSavingMode to X11's mode constants.
+const CARD16 X_DPMS_MODES[] =
+{
+  DPMSModeStandby,
+  DPMSModeSuspend,
+  DPMSModeOff
+};
+}
+
+CX11DPMSSupport::CX11DPMSSupport()
+{
+  CWinSystemX11* winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return;
+
+  Display* dpy = winSystem->GetDisplay();
+  if (!dpy)
+    return;
+
+  int event_base, error_base; // we ignore these
+  if (!DPMSQueryExtension(dpy, &event_base, &error_base))
+  {
+    CLog::Log(LOGINFO, "DPMS: X11 extension not present, power-saving will not be available");
+    return;
+  }
+
+  if (!DPMSCapable(dpy))
+  {
+    CLog::Log(LOGINFO, "DPMS: display does not support power-saving");
+    return;
+  }
+
+  m_supportedModes.push_back(SUSPEND); // best compromise
+  m_supportedModes.push_back(OFF); // next best
+  m_supportedModes.push_back(STANDBY); // rather lame, < 80% power according to DPMS spec
+}
+
+bool CX11DPMSSupport::EnablePowerSaving(PowerSavingMode mode)
+{
+  CWinSystemX11* winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return false;
+
+  Display* dpy = winSystem->GetDisplay();
+  if (!dpy)
+    return false;
+
+  // This is not needed on my ATI Radeon, but the docs say that DPMSForceLevel
+  // after a DPMSDisable (from SDL) should not normally work.
+  DPMSEnable(dpy);
+  DPMSForceLevel(dpy, X_DPMS_MODES[mode]);
+  // There shouldn't be any errors if we called DPMSEnable; if they do happen,
+  // they're asynchronous and messy to detect.
+  XFlush(dpy);
+  return true;
+}
+
+bool CX11DPMSSupport::DisablePowerSaving()
+{
+  CWinSystemX11* winSystem = dynamic_cast<CWinSystemX11*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return false;
+
+  Display* dpy = winSystem->GetDisplay();
+  if (!dpy)
+    return false;
+
+  DPMSForceLevel(dpy, DPMSModeOn);
+  DPMSDisable(dpy);
+  XFlush(dpy);
+
+  winSystem->RecreateWindow();
+
+  return true;
+}

--- a/xbmc/windowing/X11/X11DPMSSupport.h
+++ b/xbmc/windowing/X11/X11DPMSSupport.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "xbmc/powermanagement/DPMSSupport.h"
+
+class CX11DPMSSupport : public CDPMSSupport
+{
+public:
+  CX11DPMSSupport();
+  ~CX11DPMSSupport() = default;
+
+protected:
+  bool EnablePowerSaving(PowerSavingMode mode) override;
+  bool DisablePowerSaving() override;
+};

--- a/xbmc/windowing/gbm/CMakeLists.txt
+++ b/xbmc/windowing/gbm/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SOURCES OptionalsReg.cpp
             DRMLegacy.cpp
             DRMAtomic.cpp
             OffScreenModeSetting.cpp
-            WinSystemGbmEGLContext.cpp)
+            WinSystemGbmEGLContext.cpp
+            GBMDPMSSupport.cpp)
 
 set(HEADERS OptionalsReg.h
             WinSystemGbm.h
@@ -14,7 +15,8 @@ set(HEADERS OptionalsReg.h
             DRMLegacy.h
             DRMAtomic.h
             OffScreenModeSetting.h
-            WinSystemGbmEGLContext.h)
+            WinSystemGbmEGLContext.h
+            GBMDPMSSupport.h)
 
 if (OPENGL_FOUND)
   list(APPEND SOURCES WinSystemGbmGLContext.cpp)

--- a/xbmc/windowing/gbm/GBMDPMSSupport.cpp
+++ b/xbmc/windowing/gbm/GBMDPMSSupport.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GBMDPMSSupport.h"
+
+#include "ServiceBroker.h"
+#include "windowing/gbm/WinSystemGbm.h"
+
+using namespace KODI::WINDOWING::GBM;
+
+CGBMDPMSSupport::CGBMDPMSSupport()
+{
+  m_supportedModes.push_back(OFF);
+}
+
+bool CGBMDPMSSupport::EnablePowerSaving(PowerSavingMode mode)
+{
+  auto winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return false;
+
+  switch (mode)
+  {
+  case OFF:
+    return winSystem->Hide();
+  default:
+    return false;
+  }
+}
+
+bool CGBMDPMSSupport::DisablePowerSaving()
+{
+  auto winSystem = dynamic_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return false;
+
+  return winSystem->Show();
+}

--- a/xbmc/windowing/gbm/GBMDPMSSupport.h
+++ b/xbmc/windowing/gbm/GBMDPMSSupport.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "powermanagement/DPMSSupport.h"
+
+#include <memory>
+
+class CGBMDPMSSupport : public CDPMSSupport
+{
+public:
+  CGBMDPMSSupport();
+  ~CGBMDPMSSupport() = default;
+
+protected:
+  bool EnablePowerSaving(PowerSavingMode mode) override;
+  bool DisablePowerSaving() override;
+};

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -17,6 +17,7 @@
 #include "OptionalsReg.h"
 #include "platform/linux/OptionalsReg.h"
 #include "windowing/GraphicContext.h"
+#include "GBMDPMSSupport.h"
 #include "platform/linux/powermanagement/LinuxPowerSyscall.h"
 #include "settings/DisplaySettings.h"
 #include "utils/log.h"
@@ -66,6 +67,7 @@ CWinSystemGbm::CWinSystemGbm() :
     }
   }
 
+  m_dpms = std::make_shared<CGBMDPMSSupport>();
   CLinuxPowerSyscall::Register();
   m_lirc.reset(OPTIONALS::LircRegister());
   m_libinput->Start();

--- a/xbmc/windowing/osx/CMakeLists.txt
+++ b/xbmc/windowing/osx/CMakeLists.txt
@@ -1,10 +1,12 @@
-set(SOURCES OSScreenSaverOSX.cpp
+set(SOURCES CocoaDPMSSupport.cpp
+            OSScreenSaverOSX.cpp
             WinEventsOSX.mm
             WinEventsSDL.cpp
             WinSystemOSX.mm
             WinSystemOSXGL.mm
             VideoSyncOsx.cpp)
-set(HEADERS OSScreenSaverOSX.h
+set(HEADERS CocoaDPMSSupport.h
+            OSScreenSaverOSX.h
             WinEventsOSX.h
             WinEventsSDL.h
             WinSystemOSX.h

--- a/xbmc/windowing/osx/CocoaDPMSSupport.cpp
+++ b/xbmc/windowing/osx/CocoaDPMSSupport.cpp
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CocoaDPMSSupport.h"
+
+#include "ServiceBroker.h"
+#include "utils/log.h"
+
+#include <CoreFoundation/CFNumber.h>
+#include <IOKit/IOKitLib.h>
+
+CCocoaDPMSSupport::CCocoaDPMSSupport()
+{
+  m_supportedModes.push_back(OFF);
+  m_supportedModes.push_back(STANDBY);
+}
+
+bool CCocoaDPMSSupport::EnablePowerSaving(PowerSavingMode mode)
+{
+  // http://lists.apple.com/archives/Cocoa-dev/2007/Nov/msg00267.html
+  // This is an unsupported system call that might kernel panic on PPC boxes
+  // The reported OSX-PPC panic is unverified so we are going to enable this until
+  // we find out which OSX-PPC boxes have problems, then add detect/disable for those boxes.
+  io_registry_entry_t r = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/IOResources/IODisplayWrangler");
+  if (!r)
+    return false;
+
+  switch (mode)
+  {
+  case OFF:
+  case STANDBY:
+    return (IORegistryEntrySetCFProperty(r, CFSTR("IORequestIdle"), kCFBooleanTrue) == 0);
+  default:
+    return false;
+  }
+}
+
+bool CCocoaDPMSSupport::DisablePowerSaving()
+{
+  // http://lists.apple.com/archives/Cocoa-dev/2007/Nov/msg00267.html
+  // This is an unsupported system call that might kernel panic on PPC boxes
+  // The reported OSX-PPC panic is unverified so we are going to enable this until
+  // we find out which OSX-PPC boxes have problems, then add detect/disable for those boxes.
+  io_registry_entry_t r = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/IOResources/IODisplayWrangler");
+  if (!r)
+    return false;
+
+  // Turn display on
+  return (IORegistryEntrySetCFProperty(r, CFSTR("IORequestIdle"), kCFBooleanFalse) == 0);
+}

--- a/xbmc/windowing/osx/CocoaDPMSSupport.h
+++ b/xbmc/windowing/osx/CocoaDPMSSupport.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "xbmc/powermanagement/DPMSSupport.h"
+
+class CCocoaDPMSSupport : public CDPMSSupport
+{
+public:
+  CCocoaDPMSSupport();
+  ~CCocoaDPMSSupport() = default;
+
+protected:
+  bool EnablePowerSaving(PowerSavingMode mode) override;
+  bool DisablePowerSaving() override;
+};

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -40,6 +40,7 @@
 #include "platform/darwin/osx/CocoaInterface.h"
 #include "platform/darwin/DictionaryUtils.h"
 #include "platform/darwin/DarwinUtils.h"
+#include "windowing/osx/CocoaDPMSSupport.h"
 
 #include <cstdlib>
 #include <signal.h>
@@ -655,6 +656,7 @@ CWinSystemOSX::CWinSystemOSX() : CWinSystemBase(), m_lostDeviceTimer(this)
   AE::CAESinkFactory::ClearSinks();
   CAESinkDARWINOSX::Register();
   CCocoaPowerSyscall::Register();
+  m_dpms = std::make_shared<CCocoaDPMSSupport>();
 }
 
 CWinSystemOSX::~CWinSystemOSX()

--- a/xbmc/windowing/windows/CMakeLists.txt
+++ b/xbmc/windowing/windows/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES VideoSyncD3D.cpp
+            Win32DPMSSupport.cpp
             WinEventsWin32.cpp
             WinSystemWin32.cpp
             WinSystemWin32DX.cpp)
 
 set(HEADERS VideoSyncD3D.h
+            Win32DPMSSupport.h
             WinEventsWin32.h
             WinSystemWin32.h
             WinSystemWin32DX.h

--- a/xbmc/windowing/windows/Win32DPMSSupport.cpp
+++ b/xbmc/windowing/windows/Win32DPMSSupport.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "Win32DPMSSupport.h"
+
+#include "rendering/dx/RenderContext.h"
+#include "ServiceBroker.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
+#include "windowing/windows/WinSystemWin32.h"
+
+CWin32DPMSSupport::CWin32DPMSSupport()
+{
+  m_supportedModes.push_back(OFF);
+  m_supportedModes.push_back(STANDBY);
+}
+
+bool CWin32DPMSSupport::EnablePowerSaving(PowerSavingMode mode)
+{
+  auto winSystem = dynamic_cast<CWinSystemWin32*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return false;
+
+  if (!winSystem->GetGfxContext().IsFullScreenRoot())
+  {
+    CLog::Log(LOGDEBUG, "DPMS: not in fullscreen, power saving disabled");
+    return false;
+  }
+
+  switch (mode)
+  {
+  case OFF:
+    // Turn off display
+    return SendMessage(DX::Windowing()->GetHwnd(), WM_SYSCOMMAND, SC_MONITORPOWER, static_cast<LPARAM>(2)) == 0;
+  case STANDBY:
+    // Set display to low power
+    return SendMessage(DX::Windowing()->GetHwnd(), WM_SYSCOMMAND, SC_MONITORPOWER, static_cast<LPARAM>(1)) == 0;
+  default:
+    return true;
+  }
+}
+
+bool CWin32DPMSSupport::DisablePowerSaving()
+{
+  // Turn display on
+  return SendMessage(DX::Windowing()->GetHwnd(), WM_SYSCOMMAND, SC_MONITORPOWER, static_cast<LPARAM>(-1)) == 0;
+}

--- a/xbmc/windowing/windows/Win32DPMSSupport.h
+++ b/xbmc/windowing/windows/Win32DPMSSupport.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2009-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "xbmc/powermanagement/DPMSSupport.h"
+
+class CWin32DPMSSupport : public CDPMSSupport
+{
+public:
+  CWin32DPMSSupport();
+  ~CWin32DPMSSupport() = default;
+
+protected:
+  bool EnablePowerSaving(PowerSavingMode mode) override;
+  bool DisablePowerSaving() override;
+};

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -29,6 +29,7 @@
 #include "utils/SystemInfo.h"
 #include "VideoSyncD3D.h"
 #include "windowing/GraphicContext.h"
+#include "windowing/windows/Win32DPMSSupport.h"
 #include "WinEventsWin32.h"
 
 #include <algorithm>
@@ -73,6 +74,7 @@ CWinSystemWin32::CWinSystemWin32()
     m_irss.reset(new CIRServerSuite());
     m_irss->Initialize();
   }
+  m_dpms = std::make_shared<CWin32DPMSSupport>();
 }
 
 CWinSystemWin32::~CWinSystemWin32()


### PR DESCRIPTION
This is a pretty big change, I'm not sure if it was possible to organise it into smaller commits.

Basically it is a code reshuffle and moves the platform specific code to the platform specific directories (`platform/*/powermanagement/`). Then adds registration to service broker where platform dpms can register. This allows us to return a pointer to CApplication and if nullptr then dpms isn't supported.

I tried to keep the platform code the exact same, so please say something if you noticed that it has changed.

I've build and run tested on GBM/linux

I still need to do the registration for OSX and Win32 but I'm not sure where that should be done as I'm not familiar with those platforms.