### PR TITLE
Set Audiocodec name on initial AudioFrame

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -296,9 +296,6 @@ PROCESSDECODER:
   }
 
   CLog::Log(LOGINFO, "CDVDAudioCodecAndroidMediaCodec Open Android MediaCodec %s", m_formatname.c_str());
-  if (!m_decryptCodec)
-    m_processInfo.SetAudioDecoderName(m_formatname.c_str());
-
 
   m_opened = true;
   m_resettable = false;
@@ -576,6 +573,11 @@ void CDVDAudioCodecAndroidMediaCodec::GetData(DVDAudioFrame &frame)
     frame.duration = 0.0;
   if (frame.nb_frames > 0 && g_advancedSettings.CanLogComponent(LOGAUDIO))
     CLog::Log(LOGERROR, "MediaCodecAudio::GetData: frames:%d pts: %0.4f", frame.nb_frames, frame.pts);
+  if (!m_formatname.empty())
+  {
+    m_processInfo.SetAudioDecoderName(m_formatname.c_str());
+    m_formatname.clear();
+  }
 }
 
 int CDVDAudioCodecAndroidMediaCodec::GetData(uint8_t** dst)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -133,7 +133,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_iSampleFormat = AV_SAMPLE_FMT_NONE;
   m_matrixEncoding = AV_MATRIX_ENCODING_NONE;
 
-  m_processInfo.SetAudioDecoderName(m_pCodecContext->codec->name);
+  m_codecDisplayName = "ff-" + std::string(m_pCodecContext->codec->name);
   CLog::Log(LOGNOTICE,"CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder %s", m_pCodecContext->codec->name);
   return true;
 }
@@ -246,6 +246,12 @@ int CDVDAudioCodecFFmpeg::GetData(uint8_t** dst)
     int planes = av_sample_fmt_is_planar(m_pCodecContext->sample_fmt) ? m_pFrame->channels : 1;
     for (int i=0; i<planes; i++)
       dst[i] = m_pFrame->extended_data[i];
+
+    if (!m_codecDisplayName.empty())
+    {
+      m_processInfo.SetAudioDecoderName(m_codecDisplayName);
+      m_codecDisplayName.clear();
+    }
 
     return m_pFrame->nb_samples * m_pFrame->channels *
            av_get_bytes_per_sample(m_pCodecContext->sample_fmt);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -67,5 +67,6 @@ protected:
   bool m_eof;
   int m_channels;
   uint64_t m_layout;
+  std::string m_codecDisplayName;
 };
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -50,25 +50,25 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
   switch (m_format.m_streamInfo.m_type)
   {
     case CAEStreamInfo::STREAM_TYPE_AC3:
-      m_processInfo.SetAudioDecoderName("PT_AC3");
+      m_codecDisplayName = "PT_AC3";
       break;
 
     case CAEStreamInfo::STREAM_TYPE_EAC3:
-      m_processInfo.SetAudioDecoderName("PT_EAC3");
+      m_codecDisplayName = "PT_EAC3";
       break;
 
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
-      m_processInfo.SetAudioDecoderName("PT_DTSHD");
+      m_codecDisplayName = "PT_DTSHD";
       break;
 
     case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
-      m_processInfo.SetAudioDecoderName("PT_DTS");
+      m_codecDisplayName = "PT_DTS";
       m_parser.SetCoreOnly(true);
       break;
 
     case CAEStreamInfo::STREAM_TYPE_TRUEHD:
       m_trueHDBuffer.reset(new uint8_t[TRUEHD_BUF_SIZE]);
-      m_processInfo.SetAudioDecoderName("PT_TRUEHD");
+      m_codecDisplayName = "PT_TRUEHD";
       break;
 
     default:
@@ -223,6 +223,12 @@ void CDVDAudioCodecPassthrough::GetData(DVDAudioFrame &frame)
   frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration());
   frame.pts = m_currentPts;
   m_currentPts = DVD_NOPTS_VALUE;
+
+  if (!m_codecDisplayName.empty())
+  {
+    m_processInfo.SetAudioDecoderName(m_codecDisplayName);
+    m_codecDisplayName.clear();
+  }
 }
 
 int CDVDAudioCodecPassthrough::GetData(uint8_t** dst)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -62,5 +62,6 @@ private:
   // TrueHD specifics
   std::unique_ptr<uint8_t[]> m_trueHDBuffer;
   unsigned int m_trueHDoffset = 0;
+  std::string m_codecDisplayName;
 };
 


### PR DESCRIPTION
## Description
Currently VideoProcessInfo displays AudioCodec always "Unknown" -> Fix

## How Has This Been Tested?
Windows, play any stream, press "o"

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
