### PR TITLE
[GUI] Prevent scrolling in Home menu for 8 entries

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -804,7 +804,7 @@
 					<top>240</top>
 					<width>462</width>
 					<bottom>-10</bottom>
-					<movement>6</movement>
+					<movement>7</movement>
 					<focusposition>0</focusposition>
 					<onfocus>ClearProperty(listposition,home)</onfocus>
 					<onright>SetFocus($INFO[Container(9000).ListItem.Property(menu_id)])</onright>


### PR DESCRIPTION
## Description
If 8 elements are activated in Home main menu, ListContainer scrolls regardless there is enough space for displaying 8 elements.
Increasing the movement value affects the internally the count of visible elements scrolling begins.

## Motivation and Context
Several user / internal requests regarding the 8 element issue (why does it scroll ??)

## How Has This Been Tested?
Win10 estuary

## Types of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
