### PR TITLE
[network] always open TCP sockets on IPv4 & IPv6 

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -436,11 +436,10 @@ bool CAirPlayServer::Initialize()
 {
   Deinitialize();
   
-  SOCKET fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "AIRPLAY");
-  if (fd == INVALID_SOCKET)
+  m_ServerSockets = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "AIRPLAY");
+  if (m_ServerSockets.empty())
     return false;
 
-  m_servers.push_back(fd);
   CLog::Log(LOGINFO, "AIRPLAY Server: Successfully initialized");
   return true;
 }

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -311,7 +311,7 @@ CAirPlayServer::CAirPlayServer(int port, bool nonlocal) : CThread("AirPlayServer
 {
   m_port = port;
   m_nonlocal = nonlocal;
-  m_ServerSocket = INVALID_SOCKET;
+  m_ServerSockets = std::vector<SOCKET>();
   m_usePassword = false;
   m_origVolume = -1;
   CAnnouncementManager::GetInstance().AddAnnouncer(this);
@@ -346,8 +346,12 @@ void CAirPlayServer::Process()
     struct timeval  to     = {1, 0};
     FD_ZERO(&rfds);
 
-    FD_SET(m_ServerSocket, &rfds);
-    max_fd = m_ServerSocket;
+    for (SOCKET socket : m_ServerSockets)
+    {
+      FD_SET(socket, &rfds);
+      if ((intptr_t)socket > (intptr_t)max_fd)
+        max_fd = socket;
+    }
 
     for (unsigned int i = 0; i < m_connections.size(); i++)
     {
@@ -388,29 +392,32 @@ void CAirPlayServer::Process()
         }
       }
 
-      if (FD_ISSET(m_ServerSocket, &rfds))
+      for (SOCKET socket : m_ServerSockets)
       {
-        CLog::Log(LOGDEBUG, "AIRPLAY Server: New connection detected");
-        CTCPClient newconnection;
-        newconnection.m_socket = accept(m_ServerSocket, (struct sockaddr*) &newconnection.m_cliaddr, &newconnection.m_addrlen);
-        sessionCounter++;
-        newconnection.m_sessionCounter = sessionCounter;
+        if (FD_ISSET(socket, &rfds))
+        {
+          CLog::Log(LOGDEBUG, "AIRPLAY Server: New connection detected");
+          CTCPClient newconnection;
+          newconnection.m_socket = accept(socket, (struct sockaddr*) &newconnection.m_cliaddr, &newconnection.m_addrlen);
+          sessionCounter++;
+          newconnection.m_sessionCounter = sessionCounter;
 
-        if (newconnection.m_socket == INVALID_SOCKET)
-        {
-          CLog::Log(LOGERROR, "AIRPLAY Server: Accept of new connection failed: %d", errno);
-          if (EBADF == errno)
+          if (newconnection.m_socket == INVALID_SOCKET)
           {
-            Sleep(1000);
-            Initialize();
-            break;
+            CLog::Log(LOGERROR, "AIRPLAY Server: Accept of new connection failed: %d", errno);
+            if (EBADF == errno)
+            {
+              Sleep(1000);
+              Initialize();
+              break;
+            }
           }
-        }
-        else
-        {
-          CSingleLock lock (m_connectionLock);
-          CLog::Log(LOGINFO, "AIRPLAY Server: New connection added");
-          m_connections.push_back(newconnection);
+          else
+          {
+            CSingleLock lock (m_connectionLock);
+            CLog::Log(LOGINFO, "AIRPLAY Server: New connection added");
+            m_connections.push_back(newconnection);
+          }
         }
       }
     }
@@ -429,9 +436,11 @@ bool CAirPlayServer::Initialize()
 {
   Deinitialize();
   
-  if ((m_ServerSocket = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "AIRPLAY")) == INVALID_SOCKET)
+  SOCKET fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "AIRPLAY");
+  if (fd == INVALID_SOCKET)
     return false;
-  
+
+  m_servers.push_back(fd);
   CLog::Log(LOGINFO, "AIRPLAY Server: Successfully initialized");
   return true;
 }
@@ -445,12 +454,12 @@ void CAirPlayServer::Deinitialize()
   m_connections.clear();
   m_reverseSockets.clear();
 
-  if (m_ServerSocket != INVALID_SOCKET)
+  for (SOCKET socket : m_ServerSockets)
   {
-    shutdown(m_ServerSocket, SHUT_RDWR);
-    close(m_ServerSocket);
-    m_ServerSocket = INVALID_SOCKET;
+    shutdown(socket, SHUT_RDWR);
+    close(socket);
   }
+  m_ServerSockets.clear();
 }
 
 CAirPlayServer::CTCPClient::CTCPClient()

--- a/xbmc/network/AirPlayServer.h
+++ b/xbmc/network/AirPlayServer.h
@@ -103,7 +103,7 @@ private:
   CCriticalSection m_connectionLock;
   std::vector<CTCPClient> m_connections;
   std::map<std::string, int> m_reverseSockets;
-  int m_ServerSocket;
+  std::vector<SOCKET> m_ServerSockets;
   int m_port;
   bool m_nonlocal;
   bool m_usePassword;

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -24,6 +24,8 @@
 
 #include "settings/lib/ISettingCallback.h"
 
+#include "PlatformDefs.h"
+
 enum EncMode { ENC_NONE = 0, ENC_WEP = 1, ENC_WPA = 2, ENC_WPA2 = 3 };
 enum NetworkAssignment { NETWORK_DASH = 0, NETWORK_DHCP = 1, NETWORK_STATIC = 2, NETWORK_DISABLED = 3 };
 
@@ -171,8 +173,7 @@ public:
 using CNetwork = CNetworkBase;
 #endif
 
-//creates, binds and listens a tcp socket on the desired port. Set bindLocal to
-//true to bind to localhost only. The socket will listen over ipv6 if possible
-//and fall back to ipv4 if ipv6 is not available on the platform.
-int CreateTCPServerSocket(const int port, const bool bindLocal, const int backlog, const char *callerName);
+//creates, binds and listens tcp sockets on the desired port. Set bindLocal to
+//true to bind to localhost only.
+std::vector<SOCKET> CreateTCPServerSocket(const int port, const bool bindLocal, const int backlog, const char *callerName);
 

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -474,14 +474,13 @@ bool CTCPServer::InitializeBlue()
 
 bool CTCPServer::InitializeTCP()
 {
-  SOCKET fd;
-
   Deinitialize();
 
-  if ((fd = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "JSONRPC")) == INVALID_SOCKET)
+  std::vector<SOCKET> sockets = CreateTCPServerSocket(m_port, !m_nonlocal, 10, "JSONRPC");
+  if (sockets.empty())
     return false;
 
-  m_servers.push_back(fd);
+  m_servers.insert(m_servers.end(), sockets.begin(), sockets.end());
   return true;
 }
 


### PR DESCRIPTION
## Description
Dual-stack sockets don't work well, as the socket selecting is already implemented for `CTCPServer`, I only had to copy it to `CAirPlayServer` and actually open multiple sockets.

## Motivation and Context
fixes https://trac.kodi.tv/ticket/16679

## How Has This Been Tested?
tested on windows (desktop) & linux
connected via telnet to the json port over IPv4 and IPv6
looked at netstat while changing the following settings
- enabled / disabled 'Allow remote control from applications on this system'
- enabled / disabled 'Allow remote control from applications on other systems'
- enabled / disabled 'Enable AirPlay "Videos" and "Pictures" support'

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
