### PR TITLE
[PVR] CGUIWindowPVRBase multithreading fixes

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -194,7 +194,8 @@ bool CGUIWindowPVRBase::OnAction(const CAction &action)
     case ACTION_NEXT_CHANNELGROUP:
     {
       // switch to next or previous group
-      SetChannelGroup(action.GetID() == ACTION_NEXT_CHANNELGROUP ? m_channelGroup->GetNextGroup() : m_channelGroup->GetPreviousGroup());
+      const CPVRChannelGroupPtr channelGroup = GetChannelGroup();
+      SetChannelGroup(action.GetID() == ACTION_NEXT_CHANNELGROUP ? channelGroup->GetNextGroup() : channelGroup->GetPreviousGroup());
       return true;
     }
     case ACTION_MOVE_RIGHT:
@@ -248,7 +249,7 @@ void CGUIWindowPVRBase::OnInitWindow(void)
     m_viewControl.SetSelectedItem(CServiceBroker::GetPVRManager().GUIActions()->GetSelectedItemPath(m_bRadio));
 
     // This has to be done after base class OnInitWindow to restore correct selection
-    m_channelGroupsSelector->SelectChannelGroup(m_channelGroup);
+    m_channelGroupsSelector->SelectChannelGroup(GetChannelGroup());
   }
   else
   {
@@ -302,7 +303,7 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
           // late init
           InitChannelGroup();
           m_channelGroupsSelector->Initialize(this, m_bRadio);
-          m_channelGroupsSelector->SelectChannelGroup(m_channelGroup);
+          m_channelGroupsSelector->SelectChannelGroup(GetChannelGroup());
           RegisterObservers();
           HideProgressDialog();
           Refresh(true);
@@ -376,7 +377,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog(void)
   dialog->SetHeading(CVariant{g_localizeStrings.Get(19146)});
   dialog->SetItems(options);
   dialog->SetMultiSelection(false);
-  dialog->SetSelected(m_channelGroup->GroupName());
+  dialog->SetSelected(GetChannelGroup()->GroupName());
   dialog->Open();
 
   if (!dialog->IsConfirmed())
@@ -478,8 +479,9 @@ void CGUIWindowPVRBase::UpdateButtons(void)
 {
   CGUIMediaWindow::UpdateButtons();
 
-  SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + m_channelGroup->GroupName());
-  m_channelGroupsSelector->SelectChannelGroup(m_channelGroup);
+  const CPVRChannelGroupPtr channelGroup = GetChannelGroup();
+  SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + channelGroup->GroupName());
+  m_channelGroupsSelector->SelectChannelGroup(channelGroup);
 }
 
 void CGUIWindowPVRBase::ShowProgressDialog(const std::string &strText, int iProgress)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -393,14 +393,14 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog(void)
 
 bool CGUIWindowPVRBase::InitChannelGroup()
 {
-  const CPVRChannelGroupPtr group(CServiceBroker::GetPVRManager().GetPlayingGroup(m_bRadio));
+  CPVRChannelGroupPtr group(CServiceBroker::GetPVRManager().GetPlayingGroup(m_bRadio));
   if (group)
   {
     CSingleLock lock(m_critSection);
     if (m_channelGroup != group)
     {
       m_viewControl.SetSelectedItem(0);
-      SetChannelGroup(group, false);
+      SetChannelGroup(std::move(group), false);
     }
     // Path might have changed since last init. Set it always, not just on group change.
     m_vecItems->SetPath(GetDirectoryPath());
@@ -415,7 +415,7 @@ CPVRChannelGroupPtr CGUIWindowPVRBase::GetChannelGroup(void)
   return m_channelGroup;
 }
 
-void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group, bool bUpdate /* = true */)
+void CGUIWindowPVRBase::SetChannelGroup(CPVRChannelGroupPtr &&group, bool bUpdate /* = true */)
 {
   if (!group)
     return;
@@ -427,7 +427,7 @@ void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group, bool b
     {
       if (m_channelGroup)
         m_channelGroup->UnregisterObserver(this);
-      m_channelGroup = group;
+      m_channelGroup = std::move(group);
       // we need to register the window to receive changes from the new group
       m_channelGroup->RegisterObserver(this);
       if (bUpdate)

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -194,8 +194,10 @@ bool CGUIWindowPVRBase::OnAction(const CAction &action)
     case ACTION_NEXT_CHANNELGROUP:
     {
       // switch to next or previous group
-      const CPVRChannelGroupPtr channelGroup = GetChannelGroup();
-      SetChannelGroup(action.GetID() == ACTION_NEXT_CHANNELGROUP ? channelGroup->GetNextGroup() : channelGroup->GetPreviousGroup());
+      if (const CPVRChannelGroupPtr channelGroup = GetChannelGroup())
+      {
+        SetChannelGroup(action.GetID() == ACTION_NEXT_CHANNELGROUP ? channelGroup->GetNextGroup() : channelGroup->GetPreviousGroup());
+      }
       return true;
     }
     case ACTION_MOVE_RIGHT:
@@ -377,7 +379,10 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog(void)
   dialog->SetHeading(CVariant{g_localizeStrings.Get(19146)});
   dialog->SetItems(options);
   dialog->SetMultiSelection(false);
-  dialog->SetSelected(GetChannelGroup()->GroupName());
+  if (const CPVRChannelGroupPtr channelGroup = GetChannelGroup())
+  {
+    dialog->SetSelected(channelGroup->GroupName());
+  }
   dialog->Open();
 
   if (!dialog->IsConfirmed())
@@ -480,7 +485,11 @@ void CGUIWindowPVRBase::UpdateButtons(void)
   CGUIMediaWindow::UpdateButtons();
 
   const CPVRChannelGroupPtr channelGroup = GetChannelGroup();
-  SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + channelGroup->GroupName());
+  if (channelGroup)
+  {
+    SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS, g_localizeStrings.Get(19141) + ": " + channelGroup->GroupName());
+  }
+
   m_channelGroupsSelector->SelectChannelGroup(channelGroup);
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -420,7 +420,7 @@ void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group, bool b
   if (!group)
     return;
 
-  CPVRChannelGroupPtr channelGroup;
+  CPVRChannelGroupPtr updateChannelGroup;
   {
     CSingleLock lock(m_critSection);
     if (m_channelGroup != group)
@@ -430,13 +430,14 @@ void CGUIWindowPVRBase::SetChannelGroup(const CPVRChannelGroupPtr &group, bool b
       m_channelGroup = group;
       // we need to register the window to receive changes from the new group
       m_channelGroup->RegisterObserver(this);
-      channelGroup = m_channelGroup;
+      if (bUpdate)
+        updateChannelGroup = m_channelGroup;
     }
   }
 
-  if (bUpdate && channelGroup)
+  if (updateChannelGroup)
   {
-    CServiceBroker::GetPVRManager().SetPlayingGroup(channelGroup);
+    CServiceBroker::GetPVRManager().SetPlayingGroup(updateChannelGroup);
     Update(GetDirectoryPath());
   }
 }

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -105,7 +105,7 @@ namespace PVR
      * @param group The new group.
      * @param bUpdate if true, window content will be updated.
      */
-    void SetChannelGroup(const CPVRChannelGroupPtr &group, bool bUpdate = true);
+    void SetChannelGroup(CPVRChannelGroupPtr &&group, bool bUpdate = true);
 
     virtual void UpdateSelectedItemPath();
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -98,7 +98,7 @@ namespace PVR
      * @brief Get the channel group for this window.
      * @return the group or null, if no group set.
      */
-   virtual CPVRChannelGroupPtr GetChannelGroup(void);
+   CPVRChannelGroupPtr GetChannelGroup(void);
 
     /*!
      * @brief Set a new channel group, start listening to this group, optionally update window content.


### PR DESCRIPTION
Fixes a nullptr dereference which could occur after the VNSI
connection was closed by VDR:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __GI___pthread_mutex_lock (mutex=0xf0) at ../nptl/pthread_mutex_lock.c:65
65	../nptl/pthread_mutex_lock.c: No such file or directory.
[Current thread is 1 (Thread 0x7fabcc406980 (LWP 686))]
(gdb) bt
#0  __GI___pthread_mutex_lock (mutex=0xf0) at ../nptl/pthread_mutex_lock.c:65
#1  0x000055afd0fd788c in (anonymous namespace)::CRecursiveMutex::lock (this=0xf0)
    at xbmc/threads/platform/RecursiveMutex.h:45
#2  0x000055afd0fd8978 in (anonymous namespace)::CountingLockable<XbmcThreads::CRecursiveMutex>::lock (this=0xf0)
    at xbmc/threads/Lockables.h:63
#3  0x000055afd0fd87c6 in (anonymous namespace)::UniqueLock<CCriticalSection>::UniqueLock (this=0x7ffd221f0450, lockable=...)
    at xbmc/threads/Lockables.h:132
#4  0x000055afd0ff3fed in CSingleLock::CSingleLock (this=0x7ffd221f0450, cs=...) at xbmc/threads/SingleLock.h:39
#5  0x000055afd1bc6147 in PVR::CPVRChannelGroup::GroupName (this=0x0) at xbmc/pvr/channels/PVRChannelGroup.cpp:1142
#6  0x000055afd1b31555 in PVR::CGUIWindowPVRBase::UpdateButtons (this=0x55afd6d030b0)
    at xbmc/pvr/windows/GUIWindowPVRBase.cpp:480
#7  0x000055afd1b39898 in PVR::CGUIWindowPVRRecordingsBase::UpdateButtons (this=0x55afd6d030b0)
    at xbmc/pvr/windows/GUIWindowPVRRecordings.cpp:187
#8  0x000055afd1459dc7 in CGUIMediaWindow::Update (this=0x55afd6d030b0, strDirectory=..., updateFilterPath=true)
    at xbmc/windows/GUIMediaWindow.cpp:905
```
