### PR TITLE
Fix whitelistable resolutions on some platforms

### DIFF
--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -241,7 +241,7 @@ void CWinSystemAmlogic::UpdateResolutions()
     res_index = (RESOLUTION)((int)res_index + 1);
   }
 
-  // swap desktop index for desktop res if available
+  // set RES_DESKTOP
   if (ResDesktop != RES_INVALID)
   {
     CLog::Log(LOGNOTICE, "Found (%dx%d%s@%f) at %d, setting to RES_DESKTOP at %d",
@@ -250,9 +250,7 @@ void CWinSystemAmlogic::UpdateResolutions()
       resDesktop.fRefreshRate,
       (int)ResDesktop, (int)RES_DESKTOP);
 
-    RESOLUTION_INFO desktop = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
     CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop);
-    CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop) = desktop;
   }
 }
 

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -226,7 +226,7 @@ void CWinSystemAndroid::UpdateResolutions()
     res_index = (RESOLUTION)((int)res_index + 1);
   }
 
-  // swap desktop index for desktop res if available
+  // set RES_DESKTOP
   if (ResDesktop != RES_INVALID)
   {
     CLog::Log(LOGNOTICE, "Found (%dx%d%s@%f) at %d, setting to RES_DESKTOP at %d",
@@ -235,9 +235,7 @@ void CWinSystemAndroid::UpdateResolutions()
       resDesktop.fRefreshRate,
       (int)ResDesktop, (int)RES_DESKTOP);
 
-    RESOLUTION_INFO desktop = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
     CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop);
-    CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop) = desktop;
   }
 
   unsigned int num_codecs = CJNIMediaCodecList::getCodecCount();

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -147,6 +147,12 @@ void CWinSystemGbm::UpdateResolutions()
 {
   CWinSystemBase::UpdateResolutions();
 
+  UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP),
+                          0,
+                          m_DRM->m_mode->hdisplay,
+                          m_DRM->m_mode->vdisplay,
+                          m_DRM->m_mode->vrefresh);
+
   std::vector<RESOLUTION_INFO> resolutions;
 
   if (!m_DRM->GetModes(resolutions) || resolutions.empty())
@@ -159,42 +165,17 @@ void CWinSystemGbm::UpdateResolutions()
 
     for (unsigned int i = 0; i < resolutions.size(); i++)
     {
-      if(m_DRM->m_mode->hdisplay == resolutions[i].iWidth &&
-         m_DRM->m_mode->vdisplay == resolutions[i].iHeight &&
-         m_DRM->m_mode->vrefresh == resolutions[i].fRefreshRate &&
-         ((m_DRM->m_mode->flags ^ DRM_MODE_FLAG_INTERLACE) &&
-          (resolutions[i].dwFlags ^ D3DPRESENTFLAG_INTERLACED)))
-      {
-        CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz setting to RES_DESKTOP at %d",
-                  resolutions[i].iWidth,
-                  resolutions[i].iHeight,
-                  resolutions[i].iScreen,
-                  resolutions[i].iScreenWidth,
-                  resolutions[i].iScreenHeight,
-                  resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
-                  resolutions[i].fRefreshRate,
-                  (int)RES_DESKTOP);
+      CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
+      CDisplaySettings::GetInstance().AddResolutionInfo(resolutions[i]);
 
-        UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP),
-                                0,
-                                m_DRM->m_mode->hdisplay,
-                                m_DRM->m_mode->vdisplay,
-                                m_DRM->m_mode->vrefresh);
-      }
-      else
-      {
-        CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz",
-                  resolutions[i].iWidth,
-                  resolutions[i].iHeight,
-                  resolutions[i].iScreen,
-                  resolutions[i].iScreenWidth,
-                  resolutions[i].iScreenHeight,
-                  resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
-                  resolutions[i].fRefreshRate);
-
-        CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
-        CDisplaySettings::GetInstance().AddResolutionInfo(resolutions[i]);
-      }
+      CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz",
+                resolutions[i].iWidth,
+                resolutions[i].iHeight,
+                resolutions[i].iScreen,
+                resolutions[i].iScreenWidth,
+                resolutions[i].iScreenHeight,
+                resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
+                resolutions[i].fRefreshRate);
     }
   }
 

--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -209,7 +209,7 @@ void CWinSystemRpi::UpdateResolutions()
     res_index = (RESOLUTION)((int)res_index + 1);
   }
 
-  // swap desktop index for desktop res if available
+  // set RES_DESKTOP
   if (ResDesktop != RES_INVALID)
   {
     CLog::Log(LOGNOTICE, "Found (%dx%d%s@%f) at %d, setting to RES_DESKTOP at %d",
@@ -218,9 +218,7 @@ void CWinSystemRpi::UpdateResolutions()
       resDesktop.fRefreshRate,
       (int)ResDesktop, (int)RES_DESKTOP);
 
-    RESOLUTION_INFO desktop = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
     CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop);
-    CDisplaySettings::GetInstance().GetResolutionInfo(ResDesktop) = desktop;
   }
 }
 


### PR DESCRIPTION
after #13899 RES_DESKTOP won't show up in the whitelist selection on some platforms. This fixes it.

basically we were taking out the preferred resolution from the list of custom resolutions.