### PR TITLE
[Android] Blacklist OMX.MTK.AUDIO

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -75,6 +75,7 @@ static bool IsDecoderBlacklisted(const std::string &name)
 {
   static const char *blacklistDecoders[] = {
     "OMX.google",
+    "OMX.MTK",
     // End of list
     NULL
   };


### PR DESCRIPTION
## Description
MTK audio decoders decode in stream output speed which leads to glitches / delay on startup.

## Motivation and Context
Several issue reportings on Sony TV / AFTVS devices.

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
