### PR TITLE
windowing/gbm: consolidate add property functions

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -24,7 +24,6 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "utils/log.h"
-#include "windowing/gbm/DRMAtomic.h"
 
 static CWinSystemGbmGLESContext *m_pWinSystem;
 
@@ -220,17 +219,16 @@ void CRendererDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer)
 
     if(m_DRM->m_req)
     {
-      std::shared_ptr<CDRMAtomic> atomic = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "FB_ID",   buffer->m_fb_id);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "CRTC_ID", atomic->m_crtc->crtc->crtc_id);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "SRC_X",   src_x);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "SRC_Y",   src_y);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "SRC_W",   src_w);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "SRC_H",   src_h);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "CRTC_X",  crtc_x);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "CRTC_Y",  crtc_y);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "CRTC_W",  crtc_w);
-      atomic->AddPlaneProperty(atomic->m_req, atomic->m_primary_plane, "CRTC_H",  crtc_h);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "FB_ID",   buffer->m_fb_id);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "CRTC_ID", m_DRM->m_crtc->crtc->crtc_id);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "SRC_X",   src_x);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "SRC_Y",   src_y);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "SRC_W",   src_w);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "SRC_H",   src_h);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "CRTC_X",  crtc_x);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "CRTC_Y",  crtc_y);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "CRTC_W",  crtc_w);
+      m_DRM->AddProperty(m_DRM->m_req, m_DRM->m_primary_plane, "CRTC_H",  crtc_h);
     }
     else
     {

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -33,11 +33,7 @@ public:
   virtual bool InitDrm() override;
   virtual void DestroyDrm() override;
 
-  bool AddPlaneProperty(drmModeAtomicReq *req, struct plane *obj, const char *name, int value);
-
 private:
-  bool AddConnectorProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
-  bool AddCrtcProperty(drmModeAtomicReq *req, int obj_id, const char *name, int value);
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
 
   bool m_need_modeset;

--- a/xbmc/windowing/gbm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/DRMLegacy.cpp
@@ -174,38 +174,9 @@ bool CDRMLegacy::InitDrm()
   return true;
 }
 
-bool CDRMLegacy::AddConnectorProperty(const char *name, int value)
-{
-  struct connector *obj = m_connector;
-  int prop_id = 0;
-
-  for (unsigned int i = 0 ; i < obj->props->count_props ; i++)
-  {
-    if (strcmp(obj->props_info[i]->name, name) == 0)
-    {
-      prop_id = obj->props_info[i]->prop_id;
-      break;
-    }
-  }
-
-  if (prop_id < 0)
-  {
-    CLog::Log(LOGERROR, "CDRMUtils::%s - no connector property: %s", __FUNCTION__, name);
-    return false;
-  }
-
-  auto ret = drmModeConnectorSetProperty(m_fd, m_connector->connector->connector_id, prop_id, value);
-  if (ret < 0)
-  {
-    return false;
-  }
-
-  return true;
-}
-
 bool CDRMLegacy::SetActive(bool active)
 {
-  if (!AddConnectorProperty("DPMS", active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF))
+  if (!SetProperty(m_connector, "DPMS", active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF))
   {
     CLog::Log(LOGDEBUG, "CDRMLegacy::%s - failed to set DPMS property");
     return false;

--- a/xbmc/windowing/gbm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/DRMLegacy.h
@@ -33,7 +33,6 @@ public:
   virtual bool InitDrm() override;
 
 private:
-  bool AddConnectorProperty(const char *name, int value);
   bool WaitingForFlip();
   bool QueueFlip(struct gbm_bo *bo);
   static void PageFlipHandler(int fd, unsigned int frame, unsigned int sec,

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -128,6 +128,77 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
   return fb;
 }
 
+static bool GetProperties(int fd, uint32_t id, uint32_t type, struct drm_object *object)
+{
+  drmModeObjectPropertiesPtr props = drmModeObjectGetProperties(fd, id, type);
+  if (!props)
+    return false;
+
+  object->id = id;
+  object->type = type;
+  object->props = props;
+  object->props_info = new drmModePropertyPtr[props->count_props];
+
+  for (uint32_t i = 0; i < props->count_props; i++)
+    object->props_info[i] = drmModeGetProperty(fd, props->props[i]);
+
+  return true;
+}
+
+static void FreeProperties(struct drm_object *object)
+{
+  if (object->props_info)
+  {
+    for (uint32_t i = 0; i < object->props->count_props; i++)
+      drmModeFreeProperty(object->props_info[i]);
+
+    delete [] object->props_info;
+    object->props_info = nullptr;
+  }
+
+  drmModeFreeObjectProperties(object->props);
+  object->props = nullptr;
+  object->type = 0;
+  object->id = 0;
+}
+
+static uint32_t GetPropertyId(struct drm_object *object, const char *name)
+{
+  for (uint32_t i = 0; i < object->props->count_props; i++)
+    if (!strcmp(object->props_info[i]->name, name))
+      return object->props_info[i]->prop_id;
+
+  return 0;
+}
+
+bool CDRMUtils::AddProperty(drmModeAtomicReqPtr req, struct drm_object *object, const char *name, uint64_t value)
+{
+  uint32_t property_id = GetPropertyId(object, name);
+  if (property_id)
+  {
+    int ret = drmModeAtomicAddProperty(req, object->id, property_id, value);
+    if (ret > 0)
+      return true;
+  }
+
+  CLog::Log(LOGWARNING, "CDRMUtils::%s - could not %s property %s", __FUNCTION__, property_id ? "add" : "find", name);
+  return false;
+}
+
+bool CDRMUtils::SetProperty(struct drm_object *object, const char *name, uint64_t value)
+{
+  uint32_t property_id = GetPropertyId(object, name);
+  if (property_id)
+  {
+    int ret = drmModeObjectSetProperty(m_fd, object->id, object->type, property_id, value);
+    if (!ret)
+      return true;
+  }
+
+  CLog::Log(LOGWARNING, "CDRMUtils::%s - could not %s property %s", __FUNCTION__, property_id ? "set" : "find", name);
+  return false;
+}
+
 bool CDRMUtils::GetResources()
 {
   m_drm_resources = drmModeGetResources(m_fd);
@@ -161,17 +232,10 @@ bool CDRMUtils::GetConnector()
     return false;
   }
 
-  m_connector->props = drmModeObjectGetProperties(m_fd, m_connector->connector->connector_id, DRM_MODE_OBJECT_CONNECTOR);
-  if (!m_connector->props)
+  if (!GetProperties(m_fd, m_connector->connector->connector_id, DRM_MODE_OBJECT_CONNECTOR, m_connector))
   {
     CLog::Log(LOGERROR, "CDRMUtils::%s - could not get connector %u properties: %s", __FUNCTION__, m_connector->connector->connector_id, strerror(errno));
     return false;
-  }
-
-  m_connector->props_info = new drmModePropertyPtr[m_connector->props->count_props];
-  for (uint32_t i = 0; i < m_connector->props->count_props; i++)
-  {
-    m_connector->props_info[i] = drmModeGetProperty(m_fd, m_connector->props->props[i]);
   }
 
   return true;
@@ -223,17 +287,10 @@ bool CDRMUtils::GetCrtc()
     return false;
   }
 
-  m_crtc->props = drmModeObjectGetProperties(m_fd, m_crtc->crtc->crtc_id, DRM_MODE_OBJECT_CRTC);
-  if (!m_crtc->props)
+  if (!GetProperties(m_fd, m_crtc->crtc->crtc_id, DRM_MODE_OBJECT_CRTC, m_crtc))
   {
     CLog::Log(LOGERROR, "CDRMUtils::%s - could not get crtc %u properties: %s", __FUNCTION__, m_crtc->crtc->crtc_id, strerror(errno));
     return false;
-  }
-
-  m_crtc->props_info = new drmModePropertyPtr[m_crtc->props->count_props];
-  for (uint32_t i = 0; i < m_crtc->props->count_props; i++)
-  {
-    m_crtc->props_info[i] = drmModeGetProperty(m_fd, m_crtc->props->props[i]);
   }
 
   return true;
@@ -337,17 +394,10 @@ bool CDRMUtils::GetPlanes()
     return false;
   }
 
-  m_primary_plane->props = drmModeObjectGetProperties(m_fd, primary_plane_id, DRM_MODE_OBJECT_PLANE);
-  if (!m_primary_plane->props)
+  if (!GetProperties(m_fd, primary_plane_id, DRM_MODE_OBJECT_PLANE, m_primary_plane))
   {
     CLog::Log(LOGERROR, "CDRMUtils::%s - could not get primary plane %u properties: %s", __FUNCTION__, primary_plane_id, strerror(errno));
     return false;
-  }
-
-  m_primary_plane->props_info = new drmModePropertyPtr[m_primary_plane->props->count_props];
-  for (uint32_t i = 0; i < m_primary_plane->props->count_props; i++)
-  {
-    m_primary_plane->props_info[i] = drmModeGetProperty(m_fd, m_primary_plane->props->props[i]);
   }
 
   for (uint32_t i = 0; i < m_primary_plane->plane->count_formats; i++)
@@ -384,17 +434,10 @@ bool CDRMUtils::GetPlanes()
       return false;
     }
 
-    m_overlay_plane->props = drmModeObjectGetProperties(m_fd, overlay_plane_id, DRM_MODE_OBJECT_PLANE);
-    if (!m_overlay_plane->props)
+    if (!GetProperties(m_fd, overlay_plane_id, DRM_MODE_OBJECT_PLANE, m_overlay_plane))
     {
       CLog::Log(LOGERROR, "CDRMUtils::%s - could not get overlay plane %u properties: %s", __FUNCTION__, overlay_plane_id, strerror(errno));
       return false;
-    }
-
-    m_overlay_plane->props_info = new drmModePropertyPtr[m_overlay_plane->props->count_props];
-    for (uint32_t i = 0; i < m_overlay_plane->props->count_props; i++)
-    {
-      m_overlay_plane->props_info[i] = drmModeGetProperty(m_fd, m_overlay_plane->props->props[i]);
     }
 
     fourcc = 0;
@@ -594,8 +637,7 @@ void CDRMUtils::DestroyDrm()
   m_drm_resources = nullptr;
 
   drmModeFreeConnector(m_connector->connector);
-  drmModeFreeObjectProperties(m_connector->props);
-  delete [] m_connector->props_info;
+  FreeProperties(m_connector);
   delete m_connector;
   m_connector = nullptr;
 
@@ -604,21 +646,18 @@ void CDRMUtils::DestroyDrm()
   m_encoder = nullptr;
 
   drmModeFreeCrtc(m_crtc->crtc);
-  drmModeFreeObjectProperties(m_crtc->props);
-  delete [] m_crtc->props_info;
+  FreeProperties(m_crtc);
   delete m_crtc;
   m_crtc = nullptr;
 
   drmModeFreePlane(m_primary_plane->plane);
-  drmModeFreeObjectProperties(m_primary_plane->props);
-  delete [] m_primary_plane->props_info;
+  FreeProperties(m_primary_plane);
   delete m_primary_plane;
 
   if (m_overlay_plane != m_primary_plane)
   {
     drmModeFreePlane(m_overlay_plane->plane);
-    drmModeFreeObjectProperties(m_overlay_plane->props);
-    delete [] m_overlay_plane->props_info;
+    FreeProperties(m_overlay_plane);
     delete m_overlay_plane;
   }
   m_overlay_plane = nullptr;

--- a/xbmc/windowing/gbm/DRMUtils.h
+++ b/xbmc/windowing/gbm/DRMUtils.h
@@ -28,19 +28,23 @@
 #include "windowing/Resolution.h"
 #include "GBMUtils.h"
 
-struct plane
+struct drm_object
 {
-  drmModePlane *plane = nullptr;
-  drmModeObjectProperties *props = nullptr;
+  uint32_t id = 0;
+  uint32_t type = 0;
+  drmModeObjectPropertiesPtr props = nullptr;
   drmModePropertyRes **props_info = nullptr;
+};
+
+struct plane : drm_object
+{
+  drmModePlanePtr plane = nullptr;
   uint32_t format;
 };
 
-struct connector
+struct connector : drm_object
 {
-  drmModeConnector *connector = nullptr;
-  drmModeObjectProperties *props = nullptr;
-  drmModePropertyRes **props_info = nullptr;
+  drmModeConnectorPtr connector = nullptr;
 };
 
 struct encoder
@@ -48,11 +52,9 @@ struct encoder
   drmModeEncoder *encoder = nullptr;
 };
 
-struct crtc
+struct crtc : drm_object
 {
-  drmModeCrtc *crtc = nullptr;
-  drmModeObjectProperties *props = nullptr;
-  drmModePropertyRes **props_info = nullptr;
+  drmModeCrtcPtr crtc = nullptr;
 };
 
 struct drm_fb
@@ -75,6 +77,9 @@ public:
   bool GetModes(std::vector<RESOLUTION_INFO> &resolutions);
   bool SetMode(RESOLUTION_INFO res);
   void WaitVBlank();
+
+  bool AddProperty(drmModeAtomicReqPtr req, struct drm_object *object, const char *name, uint64_t value);
+  bool SetProperty(struct drm_object *object, const char *name, uint64_t value);
 
   int m_fd;
 


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
This PR consolidates handling of drm properties into generic helper functions.
Adds `AddProperty` (atomic) and `SetProperty` (legacy) to `DRMUtils` and removes the connector/crtc/plane specific variants from `DRMAtomic` and `DRMLegacy`.

## Motivation and Context
Consolidate and remove duplicated code

## How Has This Been Tested?
Kodi continues to work on my Rock64 using LibreELEC

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
