### PR TITLE
[darwin] inform about not implemented ExecWait

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2457,7 +2457,9 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
         CLog::Log(LOGNOTICE, "%s: Failed to suspend AudioEngine before launching external program", __FUNCTION__);
       }
     }
-#if defined( TARGET_POSIX) && !defined(TARGET_DARWIN)
+#if defined(TARGET_DARWIN)
+    CLog::Log(LOGNOTICE, "ExecWait is not implemented on this platform");
+#elif defined(TARGET_POSIX)
     CUtil::RunCommandLine(pMsg->strParam.c_str(), (pMsg->param1 == 1));
 #elif defined(TARGET_WINDOWS)
     CWIN32Util::XBMCShellExecute(pMsg->strParam.c_str(), (pMsg->param1 == 1));


### PR DESCRIPTION
## Description
`ExecWait` isn't implemented for darwin, inform about it in the log.

## Motivation and Context
fixes https://trac.kodi.tv/ticket/17331

## How Has This Been Tested?
compiled

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
