### PR TITLE
GUIMediaWindow: prevent vecItems from being updated by more than a si…

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -916,18 +916,31 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
 
 bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
 {
+  if (m_vecItemsUpdating)
+  {
+    CLog::Log(LOGWARNING, "CGUIMediaWindow::Update - updating in progress");
+    return false;
+  }
+
   std::string strCurrentDirectory = m_vecItems->GetPath();
   if (strCurrentDirectory == "?")
     return false;
 
+  m_vecItemsUpdating = true;
+
   if (clearCache)
     m_vecItems->RemoveDiscCache(GetID());
 
+  bool ret = true;
+
   // get the original number of items
   if (!Update(strCurrentDirectory, false))
-    return false;
+  {
+    ret = false;
+  }
 
-  return true;
+  m_vecItemsUpdating = false;
+  return ret;
 }
 
 /*!

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -27,6 +27,8 @@
 #include "playlists/SmartPlayList.h"
 #include "view/GUIViewControl.h"
 
+#include <atomic>
+
 class CFileItemList;
 class CGUIViewState;
 
@@ -189,6 +191,7 @@ protected:
   CFileItemList* m_unfilteredItems;        ///< \brief items prior to filtering using FilterItems()
   CDirectoryHistory m_history;
   std::unique_ptr<CGUIViewState> m_guiState;
+  std::atomic_bool m_vecItemsUpdating = {false};
 
   // save control state on window exit
   int m_iLastControl;


### PR DESCRIPTION
see title. prevents from multiple tasks updating vecItems at the same time

root cause should be fixed too!