### PR TITLE
fix getting user input for directory search

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -205,6 +205,8 @@ bool CDirectory::GetDirectory(const CURL& url, std::shared_ptr<IDirectory> pDire
         {
           if (!cancel)
           {
+            // @TODO ProcessRequirements() can bring up the keyboard input dialog
+            // filesystem must not depend on GUI
             if (g_application.IsCurrentThread() && pDirectory->ProcessRequirements())
             {
               authUrl.SetDomain("");

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -74,9 +74,9 @@ bool CVirtualDirectory::GetDirectory(const CURL& url, CFileItemList &items, bool
   if (!strPath.empty() && strPath != "files://")
   {
     CURL realURL = URIUtils::SubstitutePath(url);
-    m_pDir.reset(CDirectoryFactory::Create(realURL));
+    if (!m_pDir)
+      m_pDir.reset(CDirectoryFactory::Create(realURL));
     bool ret = CDirectory::GetDirectory(strPath, m_pDir, items, m_strFileMask, flags);
-    m_pDir.reset();
     return ret;
   }
 

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -60,6 +60,9 @@ namespace XFILE
 
     void AllowNonLocalSources(bool allow) { m_allowNonLocalSources = allow; };
 
+    std::shared_ptr<IDirectory> GetDirImpl() { return m_pDir; }
+    void ReleaseDirImpl() { m_pDir.reset(); }
+
   protected:
     void CacheThumbs(CFileItemList &items);
 


### PR DESCRIPTION
who would have thought that IDirectory::ProcessRequirements() brings up the keyboard for user intput

A method of an interface of some filesystem class does access the ui. indeed, here is everything wrong.