### PR TITLE
VAAPI-Settings: Fix vaapi-mpeg2 visibility

### DIFF
--- a/system/settings/freebsd.xml
+++ b/system/settings/freebsd.xml
@@ -67,6 +67,7 @@
         </setting>
         <setting id="videoplayer.usevaapimpeg2" type="boolean" parent="videoplayer.usevaapi" label="13447" help="13448">
           <requirement>HAVE_LIBVA</requirement>
+          <visible>false</visible>
           <dependencies>
             <dependency type="enable">
               <condition setting="videoplayer.usevaapi" operator="is">true</condition>

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -67,6 +67,7 @@
         </setting>
         <setting id="videoplayer.usevaapimpeg2" type="boolean" parent="videoplayer.usevaapi" label="13447" help="13448">
           <requirement>HAVE_LIBVA</requirement>
+          <visible>false</visible>
           <dependencies>
             <dependency type="enable">
               <condition setting="videoplayer.usevaapi" operator="is">true</condition>


### PR DESCRIPTION
It was reported that vaapi-mpeg2 is also visible if vaapi is not available. As the others behave correctly this adds the additional visible tag the others have. 