### PR TITLE
[fix] check write access for sqlite databases

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -68,6 +68,9 @@ bool CServiceManager::InitForTesting()
   m_network.reset(new CNetwork(*m_settings));
 
   m_profileManager.reset(new CProfilesManager(*m_settings));
+  CProfile profile("special://temp");
+  m_profileManager.get()->AddProfile(profile);
+  m_profileManager.get()->CreateProfileFolders();
 
   m_databaseManager.reset(new CDatabaseManager);
 


### PR DESCRIPTION
## Description
Kodi needs write access to sqlite databases, throw `runtime_error` exception if this requirement isn't fulfilled.

## Motivation and Context
maybe fixes https://trac.kodi.tv/ticket/15872
If Kodi can't write to `Addons*.db` it will do a repo scan (hash check + downloading xml) every few seconds as it can't store that it already has done the scan and next scan should happen in 24 hours.

## How Has This Been Tested?
disabled write access for `Addons27.db` and started Kodi.

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
