### PR TITLE
Prefer stereo streams if user has configured 2.0 in AE

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3210,6 +3210,8 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   else
     options.fullscreen = g_advancedSettings.m_fullScreenOnMovieStart && !CMediaSettings::GetInstance().DoesVideoStartWindowed();
 
+  options.preferStereo = CServiceBroker::GetActiveAE()->HasStereoAudioChannelCount();
+
   // reset VideoStartWindowed as it's a temp setting
   CMediaSettings::GetInstance().SetVideoStartWindowed(false);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2686,9 +2686,7 @@ bool CActiveAE::HasStereoAudioChannelCount()
   std::string device = CServiceBroker::GetSettings().GetString(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
   int numChannels = (m_sink.GetDeviceType(device) == AE_DEVTYPE_IEC958) ? AE_CH_LAYOUT_2_0 : CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOOUTPUT_CHANNELS);
   bool passthrough = CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOOUTPUT_CONFIG) == AE_CONFIG_FIXED ? false : CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH);
-  return numChannels == AE_CH_LAYOUT_2_0 && ! (passthrough &&
-    CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_AC3PASSTHROUGH) &&
-    CServiceBroker::GetSettings().GetBool(CSettings::SETTING_AUDIOOUTPUT_AC3TRANSCODE));
+  return numChannels == AE_CH_LAYOUT_2_0 && !passthrough;
 }
 
 bool CActiveAE::HasHDAudioChannelCount()

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -45,13 +45,15 @@ public:
     starttime = 0LL;
     startpercent = 0LL;
     fullscreen = false;
-    video_only = false;
+    videoOnly = false;
+    preferStereo = false;
   }
-  double  starttime; /* start time in seconds */
-  double  startpercent; /* start time in percent */  
+  double starttime; /* start time in seconds */
+  double startpercent; /* start time in percent */
   std::string state;  /* potential playerstate to restore to */
-  bool    fullscreen; /* player is allowed to switch to fullscreen */
-  bool    video_only; /* player is not allowed to play audio streams, video streams only */
+  bool fullscreen; /* player is allowed to switch to fullscreen */
+  bool videoOnly; /* player is not allowed to play audio streams, video streams only */
+  bool preferStereo; /* prefer stereo streams when selecting initial audio stream*/
 };
 
 class CFileItem;


### PR DESCRIPTION
## Description
For media which includes both stereo and multi channel streams we currently select by default the multichannel stream.
For most of our 2.0 users this means that much more data download as required and that extra CPU is used for downmixing.
This PR requests from AE, if we have a pure 2.0 user. If so, prefer stereo streams by default. 

## Motivation and Context
- reduce unneccessary download bandwidth
- reduce CPU
- reduce risk to be blacklisted from contentproviders (they have to pay the bill)

## How Has This Been Tested?
Win10 / amazon addon / baywatch

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
