### PR TITLE
[Nodes] Add Top 100 default node to Music Video Library

### DIFF
--- a/system/library/music/musicvideos/albums.xml
+++ b/system/library/music/musicvideos/albums.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="50" type="filter">
+<node order="60" type="filter">
 	<label>132</label>
 	<icon>DefaultMusicAlbums.png</icon>
 	<content>musicvideos</content>

--- a/system/library/music/musicvideos/directors.xml
+++ b/system/library/music/musicvideos/directors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="60" type="filter">
+<node order="70" type="filter">
  <label>20348</label>
 	<icon>DefaultDirector.png</icon>
 	<content>musicvideos</content>

--- a/system/library/music/musicvideos/studios.xml
+++ b/system/library/music/musicvideos/studios.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="70" type="filter">
+<node order="80" type="filter">
 	<label>20388</label>
 	<icon>DefaultStudios.png</icon>
 	<content>musicvideos</content>

--- a/system/library/music/musicvideos/tags.xml
+++ b/system/library/music/musicvideos/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="80" type="filter">
+<node order="90" type="filter">
 	<label>20459</label>
 	<icon>DefaultTags.png</icon>
 	<content>musicvideos</content>

--- a/system/library/music/musicvideos/top100.xml
+++ b/system/library/music/musicvideos/top100.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="50" type="filter">
+	<label>271</label>
+	<icon>DefaultMusicTop100Songs.png</icon>
+	<content>musicvideos</content>
+	<order direction="descending">playcount</order>
+	<limit>100</limit>
+</node>

--- a/system/library/video/musicvideos/albums.xml
+++ b/system/library/video/musicvideos/albums.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="60" type="filter">
+<node order="70" type="filter">
 	<label>132</label>
 	<icon>DefaultMusicAlbums.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/directors.xml
+++ b/system/library/video/musicvideos/directors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="70" type="filter">
+<node order="80" type="filter">
  <label>20348</label>
 	<icon>DefaultDirector.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/studios.xml
+++ b/system/library/video/musicvideos/studios.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="80" type="filter">
+<node order="90" type="filter">
 	<label>20388</label>
 	<icon>DefaultStudios.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/tags.xml
+++ b/system/library/video/musicvideos/tags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
-<node order="90" type="filter">
+<node order="100" type="filter">
 	<label>20459</label>
 	<icon>DefaultTags.png</icon>
 	<content>musicvideos</content>

--- a/system/library/video/musicvideos/top100.xml
+++ b/system/library/video/musicvideos/top100.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<node order="60" type="filter">
+	<label>271</label>
+	<icon>DefaultMusicTop100Songs.png</icon>
+	<content>musicvideos</content>
+	<order direction="descending">playcount</order>
+	<limit>100</limit>
+</node>


### PR DESCRIPTION
## Description
Add a top 100 music video node to default installs. Provides a nice new feature. Follow up to 
xbmc/xbmc#13953

## Motivation and Context
This has been possible for a while using a custom node, but I think it would benefit all users to have this. We already do this for music so I copied the same method which uses a default XML node. I used the same translation label ID as music.

## How Has This Been Tested?
Tested with default install as well as custom node

## Screenshots (if appropriate):
![top100_mvid](https://user-images.githubusercontent.com/1050512/40684485-6261089e-6389-11e8-8633-5f5065bbf01c.jpg)

![kodi_20180529_215722](https://user-images.githubusercontent.com/1050512/40685249-9e38f32a-638b-11e8-9701-f3f831ec55ff.png)

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
