### PR TITLE
VideoPlayer: discard buffers instead of flush when hiding video

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -265,7 +265,7 @@ void CRenderManager::ShowVideo(bool enable)
 {
   m_showVideo = enable;
   if (!enable)
-    Flush(false);
+    DiscardBuffer();
 }
 
 void CRenderManager::FrameWait(int ms)


### PR DESCRIPTION
fixes black flashes when skipping

https://trac.kodi.tv/ticket/17862 should still be ok.