### PR TITLE
RetroPlayer: Fix games running at partial speed

### DIFF
--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -20,15 +20,8 @@
 
 #include <stdint.h>
 
-#if   defined(TARGET_DARWIN)
-#include <mach/mach_time.h>
-#include <CoreVideo/CVHostTime.h>
-#elif defined(TARGET_WINDOWS)
-#include <windows.h>
-#else
-#include <time.h>
-#endif
 #include "SystemClock.h"
+#include "utils/TimeUtils.h"
 
 namespace XbmcThreads
 {
@@ -37,19 +30,9 @@ namespace XbmcThreads
     uint64_t now_time;
     static uint64_t start_time = 0;
     static bool start_time_set = false;
-#if defined(TARGET_DARWIN)
-    now_time = CVGetCurrentHostTime() *  1000 / CVGetHostClockFrequency();
-#elif defined(TARGET_WINDOWS)
-    now_time = GetTickCount64();
-#else
-    struct timespec ts = {};
-#ifdef CLOCK_MONOTONIC_RAW
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-#else
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-#endif // CLOCK_MONOTONIC_RAW
-    now_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
-#endif
+
+    now_time = static_cast<uint64_t>(1000 * CurrentHostCounter() / CurrentHostFrequency());
+
     if (!start_time_set)
     {
       start_time = now_time;


### PR DESCRIPTION
This fixes slowed-down games on Windows since the UWP merge in #12942 (specifically commit 29fb23674).

The issue was caused by switching the system clock from `timeGetTime()` to `GetTickCount64()`. The former has a precision of "five milliseconds or more", whereas the latter has a precision of "typically in the range of 10 milliseconds to 16 milliseconds". I measured 12ms.

At 60fps, we expect 16ms between frames. SNES emulators render a single frame in less than 11ms, so the additional 5ms wasn't a problem before the UWP merge. However, with `GetTickCount64()`, the 12ms error caused games to run at ~75% speed (11ms + 12ms > 16ms).

I changed `SystemClockMillis()` instead of implementing higher-res timing in GameLoop.cpp because there are possibly other systems which rely on a <= 16ms sleep time. For example, when games are playing, peripheral input is adjusted to match the game fps, which results in button pressed being delivered to the wrong frame.

Report: https://forum.kodi.tv/showthread.php?tid=325286&pid=2677673#pid2677673

## How Has This Been Tested?
Tested with SNES emulator on Windows 7, games play at full speed now.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
