### PR TITLE
[INPUTSTREAM] ensure buffer for RF 5646 language identifier

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -142,7 +142,7 @@ extern "C" {
     const uint8_t *m_ExtraData;
     unsigned int m_ExtraSize;
 
-    char m_language[4];                  /*!< @brief ISO 639 3-letter language code (empty string if undefined) */
+    char m_language[64];                 /*!< @brief RFC 5646 language code (empty string if undefined) */
 
     unsigned int m_FpsScale;             /*!< @brief Scale of 1000 and a rate of 29970 will result in 29.97 fps */
     unsigned int m_FpsRate;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -98,8 +98,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.6"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.6"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "2.0.7"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "2.0.7"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "addon-instance/Inputstream.h"
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -91,7 +91,6 @@ public:
     pPrivate = NULL;
     ExtraData = NULL;
     ExtraSize = 0;
-    memset(language, 0, sizeof(language));
     disabled = false;
     changes = 0;
     flags = StreamFlags::FLAG_NONE;
@@ -122,7 +121,7 @@ public:
   unsigned int ExtraSize; // size of extra data
 
   StreamFlags flags;
-  char language[4]; // ISO 639 3-letter language code (empty string if undefined)
+  std::string language; // RFC 5646 language code (empty string if undefined)
   bool disabled; // set when stream is disabled. (when no decoder exists)
 
   std::string name;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -325,7 +325,7 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
   if (idx >= ctx->m_streamdata.size())
   {
     CDemuxStreamSubtitle stream;
-    strcpy(stream.language, "cc");
+    stream.language = "cc";
     stream.flags = FLAG_HEARING_IMPAIRED;
     stream.codec = AV_CODEC_ID_TEXT;
     stream.uniqueId = service;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -550,8 +550,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
   toStream->flags = stream->flags;
   toStream->cryptoSession = stream->cryptoSession;
   toStream->externalInterfaces = stream->externalInterfaces;
-  for (int j=0; j<4; j++)
-    toStream->language[j] = stream->language[j];
+  toStream->language = stream->language;
 
   toStream->realtime = stream->realtime;
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1640,7 +1640,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
       }
     }
     if (langTag)
-      strncpy(stream->language, langTag->value, 3);
+      stream->language = std::string(langTag->value, 3);
 
     if( stream->type != STREAM_NONE && pStream->codecpar->extradata && pStream->codecpar->extradata_size > 0 )
     {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -208,8 +208,7 @@ bool CDVDDemuxVobsub::ParseId(SState& state, char* line)
   std::unique_ptr<CStream> stream(new CStream(this));
 
   while(*line == ' ') line++;
-  strncpy(stream->language, line, 2);
-  stream->language[2] = '\0';
+  stream->language = std::string(line, 2);
   line+=2;
 
   while(*line == ' ' || *line == ',') line++;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1124,7 +1124,7 @@ int64_t CDVDInputStreamBluray::GetLength()
   return m_dll->bd_get_title_size(m_bd);
 }
 
-static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, char* language)
+static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, std::string &language)
 {
   int i=0;
   for(;i<count;i++,info++)
@@ -1134,11 +1134,11 @@ static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, char* lang
   }
   if(i==count)
     return false;
-  memcpy(language, info->lang, 4);
+  language = reinterpret_cast<char*>(info->lang);
   return true;
 }
 
-void CDVDInputStreamBluray::GetStreamInfo(int pid, char* language)
+void CDVDInputStreamBluray::GetStreamInfo(int pid, std::string &language)
 {
   if(!m_title || m_clip >= m_title->clip_count)
     return;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -112,7 +112,7 @@ public:
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
   bool PosTime(int ms) override;
 
-  void GetStreamInfo(int pid, char* language);
+  void GetStreamInfo(int pid, std::string &language);
 
   void OverlayCallback(const BD_OVERLAY * const);
 #ifdef HAVE_LIBBLURAY_BDJ

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -389,11 +389,8 @@ CDemuxStream* CInputStreamAddon::GetStream(int streamId) const
   demuxStream->codec = codec->id;
   demuxStream->codecName = stream.m_codecInternalName;
   demuxStream->uniqueId = streamId;
-  demuxStream->language[0] = stream.m_language[0];
-  demuxStream->language[1] = stream.m_language[1];
-  demuxStream->language[2] = stream.m_language[2];
-  demuxStream->language[3] = stream.m_language[3];
   demuxStream->flags = static_cast<StreamFlags>(stream.m_flags);
+  demuxStream->language = stream.m_language;
 
   if (stream.m_ExtraData && stream.m_ExtraSize)
   {


### PR DESCRIPTION
## Description
Inputstream is curently not able to transport regional language identifiers because language in inputstream API is limited to 4 chars.
For audiostreams / audiostreamselection we need to transport / display regional information, too.

## Motivation and Context
amazon provides different spanish languages based on countrycode
Currently its not possible to display the differences in Audio settings dialog

![image](https://user-images.githubusercontent.com/22704999/40482257-7a754a64-5f54-11e8-8559-f4eafa18690e.png)

The last 2 entries are a result from passing "es-es"

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
