### PR TITLE
Fixed for Limited Range

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -210,9 +210,9 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
 
   if (m_context.UseLimitedColor())
   {
-    colour[0] = (235 - 16) * colour[0] / 255;
-    colour[1] = (235 - 16) * colour[1] / 255;
-    colour[2] = (235 - 16) * colour[2] / 255;
+    colour[0] = (235 - 16) * colour[0] / 255 + 16;
+    colour[1] = (235 - 16) * colour[1] / 255 + 16;
+    colour[2] = (235 - 16) * colour[2] / 255 + 16;
   }
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f),

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -893,9 +893,9 @@ void CGUIFontTTFBase::RenderCharacter(float posX, float posY, const Character *c
 
   if (m_renderSystem->UseLimitedColorRange())
   {
-    r = (235 - 16) * r / 255;
-    g = (235 - 16) * g / 255;
-    b = (235 - 16) * b / 255;
+    r = (235 - 16) * r / 255 + 16;
+    g = (235 - 16) * g / 255 + 16;
+    b = (235 - 16) * b / 255 + 16;
   }
 #endif
 

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -53,9 +53,9 @@ void CGUITextureGL::Begin(UTILS::Color color)
 
   if (m_renderSystem->UseLimitedColorRange())
   {
-    m_col[0] = (235 - 16) * m_col[0] / 255 + 16.0f / 255.0f;
-    m_col[1] = (235 - 16) * m_col[1] / 255 + 16.0f / 255.0f;
-    m_col[2] = (235 - 16) * m_col[2] / 255 + 16.0f / 255.0f;
+    m_col[0] = (235 - 16) * m_col[0] / 255 + 16;
+    m_col[1] = (235 - 16) * m_col[1] / 255 + 16;
+    m_col[2] = (235 - 16) * m_col[2] / 255 + 16;
   }
 
   bool hasAlpha = m_texture.m_textures[m_currentFrame]->HasAlpha() || m_col[3] < 255;

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -54,9 +54,9 @@ void CGUITextureGLES::Begin(UTILS::Color color)
 
   if (CServiceBroker::GetWinSystem()->UseLimitedColor())
   {
-    m_col[0] = (235 - 16) * m_col[0] / 255 + 16.0f / 255.0f;
-    m_col[1] = (235 - 16) * m_col[1] / 255 + 16.0f / 255.0f;
-    m_col[2] = (235 - 16) * m_col[2] / 255 + 16.0f / 255.0f;
+    m_col[0] = (235 - 16) * m_col[0] / 255 + 16;
+    m_col[1] = (235 - 16) * m_col[1] / 255 + 16;
+    m_col[2] = (235 - 16) * m_col[2] / 255 + 16;
   }
 
   bool hasAlpha = m_texture.m_textures[m_currentFrame]->HasAlpha() || m_col[3] < 255;

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -925,9 +925,9 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, UTILS::Co
 
   if (CServiceBroker::GetWinSystem()->UseLimitedColor())
   {
-    colour[0] = (235 - 16) * colour[0] / 255 + 16.0f / 255.0f;
-    colour[1] = (235 - 16) * colour[1] / 255 + 16.0f / 255.0f;
-    colour[2] = (235 - 16) * colour[2] / 255 + 16.0f / 255.0f;
+    colour[0] = (235 - 16) * colour[0] / 255 + 16;
+    colour[1] = (235 - 16) * colour[1] / 255 + 16;
+    colour[2] = (235 - 16) * colour[2] / 255 + 16;
   }
 
   glUniform4f(uniColLoc,(colour[0] / 255.0f), (colour[1] / 255.0f),
@@ -996,9 +996,9 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, UTILS::Co
 
   if (CServiceBroker::GetWinSystem()->UseLimitedColor())
   {
-    col[0] = (235 - 16) * col[0] / 255 + 16.0f / 255.0f;
-    col[1] = (235 - 16) * col[1] / 255 + 16.0f / 255.0f;
-    col[2] = (235 - 16) * col[2] / 255 + 16.0f / 255.0f;
+    col[0] = (235 - 16) * col[0] / 255 + 16;
+    col[1] = (235 - 16) * col[1] / 255 + 16;
+    col[2] = (235 - 16) * col[2] / 255 + 16;
   }
 
   for (int i=0; i<4; i++)


### PR DESCRIPTION
We had some computations wrong. Input color values are not normalized between 0.0 and 1.0 but rather between 0 and 255. Therefore the offset was added in wrong dimension.