### PR TITLE
[Win] New log group LOGWINDOWING for event message logging / allow disabling IRServerSuite in advancedsettings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3150,7 +3150,12 @@ msgctxt "#683"
 msgid "Verbose logging of [B]audio/video timing information[/B]"
 msgstr ""
 
-#empty strings from id 684 to 699
+#: xbmc/settings/AdvancedSettings.cpp
+msgctxt "#684"
+msgid "Verbose logging of [B]Windowing[/B] component"
+msgstr ""
+
+#empty strings from id 685 to 699
 
 #: xbmc/music/infoscanner/MusicInfoScanner.cpp
 #: xbmc/music/MusicDatabase.cpp

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -55,6 +55,7 @@
 #define LOGWEBSERVER  (1 << (LOGMASKBIT + 11))
 #define LOGDATABASE   (1 << (LOGMASKBIT + 12))
 #define LOGAVTIMING   (1 << (LOGMASKBIT + 13))
+#define LOGWINDOWING  (1 << (LOGMASKBIT + 14))
 
 #include "utils/params_check_macros.h"
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -255,6 +255,7 @@ void CAdvancedSettings::Initialize()
 
   m_remoteDelay = 3;
   m_controllerDeadzone = 0.2f;
+  m_bScanIRServer = true;
 
   m_playlistAsFolders = true;
   m_detectAsUdf = false;
@@ -1011,6 +1012,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   XMLUtils::GetInt(pRootElement, "remotedelay", m_remoteDelay, 0, 20);
   XMLUtils::GetFloat(pRootElement, "controllerdeadzone", m_controllerDeadzone, 0.0f, 1.0f);
+  XMLUtils::GetBoolean(pRootElement, "scanirserver", m_bScanIRServer);
+
   XMLUtils::GetUInt(pRootElement, "fanartres", m_fanartRes, 0, 9999);
   XMLUtils::GetUInt(pRootElement, "imageres", m_imageRes, 0, 9999);
   if (XMLUtils::GetString(pRootElement, "imagescalingalgorithm", tmp))

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1375,6 +1375,7 @@ void CAdvancedSettings::SettingOptionsLoggingComponentsFiller(SettingConstPtr se
   list.push_back(std::make_pair(g_localizeStrings.Get(676), LOGAUDIO));
   list.push_back(std::make_pair(g_localizeStrings.Get(680), LOGVIDEO));
   list.push_back(std::make_pair(g_localizeStrings.Get(683), LOGAVTIMING));
+  list.push_back(std::make_pair(g_localizeStrings.Get(684), LOGWINDOWING));
 #ifdef HAS_DBUS
   list.push_back(std::make_pair(g_localizeStrings.Get(674), LOGDBUS));
 #endif

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -233,6 +233,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     StringMapping m_pathSubstitutions;
     int m_remoteDelay; ///< \brief number of remote messages to ignore before repeating
     float m_controllerDeadzone;
+    bool m_bScanIRServer;
 
     bool m_playlistAsFolders;
     bool m_detectAsUdf;

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -103,6 +103,7 @@ public:
     }
   }
 #define LogF(loglevel, ...) LogFunction((loglevel), __FUNCTION__, ##__VA_ARGS__)
+#define LogFC(loglevel, component, ...) LogFunction((loglevel), __FUNCTION__, (component), ##__VA_ARGS__)
   static void MemDump(char *pData, int length);
   static bool Init(const std::string& path);
   static void PrintDebugString(const std::string& line); // universal interface for printing debug strings

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -302,12 +302,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           appPort->SetRenderGUI(wParam != 0);
         if (g_application.GetRenderGUI() != active)
           DX::Windowing()->NotifyAppActiveChange(g_application.GetRenderGUI());
-        CLog::LogF(LOGDEBUG, "WM_SHOWWINDOW -> window is %s", wParam != 0 ? "shown" : "hidden");
+        CLog::LogFC(LOGDEBUG, LOGWINDOWING, "WM_SHOWWINDOW -> window is %s", wParam != 0 ? "shown" : "hidden");
       }
       break;
     case WM_ACTIVATE:
       {
-        CLog::LogF(LOGDEBUG, "WM_ACTIVATE -> window is %s", LOWORD(wParam) != WA_INACTIVE ? "active" : "inactive");
+        CLog::LogFC(LOGDEBUG, LOGWINDOWING, "WM_ACTIVATE -> window is %s", LOWORD(wParam) != WA_INACTIVE ? "active" : "inactive");
         bool active = g_application.GetRenderGUI();
         if (HIWORD(wParam))
         {
@@ -333,20 +333,20 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         }
         if (g_application.GetRenderGUI() != active)
           DX::Windowing()->NotifyAppActiveChange(g_application.GetRenderGUI());
-        CLog::LogF(LOGDEBUG, "window is %s", g_application.GetRenderGUI() ? "active" : "inactive");
+        CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window is %s", g_application.GetRenderGUI() ? "active" : "inactive");
       }
       break;
     case WM_SETFOCUS:
     case WM_KILLFOCUS:
       g_application.m_AppFocused = uMsg == WM_SETFOCUS;
-      CLog::LogF(LOGDEBUG, "window focus %s", g_application.m_AppFocused ? "set" : "lost");
+      CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window focus %s", g_application.m_AppFocused ? "set" : "lost");
 
       DX::Windowing()->NotifyAppFocusChange(g_application.m_AppFocused);
       if (uMsg == WM_KILLFOCUS)
       {
         std::string procfile;
         if (CWIN32Util::GetFocussedProcess(procfile))
-          CLog::LogF(LOGDEBUG, "Focus switched to process %s", procfile);
+          CLog::LogFC(LOGDEBUG, LOGWINDOWING, "Focus switched to process %s", procfile);
       }
       break;
     /* needs to be reviewed after frodo. we reset the system idle timer
@@ -457,7 +457,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     {
       const unsigned int appcmd = GET_APPCOMMAND_LPARAM(lParam);
 
-      CLog::LogF(LOGDEBUG, "APPCOMMAND %d", appcmd);
+      CLog::LogFC(LOGDEBUG, LOGWINDOWING, "APPCOMMAND %d", appcmd);
 
       // Reset the screen saver
       g_application.ResetScreenSaver();
@@ -474,12 +474,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       CAction appcmdaction = CServiceBroker::GetInputManager().GetAction(iWin, key);
       if (appcmdaction.GetID())
       {
-        CLog::LogF(LOGDEBUG, "appcommand %d, action %s", appcmd, appcmdaction.GetName().c_str());
+        CLog::LogFC(LOGDEBUG, LOGWINDOWING, "appcommand %d, action %s", appcmd, appcmdaction.GetName().c_str());
         CServiceBroker::GetInputManager().QueueAction(appcmdaction);
         return true;
       }
 
-      CLog::LogF(LOGDEBUG, "unknown appcommand %d", appcmd);
+      CLog::LogFC(LOGDEBUG, LOGWINDOWING, "unknown appcommand %d", appcmd);
       return DefWindowProc(hWnd, uMsg, wParam, lParam);
     }
     case WM_GESTURENOTIFY:
@@ -660,7 +660,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           newEvent.resize.w = g_sizeMoveWidth;
           newEvent.resize.h = g_sizeMoveHight;
 
-          CLog::LogF(LOGDEBUG, "window resize event %d x %d", newEvent.resize.w, newEvent.resize.h);
+          CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window resize event %d x %d", newEvent.resize.w, newEvent.resize.h);
           // tell device about new size
           DX::Windowing()->OnResize(newEvent.resize.w, newEvent.resize.h);
           // tell application about size changes
@@ -687,7 +687,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           newEvent.move.x = g_sizeMoveX;
           newEvent.move.y = g_sizeMoveY;
 
-          CLog::LogF(LOGDEBUG, "window move event");
+          CLog::LogFC(LOGDEBUG, LOGWINDOWING, "window move event");
 
           // tell the device about new position
           DX::Windowing()->OnMove(newEvent.move.x, newEvent.move.y);

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -80,8 +80,11 @@ CWinSystemWin32::CWinSystemWin32()
   CAESinkDirectSound::Register();
   CAESinkWASAPI::Register();
   CWin32PowerSyscall::Register();
-  m_irss.reset(new CIRServerSuite());
-  m_irss->Initialize();
+  if (g_advancedSettings.m_bScanIRServer)
+  {
+    m_irss.reset(new CIRServerSuite());
+    m_irss->Initialize();
+  }
 }
 
 CWinSystemWin32::~CWinSystemWin32()


### PR DESCRIPTION
## Description
- Introduce a new LOGWINDOWING debug component log group
- Move some of Win32 related debug messages (which are mainly used for finding a bug (??) into this group
- Make IR Server Suite selectable through Settings::Input

## Motivation and Context
Make debugging / log reading great again

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
