### PR TITLE
[GUI] Invalidate underlying windows if modal dialog close

### DIFF
--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -543,6 +543,9 @@ void CGUISpinControl::SetValueFromLabel(const std::string &label)
   }
   else
     m_iValue = atoi(label.c_str());
+
+  MarkDirtyRegion();
+  SetInvalid();
 }
 
 void CGUISpinControl::SetValue(int iValue)
@@ -557,6 +560,7 @@ void CGUISpinControl::SetValue(int iValue)
   else
     m_iValue = iValue;
 
+  MarkDirtyRegion();
   SetInvalid();
 }
 


### PR DESCRIPTION
## Description
Invalidate underlying dialogs in case a modal dialog closes
This PR does not touch GUI rendering with smartredraw disabled (default)

## Motivation and Context
When using smartredraw GUI is not redrawn properly if one changes audio track during video playback (Settings -> Audio Settings -> Audio Streams -> select different stream -> Close). 
Invalidating the open dialogs after closing a modal dialog forces them to be rendered properly.

## How Has This Been Tested?
- enable smartredraw (advancedsettings)
- Play video
- settings / Audio settings / audio streams / select stream / close

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
