### PR TITLE
DVDVideoCodecDRMPRIME: fix aspect ratio and align render area

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -254,8 +254,8 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
   avpkt.size = packet.iSize;
   avpkt.dts = (packet.dts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.dts / DVD_TIME_BASE * AV_TIME_BASE);
   avpkt.pts = (packet.pts == DVD_NOPTS_VALUE) ? AV_NOPTS_VALUE : static_cast<int64_t>(packet.pts / DVD_TIME_BASE * AV_TIME_BASE);
-  // TODO: avpkt.side_data = static_cast<AVPacketSideData*>(packet.pSideData);
-  // TODO: avpkt.side_data_elems = packet.iSideDataElems;
+  avpkt.side_data = static_cast<AVPacketSideData*>(packet.pSideData);
+  avpkt.side_data_elems = packet.iSideDataElems;
 
   int ret = avcodec_send_packet(m_pCodecContext, &avpkt);
   if (ret == AVERROR(EAGAIN))

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -295,7 +295,14 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
   pVideoPicture->iWidth = m_pFrame->width;
   pVideoPicture->iHeight = m_pFrame->height;
 
-  double aspect_ratio = (float)pVideoPicture->iWidth / (float)pVideoPicture->iHeight;
+  double aspect_ratio = 0;
+  AVRational pixel_aspect = m_pFrame->sample_aspect_ratio;
+  if (pixel_aspect.num)
+    aspect_ratio = av_q2d(pixel_aspect) * pVideoPicture->iWidth / pVideoPicture->iHeight;
+
+  if (aspect_ratio <= 0.0)
+    aspect_ratio = (float)pVideoPicture->iWidth / (float)pVideoPicture->iHeight;
+
   pVideoPicture->iDisplayWidth = ((int)lrint(pVideoPicture->iHeight * aspect_ratio)) & -3;
   pVideoPicture->iDisplayHeight = pVideoPicture->iHeight;
   if (pVideoPicture->iDisplayWidth > pVideoPicture->iWidth)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -209,10 +209,10 @@ void CRendererDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer)
       return;
     }
 
-    int32_t crtc_x = (int32_t)m_destRect.x1;
-    int32_t crtc_y = (int32_t)m_destRect.y1;
-    uint32_t crtc_w = (uint32_t)m_destRect.Width();
-    uint32_t crtc_h = (uint32_t)m_destRect.Height();
+    int32_t crtc_x = static_cast<int32_t>(m_destRect.x1) & ~1;
+    int32_t crtc_y = static_cast<int32_t>(m_destRect.y1) & ~1;
+    uint32_t crtc_w = (static_cast<uint32_t>(m_destRect.Width()) + 1) & ~1;
+    uint32_t crtc_h = (static_cast<uint32_t>(m_destRect.Height()) + 1) & ~1;
     uint32_t src_x = 0;
     uint32_t src_y = 0;
     uint32_t src_w = buffer->GetWidth() << 16;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This PR fixes aspect ratio of videos with non-square video pixels, sends side data to the decoder and aligns video render area to closest even x/y/width/height.

## Motivation and Context
- MPEG2 videos with non-square pixels was rendered with wrong aspect ratio (solution copied from DVDVideoCodecFFmpeg).
- NV12 frames needs to be aligned to even x/w for proper display using some kernel drm drivers. This changes to use same alignment as `mpv` (x/y aligned down, and w/h aligned up).

## How Has This Been Tested?
Tested on Rock64 using LibreELEC and rkvpu mpeg2 hwaccel.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
