### PR TITLE
[Android] remove try / catch around main thread

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -456,16 +456,10 @@ void CXBMCApp::run()
 
   m_firstrun=false;
   android_printf(" => running XBMC_Run...");
-  try
-  {
-    CAppParamParser appParamParser;
-    status = XBMC_Run(true, appParamParser);
-    android_printf(" => XBMC_Run finished with %d", status);
-  }
-  catch(...)
-  {
-    android_printf("ERROR: Exception caught on main loop. Exiting");
-  }
+
+  CAppParamParser appParamParser;
+  status = XBMC_Run(true, appParamParser);
+  android_printf(" => XBMC_Run finished with %d", status);
 
   // If we are have not been force by Android to exit, notify its finish routine.
   // This will cause android to run through its teardown events, it calls:


### PR DESCRIPTION
## Description
Exceptions in main thread are not properly shown in logcat because of the try / catch(...) exception handlerwhich encloses application run. beside this all threads continue running without the main thread what is wrong. 

## Motivation and Context
Double busy dialog throw does not lead to termination.

## How Has This Been Tested?
Wetek HUB / python addon which calls xbmc,execBuiltIn("Container.refresh") at the moment a playVideo ListItem is returned.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
