### PR TITLE
[Android] don't reset / dequeue until data has fed

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.h
@@ -72,7 +72,7 @@ protected:
   std::string m_mime;
   std::string m_codecname;
   std::string m_formatname;
-  bool m_opened, m_resettable;
+  bool m_opened, m_codecIsFed;
   int m_samplerate;
   int m_channels;
   uint8_t* m_buffer;


### PR DESCRIPTION
## Description
Android decoders are quite sensible if one wants to reset Audio decoder before any source data is fed. In most cases the decoder goes into an unusable state.

This PR prevents the above 2 actions until the first packet is added  / fed

## Motivation and Context
Solves https://trac.kodi.tv/ticket/17883

## How Has This Been Tested?
Play avi attached to the above mentioned ticket using AFTV3

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
