### PR TITLE
Media source dialog tidyup

### DIFF
--- a/xbmc/dialogs/GUIDialogMediaSource.h
+++ b/xbmc/dialogs/GUIDialogMediaSource.h
@@ -55,6 +55,8 @@ protected:
   void UpdateButtons();
   int GetSelectedItem();
   void HighlightItem(int item);
+  std::string GetUniqueMediaSourceName();
+  static void OnMediaSourceChanged(const std::string& type, const std::string& oldName, const CMediaSource& share);
 
   std::vector<std::string> GetPaths() const;
 


### PR DESCRIPTION
Clean up of `CGUIDialogMediaSource` removing old "hack" (commented that way by author), and moving common processing into own routines.
___________

As far as I tell from testing (on Win64), there is no reason to add the media source temporarily to the list of sources in order for `GetDirectory` to be able to verify the path(s). Commented as a "hack" seems resonable to remove it now, but would like some testing on other platforms please.

Also more logical to save any source changes _before_ starting scanning and scraping the source into video or music libraries. Hence  moved calls to `CGUIWindowVideoBase::OnAssignContent()` and `CGUIWindowMusicBase::OnAssignContent()` to after unique source name has been found and saved.

Tested both `ShowAndAddMediaSource` and `ShowAndEditMediaSource` by adding and editing sources, changing name and/or paths, with multiple and single paths per source etc. for both video and music libraries.