### PR TITLE
VideoPlayer: fix -Wint-in-bool-context

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -279,8 +279,8 @@ public:
       PREDICATE_RETURN(g_LangCodeExpander.CompareISO639Codes(lh.language, audiolang)
                      , g_LangCodeExpander.CompareISO639Codes(rh.language, audiolang));
 
-      PREDICATE_RETURN(lh.flags & (StreamFlags::FLAG_FORCED && StreamFlags::FLAG_DEFAULT)
-                     , rh.flags & (StreamFlags::FLAG_FORCED && StreamFlags::FLAG_DEFAULT));
+      PREDICATE_RETURN((lh.flags & (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT)) == (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT)
+                     , (rh.flags & (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT)) == (StreamFlags::FLAG_FORCED | StreamFlags::FLAG_DEFAULT));
 
     }
 


### PR DESCRIPTION
Commit 543f31c15092a8c0e483ba641549b4545d642aa6 added code lines which
caused these warning messages:

```
xbmc/cores/VideoPlayer/VideoPlayer.cpp: In member function ‘bool PredicateSubtitlePriority::operator()(const SelectionStream&, const SelectionStream&) const’:
xbmc/cores/VideoPlayer/VideoPlayer.cpp:282:77: warning: enum constant in boolean context [-Wint-in-bool-context]
       PREDICATE_RETURN(lh.flags & (StreamFlags::FLAG_FORCED && StreamFlags::FLAG_DEFAULT)
                                                                             ^
xbmc/cores/VideoPlayer/VideoPlayer.cpp:99:9: note: in definition of macro ‘PREDICATE_RETURN’
     if((lh) != (rh)) \
         ^~
xbmc/cores/VideoPlayer/VideoPlayer.cpp:283:77: warning: enum constant in boolean context [-Wint-in-bool-context]
                      , rh.flags & (StreamFlags::FLAG_FORCED && StreamFlags::FLAG_DEFAULT));
                                                                             ^
xbmc/cores/VideoPlayer/VideoPlayer.cpp:99:17: note: in definition of macro ‘PREDICATE_RETURN’
     if((lh) != (rh)) \
                 ^~
xbmc/cores/VideoPlayer/VideoPlayer.cpp:282:77: warning: enum constant in boolean context [-Wint-in-bool-context]
       PREDICATE_RETURN(lh.flags & (StreamFlags::FLAG_FORCED && StreamFlags::FLAG_DEFAULT)
                                                                             ^
xbmc/cores/VideoPlayer/VideoPlayer.cpp:100:15: note: in definition of macro ‘PREDICATE_RETURN’
       return (lh) > (rh); \
               ^~
xbmc/cores/VideoPlayer/VideoPlayer.cpp:283:77: warning: enum constant in boolean context [-Wint-in-bool-context]
                      , rh.flags & (StreamFlags::FLAG_FORCED && StreamFlags::FLAG_DEFAULT));
                                                                             ^
xbmc/cores/VideoPlayer/VideoPlayer.cpp:100:22: note: in definition of macro ‘PREDICATE_RETURN’
       return (lh) > (rh); \
                      ^~
```

This never worked as expected; it didn't break only because by
accident, the resulting value of `FLAG_FORCED && FLAG_DEFAULT` is
`true` or `1`, which happens to equal `FLAG_DEFAULT`.