### PR TITLE
guilib/GUIListItem: use std::unique_ptr<CGUIListItemLayout>

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -165,8 +165,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
   {
     if (!item->GetFocusedLayout())
     {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*m_focusedLayout, this);
-      item->SetFocusedLayout(layout);
+      item->SetFocusedLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*m_focusedLayout, this)));
     }
     if (item->GetFocusedLayout())
     {
@@ -192,9 +191,9 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
       item->GetFocusedLayout()->SetFocusedItem(0);  // focus is not set
     if (!item->GetLayout())
     {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*m_layout);
+      CGUIListItemLayoutPtr layout(new CGUIListItemLayout(*m_layout));
       layout->SetParentControl(this);
-      item->SetLayout(layout);
+      item->SetLayout(std::move(layout));
     }
     if (item->GetFocusedLayout())
       item->GetFocusedLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -35,8 +35,6 @@ bool CGUIListItem::icompare::operator()(const std::string &s1, const std::string
 
 CGUIListItem::CGUIListItem(const CGUIListItem& item)
 {
-  m_layout = NULL;
-  m_focusedLayout = NULL;
   *this = item;
   SetInvalid();
 }
@@ -46,8 +44,6 @@ CGUIListItem::CGUIListItem(void)
   m_bIsFolder = false;
   m_bSelected = false;
   m_overlayIcon = ICON_OVERLAY_NONE;
-  m_layout = NULL;
-  m_focusedLayout = NULL;
 }
 
 CGUIListItem::CGUIListItem(const std::string& strLabel):
@@ -57,8 +53,6 @@ CGUIListItem::CGUIListItem(const std::string& strLabel):
   SetSortLabel(strLabel);
   m_bSelected = false;
   m_overlayIcon = ICON_OVERLAY_NONE;
-  m_layout = NULL;
-  m_focusedLayout = NULL;
 }
 
 CGUIListItem::~CGUIListItem(void)
@@ -352,37 +346,33 @@ void CGUIListItem::FreeMemory(bool immediately)
   if (m_layout)
   {
     m_layout->FreeResources(immediately);
-    delete m_layout;
-    m_layout = NULL;
+    m_layout.reset();
   }
   if (m_focusedLayout)
   {
     m_focusedLayout->FreeResources(immediately);
-    delete m_focusedLayout;
-    m_focusedLayout = NULL;
+    m_focusedLayout.reset();
   }
 }
 
-void CGUIListItem::SetLayout(CGUIListItemLayout *layout)
+void CGUIListItem::SetLayout(CGUIListItemLayoutPtr layout)
 {
-  delete m_layout;
-  m_layout = layout;
+  m_layout = std::move(layout);
 }
 
 CGUIListItemLayout *CGUIListItem::GetLayout()
 {
-  return m_layout;
+  return m_layout.get();
 }
 
-void CGUIListItem::SetFocusedLayout(CGUIListItemLayout *layout)
+void CGUIListItem::SetFocusedLayout(CGUIListItemLayoutPtr layout)
 {
-  delete m_focusedLayout;
-  m_focusedLayout = layout;
+  m_focusedLayout = std::move(layout);
 }
 
 CGUIListItemLayout *CGUIListItem::GetFocusedLayout()
 {
-  return m_focusedLayout;
+  return m_focusedLayout.get();
 }
 
 void CGUIListItem::SetInvalid()

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -30,9 +30,11 @@
 
 #include <map>
 #include <string>
+#include <memory>
 
 //  Forward
 class CGUIListItemLayout;
+using CGUIListItemLayoutPtr = std::unique_ptr<CGUIListItemLayout>;
 class CArchive;
 class CVariant;
 
@@ -142,10 +144,10 @@ public:
   bool HasOverlay() const;
   virtual bool IsFileItem() const { return false; };
 
-  void SetLayout(CGUIListItemLayout *layout);
+  void SetLayout(CGUIListItemLayoutPtr layout);
   CGUIListItemLayout *GetLayout();
 
-  void SetFocusedLayout(CGUIListItemLayout *layout);
+  void SetFocusedLayout(CGUIListItemLayoutPtr layout);
   CGUIListItemLayout *GetFocusedLayout();
 
   void FreeIcons();
@@ -182,8 +184,8 @@ protected:
   std::string m_strIcon;      // filename of icon
   GUIIconOverlay m_overlayIcon; // type of overlay icon
 
-  CGUIListItemLayout *m_layout;
-  CGUIListItemLayout *m_focusedLayout;
+  CGUIListItemLayoutPtr m_layout;
+  CGUIListItemLayoutPtr m_focusedLayout;
   bool m_bSelected;     // item is selected or not
 
   struct icompare

--- a/xbmc/pvr/windows/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/windows/GUIEPGGridContainer.cpp
@@ -361,8 +361,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPt
   {
     if (!item->GetFocusedLayout())
     {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*focusedlayout);
-      item->SetFocusedLayout(layout);
+      item->SetFocusedLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*focusedlayout)));
     }
 
     if (resize != -1.0f)
@@ -394,8 +393,7 @@ void CGUIEPGGridContainer::ProcessItem(float posX, float posY, const CFileItemPt
   {
     if (!item->GetLayout())
     {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*normallayout);
-      item->SetLayout(layout);
+      item->SetLayout(CGUIListItemLayoutPtr(new CGUIListItemLayout(*normallayout)));
     }
 
     if (resize != -1.0f)


### PR DESCRIPTION
Automatic memory management to make the code safer.