### PR TITLE
Eac3 encrypted

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodec.h
@@ -82,12 +82,6 @@ public:
   virtual bool AddData(const DemuxPacket &packet) = 0;
 
   /*
-   * returns nr of bytes in decode buffer
-   * the data is valid until the next call
-   */
-  virtual int GetData(uint8_t** dst) = 0;
-
-  /*
    * the data is valid until the next call
    */
   virtual void GetData(DVDAudioFrame &frame) = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
@@ -48,13 +48,13 @@ public:
 
   // required overrides
 public:
-  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
-  virtual void Dispose() override;
-  virtual bool AddData(const DemuxPacket &packet) override;
-  virtual void GetData(DVDAudioFrame &frame) override;
-  virtual void Reset() override;
-  virtual AEAudioFormat GetFormat() override { return m_format; }
-  virtual const char* GetName() override { return "mediacodec"; }
+  bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
+  void Dispose() override;
+  bool AddData(const DemuxPacket &packet) override;
+  void GetData(DVDAudioFrame &frame) override;
+  void Reset() override;
+  AEAudioFormat GetFormat() override;
+  const char* GetName() override { return "mediacodec"; }
 
 protected:
   int GetData(uint8_t** dst);
@@ -72,7 +72,7 @@ protected:
   std::string m_mime;
   std::string m_codecname;
   std::string m_formatname;
-  bool m_opened;
+  bool m_opened, m_resettable;
   int m_samplerate;
   int m_channels;
   uint8_t* m_buffer;
@@ -83,4 +83,5 @@ protected:
 
   std::shared_ptr<CJNIMediaCodec> m_codec;
   CJNIMediaCrypto *m_crypto;
+  std::shared_ptr<CDVDAudioCodec> m_decryptCodec;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
@@ -52,12 +52,12 @@ public:
   virtual void Dispose() override;
   virtual bool AddData(const DemuxPacket &packet) override;
   virtual void GetData(DVDAudioFrame &frame) override;
-  virtual int GetData(uint8_t** dst) override;
   virtual void Reset() override;
   virtual AEAudioFormat GetFormat() override { return m_format; }
   virtual const char* GetName() override { return "mediacodec"; }
-  
+
 protected:
+  int GetData(uint8_t** dst);
   int GetChannels() { return m_channels; }
   int GetEncodedChannels() { return m_channels; }
   CAEChannelInfo GetChannelMap();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -55,6 +55,12 @@ CDVDAudioCodecFFmpeg::~CDVDAudioCodecFFmpeg()
 
 bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+  if (hints.cryptoSession)
+  {
+    CLog::Log(LOGERROR,"CDVDAudioCodecFFmpeg::Open() CryptoSessions unsuppoted!");
+    return false;
+  }
+
   AVCodec* pCodec = NULL;
   bool allowdtshddecode = true;
 
@@ -128,6 +134,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_matrixEncoding = AV_MATRIX_ENCODING_NONE;
 
   m_processInfo.SetAudioDecoderName(m_pCodecContext->codec->name);
+  CLog::Log(LOGNOTICE,"CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder %s", m_pCodecContext->codec->name);
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -42,7 +42,6 @@ public:
   void Dispose() override;
   bool AddData(const DemuxPacket &packet) override;
   void GetData(DVDAudioFrame &frame) override;
-  int GetData(uint8_t** dst) override;
   void Reset() override;
   AEAudioFormat GetFormat() override { return m_format; }
   const char* GetName() override { return "FFmpeg"; }
@@ -51,6 +50,7 @@ public:
   int GetProfile() override;
 
 protected:
+  int GetData(uint8_t** dst);
   enum AEDataFormat GetDataFormat();
   int GetSampleRate();
   int GetChannels();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -40,7 +40,6 @@ public:
   void Dispose() override;
   bool AddData(const DemuxPacket &packet) override;
   void GetData(DVDAudioFrame &frame) override;
-  int GetData(uint8_t** dst) override;
   void Reset() override;
   AEAudioFormat GetFormat() override { return m_format; }
   bool NeedPassthrough() override { return true; }
@@ -48,6 +47,7 @@ public:
   int GetBufferSize() override;
 
 private:
+  int GetData(uint8_t** dst);
   CAEStreamParser m_parser;
   uint8_t* m_buffer = nullptr;
   unsigned int m_bufferSize = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -185,6 +185,12 @@ CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, CProces
   std::unique_ptr<CDVDAudioCodec> pCodec;
   CDVDCodecOptions options;
 
+  if (allowpassthrough && ptStreamType != CAEStreamInfo::STREAM_TYPE_NULL)
+    options.m_keys.push_back(CDVDCodecOption("ptstreamtype", StringUtils::SizeToString(ptStreamType)));
+
+  if (!allowdtshddecode)
+    options.m_keys.push_back(CDVDCodecOption("allowdtshddecode", "0"));
+
   // platform specifig audio decoders
   for (auto &codec : m_hwAudioCodecs)
   {
@@ -194,9 +200,6 @@ CDVDAudioCodec* CDVDFactoryCodec::CreateAudioCodec(CDVDStreamInfo &hint, CProces
       return pCodec.release();
     }
   }
-
-  if (!allowdtshddecode)
-    options.m_keys.push_back(CDVDCodecOption("allowdtshddecode", "0"));
 
   // we don't use passthrough if "sync playback to display" is enabled
   if (allowpassthrough && ptStreamType != CAEStreamInfo::STREAM_TYPE_NULL)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -353,6 +353,12 @@ CDVDVideoCodecFFmpeg::~CDVDVideoCodecFFmpeg()
 
 bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
+  if (hints.cryptoSession)
+  {
+    CLog::Log(LOGERROR,"CDVDVideoCodecFFmpeg::Open() CryptoSessions unsuppoted!");
+    return false;
+  }
+
   m_hints = hints;
   m_options = options;
 

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -349,23 +349,24 @@ int VideoPlayerCodec::ReadPCM(unsigned char *pBuffer, int size, int *actualsize)
     {
       int samples = *actualsize / (m_bitsPerSample>>3);
       int frames = samples / m_channels;
-      m_pResampler->Resample(&pBuffer, frames, m_audioPlanes, frames, 1.0);
+      m_pResampler->Resample(&pBuffer, frames, m_audioFrame.data, frames, 1.0);
       for (int i=0; i<m_planes; i++)
       {
-        m_audioPlanes[i] += frames*m_srcFormat.m_frameSize/m_planes;
+        m_audioFrame.data[i] += frames*m_srcFormat.m_frameSize/m_planes;
       }
     }
     else
     {
-      memcpy(pBuffer, m_audioPlanes[0], *actualsize);
-      m_audioPlanes[0] += (*actualsize);
+      memcpy(pBuffer, m_audioFrame.data[0], *actualsize);
+      m_audioFrame.data[0] += (*actualsize);
     }
     m_nDecodedLen -= nLen;
     return READ_SUCCESS;
   }
 
   m_nDecodedLen = 0;
-  int bytes = m_pAudioCodec->GetData(m_audioPlanes);
+  m_pAudioCodec->GetData(m_audioFrame);
+  int bytes = m_audioFrame.nb_frames * m_audioFrame.framesize;
 
   if (!bytes)
   {
@@ -390,7 +391,8 @@ int VideoPlayerCodec::ReadPCM(unsigned char *pBuffer, int size, int *actualsize)
       return READ_ERROR;
     }
 
-    bytes = m_pAudioCodec->GetData(m_audioPlanes);
+    m_pAudioCodec->GetData(m_audioFrame);
+    bytes = m_audioFrame.nb_frames * m_audioFrame.framesize;
   }
 
   m_nDecodedLen = bytes;
@@ -405,16 +407,16 @@ int VideoPlayerCodec::ReadPCM(unsigned char *pBuffer, int size, int *actualsize)
     {
       int samples = *actualsize / (m_bitsPerSample>>3);
       int frames = samples / m_channels;
-      m_pResampler->Resample(&pBuffer, frames, m_audioPlanes, frames, 1.0);
+      m_pResampler->Resample(&pBuffer, frames, m_audioFrame.data, frames, 1.0);
       for (int i=0; i<m_planes; i++)
       {
-        m_audioPlanes[i] += frames*m_srcFormat.m_frameSize/m_planes;
+        m_audioFrame.data[i] += frames*m_srcFormat.m_frameSize/m_planes;
       }
     }
     else
     {
-      memcpy(pBuffer, m_audioPlanes[0], *actualsize);
-      m_audioPlanes[0] += *actualsize;
+      memcpy(pBuffer, m_audioFrame.data[0], *actualsize);
+      m_audioFrame.data[0] += *actualsize;
     }
     m_nDecodedLen -= *actualsize;
   }

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -68,7 +68,7 @@ private:
   bool m_bCanSeek;
 
   ActiveAE::IAEResample *m_pResampler;
-  uint8_t *m_audioPlanes[8];
+  DVDAudioFrame m_audioFrame;
   int m_planes;
   bool m_needConvert;
   AEAudioFormat m_srcFormat;

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -43,6 +43,7 @@
 #include "platform/android/powermanagement/AndroidPowerSyscall.h"
 #include "addons/interfaces/platform/android/System.h"
 #include "platform/android/drm/MediaDrmCryptoSession.h"
+#include <androidjni/MediaCodecList.h>
 
 #include <EGL/egl.h>
 #include <EGL/eglplatform.h>
@@ -236,6 +237,17 @@ void CWinSystemAndroid::UpdateResolutions()
     RESOLUTION_INFO desktop = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
     CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop);
     CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop) = desktop;
+  }
+
+  unsigned int num_codecs = CJNIMediaCodecList::getCodecCount();
+  for (int i = 0; i < num_codecs; i++)
+  {
+    CJNIMediaCodecInfo codec_info = CJNIMediaCodecList::getCodecInfoAt(i);
+    if (codec_info.isEncoder())
+      continue;
+
+    std::string codecname = codec_info.getName();
+    CLog::Log(LOGNOTICE, "Mediacodec: %s", codecname.c_str());
   }
 }
 


### PR DESCRIPTION
## Description
This PR continues implmentation of the Android MediaCodec audio decoder.

- Use system decoder if available / matching to users needs
- Implement raw (pure encrypting) decoder

## Motivation and Context
Allow encrypted dolby streams for android (amazon addon)

## How Has This Been Tested?
shield + aftv with following settings:

### Source eac3 5.1 clear (not encrypted):
- Channels = 2,0 Passthrough off -> internal dolby decoder is used (aftv3)
- Channels = 5.1, Passthrough off -> FFMpeg decoder is used
- Passthrough on : Passthrough decoder is used

### Source eac3 5.1 drm encrypted:
- Channels = 2,0 Passthrough off -> internal dolby decoder is used (aftv3)
- Channels = 5.1, Passthrough off -> Raw decrypter + FFMpeg decoder is used
- Passthrough on : raw decrypter + Passthrough decoder is used

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
