### PR TITLE
PVRClient: protect access to m_timertypes

### DIFF
--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -103,6 +103,8 @@ ADDON::AddonPtr CPVRClient::GetRunningInstance() const
 
 void CPVRClient::ResetProperties(int iClientId /* = PVR_INVALID_CLIENT_ID */)
 {
+  CSingleLock lock(m_critSection);
+
   /* initialise members */
   m_strUserPath           = CSpecialProtocol::TranslatePath(Profile());
   m_strClientPath         = CSpecialProtocol::TranslatePath(Path());
@@ -503,6 +505,7 @@ bool CPVRClient::GetAddonProperties(void)
     retVal = PVR_ERROR_NO_ERROR; // timer support is optional.
 
   /* update the members */
+  CSingleLock lock(m_critSection);
   m_strBackendName      = strBackendName;
   m_strConnectionString = strConnectionString;
   m_strFriendlyName     = strFriendlyName;
@@ -1016,6 +1019,7 @@ PVR_ERROR CPVRClient::UpdateTimer(const CPVRTimerInfoTag &timer)
 
 PVR_ERROR CPVRClient::GetTimerTypes(CPVRTimerTypes& results) const
 {
+  CSingleLock lock(m_critSection);
   results = m_timertypes;
   return PVR_ERROR_NO_ERROR;
 }


### PR DESCRIPTION
Probably many more attributes need to be protected, but this commit
aims to fix just this crash bug:

```
==2579==ERROR: AddressSanitizer: heap-use-after-free on address 0x611003c48200 at pc 0x555558929511 bp 0x7fffc7fc2710 sp 0x7fffc7fc2708
READ of size 8 at 0x611003c48200 thread T168 (PVRManager)
    #0 0x555558929510 in std::_Sp_counted_ptr<PVR::CPVRTimerType*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d5510)
    #1 0x555557165886 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x1c11886)
    #2 0x555557162ff9 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x1c0eff9)
    #3 0x555558913621 in std::__shared_ptr<PVR::CPVRTimerType, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33bf621)
    #4 0x555558913663 in std::shared_ptr<PVR::CPVRTimerType>::~shared_ptr() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33bf663)
    #5 0x555558926430 in void std::_Destroy<std::shared_ptr<PVR::CPVRTimerType> >(std::shared_ptr<PVR::CPVRTimerType>*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d2430)
    #6 0x555558924b2e in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<PVR::CPVRTimerType>*>(std::shared_ptr<PVR::CPVRTimerType>*, std::shared_ptr<PVR::CPVRTimerType>*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d0b2e)
    #7 0x5555589201a7 in void std::_Destroy<std::shared_ptr<PVR::CPVRTimerType>*>(std::shared_ptr<PVR::CPVRTimerType>*, std::shared_ptr<PVR::CPVRTimerType>*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33cc1a7)
    #8 0x55555891a094 in void std::_Destroy<std::shared_ptr<PVR::CPVRTimerType>*, std::shared_ptr<PVR::CPVRTimerType> >(std::shared_ptr<PVR::CPVRTimerType>*, std::shared_ptr<PVR::CPVRTimerType>*, std::allocator<std::shared_ptr<PVR::CPVRTimerType> >&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33c6094)
    #9 0x555558916a51 in std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > >::~vector() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33c2a51)
    #10 0x555558e3fe5b in PVR::CPVRTimerType::CreateFromAttributes(unsigned int, unsigned int, int) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x38ebe5b)
    #11 0x555558e0ac61 in PVR::CPVRTimerInfoTag::CPVRTimerInfoTag(bool) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x38b6c61)
    #12 0x555558e26831 in PVR::CPVRTimers::UpdateEntries(PVR::CPVRTimersContainer const&, std::vector<int, std::allocator<int> > const&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x38d2831)
    #13 0x555558e24fa6 in PVR::CPVRTimers::Update() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x38d0fa6)
    #14 0x555558e24b11 in PVR::CPVRTimers::Load() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x38d0b11)
    #15 0x555558fd3397 in PVR::CPVRManager::LoadComponents(PVR::CPVRGUIProgressHandler*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x3a7f397)
    #16 0x555558fd2362 in PVR::CPVRManager::Process() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x3a7e362)
    #17 0x555558038fe0 in CThread::Action() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x2ae4fe0)
    #18 0x5555580386cc in CThread::staticThread(void*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x2ae46cc)
    #19 0x7ffff6c0e5a9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x75a9)
    #20 0x7fffee013cbe in __clone (/lib/x86_64-linux-gnu/libc.so.6+0xf6cbe)

0x611003c48200 is located 0 bytes inside of 216-byte region [0x611003c48200,0x611003c482d8)
freed by thread T166 (JobWorker) here:
    #0 0x7ffff6f01040 in operator delete(void*) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdc040)
    #1 0x555558e4071b in PVR::CPVRTimerType::~CPVRTimerType() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x38ec71b)
    #2 0x555558929540 in std::_Sp_counted_ptr<PVR::CPVRTimerType*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d5540)
    #3 0x555557165886 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x1c11886)
    #4 0x55555738a63a in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_count<(__gnu_cxx::_Lock_policy)2> const&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x1e3663a)
    #5 0x555558926844 in std::__shared_ptr<PVR::CPVRTimerType, (__gnu_cxx::_Lock_policy)2>::operator=(std::__shared_ptr<PVR::CPVRTimerType, (__gnu_cxx::_Lock_policy)2> const&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d2844)
    #6 0x55555892686e in std::shared_ptr<PVR::CPVRTimerType>::operator=(std::shared_ptr<PVR::CPVRTimerType> const&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d286e)
    #7 0x5555589268b8 in std::shared_ptr<PVR::CPVRTimerType>* std::__copy_move<false, false, std::random_access_iterator_tag>::__copy_m<std::shared_ptr<PVR::CPVRTimerType> const*, std::shared_ptr<PVR::CPVRTimerType>*>(std::shared_ptr<PVR::CPVRTimerType> const*, std::shared_ptr<PVR::CPVRTimerType> const*, std::shared_ptr<PVR::CPVRTimerType>*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d28b8)
    #8 0x555558924ed2 in std::shared_ptr<PVR::CPVRTimerType>* std::__copy_move_a<false, std::shared_ptr<PVR::CPVRTimerType> const*, std::shared_ptr<PVR::CPVRTimerType>*>(std::shared_ptr<PVR::CPVRTimerType> const*, std::shared_ptr<PVR::CPVRTimerType> const*, std::shared_ptr<PVR::CPVRTimerType>*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33d0ed2)
    #9 0x55555892094e in __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType>*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > > std::__copy_move_a2<false, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType> const*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType>*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > > >(__gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType> const*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType> const*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType>*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33cc94e)
    #10 0x55555891b4ad in __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType>*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > > std::copy<__gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType> const*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType>*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > > >(__gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType> const*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType> const*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >, __gnu_cxx::__normal_iterator<std::shared_ptr<PVR::CPVRTimerType>*, std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > >) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33c74ad)
    #11 0x55555891757f in std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > >::operator=(std::vector<std::shared_ptr<PVR::CPVRTimerType>, std::allocator<std::shared_ptr<PVR::CPVRTimerType> > > const&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x33c357f)
    #12 0x5555588e314e in PVR::CPVRClient::GetAddonProperties() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x338f14e)
    #13 0x555558f89eec in PVR::CPVRClients::ConnectionStateChange(PVR::CPVRClient*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, PVR_CONNECTION_STATE, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x3a35eec)
    #14 0x55555904915e in PVR::CPVRClientConnectionJob::DoWork() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x3af515e)
    #15 0x555557ea8995 in CJobWorker::Process() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x2954995)
    #16 0x555558038fe0 in CThread::Action() (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x2ae4fe0)
    #17 0x5555580386cc in CThread::staticThread(void*) (/usr/local/stow/kodi-asan/lib/kodi/kodi-x11+0x2ae46cc)
    #18 0x7ffff6c0e5a9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x75a9)
```
