### PR TITLE
RendererDRMPRIME: support drm format modifier

### DIFF
--- a/cmake/modules/FindLibDRM.cmake
+++ b/cmake/modules/FindLibDRM.cmake
@@ -14,7 +14,7 @@
 #   LibDRM::LibDRM   - The LibDRM library
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBDRM libdrm QUIET)
+  pkg_check_modules(PC_LIBDRM libdrm>=2.4.71 QUIET)
 endif()
 
 find_path(LIBDRM_INCLUDE_DIR NAMES drm.h

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -175,6 +175,7 @@ void CRendererDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer)
   if (descriptor && descriptor->nb_layers)
   {
     uint32_t handles[4] = {0}, pitches[4] = {0}, offsets[4] = {0};
+    uint64_t modifier[4] = {0};
     int ret;
 
     // convert Prime FD to GEM handle
@@ -192,17 +193,19 @@ void CRendererDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer)
 
     for (int plane = 0; plane < layer->nb_planes; plane++)
     {
-      uint32_t handle = buffer->m_handles[layer->planes[plane].object_index];
+      int object = layer->planes[plane].object_index;
+      uint32_t handle = buffer->m_handles[object];
       if (handle && layer->planes[plane].pitch)
       {
         handles[plane] = handle;
         pitches[plane] = layer->planes[plane].pitch;
         offsets[plane] = layer->planes[plane].offset;
+        modifier[plane] = descriptor->objects[object].format_modifier;
       }
     }
 
     // add the video frame FB
-    ret = drmModeAddFB2(m_DRM->m_fd, buffer->GetWidth(), buffer->GetHeight(), layer->format, handles, pitches, offsets, &buffer->m_fb_id, 0);
+    ret = drmModeAddFB2WithModifiers(m_DRM->m_fd, buffer->GetWidth(), buffer->GetHeight(), layer->format, handles, pitches, offsets, modifier, &buffer->m_fb_id, 0);
     if (ret < 0)
     {
       CLog::Log(LOGERROR, "CRendererDRMPRIME::%s - failed to add drm layer %d, ret = %d", __FUNCTION__, buffer->m_fb_id, ret);


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This PR adds support for drm format modifiers in the DRM PRIME renderer.

Note: This adds a requirement on libdrm version 2.4.71 or newer.

## Motivation and Context
Make DRM PRIME renderer future proof for upcoming v4l2 decoders that may use tiled drm formats.

## How Has This Been Tested?
Existing drm prime decoder rkmpp continues to work.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
