### PR TITLE
Resolution: Allow deviation of max 0.01 instead of 0.005

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -99,7 +99,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
     if (info.iScreenWidth == width &&
         info.iScreen == curr.iScreen &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.005f))
+        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
       CLog::Log(LOGDEBUG, "Matched exact whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
       resolution = i;
@@ -118,7 +118,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
     if (info.iScreenWidth == width &&
         info.iScreen == curr.iScreen &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.005f))
+        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
     {
       CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
       resolution = i;
@@ -139,7 +139,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
     if (info.iScreenWidth == desktop_info.iWidth &&
         info.iScreen == desktop_info.iScreen &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.005f))
+        MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
       CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
       resolution = i;
@@ -160,7 +160,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, bool is
     if (info.iScreenWidth == desktop_info.iWidth &&
         info.iScreen == desktop_info.iScreen &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (desktop_info.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
-        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.005f))
+        MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
     {
       CLog::Log(LOGDEBUG, "Matched fuzzy whitelisted Resolution %s (%d)", info.strMode.c_str(), i);
       resolution = i;


### PR DESCRIPTION
This is a slight regression from before. With 0.005 some fractional modelines don't match properly anymore. 

Let's allow a deviation of max 0.01. Means for 23.976 fps content we allow 23.986 or 23.966 - which does not really harm as it would be 200 ms out of sync after > 15 minutes.

See reference: https://forum.kodi.tv/showthread.php?tid=298462&page=230