### PR TITLE
[Android] add addon getter for main class name (org/xbmc/kodi)

### DIFF
--- a/xbmc/addons/interfaces/platform/android/System.cpp
+++ b/xbmc/addons/interfaces/platform/android/System.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "System.h"
+#include "CompileInfo.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h"
 
@@ -33,6 +34,7 @@ void Interface_Android::Register()
 {
   function_table.get_jni_env = get_jni_env;
   function_table.get_sdk_version = get_sdk_version;
+  function_table.get_class_name = get_class_name;
   CAddonDll::RegisterInterface(Get);
 }
 
@@ -55,5 +57,11 @@ int Interface_Android::get_sdk_version()
 {
   return CXBMCApp::get()->getActivity()->sdkVersion;
 }
+
+const char *Interface_Android::get_class_name()
+{
+  return CCompileInfo::GetClass();
+}
+
 
 } //namespace ADDON

--- a/xbmc/addons/interfaces/platform/android/System.h
+++ b/xbmc/addons/interfaces/platform/android/System.h
@@ -31,6 +31,7 @@ struct Interface_Android
 
   static void* get_jni_env();
   static int get_sdk_version();
+  static const char *get_class_name();
 };
 
 } //namespace ADDON

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/platform/android/System.h
@@ -34,13 +34,14 @@
  */
 
 static const char* INTERFACE_ANDROID_SYSTEM_NAME = "ANDROID_SYSTEM";
-static const char* INTERFACE_ANDROID_SYSTEM_VERSION = "1.0.0";
-static const char* INTERFACE_ANDROID_SYSTEM_VERSION_MIN = "1.0.0";
+static const char* INTERFACE_ANDROID_SYSTEM_VERSION = "1.0.1";
+static const char* INTERFACE_ANDROID_SYSTEM_VERSION_MIN = "1.0.1";
 
 struct AddonToKodiFuncTable_android_system
 {
   void* (*get_jni_env)();
   int (*get_sdk_version)();
+  const char *(*get_class_name)();
 };
 
 //==============================================================================
@@ -97,6 +98,22 @@ namespace platform
         return m_interface->get_sdk_version();
 
       return 0;
+    }
+
+    //============================================================================
+    ///
+    /// \ingroup cpp_kodi_platform
+    /// @brief request the android main class name e.g. org.xbmc.kodi.
+    ///
+    /// @param[in]:
+    /// @return package class name
+    ///
+    inline std::string GetClassName()
+    {
+      if (m_interface)
+        return m_interface->get_class_name();
+
+      return std::string();
     }
 
   private:


### PR DESCRIPTION
## Description
If an addon wants to load JAVA classes (JNI) provided in kodi package, it need to know the main class name used when packaging for the class loading process.

This PR extends the Android specific SystemAPI for this value.

## Motivation and Context
MediaDRM OnEventListener Java class has to be loaded from addon

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
