### PR TITLE
[Estuary] Fix mvid skin home page target so nodes work

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -670,7 +670,7 @@
 						<include>WidgetGroupListCommon</include>
 						<pagecontrol>16010</pagecontrol>
 						<include content="WidgetListCategories" condition="Library.HasContent(musicvideos) + !Skin.HasSetting(home_no_categories_widget)">
-							<param name="content_path" value="library://music/musicvideos/"/>
+							<param name="content_path" value="library://video/musicvideos/"/>
 							<param name="widget_header" value="$LOCALIZE[31148]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="16900"/>


### PR DESCRIPTION
## Description
I stumbled on this trying to work out why my "Top 100" music video node didn't work. When I created a new node, it didn't show up. I looked at the videos >> music video link and the node showed there, but not on the main menu. This change doesn't seem to effect anything else that I can tell but now nodes will show on the main sub menu header.


## Motivation and Context
I wanted to create a new node for Music Videos and for it to show in the sub menu header

## How Has This Been Tested?
Tested home menu and a custom node

## Screenshots (if appropriate):
![new_mvid_node](https://user-images.githubusercontent.com/1050512/40672445-be9cd0e8-6366-11e8-92b1-f22fa37976ae.jpg)
NOTE: Top 100 is the custom music video node and now displays as expected

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
