### PR TITLE
[curl] fix curl options after #13909

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -841,7 +841,7 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
         {
           SetCustomRequest(value);
         }
-        if (name == "verifypeer")
+        else if (name == "verifypeer")
         {
           if (value == "false")
             m_verifyPeer = false;


### PR DESCRIPTION
## Motivation and Context
error slipped in at #13909

## How Has This Been Tested?
@rbuehlma reported it works again

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
