### PR TITLE
fix issues related to DialogBusy

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3875,7 +3875,7 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
   bool bUseDim = false;
   if (!forceType)
   {
-    if (CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog())
+    if (CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true))
       bUseDim = true;
     else if (m_appPlayer.IsPlayingVideo() && m_ServiceManager->GetSettings().GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE))
       bUseDim = true;

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -72,7 +72,7 @@ void CAutorun::ExecuteAutorun(const std::string& path, bool bypassSettings, bool
   {
     if (g_application.GetAppPlayer().IsPlayingAudio() ||
         g_application.GetAppPlayer().IsPlayingVideo() ||
-        CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog())
+        CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true))
     {
       return;
     }

--- a/xbmc/addons/interfaces/GUI/AddonGUIWindow.cpp
+++ b/xbmc/addons/interfaces/GUI/AddonGUIWindow.cpp
@@ -334,9 +334,10 @@ void CGUIAddonWindowDialog::Show_Internal(bool show /* = true */)
     // this dialog is derived from GUiMediaWindow
     // make sure it is rendered last
     m_renderOrder = RENDER_ORDER_DIALOG;
-    while (m_bRunning && !g_application.m_bStop)
+    while (m_bRunning)
     {
-      ProcessRenderLoop();
+      if (!ProcessRenderLoop(false))
+        break;
     }
   }
   else // hide

--- a/xbmc/addons/interfaces/GUI/Window.cpp
+++ b/xbmc/addons/interfaces/GUI/Window.cpp
@@ -1304,9 +1304,10 @@ void CGUIAddonWindowDialog::Show_Internal(bool show /* = true */)
     // this dialog is derived from GUIMediaWindow
     // make sure it is rendered last
     m_renderOrder = RENDER_ORDER_DIALOG;
-    while (m_bRunning && !g_application.m_bStop)
+    while (m_bRunning)
     {
-      ProcessRenderLoop();
+      if (!ProcessRenderLoop(false))
+        break;
     }
   }
   else // hide

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -114,7 +114,7 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
 }
 
 CGUIDialogBusy::CGUIDialogBusy(void)
-  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::PARENTLESS_MODAL),
+  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml", DialogModalityType::MODAL),
     m_bLastVisible(false)
 {
   m_loadType = LOAD_ON_GUI_INIT;

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -208,9 +208,10 @@ void CGUIDialog::Open_Internal(bool bProcessRenderLoop, const std::string &param
 
     lock.Leave();
 
-    while (m_active && !g_application.m_bStop)
+    while (m_active)
     {
-      CServiceBroker::GetGUI()->GetWindowManager().ProcessRenderLoop();
+      if (!CServiceBroker::GetGUI()->GetWindowManager().ProcessRenderLoop(false))
+        break;
     }
   }
 }

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -34,8 +34,7 @@
 enum class DialogModalityType
 {
   MODELESS,
-  MODAL,
-  PARENTLESS_MODAL
+  MODAL
 };
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(pop)
@@ -63,7 +62,7 @@ public:
 
   bool IsDialogRunning() const override { return m_active; };
   bool IsDialog() const override { return true;};
-  bool IsModalDialog() const override { return m_modalityType == DialogModalityType::MODAL || m_modalityType == DialogModalityType::PARENTLESS_MODAL; };
+  bool IsModalDialog() const override { return m_modalityType == DialogModalityType::MODAL; };
   virtual DialogModalityType GetModalityType() const { return m_modalityType; };
 
   void SetAutoClose(unsigned int timeoutMs);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -828,7 +828,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   }
 
   // don't activate a window if there are active modal dialogs of type MODAL
-  if (!force && HasModalDialog({ DialogModalityType::MODAL }))
+  if (!force && HasModalDialog(true))
   {
     CLog::Log(LOGINFO, "Activate of window '%i' refused because there are active modal dialogs", iWindowID);
     g_audioManager.PlayActionSound(CAction(ACTION_ERROR));
@@ -1382,7 +1382,7 @@ void CGUIWindowManager::RemoveDialog(int id)
                          m_activeDialogs.end());
 }
 
-bool CGUIWindowManager::HasModalDialog(const std::vector<DialogModalityType>& types, bool ignoreClosing /* = true */) const
+bool CGUIWindowManager::HasModalDialog(bool ignoreClosing) const
 {
   CSingleLock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   for (const auto& window : m_activeDialogs)
@@ -1391,25 +1391,15 @@ bool CGUIWindowManager::HasModalDialog(const std::vector<DialogModalityType>& ty
         window->IsModalDialog() &&
         (!ignoreClosing || !window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE)))
     {
-      if (!types.empty())
-      {
-        CGUIDialog *dialog = static_cast<CGUIDialog*>(window);
-        for (const auto &type : types)
-        {
-          if (dialog->GetModalityType() == type)
-            return true;
-        }
-      }
-      else
-        return true;
+      return true;
     }
   }
   return false;
 }
 
-bool CGUIWindowManager::HasVisibleModalDialog(const std::vector<DialogModalityType>& types) const
+bool CGUIWindowManager::HasVisibleModalDialog() const
 {
-  return HasModalDialog(types, false);
+  return HasModalDialog(false);
 }
 
 int CGUIWindowManager::GetTopmostDialog(bool modal, bool ignoreClosing) const

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1312,7 +1312,7 @@ CGUIWindow* CGUIWindowManager::GetWindow(int id) const
   return nullptr;
 }
 
-void CGUIWindowManager::ProcessRenderLoop(bool renderOnly /*= false*/)
+bool CGUIWindowManager::ProcessRenderLoop(bool renderOnly)
 {
   if (g_application.IsCurrentThread() && m_pCallback)
   {
@@ -1323,6 +1323,10 @@ void CGUIWindowManager::ProcessRenderLoop(bool renderOnly /*= false*/)
     m_pCallback->Render();
     m_iNested--;
   }
+  if (g_application.m_bStop)
+    return false;
+  else
+    return true;
 }
 
 void CGUIWindowManager::SetCallback(IWindowManagerCallback& callback)

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -201,8 +201,8 @@ public:
   void AddMsgTarget( IMsgTargetCallback* pMsgTarget );
   int GetActiveWindow() const;
   int GetActiveWindowOrDialog() const;
-  bool HasModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>(), bool ignoreClosing = true) const;
-  bool HasVisibleModalDialog(const std::vector<DialogModalityType>& types = std::vector<DialogModalityType>()) const;
+  bool HasModalDialog(bool ignoreClosing) const;
+  bool HasVisibleModalDialog() const;
   bool IsDialogTopmost(int id, bool modal = false) const;
   bool IsDialogTopmost(const std::string &xmlFile, bool modal = false) const;
   bool IsModalDialogTopmost(int id) const;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -257,7 +257,7 @@ private:
    */
   void ActivateWindow_Internal(int windowID, const std::vector<std::string> &params, bool swappingWindows, bool force = false);
 
-  void ProcessRenderLoop(bool renderOnly = false);
+  bool ProcessRenderLoop(bool renderOnly);
 
   bool HandleAction(const CAction &action) const;
 

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -808,7 +808,7 @@ bool CGUIControlsGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int co
     // SYSTEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case SYSTEM_HAS_ACTIVE_MODAL_DIALOG:
-      value = CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog();
+      value = CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true);
       return true;
     case SYSTEM_HAS_VISIBLE_MODAL_DIALOG:
       value = CServiceBroker::GetGUI()->GetWindowManager().HasVisibleModalDialog();

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -34,6 +34,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "ModuleXbmcgui.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "WindowException.h"
@@ -499,59 +500,26 @@ namespace XBMCAddon
       return dlg->IsCanceled();
     }
 
+    // deprecated because wrong
+    // modal dialogs can't be called from python using a proxy class with async
+    // messaging. there can only be one DialogBusy at a time.
     DialogBusy::~DialogBusy() { XBMC_TRACE; deallocating(); }
-
     void DialogBusy::deallocating()
     {
-      XBMC_TRACE;
-
-      if (dlg && open)
-      {
-        DelayedCallGuard dg;
-        dlg->Close();
-      }
     }
-
     void DialogBusy::create()
     {
-      DelayedCallGuard dcguard(languageHook);
-      CGUIDialogBusy* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusy>(WINDOW_DIALOG_BUSY);
-
-      if (pDialog == nullptr)
-        throw WindowException("Error: Window is NULL, this is not possible :-)");
-
-      dlg = pDialog;
-      open = true;
-
-      pDialog->Open();
+      CLog::Log(LOGWARNING, "using DialogBusy from python results in nop now");
     }
-
     void DialogBusy::update(int percent) const
     {
-      DelayedCallGuard dcguard(languageHook);
-
-      if (dlg == nullptr)
-        throw WindowException("Dialog not created.");
-
-      if (percent >= -1 && percent <= 100)
-        dlg->SetProgress(percent);
-
     }
-
     void DialogBusy::close()
     {
-      DelayedCallGuard dcguard(languageHook);
-      if (dlg == nullptr)
-        throw WindowException("Dialog not created.");
-      dlg->Close();
-      open = false;
     }
-
     bool DialogBusy::iscanceled() const
     {
-      if (dlg == nullptr)
-        throw WindowException("Dialog not created.");
-      return dlg->IsCanceled();
+      return false;
     }
 
     DialogProgressBG::~DialogProgressBG() { XBMC_TRACE; deallocating(); }

--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -733,19 +733,17 @@ namespace XBMCAddon
     /// @brief <b>Kodi's busy dialog class</b>
     ///
     ///-----------------------------------------------------------------------
-    /// @python_v17 New class added.
+    /// @python_v18 removed, usage results in nop!
     ///
     class DialogBusy : public AddonClass
     {
-      CGUIDialogBusy* dlg;
-      bool open;
 
     protected:
       void deallocating() override;
 
     public:
 
-      DialogBusy() : dlg(NULL), open(false) {}
+      DialogBusy() {}
       ~DialogBusy() override;
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -760,7 +758,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
-      /// @python_v17 New method added
+      /// @python_v18 removed, usage results in nop!
       ///
       /// **Example:**
       /// ~~~~~~~~~~~~~{.py}
@@ -789,7 +787,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
-      /// @python_v17 New method added
+      /// @python_v18 removed, usage results in nop!
       ///
       update(...);
 #else
@@ -806,7 +804,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
-      /// @python_v17 New method added
+      /// @python_v18 removed, usage results in nop!
       ///
       close(...);
 #else
@@ -825,7 +823,7 @@ namespace XBMCAddon
       ///
       ///
       ///------------------------------------------------------------------------
-      /// @python_v17 New method added
+      /// @python_v18 removed, usage results in nop!
       ///
       iscanceled(...);
 #else

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -47,6 +47,7 @@
 #include "guilib/TextureManager.h"
 #include "Util.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
+#include "input/WindowTranslator.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/LangCodeExpander.h"
@@ -109,6 +110,25 @@ namespace XBMCAddon
       XBMC_TRACE;
       if (! function)
         return;
+
+      // builtins is no anarchy
+      // enforce some rules here
+      // DialogBusy must not be activated, it is modal dialog
+      std::string execute;
+      std::vector<std::string> params;
+      CUtil::SplitExecFunction(function, execute, params);
+      StringUtils::ToLower(execute);
+      if (StringUtils::EqualsNoCase(execute, "activatewindow") ||
+          StringUtils::EqualsNoCase(execute, "closedialog"))
+      {
+        int win = CWindowTranslator::TranslateWindow(params[0]);
+        if (win == WINDOW_DIALOG_BUSY)
+        {
+          CLog::Log(LOGWARNING, "addons must not activate DialogBusy");
+          return;
+        }
+      }
+
       if (wait)
         CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, function);
       else

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -874,8 +874,8 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
   m_musicInfoLoader.SetProgressCallback(m_dlgProgress);
   m_musicInfoLoader.Load(items);
 
-  bool bShowProgress=!CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog();
-  bool bProgressVisible=false;
+  bool bShowProgress = !CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true);
+  bool bProgressVisible = false;
 
   unsigned int tick=XbmcThreads::SystemClockMillis();
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -211,8 +211,8 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
   loader.SetProgressCallback(m_dlgProgress);
   loader.Load(items);
 
-  bool bShowProgress=!CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog();
-  bool bProgressVisible=false;
+  bool bShowProgress = !CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true);
+  bool bProgressVisible = false;
 
   unsigned int tick=XbmcThreads::SystemClockMillis();
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -2185,9 +2185,9 @@ std::string CGUIMediaWindow::RemoveParameterFromPath(const std::string &strDirec
   return strDirectory;
 }
 
-void CGUIMediaWindow::ProcessRenderLoop(bool renderOnly)
+bool CGUIMediaWindow::ProcessRenderLoop(bool renderOnly)
 {
-  CServiceBroker::GetGUI()->GetWindowManager().ProcessRenderLoop(renderOnly);
+  return CServiceBroker::GetGUI()->GetWindowManager().ProcessRenderLoop(renderOnly);
 }
 
 bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool useDir)
@@ -2247,7 +2247,8 @@ bool CGUIMediaWindow::WaitGetDirectoryItems(CGetDirectoryItems &items)
 
     while (!m_updateEvent.WaitMSec(1))
     {
-      ProcessRenderLoop(false);
+      if (!ProcessRenderLoop(false))
+        break;
     }
 
     if (m_updateAborted || !items.m_result)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1751,8 +1751,11 @@ bool CGUIMediaWindow::OnPopupMenu(int itemIdx)
 
   if (InRange(static_cast<size_t>(idx), pluginMenuRange))
   {
+    bool saveVal = m_backgroundLoad;
+    m_backgroundLoad = false;
     CApplicationMessenger::GetInstance().SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
         item->GetProperty(StringUtils::Format("contextmenuaction(%i)", idx - pluginMenuRange.first)).asString());
+    m_backgroundLoad = saveVal;
     return true;
   }
 

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -186,7 +186,7 @@ protected:
    */
   static std::string RemoveParameterFromPath(const std::string &strDirectory, const std::string &strParameter);
 
-  void ProcessRenderLoop(bool renderOnly = false);
+  bool ProcessRenderLoop(bool renderOnly);
 
   XFILE::CVirtualDirectory m_rootDir;
   CGUIViewControl m_viewControl;

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -192,6 +192,20 @@ protected:
   CDirectoryHistory m_history;
   std::unique_ptr<CGUIViewState> m_guiState;
   std::atomic_bool m_vecItemsUpdating = {false};
+  class CUpdateGuard
+  {
+  public:
+    CUpdateGuard(std::atomic_bool &update) : m_update(update)
+    {
+      m_update = true;
+    }
+    ~CUpdateGuard()
+    {
+      m_update = false;
+    }
+  protected:
+    std::atomic_bool &m_update;
+  };
 
   // save control state on window exit
   int m_iLastControl;
@@ -212,5 +226,5 @@ protected:
    \sa Update
    */
   std::string m_strFilterPath;
-  bool m_useBusyDialog = false;
+  bool m_backgroundLoad = false;
 };

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -31,6 +31,10 @@
 
 class CFileItemList;
 class CGUIViewState;
+namespace
+{
+class CGetDirectoryItems;
+}
 
 // base class for all media windows
 class CGUIMediaWindow : public CGUIWindow
@@ -168,6 +172,7 @@ protected:
   void OnRenameItem(int iItem);
   bool WaitForNetwork() const;
   bool GetDirectoryItems(CURL &url, CFileItemList &items, bool useDir);
+  bool WaitGetDirectoryItems(CGetDirectoryItems &items);
 
   /*! \brief Translate the folder to start in from the given quick path
    \param url the folder the user wants
@@ -206,6 +211,9 @@ protected:
   protected:
     std::atomic_bool &m_update;
   };
+  CEvent m_updateEvent;
+  std::atomic_bool m_updateAborted;
+  std::atomic_bool m_updateJobActive = {false};
 
   // save control state on window exit
   int m_iLastControl;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -164,7 +164,7 @@ bool CGUIWindowLoginScreen::OnBack(int actionID)
 
 void CGUIWindowLoginScreen::FrameMove()
 {
-  if (GetFocusedControlID() == CONTROL_BIG_LIST && !CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog())
+  if (GetFocusedControlID() == CONTROL_BIG_LIST && !CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true))
   {
     if (m_viewControl.HasControl(CONTROL_BIG_LIST))
       m_iSelectedItem = m_viewControl.GetSelectedItem();


### PR DESCRIPTION
- fixes multiple updates of GUIMediaWindow's vecItems at the same time by ignoring updates/refreshes, if update is already in progress

- do not use background loading when context menu (GUiMediaWindow) is active. This resulted in an busyDialog obscured by a selectDialog

- do not bring up busy dialog for GUIMediaWindow if it is in use

- python scripts must not activate busyDialog. 

fixes .i.e. https://trac.kodi.tv/ticket/17896#comment:2
also (most likely) https://trac.kodi.tv/ticket/17892