### PR TITLE
Include cleanup

### DIFF
--- a/xbmc/ApplicationStackHelper.cpp
+++ b/xbmc/ApplicationStackHelper.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
+#include "threads/SingleLock.h"
 #include "Util.h"
 
 using namespace XFILE;

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -36,6 +36,7 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfilesManager.h"
 #include "settings/Settings.h"
+#include "xbmc/settings/lib/Setting.h"
 #include "playlists/PlayList.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -20,6 +20,7 @@
 
 #include "BackgroundInfoLoader.h"
 #include "FileItem.h"
+#include "threads/Thread.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "URL.h"

--- a/xbmc/BackgroundInfoLoader.h
+++ b/xbmc/BackgroundInfoLoader.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include "threads/Thread.h"
+#include "threads/IRunnable.h"
 #include "IProgressCallback.h"
 #include "threads/CriticalSection.h"
 
@@ -29,6 +29,7 @@
 
 class CFileItem; typedef std::shared_ptr<CFileItem> CFileItemPtr;
 class CFileItemList;
+class CThread;
 
 class IBackgroundLoaderObserver
 {

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -32,7 +32,7 @@
 
 #include "addons/IAddon.h"
 #include "guilib/GUIListItem.h"
-#include "GUIPassword.h"
+#include "LockType.h"
 #include "pvr/PVRTypes.h"
 #include "threads/CriticalSection.h"
 #include "utils/IArchivable.h"

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -20,7 +20,6 @@
  *
  */
 
-#include <map>
 #include <string>
 #include <vector>
 

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -25,22 +25,12 @@
 
 #include "settings/lib/ISettingCallback.h"
 #include "settings/lib/Setting.h"
+#include "LockType.h"
 
 class CFileItem;
 class CMediaSource;
 
 typedef std::vector<CMediaSource> VECSOURCES;
-
-typedef enum
-{
-  LOCK_MODE_UNKNOWN            = -1,
-  LOCK_MODE_EVERYONE           =  0,
-  LOCK_MODE_NUMERIC            =  1,
-  LOCK_MODE_GAMEPAD            =  2,
-  LOCK_MODE_QWERTY             =  3,
-  LOCK_MODE_SAMBA              =  4,
-  LOCK_MODE_EEPROM_PARENTAL    =  5
-} LockType;
 
 namespace LOCK_LEVEL {
   /**

--- a/xbmc/GUIPassword.h
+++ b/xbmc/GUIPassword.h
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "settings/lib/ISettingCallback.h"
-#include "settings/lib/Setting.h"
+#include "settings/lib/SettingLevel.h"
 #include "LockType.h"
 
 class CFileItem;

--- a/xbmc/LockType.h
+++ b/xbmc/LockType.h
@@ -1,0 +1,32 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+typedef enum
+{
+  LOCK_MODE_UNKNOWN            = -1,
+  LOCK_MODE_EVERYONE           =  0,
+  LOCK_MODE_NUMERIC            =  1,
+  LOCK_MODE_GAMEPAD            =  2,
+  LOCK_MODE_QWERTY             =  3,
+  LOCK_MODE_SAMBA              =  4,
+  LOCK_MODE_EEPROM_PARENTAL    =  5
+} LockType;

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -21,7 +21,7 @@
 
 #include <string>
 #include <vector>
-#include "GUIPassword.h"
+#include "LockType.h"
 
 /*!
 \ingroup windows

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -28,6 +28,7 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "Util.h"
+#include "GUIPassword.h"
 #include "guilib/LocalizeStrings.h"
 #include "filesystem/Directory.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -27,6 +27,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
+#include "settings/lib/Setting.h"
 #include "utils/log.h"
 
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -48,6 +48,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
+#include "GUIPassword.h"
 #include "Util.h"
 #include "interfaces/builtins/Builtins.h"
 

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -40,6 +40,7 @@
 #include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "settings/MediaSourceSettings.h"
+#include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "AddonDatabase.h"

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -32,6 +32,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
+#include "settings/lib/Setting.h"
 #include "threads/SingleLock.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -36,6 +36,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "threads/SystemClock.h"
+#include "threads/SingleLock.h"
 #include "URL.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -31,6 +31,7 @@
 #include "cores/VideoSettings.h"
 #include "cores/VideoPlayer/DVDStreamInfo.h"
 #include "threads/Thread.h"
+#include "threads/IRunnable.h"
 #include "utils/Geometry.h"
 
 // worst case number of buffers. 12 for decoder. 8 for multi-threading in ffmpeg. NUM_BUFFERS for renderer.

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -24,6 +24,7 @@
 #include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "threads/Thread.h"
+#include "threads/IRunnable.h"
 
 #define PROGRESS_CONTROL 10
 

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -30,7 +30,7 @@
 #include "utils/URIUtils.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "threads/Thread.h"
+#include "threads/IRunnable.h"
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 #include "URL.h"

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -22,6 +22,9 @@
 #include "IDirectory.h"
 #include "MediaSource.h"
 
+#include <memory>
+#include <string>
+
 namespace XFILE
 {
 

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -51,6 +51,7 @@
 #include "utils/StringUtils.h"
 #include "Util.h"
 #include "settings/Settings.h"
+#include "settings/lib/Setting.h"
 #include "AppParamParser.h"
 #include "AppInboundProtocol.h"
 

--- a/xbmc/input/KeyboardLayoutManager.cpp
+++ b/xbmc/input/KeyboardLayoutManager.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "filesystem/Directory.h"
 #include "URL.h"
+#include "settings/lib/Setting.h"
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
 

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -19,6 +19,7 @@
  *
  */
 #include <vector>
+#include <list>
 
 #include "IAnnouncer.h"
 #include "FileItem.h"

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -25,6 +25,7 @@
 #include "music/Artist.h"
 #include "music/Album.h"
 #include "FileItem.h"
+#include "MediaSource.h"
 #include "threads/Event.h"
 
 class CFileItem;

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -23,6 +23,7 @@
 #include "MusicInfoScraper.h"
 #include "music/MusicDatabase.h"
 #include "threads/Thread.h"
+#include "threads/IRunnable.h"
 
 class CAlbum;
 class CArtist;

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -33,6 +33,7 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "settings/lib/Setting.h"
 #include "settings/windows/GUIControlSettings.h"
 #include "URL.h"
 #include "utils/log.h"

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -36,6 +36,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/lib/Setting.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
 #include "utils/XMLUtils.h"

--- a/xbmc/profiles/Profile.h
+++ b/xbmc/profiles/Profile.h
@@ -20,6 +20,7 @@
  */
 
 #include "GUIPassword.h"
+#include "LockType.h"
 
 #include <string>
 #include <vector>

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -20,6 +20,7 @@
 
 #include "GUIWindowPrograms.h"
 #include "Util.h"
+#include "GUIPassword.h"
 #include "addons/GUIDialogAddonInfo.h"
 #include "Autorun.h"
 #include "dialogs/GUIDialogMediaSource.h"

--- a/xbmc/pvr/PVRGUIActions.cpp
+++ b/xbmc/pvr/PVRGUIActions.cpp
@@ -39,7 +39,7 @@
 #include "network/Network.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
-#include "threads/Thread.h"
+#include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -19,8 +19,6 @@
  *
  */
 
-#include <map>
-
 #include "XBDateTime.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -20,7 +20,6 @@
  */
 
 #include <memory>
-#include <vector>
 
 #include "utils/Observer.h"
 #include "windows/GUIMediaWindow.h"

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -28,6 +28,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "threads/IRunnable.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -20,7 +20,7 @@
 
 #include "SettingConditions.h"
 #include "Application.h"
-#include "GUIPassword.h"
+#include "LockType.h"
 #include "Util.h"
 #include "addons/AddonManager.h"
 #include "addons/binary-addons/BinaryAddonManager.h"

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -19,7 +19,6 @@
  *
  */
 
-#include <map>
 #include <memory>
 #include <set>
 #include <string>

--- a/xbmc/threads/IRunnable.h
+++ b/xbmc/threads/IRunnable.h
@@ -1,6 +1,5 @@
-#pragma once
 /*
- *      Copyright (C) 2010-2013 Team XBMC
+ *      Copyright (C) 2005-2013 Team XBMC
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,13 +18,12 @@
  *
  */
 
-#include "AE.h"
-#include "threads/IRunnable.h"
+#pragma once
 
-class IThreadedAE : public IAE, public IRunnable
+class IRunnable
 {
 public:
-  virtual void Run () = 0;
-  virtual void Stop() = 0;
+  virtual void Run()=0;
+  virtual void Cancel() {};
+  virtual ~IRunnable() = default;
 };
-

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -22,6 +22,7 @@
 
 #include "threads/SystemClock.h"
 #include "Thread.h"
+#include "IRunnable.h"
 #include "threads/SingleLock.h"
 #include "commons/Exception.h"
 #include <stdlib.h>

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -34,13 +34,7 @@
 #include <mach/mach.h>
 #endif
 
-class IRunnable
-{
-public:
-  virtual void Run()=0;
-  virtual void Cancel() {};
-  virtual ~IRunnable() = default;
-};
+class IRunnable;
 
 // minimum as mandated by XTL
 #define THREAD_MINSTACKSIZE 0x10000

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "threads/Event.h"
+#include "threads/IRunnable.h"
 
 #include "threads/test/TestHelpers.h"
 

--- a/xbmc/threads/test/TestSharedSection.cpp
+++ b/xbmc/threads/test/TestSharedSection.cpp
@@ -21,6 +21,7 @@
 #include "threads/SharedSection.h"
 #include "threads/SingleLock.h"
 #include "threads/Event.h"
+#include "threads/IRunnable.h"
 #include "threads/test/TestHelpers.h"
 
 #include <stdio.h>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -22,6 +22,7 @@
 
 #include "guilib/GUIDialog.h"
 #include "FileItem.h"
+#include "MediaSource.h"
 
 class CVideoDatabase;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -61,6 +61,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "storage/MediaManager.h"
+#include "threads/IRunnable.h"
 #include "threads/SystemClock.h"
 #include "utils/FileUtils.h"
 #include "utils/LabelFormatter.h"

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -52,7 +52,7 @@
 #include "input/InputManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
-#include "threads/Thread.h"
+#include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "utils/JobManager.h"

--- a/xbmc/windows/GUIWindowScreensaver.cpp
+++ b/xbmc/windows/GUIWindowScreensaver.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "GUIWindowScreensaver.h"
-
+#include "GUIPassword.h"
 #include "Application.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"


### PR DESCRIPTION
Reduce header dependencies to speed up the build, and to make the code more correct. A lot of important includes were missing which was no problem because other headers had too many includes.