### PR TITLE
Fixed: IsType check now uses m_strDynPath

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1066,6 +1066,9 @@ bool CFileItem::IsPythonScript() const
 
 bool CFileItem::IsType(const char *ext) const
 {
+  if (!m_strDynPath.empty())
+    return URIUtils::HasExtension(m_strDynPath, ext);
+
   return URIUtils::HasExtension(m_strPath, ext);
 }
 


### PR DESCRIPTION
Recent commits moved some stream urls from the `m_strPath` to `m_strDynPath`. However not all checks in `FileItem.cpp` where updated for this change. 

## Description
This PR fixes the `IsType` check and fixes the issue that internet streams from an add-on are seen as local streams and do not get any http headers set. Discussed this with @FernetMenta on Slack.

## Motivation and Context
See the description.

## How Has This Been Tested?
Tested this with my Retrospect Add-on and the latest x64 Windows sources.

## Types of change
Expanded the `IsType` check to first see if there is a `m_strDynPath` and use that one if there was.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
