### PR TITLE
[Android] break on first audiocodec match / implement blacklist

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -60,10 +60,25 @@ static bool IsDownmixDecoder(const std::string &name)
 {
   static const char *downmixDecoders[] = {
     "OMX.dolby",
-    // End of Rockchip
+    // End of list
     NULL
   };
   for (const char **ptr = downmixDecoders; *ptr; ptr++)
+  {
+    if (!strnicmp(*ptr, name.c_str(), strlen(*ptr)))
+      return true;
+  }
+  return false;
+}
+
+static bool IsDecoderBlacklisted(const std::string &name)
+{
+  static const char *blacklistDecoders[] = {
+    "OMX.google",
+    // End of list
+    NULL
+  };
+  for (const char **ptr = blacklistDecoders; *ptr; ptr++)
   {
     if (!strnicmp(*ptr, name.c_str(), strlen(*ptr)))
       return true;
@@ -208,6 +223,9 @@ bool CDVDAudioCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 
       std::string codecName = codec_info.getName();
 
+      if (IsDecoderBlacklisted(codecName))
+        continue;
+
       if (m_hints.channels > 2 && !stereoDownmixAllowed && IsDownmixDecoder(codecName))
         continue;
 
@@ -222,6 +240,7 @@ bool CDVDAudioCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           continue;
         }
         CLog::Log(LOGINFO, "CDVDAudioCodecAndroidMediaCodec: Selected audio decoder: %s", codecName.c_str());
+        break;
       }
     }
   }


### PR DESCRIPTION
## Description
- Break codec search loop for audio codecs if first match is found
- Implement blacklist for audio codecs and eliminate OMX.google s/w decoders

## Motivation and Context
No need to select another decoder if we found one, assuming that the first one is the "right" one.

## How Has This Been Tested?
AFTV 2015 / avi stream with mp3 audio track

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
