### PR TITLE
Fixed: use fadelabel instead of textbox for Estuary notications so th…

### DIFF
--- a/addons/skin.estuary/xml/DialogNotification.xml
+++ b/addons/skin.estuary/xml/DialogNotification.xml
@@ -37,7 +37,7 @@
 				<scrollout>false</scrollout>
 				<pauseatend>2000</pauseatend>
 			</control>
-			<control type="textbox" id="402">
+			<control type="fadelabel" id="402">
 				<description>Line 2 Label</description>
 				<left>151</left>
 				<top>68</top>
@@ -45,6 +45,8 @@
 				<height>60</height>
 				<font>font27_narrow</font>
 				<aligny>center</aligny>
+				<scrollout>false</scrollout>
+				<pauseatend>2000</pauseatend>
 			</control>
 		</control>
 	</controls>


### PR DESCRIPTION
In Confluence the notification dialog had a fixed title and scrolling text. In Estuary that got swapped somehow. This causes texts for notifications to wrap instead of scroll. 

## Description
Replaced the `textbox` for the notification text with a a `fadelabel`. 

## Motivation and Context
This makes it consistent with notification dialogs of other skins.

## How Has This Been Tested?
Replaced the old DialogNotification.xml with the modified one and triggered a notification via the API.

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
