### PR TITLE
ContextMenuManager: reserve space in CContextButtons

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -216,6 +216,7 @@ bool CONTEXTMENU::ShowFor(const CFileItemPtr& fileItem, const CContextMenuItem& 
     return true;
 
   CContextButtons buttons;
+  buttons.reserve(menuItems.size());
   for (size_t i = 0; i < menuItems.size(); ++i)
     buttons.Add(i, menuItems[i]->GetLabel(*fileItem));
 


### PR DESCRIPTION
Eliminate all but one std::vector reallocations.