### PR TITLE
don't depend on m_alreadyStarted when doing GetInfo() vis addon inquiry

### DIFF
--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -450,7 +450,7 @@ void CGUIVisualisationControl::CreateBuffers()
   // Get the number of buffers from the current vis
   VIS_INFO info { false, 0 };
 
-  if (m_instance && m_alreadyStarted)
+  if (m_instance)
     m_instance->GetInfo(&info);
 
   m_numBuffers = info.iSyncDelay + 1;


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->
When CreateBuffers() is about to call a vis addons GetInfo(), it also checks if the addon was already started. As CreateBuffers() is called long before the vis addon is started, the condition that allows the call to GetInfo() always evaluates to false, so GetInfo() is never called (CreateBuffers() seems to be the only occurence), in consequence addons that need bWantsFreq=true to receive FFT data in the AudioData() method won't work (they won't ever receive anything to display).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Make visaddons that depend on FFT data work

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested with visualization.nastyfft which requires FFT data, which won't render anything useful without that. Also checked other visualizations that don't implement GetInfo(), which still work fine afterwards.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
